### PR TITLE
[WiP][CR]Map memory

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -221,6 +221,8 @@ class game
 
         std::unique_ptr<Creature_tracker> critter_tracker;
 
+        std::unique_ptr<map> map_memory_ptr;
+
         /**
          * Add an entry to @ref game::events. For further information see event.h
          * @param type Type of event.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1582,6 +1582,8 @@ void map::furn_set( const tripoint &p, const furn_id new_furniture )
     // @todo Limit to changes that affect move cost, traps and stairs
     set_pathfinding_cache_dirty( p.z );
 
+    set_map_memory_dirty( p );
+
     // Make sure the furniture falls if it needs to
     support_dirty( p );
     tripoint above( p.x, p.y, p.z + 1 );
@@ -1785,6 +1787,8 @@ void map::ter_set( const tripoint &p, const ter_id new_terrain )
 
     // @todo Limit to changes that affect move cost, traps and stairs
     set_pathfinding_cache_dirty( p.z );
+
+    set_map_memory_dirty( p );
 
     tripoint above( p.x, p.y, p.z + 1 );
     // Make sure that if we supported something and no longer do so, it falls down
@@ -4471,6 +4475,7 @@ item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
         }
 
         support_dirty( tile );
+        set_map_memory_dirty( tile );
         return add_item( tile, obj );
     };
 
@@ -5669,6 +5674,35 @@ void map::debug()
  inp_mngr.wait_for_any_key();
 }
 
+void map::memorize_submap( const tripoint &submap_coord, const bool submap_mask[SEEX][SEEY] )
+{
+    const submap *sm_real = MAPBUFFER.lookup_submap( submap_coord );
+    if( sm_real == nullptr ) {
+        debugmsg( "Tried to memorize a null submap %d,%d,%d",
+                  submap_coord.x, submap_coord.y, submap_coord.z );
+        return;
+    }
+
+    submap *sm_memorized = map_memory_buffer.lookup_submap( submap_coord );
+    if( sm_memorized == nullptr ) {
+        // @todo Should be an error
+        return;
+    }
+
+    for( size_t x = 0; x < SEEX; x++ ) {
+        for( size_t y = 0; y < SEEY; y++ ) {
+            if( !submap_mask[x][y] ) {
+                continue;
+            }
+
+            sm_memorized->ter[x][y] = sm_real->ter[x][y];
+            sm_memorized->frn[x][y] = sm_real->frn[x][y];
+            sm_memorized->itm[x][y] = sm_real->itm[x][y];
+            // @todo Traps, fields
+        }
+    }
+}
+
 void map::update_visibility_cache( const int zlev ) {
     visibility_variables_cache.variables_set = true; // Not used yet
     visibility_variables_cache.g_light_level = (int)g->light_level( zlev );
@@ -5682,17 +5716,47 @@ void map::update_visibility_cache( const int zlev ) {
     int sm_squares_seen[MAPSIZE][MAPSIZE];
     std::memset(sm_squares_seen, 0, sizeof(sm_squares_seen));
 
-    auto &visibility_cache = get_cache( zlev ).visibility_cache;
+    auto &cache = get_cache( zlev );
+    auto &visibility_cache = cache.visibility_cache;
+    auto &map_memory_dirty = cache.map_memory_dirty;
+    // @todo Move to option
+    bool do_memorize = true;
+    bool submap_mask[SEEX][SEEY];
 
     tripoint p;
     p.z = zlev;
     int &x = p.x;
     int &y = p.y;
-    for( x = 0; x < MAPSIZE * SEEX; x++ ) {
-        for( y = 0; y < MAPSIZE * SEEY; y++ ) {
-            lit_level ll = apparent_light_at( p, visibility_variables_cache );
-            visibility_cache[x][y] = ll;
-            sm_squares_seen[ x / SEEX ][ y / SEEY ] += (ll == LL_BRIGHT || ll == LL_LIT);
+    for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
+        for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
+            if( do_memorize ) {
+                std::uninitialized_fill_n( &submap_mask[0][0], SEEX * SEEY, false );
+            }
+
+            bool memorize_this = false;
+
+            for( int sx = 0; sx < SEEX; ++sx ) {
+                for( int sy = 0; sy < SEEY; ++sy ) {
+                    x = sx + smx * SEEX;
+                    y = sy + smy * SEEY;
+
+                    lit_level ll = apparent_light_at( p, visibility_variables_cache );
+                    visibility_cache[x][y] = ll;
+                    bool is_seen = ll == LL_BRIGHT || ll == LL_LIT;
+                    sm_squares_seen[ x / SEEX ][ y / SEEY ] += is_seen;
+                    // Update map memory (if needed)
+                    if( is_seen && do_memorize && map_memory_dirty[x][y] ) {
+                        map_memory_dirty[x][y] = false;
+                        submap_mask[sx][sy] = true;
+                        memorize_this = true;
+                    }
+                }
+            }
+
+            if( memorize_this ) {
+                const auto abs_sm = map::abs_sub + tripoint( smx, smy, 0 );
+                memorize_submap( abs_sm, submap_mask );
+            }
         }
     }
 
@@ -5889,6 +5953,82 @@ void map::draw( WINDOW* w, const tripoint &center )
 
         while( x < maxxrender ) {
             wputch( w, c_black, ' ' );
+            x++;
+        }
+    }
+}
+
+// @todo De-copypasta
+void map::draw_masked( WINDOW *w, const tripoint &center, const map &mask )
+{
+    // We only need to draw anything if we're not in tiles mode.
+    if( is_draw_tiles_mode() ) {
+        return;
+    }
+
+    const auto &mask_cache = mask.get_cache_ref( center.z ).visibility_cache;
+
+    tripoint p;
+    p.z = center.z;
+    int &x = p.x;
+    int &y = p.y;
+    for( y = center.y - getmaxy(w) / 2; y <= center.y + getmaxy(w) / 2; y++ ) {
+        if( y - center.y + getmaxy(w) / 2 >= getmaxy(w) ){
+            continue;
+        }
+
+        wmove( w, y - center.y + getmaxy(w) / 2, 0 );
+
+        if( y < 0 || y >= MAPSIZE * SEEY ) {
+            continue;
+        }
+
+        x = center.x - getmaxx(w) / 2;
+        while( x < 0 ) {
+            x++;
+        }
+
+        int lx;
+        int ly;
+        const int maxxrender = center.x - getmaxx(w) / 2 + getmaxx(w);
+        const int maxx = std::min( MAPSIZE * SEEX, maxxrender );
+        while( x < maxx ) {
+            submap *cur_submap = get_submap_at( p, lx, ly );
+            submap *sm_below = p.z > -OVERMAP_DEPTH ?
+                get_submap_at( p.x, p.y, p.z - 1, lx, ly ) : cur_submap;
+            while( lx < SEEX && x < maxx )  {
+const int k = p.x + getmaxx(w) / 2 - center.x;
+const int j = p.y + getmaxy(w) / 2 - center.y;
+                if( cur_submap == nullptr ) {
+mvwputch(w, j, k, c_white, '?');
+                    lx++;
+                    x++;
+                    continue;
+                }
+                const lit_level mask_light = mask_cache[x][y];
+                if( mask_light == LL_DARK || mask_light == LL_BLANK ) {
+                    const maptile curr_maptile = maptile( cur_submap, lx, ly );
+
+if(curr_maptile.get_ter()==t_null)mvwputch(w, j, k, c_white, '?');
+                    const bool just_this_zlevel =
+                        draw_maptile( w, g->u, p, curr_maptile,
+                                      false, true, center,
+                                      true, false, false );
+                    if( !just_this_zlevel && sm_below != nullptr ) {
+                        p.z--;
+                        const maptile tile_below = maptile( sm_below, lx, ly );
+                        draw_from_above( w, g->u, p, tile_below, false, center,
+                                         true, false, false );
+                        p.z++;
+                    }
+                }
+
+                lx++;
+                x++;
+            }
+        }
+
+        while( x < maxxrender ) {
             x++;
         }
     }
@@ -6611,6 +6751,28 @@ void map::saven( const int gridx, const int gridy, const int gridz )
                   << "  gridn: " << gridn;
     submap_to_save->turn_last_touched = int(calendar::turn);
     MAPBUFFER.add_submap( abs_x, abs_y, abs_z, submap_to_save );
+}
+
+void map::load_memorized( const tripoint &sm_loc )
+{
+    set_abs_sub( sm_loc.x, sm_loc.y, sm_loc.z );
+    int minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z;
+    int maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z;
+    for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
+        for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
+            for( int gridz = minz; gridz <= maxz; gridz++ ) {
+                const size_t gridn = get_nonant( gridx, gridy, gridz );
+                submap *tmpsub = map_memory_buffer.lookup_submap( abs_sub.x + gridx, abs_sub.y + gridy, gridz );
+                if( tmpsub == nullptr ) {
+                    tmpsub = new submap();
+                    // We want it to exist so that we can change it in @ref memorize_submap
+                    map_memory_buffer.add_submap( abs_sub.x + gridx, abs_sub.y + gridy, gridz, tmpsub );
+                }
+
+                setsubmap( gridn, tmpsub );
+            }
+        }
+    }
 }
 
 // worldx & worldy specify where in the world this is;
@@ -8160,8 +8322,16 @@ level_cache::level_cache()
     std::fill_n( &transparency_cache[0][0], map_dimensions, 0.0f );
     std::fill_n( &seen_cache[0][0], map_dimensions, 0.0f );
     std::fill_n( &visibility_cache[0][0], map_dimensions, LL_DARK );
+    std::fill_n( &map_memory_dirty[0][0], map_dimensions, true );
     veh_in_active_range = false;
     std::fill_n( &veh_exists_at[0][0], map_dimensions, false );
+}
+
+void map::set_map_memory_dirty( const tripoint &p )
+{
+    if( inbounds( p ) ) {
+        get_cache( p.z ).map_memory_dirty[p.x][p.y] = true;
+    }
 }
 
 pathfinding_cache::pathfinding_cache()

--- a/src/map.h
+++ b/src/map.h
@@ -152,6 +152,7 @@ struct level_cache {
     float transparency_cache[MAPSIZE*SEEX][MAPSIZE*SEEY];
     float seen_cache[MAPSIZE*SEEX][MAPSIZE*SEEY];
     lit_level visibility_cache[MAPSIZE*SEEX][MAPSIZE*SEEY];
+    bool map_memory_dirty[MAPSIZE*SEEX][MAPSIZE*SEEY];
 
     bool veh_in_active_range;
     bool veh_exists_at[SEEX * MAPSIZE][SEEY * MAPSIZE];
@@ -225,6 +226,8 @@ class map
     }
 
     void set_pathfinding_cache_dirty( const int zlev );
+
+    void set_map_memory_dirty( const tripoint &p );
     /*@}*/
 
 
@@ -277,6 +280,11 @@ class map
                  const bool inorder = false) const;
 
     /**
+     * Draws parts of the map NOT visible on the masking map.
+     */
+    void draw_masked( WINDOW *w, const tripoint &center, const map &mask );
+
+    /**
      * Add currently loaded submaps (in @ref grid) to the @ref mapbuffer.
      * They will than be stored by that class and can be loaded from that class.
      * This can be called several times, the mapbuffer takes care of adding
@@ -315,6 +323,8 @@ class map
      *  after 3D migration is complete.
      */
     void vertical_shift( const int newz );
+
+    void load_memorized( const tripoint &sm_loc );
 
  void clear_spawns();
  void clear_traps();
@@ -1439,6 +1449,8 @@ private:
     // Second argument refers to whether we have to get a roof (we're over an unpassable tile)
     // or can just return air because we bashed down an entire floor tile
     ter_id get_roof( const tripoint &p, bool allow_air );
+
+    void memorize_submap( const tripoint &submap_coord, const bool submap_mask[SEEX][SEEY] );
 
  // Iterates over every item on the map, passing each item to the provided function.
  template<typename T>

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -20,6 +20,12 @@ class mapbuffer
         mapbuffer();
         ~mapbuffer();
 
+        /**
+         * Sets path for this mapbuffer.
+         * Must be called before it is used.
+         */
+        void init( std::string path );
+
         /** Load the entire world from savefiles into submaps in this instance. **/
         void load( std::string worldname );
         /** Store all submaps in this instance into savefiles.
@@ -79,8 +85,10 @@ class mapbuffer
                         const tripoint &om_addr, std::list<tripoint> &submaps_to_delete,
                         bool delete_after_save );
         submap_map_t submaps;
+        std::string path;
 };
 
 extern mapbuffer MAPBUFFER;
+extern mapbuffer map_memory_buffer;
 
 #endif


### PR DESCRIPTION
Very [WiP], but I decided to PR because maybe someone has some good tip on how to do it just right, without tangling unrelated parts too much.

At the moment it looks like this:
* Memorized map is a second `map`, drawn with a function very similar to the first one
* Memorized map has its own `mapbuffer` that saves its contents inside directory with name like `base64(u.name)/map_memory` - similar to other player save files, except it's a directory
* Memorized maps have submaps just like normal maps, select contents (terrain, furniture and items) of the submap are copied to the memorized map on visibility cache building
* There is a cache to avoid re-copying things over and over

The advantages of my approach are:
* No need to write a second tile drawing function, memorized maps can be drawn very similarly to real ones
* Easy to extend to more elements like traps, vehicles, fields, computers etc.
* No need to write new save/load functions, only need to point them to the new file
* There are no problems like offscreen change modifying memorized map - even if a whole city burns down, it will stay intact, in character's memory (until the character looks at the ashes)
* The cache and copying mechanism could be very easily used to implement alarming on item spotted - like safe mode except for items. Since all items are memorized, it's easy to just check for differences, meaning no need to re-report existing items.

Problems, hence [CR]:
* `mapbuffer` is hardcoded for a specific path. I am not sure if my workaround is good. I added a new `init` method on `mapbuffer`, which sets the path for a given buffer.
* `map` is hardcoded to use the global `mapbuffer MAPBUFFER`. I added a new set of functions that skips the real map stuff. But it may be better to inject a `mapbuffer` reference somewhere instead.
* Memorized `map` and real `map` share only a relatively small subset of functions: drawing, having submaps, looking up submaps from buffer, submaps being on a 2D/3D grid. Having memorized `map` keep caches and expose functions like `ter_set` is not really right. The most right thing I can think of would be extracting `map_base` or something like that. Otherwise I'd need to reinvent quite a bit of stuff, which I'd rather avoid.