### PR TITLE
Fix vehicle cache debugmsgs

### DIFF
--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -278,7 +278,7 @@ ter_t null_terrain_t() {
   new_terrain.name_ = translate_marker( "nothing" );
   new_terrain.symbol_.fill( ' ' );
   new_terrain.color_.fill( c_white );
-  new_terrain.movecost = 2;
+  new_terrain.movecost = 0;
   new_terrain.transparent = true;
   new_terrain.set_flag("TRANSPARENT");
   new_terrain.set_flag("DIGGABLE");


### PR DESCRIPTION
Treating null terrain as passable breaks the assumption that things can't move into a null tile. This is a perfectly fine assumption to make, as moving into a null tile shouldn't happen.

Creatures on null tiles - outside map - would check vehicles on their tiles. Since those checks happen a lot, they would be made with optimized function that skips bounds check. This function only works faster than the one with bounds checks if everything is in bounds, so it warns if it is used "wrong".

Alternatives would be to drop the optimization and just check bounds (those creature tile checks are costly already, as seen when profiling), special case null tiles wherever skipped bounds checks are involved (ugly!), ensure critters aren't on null tiles before processing them, or optimize it in some different way that doesn't require relatively expensive vehicle checks.
But I can't really think of a reason for why should null terrain be passable.