### PR TITLE
[WiP][CR]Make pain cause morale penalty

### DIFF
--- a/data/json/morale_types.json
+++ b/data/json/morale_types.json
@@ -278,5 +278,10 @@
     "id": "morale_perm_filthy",
     "type": "morale_type",
     "text": "Filthy Gear"
+  },
+  {
+    "id": "morale_pain",
+    "type": "morale_type",
+    "text": "Pain"
   }
 ]

--- a/src/morale.h
+++ b/src/morale.h
@@ -129,7 +129,7 @@ class player_morale
 
         void update_stylish_bonus();
         void update_squeamish_penalty();
-        void update_masochist_bonus();
+        void update_pain_effect();
         void update_bodytemp_penalty( int ticks );
         void update_constrained_penalty();
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -990,12 +990,6 @@ int player::calc_focus_equilibrium() const
     }
 
     int eff_morale = get_morale_level();
-    // Factor in perceived pain, since it's harder to rest your mind while your body hurts.
-    // Cenobites don't mind, though
-    if( !has_trait( trait_CENOBITE ) ) {
-        eff_morale = eff_morale - get_perceived_pain();
-    }
-
     if( eff_morale < -99 ) {
         // At very low morale, focus goes up at 1% of the normal rate.
         focus_gain_rate = 1;


### PR DESCRIPTION
This was proposed a bunch of times. The weird effect pain has on focus (directly) instead of going through morale (like other effects) produced a bunch of amusing screenshots. Pain of having broken arms is currently less unpleasant than eating raw cabbage.

There are two problems:
* Do we want 50+ pain to make it impossible to craft? Current morale crafting mechanic is very unforgiving. This could quickly stack: infection + bad weather and you can't boil water. This is a pretty major problem, hence [CR]
* Traits: Masochist and friends. In current version, base Masochist is useless (at best, it slows down focus loss by 25%), but it offers an illusion of working, by pretending that it has an effect other than affecting focus. This is impossible to preserve if pain is to affect morale directly.

As for the latter, here I changed it as follows:
* Base masochist prevents all morale loss from pain. Pain still causes massive stat and speed penalties, so there is no reason to be in pain. It doesn't give any bonuses, just prevents penalties.
* Mutant masochism prevents all pain morale penalties and gives +pain/2.5 morale on top, like in current version.

Overall that's a huge buff to the terrible Masochist trait, small buff to medical masochist trait, no buff to cenobite, and a small buff to characters who find themselves in rare situation of having high pain and high morale while not being a masochist.