### PR TITLE
Conditional nesting in mapgen - by overmap neighbor adjacency

### DIFF
--- a/data/json/mapgen/house/house_suicide.json
+++ b/data/json/mapgen/house/house_suicide.json
@@ -84,7 +84,7 @@
         { "group": "bedroom", "x": [ 14, 20 ], "y": [ 17, 20 ], "chance": 80, "repeat": [ 1, 4 ] }
       ],
       "place_nested": [
-        { "entries": [ [ "bathroom_suicide", 100 ] ], "x": 18, "y": 13 }
+        { "chunks": [ [ "bathroom_suicide", 100 ] ], "x": 18, "y": 13 }
       ]
     }
   },

--- a/data/json/mapgen/swamp_shack.json
+++ b/data/json/mapgen/swamp_shack.json
@@ -1,5 +1,16 @@
 [
   {
+    "type": "palette",
+    "id": "swamp_background",
+    "terrain": {
+      " ": [ "t_swater_dp", "t_swater_sh", "t_swater_sh", "t_dirt", "t_dirt", "t_dirt", "t_dirt", "t_grass", "t_grass", "t_grass", "t_grass", "t_grass", "t_grass", "t_underbrush", "t_tree", "t_tree_young" ],
+      "i": "t_water_sh"
+    },
+    "furniture": {
+      "i": "f_cattails" 
+    }
+  },
+  {
     "type": "mapgen",
     "method": "json",
     "om_terrain": [ "hunter_shack" ],
@@ -7,30 +18,33 @@
     "object": {
       "fill_ter": "t_floor",
       "rows": [
-        "          i             ",
-        " i       i i    i       ",
-        "     i   i  i    i  ii  ",
-        "        i   i      ii   ",
-        "   i         ii      i  ",
-        "     i    i       i     ",
-        "  i            ii       ",
-        "ii  i    -----------iii ",
-        "i     i  -CSn.....d- i  ",
-        " i       -....---+--    ",
-        "  i   i  -B..D-@..d-    ",
-        "         -B...-@..d-  i ",
-        "   i i   -bbTc-s.ss- i  ",
-        "  i   i  ---o---+---    ",
-        "  i    i i=V,,^,,,,,  i ",
-        "   i     ,,,,,,,,X=   i ",
-        "      i  ,=&&,xxXX=i  i ",
-        "    ii i  =========  i  ",
-        "       i  i   i       ii",
-        "  i        i   i       i",
-        "     i  i       i ii    ",
-        "      ii i     i i   i  ",
-        "   i      ii    i i i   ",
-        "                i   i   "
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "       -----------      ",
+        "       -CSn.....d-      ",
+        "       -....---+--      ",
+        "       -B..D-@..d-      ",
+        "       -B...-@..d-      ",
+        "       -bbTc-s.ss-      ",
+        "       ---o---+---      ",
+        "        =V,,^,,,,,      ",
+        "       ,,,,,,,,X=       ",
+        "       ,=&&,xxXX=       ",
+        "        =========       ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [
+        "swamp_background"
       ],
       "mapping": {
         "B": {
@@ -83,7 +97,6 @@
         }
       },
       "terrain": {
-        " ": [ "t_swater_dp", "t_swater_sh", "t_swater_sh", "t_dirt", "t_dirt", "t_dirt", "t_dirt", "t_grass", "t_grass", "t_grass", "t_grass", "t_grass", "t_grass", "t_underbrush", "t_tree", "t_tree_young" ],
         "&": "t_dirt",
         "+": "t_door_c",
         ",": [ "t_dirt", "t_dirt", "t_dirt", "t_dirt", "t_dirt", "t_dirt", "t_grass" ],
@@ -93,7 +106,6 @@
         "V": "t_dirt",
         "X": "t_dirt",
         "^": "t_dirt",
-        "i": [ "t_swater_dp", "t_swater_sh", "t_swater_sh", "t_dirt", "t_dirt", "t_dirt", "t_grass", "t_grass", "t_grass", "t_underbrush" ],
         "o": "t_window_domestic",
         "x": "t_dirt"
       },
@@ -112,11 +124,61 @@
         "b": "f_makeshift_bed",
         "c": "f_chair",
         "d": "f_rack",
-        "i": [ "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_null", "f_cattails", "f_cattails", "f_cattails", "f_cattails" ],
         "n": "f_counter",
         "s": "f_counter",
         "x": "f_crate_o"
-      }
+      },
+      "place_nested": [
+        { "entries": [ "swamp_background_6x6" ], "x": 0, "y": 0, "neighbors": { "north": "forest_water" } },
+        { "entries": [ "swamp_background_6x6" ], "x": [ 5, 12 ], "y": 0, "neighbors": { "north": "forest_water"}, "repeat": 4 },
+        { "entries": [ "swamp_background_6x6" ], "x": 18, "y": 0, "neighbors": { "north": "forest_water" } },
+        { "entries": [ "swamp_background_6x6" ], "x": 18, "y": 0, "neighbors": { "east": "forest_water" } },
+        { "entries": [ "swamp_background_6x6" ], "x": 18, "y": [ 5, 12 ], "neighbors": { "east": "forest_water"}, "repeat": 4 },
+        { "entries": [ "swamp_background_6x6" ], "x": 18, "y": 18, "neighbors": { "east": "forest_water" } },
+        { "entries": [ "swamp_background_6x6" ], "x": 0, "y": 18, "neighbors": { "south": "forest_water" } },
+        { "entries": [ "swamp_background_6x6" ], "x": [ 5, 11 ], "y": 18, "neighbors": { "south": "forest_water"}, "repeat": 4 },
+        { "entries": [ "swamp_background_6x6" ], "x": 18, "y": 18, "neighbors": { "south": "forest_water" } },
+        { "entries": [ "swamp_background_6x6" ], "x": 0, "y": 0, "neighbors": { "west": "forest_water" } },
+        { "entries": [ "swamp_background_6x6" ], "x": 0, "y": [ 5, 12 ], "neighbors": { "west": "forest_water"}, "repeat": 4 },
+        { "entries": [ "swamp_background_6x6" ], "x": 0, "y": 18, "neighbors": { "west": "forest_water" } }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "swamp_background_6x6",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [
+        "swamp_background"
+      ],
+      "place_nested": [
+        { "entries": [ [ "cattail", 1 ], [ "null", 0 ] ], "x": [ 0, 6 ], "y": [ 0, 6 ] }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "cattail",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [
+        "i"
+      ],
+      "palettes": [
+        "swamp_background"
+      ]
     }
   },
   {
@@ -151,6 +213,9 @@
         "  ;;;;;;;;;;;;;;;;;;;;;;",
         "             ;;;;;;;;;;;",
         "              ;;;;;;;;;;"
+      ],
+      "palettes": [
+        "swamp_background"
       ],
       "mapping": {
         "B": {
@@ -227,7 +292,6 @@
         }
       },
       "terrain": {
-        " ": [ "t_swater_dp", "t_swater_sh", "t_swater_sh", "t_dirt", "t_dirt", "t_dirt", "t_dirt", "t_grass", "t_grass", "t_grass", "t_grass", "t_grass", "t_grass", "t_underbrush", "t_tree", "t_tree_young" ],
         "#": "t_dirtmound",
         "&": "t_dirt",
         "+": "t_door_c",

--- a/data/json/mapgen/swamp_shack.json
+++ b/data/json/mapgen/swamp_shack.json
@@ -2,12 +2,12 @@
   {
     "type": "palette",
     "id": "swamp_background",
+    "furniture": {
+      "i": "f_cattails"
+    },
     "terrain": {
       " ": [ "t_swater_dp", "t_swater_sh", "t_swater_sh", "t_dirt", "t_dirt", "t_dirt", "t_dirt", "t_grass", "t_grass", "t_grass", "t_grass", "t_grass", "t_grass", "t_underbrush", "t_tree", "t_tree_young" ],
       "i": "t_water_sh"
-    },
-    "furniture": {
-      "i": "f_cattails" 
     }
   },
   {
@@ -129,18 +129,18 @@
         "x": "f_crate_o"
       },
       "place_nested": [
-        { "entries": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 0, 6 ], "neighbors": { "north": "forest_water" } },
-        { "entries": [ "cattail", "null" ], "x": [ 7, 17 ], "y": [ 0, 6 ], "neighbors": { "north": "forest_water"}, "repeat": 4 },
-        { "entries": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 0, 6 ], "neighbors": { "north": "forest_water" } },
-        { "entries": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 0, 6 ], "neighbors": { "east": "forest_water" } },
-        { "entries": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 7, 17 ], "neighbors": { "east": "forest_water"}, "repeat": 4 },
-        { "entries": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 18, 23 ], "neighbors": { "east": "forest_water" } },
-        { "entries": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 18, 23 ], "neighbors": { "south": "forest_water" } },
-        { "entries": [ "cattail", "null" ], "x": [ 7, 17 ], "y": [ 18, 23 ], "neighbors": { "south": "forest_water"}, "repeat": 4 },
-        { "entries": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 18, 23 ], "neighbors": { "south": "forest_water" } },
-        { "entries": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 0, 6 ], "neighbors": { "west": "forest_water" } },
-        { "entries": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 7, 17 ], "neighbors": { "west": "forest_water"}, "repeat": 4 },
-        { "entries": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 18, 23 ], "neighbors": { "west": "forest_water" } }
+        { "chunks": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 0, 6 ], "neighbors": { "north": "forest_water" } },
+        { "chunks": [ "cattail", "null" ], "x": [ 7, 17 ], "y": [ 0, 6 ], "neighbors": { "north": "forest_water" }, "repeat": 4 },
+        { "chunks": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 0, 6 ], "neighbors": { "north": "forest_water" } },
+        { "chunks": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 0, 6 ], "neighbors": { "east": "forest_water" } },
+        { "chunks": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 7, 17 ], "neighbors": { "east": "forest_water" }, "repeat": 4 },
+        { "chunks": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 18, 23 ], "neighbors": { "east": "forest_water" } },
+        { "chunks": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 18, 23 ], "neighbors": { "south": "forest_water" } },
+        { "chunks": [ "cattail", "null" ], "x": [ 7, 17 ], "y": [ 18, 23 ], "neighbors": { "south": "forest_water" }, "repeat": 4 },
+        { "chunks": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 18, 23 ], "neighbors": { "south": "forest_water" } },
+        { "chunks": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 0, 6 ], "neighbors": { "west": "forest_water" } },
+        { "chunks": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 7, 17 ], "neighbors": { "west": "forest_water" }, "repeat": 4 },
+        { "chunks": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 18, 23 ], "neighbors": { "west": "forest_water" } }
       ]
     }
   },
@@ -149,13 +149,11 @@
     "method": "json",
     "nested_mapgen_id": "cattail",
     "object": {
-      "mapgensize": [ 1, 1 ],
-      "rows": [
-        "i"
-      ],
+      "rows": [ "i" ],
       "palettes": [
         "swamp_background"
-      ]
+      ],
+      "mapgensize": [ 1, 1 ]
     }
   },
   {

--- a/data/json/mapgen/swamp_shack.json
+++ b/data/json/mapgen/swamp_shack.json
@@ -129,41 +129,18 @@
         "x": "f_crate_o"
       },
       "place_nested": [
-        { "entries": [ "swamp_background_6x6" ], "x": 0, "y": 0, "neighbors": { "north": "forest_water" } },
-        { "entries": [ "swamp_background_6x6" ], "x": [ 5, 12 ], "y": 0, "neighbors": { "north": "forest_water"}, "repeat": 4 },
-        { "entries": [ "swamp_background_6x6" ], "x": 18, "y": 0, "neighbors": { "north": "forest_water" } },
-        { "entries": [ "swamp_background_6x6" ], "x": 18, "y": 0, "neighbors": { "east": "forest_water" } },
-        { "entries": [ "swamp_background_6x6" ], "x": 18, "y": [ 5, 12 ], "neighbors": { "east": "forest_water"}, "repeat": 4 },
-        { "entries": [ "swamp_background_6x6" ], "x": 18, "y": 18, "neighbors": { "east": "forest_water" } },
-        { "entries": [ "swamp_background_6x6" ], "x": 0, "y": 18, "neighbors": { "south": "forest_water" } },
-        { "entries": [ "swamp_background_6x6" ], "x": [ 5, 11 ], "y": 18, "neighbors": { "south": "forest_water"}, "repeat": 4 },
-        { "entries": [ "swamp_background_6x6" ], "x": 18, "y": 18, "neighbors": { "south": "forest_water" } },
-        { "entries": [ "swamp_background_6x6" ], "x": 0, "y": 0, "neighbors": { "west": "forest_water" } },
-        { "entries": [ "swamp_background_6x6" ], "x": 0, "y": [ 5, 12 ], "neighbors": { "west": "forest_water"}, "repeat": 4 },
-        { "entries": [ "swamp_background_6x6" ], "x": 0, "y": 18, "neighbors": { "west": "forest_water" } }
-      ]
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
-    "nested_mapgen_id": "swamp_background_6x6",
-    "object": {
-      "mapgensize": [ 6, 6 ],
-      "rows": [
-        "      ",
-        "      ",
-        "      ",
-        "      ",
-        "      ",
-        "      ",
-        "      "
-      ],
-      "palettes": [
-        "swamp_background"
-      ],
-      "place_nested": [
-        { "entries": [ [ "cattail", 1 ], [ "null", 0 ] ], "x": [ 0, 6 ], "y": [ 0, 6 ] }
+        { "entries": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 0, 6 ], "neighbors": { "north": "forest_water" } },
+        { "entries": [ "cattail", "null" ], "x": [ 7, 17 ], "y": [ 0, 6 ], "neighbors": { "north": "forest_water"}, "repeat": 4 },
+        { "entries": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 0, 6 ], "neighbors": { "north": "forest_water" } },
+        { "entries": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 0, 6 ], "neighbors": { "east": "forest_water" } },
+        { "entries": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 7, 17 ], "neighbors": { "east": "forest_water"}, "repeat": 4 },
+        { "entries": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 18, 23 ], "neighbors": { "east": "forest_water" } },
+        { "entries": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 18, 23 ], "neighbors": { "south": "forest_water" } },
+        { "entries": [ "cattail", "null" ], "x": [ 7, 17 ], "y": [ 18, 23 ], "neighbors": { "south": "forest_water"}, "repeat": 4 },
+        { "entries": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 18, 23 ], "neighbors": { "south": "forest_water" } },
+        { "entries": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 0, 6 ], "neighbors": { "west": "forest_water" } },
+        { "entries": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 7, 17 ], "neighbors": { "west": "forest_water"}, "repeat": 4 },
+        { "entries": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 18, 23 ], "neighbors": { "west": "forest_water" } }
       ]
     }
   },

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1228,7 +1228,7 @@ public:
     neighborhood_check neighbors;
     jmapgen_nested( JsonObject &jsi ) : jmapgen_piece(), neighbors( jsi.get_object( "neighbors" ) )
     {
-        JsonArray jarr = jsi.get_array( "entries" );
+        JsonArray jarr = jsi.get_array( "chunks" );
         while( jarr.has_more() ) {
             if( jarr.test_array() ) {
                 JsonArray inner = jarr.next_array();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -642,13 +642,13 @@ public:
     // PieceType, they *can not* be of any other type.
     std::vector<PieceType> alternatives;
     jmapgen_alternativly() = default;
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float mon_density ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float mon_density ) const override
     {
         if( alternatives.empty() ) {
             return;
         }
         auto &chosen = alternatives[rng( 0, alternatives.size() - 1 )];
-        chosen.apply( m, x, y, mon_density );
+        chosen.apply( dat, x, y, mon_density );
     }
 };
 
@@ -672,9 +672,9 @@ public:
             jsi.throw_error( "invalid field type", "field" );
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
     {
-        m.add_field( tripoint( x.get(), y.get(), m.get_abs_sub().z ), ftype, density, age );
+        dat.m.add_field( tripoint( x.get(), y.get(), dat.m.get_abs_sub().z ), ftype, density, age );
     }
 };
 /**
@@ -691,9 +691,9 @@ public:
             jsi.throw_error( "unknown npc class", "class" );
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
     {
-        m.place_npc( x.get(), y.get(), npc_class );
+        dat.m.place_npc( x.get(), y.get(), npc_class );
     }
 };
 /**
@@ -712,14 +712,14 @@ public:
             jsi.throw_error("jmapgen_sign: needs either signage or snippet");
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
     {
         const int rx = x.get();
         const int ry = y.get();
-        m.furn_set( rx, ry, f_null );
-        m.furn_set( rx, ry, furn_str_id( "f_sign" ) );
+        dat.m.furn_set( rx, ry, f_null );
+        dat.m.furn_set( rx, ry, furn_str_id( "f_sign" ) );
 
-        tripoint abs_sub = m.get_abs_sub();
+        tripoint abs_sub = dat.m.get_abs_sub();
 
         std::string signtext;
 
@@ -740,7 +740,7 @@ public:
             }
             signtext = apply_all_tags(signtext, cityname);
         }
-        m.set_signage( tripoint( rx, ry, m.get_abs_sub().z ), signtext );
+        dat.m.set_signage( tripoint( rx, ry, dat.m.get_abs_sub().z ), signtext );
     }
     std::string apply_all_tags(std::string signtext, const std::string &cityname) const
     {
@@ -765,12 +765,12 @@ public:
             jsi.throw_error( "no such item group", "item_group" );
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
     {
         const int rx = x.get();
         const int ry = y.get();
-        m.furn_set( rx, ry, f_null );
-        m.place_vending( rx, ry, item_group_id, reinforced );
+        dat.m.furn_set( rx, ry, f_null );
+        dat.m.place_vending( rx, ry, item_group_id, reinforced );
     }
 };
 /**
@@ -784,16 +784,16 @@ public:
     , amount( jsi, "amount", 0, 0 )
     {
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
     {
         const int rx = x.get();
         const int ry = y.get();
         const long charges = amount.get();
-        m.furn_set( rx, ry, f_null );
+        dat.m.furn_set( rx, ry, f_null );
         if( charges == 0 ) {
-            m.place_toilet( rx, ry ); // Use the default charges supplied as default values
+            dat.m.place_toilet( rx, ry ); // Use the default charges supplied as default values
         } else {
-            m.place_toilet( rx, ry, charges );
+            dat.m.place_toilet( rx, ry, charges );
         }
     }
 };
@@ -817,19 +817,19 @@ public:
             }
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
     {
         const int rx = x.get();
         const int ry = y.get();
         long charges = amount.get();
-        m.furn_set( rx, ry, f_null );
+        dat.m.furn_set( rx, ry, f_null );
         if( charges == 0 ) {
             charges = rng( 10000, 50000 );
         }
         if (fuel != "") {
-            m.place_gas_pump( rx, ry, charges, fuel );
+            dat.m.place_gas_pump( rx, ry, charges, fuel );
         } else {
-            m.place_gas_pump( rx, ry, charges );
+            dat.m.place_gas_pump( rx, ry, charges );
         }
     }
 };
@@ -854,14 +854,14 @@ public:
             jsi.throw_error( "no such item type", "liquid" );
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
     {
         if ( one_in(chance.get()) ){
             item newliquid( liquid, calendar::turn );
             if ( amount.valmax > 0 ){
                 newliquid.charges = amount.get();
             }
-            m.add_item_or_charges( tripoint(x.get(), y.get(), m.get_abs_sub().z), newliquid );
+            dat.m.add_item_or_charges( tripoint(x.get(), y.get(), dat.m.get_abs_sub().z), newliquid );
         }
     }
 };
@@ -883,9 +883,9 @@ public:
             jsi.throw_error( "no such item group", "item" );
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
     {
-        m.place_items( group_id, chance.get(), x.val, y.val, x.valmax, y.valmax, true, 0 );
+        dat.m.place_items( group_id, chance.get(), x.val, y.val, x.valmax, y.valmax, true, 0 );
     }
 };
 
@@ -919,12 +919,12 @@ class jmapgen_loot : public jmapgen_piece {
             }
         }
 
-        void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+        void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
         {
             if( rng( 0, 99 ) < chance ) {
                 const Item_spawn_data *const isd = &result_group;
                 const std::vector<item> spawn = isd->create( calendar::turn );
-                m.spawn_items( tripoint( rng( x.val, x.valmax ), rng( y.val, y.valmax ), m.get_abs_sub().z ), spawn );
+                dat.m.spawn_items( tripoint( rng( x.val, x.valmax ), rng( y.val, y.valmax ), dat.m.get_abs_sub().z ), spawn );
             }
         }
 
@@ -953,9 +953,9 @@ public:
             jsi.throw_error( "no such monster group", "monster" );
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float mdensity ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float mdensity ) const override
     {
-        m.place_spawns( id, chance.get(), x.val, y.val, x.valmax, y.valmax, density == -1.0f ? mdensity : density );
+        dat.m.place_spawns( id, chance.get(), x.val, y.val, x.valmax, y.valmax, density == -1.0f ? mdensity : density );
     }
 };
 /**
@@ -978,9 +978,9 @@ public:
             jsi.throw_error( "no such monster", "monster" );
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mdensity*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mdensity*/ ) const override
     {
-        m.add_spawn( id, 1, x.get(), y.get(), friendly, -1, -1, name );
+        dat.m.add_spawn( id, 1, x.get(), y.get(), friendly, -1, -1, name );
     }
 };
 /**
@@ -1017,12 +1017,12 @@ public:
             jsi.throw_error( "no such vehicle type or group", "vehicle" );
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
     {
         if( !x_in_y( chance.get(), 100 ) ) {
             return;
         }
-        m.add_vehicle( type, point(x.get(), y.get()), random_entry( rotation ), fuel, status );
+        dat.m.add_vehicle( type, point(x.get(), y.get()), random_entry( rotation ), fuel, status );
     }
 };
 /**
@@ -1045,11 +1045,11 @@ public:
             jsi.throw_error( "no such item type", "item" );
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
     {
         const int c = chance.get();
         if ( c == 1 || one_in( c ) ) {
-            m.spawn_item( x.get(), y.get(), type, amount.get() );
+            dat.m.spawn_item( x.get(), y.get(), type, amount.get() );
         }
     }
 };
@@ -1079,10 +1079,10 @@ public:
         }
         id = sid.id();
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mdensity*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mdensity*/ ) const override
     {
-        const tripoint actual_loc = tripoint( x.get(), y.get(), m.get_abs_sub().z );
-        m.add_trap( actual_loc, id );
+        const tripoint actual_loc = tripoint( x.get(), y.get(), dat.m.get_abs_sub().z );
+        dat.m.add_trap( actual_loc, id );
     }
 };
 /**
@@ -1094,9 +1094,9 @@ public:
     furn_id id;
     jmapgen_furniture( JsonObject &jsi ) : jmapgen_furniture( jsi.get_string( "furn" ) ) {}
     jmapgen_furniture( const std::string &fid ) : jmapgen_piece(), id( furn_id( fid ) ) {}
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mdensity*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mdensity*/ ) const override
     {
-        m.furn_set( x.get(), y.get(), id );
+        dat.m.furn_set( x.get(), y.get(), id );
     }
 };
 /**
@@ -1108,9 +1108,9 @@ public:
     ter_id id;
     jmapgen_terrain( JsonObject &jsi ) : jmapgen_terrain( jsi.get_string( "ter" ) ) {}
     jmapgen_terrain( const std::string &tid ) : jmapgen_piece(), id( ter_id( tid ) ) {}
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mdensity*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mdensity*/ ) const override
     {
-        m.ter_set( x.get(), y.get(), id );
+        dat.m.ter_set( x.get(), y.get(), id );
     }
 };
 /**
@@ -1134,9 +1134,9 @@ public:
         }
         jsi.read( "overwrite", overwrite );
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
     {
-        m.make_rubble( tripoint( x.get(), y.get(), m.get_abs_sub().z ), rubble_type, items, floor_type, overwrite );
+        dat.m.make_rubble( tripoint( x.get(), y.get(), dat.m.get_abs_sub().z ), rubble_type, items, floor_type, overwrite );
     }
 };
 
@@ -1170,13 +1170,13 @@ public:
             }
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float /*mon_density*/ ) const override
     {
         const int rx = x.get();
         const int ry = y.get();
-        m.ter_set( rx, ry, t_console );
-        m.furn_set( rx, ry, f_null );
-        computer *cpu = m.add_computer( tripoint( rx, ry, m.get_abs_sub().z ), name, security );
+        dat.m.ter_set( rx, ry, t_console );
+        dat.m.furn_set( rx, ry, f_null );
+        computer *cpu = dat.m.add_computer( tripoint( rx, ry, dat.m.get_abs_sub().z ), name, security );
         for( const auto &opt : options ) {
             cpu->add_option( opt );
         }
@@ -1202,7 +1202,7 @@ public:
             entries.add( inner.get_string( 0 ), inner.get_int( 1 ) );
         }
     }
-    void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, const float d ) const override
+    void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const float d ) const override
     {
         const std::string *res = entries.pick();
         if( res == nullptr || res->empty() ) {
@@ -1221,7 +1221,7 @@ public:
             return;
         }
 
-        ptr->nest( m, x.get(), y.get(), d );
+        ptr->nest( dat, x.get(), y.get(), d );
     }
 };
 
@@ -1751,7 +1751,7 @@ void mapgen_function_json_base::setup_common()
  * (set|line|square)_(ter|furn|trap|radiation); simple (x, y, int) or (x1,y1,x2,y2, int) functions
  * todo; optimize, though gcc -O2 optimizes enough that splitting the switch has no effect
  */
-bool jmapgen_setmap::apply( map &m, int offset_x, int offset_y ) const {
+bool jmapgen_setmap::apply( const mapgendata &dat, int offset_x, int offset_y ) const {
     if( chance != 1 && !one_in( chance ) ) {
         return true;
     }
@@ -1764,6 +1764,7 @@ bool jmapgen_setmap::apply( map &m, int offset_x, int offset_y ) const {
     const auto x2_get = std::bind( get, x2, offset_x );
     const auto y2_get = std::bind( get, y2, offset_y );
 
+    map &m = dat.m;
     const int trepeat = repeat.get();
     for (int i = 0; i < trepeat; i++) {
         switch(op) {
@@ -1879,13 +1880,13 @@ void mapgen_function_json::generate( map *m, const oter_id &terrain_type, const 
         formatted_set_incredibly_simple( m );
     }
     for( auto &elem : setmap_points ) {
-        elem.apply( *m, 0, 0 );
+        elem.apply( md, 0, 0 );
     }
     if ( ! luascript.empty() ) {
         lua_mapgen( m, terrain_type, md, t, d, luascript );
     }
 
-    objects.apply( *m, 0, 0, d );
+    objects.apply( md, 0, 0, d );
 
     m->rotate( rotation.get() );
 
@@ -1894,37 +1895,37 @@ void mapgen_function_json::generate( map *m, const oter_id &terrain_type, const 
     }
 }
 
-void mapgen_function_json_nested::nest( map &m, int offset_x, int offset_y, float density ) const
+void mapgen_function_json_nested::nest( const mapgendata &dat, int offset_x, int offset_y, float density ) const
 {
     if( do_format ) {
-        formatted_set_incredibly_simple( &m );
+        formatted_set_incredibly_simple( &dat.m );
     }
 
     for( auto &elem : setmap_points ) {
-        elem.apply( m, offset_x, offset_y );
+        elem.apply( dat, offset_x, offset_y );
     }
 
-    objects.apply( m, offset_x, offset_y, density );
+    objects.apply( dat, offset_x, offset_y, density );
 }
 
 /*
  * Apply mapgen as per a derived-from-json recipe; in theory fast, but not very versatile
  */
-void jmapgen_objects::apply( map &m, float density ) const {
+void jmapgen_objects::apply( const mapgendata &dat, float density ) const {
     for( auto &obj : objects ) {
         const auto &where = obj.first;
         const auto &what = *obj.second;
         const int repeat = where.repeat.get();
         for( int i = 0; i < repeat; i++ ) {
-            what.apply( m, where.x, where.y, density );
+            what.apply( dat, where.x, where.y, density );
         }
     }
 }
 
-void jmapgen_objects::apply( map &m, int offset_x, int offset_y, float density ) const {
+void jmapgen_objects::apply( const mapgendata &dat, int offset_x, int offset_y, float density ) const {
     if( offset_x == 0 && offset_y == 0 ) {
         // It's a bit faster
-        apply( m, density );
+        apply( dat, density );
         return;
     }
 
@@ -1934,7 +1935,7 @@ void jmapgen_objects::apply( map &m, int offset_x, int offset_y, float density )
         const auto &what = *obj.second;
         const int repeat = where.repeat.get();
         for( int i = 0; i < repeat; i++ ) {
-            what.apply( m, where.x, where.y, density );
+            what.apply( dat, where.x, where.y, density );
         }
     }
 }
@@ -2018,7 +2019,7 @@ void map::draw_map(const oter_id terrain_type, const oter_id t_north, const oter
     std::array<int, 8> nesw_fac = {{ 0, 0, 0, 0, 0, 0, 0, 0 }};
     int &n_fac = nesw_fac[0], &e_fac = nesw_fac[1], &s_fac = nesw_fac[2], &w_fac = nesw_fac[3];
 
-    mapgendata dat( t_north, t_east, t_south, t_west, t_neast, t_seast, t_swest, t_nwest, t_above, zlevel, rsettings, this );
+    mapgendata dat( t_north, t_east, t_south, t_west, t_neast, t_seast, t_swest, t_nwest, t_above, zlevel, *rsettings, *this );
 
     computer *tmpcomp = NULL;
     bool terrain_type_found = true;

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -105,7 +105,7 @@ struct jmapgen_setmap {
     ) :
        x(ix), y(iy), x2(ix2), y2(iy2), op(iop), val(ival), chance(ione_in), repeat(irepeat), rotation(irotation),
        fuel(ifuel), status(istatus) {}
-    bool apply( map &m, int offset_x, int offset_y ) const;
+    bool apply( const mapgendata &dat, int offset_x, int offset_y ) const;
 };
 
 /**
@@ -133,8 +133,8 @@ class jmapgen_piece {
 protected:
     jmapgen_piece() { }
 public:
-    /** Place something on the map m at (x,y). mon_density */
-    virtual void apply( map &m, const jmapgen_int &x, const jmapgen_int &y, float mon_density ) const = 0;
+    /** Place something on the map from mapgendata dat, at (x,y). mon_density */
+    virtual void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, float mon_density ) const = 0;
     virtual ~jmapgen_piece() { }
 };
 
@@ -223,8 +223,8 @@ struct jmapgen_objects {
     template<typename PieceType>
     void load_objects(JsonObject &jsi, const std::string &member_name);
 
-    void apply( map &m, float density ) const;
-    void apply( map &m, int offset_x, int offset_y, float density ) const;
+    void apply( const mapgendata &dat, float density ) const;
+    void apply( const mapgendata &dat, int offset_x, int offset_y, float density ) const;
 
 private:
     /**
@@ -295,7 +295,7 @@ class mapgen_function_json_nested : public mapgen_function_json_base {
         mapgen_function_json_nested( const std::string s );
         ~mapgen_function_json_nested() override { }
 
-        void nest( map &m, int offset_x, int offset_y, float density ) const;
+        void nest( const mapgendata &dat, int offset_x, int offset_y, float density ) const;
     protected:
         bool setup_internal( JsonObject &jo ) override;
 };

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -256,7 +256,7 @@ class mapgen_function_json_base {
         virtual bool setup_internal( JsonObject &jo ) = 0;
         virtual void setup_setmap_internal() { };
 
-        void formatted_set_incredibly_simple( map *m ) const;
+        void formatted_set_incredibly_simple( map &m, int offset_x, int offset_y ) const;
 
         bool do_format;
         bool is_ready;

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -41,30 +41,14 @@ const mtype_id mon_zombie( "mon_zombie" );
 
 mapgendata::mapgendata( oter_id north, oter_id east, oter_id south, oter_id west,
                         oter_id northeast, oter_id southeast, oter_id southwest, oter_id northwest,
-                        oter_id up, int z, const regional_settings *rsettings, map *mp )
+                        oter_id up, int z, const regional_settings &rsettings, map &mp )
+    : t_nesw( { north, east, south, west, northeast, southeast, southwest, northwest } )
+    , t_above( up )
+    , zlevel( z )
+    , region( rsettings )
+    , m( mp )
+    , default_groundcover( region.default_groundcover )
 {
-    t_nesw[0] = north;
-    t_nesw[1] = east;
-    t_nesw[2] = south;
-    t_nesw[3] = west;
-    t_nesw[4] = northeast;
-    t_nesw[5] = southeast;
-    t_nesw[6] = southwest;
-    t_nesw[7] = northwest;
-    t_above = up;
-    zlevel = z;
-    n_fac = 0;
-    e_fac = 0;
-    s_fac = 0;
-    w_fac = 0;
-    ne_fac = 0;
-    se_fac = 0;
-    sw_fac = 0;
-    nw_fac = 0;
-    region = rsettings;
-    m = mp;
-    // making a copy so we can fudge values if desired
-    default_groundcover = region->default_groundcover;
 }
 
 tripoint rotate_point( const tripoint &p, int rotations )
@@ -377,10 +361,10 @@ ter_id clay_or_sand()
 }
 
 void mapgendata::square_groundcover(const int x1, const int y1, const int x2, const int y2) {
-    m->draw_square_ter( this->default_groundcover, x1, y1, x2, y2);
+    m.draw_square_ter( this->default_groundcover, x1, y1, x2, y2);
 }
 void mapgendata::fill_groundcover() {
-    m->draw_fill_background( this->default_groundcover );
+    m.draw_fill_background( this->default_groundcover );
 }
 bool mapgendata::is_groundcover( const ter_id iid ) const {
     for( const auto &pr : default_groundcover ) {
@@ -460,24 +444,24 @@ void ter_or_furn_set( map * m, const int x, const int y, const ter_furn_id & tfi
 void mapgen_field(map *m, oter_id, mapgendata dat, int turn, float)
 {
     // random area of increased vegetation. Or lava / toxic sludge / etc
-    const bool boosted_vegetation = ( dat.region->field_coverage.boost_chance > rng( 0, 1000000 ) );
+    const bool boosted_vegetation = ( dat.region.field_coverage.boost_chance > rng( 0, 1000000 ) );
     const int & mpercent_bush = ( boosted_vegetation ?
-       dat.region->field_coverage.boosted_mpercent_coverage :
-       dat.region->field_coverage.mpercent_coverage
+       dat.region.field_coverage.boosted_mpercent_coverage :
+       dat.region.field_coverage.mpercent_coverage
     );
 
-    ter_furn_id altbush = dat.region->field_coverage.pick( true ); // one dominant plant type ( for boosted_vegetation == true )
+    ter_furn_id altbush = dat.region.field_coverage.pick( true ); // one dominant plant type ( for boosted_vegetation == true )
 
     for (int i = 0; i < SEEX * 2; i++) {
         for (int j = 0; j < SEEY * 2; j++) {
             m->ter_set(i, j, dat.groundcover() ); // default is
             if ( mpercent_bush > rng(0, 1000000) ) { // yay, a shrub ( or tombstone )
-                if ( boosted_vegetation && dat.region->field_coverage.boosted_other_mpercent > rng(0, 1000000) ) {
+                if ( boosted_vegetation && dat.region.field_coverage.boosted_other_mpercent > rng(0, 1000000) ) {
                     // already chose the lucky terrain/furniture/plant/rock/etc
                     ter_or_furn_set(m, i, j, altbush );
                 } else {
                     // pick from weighted list
-                    ter_or_furn_set(m, i, j, dat.region->field_coverage.pick( false ) );
+                    ter_or_furn_set(m, i, j, dat.region.field_coverage.pick( false ) );
                 }
             }
         }

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -381,6 +381,26 @@ ter_id mapgendata::groundcover() {
     return tid != nullptr ? *tid : t_null;
 }
 
+const oter_id &mapgendata::neighbor_at( om_direction::type dir ) const
+{
+    // @todo De-uglify, implement proper conversion somewhere
+    switch( dir ) {
+        case om_direction::type::north:
+            return north();
+        case om_direction::type::east:
+            return east();
+        case om_direction::type::south:
+            return south();
+        case om_direction::type::west:
+            return west();
+        default:
+            break;
+    }
+
+    debugmsg( "Tried to get neighbor from invalid direction %d", dir );
+    return north();
+}
+
 void mapgen_rotate( map * m, oter_id terrain_type, bool north_is_down ) {
     const auto dir = terrain_type->get_dir();
     m->rotate( static_cast<int>( north_is_down ? om_direction::opposite( dir ) : dir ) );

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -42,7 +42,7 @@ const mtype_id mon_zombie( "mon_zombie" );
 mapgendata::mapgendata( oter_id north, oter_id east, oter_id south, oter_id west,
                         oter_id northeast, oter_id southeast, oter_id southwest, oter_id northwest,
                         oter_id up, int z, const regional_settings &rsettings, map &mp )
-    : t_nesw( { north, east, south, west, northeast, southeast, southwest, northwest } )
+    : t_nesw{ north, east, south, west, northeast, southeast, southwest, northwest }
     , t_above( up )
     , zlevel( z )
     , region( rsettings )

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -33,15 +33,16 @@ public:
   void set_dir(int dir_in, int val);
   void fill(int val);
   int& dir(int dir_in);
-  oter_id  north() const { return t_nesw[0]; }
-  oter_id  east()  const { return t_nesw[1]; }
-  oter_id  south() const { return t_nesw[2]; }
-  oter_id  west()  const { return t_nesw[3]; }
-  oter_id  neast() const { return t_nesw[4]; }
-  oter_id  seast() const { return t_nesw[5]; }
-  oter_id  swest() const { return t_nesw[6]; }
-  oter_id  nwest() const { return t_nesw[7]; }
-  oter_id  above() const { return t_above; }
+  const oter_id &north() const { return t_nesw[0]; }
+  const oter_id &east()  const { return t_nesw[1]; }
+  const oter_id &south() const { return t_nesw[2]; }
+  const oter_id &west()  const { return t_nesw[3]; }
+  const oter_id &neast() const { return t_nesw[4]; }
+  const oter_id &seast() const { return t_nesw[5]; }
+  const oter_id &swest() const { return t_nesw[6]; }
+  const oter_id &nwest() const { return t_nesw[7]; }
+  const oter_id &above() const { return t_above; }
+  const oter_id &neighbor_at( om_direction::type dir ) const;
   void fill_groundcover();
   void square_groundcover(const int x1, const int y1, const int x2, const int y2);
   ter_id groundcover();

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -14,22 +14,22 @@ struct mapgendata
 {
 public:
   oter_id t_nesw[8];
-  int n_fac; // dir == 0
-  int e_fac; // dir == 1
-  int s_fac; // dir == 2
-  int w_fac; // dir == 3
-  int ne_fac; // dir == 4
-  int se_fac; // dir == 5
-  int sw_fac; // dir == 6
-  int nw_fac; // dir == 7
+  int n_fac = 0;  // dir == 0
+  int e_fac = 0;  // dir == 1
+  int s_fac = 0;  // dir == 2
+  int w_fac = 0;  // dir == 3
+  int ne_fac = 0; // dir == 4
+  int se_fac = 0; // dir == 5
+  int sw_fac = 0; // dir == 6
+  int nw_fac = 0; // dir == 7
   oter_id t_above;
   int zlevel;
-  const regional_settings * region;
-  map * m;
+  const regional_settings &region;
+  map &m;
   weighted_int_list<ter_id> default_groundcover;
   mapgendata(oter_id t_north, oter_id t_east, oter_id t_south, oter_id t_west,
              oter_id t_neast, oter_id t_seast, oter_id t_swest, oter_id t_nwest,
-             oter_id up, int z, const regional_settings * rsettings, map * mp );
+             oter_id up, int z, const regional_settings &rsettings, map &mp );
   void set_dir(int dir_in, int val);
   void fill(int val);
   int& dir(int dir_in);

--- a/tools/format/format.conf
+++ b/tools/format/format.conf
@@ -486,6 +486,7 @@ mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:entries
 mapgen(:@)?:object:(place_)?nested:.(:@)?:x=NOWRAP
 mapgen(:@)?:object:(place_)?nested:.(:@)?:y=NOWRAP
 mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:entries:@=NOWRAP
+mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:neighbors:@=NOWRAP
 
 mapgen(:@)?:lua
 

--- a/tools/format/format.conf
+++ b/tools/format/format.conf
@@ -482,11 +482,16 @@ mapgen(:@)?:object:(mapping:.:|place_)?computers(:.)?(:@)?:failures:@:action
 mapgen(:@)?:object:(place_)?nested=WRAP
 mapgen(:@)?:object:mapping:.:nested
 mapgen(:@)?:object:(mapping:.:|place_)?nested:.(:@)?=NOWRAP
-mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:entries
+mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:chunks=NOWRAP
 mapgen(:@)?:object:(place_)?nested:.(:@)?:x=NOWRAP
 mapgen(:@)?:object:(place_)?nested:.(:@)?:y=NOWRAP
-mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:entries:@=NOWRAP
-mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:neighbors:@=NOWRAP
+mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:chunks:@=NOWRAP
+mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:neighbors=NOWRAP
+mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:neighbors:north
+mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:neighbors:east
+mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:neighbors:south
+mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:neighbors:west
+mapgen(:@)?:object:(mapping:.:|place_)?nested(:.)?(:@)?:repeat
 
 mapgen(:@)?:lua
 


### PR DESCRIPTION
A step in the direction of jsonized labs. Still not there yet, but not far from it.

A nested entry now has an optional `"neighbors"` field. If the field exists, the nested mapgen will only be applied if all the neighbors match the ones specified there. For example:
```
{
  "chunks": [ "gun_with_casings", "shrubs_3x3" ],
  x: [ 10, 20 ],
  y: [ 10, 20 ],
  "neighbors": { "north": [ "forest", "field" }, "south": [ "forest", "field" ] }
}
```

In this case one of the two nested mapgens will be applied at random point in square from `[ 10, 10 ]` to `[ 20, 20 ]` only if north is a forest or field and south is a forest or field (can be mixed, like north being forest and south being field).

I edited the `swamp_shack.json` to show this new feature. The changes are as follows:
* Moved the shack to center of the block, like most structures
* Removed random chance of cattail on mixed terrain (they should only grow on shallow water)
* Each side (north/east/south/west) gets an average of 2.5 cattails (in shallow, fresh water) if that side is adjacent to a swamp

Additionally, minor tweaks:
* Supply `const mapgendata &` instead of `map *` to json mapgen pieces. That structure is already created in mapgen above and it usually goes to waste. This structure contains adjacency data (for the feature here), but also "biome" data. Biomes are nowhere near functional, but having this data would make it somewhat more likely that this will move somewhere sometime.
* Minor refactor of `mapgendata` structure.