### PR TITLE
[CR]Extract ranged attack times to skill json

### DIFF
--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -68,7 +68,7 @@
         "type" : "skill",
         "ident" : "archery",
         "name" : "archery",
-        "description" : "Your skill in using bow weapons, from hand-carved self bows to complex hunting crossbows.  Quiet and effective, they require strength of body and sight to wield, and are not terribly accurate over a long distance.",
+        "description" : "Your skill in using bow weapons, from hand-carved self bows to complex compound bows.  Quiet and effective, they require strength of body and sight to wield, and are not terribly accurate over a long distance.",
         "tags" : ["combat_skill"],
         "ranged_data": {
             "min_fire_time": 20,

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -69,7 +69,12 @@
         "ident" : "archery",
         "name" : "archery",
         "description" : "Your skill in using bow weapons, from hand-carved self bows to complex hunting crossbows.  Quiet and effective, they require strength of body and sight to wield, and are not terribly accurate over a long distance.",
-        "tags" : ["combat_skill"]
+        "tags" : ["combat_skill"],
+        "ranged_data": {
+            "min_fire_time": 20,
+            "base_fire_time": 220,
+            "fire_time_skill_scaling": 25
+        }
     },{
         "type" : "skill",
         "ident" : "bashing",
@@ -98,13 +103,23 @@
         "ident" : "launcher",
         "name" : "launchers",
         "description" : "Your skill in using heavy weapons like rocket, grenade or missile launchers.  These weapons have a variety of applications and may carry immense destructive power, but they are cumbersome and hard to manage.",
-        "tags" : ["combat_skill"]
+        "tags" : ["combat_skill"],
+        "ranged_data": {
+            "min_fire_time": 30,
+            "base_fire_time": 200,
+            "fire_time_skill_scaling": 20
+        }
     },{
         "type" : "skill",
         "ident" : "melee",
         "name" : "melee",
         "description" : "Your skill and finesse in personal combat, both with and without a weapon.  Higher levels can significantly increase the accuracy and effectiveness of your physical attacks.",
-        "tags" : ["combat_skill"]
+        "tags" : ["combat_skill"],
+        "ranged_data": {
+            "min_fire_time": 50,
+            "base_fire_time": 200,
+            "fire_time_skill_scaling": 20
+        }
     },{
         "type" : "skill",
         "ident" : "stabbing",
@@ -116,7 +131,12 @@
         "ident" : "throw",
         "name" : "throwing",
         "description" : "Your skill in throwing objects over a distance.  Skill increases accuracy, and at higher levels, the range of a throw.",
-        "tags" : ["combat_skill"]
+        "tags" : ["combat_skill"], 
+        "ranged_data": {
+            "min_fire_time": 50,
+            "base_fire_time": 220,
+            "fire_time_skill_scaling": 25
+        }
     },{
         "type" : "skill",
         "ident" : "unarmed",
@@ -128,25 +148,45 @@
         "ident" : "pistol",
         "name" : "handguns",
         "description" : "Handguns have poor accuracy compared to rifles, but are usually quick to fire and reload faster than other guns.  They are very effective at close quarters, though unsuited for long range engagement.",
-        "tags" : ["combat_skill"]
+        "tags" : ["combat_skill"],
+        "ranged_data": {
+            "min_fire_time": 10,
+            "base_fire_time": 80,
+            "fire_time_skill_scaling": 10
+        }
     },{
         "type" : "skill",
         "ident" : "rifle",
         "name" : "rifles",
         "description" : "Rifles have terrific range and accuracy compared to other firearms, but may be slow to fire and reload, and can prove difficult to use in close quarters.  Fully automatic rifles can fire rapidly, but are harder to handle properly.",
-        "tags" : ["combat_skill"]
+        "tags" : ["combat_skill"],
+        "ranged_data": {
+            "min_fire_time": 30,
+            "base_fire_time": 150,
+            "fire_time_skill_scaling": 15
+        }
     },{
         "type" : "skill",
         "ident" : "shotgun",
         "name" : "shotguns",
         "description" : "Shotguns are easy to shoot and can inflict massive damage, but their effectiveness and accuracy decline rapidly with range.  Slugs can be loaded into shotguns to provide greater range, though they are somewhat inaccurate.",
-        "tags" : ["combat_skill"]
+        "tags" : ["combat_skill"],
+        "ranged_data": {
+            "min_fire_time": 70,
+            "base_fire_time": 150,
+            "fire_time_skill_scaling": 25
+        }
     },{
         "type" : "skill",
         "ident" : "smg",
         "name" : "submachine guns",
         "description" : "Comprised of an automatic rifle carbine designed to fire a pistol cartridge, submachine guns can reload and fire quickly, sometimes in bursts, but they are relatively inaccurate and may be prone to mechanical failures.",
-        "tags" : ["combat_skill"]
+        "tags" : ["combat_skill"],
+        "ranged_data": {
+            "min_fire_time": 20,
+            "base_fire_time": 80,
+            "fire_time_skill_scaling": 10
+        }
     },
     {
         "type" : "skill",

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1397,30 +1397,10 @@ static projectile make_gun_projectile( const item &gun ) {
 
 int time_to_fire( const Character &p, const itype &firingt )
 {
-    struct time_info_t {
-        int min_time;  // absolute floor on the time taken to fire.
-        int base;      // the base or max time taken to fire.
-        int reduction; // the reduction in time given per skill level.
-    };
-
-    static std::map<skill_id, time_info_t> const map {
-        {skill_id {"pistol"},   {10, 80,  10}},
-        {skill_id {"shotgun"},  {70, 150, 25}},
-        {skill_id {"smg"},      {20, 80,  10}},
-        {skill_id {"rifle"},    {30, 150, 15}},
-        {skill_id {"archery"},  {20, 220, 25}},
-        {skill_id {"throw"},    {50, 220, 25}},
-        {skill_id {"launcher"}, {30, 200, 20}},
-        {skill_id {"melee"},    {50, 200, 20}}
-    };
-
     const skill_id &skill_used = firingt.gun.get()->skill_used;
-    auto const it = map.find( skill_used );
-    // TODO: maybe JSON-ize this in some way? Probably as part of the skill class.
-    static const time_info_t default_info{ 50, 220, 25 };
-
-    time_info_t const &info = (it == map.end()) ? default_info : it->second;
-    return std::max(info.min_time, info.base - info.reduction * p.get_skill_level( skill_used ));
+    const ranged_skill_data &info = skill_used.obj().get_ranged_data();
+    return std::max( info.min_fire_time,
+                     info.base_fire_time - info.fire_time_skill_scaling * p.get_skill_level( skill_used ) );
 }
 
 static void cycle_action( item& weap, const tripoint &pos ) {

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -65,6 +65,20 @@ class target_handler
                                          const target_callback &on_ammo_change = target_callback() );
 };
 
+struct ranged_skill_data
+{
+    ranged_skill_data()
+    {}
+
+    // @todo Push those to mod settings or a null skill
+    // Absolute floor on the time taken to fire.
+    int min_fire_time = 50;
+    // The base or max time taken to fire.
+    int base_fire_time = 220;
+    // The reduction in time given per skill level.
+    int fire_time_skill_scaling = 25;
+};
+
 int range_with_even_chance_of_good_hit( int dispersion );
 
 #endif // RANGED_H

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -65,8 +65,7 @@ class target_handler
                                          const target_callback &on_ammo_change = target_callback() );
 };
 
-struct ranged_skill_data
-{
+struct ranged_skill_data {
     ranged_skill_data()
     {}
 

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -46,7 +46,7 @@ bool string_id<Skill>::is_valid() const
 
 Skill::Skill()
     : Skill( skill_id::NULL_ID(), "nothing", "The zen-most skill there is.",
-           std::set<std::string> {} )
+             std::set<std::string> {} )
 {
 }
 

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -3,6 +3,7 @@
 #include "options.h"
 #include "debug.h"
 #include "translations.h"
+#include "ranged.h"
 
 #include <algorithm>
 #include <iterator>
@@ -43,15 +44,17 @@ bool string_id<Skill>::is_valid() const
     return Skill::get( *this ) != invalid_skill;
 }
 
-Skill::Skill() : Skill( skill_id::NULL_ID(), "nothing", "The zen-most skill there is.",
-                            std::set<std::string> {} )
+Skill::Skill()
+    : Skill( skill_id::NULL_ID(), "nothing", "The zen-most skill there is.",
+           std::set<std::string> {} )
 {
 }
 
 Skill::Skill( skill_id ident, std::string name, std::string description,
               std::set<std::string> tags )
-    : _ident( std::move( ident ) ), _name( std::move( name ) ),
-      _description( std::move( description ) ), _tags( std::move( tags ) )
+    : _ident( std::move( ident ) ), _name( std::move( name ) )
+    , _description( std::move( description ) ), _tags( std::move( tags ) )
+    , _ranged_data( new ranged_skill_data() )
 {
 }
 
@@ -96,6 +99,13 @@ void Skill::load_skill( JsonObject &jsobj )
     } else {
         skills.push_back( sk );
     }
+
+    if( jsobj.has_object( "ranged_data" ) ) {
+        JsonObject rdobj = jsobj.get_object( "ranged_data" );
+        sk._ranged_data->min_fire_time = rdobj.get_int( "min_fire_time" );
+        sk._ranged_data->base_fire_time = rdobj.get_int( "base_fire_time" );
+        sk._ranged_data->fire_time_skill_scaling = rdobj.get_int( "fire_time_skill_scaling" );
+    }
 }
 
 skill_id Skill::from_legacy_int( const int legacy_id )
@@ -136,6 +146,11 @@ bool Skill::is_combat_skill() const
 bool Skill::is_contextual_skill() const
 {
     return _tags.count( "contextual_skill" ) > 0;
+}
+
+const ranged_skill_data &Skill::get_ranged_data() const
+{
+    return *_ranged_data;
 }
 
 SkillLevel::SkillLevel( int level, int exercise, bool isTraining, int lastPracticed,

--- a/src/skill.h
+++ b/src/skill.h
@@ -11,9 +11,12 @@
 #include <vector>
 #include <set>
 #include <iosfwd>
+#include <memory>
 
 class Skill;
 using skill_id = string_id<Skill>;
+
+struct ranged_skill_data;
 
 class Skill
 {
@@ -22,6 +25,7 @@ class Skill
         std::string _name;
         std::string _description;
         std::set<std::string> _tags;
+        std::shared_ptr<ranged_skill_data> _ranged_data;
         // these are not real skills, they depend on context
         static std::map<skill_id, Skill> contextual_skills;
     public:
@@ -67,6 +71,7 @@ class Skill
 
         bool is_combat_skill() const;
         bool is_contextual_skill() const;
+        const ranged_skill_data &get_ranged_data() const;
 };
 
 class SkillLevel : public JsonSerializer, public JsonDeserializer


### PR DESCRIPTION
Currently ranged attack times are tied to skills and hardcoded. Both of those are bad. Here I fix only the latter.

[CR] because there may be some simple way to get rid of per-skill settings altogether and just push it to be completely per-item, as it should be.