### PR TITLE
Prevent artifact type overwriting

### DIFF
--- a/src/artifact.cpp
+++ b/src/artifact.cpp
@@ -1164,7 +1164,8 @@ bool save_artifacts( const std::string &path )
     return write_to_file_exclusive( path, [&]( std::ostream &fout ) {
         JsonOut json( fout );
         json.start_array();
-        for( const itype *e : item_controller->all() ) {
+        // We only want runtime types, otherwise static artifacts are loaded twice (on init and then on game load)
+        for( const itype *e : item_controller->get_runtime_types() ) {
             if( !e->artifact ) {
                 continue;
             }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -446,6 +446,12 @@ void Item_factory::add_actor( iuse_actor *ptr ) {
 }
 
 void Item_factory::add_item_type( const itype &def ) {
+    if( m_runtimes.count( def.id ) > 0 ) {
+        // Do NOT allow overwriting it, it's undefined behavior
+        debugmsg( "Tried to add runtime type %s, but it exists already", def.id.c_str() );
+        return;
+    }
+
     auto &new_item_ptr = m_runtimes[ def.id ];
     new_item_ptr.reset( new itype( def ) );
     if( frozen ) {
@@ -2420,6 +2426,17 @@ std::vector<const itype *> Item_factory::all() const {
     return res;
 }
 
+std::vector<const itype *> Item_factory::get_runtime_types() const
+{
+    std::vector<const itype *> res;
+    res.reserve( m_runtimes.size() );
+    for( const auto &e : m_runtimes ) {
+        res.push_back( e.second.get() );
+    }
+
+    return res;
+}
+
 /** Find all templates matching the UnaryPredicate function */
 std::vector<const itype *> Item_factory::find( const std::function<bool( const itype & )> &func ) {
     std::vector<const itype *> res;
@@ -2435,7 +2452,7 @@ std::vector<const itype *> Item_factory::find( const std::function<bool( const i
 Item_tag Item_factory::create_artifact_id() const
 {
     Item_tag id;
-    int i = m_templates.size();
+    int i = m_runtimes.size();
     do {
         id = string_format( "artifact_%d", i );
         i++;

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -227,6 +227,9 @@ class Item_factory
         /** Get all item templates (both static and runtime) */
         std::vector<const itype *> all() const;
 
+        /** Get item types created at runtime. */
+        std::vector<const itype *> get_runtime_types() const;
+
         /** Find all item templates (both static and runtime) matching UnaryPredicate function */
         static std::vector<const itype *> find( const std::function<bool( const itype & )> &func );
 


### PR DESCRIPTION
Overwriting a runtime type can cause undefined behavior and should not be allowed.
Despite this, it is a relatively common occurrence in most saves, due to another bug where static artifact types are saved along with runtime types, then loaded twice (once from data, once from save).
The only static artifact in the core game is a fake item for testing, but mods could be affected.

Also fixed a minor bug with artifact ID generation: the IDs were in the form of `artifact_%d` where `%d` was size of static item vector, but artifacts are runtime types. This didn't cause any major problems because there is a safety check that prevented overwriting (just there), though.