### PR TITLE
Fix mission name comparisons

### DIFF
--- a/data/json/mapgen/shelter.json
+++ b/data/json/mapgen/shelter.json
@@ -67,7 +67,7 @@
         "6": {
           "name": "Evac shelter computer", "options": [
             { "name": "Emergency Message", "action": "emerg_mess" },
-            { "name": "Disable External Power", "action": "complete_mission" },
+            { "name": "Disable External Power", "action": "complete_disable_external_power" },
             { "name": "Contact Us", "action": "emerg_ref_center" }
           ]
         }

--- a/src/computer.cpp
+++ b/src/computer.cpp
@@ -38,6 +38,16 @@ const efftype_id effect_stemcell_treatment( "stemcell_treatment" );
 
 int alerts = 0;
 
+computer_option::computer_option()
+    : name( "Unknown" ), action( COMPACT_NULL ), security( 0 )
+{
+}
+
+computer_option::computer_option( std::string N, computer_action A, int S )
+    : name( N ), action( A ), security( S )
+{
+}
+
 computer::computer( const std::string &new_name, int new_security ): name( new_name )
 {
     security = new_security;
@@ -199,11 +209,11 @@ void computer::use()
                     } else {
                         // Successfully hacked function
                         options[ch].security = 0;
-                        activate_function(current.action, ch);
+                        activate_function( current.action );
                     }
                 }
             } else { // No need to hack, just activate
-                activate_function(current.action, ch);
+                activate_function( current.action );
             }
             reset_terminal();
         } // Done processing a selected option.
@@ -318,7 +328,7 @@ static item *pick_usb()
     return nullptr;
 }
 
-void computer::activate_function(computer_action action, char ch)
+void computer::activate_function( computer_action action )
 {
     // Token move cost for any action, if an action takes longer decrement moves further.
     g->u.moves -= 30;
@@ -766,9 +776,10 @@ of pureed bone & LSD."));
         g->u.mod_pain( rng(40, 90) );
         break;
 
-    case COMPACT_COMPLETE_MISSION:
+    case COMPACT_COMPLETE_DISABLE_EXTERNAL_POWER:
         for( auto miss : g->u.get_active_missions() ) {
-            if (miss->name() == options[ch].name){
+            static const mission_type_id commo_2 = mission_type_id( "MISSION_OLD_GUARD_NEC_COMMO_2" );
+            if( miss->mission_id() == commo_2 ) {
                 print_error(_("--ACCESS GRANTED--"));
                 print_error(_("Mission Complete!"));
                 miss->step_complete( 1 );
@@ -1562,7 +1573,7 @@ computer_action computer_action_from_string( const std::string &str )
         { "elevator_on", COMPACT_ELEVATOR_ON },
         { "amigara_log", COMPACT_AMIGARA_LOG },
         { "amigara_start", COMPACT_AMIGARA_START },
-        { "complete_mission", COMPACT_COMPLETE_MISSION },
+        { "complete_disable_external_power", COMPACT_COMPLETE_DISABLE_EXTERNAL_POWER },
         { "repeater_mod", COMPACT_REPEATER_MOD },
         { "download_software", COMPACT_DOWNLOAD_SOFTWARE },
         { "blood_anal", COMPACT_BLOOD_ANAL },

--- a/src/computer.h
+++ b/src/computer.h
@@ -3,6 +3,7 @@
 #define COMPUTER_H
 
 #include "cursesdef.h" // WINDOW
+#include "string_id.h"
 #include <vector>
 #include <string>
 
@@ -33,7 +34,7 @@ enum computer_action {
     COMPACT_ELEVATOR_ON,
     COMPACT_AMIGARA_LOG,
     COMPACT_AMIGARA_START,
-    COMPACT_COMPLETE_MISSION,   //Completes the mission that has the same name as the computer action
+    COMPACT_COMPLETE_DISABLE_EXTERNAL_POWER, // Completes "Disable External Power" mission
     COMPACT_REPEATER_MOD,       //Converts a terminal in a radio station into a 'repeater', locks terminal and completes mission
     COMPACT_DOWNLOAD_SOFTWARE,
     COMPACT_BLOOD_ANAL,
@@ -82,11 +83,8 @@ struct computer_option {
     computer_action action;
     int security;
 
-    computer_option() {
-        name = "Unknown", action = COMPACT_NULL, security = 0;
-    };
-    computer_option( std::string N, computer_action A, int S ) :
-        name( N ), action( A ), security( S ) {};
+    computer_option();
+    computer_option( std::string N, computer_action A, int S );
 
     static computer_option from_json( JsonObject &jo );
 };
@@ -145,7 +143,7 @@ class computer
         static std::vector<std::string> lab_notes;
 
         // Called by use()
-        void activate_function( computer_action action, char ch );
+        void activate_function( computer_action action );
         // Generally called when we fail a hack attempt
         void activate_random_failure();
         // ...but we can also choose a specific failure.

--- a/src/computer.h
+++ b/src/computer.h
@@ -3,7 +3,6 @@
 #define COMPUTER_H
 
 #include "cursesdef.h" // WINDOW
-#include "string_id.h"
 #include <vector>
 #include <string>
 

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -456,7 +456,7 @@ std::string mission::name()
     if (type == NULL) {
         return "NULL";
     }
-    return _( type->name );
+    return _( type->name.c_str() );
 }
 
 mission_type_id mission::mission_id()

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -456,7 +456,7 @@ std::string mission::name()
     if (type == NULL) {
         return "NULL";
     }
-    return type->name;
+    return _( type->name );
 }
 
 mission_type_id mission::mission_id()

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -215,6 +215,7 @@ void mission::step_complete( const int _step )
         case MGOAL_FIND_MONSTER:
         case MGOAL_ASSASSINATE:
         case MGOAL_KILL_MONSTER:
+        case MGOAL_COMPUTER_TOGGLE:
             // Go back and report.
             set_target_to_mission_giver();
             break;

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -253,7 +253,7 @@ void mission_type::load( JsonObject &jo, const std::string &src )
 {
     const bool strict = src == "dda";
 
-    mandatory( jo, was_loaded, "name", name, translated_string_reader );
+    mandatory( jo, was_loaded, "name", name );
 
     mandatory( jo, was_loaded, "difficulty", difficulty );
     mandatory( jo, was_loaded, "value", value );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1720,7 +1720,8 @@ void dialogue::gen_responses( const talk_topic &the_topic )
     } else if( topic == "TALK_OLD_GUARD_NEC_COMMO" ) {
         if( g->u.has_trait( trait_PROF_FED ) ) {
             for( auto miss_it : g->u.get_active_missions() ) {
-                if( miss_it->name() == "Locate Commo Team" && !p->has_effect( effect_gave_quest_item ) ) {
+                if( miss_it->mission_id() == mission_type_id( "MISSION_OLD_GUARD_NEC_1" ) &&
+                    !p->has_effect( effect_gave_quest_item ) ) {
                     add_response( _( "[MISSION] The captain sent me to get a frequency list from you." ),
                                   "TALK_OLD_GUARD_NEC_COMMO_FREQ" );
                 }
@@ -1794,7 +1795,8 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         add_response( _( "Interesting..." ), "TALK_FREE_MERCHANT_STOCKS" );
     } else if( topic == "TALK_RANCH_FOREMAN" ) {
         for( auto miss_it : g->u.get_active_missions() ) {
-            if( miss_it->name() == "Retrieve Prospectus" && !p->has_effect( effect_gave_quest_item ) ) {
+            if( miss_it->mission_id() == mission_type_id( "MISSION_FREE_MERCHANTS_EVAC_3" ) &&
+                !p->has_effect( effect_gave_quest_item ) ) {
                 add_response(
                     _( "[MISSION] The merchant at the Refugee Center sent me to get a prospectus from you." ),
                     "TALK_RANCH_FOREMAN_PROSPECTUS" );


### PR DESCRIPTION
Closes #20818

There were 3 cases where translated mission name was used instead of ID:
* Get Prospectus mission
* Find Commo Team mission
* Complete Mission computer action

First one was simple, second one is like the first one except not testable because Find Commo Team mission is not used anywhere.
The third option would require adding new fields to the weird computer code (it has horrible non-json format), but fortunately this action is used by exactly one mission, so I just changed it to be "Complete that one specific mission" action instead. This also allowed me to scrap another hack from `computer::activate_function`.

Other minor fixes:
* Made mission name translated on print rather than on load
* When completing computer mission steps, point back to mission giver. Lack of this behavior was particularly confusing in case of "complete mission" action, which gives no indication that you have to go back to mission giver to complete the mission.