### PR TITLE
Fix NPC training

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -628,6 +628,10 @@ player::player() : Character()
 
     morale.reset( new player_morale() );
     last_craft.reset( new craft_command() );
+
+    ma_styles = {{
+        style_none, style_kicks
+    }};
 }
 
 player::~player() = default;
@@ -7784,11 +7788,7 @@ bool player::pick_style() // Style selection menu
     // if no selected styles, cursor starts from no-style
 
     // Any other keys quit the menu
-    std::vector<matype_id> selectable_styles = {{
-        style_none, style_kicks
-    }};
-    const std::vector<matype_id> &real_styles = has_active_bionic( bio_cqb ) ? bio_cqb_styles : ma_styles;
-    selectable_styles.insert( selectable_styles.end(), real_styles.begin(), real_styles.end() );
+    const std::vector<matype_id> &selectable_styles = has_active_bionic( bio_cqb ) ? bio_cqb_styles : ma_styles;
 
     input_context ctxt( "MELEE_STYLE_PICKER" );
     ctxt.register_action( "SHOW_DESCRIPTION" );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -48,6 +48,8 @@
 static const trait_id trait_HYPEROPIC( "HYPEROPIC" );
 static const trait_id trait_MYOPIC( "MYOPIC" );
 
+static const matype_id style_kicks( "style_kicks" );
+
 static const std::array<std::string, NUM_OBJECTS> obj_type_name = { { "OBJECT_NONE", "OBJECT_ITEM", "OBJECT_ACTOR", "OBJECT_PLAYER",
     "OBJECT_NPC", "OBJECT_MONSTER", "OBJECT_VEHICLE", "OBJECT_TRAP", "OBJECT_FIELD",
     "OBJECT_TERRAIN", "OBJECT_FURNITURE"
@@ -465,6 +467,13 @@ void player::load(JsonObject &data)
     }
 
     data.read("ma_styles", ma_styles);
+    // Fix up old ma_styles that doesn't include fake styles
+    if( std::find( ma_styles.begin(), ma_styles.end(), style_kicks ) == ma_styles.end() && style_kicks.is_valid() ) {
+        ma_styles.insert( ma_styles.begin(), style_kicks );
+    }
+    if( std::find( ma_styles.begin(), ma_styles.end(), matype_id::NULL_ID() ) == ma_styles.end() ) {
+        ma_styles.insert( ma_styles.begin(), matype_id::NULL_ID() );
+    }
     data.read( "addictions", addictions );
 
     JsonArray traps = data.get_array("known_traps");
@@ -901,6 +910,7 @@ void npc_chatbin::serialize(JsonOut &json) const
         json.member( "mission_selected", mission_selected->get_id() );
     }
     json.member( "skill", skill );
+    json.member( "style", style );
     json.member( "missions", mission::to_uid_vector( missions ) );
     json.member( "missions_assigned", mission::to_uid_vector( missions_assigned ) );
     json.end_object();
@@ -920,6 +930,7 @@ void npc_chatbin::deserialize(JsonIn &jsin)
     }
 
     data.read( "skill", skill );
+    data.read( "style", style );
 
     std::vector<int> tmpmissions;
     data.read( "missions", tmpmissions );

--- a/src/string_id_null_ids.cpp
+++ b/src/string_id_null_ids.cpp
@@ -23,6 +23,7 @@ MAKE_NULL_ID( ammunition_type, "NULL" );
 MAKE_NULL_ID( vpart_info, "null" );
 MAKE_NULL_ID( emit, "null" );
 MAKE_NULL_ID( anatomy, "null_anatomy" );
+MAKE_NULL_ID( martialart, "style_none" );
 
 
 #define MAKE_NULL_ID2( type, ... ) \


### PR DESCRIPTION
Closes #22079 (well, I couldn't reproduce the bug directly, but I fixed all the most probable causes)
Closes #21491 (same as above)
Fixes #22167 (this one more certainly)
Fixes #21184
Fixes #18642
Closes #19194 (not sure if fixed here or earlier, but can't reproduce)

The above are most likely instances of just two bugs fixed here:
* On training, assigned missions were cleared without a proper check for whether the mission is actually assigned to the player, assigned to anyone, or even just assignable
* Training of skills and martial arts is a weird hybrid that notes the selected skill/martial art, then recovers it at the training time. This is fragile, as the only way to note that we want a martial art and not a skill is to unset the skill. Now enforced by unsetting martial art training when setting skill training and vice versa.

Also minor adjustments:
* Styles are presented first in train menu. While currently NPCs can only teach brawling, later it may become important
* If by some bugged way the NPC tries to teach the player a skill that the player isn't worse at than the NPC, the teaching will fail
* As above, but for martial art styles that the player has
* Player now knows "no style" and "kicking style" martial arts instead of just being able to select them
* "no style" becomes the null style
* Fixed comment about training cost - it's in dollars, not cents