### PR TITLE
Fix monster upgrade selection

### DIFF
--- a/data/json/monstergroups.json
+++ b/data/json/monstergroups.json
@@ -1174,7 +1174,7 @@
     },{
     "type":"monstergroup",
     "name" : "GROUP_ZOMBIE_UPGRADE",
-    "default" : "mon_zombie_spitter",
+    "default" : "mon_zombie_tough",
     "//" : "Masters pick from here when upgrading; no dogs, bionics, or profession-types",
     "monsters" : [
       { "monster" : "mon_zombie_grabber", "freq" : 10, "cost_multiplier" : 5 },

--- a/data/json/monsters.json
+++ b/data/json/monsters.json
@@ -6406,6 +6406,10 @@
     "death_drops": "default_zombie_death_drops",
     "death_function": [ "NORMAL" ],
     "burn_into": "mon_zombie_scorched",
+    "upgrades": {
+      "half_life": 28,
+      "into_group": "GROUP_ZOMBIE_UPGRADE"
+    },
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "BLEED", "NO_BREATHE", "REVIVES", "BONES", "PUSH_MON" ]
   },
   {

--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -70,16 +70,11 @@ const MonsterGroup &MonsterGroupManager::GetUpgradedMonsterGroup( const mongroup
 
 //Quantity is adjusted directly as a side effect of this function
 MonsterGroupResult MonsterGroupManager::GetResultFromGroup(
-    const mongroup_id& group_name, int *quantity, int turn ){
+    const mongroup_id& group_name, int *quantity ){
     int spawn_chance = rng(1, 1000);
     auto &group = GetUpgradedMonsterGroup( group_name );
     //Our spawn details specify, by default, a single instance of the default monster
     MonsterGroupResult spawn_details = MonsterGroupResult(group.defaultMonster, 1);
-    //If the default monster is too difficult, replace this with NULL_ID.
-    if(turn != -1 &&
-       (turn + 900 < MINUTES(STARTING_MINUTES) + HOURS( group.defaultMonster.obj().difficulty))) {
-        spawn_details = MonsterGroupResult();
-    }
 
     bool monster_found = false;
     // Step through spawn definitions from the monster group until one is found or
@@ -87,9 +82,6 @@ MonsterGroupResult MonsterGroupManager::GetResultFromGroup(
         const mtype& mt = it->name.obj();
         // There's a lot of conditions to work through to see if this spawn definition is valid
         bool valid_entry = true;
-        // I don't know what turn == -1 is checking for, but it makes monsters always valid for difficulty purposes
-        valid_entry = valid_entry && (turn == -1 ||
-                                      (turn + 900) >= (MINUTES(STARTING_MINUTES) + HOURS(mt.difficulty)));
         // If we are in classic mode, require the monster type to be either CLASSIC or WILDLIFE
         if(get_option<bool>( "CLASSIC_ZOMBIES" ) ) {
             valid_entry = valid_entry && (mt.in_category("CLASSIC") ||
@@ -404,4 +396,19 @@ void MonsterGroupManager::check_group_definitions()
             }
         }
     }
+}
+
+const mtype_id &MonsterGroupManager::GetRandomMonsterFromGroup( const mongroup_id &group_name )
+{
+    int spawn_chance = rng( 1, 1000 );
+    const auto &group = group_name.obj();
+    for( auto it = group.monsters.begin(); it != group.monsters.end(); ++it ) {
+        if( it->frequency >= spawn_chance ) {
+            return it->name;
+        } else {
+            spawn_chance -= it->frequency;
+        }
+    }
+
+    return group.defaultMonster;
 }

--- a/src/mongroup.h
+++ b/src/mongroup.h
@@ -169,14 +169,18 @@ class MonsterGroupManager
         static void LoadMonsterBlacklist( JsonObject &jo );
         static void LoadMonsterWhitelist( JsonObject &jo );
         static void FinalizeMonsterGroups();
-        static MonsterGroupResult GetResultFromGroup( const mongroup_id &group,
-                int *quantity = 0, int turn = -1 );
+        static MonsterGroupResult GetResultFromGroup( const mongroup_id &group, int *quantity = 0 );
         static bool IsMonsterInGroup( const mongroup_id &group, const mtype_id &id );
         static bool isValidMonsterGroup( const mongroup_id &group );
         static const mongroup_id &Monster2Group( const mtype_id &id );
         static std::vector<mtype_id> GetMonstersFromGroup( const mongroup_id &group );
         static const MonsterGroup &GetMonsterGroup( const mongroup_id &group );
         static const MonsterGroup &GetUpgradedMonsterGroup( const mongroup_id &group );
+        /**
+         * Gets a random monster, weighted by frequency.
+         * Ignores cost multiplier.
+         */
+        static const mtype_id &GetRandomMonsterFromGroup( const mongroup_id &group );
 
         static void check_group_definitions();
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -301,8 +301,7 @@ void monster::try_upgrade(bool pin_time) {
         if( type->upgrade_into ) {
             poly( type->upgrade_into );
         } else {
-            const std::vector<mtype_id> monsters = MonsterGroupManager::GetMonstersFromGroup(type->upgrade_group);
-            const mtype_id &new_type = random_entry( monsters );
+            const mtype_id &new_type = MonsterGroupManager::GetRandomMonsterFromGroup( type->upgrade_group );
             if( new_type ) {
                 poly( new_type );
             }


### PR DESCRIPTION
Fixes #13803

Now monster upgrades should respect both frequency and default monster.
Also three minor, related changes:
* Got rid of `turn` argument from `MonsterGroupManager::GetResultFromGroup`. It simply wasn't used.
* Changed default monster for singly-upgraded zombie group to tough zombie. Was spitter.
* Allowed tough zombie to evolve into same types as regular zombie.