### PR TITLE
[WiP]Allow NPCs to change attitude when changing opinion

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -437,9 +437,10 @@ void character_edit_menu()
                 smenu.addentry( 4, true, 's', _( "Set opinion, let attitude change \"naturally\"" ) );
                 smenu.addentry( 5, true, 'r', _( "Set opinion, reset attitude" ) );
                 smenu.addentry( 999, true, 'q', "%s", _( "[q]uit" ) );
-                std::array<int*, 4> bound_vals = {{
-                    &opinion.trust, &opinion.fear, &opinion.value, &opinion.anger
-                }};
+                std::array<int *, 4> bound_vals = {{
+                        &opinion.trust, &opinion.fear, &opinion.value, &opinion.anger
+                    }
+                };
                 smenu.selected = 0;
                 smenu.query();
                 switch( smenu.ret ) {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -112,11 +112,12 @@ void character_edit_menu()
         } else {
             data << _( "No destination." ) << std::endl;
         }
-        data << string_format( _( "Trust: %d" ), np->op_of_u.trust ) << " "
-             << string_format( _( "Fear: %d" ), np->op_of_u.fear ) << " "
-             << string_format( _( "Value: %d" ), np->op_of_u.value ) << " "
-             << string_format( _( "Anger: %d" ), np->op_of_u.anger ) << " "
-             << string_format( _( "Owed: %d" ), np->op_of_u.owed ) << std::endl;
+        const npc_opinion &op_of_u = np->get_opinion_of( g->u );
+        data << string_format( _( "Trust: %d" ), op_of_u.trust ) << " "
+             << string_format( _( "Fear: %d" ), op_of_u.fear ) << " "
+             << string_format( _( "Value: %d" ), op_of_u.value ) << " "
+             << string_format( _( "Anger: %d" ), op_of_u.anger ) << " "
+             << string_format( _( "Owed: %d" ), op_of_u.owed ) << std::endl;
 
         data << string_format( _( "Aggression: %d" ), int( np->personality.aggression ) ) << " "
              << string_format( _( "Bravery: %d" ), int( np->personality.bravery ) ) << " "
@@ -136,7 +137,7 @@ void character_edit_menu()
 
     enum { D_SKILLS, D_STATS, D_ITEMS, D_DELETE_ITEMS, D_ITEM_WORN,
            D_HP, D_MORALE, D_PAIN, D_NEEDS, D_HEALTHY, D_STATUS, D_MISSION_ADD, D_MISSION_EDIT,
-           D_TELE, D_MUTATE, D_CLASS
+           D_TELE, D_MUTATE, D_CLASS, D_OPINION
          };
     nmenu.addentry( D_SKILLS, true, 's', "%s", _( "Edit [s]kills" ) );
     nmenu.addentry( D_STATS, true, 't', "%s", _( "Edit s[t]ats" ) );
@@ -156,6 +157,7 @@ void character_edit_menu()
     if( p.is_npc() ) {
         nmenu.addentry( D_MISSION_ADD, true, 'm', "%s", _( "Add [m]ission" ) );
         nmenu.addentry( D_CLASS, true, 'c', "%s", _( "Randomize with [c]lass" ) );
+        nmenu.addentry( D_OPINION, true, 'O', "%s", _( "Adjust [O]pinion" ) );
     }
     nmenu.addentry( 999, true, 'q', "%s", _( "[q]uit" ) );
     nmenu.selected = 0;
@@ -421,6 +423,50 @@ void character_edit_menu()
                 np->randomize( ids[ classes.ret ] );
             }
         }
+        break;
+        case D_OPINION: {
+            bool loop = true;
+            npc_opinion opinion = np->get_opinion_of( g->u );
+            while( loop ) {
+                uimenu smenu;
+                smenu.return_invalid = true;
+                smenu.addentry( 0, true, 't', "%s: %d", _( "Trust" ), opinion.trust );
+                smenu.addentry( 1, true, 'f', "%s: %d", _( "Fear" ), opinion.fear );
+                smenu.addentry( 2, true, 'v', "%s: %d", _( "Value" ), opinion.value );
+                smenu.addentry( 3, true, 'a', "%s: %d", _( "Anger" ), opinion.anger );
+                smenu.addentry( 4, true, 's', _( "Set opinion, let attitude change \"naturally\"" ) );
+                smenu.addentry( 5, true, 'r', _( "Set opinion, reset attitude" ) );
+                smenu.addentry( 999, true, 'q', "%s", _( "[q]uit" ) );
+                std::array<int*, 4> bound_vals = {{
+                    &opinion.trust, &opinion.fear, &opinion.value, &opinion.anger
+                }};
+                smenu.selected = 0;
+                smenu.query();
+                switch( smenu.ret ) {
+                        int value;
+                    case 0:
+                    case 1:
+                    case 2:
+                    case 3:
+                        if( query_int( value, _( "Set the value to? Currently: %d" ), *bound_vals[smenu.ret] ) ) {
+                            *bound_vals[smenu.ret] = value;
+                        }
+                        break;
+                    case 4:
+                        np->set_opinion_of( g->u, opinion, false );
+                        loop = false;
+                        break;
+                    case 5:
+                        np->set_opinion_of( g->u, opinion, true );
+                        loop = false;
+                        break;
+                    default:
+                        loop = false;
+                        break;
+                }
+            }
+        }
+        break;
     }
 }
 

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -53,7 +53,9 @@ void deny_equipment( npc & );        // p gets "asked_for_item"
 void deny_train( npc & );            // p gets "asked_to_train"
 void deny_personal_info( npc & );    // p gets "asked_personal_info"
 void hostile( npc & );               // p turns hostile to u
+void hostile_murder( npc & );        // guilt+hostile
 void flee( npc & );
+void guilt( npc & );                 // If p is non-hostile, mark them as attacked by player
 void leave( npc & );                 // p becomes indifferent
 void stranger_neutral( npc & );      // p is now neutral towards you
 

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -663,7 +663,7 @@ void mission_start::recruit_tracker( mission *miss )
     temp->attitude = NPCATT_TALK;
     temp->mission = NPC_MISSION_SHOPKEEP;
     temp->personality.aggression -= 1;
-    temp->op_of_u.owed = 10;
+    temp->mod_owed( g->u, 10 );
     temp->add_new_mission( mission::reserve_new( mission_type_id( "MISSION_JOIN_TRACKER" ), temp->getID() ) );
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1170,14 +1170,6 @@ void npc::form_opinion( const player &u )
              name.c_str(), npc_attitude_name( attitude ).c_str() );
 }
 
-// Mugging, waiting to kill, and trying to kill are all hostility
-// So NPCs shouldn't change between those
-enum class attitude_group {
-    neutral = 0,
-    hostile,
-    fearful
-};
-
 attitude_group get_attitude_group( npc_attitude att )
 {
     switch( att ) {
@@ -1187,6 +1179,9 @@ attitude_group get_attitude_group( npc_attitude att )
             return attitude_group::hostile;
         case NPCATT_FLEE:
             return attitude_group::fearful;
+        case NPCATT_FOLLOW:
+        case NPCATT_LEAD:
+            return attitude_group::friendly;
         default:
             break;
     }
@@ -1202,47 +1197,59 @@ npc_attitude attitude_from_group( attitude_group group )
             return NPCATT_KILL;
         case attitude_group::fearful:
             return NPCATT_FLEE;
+        case attitude_group::friendly:
+            return NPCATT_FOLLOW;
     }
     return NPCATT_NULL;
 }
 
-void note_attitude_change( const npc &whose, npc_attitude old_attitude )
+npc_attitude npc::get_attitude() const
 {
-    attitude_group new_group = get_attitude_group( whose.attitude );
-    attitude_group old_group = get_attitude_group( old_attitude );
-    if( new_group == old_group || !g->u.sees( whose ) ) {
-        // Attitude didn't change or we didn't see it
-        return;
-    }
-
-    switch( new_group ) {
-        case attitude_group::hostile:
-            add_msg( m_bad, _( "%s gets angry!" ), whose.name.c_str() );
-            break;
-        case attitude_group::fearful:
-            add_msg( m_warning, _( "%s gets scared!" ), whose.name.c_str() );
-            break;
-        default:
-            if( old_group == attitude_group::hostile ) {
-                add_msg( m_good, _( "%s calms down." ), whose.name.c_str() );
-            } else if( old_group == attitude_group::fearful ) {
-                add_msg( _( "%s is no longer afraid." ), whose.name.c_str() );
-            }
-            break;
-    }
+    return attitude;
 }
 
-attitude_group expected_attitude_group( const npc_opinion &op, const npc_personality &pr )
+void npc::set_attitude( npc_attitude new_attitude )
+{
+    if( new_attitude == attitude ) {
+        return;
+    }
+    attitude_group new_group = get_attitude_group( new_attitude );
+    attitude_group old_group = get_attitude_group( attitude );
+    if( new_group != old_group && g->u.sees( *this ) ) {
+        switch( new_group ) {
+            case attitude_group::hostile:
+                add_msg( m_bad, _( "%s gets angry!" ), name.c_str() );
+                break;
+            case attitude_group::fearful:
+                add_msg( m_warning, _( "%s gets scared!" ), name.c_str() );
+                break;
+            default:
+                if( old_group == attitude_group::hostile ) {
+                    add_msg( m_good, _( "%s calms down." ), name.c_str() );
+                } else if( old_group == attitude_group::fearful ) {
+                    add_msg( _( "%s is no longer afraid." ), name.c_str() );
+                }
+                break;
+        }
+    }
+    attitude = new_attitude;
+}
+
+attitude_group npc::expected_attitude_group( const npc_opinion &op, bool )
 {
     // The NPC is too aggressive to talk or run
-    if( 2 * ( pr.aggression + op.anger ) >= op.fear - pr.bravery + 10 + op.value + op.trust ) {
+    if( 2 * ( personality.aggression + op.anger ) >= op.fear - personality.bravery + 10 + op.value + op.trust ) {
         return attitude_group::hostile;
     }
     // The NPC is too scared to talk or just wants to play it safe
-    if( op.fear - pr.bravery >= 5 + op.value + op.trust || op.trust < -7 ) {
+    if( op.fear - personality.bravery >= 5 + op.value + op.trust || op.trust < -7 ) {
         return attitude_group::fearful;
     }
     // Stable enough to talk
+    if( is_friend() ) {
+        return attitude_group::friendly;
+    }
+
     return attitude_group::neutral;
 }
 
@@ -1252,15 +1259,16 @@ const npc_opinion &attitude_opinion_offset( npc_attitude attitude )
     // Could be an array, but then it would be less readable
     // Trust, Fear, Value, Anger
     static const std::unordered_map<npc_attitude, npc_opinion> opp_map = {{
-        // Keep killin'
-        { NPCATT_KILL, { -2, -2, -2, 2 } },
-        // Don't kill, don't run, don't trust
-        { NPCATT_MUG, { -2, -2, 0, 0 } },
-        // Don't fear, but don't get mad just yet
-        { NPCATT_WAIT_FOR_LEAVE, { -1, -2, 0, 0 } },
-        // Don't get mad, but don't get friendly either
-        { NPCATT_FLEE, { -2, 2, 0, 0 } }
-    }};
+            // Keep killin'
+            { NPCATT_KILL, { -2, -2, -2, 2 } },
+            // Don't kill, don't run, don't trust
+            { NPCATT_MUG, { -2, -2, 0, 0 } },
+            // Don't fear, but don't get mad just yet
+            { NPCATT_WAIT_FOR_LEAVE, { -1, -2, 0, 0 } },
+            // Don't get mad, but don't get friendly either
+            { NPCATT_FLEE, { -2, 2, 0, 0 } }
+        }
+    };
     // @todo Friendliness is not an attitude, but NPCs should avoid going un-friendly
     static const npc_opinion default_offset{ 0, 0, 0, 0 };
     const auto iter = opp_map.find( attitude );
@@ -1270,11 +1278,12 @@ const npc_opinion &attitude_opinion_offset( npc_attitude attitude )
     return default_offset;
 }
 
-void npc::set_opinion_of( const player &, const npc_opinion &op, bool ignore_attitude )
+npc_attitude npc::expected_attitude( const npc_opinion &op, bool ignore_attitude ) const
 {
     npc_attitude old_attitude = attitude;
     npc_attitude new_attitude = attitude;
-    attitude_group new_group = expected_attitude_group( ignore_attitude ? op : ( op + attitude_opinion_offset( attitude ) ), personality );
+    attitude_group new_group = expected_attitude_group( ignore_attitude ? op :
+                               ( op + attitude_opinion_offset( attitude ) ), personality );
     if( !ignore_attitude ) {
         attitude_group old_group = get_attitude_group( old_attitude );
         // Compare groups and not direct attitudes to keep muggers from getting angry or talkatives from ignoring etc.
@@ -1289,13 +1298,18 @@ void npc::set_opinion_of( const player &, const npc_opinion &op, bool ignore_att
     if( new_group == attitude_group::neutral && my_fac != nullptr && my_fac->likes_u < -10 ) {
         new_attitude = NPCATT_KILL;
     }
+    return new_attitude;
+}
+
+void npc::set_opinion_of( const player &, const npc_opinion &op, bool ignore_attitude )
+{
+    npc_attitude new_attitude = expected_attitude( op, ignore_attitude );
     if( new_attitude == NPCATT_KILL ) {
         // Handle faction anger
         make_angry();
     }
-    attitude = new_attitude;
+    set_attitude( new_attitude );
     opinion_of_player = op;
-    note_attitude_change( *this, old_attitude );
 }
 
 void npc::mod_opinion_of( const player &u, const npc_opinion &offset )

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1029,6 +1029,8 @@ bool npc::wield( item &it )
 
 void npc::form_opinion( const player &u )
 {
+    npc_opinion op_of_u;
+
     // FEAR
     if( u.weapon.is_gun() ) {
         // @todo: Make bows not guns
@@ -1162,19 +1164,158 @@ void npc::form_opinion( const player &u )
         }
     }
 
-    if( op_of_u.fear < personality.bravery + 10 &&
-        op_of_u.fear - personality.aggression > -10 && op_of_u.trust > -8 ) {
-        attitude = NPCATT_TALK;
-    } else if( op_of_u.fear - 2 * personality.aggression - personality.bravery < -30 ) {
-        attitude = NPCATT_KILL;
-    } else if( my_fac != nullptr && my_fac->likes_u < -10 ) {
-        attitude = NPCATT_KILL;
-    } else {
-        attitude = NPCATT_FLEE;
-    }
+    set_opinion_of( u, op_of_u, true );
 
     add_msg( m_debug, "%s formed an opinion of u: %s",
              name.c_str(), npc_attitude_name( attitude ).c_str() );
+}
+
+// Mugging, waiting to kill, and trying to kill are all hostility
+// So NPCs shouldn't change between those
+enum class attitude_group {
+    neutral = 0,
+    hostile,
+    fearful
+};
+
+attitude_group get_attitude_group( npc_attitude att )
+{
+    switch( att ) {
+        case NPCATT_MUG:
+        case NPCATT_WAIT_FOR_LEAVE:
+        case NPCATT_KILL:
+            return attitude_group::hostile;
+        case NPCATT_FLEE:
+            return attitude_group::fearful;
+        default:
+            break;
+    }
+    return attitude_group::neutral;
+}
+
+npc_attitude attitude_from_group( attitude_group group )
+{
+    switch( group ) {
+        case attitude_group::neutral:
+            return NPCATT_NULL;
+        case attitude_group::hostile:
+            return NPCATT_KILL;
+        case attitude_group::fearful:
+            return NPCATT_FLEE;
+    }
+    return NPCATT_NULL;
+}
+
+void note_attitude_change( const npc &whose, npc_attitude old_attitude )
+{
+    attitude_group new_group = get_attitude_group( whose.attitude );
+    attitude_group old_group = get_attitude_group( old_attitude );
+    if( new_group == old_group || !g->u.sees( whose ) ) {
+        // Attitude didn't change or we didn't see it
+        return;
+    }
+
+    switch( new_group ) {
+        case attitude_group::hostile:
+            add_msg( m_bad, _( "%s gets angry!" ), whose.name.c_str() );
+            break;
+        case attitude_group::fearful:
+            add_msg( m_warning, _( "%s gets scared!" ), whose.name.c_str() );
+            break;
+        default:
+            if( old_group == attitude_group::hostile ) {
+                add_msg( m_good, _( "%s calms down." ), whose.name.c_str() );
+            } else if( old_group == attitude_group::fearful ) {
+                add_msg( _( "%s is no longer afraid." ), whose.name.c_str() );
+            }
+            break;
+    }
+}
+
+attitude_group expected_attitude_group( const npc_opinion &op, const npc_personality &pr )
+{
+    // The NPC is too aggressive to talk or run
+    if( 2 * ( pr.aggression + op.anger ) >= op.fear - pr.bravery + 10 + op.value + op.trust ) {
+        return attitude_group::hostile;
+    }
+    // The NPC is too scared to talk or just wants to play it safe
+    if( op.fear - pr.bravery >= 5 + op.value + op.trust || op.trust < -7 ) {
+        return attitude_group::fearful;
+    }
+    // Stable enough to talk
+    return attitude_group::neutral;
+}
+
+// This prevents NPC attitude from flickering due to small changes in opinion
+const npc_opinion &attitude_opinion_offset( npc_attitude attitude )
+{
+    // Could be an array, but then it would be less readable
+    // Trust, Fear, Value, Anger
+    static const std::unordered_map<npc_attitude, npc_opinion> opp_map = {{
+        // Keep killin'
+        { NPCATT_KILL, { -2, -2, -2, 2 } },
+        // Don't kill, don't run, don't trust
+        { NPCATT_MUG, { -2, -2, 0, 0 } },
+        // Don't fear, but don't get mad just yet
+        { NPCATT_WAIT_FOR_LEAVE, { -1, -2, 0, 0 } },
+        // Don't get mad, but don't get friendly either
+        { NPCATT_FLEE, { -2, 2, 0, 0 } }
+    }};
+    // @todo Friendliness is not an attitude, but NPCs should avoid going un-friendly
+    static const npc_opinion default_offset{ 0, 0, 0, 0 };
+    const auto iter = opp_map.find( attitude );
+    if( iter != opp_map.end() ) {
+        return iter->second;
+    }
+    return default_offset;
+}
+
+void npc::set_opinion_of( const player &, const npc_opinion &op, bool ignore_attitude )
+{
+    npc_attitude old_attitude = attitude;
+    npc_attitude new_attitude = attitude;
+    attitude_group new_group = expected_attitude_group( ignore_attitude ? op : ( op + attitude_opinion_offset( attitude ) ), personality );
+    if( !ignore_attitude ) {
+        attitude_group old_group = get_attitude_group( old_attitude );
+        // Compare groups and not direct attitudes to keep muggers from getting angry or talkatives from ignoring etc.
+        if( old_group != new_group ) {
+            new_attitude = attitude_from_group( new_group );
+        }
+    } else {
+        new_attitude = attitude_from_group( new_group );
+    }
+    // If the faction is hostile, we can't be neutral - either kill or run
+    // @todo If the NPC's impression makes player look like a friend, make the faction less angry
+    if( new_group == attitude_group::neutral && my_fac != nullptr && my_fac->likes_u < -10 ) {
+        new_attitude = NPCATT_KILL;
+    }
+    if( new_attitude == NPCATT_KILL ) {
+        // Handle faction anger
+        make_angry();
+    }
+    attitude = new_attitude;
+    opinion_of_player = op;
+    note_attitude_change( *this, old_attitude );
+}
+
+void npc::mod_opinion_of( const player &u, const npc_opinion &offset )
+{
+    set_opinion_of( u, opinion_of_player + offset, false );
+}
+
+void npc::mod_opinion_of( const player &u, int trust, int fear, int value, int anger )
+{
+    mod_opinion_of( u, npc_opinion( trust, fear, value, anger ) );
+}
+
+const npc_opinion &npc::get_opinion_of( const player & ) const
+{
+    return opinion_of_player;
+}
+
+void npc::mod_owed( const player &, int value )
+{
+    opinion_of_player.owed += value;
 }
 
 float npc::vehicle_danger( int radius ) const
@@ -1213,24 +1354,10 @@ float npc::vehicle_danger( int radius ) const
     return danger;
 }
 
-bool npc::turned_hostile() const
-{
-    return ( op_of_u.anger >= hostile_anger_level() );
-}
-
-int npc::hostile_anger_level() const
-{
-    return ( 20 + op_of_u.fear - personality.aggression );
-}
-
 void npc::make_angry()
 {
     if( is_enemy() ) {
         return; // We're already angry!
-    }
-
-    if( g->u.sees( *this ) ) {
-        add_msg( _( "%s gets angry!" ), name.c_str() );
     }
 
     // Make associated faction, if any, angry at the player too.
@@ -1238,11 +1365,8 @@ void npc::make_angry()
         my_fac->likes_u = std::max( -50, my_fac->likes_u - 50 );
         my_fac->respects_u = std::max( -50, my_fac->respects_u - 50 );
     }
-    if( op_of_u.fear > 10 + personality.aggression + personality.bravery ) {
-        attitude = NPCATT_FLEE; // We don't want to take u on!
-    } else {
-        attitude = NPCATT_KILL; // Yeah, we think we could take you!
-    }
+    // The faction anger should be enough for now, just re-apply opinion
+    set_opinion_of( g->u, opinion_of_player, true );
 }
 
 void npc::on_attacked( const Creature &attacker )
@@ -1602,7 +1726,7 @@ bool npc::is_friend() const
 
 bool npc::is_minion() const
 {
-    return is_friend() && op_of_u.trust >= 5;
+    return is_friend() && get_opinion_of( g->u ).trust >= 5;
 }
 
 bool npc::guaranteed_hostile() const
@@ -1829,6 +1953,7 @@ std::string npc::short_description() const
 std::string npc::opinion_text() const
 {
     std::stringstream ret;
+    const npc_opinion &op_of_u = get_opinion_of( g->u );
     if( op_of_u.trust <= -10 ) {
         ret << _( "Completely untrusting" );
     } else if( op_of_u.trust <= -6 ) {
@@ -2026,8 +2151,6 @@ std::string npc_attitude_name( npc_attitude att )
             return _( "Attacking to kill" );
         case NPCATT_FLEE:          // Get away from the player
             return _( "Fleeing" );
-        case NPCATT_HEAL:          // Get to the player and heal them
-            return _( "Healing you" );
         default:
             break;
     }
@@ -2294,6 +2417,7 @@ void npc::process_turn()
 {
     player::process_turn();
 
+    const npc_opinion &op_of_u = get_opinion_of( g->u );
     if( is_following() && calendar::once_every( 1_hours ) &&
         get_hunger() < 200 && get_thirst() < 100 && op_of_u.trust < 5 ) {
         // Friends who are well fed will like you more
@@ -2307,7 +2431,7 @@ void npc::process_turn()
         // Being barely hungry and thirsty, not in pain and not wounded means good care
         int state_penalty = get_hunger() + get_thirst() + ( 100 - hp_percentage() ) + get_pain();
         if( x_in_y( trust_chance, 240 + 10 * op_penalty + state_penalty ) ) {
-            op_of_u.trust++;
+            mod_opinion_of( g->u, 1, 0, 0, 0 );
         }
 
         // TODO: Similar checks for fear and anger

--- a/src/npc.h
+++ b/src/npc.h
@@ -62,6 +62,19 @@ enum npc_attitude : int {
 
 std::string npc_attitude_name( npc_attitude );
 
+// Attitudes are grouped by overall behavior towards player
+enum class attitude_group : int {
+    neutral = 0, // Doesn't particularly mind the player
+    hostile, // Not necessarily attacking, but also mugging, exploiting etc.
+    fearful, // Run
+    friendly // Follow, defend, listen
+};
+
+// What group does an attitude belong to?
+attitude_group get_attitude_group( npc_attitude att );
+// Get representative (default) attitude of the group
+npc_attitude attitude_from_group( attitude_group group );
+
 enum npc_mission : int {
     NPC_MISSION_NULL = 0, // Nothing in particular
     NPC_MISSION_LEGACY_1,
@@ -731,7 +744,6 @@ class npc : public player
 
         // #############   VALUES   ################
 
-        npc_attitude attitude; // What we want to do to the player
         npc_class_id myclass; // What's our archetype?
         std::string idz; // A temp variable used to inform the game which npc json to use as a template
         mission_type_id miss_id; // A temp variable used to link to the correct mission
@@ -835,7 +847,7 @@ class npc : public player
          * Offsets NPC's opinion of a character by some value, then recalculates attitude.
          * Respects NPC's current attitude.
          */
-         /*@{*/
+        /*@{*/
         void mod_opinion_of( const player &u, const npc_opinion &offset );
         void mod_opinion_of( const player &u, int trust, int fear, int value, int anger );
         /*@}*/
@@ -850,6 +862,28 @@ class npc : public player
          * Changes the amount of money NPC owes to player.
          */
         void mod_owed( const player &u, int amount );
+
+        /**
+         * What attitude would this NPC have if we called @set_opinion_of of g->u to given opinion?
+         */
+        npc_attitude expected_attitude( npc_opinion &at_opinion_u, bool ignore_attitude = false ) const;
+        /**
+         * As @ref expected_attitude but for attitude groups.
+         */
+        attitude_group expected_attitude_group( npc_opinion &at_opinion_u, bool ignore_attitude = false ) const;
+
+        /**
+         * Returns attitude to player and friends.
+         */
+        npc_attitude get_attitude() const;
+        /**
+         * Sets the attitude and informs the player of the change (if we can see the NPC).
+         */
+        void set_attitude( npc_attitude new_attitude );
+
+        // What we want to do to the player and their friends
+        // @todo Finish encapsulating
+        npc_attitude attitude;
 
     protected:
         void store( JsonOut &jsout ) const;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -282,11 +282,8 @@ void npc::move()
     //faction opinion determines if it should consider you hostile
     if( !is_enemy() && guaranteed_hostile() && sees( g->u ) ) {
         add_msg( m_debug, "NPC %s turning hostile because is guaranteed_hostile()", name.c_str() );
-        if( op_of_u.fear > 10 + personality.aggression + personality.bravery ) {
-            attitude = NPCATT_FLEE;    // We don't want to take u on!
-        } else {
-            attitude = NPCATT_KILL;    // Yeah, we think we could take you!
-        }
+        // Just re-set our opinion, handle hostility there
+        set_opinion_of( g->u, opinion_of_player, false );
     }
 
     // This bypasses the logic to determine the npc action, but this all needs to be rewritten anyway.
@@ -2504,6 +2501,7 @@ void npc::heal_player( player &patient )
     consume_charges( used, charges_used );
 
     if( !patient.is_npc() ) {
+        const npc_opinion &op_of_u = get_opinion_of( patient );
         // Test if we want to heal the player further
         if( op_of_u.value * 4 + op_of_u.trust + personality.altruism * 3 +
             ( fac_has_value( FACVAL_CHARITABLE ) ?  5 : 0 ) +
@@ -2713,6 +2711,7 @@ void npc::mug_player( player &mark )
                        ( ( 10 - personality.aggression ) * .04 ) -
                        ( ( 10 - personality.collector )  * .06 );
     if( !mark.is_npc() ) {
+        const npc_opinion &op_of_u = get_opinion_of( mark );
         value_mod += ( op_of_u.fear * .08 );
         value_mod -= ( ( 8 - op_of_u.value ) * .07 );
     }
@@ -2750,7 +2749,8 @@ void npc::mug_player( player &mark )
     i_add( stolen );
     moves -= 100;
     if( !mark.is_npc() ) {
-        op_of_u.value -= rng( 0, 1 );  // Decrease the value of the player
+        // Decrease the value of the player
+        mod_opinion_of( mark, 0, 0, -rng( 0, 1 ), 0 );
     }
 }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1082,7 +1082,7 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
         return _( "Okay, here you go." );
 
     } else if( topic == "TALK_DENY_EQUIPMENT" ) {
-        if( p->op_of_u.anger >= p->hostile_anger_level() - 4 ) {
+        if( p->get_opinion_of( g->u ).anger >= p->hostile_anger_level() - 4 ) {
             return _( "<no>, and if you ask again, <ill_kill_you>!" );
         } else {
             return _( "<no><punc> <fuck_you>!" );
@@ -1493,6 +1493,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
     }
     // Can be nullptr! Check before dereferencing
     mission *miss = p->chatbin.mission_selected;
+    const npc_opinion &op_of_u = p->get_opinion_of( g->u );
 
     if( topic == "TALK_GUARD" ) {
         add_response_done( _( "Don't mind me..." ) );
@@ -1554,7 +1555,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             SUCCESS( "TALK_MISSION_FAILURE" );
             SUCCESS_OPINION( -1, 0, -1, 1, 0 );
             RESPONSE( _( "Not yet." ) );
-            TRIAL( TALK_TRIAL_LIE, 10 + p->op_of_u.trust * 3 );
+            TRIAL( TALK_TRIAL_LIE, 10 + op_of_u.trust * 3 );
             SUCCESS( "TALK_NONE" );
             FAILURE( "TALK_MISSION_FAILURE" );
             FAILURE_OPINION( -3, 0, -1, 2, 0 );
@@ -1562,7 +1563,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             add_response_none( _( "Not yet." ) );
             if( mission->get_type().goal == MGOAL_KILL_MONSTER ) {
                 RESPONSE( _( "Yup, I killed it." ) );
-                TRIAL( TALK_TRIAL_LIE, 10 + p->op_of_u.trust * 5 );
+                TRIAL( TALK_TRIAL_LIE, 10 + op_of_u.trust * 5 );
                 SUCCESS( "TALK_MISSION_SUCCESS" );
                 SUCCESS_ACTION( &talk_function::mission_success );
                 FAILURE( "TALK_MISSION_SUCCESS_LIE" );
@@ -1676,11 +1677,11 @@ void dialogue::gen_responses( const talk_topic &the_topic )
 
     } else if( topic == "TALK_EVAC_GUARD3_HIDE2" ) {
         RESPONSE( _( "Get bent, traitor!" ) );
-        TRIAL( TALK_TRIAL_INTIMIDATE, 20 + p->op_of_u.fear * 3 );
+        TRIAL( TALK_TRIAL_INTIMIDATE, 20 + op_of_u.fear * 3 );
         SUCCESS( "TALK_EVAC_GUARD3_HOSTILE" );
         FAILURE( "TALK_EVAC_GUARD3_INSULT" );
         RESPONSE( _( "Got something to hide?" ) );
-        TRIAL( TALK_TRIAL_PERSUADE, 10 + p->op_of_u.trust * 3 );
+        TRIAL( TALK_TRIAL_PERSUADE, 10 + op_of_u.trust * 3 );
         SUCCESS( "TALK_EVAC_GUARD3_DEAD" );
         FAILURE( "TALK_EVAC_GUARD3_INSULT" );
 
@@ -2039,7 +2040,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         if( p->has_effect( effect_asked_for_item ) ) {
             add_response_none( _( "Okay, fine." ) );
         } else {
-            int score = p->op_of_u.trust + p->op_of_u.value * 3 +
+            int score = op_of_u.trust + op_of_u.value * 3 +
                         p->personality.altruism * 2;
             int missions_value = p->assigned_missions_value();
             if( g->u.has_amount( "mininuke", 1 ) ) {
@@ -2077,7 +2078,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             SUCCESS( "TALK_GIVE_EQUIPMENT" );
             SUCCESS_ACTION( &talk_function::give_equipment );
             SUCCESS_OPINION( -3, 2, -2, 2,
-                             ( g->u.intimidation() + p->op_of_u.fear -
+                             ( g->u.intimidation() + op_of_u.fear -
                                p->personality.bravery - p->intimidation() ) * 500 );
             FAILURE( "TALK_DENY_EQUIPMENT" );
             FAILURE_OPINION( -3, 1, -3, 5, 0 );
@@ -2155,11 +2156,11 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         } else if( p->has_effect( effect_asked_to_follow ) ) {
             add_response_none( _( "Right, right, I'll ask later." ) );
         } else {
-            int strength = 4 * p->op_of_u.fear + p->op_of_u.value + p->op_of_u.trust +
+            int strength = 4 * op_of_u.fear + op_of_u.value + op_of_u.trust +
                            ( 10 - p->personality.bravery );
-            int weakness = 3 * ( p->personality.altruism - std::max( 0, p->op_of_u.fear ) ) +
-                           p->personality.bravery - 3 * p->op_of_u.anger + 2 * p->op_of_u.value;
-            int friends = 2 * p->op_of_u.trust + 2 * p->op_of_u.value - 2 * p->op_of_u.anger;
+            int weakness = 3 * ( p->personality.altruism - std::max( 0, op_of_u.fear ) ) +
+                           p->personality.bravery - 3 * op_of_u.anger + 2 * op_of_u.value;
+            int friends = 2 * op_of_u.trust + 2 * op_of_u.value - 2 * op_of_u.anger;
             RESPONSE( _( "I can keep you safe." ) );
             TRIAL( TALK_TRIAL_PERSUADE, strength * 2 );
             SUCCESS( "TALK_AGREE_FOLLOW" );
@@ -2201,7 +2202,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         add_response_none( _( "Oh, okay." ) );
 
     } else if( topic == "TALK_LEADER" ) {
-        int persuade = p->op_of_u.fear + p->op_of_u.value + p->op_of_u.trust -
+        int persuade = op_of_u.fear + op_of_u.value + op_of_u.trust -
                        p->personality.bravery - p->personality.aggression;
         if( p->has_destination() ) {
             add_response( _( "How much further?" ), "TALK_HOW_MUCH_FURTHER" );
@@ -2277,8 +2278,8 @@ void dialogue::gen_responses( const talk_topic &the_topic )
                 ret.back().success.next_topic.reason = reasons.str();
             } else {
                 RESPONSE( _( "Can you teach me anything?" ) );
-                int commitment = 3 * p->op_of_u.trust + 1 * p->op_of_u.value -
-                                 3 * p->op_of_u.anger;
+                int commitment = 3 * op_of_u.trust + 1 * op_of_u.value -
+                                 3 * op_of_u.anger;
                 TRIAL( TALK_TRIAL_PERSUADE, commitment * 2 );
                 SUCCESS( "TALK_TRAIN" );
                 FAILURE( "TALK_DENY_PERSONAL" );
@@ -2412,7 +2413,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
                 SUCCESS_ACTION( &talk_function::player_weapon_drop );
                 SUCCESS_OPINION( 4, -3, 0, 0, 0 );
             }
-            int diff = 50 + p->personality.bravery - 2 * p->op_of_u.fear + 2 * p->op_of_u.trust;
+            int diff = 50 + p->personality.bravery - 2 * op_of_u.fear + 2 * op_of_u.trust;
             RESPONSE( _( "Don't worry, I'm not going to hurt you." ) );
             TRIAL( TALK_TRIAL_PERSUADE, diff );
             SUCCESS( "TALK_STRANGER_NEUTRAL" );
@@ -2439,8 +2440,8 @@ void dialogue::gen_responses( const talk_topic &the_topic )
     } else if( topic == "TALK_STRANGER_AGGRESSIVE" || topic == "TALK_MUG" ) {
         if( !g->u.unarmed_attack() ) {
             int chance = 30 + p->personality.bravery - 3 * p->personality.aggression +
-                         2 * p->personality.altruism - 2 * p->op_of_u.fear +
-                         3 * p->op_of_u.trust;
+                         2 * p->personality.altruism - 2 * op_of_u.fear +
+                         3 * op_of_u.trust;
             RESPONSE( _( "!Calm down.  I'm not going to hurt you." ) );
             TRIAL( TALK_TRIAL_PERSUADE, chance );
             SUCCESS( "TALK_STRANGER_WARY" );
@@ -2464,8 +2465,8 @@ void dialogue::gen_responses( const talk_topic &the_topic )
 
         } else if( topic == "TALK_MUG" ) {
             int chance = 35 + p->personality.bravery - 3 * p->personality.aggression +
-                         2 * p->personality.altruism - 2 * p->op_of_u.fear +
-                         3 * p->op_of_u.trust;
+                         2 * p->personality.altruism - 2 * op_of_u.fear +
+                         3 * op_of_u.trust;
             RESPONSE( _( "!Calm down.  I'm not going to hurt you." ) );
             TRIAL( TALK_TRIAL_PERSUADE, chance );
             SUCCESS( "TALK_STRANGER_WARY" );
@@ -2568,6 +2569,7 @@ int talk_trial::calc_chance( const dialogue &d ) const
     }
 
     npc &p = *d.beta;
+    const npc_opinion &op_of_u = p.get_opinion_of( g->u );
     int chance = difficulty;
     switch( type ) {
         case TALK_TRIAL_NONE:
@@ -2575,7 +2577,7 @@ int talk_trial::calc_chance( const dialogue &d ) const
             dbg( D_ERROR ) << "called calc_chance with invalid talk_trial value: " << type;
             break;
         case TALK_TRIAL_LIE:
-            chance += u.talk_skill() - p.talk_skill() + p.op_of_u.trust * 3;
+            chance += u.talk_skill() - p.talk_skill() + op_of_u.trust * 3;
             if( u.has_trait( trait_TRUTHTELLER ) ) {
                 chance -= 40;
             }
@@ -2599,7 +2601,7 @@ int talk_trial::calc_chance( const dialogue &d ) const
             break;
         case TALK_TRIAL_PERSUADE:
             chance += u.talk_skill() - int( p.talk_skill() / 2 ) +
-                      p.op_of_u.trust * 2 + p.op_of_u.value;
+                      op_of_u.trust * 2 + op_of_u.value;
             if( u.has_trait( trait_ELFAEYES ) ) {
                 chance += 20;
             }
@@ -2629,7 +2631,7 @@ int talk_trial::calc_chance( const dialogue &d ) const
             }
             break;
         case TALK_TRIAL_INTIMIDATE:
-            chance += u.intimidation() - p.intimidation() + p.op_of_u.fear * 2 -
+            chance += u.intimidation() - p.intimidation() + op_of_u.fear * 2 -
                       p.personality.bravery * 2;
             if( u.has_trait( trait_MINOTAUR ) ) {
                 chance += 15;
@@ -2803,7 +2805,7 @@ void talk_function::mission_success( npc &p )
 
     int miss_val = cash_to_favor( p, miss->get_value() );
     npc_opinion tmp( 0, 0, 1 + miss_val / 5, -1, 0 );
-    p.op_of_u += tmp;
+    p.mod_opinion_of( g->u, tmp );
     if( p.my_fac != nullptr ) {
         int fac_val = std::min( 1 + miss_val / 10, 10 );
         p.my_fac->likes_u += fac_val;
@@ -2821,7 +2823,7 @@ void talk_function::mission_failure( npc &p )
         return;
     }
     npc_opinion tmp( -1, 0, -1, 1, 0 );
-    p.op_of_u += tmp;
+    p.mod_opinion_of( g->u, tmp );
     miss->fail();
 }
 
@@ -2858,7 +2860,7 @@ void talk_function::mission_reward( npc &p )
     }
 
     int mission_value = miss->get_value();
-    p.op_of_u.owed += mission_value;
+    p.mod_owed( g->u, mission_value );
     trade( p, 0, _( "Reward" ) );
 }
 
@@ -2952,9 +2954,10 @@ void talk_function::give_equipment( npc &p )
 {
     std::vector<item_pricing> giving = init_selling( p );
     int chosen = -1;
+    const npc_opinion &op_of_u = p.get_opinion_of( g->u );
     while( chosen == -1 && giving.size() > 1 ) {
         int index = rng( 0, giving.size() - 1 );
-        if( giving[index].price < p.op_of_u.owed ) {
+        if( giving[index].price < op_of_u.owed ) {
             chosen = index;
         }
         giving.erase( giving.begin() + index );
@@ -2971,7 +2974,7 @@ void talk_function::give_equipment( npc &p )
     popup( _( "%1$s gives you a %2$s" ), p.name.c_str(), it.tname().c_str() );
 
     g->u.i_add( it );
-    p.op_of_u.owed -= giving[chosen].price;
+    p.mod_owed( g->u, -giving[chosen].price );
     p.add_effect( effect_asked_for_item, 1800 );
 }
 
@@ -3202,14 +3205,15 @@ void talk_function::lead_to_safety( npc &p )
 
 bool pay_npc( npc &np, int cost )
 {
-    if( np.op_of_u.owed >= cost ) {
-        np.op_of_u.owed -= cost;
+    const npc_opinion &op_of_u = np.get_opinion_of( g->u );
+    if( op_of_u.owed >= cost ) {
+        np.mod_owed( g->u, -cost );
         return true;
     }
 
-    if( g->u.cash + ( unsigned long )np.op_of_u.owed >= ( unsigned long )cost ) {
-        g->u.cash -= cost - np.op_of_u.owed;
-        np.op_of_u.owed = 0;
+    if( g->u.cash + ( unsigned long )op_of_u.owed >= ( unsigned long )cost ) {
+        g->u.cash -= cost - op_of_u.owed;
+        np.mod_owed( g->u, -op_of_u.owed );
         return true;
     }
 
@@ -3464,7 +3468,7 @@ void talk_response::do_formatting( const dialogue &d, char const letter )
 talk_topic talk_response::effect_t::apply( dialogue &d ) const
 {
     effect( *d.beta );
-    d.beta->op_of_u += opinion;
+    d.beta->mod_opinion_of( g->u, opinion );
     if( d.beta->turned_hostile() ) {
         d.beta->make_angry();
         return talk_topic( "TALK_DONE" );
@@ -3730,8 +3734,9 @@ TAB key to switch lists, letters to pick items, Enter to finalize, Esc to quit,\
     // Just exchanging items, no barter involved
     const bool ex = p.is_friend();
 
+    const npc_opinion &op_of_u = p.get_opinion_of( g->u );
     // How much cash you get in the deal (negative = losing money)
-    long cash = cost + p.op_of_u.owed;
+    long cash = cost + op_of_u.owed;
     bool focus_them = true; // Is the focus on them?
     bool update = true;     // Re-draw the screen?
     size_t them_off = 0, you_off = 0; // Offset from the start of the list
@@ -3983,7 +3988,7 @@ TAB key to switch lists, letters to pick items, Enter to finalize, Esc to quit,\
 
         if( !ex && cash > ( int )p.cash ) {
             // Trade was forced, give the NPC's cash to the player.
-            p.op_of_u.owed = ( cash - p.cash );
+            p.mod_owed( g->u, cash - p.cash - op_of_u.owed );
             g->u.cash += p.cash;
             p.cash = 0;
         } else if( !ex ) {
@@ -4291,8 +4296,7 @@ void load_talk_topic( JsonObject &jo )
 
 std::string npc::pick_talk_topic( const player &u )
 {
-    //form_opinion(u);
-    ( void )u;
+    const npc_opinion &op_of_u = get_opinion_of( u );
     if( personality.aggression > 0 ) {
         if( op_of_u.fear * 2 < personality.bravery && personality.altruism < 0 ) {
             return "TALK_MUG";

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1121,7 +1121,8 @@ void npc::load(JsonObject &data)
         attitude = npc_attitude(atttmp);
         static const std::set<npc_attitude> legacy_attitudes = {{
             NPCATT_LEGACY_1, NPCATT_LEGACY_2, NPCATT_LEGACY_3,
-            NPCATT_LEGACY_4, NPCATT_LEGACY_5, NPCATT_LEGACY_6
+            NPCATT_LEGACY_4, NPCATT_LEGACY_5, NPCATT_LEGACY_6,
+            NPCATT_LEGACY_7
         }};
         if( legacy_attitudes.count( attitude ) > 0 ) {
             attitude = NPCATT_NULL;
@@ -1140,9 +1141,7 @@ void npc::load(JsonObject &data)
         restock = stock;
     }
 
-    if( !data.read( "opinion_of_player", opinion_of_player ) ) {
-        data.read( "op_of_u", opinion_of_player );
-    }
+    data.read( "op_of_u", opinion_of_player );
     data.read("chatbin", chatbin);
     if( !data.read( "rules", rules ) ) {
         data.read("misc_rules", rules);
@@ -1208,7 +1207,7 @@ void npc::store(JsonOut &json) const
         json.member( "my_fac", my_fac->id.c_str() );
     }
     json.member( "attitude", (int)attitude );
-    json.member( "opinion_of_player", opinion_of_player );
+    json.member( "op_of_u", opinion_of_player );
     json.member("chatbin", chatbin);
     json.member("rules", rules);
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1140,7 +1140,9 @@ void npc::load(JsonObject &data)
         restock = stock;
     }
 
-    data.read("op_of_u", op_of_u);
+    if( !data.read( "opinion_of_player", opinion_of_player ) ) {
+        data.read( "op_of_u", opinion_of_player );
+    }
     data.read("chatbin", chatbin);
     if( !data.read( "rules", rules ) ) {
         data.read("misc_rules", rules);
@@ -1206,7 +1208,7 @@ void npc::store(JsonOut &json) const
         json.member( "my_fac", my_fac->id.c_str() );
     }
     json.member( "attitude", (int)attitude );
-    json.member("op_of_u", op_of_u);
+    json.member( "opinion_of_player", opinion_of_player );
     json.member("chatbin", chatbin);
     json.member("rules", rules);
 

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -182,3 +182,29 @@ TEST_CASE( "snippet-tag-test" )
     CHECK( SNIPPET.all_ids_from_category( "<mywp>" ).empty() );
     CHECK( SNIPPET.all_ids_from_category( "<ammo>" ).empty() );
 }
+
+std::string npc_attitude_name( npc_attitude att );
+
+TEST_CASE( "opinion-test" )
+{
+    npc model_npc = create_model();
+    npc other_npc = create_model();
+    static const npc_opinion no_change;
+    // Create a bunch of personalities, make sure everyone is sane
+    for( size_t i = 0; i < 100; i++ ) {
+        model_npc.personality.aggression = rng( -10, 10 );
+        model_npc.personality.bravery = rng( -10, 10 );
+        model_npc.personality.collector = rng( -10, 10 );
+        model_npc.personality.altruism = rng( -10, 10 );
+        // Roll a bunch of opinions, make sure they "stick"
+        for( size_t i = 0; i < 100; i++ ) {
+            npc_opinion op( rng( -20, 20 ), rng( -20, 20 ), rng( -20, 20 ), rng( -20, 20 ) );
+            model_npc.set_opinion_of( other_npc, op, true );
+            npc_attitude old_att = model_npc.attitude;
+            // Not-changing opinion should not-change attitude
+            model_npc.mod_opinion_of( other_npc, no_change );
+            INFO( npc_attitude_name( old_att ) + " -> " + npc_attitude_name( model_npc.attitude ) );
+            CHECK( model_npc.attitude == old_att );
+        }
+    }
+}


### PR DESCRIPTION
Current master:
* NPCs only form their opinion at the first impression, when intentionally attacked, when the player makes them very mad, or when convinced by the player to do so.
* A NPC has one common opinion for all the players in the world. That is, "A player robbed me, I'll purge the world from players".
* NPC opinion/attitude code is scattered all over the place and using fields.

Here:
* [x] NPCs can change their attitude (hostile/flee/neutral/friendly) if their opinion changes enough. They have some resistance to change, but will no longer tolerate abuse indefinitely.
* [ ] NPCs still have one opinion of all players in the world. But it's easy to change now, because of point below:
* [x] NPC opinion code is encapsulated, so any change to opinion may result in change to attitude that "makes sense" for this opinion (ie. scared->flee, mad->kill, unscared+unmad->calm down).
* [ ] Intimidating a NPC and failing, then killing the NPC who defends itself, should count as murder.

This also sets up the stage for dynamic NPC opinion. For example, making a NPC suddenly start fearing the player if hurt badly or if the player pulls out a shotgun.