### PR TITLE
Encapsulate visible consequences of dialogue actions

### DIFF
--- a/src/npc.h
+++ b/src/npc.h
@@ -143,7 +143,7 @@ struct npc_opinion {
         return *this;
     }
 
-    npc_opinion &operator+( const npc_opinion &rhs ) {
+    npc_opinion operator+( const npc_opinion &rhs ) {
         return ( npc_opinion( *this ) += rhs );
     }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -82,6 +82,15 @@ enum talk_trial_type {
     NUM_TALK_TRIALS
 };
 
+enum class dialogue_consequence {
+    none = 0,
+    hostile,
+    helpless,
+    action
+};
+
+using dialogue_fun_ptr = std::add_pointer<void( npc & )>::type;
+
 /**
  * If not TALK_TRIAL_NONE, it defines how to decide whether the responses succeeds (e.g. the
  * NPC believes the lie). The difficulty is a 0...100 percent chance of success (!), 100 means
@@ -125,7 +134,7 @@ struct talk_topic {
 struct talk_response {
     /**
      * What the player character says (literally). Should already be translated and will be
-     * displayed. The first character controls the color of it ('*'/'&'/'!').
+     * displayed.
      */
     std::string text;
     talk_trial trial;
@@ -140,24 +149,41 @@ struct talk_response {
      * TALK_TRIAL_NONE it always succeeds.
      */
     struct effect_t {
-        /**
-         * How (if at all) the NPCs opinion of the player character (@ref npc::op_of_u) will change.
-         */
-        npc_opinion opinion;
-        /**
-         * Function that is called when the response is chosen.
-         */
-        std::function<void( npc & )> effect = &talk_function::nothing;
-        /**
-         * Topic to switch to. TALK_DONE ends the talking, TALK_NONE keeps the current topic.
-         */
-        talk_topic next_topic = talk_topic( "TALK_NONE" );
+            /**
+             * How (if at all) the NPCs opinion of the player character (@ref npc::op_of_u) will change.
+             */
+            npc_opinion opinion;
+            /**
+             * Topic to switch to. TALK_DONE ends the talking, TALK_NONE keeps the current topic.
+             */
+            talk_topic next_topic = talk_topic( "TALK_NONE" );
 
-        talk_topic apply( dialogue &d ) const;
-        void load_effect( JsonObject &jo );
+            talk_topic apply( dialogue &d ) const;
+            dialogue_consequence get_consequence( const dialogue &d ) const;
 
-        effect_t() = default;
-        effect_t( JsonObject );
+            const std::function<void( npc & )> &get_effect() const {
+                return effect;
+            }
+
+            /**
+             * Sets the effect and consequence based on function pointer.
+             */
+            void set_effect( dialogue_fun_ptr effect );
+            /**
+             * Sets the effect to a function object and consequence to explicitly given one.
+             */
+            void set_effect_consequence( std::function<void( npc & )> eff, dialogue_consequence con );
+
+            void load_effect( JsonObject &jo );
+
+            effect_t() = default;
+            effect_t( JsonObject );
+        private:
+            /**
+             * Function that is called when the response is chosen.
+             */
+            std::function<void( npc & )> effect = &talk_function::nothing;
+            dialogue_consequence guaranteed_consequence = dialogue_consequence::none;
     };
     effect_t success;
     effect_t failure;
@@ -170,6 +196,7 @@ struct talk_response {
     nc_color color = c_white;
 
     void do_formatting( const dialogue &d, char letter );
+    std::set<dialogue_consequence> get_consequences( const dialogue &d ) const;
 
     talk_response() = default;
     talk_response( JsonObject );
@@ -241,10 +268,18 @@ struct dialogue {
         talk_response &add_response_none( const std::string &text );
         /**
          * Add a simple response that switches the topic to the new one and executes the given
-         * action. The response always succeeds.
+         * action. The response always succeeds. Consequence is based on function used.
          */
         talk_response &add_response( const std::string &text, const std::string &r,
-                                     std::function<void( npc & )> effect_success );
+                                     dialogue_fun_ptr effect_success );
+
+        /**
+         * Add a simple response that switches the topic to the new one and executes the given
+         * action. The response always succeeds. Consequence must be explicitly specified.
+         */
+        talk_response &add_response( const std::string &text, const std::string &r,
+                                     std::function<void( npc & )> effect_success,
+                                     dialogue_consequence consequence );
         /**
          * Add a simple response that switches the topic to the new one and sets the currently
          * talked about mission to the given one. The mission pointer must be valid.
@@ -385,8 +420,11 @@ static std::map<std::string, json_talk_topic> json_talk_topics;
 #define FAILURE_OPINION(T, F, V, A, O)   ret.back().failure.opinion =\
         npc_opinion(T, F, V, A, O)
 
-#define SUCCESS_ACTION(func)  ret.back().success.effect = func
-#define FAILURE_ACTION(func)  ret.back().failure.effect = func
+#define SUCCESS_ACTION(func)  ret.back().success.set_effect( func )
+#define FAILURE_ACTION(func)  ret.back().failure.set_effect( func )
+
+#define SUCCESS_ACTION_CONSEQUENCE(func, con)  ret.back().success.set_effect_consequence( func, con )
+#define FAILURE_ACTION_CONSEQUENCE(func, con)  ret.back().failure.set_effect_consequence( func, con )
 
 #define dbg(x) DebugLog((DebugLevel)(x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
 
@@ -1433,10 +1471,19 @@ talk_response &dialogue::add_response_none( const std::string &text )
 }
 
 talk_response &dialogue::add_response( const std::string &text, const std::string &r,
-                                       std::function<void( npc & )> effect_success )
+                                       dialogue_fun_ptr effect_success )
 {
     talk_response &result = add_response( text, r );
-    result.success.effect = effect_success;
+    result.success.set_effect( effect_success );
+    return result;
+}
+
+talk_response &dialogue::add_response( const std::string &text, const std::string &r,
+                                     std::function<void( npc & )> effect_success,
+                                     dialogue_consequence consequence )
+{
+    talk_response &result = add_response( text, r );
+    result.success.set_effect_consequence( effect_success, consequence );
     return result;
 }
 
@@ -1994,7 +2041,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         for( const auto &entry : entries ) {
             if( g->u.cash >= entry.cost ) {
                 add_response( entry.desc, "TALK_DONE" );
-                SUCCESS_ACTION( std::bind( buy_alcohol, entry ) );
+                SUCCESS_ACTION_CONSEQUENCE( std::bind( buy_alcohol, entry ), dialogue_consequence::none );
             }
         }
 
@@ -2185,7 +2232,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             FAILURE( "TALK_DENY_FOLLOW" );
             FAILURE_ACTION( &talk_function::deny_follow );
             FAILURE_OPINION( -1, -2, -1, 1, 0 );
-            RESPONSE( _( "!I'll kill you if you don't." ) );
+            RESPONSE( _( "I'll kill you if you don't." ) );
             TRIAL( TALK_TRIAL_INTIMIDATE, strength * 2 );
             SUCCESS( "TALK_AGREE_FOLLOW" );
             SUCCESS_ACTION( &talk_function::follow );
@@ -2370,7 +2417,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             combat_engagement eng = setting.rule;
             add_response( setting.description, "TALK_NONE", [eng]( npc & np ) {
                 np.rules.engagement = eng;
-            } );
+            }, dialogue_consequence::none );
         }
         add_response_none( _( "Never mind." ) );
 
@@ -2395,7 +2442,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             aim_rule ar = setting.rule;
             add_response( setting.description, "TALK_NONE", [ar]( npc & np ) {
                 np.rules.aim = ar;
-            } );
+            }, dialogue_consequence::none );
         }
         add_response_none( _( "Never mind." ) );
 
@@ -2430,14 +2477,14 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             FAILURE_ACTION( &talk_function::flee );
         }
         if( !p->unarmed_attack() ) {
-            RESPONSE( _( "!Drop your weapon!" ) );
+            RESPONSE( _( "Drop your weapon!" ) );
             TRIAL( TALK_TRIAL_INTIMIDATE, 30 );
             SUCCESS( "TALK_WEAPON_DROPPED" );
             SUCCESS_ACTION( &talk_function::drop_weapon );
             FAILURE( "TALK_DONE" );
             FAILURE_ACTION( &talk_function::hostile );
         }
-        RESPONSE( _( "!Get out of here or I'll kill you." ) );
+        RESPONSE( _( "Get out of here or I'll kill you." ) );
         TRIAL( TALK_TRIAL_INTIMIDATE, 20 );
         SUCCESS( "TALK_DONE" );
         SUCCESS_ACTION( &talk_function::flee );
@@ -2449,14 +2496,14 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             int chance = 30 + p->personality.bravery - 3 * p->personality.aggression +
                          2 * p->personality.altruism - 2 * p->op_of_u.fear +
                          3 * p->op_of_u.trust;
-            RESPONSE( _( "!Calm down.  I'm not going to hurt you." ) );
+            RESPONSE( _( "Calm down.  I'm not going to hurt you." ) );
             TRIAL( TALK_TRIAL_PERSUADE, chance );
             SUCCESS( "TALK_STRANGER_WARY" );
             SUCCESS_OPINION( 1, -1, 0, 0, 0 );
             SUCCESS_ACTION( &talk_function::stranger_neutral );
             FAILURE( "TALK_DONE" );
             FAILURE_ACTION( &talk_function::hostile );
-            RESPONSE( _( "!Screw you, no." ) );
+            RESPONSE( _( "Screw you, no." ) );
             TRIAL( TALK_TRIAL_INTIMIDATE, chance - 5 );
             SUCCESS( "TALK_STRANGER_SCARED" );
             SUCCESS_OPINION( -2, 1, 0, 1, 0 );
@@ -2474,14 +2521,14 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             int chance = 35 + p->personality.bravery - 3 * p->personality.aggression +
                          2 * p->personality.altruism - 2 * p->op_of_u.fear +
                          3 * p->op_of_u.trust;
-            RESPONSE( _( "!Calm down.  I'm not going to hurt you." ) );
+            RESPONSE( _( "Calm down.  I'm not going to hurt you." ) );
             TRIAL( TALK_TRIAL_PERSUADE, chance );
             SUCCESS( "TALK_STRANGER_WARY" );
             SUCCESS_OPINION( 1, -1, 0, 0, 0 );
             SUCCESS_ACTION( &talk_function::stranger_neutral );
             FAILURE( "TALK_DONE" );
             FAILURE_ACTION( &talk_function::hostile );
-            RESPONSE( _( "!Screw you, no." ) );
+            RESPONSE( _( "Screw you, no." ) );
             TRIAL( TALK_TRIAL_INTIMIDATE, chance - 5 );
             SUCCESS( "TALK_STRANGER_SCARED" );
             SUCCESS_OPINION( -2, 1, 0, 1, 0 );
@@ -3458,11 +3505,12 @@ void talk_response::do_formatting( const dialogue &d, char const letter )
     int const fold_width = FULL_SCREEN_WIDTH / 2 - 2 - 2;
     formatted_text = foldstring( ftext, fold_width );
 
-    if( text[0] == '!' ) {
+    std::set<dialogue_consequence> consequences = get_consequences( d );
+    if(  consequences.count( dialogue_consequence::hostile ) > 0 ) {
         color = c_red;
-    } else if( text[0] == '*' ) {
+    } else if( text[0] == '*' || consequences.count( dialogue_consequence::helpless ) > 0 ) {
         color = c_light_red;
-    } else if( text[0] == '&' ) {
+    } else if( text[0] == '&' || consequences.count( dialogue_consequence::action ) > 0 ) {
         color = c_green;
     } else {
         color = c_white;
@@ -3490,6 +3538,45 @@ talk_topic talk_response::effect_t::apply( dialogue &d ) const
     }
 
     return next_topic;
+}
+
+void talk_response::effect_t::set_effect_consequence( std::function<void (npc&)> fun, dialogue_consequence con )
+{
+    effect = fun;
+    guaranteed_consequence = con;
+}
+
+void talk_response::effect_t::set_effect( dialogue_fun_ptr ptr )
+{
+    effect = ptr;
+    // Kinda hacky
+    if( ptr == &talk_function::hostile ) {
+        guaranteed_consequence = dialogue_consequence::hostile;
+    } else if( ptr == &talk_function::player_weapon_drop || ptr == &talk_function::player_weapon_away || ptr == &talk_function::start_mugging ) {
+        guaranteed_consequence = dialogue_consequence::helpless;
+    } else {
+        guaranteed_consequence = dialogue_consequence::none;
+    }
+}
+
+std::set<dialogue_consequence> talk_response::get_consequences( const dialogue &d ) const
+{
+    int chance = trial.calc_chance( d );
+    if( chance >= 100 ) {
+        return {{ success.get_consequence( d ) }};
+    } else if( chance <= 0 ) {
+        return {{ failure.get_consequence( d ) }};
+    }
+
+    return {{ success.get_consequence( d ), failure.get_consequence( d ) }};
+}
+
+dialogue_consequence talk_response::effect_t::get_consequence( const dialogue &d ) const
+{
+    if( d.beta->op_of_u.anger + opinion.anger >= d.beta->hostile_anger_level() ) {
+        return dialogue_consequence::hostile;
+    }
+    return guaranteed_consequence;
 }
 
 talk_topic dialogue::opt( const talk_topic &topic )
@@ -3537,13 +3624,12 @@ talk_topic dialogue::opt( const talk_topic &topic )
             }
             ch -= 'a';
         } while( ( ch < 0 || ch >= ( int )responses.size() ) );
-        okay = false;
-        if( responses[ch].color == c_white || responses[ch].color == c_green ) {
-            okay = true;
-        } else if( responses[ch].color == c_red && query_yn( _( "You may be attacked! Proceed?" ) ) ) {
-            okay = true;
-        } else if( responses[ch].color == c_light_red && query_yn( _( "You'll be helpless! Proceed?" ) ) ) {
-            okay = true;
+        okay = true;
+        std::set<dialogue_consequence> consequences = responses[ch].get_consequences( *this );
+        if( consequences.count( dialogue_consequence::hostile ) > 0 ) {
+            okay = query_yn( _( "You may be attacked! Proceed?" ) );
+        } else if( consequences.count( dialogue_consequence::helpless ) > 0 ) {
+            okay = query_yn( _( "You'll be helpless! Proceed?" ) );
         }
     } while( !okay );
     history.push_back( "" );
@@ -4077,7 +4163,7 @@ void talk_response::effect_t::load_effect( JsonObject &jo )
         };
         const auto iter = static_functions_map.find( type );
         if( iter != static_functions_map.end() ) {
-            effect = iter->second;
+            set_effect( iter->second );
             return;
         }
         // more functions can be added here, they don't need to be in the map above.

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3563,9 +3563,9 @@ std::set<dialogue_consequence> talk_response::get_consequences( const dialogue &
 {
     int chance = trial.calc_chance( d );
     if( chance >= 100 ) {
-        return {{ success.get_consequence( d ) }};
+        return { success.get_consequence( d ) };
     } else if( chance <= 0 ) {
-        return {{ failure.get_consequence( d ) }};
+        return { failure.get_consequence( d ) };
     }
 
     return {{ success.get_consequence( d ), failure.get_consequence( d ) }};


### PR DESCRIPTION
Centralized processing of dialogue warnings such as "this action will get you attacked".
Now danger is calculated when presenting the option, at least for intimidation. Rather than being hackily encoded by prepending the action with `!`, the effect is calculated from two components:
* "Guaranteed consequence" is a hardcoded effect of the dialogue function of the option. For example, telling an angry NPC to chill and failing will make the NPC hostile.
* "Implied" consequence. Currently only due to heavy anger. A very angry NPC will go hostile. The hostility of angry NPCs not changed here. Still, can be easily tested by telling NPC "join me or I'll kill you" a bunch of times and failing each time.

Needed to make #23043 manageable. That PR will change NPC behavior when their opinion changes, so being warned that the NPC is losing temper (or looking terrified) will be very useful there.

No major functional changes.