### PR TITLE
Prevent critters from teleporting from fire

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5833,7 +5833,7 @@ void game::monmove()
         }
 
         // Critters in impassable tiles get pushed away, unless it's not impassable for them
-        if( !critter.is_dead() && g->m.impassable( critter.pos() ) && !critter.can_move_to( critter.pos() ) ) {
+        if( !critter.is_dead() && m.impassable( critter.pos() ) && !critter.can_move_to( critter.pos() ) ) {
             dbg(D_ERROR) << "game:monmove: " << critter.name().c_str()
                          << " can't move to its location! (" << critter.posx()
                          << ":" << critter.posy() << ":" << critter.posz() << "), "


### PR DESCRIPTION
Closes #11859

Critters can no longer teleport from passable tiles. They can still teleport from impassable tiles spawning on them (tiles spawning on critters can't be easily prevented with current code), but only from those.

Special case for critters which can treat some tiles as passable, even when they aren't: climbable tiles are passable for climbing monsters. Handled here by checking `can_move_to` for impassable tiles.