### PR TITLE
Fix morale effect bonus/penalty

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -1685,13 +1685,13 @@
         "name": [ "Happy", "Happy", "Happy", "Happy", "Happy",
                   "Joyful", "Joyful", "Joyful", "Joyful", "Joyful",
                   "Elated" ],
-        "max_duration": 250,
+        "max_intensity": 25,
         "int_dur_factor": 10,
         "scaling_mods": {
-            "speed_mod": [0.4],
-            "str_mod": [0.0555],
+            "speed_mod": [0.42],
+            "str_mod": [0.06],
             "dex_mod": [0.05],
-            "int_mod": [0.08],
+            "int_mod": [0.084],
             "per_mod": [0.1]
         }
     },
@@ -1704,10 +1704,10 @@
         "max_intensity": 1000,
         "int_dur_factor": 10,
         "scaling_mods": {
-            "speed_mod": [-0.4],
-            "str_mod": [-0.0555],
+            "speed_mod": [-0.42],
+            "str_mod": [-0.06],
             "dex_mod": [-0.05],
-            "int_mod": [-0.08],
+            "int_mod": [-0.084],
             "per_mod": [-0.1]
         },
         "miss_messages": [ [ "What's the point of fighting?", 1 ] ]


### PR DESCRIPTION
It was supposed to cap at +1/+1/+2/+2 for str/dex/int/per, and +10 speed, at 250 morale.
But I forgot that scaling effects of morale start at intensity 2. Adjusted effects so that the cap is properly reached.

This makes negative morale effects scale a bit more, but no one really gets to the point where it matters (-100 morale or so). We may need to extend the morale scale down some day (ie. push the "bawww, I'm too sad to boil water" threshold lower).