### PR TITLE
[RDY]Morale craft speed penalty

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -32,13 +32,13 @@
     "id": "ACT_CRAFT",
     "type": "activity_type",
     "stop_phrase": "Stop crafting?",
-    "based_on": "speed"
+    "based_on": "neither"
   },
   {
     "id": "ACT_LONGCRAFT",
     "type": "activity_type",
     "stop_phrase": "Stop crafting?",
-    "based_on": "speed"
+    "based_on": "neither"
   },
   {
     "id": "ACT_DISASSEMBLE",

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1971,9 +1971,14 @@ void activity_handlers::wait_npc_finish( player_activity *act, player *p )
 
 void activity_handlers::craft_do_turn( player_activity *act, player *p )
 {
-    float crafting_speed = p->crafting_speed_multiplier( recipe_id( act->name ).obj(), true );
+    const recipe &rec = recipe_id( act->name ).obj();
+    float crafting_speed = p->crafting_speed_multiplier( rec, true );
     if( crafting_speed <= 0.0f ) {
-        p->add_msg_if_player( m_bad, _( "You are too frustrated to continue and just give up." ) );
+        if( p->lighting_craft_speed_multiplier( rec ) <= 0.0f ) {
+            p->add_msg_if_player( m_bad, _( "You can no longer see well enough to keep crafting." ) );
+        } else {
+            p->add_msg_if_player( m_bad, _( "You are too frustrated to continue and just give up." ) );
+        }
         act->set_to_null();
         return;
     }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -50,6 +50,8 @@ using namespace activity_handlers;
 const std::map< activity_id, std::function<void( player_activity *, player *)> > activity_handlers::do_turn_functions =
 {
     { activity_id( "ACT_BURROW" ), burrow_do_turn },
+    { activity_id( "ACT_CRAFT" ), craft_do_turn },
+    { activity_id( "ACT_LONGCRAFT" ), craft_do_turn },
     { activity_id( "ACT_FILL_LIQUID" ), fill_liquid_do_turn },
     { activity_id( "ACT_PICKAXE" ), pickaxe_do_turn },
     { activity_id( "ACT_DROP" ), drop_do_turn },
@@ -1965,6 +1967,22 @@ void activity_handlers::wait_npc_finish( player_activity *act, player *p )
 {
     p->add_msg_if_player( _( "%s finishes with you..." ), act->str_values[0].c_str() );
     act->set_to_null();
+}
+
+void activity_handlers::craft_do_turn( player_activity *act, player *p )
+{
+    float crafting_speed = p->crafting_speed_multiplier( recipe_id( act->name ).obj(), true );
+    if( crafting_speed <= 0.0f ) {
+        p->add_msg_if_player( m_bad, _( "You are too frustrated to continue and just give up." ) );
+        act->set_to_null();
+        return;
+    }
+    act->moves_left -= crafting_speed * p->get_moves();
+    p->set_moves( 0 );
+    if( calendar::once_every( 1_hours ) && crafting_speed < 0.75f ) {
+        // @todo Describe the causes of slowdown
+        p->add_msg_if_player( m_bad, _( "You can't focus and are working slowly." ) );
+    }
 }
 
 void activity_handlers::craft_finish( player_activity *act, player *p )

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -26,6 +26,7 @@ namespace activity_handlers
 
 /** activity_do_turn functions: */
 void burrow_do_turn( player_activity *act, player *p );
+void craft_do_turn( player_activity *act, player *p );
 void fill_liquid_do_turn( player_activity *act, player *p );
 void pickaxe_do_turn( player_activity *act, player *p );
 void drop_do_turn( player_activity *act, player *p );

--- a/src/character.h
+++ b/src/character.h
@@ -30,6 +30,7 @@ struct mutation_branch;
 class bionic_collection;
 struct bionic_data;
 using bionic_id = string_id<bionic_data>;
+class recipe;
 
 enum vision_modes {
     DEBUG_NIGHTVISION,

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -81,7 +81,7 @@ void craft_command::execute()
     }
 
     auto type = activity_id( is_long ? "ACT_LONGCRAFT" : "ACT_CRAFT" );
-    auto activity = player_activity( type, crafter->time_to_craft( *rec, batch_size ), -1, INT_MIN,
+    auto activity = player_activity( type, crafter->base_time_to_craft( *rec, batch_size ), -1, INT_MIN,
                                      rec->ident().str() );
     activity.values.push_back( batch_size );
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -483,10 +483,9 @@ const recipe *select_crafting_recipe( int &batch_size )
                                g->u.get_skill_level( current[line]->skill_used ) );
                 }
 
-                const int turns = g->u.time_to_craft( *current[line], count ) / MOVES( 1 );
-                const std::string text = string_format( _( "Time to complete: %s" ),
-                                                        to_string( time_duration::from_turns( turns ) ) );
-                ypos += fold_and_print( w_data, ypos, xpos, pane, col, text );
+                const int expected_turns = g->u.expected_time_to_craft( *current[line], count ) / MOVES( 1 );
+                ypos += fold_and_print( w_data, ypos, xpos, pane, col, _( "Time to complete: %s" ),
+                                        to_string( time_duration::from_turns( expected_turns ) ) );
 
                 mvwprintz( w_data, ypos++, xpos, col, _( "Dark craftable? %s" ),
                            current[line]->has_flag( "BLIND_EASY" ) ? _( "Easy" ) :

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -648,13 +648,14 @@ static void draw_can_craft_indicator( const catacurses::window &w, const int mar
     right_print( w, margin_y + 1, 1, c_black, "        " );
     // Draw text
     right_print( w, margin_y, 1, c_light_gray, _( "can craft:" ) );
-    if( g->u.lighting_craft_speed_multiplier( rec ) == 0.0f ) {
+    if( g->u.lighting_craft_speed_multiplier( rec ) <= 0.0f ) {
         right_print( w, margin_y + 1, 1, i_red, _( "too dark" ) );
-    } else if( !g->u.has_morale_to_craft() ) {
+    } else if( g->u.crafting_speed_multiplier( rec ) <= 0.0f ) {
+        // Technically not always only too sad, but must be too sad
         right_print( w, margin_y + 1, 1, i_red, _( "too sad" ) );
-    } else if( g->u.lighting_craft_speed_multiplier( rec ) < 1.0f ) {
+    } else if( g->u.crafting_speed_multiplier( rec ) < 1.0f ) {
         right_print( w, margin_y + 1, 1, i_yellow, string_format( _( "slow %d%%" ),
-                     int( g->u.lighting_craft_speed_multiplier( rec ) * 100 ) ) );
+                     int( g->u.crafting_speed_multiplier( rec ) * 100 ) ) );
     } else {
         right_print( w, margin_y + 1, 1, i_green, _( "yes" ) );
     }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1068,6 +1068,10 @@ int Creature::get_perceived_pain() const
     return get_pain();
 }
 
+int Creature::get_moves() const
+{
+    return moves;
+}
 void Creature::mod_moves(int nmoves)
 {
     moves += nmoves;

--- a/src/creature.h
+++ b/src/creature.h
@@ -356,8 +356,9 @@ class Creature
         virtual int get_pain() const;
         virtual int get_perceived_pain() const;
 
-        virtual void mod_moves( int nmoves );
-        virtual void set_moves( int nmoves );
+        int get_moves() const;
+        void mod_moves( int nmoves );
+        void set_moves( int nmoves );
 
         virtual bool in_sleep_state() const;
 

--- a/src/player.h
+++ b/src/player.h
@@ -1235,7 +1235,14 @@ class player : public Character
         float morale_crafting_speed_multiplier( const recipe & rec ) const;
         float lighting_craft_speed_multiplier( const recipe & rec ) const;
         float crafting_speed_multiplier( const recipe &rec, bool in_progress = false ) const;
-        int time_to_craft( const recipe &rec, int batch_size = 1 );
+        /**
+         * Time to craft not including speed multiplier
+         */
+        int base_time_to_craft( const recipe &rec, int batch_size = 1 ) const;
+        /**
+         * Expected time to craft a recipe, with assumption that multipliers stay constant.
+         */
+        int expected_time_to_craft( const recipe &rec, int batch_size = 1 ) const;
         std::vector<const item *> get_eligible_containers_for_crafting() const;
         bool check_eligible_containers_for_crafting( const recipe &rec, int batch_size = 1 ) const;
         bool has_morale_to_craft() const;

--- a/src/player.h
+++ b/src/player.h
@@ -1232,7 +1232,9 @@ class player : public Character
                                                        const recipe *r ) const;
 
         // crafting.cpp
+        float morale_crafting_speed_multiplier( const recipe & rec ) const;
         float lighting_craft_speed_multiplier( const recipe & rec ) const;
+        float crafting_speed_multiplier( const recipe &rec, bool in_progress = false ) const;
         int time_to_craft( const recipe &rec, int batch_size = 1 );
         std::vector<const item *> get_eligible_containers_for_crafting() const;
         bool check_eligible_containers_for_crafting( const recipe &rec, int batch_size = 1 ) const;


### PR DESCRIPTION
Currently there is no craft speed penalty for low morale, only a stonewall at -50 morale.
Changed to craft speed penalty for low morale.

The formula is as follows:
* If morale is not negative, no penalty
* For every skill requirement for a given recipe:
* * If crafter's skill is at least 2 times the requirement, no change
* * Otherwise multiply effective morale by `2 * requirement / crafter_skill`
* Divide crafting speed by `1.0f + ( -effective_morale / 50.0f )`
* If crafting speed is below 33%, you can't start a craft
* If crafting speed is below 20%, you stop current craft

The crafting speed is recalculated every single turn. This crafting speed also includes light penalty.
Important note: this change also means that losing light during crafting will now stop the activity!

The intentions are:
* Easy jobs (boiling water) will not be penalized noticeably
* Experts will have no problems with things trivial for them (ie. `skill > 2 * requirement`)
* Crafts that would increase skills are penalized the most
* You need non-negative (or at least only weakly negative) morale to effectively craft hard things

[CR] because both the formula and the intentions may be wrong.
Performance isn't perfect (it could be cached), but this shouldn't be costly enough to be noticeable, not even when repeated every single turn.

[WiP] because at the moment the penalty is applied twice - once for job length (at start of activity), once during crafting.