### PR TITLE
[CR] Using items and Reading books wields instead of pickup

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10560,16 +10560,27 @@ void game::wield()
     }
 }
 
-void game::read()
-{
-    // Can read items from inventory or within one tile (including in vehicles)
-    auto loc = game_menus::inv::read( u );
 
-    if( loc ) {
-        u.read( loc.obtain( u ) );
-    } else {
-        add_msg( _( "Never mind." ) );
+void game::read() {
+    // Can read items from inventory or within one tile (including in vehicles)
+    auto loc = game_menus::inv::read(u);
+
+    if (!loc) {
+        add_msg(_("Never mind."));
+        return;
     }
+
+    auto item = loc.get_item();
+    int pos;
+
+    if (u.has_item(*loc)) {
+        pos = u.get_item_position(item);
+
+    } else {
+        wield(loc);
+        pos = -1;
+    }
+    u.read(pos);
 }
 
 void game::chat()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6601,10 +6601,18 @@ void game::use_item( int pos )
             add_msg( _( "Never mind." ) );
             return;
         }
-        int obtain_cost = loc.obtain_cost( u );
-        pos = loc.obtain( u );
-        // This method only handles items in te inventory, so refund the obtain cost.
-        u.moves += obtain_cost;
+
+        auto item = loc.get_item();
+
+        if(u.has_item(*loc))
+        {
+            pos = u.get_item_position(item);
+
+        } else{
+            wield(loc);
+            pos = -1;
+        }
+
     }
 
     refresh_all();

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -510,8 +510,15 @@ class activatable_inventory_preset : public pickup_inventory_preset
                                      "Needs at least %d charges", loc->ammo_required() ),
                            loc->ammo_required() );
             }
+            if( !p.has_item( *loc ) ) {
 
-            return pickup_inventory_preset::get_denial( loc );
+                const auto ret = p.can_wield( *loc );
+
+                if( !ret.success() ) {
+                    return trim_punctuation_marks( ret.str() );
+                }
+            }
+            return std::string();
         }
 
     protected:

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -686,7 +686,16 @@ class read_inventory_preset: public pickup_inventory_preset
             if( p.get_book_reader( *loc, denials ) == nullptr && !denials.empty() ) {
                 return denials.front();
             }
-            return pickup_inventory_preset::get_denial( loc );
+
+            if( !p.has_item( *loc ) ) {
+
+                const auto ret = p.can_wield( *loc );
+
+                if( !ret.success() ) {
+                    return trim_punctuation_marks( ret.str() );
+                }
+            }
+            return std::string();
         }
 
     private:


### PR DESCRIPTION
My take on fixing #23957 .

`a`ctivating items and `R`eading books make the player wield the item or book instead of picking it up.

This only happen if the item/book isn't in the player inventory yet.

If the player already wields something, they will be asked what they want to do with their current 'weapon'.