### PR TITLE
Removed comma to fix professions.json

### DIFF
--- a/data/mods/Medieval_Stuff/professions.json
+++ b/data/mods/Medieval_Stuff/professions.json
@@ -32,7 +32,7 @@
                     "shield_wooden_large",
                     "waterskin",
                     "khopesh"
-                ],
+                ]
             },
             "male": [
                 "sleeveless_tunic"


### PR DESCRIPTION
#### Summary
```SUMMARY: Bugfixes "Removed comma to fix professions.json"```

#### Purpose of change
Fixes #27408
cdda failed to run due to invalid json
#### Describe the solution
fix json
#### Describe alternatives you've considered
none
#### Additional context
none