### PR TITLE
Recipe to make t-shirt from long-sleeved shirt.

### DIFF
--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -1015,6 +1015,18 @@
     "components": [ [ [ "rag", 5 ] ] ]
   },
   {
+    "result": "tshirt",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "time": 2000,
+    "autolearn": true,
+    "byproducts": [ [ "rag", 2 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "longshirt", 1 ] ] ]
+  },
+  {
     "result": "tunic",
     "type": "recipe",
     "category": "CC_ARMOR",


### PR DESCRIPTION
#### Summary
`SUMMARY: Content "added recipe for long-sleeved shirt to t-shirt"`

#### Purpose of change
It seems rather odd that survivors don't know how to cut off some sleeves from a long-sleeved shirt to make a t-shirt, especially when they know how to do so for leather jackets to leather vests.

#### Describe the solution
Adds a recipe for t-shirts that is mostly just copy-pasting the leather jacket to leather vests recipe and switching some words and numbers around.

#### Describe alternatives you've considered
Not adding the recipe in at all, since it's rather unimportant anyway.

#### Additional context
N/A
