### PR TITLE
Change all instances of 'volume' in JSONs to be a metric string II: The Empre Strikes Back

### DIFF
--- a/data/json/items/armor/backpacks.json
+++ b/data/json/items/armor/backpacks.json
@@ -198,7 +198,7 @@
     "encumbrance": 30,
     "warmth": 5,
     "material_thickness": 2,
-    "container_data": { "contains": 40, "seals": true, "watertight": true },
+    "container_data": { "contains": "10 L", "seals": true, "watertight": true },
     "flags": [ "OVERSIZE", "BELTED", "WATER_FRIENDLY" ]
   },
   {

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -422,7 +422,7 @@
     "description": "Stiff leather boots with intricate embroidery and one-inch heels.  They look good, but aren't made for running.  Each boot is large enough to conceal a small holdout pistol.",
     "coverage": 95,
     "proportional": { "weight": 1.2, "volume": 1.2, "price": 2, "encumbrance": 2 },
-    "use_action": { "type": "holster", "max_volume": 1, "max_weight": 600, "draw_cost": 80, "multi": 2, "skills": [ "pistol" ] },
+    "use_action": { "type": "holster", "max_volume": "250 ml", "max_weight": 600, "draw_cost": 80, "multi": 2, "skills": [ "pistol" ] },
     "extend": { "flags": [ "FANCY" ] }
   },
   {

--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -14,7 +14,7 @@
     "coverage": 5,
     "encumbrance": 5,
     "material_thickness": 1,
-    "use_action": { "type": "holster", "max_volume": 15, "draw_cost": 150, "skills": [ "smg", "shotgun", "rifle", "launcher" ] },
+    "use_action": { "type": "holster", "max_volume": "3750 ml", "draw_cost": 150, "skills": [ "smg", "shotgun", "rifle", "launcher" ] },
     "flags": [ "BELTED", "OVERSIZE", "NO_QUICKDRAW" ]
   },
   {
@@ -33,7 +33,14 @@
     "encumbrance": 4,
     "material_thickness": 1,
     "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ],
-    "use_action": { "type": "holster", "max_volume": 2, "min_volume": 0, "max_weight": 1000, "draw_cost": 150, "skills": [ "pistol" ] }
+    "use_action": {
+      "type": "holster",
+      "max_volume": "500 ml",
+      "min_volume": 0,
+      "max_weight": 1000,
+      "draw_cost": 150,
+      "skills": [ "pistol" ]
+    }
   },
   {
     "id": "bow_sling",
@@ -52,7 +59,7 @@
     "encumbrance": 7,
     "material_thickness": 1,
     "flags": [ "OVERSIZE", "WAIST" ],
-    "use_action": { "type": "holster", "max_volume": 20, "min_volume": 2, "skills": [ "archery" ] }
+    "use_action": { "type": "holster", "max_volume": "5 L", "min_volume": "500 ml", "skills": [ "archery" ] }
   },
   {
     "id": "holster",
@@ -69,7 +76,7 @@
     "coverage": 5,
     "encumbrance": 5,
     "material_thickness": 1,
-    "use_action": { "type": "holster", "max_volume": 5, "min_volume": 2, "skills": [ "pistol", "smg", "shotgun" ] },
+    "use_action": { "type": "holster", "max_volume": "1250 ml", "min_volume": "500 ml", "skills": [ "pistol", "smg", "shotgun" ] },
     "flags": [ "WAIST", "OVERSIZE" ]
   },
   {
@@ -79,7 +86,7 @@
     "name": "fast draw holster",
     "description": "A comfortable quick draw holster for small guns.  Activate to holster/draw a gun.",
     "encumbrance": 2,
-    "use_action": { "type": "holster", "max_volume": 4, "draw_cost": 80, "skills": [ "pistol", "shotgun" ] }
+    "use_action": { "type": "holster", "max_volume": "1 L", "draw_cost": 80, "skills": [ "pistol", "shotgun" ] }
   },
   {
     "id": "bholster",
@@ -93,7 +100,14 @@
     "material": "plastic",
     "covers": [ "LEGS" ],
     "encumbrance": 1,
-    "use_action": { "type": "holster", "max_volume": 2, "min_volume": 0, "max_weight": 1000, "draw_cost": 210, "skills": [ "pistol" ] },
+    "use_action": {
+      "type": "holster",
+      "max_volume": "500 ml",
+      "min_volume": 0,
+      "max_weight": 1000,
+      "draw_cost": 210,
+      "skills": [ "pistol" ]
+    },
     "flags": [ "SKINTIGHT", "WATER_FRIENDLY" ]
   },
   {
@@ -113,7 +127,7 @@
     "encumbrance": 2,
     "storage": "3 L",
     "material_thickness": 2,
-    "use_action": { "type": "holster", "max_volume": 15, "min_volume": 5, "skills": [ "smg", "shotgun", "rifle" ] },
+    "use_action": { "type": "holster", "max_volume": "3750 ml", "min_volume": "1250 ml", "skills": [ "smg", "shotgun", "rifle" ] },
     "flags": [ "WATER_FRIENDLY", "STURDY", "WAIST" ]
   },
   {
@@ -132,7 +146,7 @@
     "coverage": 10,
     "encumbrance": 2,
     "material_thickness": 1,
-    "use_action": { "type": "holster", "min_volume": 5, "max_volume": 8, "skills": [ "pistol", "smg", "shotgun", "rifle" ] },
+    "use_action": { "type": "holster", "min_volume": "1250 ml", "max_volume": "2 L", "skills": [ "pistol", "smg", "shotgun", "rifle" ] },
     "flags": [ "WAIST", "OVERSIZE" ]
   }
 ]

--- a/data/json/items/comestibles/irradiated_veggy.json
+++ b/data/json/items/comestibles/irradiated_veggy.json
@@ -120,7 +120,7 @@
     "price": 320,
     "material": "veggy",
     "flags": [ "FREEZERBURN", "SMOKABLE" ],
-    "volume": 1
+    "volume": "250 ml"
   },
   {
     "type": "COMESTIBLE",
@@ -136,7 +136,7 @@
     "description": "An irradiated cluster of celery will remain edible nearly forever.  Sterilized using radiation, so it's safe to eat.",
     "price": 220,
     "material": "veggy",
-    "volume": 1
+    "volume": "250 ml"
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/nuts.json
+++ b/data/json/items/comestibles/nuts.json
@@ -425,7 +425,7 @@
     "comestible_type": "FOOD",
     "symbol": "%",
     "quench": -5,
-    "//": "most acorns contain various amount of tannins, which can make you fairly sick.  it also tastes pretty bad.",
+    "//": "no vitamins here",
     "healthy": -5,
     "calories": 114,
     "description": "A handful of acorns, still in their shells.  Squirrels like them, but they're not very good for you to eat in this state.",
@@ -434,7 +434,6 @@
     "volume": "250 ml",
     "flags": [ "EDIBLE_FROZEN", "NUTRIENT_OVERRIDE" ],
     "charges": 4,
-    "//": "no vitamins here",
     "fun": -20
   },
   {
@@ -465,6 +464,6 @@
     "price": 90,
     "material": "nut",
     "vitamins": [ [ "calcium", 4 ], [ "iron", 4 ] ],
-    "volume": 1
+    "volume": "250 ml"
   }
 ]

--- a/data/json/items/comestibles/nuts.json
+++ b/data/json/items/comestibles/nuts.json
@@ -425,7 +425,7 @@
     "comestible_type": "FOOD",
     "symbol": "%",
     "quench": -5,
-    "//": "no vitamins here",
+    "//": "most acorns contain various amount of tannins, which can make you fairly sick.  it also tastes pretty bad.",
     "healthy": -5,
     "calories": 114,
     "description": "A handful of acorns, still in their shells.  Squirrels like them, but they're not very good for you to eat in this state.",
@@ -434,6 +434,7 @@
     "volume": "250 ml",
     "flags": [ "EDIBLE_FROZEN", "NUTRIENT_OVERRIDE" ],
     "charges": 4,
+    "//2": "no vitamins here",
     "fun": -20
   },
   {

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -12,7 +12,7 @@
     "calories": 1000,
     "description": "Not very nutritious.  Warning: contains calories, unsuitable for breatharians.",
     "price": 100,
-    "volume": 1
+    "volume": "250 ml"
   },
   {
     "type": "COMESTIBLE",
@@ -640,7 +640,7 @@
     "price": 0,
     "material": "veggy",
     "flags": "TRADER_AVOID",
-    "volume": 1
+    "volume": "250 ml"
   },
   {
     "type": "COMESTIBLE",
@@ -657,7 +657,7 @@
     "price": 0,
     "material": "veggy",
     "flags": "TRADER_AVOID",
-    "volume": 1
+    "volume": "250 ml"
   },
   {
     "type": "COMESTIBLE",
@@ -673,6 +673,6 @@
     "description": "Some nectar.  Seeing this item is a bug.",
     "price": 0,
     "flags": "TRADER_AVOID",
-    "volume": 1
+    "volume": "250 ml"
   }
 ]

--- a/data/json/items/containers.json
+++ b/data/json/items/containers.json
@@ -266,7 +266,7 @@
     "material": "paper",
     "symbol": ")",
     "color": "white",
-    "contains": 1
+    "contains": "250 ml"
   },
   {
     "id": "box_small",
@@ -281,7 +281,7 @@
     "material": "paper",
     "symbol": ")",
     "color": "brown",
-    "contains": 4
+    "contains": "1 L"
   },
   {
     "id": "box_medium",
@@ -297,7 +297,7 @@
     "material": "paper",
     "symbol": ")",
     "color": "brown",
-    "contains": 12
+    "contains": "3 L"
   },
   {
     "id": "box_large",
@@ -350,7 +350,7 @@
     "contains": "2 L",
     "seals": true,
     "watertight": true,
-    "armor_data": { "covers": [ "TORSO" ], "coverage": 15, "storage": 4, "material_thickness": 1 },
+    "armor_data": { "covers": [ "TORSO" ], "coverage": 15, "storage": "1 L", "material_thickness": 1 },
     "flags": [ "BELTED" ]
   },
   {

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -205,7 +205,7 @@
     "material": [ "nomex" ],
     "flags": [ "NO_SALVAGE" ],
     "weight": 42,
-    "volume": 1
+    "volume": "250 ml"
   },
   {
     "type": "GENERIC",
@@ -696,7 +696,7 @@
     "price_postapoc": 100,
     "material": "iron",
     "weight": 3220,
-    "volume": 3
+    "volume": "750 ml"
   },
   {
     "type": "GENERIC",
@@ -710,7 +710,7 @@
     "price_postapoc": 500,
     "material": "steel",
     "weight": 8440,
-    "volume": 20
+    "volume": "5 L"
   },
   {
     "type": "GENERIC",
@@ -770,7 +770,7 @@
     "price_postapoc": 100,
     "material": "iron",
     "weight": 226,
-    "volume": 1
+    "volume": "250 ml"
   },
   {
     "type": "GENERIC",
@@ -784,7 +784,7 @@
     "price_postapoc": 100,
     "material": "iron",
     "weight": 226,
-    "volume": 1
+    "volume": "250 ml"
   },
   {
     "type": "GENERIC",
@@ -824,7 +824,7 @@
     "price": 1000,
     "material": [ "aluminum", "plastic" ],
     "weight": 725,
-    "volume": 3
+    "volume": "750 ml"
   },
   {
     "type": "GENERIC",
@@ -836,7 +836,7 @@
     "price": 1000,
     "material": [ "steel", "plastic" ],
     "weight": 11339,
-    "volume": 12
+    "volume": "3 L"
   },
   {
     "type": "GENERIC",
@@ -1450,7 +1450,7 @@
     "price": 1000,
     "material": [ "steel", "plastic" ],
     "weight": 110,
-    "volume": 1
+    "volume": "250 ml"
   },
   {
     "type": "GENERIC",
@@ -1506,7 +1506,7 @@
     "price_postapoc": 100,
     "material": [ "aluminum", "plastic" ],
     "weight": 2857,
-    "volume": 4
+    "volume": "1 L"
   },
   {
     "type": "GENERIC",
@@ -1547,7 +1547,7 @@
     "material": "cotton",
     "flags": [ "NO_SALVAGE", "TRADER_AVOID" ],
     "weight": 80,
-    "volume": 1
+    "volume": "250 ml"
   },
   {
     "id": "pipe_cleaner",
@@ -1589,7 +1589,7 @@
     "price_postapoc": 0,
     "material": "steel",
     "weight": 50,
-    "volume": 1
+    "volume": "250 ml"
   },
   {
     "id": "l_HFPack",
@@ -2372,7 +2372,7 @@
     "price": 100,
     "material": [ "paper" ],
     "weight": 80,
-    "volume": 2
+    "volume": "500 ml"
   },
   {
     "type": "GENERIC",
@@ -2564,7 +2564,7 @@
     "price": 2000,
     "material": "veggy",
     "weight": 420,
-    "volume": 4
+    "volume": "1 L"
   },
   {
     "type": "GENERIC",
@@ -2578,7 +2578,7 @@
     "price": 300,
     "material": "veggy",
     "weight": 100,
-    "volume": 1
+    "volume": "250 ml"
   },
   {
     "id": "cash_card",
@@ -2985,7 +2985,7 @@
     "price_postapoc": 2000,
     "material": [ "steel", "plastic", "wood" ],
     "weight": 11339,
-    "volume": 12
+    "volume": "3 L"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/generic/casing.json
+++ b/data/json/items/generic/casing.json
@@ -330,7 +330,7 @@
     "description": "An empty steel tube which once contained a 152mm ATGM.  Now it's essentially just a huge pipe.",
     "material": "steel",
     "weight": 9500,
-    "volume": 30
+    "volume": "7500 ml"
   },
   {
     "id": "shot_hull",

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -139,7 +139,7 @@
     "symbol": ")",
     "description": "A perfectly ordinary ceramic soup bowl.",
     "copy-from": "base_ceramic_dish",
-    "container_data": { "contains": 2, "watertight": true },
+    "container_data": { "contains": "500 ml", "watertight": true },
     "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
   },
   {
@@ -151,7 +151,7 @@
     "description": "A light ceramic teacup.  Quite classy.",
     "copy-from": "base_ceramic_dish",
     "proportional": { "weight": 0.6 },
-    "container_data": { "contains": 1, "watertight": true },
+    "container_data": { "contains": "250 ml", "watertight": true },
     "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
   },
   {
@@ -163,7 +163,7 @@
     "description": "A ceramic coffee cup with a logo on the side.",
     "copy-from": "base_ceramic_dish",
     "proportional": { "weight": 0.8 },
-    "container_data": { "contains": 1, "watertight": true },
+    "container_data": { "contains": "250 ml", "watertight": true },
     "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
     "snippet_category": [
       { "id": "mug1", "text": "The side of the mug reads 'World's Greatest Dad'." },
@@ -211,7 +211,7 @@
     "looks_like": "ceramic_cup",
     "proportional": { "weight": 0.8 },
     "copy-from": "base_tin_dish",
-    "container_data": { "contains": 1, "watertight": true },
+    "container_data": { "contains": "250 ml", "watertight": true },
     "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
   },
   {
@@ -222,7 +222,7 @@
     "description": "A small pewter serving bowl without a lid.  Holds 250 ml of liquid.",
     "copy-from": "base_tin_dish",
     "symbol": "u",
-    "container_data": { "contains": 1, "watertight": true },
+    "container_data": { "contains": "250 ml", "watertight": true },
     "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
   },
   {
@@ -245,7 +245,7 @@
     "symbol": "U",
     "description": "A tall drinking glass.",
     "copy-from": "base_glass_dish",
-    "container_data": { "contains": 2, "watertight": true },
+    "container_data": { "contains": "500 ml", "watertight": true },
     "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ]
   },
   {
@@ -258,7 +258,7 @@
     "symbol": "Y",
     "description": "A stemmed drinking glass that makes you feel very fancy when you drink from it.",
     "copy-from": "base_glass_dish",
-    "container_data": { "contains": 1, "watertight": true },
+    "container_data": { "contains": "250 ml", "watertight": true },
     "qualities": [ [ "CONTAIN", 1 ] ]
   },
   {
@@ -269,7 +269,7 @@
     "symbol": "u",
     "description": "A glass bowl for soup or dessert.",
     "copy-from": "base_glass_dish",
-    "container_data": { "contains": 2, "watertight": true },
+    "container_data": { "contains": "500 ml", "watertight": true },
     "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ]
   },
   {
@@ -290,7 +290,7 @@
     "symbol": "U",
     "description": "A durable plastic drinking vessel.  This one is made of clear acrylic and looks almost like glass.",
     "copy-from": "base_plastic_dish",
-    "container_data": { "contains": 2, "watertight": true },
+    "container_data": { "contains": "500 ml", "watertight": true },
     "qualities": [ [ "CONTAIN", 1 ] ]
   },
   {
@@ -302,7 +302,7 @@
     "description": "A plastic bowl with a convenient sealing lid.  Holds 750 ml of liquid.",
     "copy-from": "base_plastic_dish",
     "volume": "750 ml",
-    "container_data": { "contains": 3, "seals": true, "watertight": true },
+    "container_data": { "contains": "750 ml", "seals": true, "watertight": true },
     "qualities": [ [ "CONTAIN", 1 ] ]
   },
   {
@@ -314,7 +314,7 @@
     "proportional": { "weight": 0.6, "volume": 0.5 },
     "description": "A plastic bowl designed for use by children.",
     "copy-from": "base_plastic_dish",
-    "container_data": { "contains": 1, "watertight": true },
+    "container_data": { "contains": "250 ml", "watertight": true },
     "qualities": [ [ "CONTAIN", 1 ] ],
     "snippet_category": [
       { "id": "kbowl1", "text": "This bowl is decorated with cartoon bears." },
@@ -624,7 +624,7 @@
     "weight": 550,
     "volume": "2 L",
     "bashing": 6,
-    "container_data": { "contains": 8, "watertight": true }
+    "container_data": { "contains": "2 L", "watertight": true }
   },
   {
     "type": "GENERIC",
@@ -638,7 +638,7 @@
     "weight": 3000,
     "volume": "2 L",
     "bashing": 10,
-    "container_data": { "contains": 8, "watertight": true }
+    "container_data": { "contains": "2 L", "watertight": true }
   },
   {
     "type": "GENERIC",
@@ -652,7 +652,7 @@
     "weight": 750,
     "volume": "2 L",
     "bashing": 6,
-    "container_data": { "contains": 8, "watertight": true }
+    "container_data": { "contains": "2 L", "watertight": true }
   },
   {
     "type": "GENERIC",
@@ -666,7 +666,7 @@
     "weight": 650,
     "volume": "2 L",
     "bashing": 4,
-    "container_data": { "contains": 8, "watertight": true }
+    "container_data": { "contains": "2 L", "watertight": true }
   },
   {
     "type": "GENERIC",
@@ -681,7 +681,7 @@
     "volume": "9 L",
     "//": "Volume assumes you can stick some stuff in the pot inside your bag",
     "bashing": 8,
-    "container_data": { "contains": 48, "watertight": true }
+    "container_data": { "contains": "12 L", "watertight": true }
   },
   {
     "id": "pot_canning",
@@ -697,7 +697,7 @@
     "material": "steel",
     "symbol": ")",
     "color": "dark_gray",
-    "container_data": { "contains": 100, "watertight": true },
+    "container_data": { "contains": "25 L", "watertight": true },
     "qualities": [ [ "COOK", 3 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "CHEM", 1 ] ],
     "use_action": "HEAT_FOOD"
   },
@@ -714,7 +714,7 @@
     "weight": 2628,
     "volume": "1 L",
     "bashing": 12,
-    "container_data": { "contains": 4, "watertight": true },
+    "container_data": { "contains": "1 L", "watertight": true },
     "delete": { "qualities": [ [ "COOK", 3 ] ] },
     "extend": { "qualities": [ [ "HAMMER", 1 ], [ "COOK", 2 ] ] }
   },
@@ -731,7 +731,7 @@
     "weight": 528,
     "volume": "1 L",
     "bashing": 8,
-    "container_data": { "contains": 8, "watertight": true },
+    "container_data": { "contains": "2 L", "watertight": true },
     "delete": { "qualities": [ [ "COOK", 3 ] ] },
     "extend": { "qualities": [ [ "COOK", 2 ] ] }
   },
@@ -748,7 +748,7 @@
     "weight": 628,
     "volume": "1 L",
     "bashing": 7,
-    "container_data": { "contains": 4, "watertight": true },
+    "container_data": { "contains": "1 L", "watertight": true },
     "delete": { "qualities": [ [ "COOK", 3 ] ] },
     "extend": { "qualities": [ [ "COOK", 2 ] ] }
   },
@@ -767,7 +767,7 @@
     "material": "steel",
     "symbol": ")",
     "color": "light_gray",
-    "container_data": { "contains": 4, "watertight": true },
+    "container_data": { "contains": "1 L", "watertight": true },
     "qualities": [ [ "COOK", 2 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
     "use_action": "HEAT_FOOD"
   },
@@ -786,7 +786,7 @@
     "material": "copper",
     "symbol": ")",
     "color": "light_red",
-    "container_data": { "contains": 4, "watertight": true },
+    "container_data": { "contains": "1 L", "watertight": true },
     "qualities": [ [ "COOK", 2 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
     "use_action": "HEAT_FOOD"
   },
@@ -802,7 +802,7 @@
     "weight": 728,
     "volume": "1500 ml",
     "bashing": 5,
-    "container_data": { "contains": 6, "watertight": true },
+    "container_data": { "contains": "1500 ml", "watertight": true },
     "delete": { "qualities": [ [ "COOK", 3 ] ] }
   },
   {

--- a/data/json/items/tools.json
+++ b/data/json/items/tools.json
@@ -1291,7 +1291,7 @@
     "material": "clay",
     "symbol": ")",
     "color": "brown",
-    "container_data": { "contains": 8, "watertight": true },
+    "container_data": { "contains": "2 L", "watertight": true },
     "qualities": [ [ "COOK", 3 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "CHEM", 1 ] ],
     "use_action": "HEAT_FOOD",
     "flags": [ "ALLOWS_REMOTE_USE" ]
@@ -1323,7 +1323,7 @@
     "material": "clay",
     "symbol": ")",
     "color": "brown",
-    "container_data": { "contains": 3, "watertight": true },
+    "container_data": { "contains": "750 ml", "watertight": true },
     "qualities": [ [ "BOIL", 1 ] ]
   },
   {
@@ -4989,7 +4989,7 @@
     "material": "stone",
     "symbol": ";",
     "color": "dark_gray",
-    "container_data": { "contains": 6, "watertight": true },
+    "container_data": { "contains": "1500 ml", "watertight": true },
     "qualities": [ [ "COOK", 2 ], [ "BOIL", 1 ], [ "CONTAIN", 1 ] ],
     "use_action": "HEAT_FOOD",
     "flags": [ "ALLOWS_REMOTE_USE" ]
@@ -5857,7 +5857,7 @@
     "material": "steel",
     "symbol": ")",
     "color": "dark_gray",
-    "container_data": { "contains": 2, "watertight": true },
+    "container_data": { "contains": "500 ml", "watertight": true },
     "qualities": [ [ "BOIL", 1 ] ]
   },
   {
@@ -6224,7 +6224,7 @@
     "symbol": "*",
     "color": "red",
     "explode_in_fire": true,
-    "explosion": { "power": 250, "shrapnel": { "casing_mass": 2500, "fragment_mass": 2.0, "drop": "scrap", "recovery": 20 } },
+    "explosion": { "power": 250, "shrapnel": { "casing_mass": 2500, "fragment_mass": 2, "drop": "scrap", "recovery": 20 } },
     "use_action": {
       "target": "tool_black_powder_charge_act",
       "msg": "You light the fuse on the black gunpowder charge.  Get rid of it quickly!",
@@ -6252,13 +6252,13 @@
     "max_charges": 20,
     "turns_per_charge": 1,
     "explode_in_fire": true,
-    "explosion": { "power": 250, "shrapnel": { "casing_mass": 2500, "fragment_mass": 2.0, "drop": "scrap", "recovery": 20 } },
+    "explosion": { "power": 250, "shrapnel": { "casing_mass": 2500, "fragment_mass": 2, "drop": "scrap", "recovery": 20 } },
     "use_action": {
       "type": "explosion",
       "sound_volume": 0,
       "sound_msg": "Kshhh.",
       "no_deactivate_msg": "You've already lit the fuse - run!",
-      "explosion": { "power": 500, "shrapnel": { "casing_mass": 2500, "fragment_mass": 2.0, "drop": "scrap", "recovery": 20 } }
+      "explosion": { "power": 500, "shrapnel": { "casing_mass": 2500, "fragment_mass": 2, "drop": "scrap", "recovery": 20 } }
     },
     "flags": [ "BOMB", "TRADER_AVOID" ]
   },
@@ -7249,7 +7249,7 @@
     "symbol": ")",
     "color": "light_gray",
     "looks_like": "pot_canning",
-    "container_data": { "contains": 8, "seals": true, "watertight": true },
+    "container_data": { "contains": "2 L", "seals": true, "watertight": true },
     "qualities": [ [ "COOK", 3 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "CHEM", 1 ] ],
     "use_action": "HEAT_FOOD",
     "flags": [ "ALLOWS_REMOTE_USE" ]

--- a/data/json/items/vehicle/cargo.json
+++ b/data/json/items/vehicle/cargo.json
@@ -87,6 +87,6 @@
     "name": "animal locker",
     "description": "A locker used to contain animals safely during transportation if installed properly.  There is room for animal food and other animal care goods.  It is meant to hold medium or smaller animals for transport.  Use it on a suitable animal to capture, use it on an empty tile to release.",
     "weight": 10000,
-    "volume": 125
+    "volume": "31250 ml"
   }
 ]

--- a/data/json/items/vehicle/engineering.json
+++ b/data/json/items/vehicle/engineering.json
@@ -49,7 +49,7 @@
     "material": "steel",
     "category": "veh_parts",
     "price": 8500,
-    "volume": 29
+    "volume": "7250 ml"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/vehicle/farming.json
+++ b/data/json/items/vehicle/farming.json
@@ -12,7 +12,7 @@
     "material": "steel",
     "category": "veh_parts",
     "price": 3500,
-    "volume": 28
+    "volume": "7 L"
   },
   {
     "type": "GENERIC",


### PR DESCRIPTION
<!--
### How to use
Leave the headings unless they don't apply to your PR, replace commented out text (surrounded with <!–– and ––>) with text describing your PR.
NOTE: Please grant permission for repository maintainers to edit your PR.
It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
<!--
A one-line description of your change that will be extracted and added to the [project changelog](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt).

The format is (ignore the square brackets): ```SUMMARY: [Category] "[description]"```

The categories to choose from are:

* Features
* Content
* Interface
* Mods
* Balance
* Bugfixes
* Performance
* Infrastructure
* Build
* I18N

Example: ```SUMMARY: Content "Adds new mutation category 'Mouse'"```

See the [Changelog Guidelines](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md) for explanations of the categories.
-->

SUMMARY: Infrastructure "Change all instances of 'volume' in JSONs to be a metric string again"

#### Purpose of change
<!--
If there's an existing issue describing the problem this PR addresses or the feature it adds, please link it like: ```#1234```
If it *fully* resolves an issue, link it like: ```Fixes #1234```
Even if the issue describes the problem, please provide a few-sentence summary here.
Example: ```Fixes #1234 - XL mutants cannot wear arm/leg splints due to missing OVERSIZE flag.```
If there is no related issue, please describe the issue you are addressing, including how to trigger a bug if this is a bugfix.
Don't put the backticks around the `#` and issue or pull request number to allow the GitHub automatically reference to it.
-->

An update to #33367.

#### Describe the solution
<!--
How does the feature work, or how does this fix a bug?
The easier you make your solution to understand, the faster it can get merged.
-->

I've made a proper JSON parser now which can change all types of keys including subkeys. 

Changes `'storage', 'contains', 'min_volume', 'max_volume', 'min_pet_volume', 'integral_volume', 'volume'` under the subkeys `'use_action', 'workbench', 'container_data', 'armor_data'` to use metric units.

#### Describe alternatives you've considered
<!--
A clear and concise description of any alternative solutions or features you've considered.
-->

#### Additional context
<!--
Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.
-->

The change to the comment key in nuts.json: `"//2"` is to prevent duplicate keys being removed when converting from json to javascript object.

The change in fragment mass from `2.0` to `2` is also due to javascript object conversion. Javascript only has one number type and doesn't distinguish between ints and floats. I assume this doesn't cause any problems.