### PR TITLE
Add Debian/Ubuntu install instructions to releases page

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -50,4 +50,10 @@ Ncurses and tiles version available in [official repos](https://src.fedoraprojec
 
 `sudo dnf install cataclysm-dda`
 
+## Debian / Ubuntu
+
+Ncurses and tiles version available in [official repos](https://tracker.debian.org/pkg/cataclysm-dda)
+
+`sudo apt install cataclysm-dda-curses cataclysm-dda-sdl`
+
 [![Packaging status](https://repology.org/badge/vertical-allrepos/cataclysm-dda.svg)](https://repology.org/project/cataclysm-dda/versions)


### PR DESCRIPTION
#### Summary

```SUMMARY: None```

#### Purpose of change

Document on the releases page how users can obtain the game from the official Debian and Ubuntu repositories.

#### Additional context

#37833