### PR TITLE
Reduced topographagnosia's point gain to 1

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -577,7 +577,7 @@
     "type": "mutation",
     "id": "UNOBSERVANT",
     "name": "Topographagnosia",
-    "points": -5,
+    "points": -1,
     "description": "Focal brain damage has rendered you incapable of recognizing landmarks and orienting yourself in your surroundings, severely crippling your sight radius on the overmap.",
     "valid": false,
     "starting_trait": true,


### PR DESCRIPTION
#### Summary
```SUMMARY: Balance "Reduced the point gain from topographognosia from -5 to -1"```


#### Purpose of change
Topographognosia is really not an overly hampering trait to begin with. The overmap range is, while convenient, really not something game-changing which would merit such a high point gain. A pair of binoculars makes the change unnoticeable. Other traits with a similar cost include deaf, flimsy, and so on. Furthermore, the scout trait only costs one point.


#### Describe the solution
I reduced the trait's point gain from -5 to -1.


#### Describe alternatives you've considered
Reducing the point gain to -2 might be reasonable as well.

#### Testing
Started a new character with the trait, and everything worked as expected.