### PR TITLE
pkg-config build improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -662,8 +662,8 @@ else
 
   # Link to ncurses if we're using a non-tiles, Linux build
   ifeq ($(HAVE_PKGCONFIG),1)
-    CXXFLAGS += $(shell pkg-config --cflags $(NCURSES_PREFIX))
-    LDFLAGS += $(shell pkg-config --libs $(NCURSES_PREFIX))
+    CXXFLAGS += $(shell $(PKG_CONFIG) --cflags $(NCURSES_PREFIX))
+    LDFLAGS += $(shell $(PKG_CONFIG) --libs $(NCURSES_PREFIX))
   else
     ifeq ($(HAVE_NCURSES5CONFIG),1)
       CXXFLAGS += $(shell $(NCURSES_PREFIX)5-config --cflags)

--- a/Makefile
+++ b/Makefile
@@ -528,7 +528,6 @@ ifeq ($(shell git rev-parse --is-inside-work-tree),true)
 endif
 
 PKG_CONFIG = $(CROSS)pkg-config
-SDL2_CONFIG = $(CROSS)sdl2-config
 
 ifeq ($(SOUND), 1)
   ifneq ($(TILES),1)
@@ -595,14 +594,14 @@ ifdef TILES
       endif
     endif
   else # not osx
-    CXXFLAGS += $(shell $(SDL2_CONFIG) --cflags)
+    CXXFLAGS += $(shell $(PKG_CONFIG) sdl2 --cflags)
     CXXFLAGS += $(shell $(PKG_CONFIG) SDL2_image --cflags)
     CXXFLAGS += $(shell $(PKG_CONFIG) SDL2_ttf --cflags)
 
     ifdef STATIC
-      LDFLAGS += $(shell $(SDL2_CONFIG) --static-libs)
+      LDFLAGS += $(shell $(PKG_CONFIG) sdl2 --static --libs)
     else
-      LDFLAGS += $(shell $(SDL2_CONFIG) --libs)
+      LDFLAGS += $(shell $(PKG_CONFIG) sdl2 --libs)
     endif
 
     LDFLAGS += -lSDL2_ttf -lSDL2_image


### PR DESCRIPTION
#### Summary

```SUMMARY: None```

#### Purpose of change

 * the PKG_CONFIG variable was not consistently used
 * pkg-config can also be used for finding SDL2 flags

#### Describe the solution

 * use PKG_CONFIG where possible (there is still a place left where pkg-config is used for Mac cross building; but I'm not able to test this)
 * replace SDL2_CONFIG with PKG_CONFIG calls