### PR TITLE
Add option for aim window position

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1531,7 +1531,7 @@ void options_manager::add_options_interface()
     { { "left", translate_marker( "Left" ) }, { "right", translate_marker( "Right" ) }, { "overlapping", translate_marker( "Overlapping" ) } },
     "left"
        );
-	   
+
     add( "AIM_WINDOW_POSITION", "interface", translate_marker( "Aim window position" ),
          translate_marker( "Switch between aim window being left or right." ),
     { { "left", translate_marker( "Left" ) }, { "right", translate_marker( "Right" ) } },

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1531,6 +1531,12 @@ void options_manager::add_options_interface()
     { { "left", translate_marker( "Left" ) }, { "right", translate_marker( "Right" ) }, { "overlapping", translate_marker( "Overlapping" ) } },
     "left"
        );
+	   
+    add( "AIM_WINDOW_POSITION", "interface", translate_marker( "Aim window position" ),
+         translate_marker( "Switch between aim window being left or right." ),
+    { { "left", translate_marker( "Left" ) }, { "right", translate_marker( "Right" ) } },
+    "right"
+       );
 
     add( "ACCURACY_DISPLAY", "interface", translate_marker( "Aim window display style" ),
          translate_marker( "How should confidence and steadiness be communicated to the player." ),

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1385,12 +1385,10 @@ std::vector<tripoint> target_handler::target_ui( player &pc, target_mode mode,
         height = 25;
     }
 
-    int aimX = 0;
+    int aimX = TERMX;
     std::string position = get_option<std::string>( "AIM_WINDOW_POSITION" );
     if( position == "left" ) {
         aimX = width;
-    } else if( position == "right" ) {
-        aimX = TERMX;
     }
 
     catacurses::window w_target = catacurses::newwin( height, width, point( aimX - width, top ) );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1385,14 +1385,14 @@ std::vector<tripoint> target_handler::target_ui( player &pc, target_mode mode,
         height = 25;
     }
 
-	int aimX = 0;
-	std::string position = get_option<std::string>( "AIM_WINDOW_POSITION" );
+    int aimX = 0;
+    std::string position = get_option<std::string>( "AIM_WINDOW_POSITION" );
     if( position == "left" ) {
         aimX = width;
     } else if( position == "right" ) {
         aimX = TERMX;
     }
-	
+
     catacurses::window w_target = catacurses::newwin( height, width, point( aimX - width, top ) );
 
     input_context ctxt( "TARGET" );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1384,7 +1384,16 @@ std::vector<tripoint> target_handler::target_ui( player &pc, target_mode mode,
         // Cover up more low-value ui elements if we're tight on space.
         height = 25;
     }
-    catacurses::window w_target = catacurses::newwin( height, width, point( TERMX - width, top ) );
+
+	int aimX = 0;
+	std::string position = get_option<std::string>( "AIM_WINDOW_POSITION" );
+    if( position == "left" ) {
+        aimX = width;
+    } else if( position == "right" ) {
+        aimX = TERMX;
+    }
+	
+    catacurses::window w_target = catacurses::newwin( height, width, point( aimX - width, top ) );
 
     input_context ctxt( "TARGET" );
     ctxt.set_iso( true );


### PR DESCRIPTION
#### Summary
```SUMMARY: Interface "Add option for aim window position"```

#### Purpose of change
Second part of #36804. Closes #36327.

#### Describe the solution
Adds "Aim window position" in the interface options, where the options are left and right (right is default).

#### Describe alternatives you've considered
Any different way to manage all these left/right panel options, but I'm not able to think of any.

#### Testing
Compile and run game, then set each configuration of panel position for sidebar and aim window. Tested on fullscreen and windowed (smallest terminal size).

#### Additional context
See original issue for screenshots of how it looks now.