### PR TITLE
Honour CPPFLAGS also while building tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -46,7 +46,7 @@ clean:
 $(shell mkdir -p $(ODIR))
 
 $(ODIR)/%.o: %.cpp
-	$(CXX) $(DEFINES) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) -c $< -o $@
 
 .PHONY: clean check tests
 


### PR DESCRIPTION
#### Summary

SUMMARY: None

#### Purpose of change

When CPPFLAGS are set by the build system, they are currently only used for building the main binaries, not the tests.
To make this more consistent, use them also for building the tests.