### PR TITLE
Aftershock: Profession Bugfixing

### DIFF
--- a/data/mods/Aftershock/items/gun/laser.json
+++ b/data/mods/Aftershock/items/gun/laser.json
@@ -30,5 +30,13 @@
     "modes": [ [ "MULTI", "trilaser", 3 ] ],
     "ammo_effects": [ "LASER" ],
     "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON-FOULING", "NEEDS_NO_LUBE" ]
+  },
+  {
+    "id": "afs_sentinel_laser_mon",
+    "type": "GUN",
+    "copy-from": "afs_sentinel_laser",
+    "name": { "str": "wrist-trilaser" },
+    "ups_charges": 0,
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NO_AMMO", "NON-FOULING", "NEEDS_NO_LUBE" ]
   }
 ]

--- a/data/mods/Aftershock/mobs/robots.json
+++ b/data/mods/Aftershock/mobs/robots.json
@@ -195,7 +195,7 @@
       {
         "type": "gun",
         "cooldown": 15,
-        "gun_type": "afs_sentinel_laser",
+        "gun_type": "afs_sentinel_laser_mon",
         "ranges": [ [ 0, 12, "DEFAULT" ] ],
         "targeting_sound": "\"Dispatching hostile with lethal force.\""
       }

--- a/data/mods/Aftershock/player/professions.json
+++ b/data/mods/Aftershock/player/professions.json
@@ -65,16 +65,12 @@
     "points": 4,
     "items": {
       "both": {
-        "items": [
-          "phase_immersion_suit",
-          "dimensional_anchor",
-          "socks",
-          "afs_calorie_pill",
-          "crowbar",
-          "afs_atomic_smartphone",
-          "undershirt"
-        ],
-        "entries": [ { "item": "afs_sundew", "container-item": "camelbak" } ]
+        "items": [ "socks", "afs_calorie_pill", "crowbar", "afs_atomic_smartphone", "undershirt", "dump_pouch" ],
+        "entries": [
+          { "item": "water_clean", "container-item": "camelbak" },
+          { "item": "phase_immersion_suit", "ammo-item": "heavy_atomic_battery_cell", "charges": 10000 },
+          { "item": "dimensional_anchor", "ammo-item": "medium_atomic_battery_cell", "charges": 5000 }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "boy_shorts" ]


### PR DESCRIPTION
#### Summary

SUMMARY: None

#### Purpose of change

Fix a few minor bugs related to Aftershock Professions

#### Describe the solution

First issue was that Wraitheon Sentinel's from the Executive profession could no longer shoot their lasers, due to the UPS draw of the weapons

Second Issue was that the Planar Frontiersman didn't spawn with enough inventory space for their gear. And that both the Anchor and Immersion Suit spawned uncharged.

#### Testing

No load errors

