### PR TITLE
Rename Schizophrenic trait

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1279,9 +1279,9 @@
   {
     "type": "mutation",
     "id": "SCHIZOPHRENIC",
-    "name": { "str": "Schizophrenic" },
+    "name": { "str": "Kaluptic Psychosis" },
     "points": -3,
-    "description": "You will periodically suffer from delusions, ranging from minor effects to full visual hallucinations.  Some of these effects may be controlled through the use of Thorazine.",
+    "description": "Ever since the sky first broke you have felt unwell, with your head split by alien thoughts.  You will periodically suffer from delusions, ranging from minor effects to full visual hallucinations.  Some of these effects may be controlled through the use of Thorazine.",
     "starting_trait": true,
     "valid": false,
     "category": [ "MEDICAL" ]


### PR DESCRIPTION
#### Summary

SUMMARY: Content "Rename Schizophrenic"

#### Purpose of change

The in-game schizophrenia trait is fairly simplistic unrealistic and incomplete depiction of the various real symptoms of Schizophrenia. To me, it seems to mostly limits itself to simulating hallucinations, and even then it does so in a fairly gamified and not very accurate way.

Game lore already states that blob infection can manifest itself as diverse and sometimes bizarre mental conditions. And this changes the old trait into one of those blob 'psychotic effects', to better reflect this lore in-game, and to get rid of the unrealistic depiction of schizophrenia.

#### Describe the solution

Renamed the trait to `Kaluptic Psychosis`. With kaluptic being some sort of bastardization of `kalúptō`, which is half of the greek word for apocalypse. 

### Describe alternatives you've considered

Not changing anything. Have someone else try to accurately simulate schizophrenia later on.

#### Testing

Tests Pass.
