### PR TITLE
Kevin Grande must leave the project forever 2

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -12,6 +12,8 @@
 #include "catacharset.h"
 #include "messages.h"
 #include "itype.h"
+
+#include <cmath>
 #include <queue>
 #include <math.h>    //sqrt
 #include <algorithm> //std::min


### PR DESCRIPTION
We are the Grey Committee. 

Cataclysm started as great Community Project. But recent events indicate that normal and healthy relationship between Community and Developers are lost and development going nowhere. Main reason of this is Kevin Grenade.

Kevin Grenade, current Project Leader deemed exclusively rights on everything in Cataclysm, violating project license and intellectual honesty. 

He does not respect community opinion and opinion of his own development team alike. Reasoning with him became pointless long time ago. A lot of people left project because of his attitude and decision making.

Worse of all that project development start going with questionable ways at best. Instead of proper and logical decision making changes start becoming more and more chaotic and subjective. Game becoming a mess.

So we are decided that time for compromises has passed. The Grey Committee was created to fight back.

Our Manifesto is simple:
1) Kevin Grande must leave the project forever.
2) New Development Leader must re-establish normal relation between Development Team and Community.
3) All bans since beginning Kevin Grenade leadership must be revoked.

This goals are not negotiable and can be considered as our ultimatum.

To achieve our goals, we will engage Kevin Grenade and ones who blindly supports his behavior in various ways of informational and psychological warfare.

We are not going allow some false dictator to steal our project and reduce it to dust.

«In the struggle you will gain your rights»
Grey Committee.



To make our word loud we will repeat this message for ... a couple of times.
1
