### PR TITLE
Ravines

### DIFF
--- a/data/json/mapgen/ravine.json
+++ b/data/json/mapgen/ravine.json
@@ -1,14 +1,14 @@
 [
-    {
-      "type": "mapgen",
-      "method": "json",
-      "om_terrain": [ "ravine" ],
-      "object": { "fill_ter": "t_open_air" }
-    },
-    {
-      "type": "mapgen",
-      "method": "json",
-      "om_terrain": [ "ravine_floor" ],
-      "object": { "fill_ter": "t_region_groundcover" }
-    }
-  ]
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "ravine" ],
+    "object": { "fill_ter": "t_open_air" }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "ravine_floor" ],
+    "object": { "fill_ter": "t_region_groundcover" }
+  }
+]

--- a/data/json/mapgen/ravine.json
+++ b/data/json/mapgen/ravine.json
@@ -1,0 +1,14 @@
+[
+    {
+      "type": "mapgen",
+      "method": "json",
+      "om_terrain": [ "ravine" ],
+      "object": { "fill_ter": "t_open_air" }
+    },
+    {
+      "type": "mapgen",
+      "method": "json",
+      "om_terrain": [ "ravine_floor" ],
+      "object": { "fill_ter": "t_region_groundcover" }
+    }
+  ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_ravines.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_ravines.json
@@ -1,19 +1,19 @@
 [
-    {
-        "type": "overmap_terrain",
-        "abstract": "generic_ravine",
-        "name": "ravine",
-        "sym": ".",
-        "color": "blue",
-        "see_cost": 1
-    },
-    {
-        "type": "overmap_terrain",
-        "id": "ravine",
-        "copy-from": "generic_ravine",    
-        "flags": [ "NO_ROTATE", "RAVINE" ]
-    },
-    {
+  {
+    "type": "overmap_terrain",
+    "abstract": "generic_ravine",
+    "name": "ravine",
+    "sym": ".",
+    "color": "blue",
+    "see_cost": 1
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "ravine",
+    "copy-from": "generic_ravine",
+    "flags": [ "NO_ROTATE", "RAVINE" ]
+  },
+  {
     "type": "overmap_terrain",
     "id": "ravine_edge",
     "copy-from": "generic_ravine",
@@ -41,6 +41,5 @@
     "name": "Ravine floor",
     "color": "light_gray",
     "flags": [ "NO_ROTATE", "RAVINE" ]
-
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_ravines.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_ravines.json
@@ -1,0 +1,46 @@
+[
+    {
+        "type": "overmap_terrain",
+        "abstract": "generic_ravine",
+        "name": "ravine",
+        "sym": ".",
+        "color": "blue",
+        "see_cost": 1
+    },
+    {
+        "type": "overmap_terrain",
+        "id": "ravine",
+        "copy-from": "generic_ravine",    
+        "flags": [ "NO_ROTATE", "RAVINE" ]
+    },
+    {
+    "type": "overmap_terrain",
+    "id": "ravine_edge",
+    "copy-from": "generic_ravine",
+    "sym": "v",
+    "name": "cliffside",
+    "color": "light_gray",
+    "flags": [ "NO_ROTATE", "RAVINE_EDGE" ],
+    "mapgen": [ { "method": "builtin", "name": "ravine_edge" } ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "ravine_floor_edge",
+    "copy-from": "generic_ravine",
+    "sym": "^",
+    "name": "cliffside",
+    "color": "light_gray",
+    "flags": [ "NO_ROTATE", "RAVINE_EDGE" ],
+    "mapgen": [ { "method": "builtin", "name": "ravine_edge" } ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "ravine_floor",
+    "copy-from": "generic_ravine",
+    "sym": ".",
+    "name": "Ravine floor",
+    "color": "light_gray",
+    "flags": [ "NO_ROTATE", "RAVINE" ]
+
+  }
+]

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -231,12 +231,7 @@
         { "om_terrain": "island_field", "om_terrain_match_type": "TYPE", "alias": "field" }
       ]
     },
-    "overmap_ravine_settings": {
-      "num_ravines": 0,
-      "ravine_width": 3,
-      "ravine_range": 45,
-      "ravine_depth": -3
-    },
+    "overmap_ravine_settings": { "num_ravines": 0, "ravine_width": 3, "ravine_range": 45, "ravine_depth": -3 },
     "overmap_forest_settings": {
       "noise_threshold_forest": 0.2,
       "noise_threshold_forest_thick": 0.25,

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -231,6 +231,12 @@
         { "om_terrain": "island_field", "om_terrain_match_type": "TYPE", "alias": "field" }
       ]
     },
+    "overmap_ravine_settings": {
+      "num_ravines": 0,
+      "ravine_width": 3,
+      "ravine_range": 45,
+      "ravine_depth": -3
+    },
     "overmap_forest_settings": {
       "noise_threshold_forest": 0.2,
       "noise_threshold_forest_thick": 0.25,

--- a/data/mods/desert_region/desert_regional_map_settings.json
+++ b/data/mods/desert_region/desert_regional_map_settings.json
@@ -127,6 +127,7 @@
       "shore_extendable_overmap_terrain": [ "forest", "forest_thick", "forest_water", "field" ],
       "shore_extendable_overmap_terrain_aliases": [  ]
     },
+    "overmap_ravine_settings": { "num_ravines": 5, "ravine_width": 3, "ravine_range": 45, "ravine_depth": -3 },
     "overmap_forest_settings": {
       "noise_threshold_forest": 0.5,
       "noise_threshold_forest_thick": 0.55,

--- a/data/mods/rural_biome/rural_regional_map_settings.json
+++ b/data/mods/rural_biome/rural_regional_map_settings.json
@@ -196,6 +196,7 @@
       },
       "boosted_other_percent": 50.0
     },
+    "overmap_ravine_settings": { "num_ravines": 0, "ravine_width": 3, "ravine_range": 45, "ravine_depth": -3 },
     "overmap_lake_settings": {
       "noise_threshold_lake": 0.25,
       "lake_size_min": 20,

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -151,6 +151,7 @@ building_gen_pointer get_mapgen_cfunction( const std::string &ident )
             { "ants_queen", &mapgen_ants_queen },
             { "tutorial", &mapgen_tutorial },
             { "lake_shore", &mapgen_lake_shore },
+            { "ravine_edge", &mapgen_ravine_edge },
         }
     };
     const auto iter = pointers.find( ident );
@@ -3281,6 +3282,92 @@ void mapgen_lake_shore( mapgendata &dat )
     // We previously placed our shallow water but actually did a t_null instead to make sure that we didn't
     // pick up shallow water from our extended terrain. Now turn those nulls into t_water_sh.
     m->translate( t_null, t_water_sh );
+}
+
+void mapgen_ravine_edge( mapgendata &dat )
+{
+    map *const m = &dat.m;
+    if( dat.zlevel() == 0 ) {
+        dat.fill_groundcover();
+    } else {
+        m->draw_fill_background( t_rock );
+    }
+
+    auto is_ravine = [&]( const oter_id & id ) {
+        return id.obj().is_ravine();
+    };
+
+    const auto is_ravine_edge = [&]( const oter_id & id ) {
+        return id.obj().is_ravine_edge();
+    };
+
+    const bool n_ravine  = is_ravine( dat.north() );
+    const bool e_ravine  = is_ravine( dat.east() );
+    const bool s_ravine  = is_ravine( dat.south() );
+    const bool w_ravine  = is_ravine( dat.west() );
+    const bool nw_ravine = is_ravine( dat.nwest() );
+    const bool ne_ravine = is_ravine( dat.neast() );
+    const bool se_ravine = is_ravine( dat.seast() );
+
+    const bool n_ravine_edge = is_ravine_edge( dat.north() );
+    const bool e_ravine_edge = is_ravine_edge( dat.east() );
+    const bool s_ravine_edge = is_ravine_edge( dat.south() );
+    const bool w_ravine_edge = is_ravine_edge( dat.west() );
+
+    const bool straight = ( ( n_ravine_edge && s_ravine_edge ) || ( e_ravine_edge &&
+                            w_ravine_edge ) ) &&
+                          ( n_ravine || s_ravine || w_ravine || e_ravine );
+    const bool interior_corner = !straight && !( n_ravine || s_ravine || w_ravine || e_ravine );
+    const bool exterior_corner = !straight && ( n_ravine || s_ravine || w_ravine || e_ravine );
+
+    if( straight ) {
+        for( int x = 0; x < SEEX * 2; x++ ) {
+            int ground_edge = 12 + rng( 1, 3 );
+            line( m, t_null, point( x, ++ground_edge ), point( x, SEEY * 2 ) );
+        }
+        if( w_ravine ) {
+            m->rotate( 1 );
+        }
+        if( n_ravine ) {
+            m->rotate( 2 );
+        }
+        if( e_ravine ) {
+            m->rotate( 3 );
+        }
+    } else if( interior_corner ) {
+        for( int x = 0; x < SEEX * 2; x++ ) {
+            int ground_edge = 12 + rng( 1, 3 ) + x;
+            line( m, t_null, point( x, ++ground_edge ), point( x, SEEY * 2 ) );
+        }
+        if( nw_ravine ) {
+            m->rotate( 1 );
+        }
+        if( ne_ravine ) {
+            m->rotate( 2 );
+        }
+        if( se_ravine ) {
+            m->rotate( 3 );
+        }
+    } else if( exterior_corner ) {
+        for( int x = 0; x < SEEX * 2; x++ ) {
+            int ground_edge =  12  + rng( 1, 3 ) - x;
+            line( m, t_null, point( x, --ground_edge ), point( x, SEEY * 2 - 1 ) );
+        }
+        if( w_ravine && s_ravine ) {
+            m->rotate( 1 );
+        }
+        if( w_ravine && n_ravine ) {
+            m->rotate( 2 );
+        }
+        if( e_ravine && n_ravine ) {
+            m->rotate( 3 );
+        }
+    }
+    if( dat.zlevel() == dat.region.overmap_ravine.ravine_depth ) {
+        m->translate( t_null, dat.groundcover() );
+    } else {
+        m->translate( t_null, t_open_air );
+    }
 }
 
 void mremove_trap( map *m, const point &p )

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -75,6 +75,7 @@ void mapgen_ants_larvae( mapgendata &dat );
 void mapgen_ants_queen( mapgendata &dat );
 void mapgen_tutorial( mapgendata &dat );
 void mapgen_lake_shore( mapgendata &dat );
+void mapgen_ravine_edge( mapgendata &dat );
 
 // Temporary wrappers
 void mremove_trap( map *m, const point & );

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -168,6 +168,8 @@ enum class oter_flags : int {
     subway_connection,
     lake,
     lake_shore,
+    ravine,
+    ravine_edge,
     generic_loot,
     risk_high,
     risk_low,
@@ -352,6 +354,14 @@ struct oter_t {
 
         bool is_lake_shore() const {
             return type->has_flag( oter_flags::lake_shore );
+        }
+
+        bool is_ravine() const {
+            return type->has_flag( oter_flags::ravine );
+        }
+
+        bool is_ravine_edge() const {
+            return type->has_flag( oter_flags::ravine_edge );
         }
 
     private:

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -170,6 +170,8 @@ static const std::map<std::string, oter_flags> oter_flags_map = {
     { "SUBWAY", oter_flags::subway_connection },
     { "LAKE", oter_flags::lake },
     { "LAKE_SHORE", oter_flags::lake_shore },
+    { "RAVINE", oter_flags::ravine },
+    { "RAVINE_EDGE", oter_flags::ravine_edge },
     { "GENERIC_LOOT", oter_flags::generic_loot },
     { "RISK_HIGH", oter_flags::risk_high },
     { "RISK_LOW", oter_flags::risk_low },
@@ -436,6 +438,7 @@ class overmap
         void build_tunnel( const tripoint_om_omt &p, int s, om_direction::type dir );
         bool build_slimepit( const tripoint_om_omt &origin, int s );
         void build_mine( const tripoint_om_omt &origin, int s );
+        void place_ravines();
 
         // Connection laying
         pf::path<point_om_omt> lay_out_connection(

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -308,6 +308,27 @@ static void load_overmap_forest_settings(
     }
 }
 
+static void load_overmap_ravine_settings(
+    const JsonObject &jo, overmap_ravine_settings &overmap_ravine_settings, const bool strict,
+    const bool overlay )
+{
+    if( !jo.has_object( "overmap_ravine_settings" ) ) {
+        if( strict ) {
+            jo.throw_error( "\"overmap_ravine_settings\": { … } required for default" );
+        }
+    } else {
+        JsonObject overmap_ravine_settings_jo = jo.get_object( "overmap_ravine_settings" );
+        read_and_set_or_throw<int>( overmap_ravine_settings_jo, "num_ravines",
+                                    overmap_ravine_settings.num_ravines, !overlay );
+        read_and_set_or_throw<int>( overmap_ravine_settings_jo, "ravine_range",
+                                    overmap_ravine_settings.ravine_range, !overlay );
+        read_and_set_or_throw<int>( overmap_ravine_settings_jo, "ravine_width",
+                                    overmap_ravine_settings.ravine_width, !overlay );
+        read_and_set_or_throw<int>( overmap_ravine_settings_jo, "ravine_depth",
+                                    overmap_ravine_settings.ravine_depth, !overlay );
+    }
+}
+
 static void load_overmap_lake_settings( const JsonObject &jo,
                                         overmap_lake_settings &overmap_lake_settings,
                                         const bool strict, const bool overlay )
@@ -567,6 +588,8 @@ void load_region_settings( const JsonObject &jo )
 
     load_overmap_lake_settings( jo, new_region.overmap_lake, strict, false );
 
+    load_overmap_ravine_settings( jo, new_region.overmap_ravine, strict, false );
+
     load_region_terrain_and_furniture_settings( jo, new_region.region_terrain_and_furniture, strict,
             false );
 
@@ -716,6 +739,8 @@ void apply_region_overlay( const JsonObject &jo, regional_settings &region )
     load_overmap_forest_settings( jo, region.overmap_forest, false, true );
 
     load_overmap_lake_settings( jo, region.overmap_lake, false, true );
+
+    load_overmap_ravine_settings( jo, region.overmap_ravine, false, true );
 
     load_region_terrain_and_furniture_settings( jo, region.region_terrain_and_furniture, false, true );
 }

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -204,6 +204,16 @@ struct overmap_lake_settings {
     overmap_lake_settings() = default;
 };
 
+struct overmap_ravine_settings {
+    int num_ravines = 0;
+    int ravine_range = 45;
+    int ravine_width = 1;
+    int ravine_depth = -3;
+
+    void finalize();
+    overmap_ravine_settings() = default;
+};
+
 struct map_extras {
     unsigned int chance;
     weighted_int_list<std::string> values;
@@ -243,6 +253,7 @@ struct regional_settings {
     overmap_feature_flag_settings overmap_feature_flag;
     overmap_forest_settings overmap_forest;
     overmap_lake_settings overmap_lake;
+    overmap_ravine_settings overmap_ravine;
     region_terrain_and_furniture_settings region_terrain_and_furniture;
 
     std::unordered_map<std::string, map_extras> region_extras;


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Create ravines in desert regions"

#### Purpose of change
Our current plans for Aftershock involve replacing its New England like map with something that resembles a mix between Hoth and Ganymede. 

Halfway through testing a very bare bones implementation of this exoplanet region, I noticed that a map that was nothing but flat glacier was really boring and that I needed something to both break the monotony of the overlap display, and to make transversing the map slightly harder and more interesting
 
The idea of adding ravine-like features (they are actually inspired by Europa's Lineae) to the overmap, came out as a possible solution to those two problems, and thats what I did.

#### Describe the solution
Here are a few Ravines separating several different cities

![image](https://user-images.githubusercontent.com/5290912/94213623-8ea4c780-fe94-11ea-8ce0-fbff5ee8caa6.png)

#### Testing

Load a game with Desert Region mod enabled and disable. Look at the Ravines or at the lack of them.

#### Additional context

The Biome these were intended for, (the mentioned frozen exoplanet) wont have overmap level water features, and as such, these dont interact or handle conflicts with rivers and lakes.