### PR TITLE
[Aftershock] Adjust monster spawns

### DIFF
--- a/data/mods/Aftershock/mobs/monster_groups.json
+++ b/data/mods/Aftershock/mobs/monster_groups.json
@@ -3,7 +3,7 @@
     "type": "monstergroup",
     "name": "GROUP_ZOMBIE",
     "monsters": [
-      { "monster": "mon_afs_headless_horror", "freq": 20, "cost_multiplier": 2, "starts":400 },
+      { "monster": "mon_afs_headless_horror", "freq": 20, "cost_multiplier": 2, "starts": 400 },
       { "monster": "mon_zombie_upliftedbear", "freq": 5, "cost_multiplier": 10, "starts": 1086 },
       { "monster": "mon_uplifted_ape_zed", "freq": 8, "cost_multiplier": 10, "starts": 1086 }
     ]

--- a/data/mods/Aftershock/mobs/monster_groups.json
+++ b/data/mods/Aftershock/mobs/monster_groups.json
@@ -3,7 +3,7 @@
     "type": "monstergroup",
     "name": "GROUP_ZOMBIE",
     "monsters": [
-      { "monster": "mon_afs_headless_horror", "freq": 20, "cost_multiplier": 20 },
+      { "monster": "mon_afs_headless_horror", "freq": 20, "cost_multiplier": 2, "starts":400 },
       { "monster": "mon_zombie_upliftedbear", "freq": 5, "cost_multiplier": 10, "starts": 1086 },
       { "monster": "mon_uplifted_ape_zed", "freq": 8, "cost_multiplier": 10, "starts": 1086 }
     ]
@@ -86,8 +86,8 @@
     "type": "monstergroup",
     "default": "mon_null",
     "monsters": [
-      { "monster": "mon_zombie_upliftedbear", "freq": 10, "cost_multiplier": 1, "pack_size": [ 2, 3 ] },
-      { "monster": "mon_uplifted_ape_zed", "freq": 10, "cost_multiplier": 1, "pack_size": [ 2, 3 ] }
+      { "monster": "mon_zombie_upliftedbear", "freq": 10, "cost_multiplier": 1, "pack_size": [ 2, 3 ], "starts": 1086 },
+      { "monster": "mon_uplifted_ape_zed", "freq": 10, "cost_multiplier": 1, "pack_size": [ 2, 3 ], "starts": 1086 }
     ]
   },
   {


### PR DESCRIPTION
#### Summary

SUMMARY: Mods "Adjust monster spawns for Balance"


#### Purpose of change
Adjusting the spawns for some of Aftershocks monsters so there are much fewer day 1 spawns of advanced monsters. Fixes #44477

#### Describe the solution

Adjusting spawn details

#### Describe alternatives you've considered
Finding out what happened to Snow, maker of the hit single Informer.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
