### PR TITLE
Handle more than one active missions in ROBOFAC_MERC_1 dialogue

### DIFF
--- a/data/json/npcs/robofac/NPC_ROBOFAC_MERC_1.json
+++ b/data/json/npcs/robofac/NPC_ROBOFAC_MERC_1.json
@@ -82,6 +82,11 @@
     "responses": [
       { "text": "About that job…", "topic": "TALK_MISSION_INQUIRE", "condition": "has_assigned_mission" },
       {
+        "text": "About those jobs…",
+        "topic": "TALK_MISSION_LIST_ASSIGNED",
+        "condition": "has_many_assigned_missions"
+      },
+      {
         "text": "Who are you?",
         "condition": { "not": { "u_has_var": "robofac_merc_1_stay", "type": "dialogue", "context": "robofac_merc_1", "value": "yes" } },
         "topic": "TALK_ROBOFAC_MERC_1_WHO"


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Handle more than one active missions in ROBOFAC_MERC_1 dialogue"

#### Purpose of change

Fixes #45140 

#### Describe the solution

Add a text option that allows you to check the status for both missions.

#### Testing

Test that the new text option appears

