### PR TITLE
Exploit human psychology

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -209,7 +209,9 @@ struct availability {
     private:
         const recipe *rec;
         mutable float proficiency_time_maluses = -1.0f;
+        mutable float max_proficiency_time_maluses = -1.0f;
         mutable float proficiency_skill_maluses = -1.0f;
+        mutable float max_proficiency_skill_maluses = -1.0f;
     public:
         float get_proficiency_time_maluses() const {
             if( proficiency_time_maluses < 0 ) {
@@ -219,6 +221,14 @@ struct availability {
 
             return proficiency_time_maluses;
         }
+        float get_max_proficiency_time_maluses() const {
+            if( max_proficiency_time_maluses < 0 ) {
+                Character &player = get_player_character();
+                max_proficiency_time_maluses = rec->max_proficiency_time_maluses( player );
+            }
+
+            return max_proficiency_time_maluses;
+        }
         float get_proficiency_skill_maluses() const {
             if( proficiency_skill_maluses < 0 ) {
                 Character &player = get_player_character();
@@ -226,6 +236,14 @@ struct availability {
             }
 
             return proficiency_skill_maluses;
+        }
+        float get_max_proficiency_skill_maluses() const {
+            if( max_proficiency_skill_maluses < 0 ) {
+                Character &player = get_player_character();
+                max_proficiency_skill_maluses = rec->max_proficiency_skill_maluses( player );
+            }
+
+            return max_proficiency_skill_maluses;
         }
 
         nc_color selected_color() const {
@@ -405,19 +423,24 @@ static std::vector<std::string> recipe_info(
         oss << _( "<color_red>Cannot be crafted because the same item is needed "
                   "for multiple components</color>\n" );
     }
+
+    const bool disp_prof_msg = avail.has_proficiencies && !recp.is_nested();
     const float time_maluses = avail.get_proficiency_time_maluses();
+    const float max_time_malus = avail.get_max_proficiency_time_maluses();
     const float skill_maluses = avail.get_proficiency_skill_maluses();
-    if( time_maluses != 1.0 && skill_maluses != 0.0 ) {
-        oss << string_format( _( "<color_yellow>This recipe will take %.1fx as long as normal, "
-                                 "and your effective skill will be %.2f levels lower than normal, because you "
-                                 "lack some of the proficiencies used.</color>\n" ), time_maluses, skill_maluses );
-    } else if( time_maluses != 1.0 ) {
-        oss << string_format( _( "<color_yellow>This recipe will take %.1fx as long as normal, "
-                                 "because you lack some of the proficiencies used.</color>\n" ), time_maluses );
-    } else if( skill_maluses != 0.0 ) {
+    const float max_skill_malus = avail.get_max_proficiency_skill_maluses();
+    if( disp_prof_msg && time_maluses < max_time_malus && skill_maluses < max_skill_malus ) {
+        oss << string_format( _( "<color_green>This recipe will be %.2fx faster than normal, "
+                                 "and your effective skill will be %.2f levels higher than normal, because of "
+                                 "the proficiencies you have.</color>\n" ),
+                              max_time_malus / time_maluses, max_skill_malus - skill_maluses );
+    } else if( disp_prof_msg && time_maluses < max_time_malus ) {
+        oss << string_format( _( "<color_green>This recipe will be %.2fx faster than normal, "
+                                 "because of the proficiencies you have.</color>\n" ), max_time_malus / time_maluses );
+    } else if( disp_prof_msg && skill_maluses < max_skill_malus ) {
         oss << string_format(
-                _( "<color_yellow>Your effective skill will be %.2f levels lower than normal, "
-                   "because you lack some of the proficiencies used.</color>\n" ), skill_maluses );
+                _( "<color_green>Your effective skill will be %.2f levels higher than normal, "
+                   "because of the proficiencies you have.</color>\n" ), max_skill_malus - skill_maluses );
     }
     if( !can_craft_this && !avail.has_proficiencies ) {
         oss << _( "<color_red>Cannot be crafted because you lack"

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -760,15 +760,15 @@ static std::string profstring( const prof_penalty &prof,
     }
 
     if( prof.time_mult == 1.0f ) {
-        return string_format( _( "<color_%s>%s</color> (<color_%s>%.2f\u00a0skill penalty</color>%s)" ),
+        return string_format( _( "<color_%s>%s</color> (<color_%s>%.2f\u00a0skill bonus</color>%s)" ),
                               name_color, prof.id->name(), color, prof.skill_penalty, mitigated_str );
     } else if( prof.skill_penalty == 0.0f ) {
-        return string_format( _( "<color_%s>%s</color> (<color_%s>%.1fx\u00a0time</color>%s)" ),
+        return string_format( _( "<color_%s>%s</color> (<color_%s>%.2fx\u00a0time</color>%s)" ),
                               name_color, prof.id->name(), color, prof.time_mult, mitigated_str );
     }
 
     return string_format(
-               _( "<color_%s>%s</color> (<color_%s>%.1fx\u00a0time, %.2f\u00a0skill penalty</color>%s)" ),
+               _( "<color_%s>%s</color> (<color_%s>%.2fx\u00a0time, %.2f\u00a0skill bonus</color>%s)" ),
                name_color, prof.id->name(), color, prof.time_mult, prof.skill_penalty, mitigated_str );
 }
 
@@ -787,7 +787,7 @@ std::string recipe::used_proficiencies_string( const Character *c ) const
         }
     }
 
-    std::string color = "light_gray";
+    std::string color = "light_green";
     std::string used = enumerate_as_string( used_profs.begin(),
     used_profs.end(), [&]( const prof_penalty & prof ) {
         return profstring( prof, color );
@@ -876,6 +876,15 @@ float recipe::proficiency_time_maluses( const Character &crafter ) const
     return total_malus;
 }
 
+float recipe::max_proficiency_time_maluses( const Character & ) const
+{
+    float total_malus = 1.0f;
+    for( const recipe_proficiency &prof : proficiencies ) {
+        total_malus *= prof.time_multiplier;
+    }
+    return total_malus;
+}
+
 static float proficiency_skill_malus( const Character &crafter, const recipe_proficiency &prof )
 {
     if( !crafter.has_proficiency( prof.id ) &&
@@ -896,6 +905,15 @@ float recipe::proficiency_skill_maluses( const Character &crafter ) const
     float total_malus = 0.f;
     for( const recipe_proficiency &prof : proficiencies ) {
         total_malus += proficiency_skill_malus( crafter, prof );
+    }
+    return total_malus;
+}
+
+float recipe::max_proficiency_skill_maluses( const Character & ) const
+{
+    float total_malus = 0.f;
+    for( const recipe_proficiency &prof : proficiencies ) {
+        total_malus += prof.skill_penalty;
     }
     return total_malus;
 }
@@ -923,7 +941,7 @@ std::string recipe::missing_proficiencies_string( const Character *crafter ) con
         }
     }
 
-    std::string color = "yellow";
+    std::string color = "dark_gray";
     std::string missing = enumerate_as_string( missing_profs.begin(),
     missing_profs.end(), [&]( const prof_penalty & prof ) {
         return profstring( prof, color, crafter->has_prof_prereqs( prof.id ) ? "cyan" : "red" );

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -215,8 +215,12 @@ class recipe
         std::vector<proficiency_id> used_proficiencies() const;
         // The time malus due to proficiencies lacking
         float proficiency_time_maluses( const Character &crafter ) const;
+        // The time malus if all the proficiencies were lacking
+        float max_proficiency_time_maluses( const Character &crafter ) const;
         // The skill malus due to proficiencies lacking
         float proficiency_skill_maluses( const Character &crafter ) const;
+        // The max skill malus due to proficiencies lacking
+        float max_proficiency_skill_maluses( const Character &crafter ) const;
 
         // How active of exercise this recipe is
         float exertion_level() const;


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Frame proficiencies as bonuses to crafting time as opposed to maluses.

#### Describe the solution
Convert displays to percentages, adjust grammar, and apply some math to the numbers before display.

![image](https://user-images.githubusercontent.com/42699974/224247459-405a9078-4fe1-40ee-a949-6e8ed24da338.png)
![image](https://user-images.githubusercontent.com/42699974/224247384-0d9d8e0f-c1fb-418f-9977-7157489c0791.png)
![image](https://user-images.githubusercontent.com/42699974/224247425-dcb68304-f862-4586-ba2f-fd4cb7ef85dc.png)

![image](https://user-images.githubusercontent.com/42699974/224247479-da882323-4170-4006-90b6-262e1e43b57e.png)
![image](https://user-images.githubusercontent.com/42699974/224247432-28fd7d67-3ac2-4b92-9cf8-1f0dc397dcbb.png)

![image](https://user-images.githubusercontent.com/42699974/224247497-d25bfee1-8087-4105-8fbe-b5d35ab466a0.png)
![image](https://user-images.githubusercontent.com/42699974/224247442-8120d5d9-1e53-4c4a-99c9-e2755933d5ab.png)
(JSON for this recipe edited)

<details>
<summary>Really old images</summary>

![image](https://user-images.githubusercontent.com/42699974/102442140-84e4b900-3fd8-11eb-9ad0-62cc0fbd0bcf.png)
![image](https://user-images.githubusercontent.com/42699974/102442181-a5ad0e80-3fd8-11eb-976d-781433487f94.png)
</details>

#### Describe alternatives you've considered
<details>
<summary>Even more ancient images</summary>
(The math may be wrong on some of these)
Keeping white text/using multiplicative:
![image](https://user-images.githubusercontent.com/42699974/102383773-c5b0e380-3f80-11eb-8fa8-9112a8dd4412.png)
Using inverted multiplicative:
![image](https://user-images.githubusercontent.com/42699974/102383781-c8133d80-3f80-11eb-80bb-cf4c315bfd3b.png)
Using inverted percentages:
![image](https://user-images.githubusercontent.com/42699974/102383789-ca759780-3f80-11eb-8cb3-efd619f15f17.png)
Using fractions:
![image](https://user-images.githubusercontent.com/42699974/102383797-cd708800-3f80-11eb-8cd6-f4ffe8569581.png)
![image](https://user-images.githubusercontent.com/42699974/102383811-d06b7880-3f80-11eb-9a55-ef68a026f1b9.png)
</details>

#### Testing
See images.

#### Additional context
I'm not a particularly huge fan of doing this, but it's probably a good idea.