### PR TITLE
Seal only full containers on spawn

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6817,7 +6817,11 @@ bool item::is_map() const
 
 bool item::seal()
 {
-    return contents.seal_all_pockets();
+    if( is_container_full() ) {
+        return contents.seal_all_pockets();
+    } else {
+        return false;
+    }
 }
 
 bool item::is_container() const


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Seal only full containers on spawn"

#### Purpose of change

Fixes #45650

#### Describe the solution

Only allow sealing of containers if they are full of their contents when spawning.

This does not fix existing spawned items in the game, nor does it fix items on game load.

#### Describe alternatives you've considered

Forcing all sealable and spoilable item JSON to comply to the rule. That would be a massive undertaking.

#### Testing

Full test program: no errors.

Crafted some sealed items to see if any problems with crafting. Fruit slice, canned beans, and canned fruit are all sealed.

Teleported to cities and checked kitchens, restaurants, grocery stores and so on. Looked for sealed containers with only full contents. 99% success except for the situation mentioned below.

Sometimes a container will spawn sealed with contents being 13/25. This looks like a rounding error and so the algorithm sees it as not being able to hold any more of the item, so it passes the check for being full. A separate PR IMO would be needed to fix that as it is a different issue.

#### Additional context

This feels like too simple of a solution and that I might have missed something. Some other people testing it would be appreciated.