### PR TITLE
Transhumanism rework: Bionic slots

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -92,13 +92,6 @@
   },
   {
     "type": "EXTERNAL_OPTION",
-    "name": "CBM_SLOTS_ENABLED",
-    "info": "Enables CBM slots mechanics.  If true CBM slots are enabled.",
-    "stype": "bool",
-    "value": false
-  },
-  {
-    "type": "EXTERNAL_OPTION",
     "name": "SPAWN_ANIMAL_DENSITY",
     "info": "A scaling factor that determines density of wild, formerly domesticated and mutated animal spawns.",
     "stype": "float",

--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -26,7 +26,11 @@
     "smash_message": "You smash the %s with a powerful shoulder-check.",
     "safe_bionic_slots": 40,
     "max_bionic_slots": 80,
-    "faults": [ { "effect": "open_skin", "slots_requirement": 40 } ]
+    "faults": [
+      { "effect": "open_skin", "slots_requirement": 40 },
+      { "effect": "nerve_pain", "slots_requirement": 50 },
+      { "effect": "nerve_pain_2", "slots_requirement": 60 }
+    ]
   },
   {
     "id": "head",
@@ -56,7 +60,11 @@
     "smash_efficiency": 0.25,
     "safe_bionic_slots": 9,
     "max_bionic_slots": 18,
-    "faults": [ { "effect": "open_skin", "slots_requirement": 9 } ]
+    "faults": [
+      { "effect": "open_skin", "slots_requirement": 9 },
+      { "effect": "nerve_pain", "slots_requirement": 11 },
+      { "effect": "nerve_pain_2", "slots_requirement": 15 }
+    ]
   },
   {
     "id": "eyes",
@@ -82,7 +90,11 @@
     "smash_efficiency": 0.25,
     "safe_bionic_slots": 2,
     "max_bionic_slots": 4,
-    "faults": [ { "effect": "open_skin", "slots_requirement": 2 } ]
+    "faults": [
+      { "effect": "open_skin", "slots_requirement": 2 },
+      { "effect": "nerve_pain", "slots_requirement": 3 },
+      { "effect": "nerve_pain_2", "slots_requirement": 4 }
+    ]
   },
   {
     "id": "mouth",
@@ -109,7 +121,11 @@
     "smash_efficiency": 0.25,
     "safe_bionic_slots": 2,
     "max_bionic_slots": 4,
-    "faults": [ { "effect": "open_skin", "slots_requirement": 2 } ]
+    "faults": [
+      { "effect": "open_skin", "slots_requirement": 2 },
+      { "effect": "nerve_pain", "slots_requirement": 3 },
+      { "effect": "nerve_pain_2", "slots_requirement": 4 }
+    ]
   },
   {
     "id": "arm_l",
@@ -141,7 +157,11 @@
     "smash_message": "You elbow-smash the %s.",
     "safe_bionic_slots": 10,
     "max_bionic_slots": 20,
-    "faults": [ { "effect": "open_skin", "slots_requirement": 10 } ]
+    "faults": [
+      { "effect": "open_skin", "slots_requirement": 10 },
+      { "effect": "nerve_pain", "slots_requirement": 12 },
+      { "effect": "nerve_pain_2", "slots_requirement": 15 }
+    ]
   },
   {
     "id": "arm_r",
@@ -172,7 +192,11 @@
     "smash_message": "You elbow-smash the %s.",
     "safe_bionic_slots": 10,
     "max_bionic_slots": 20,
-    "faults": [ { "effect": "open_skin", "slots_requirement": 10 } ]
+    "faults": [
+      { "effect": "open_skin", "slots_requirement": 10 },
+      { "effect": "nerve_pain", "slots_requirement": 12 },
+      { "effect": "nerve_pain_2", "slots_requirement": 15 }
+    ]
   },
   {
     "id": "hand_l",
@@ -201,7 +225,11 @@
     "smash_message": "You smash the %s with your fist.",
     "safe_bionic_slots": 3,
     "max_bionic_slots": 5,
-    "faults": [ { "effect": "open_skin", "slots_requirement": 3 } ]
+    "faults": [
+      { "effect": "open_skin", "slots_requirement": 3 },
+      { "effect": "nerve_pain", "slots_requirement": 4 },
+      { "effect": "nerve_pain_2", "slots_requirement": 5 }
+    ]
   },
   {
     "id": "hand_r",
@@ -230,7 +258,11 @@
     "smash_message": "You smash the %s with your fist.",
     "safe_bionic_slots": 3,
     "max_bionic_slots": 5,
-    "faults": [ { "effect": "open_skin", "slots_requirement": 3 } ]
+    "faults": [
+      { "effect": "open_skin", "slots_requirement": 3 },
+      { "effect": "nerve_pain", "slots_requirement": 4 },
+      { "effect": "nerve_pain_2", "slots_requirement": 5 }
+    ]
   },
   {
     "id": "leg_l",
@@ -262,7 +294,11 @@
     "smash_message": "You bring your knee down on the %s, smashing it.",
     "safe_bionic_slots": 15,
     "max_bionic_slots": 30,
-    "faults": [ { "effect": "open_skin", "slots_requirement": 15 } ]
+    "faults": [
+      { "effect": "open_skin", "slots_requirement": 15 },
+      { "effect": "nerve_pain", "slots_requirement": 20 },
+      { "effect": "nerve_pain_2", "slots_requirement": 25 }
+    ]
   },
   {
     "id": "leg_r",
@@ -294,7 +330,11 @@
     "smash_message": "You bring your knee down on the %s, smashing it.",
     "safe_bionic_slots": 15,
     "max_bionic_slots": 30,
-    "faults": [ { "effect": "open_skin", "slots_requirement": 15 } ]
+    "faults": [
+      { "effect": "open_skin", "slots_requirement": 15 },
+      { "effect": "nerve_pain", "slots_requirement": 20 },
+      { "effect": "nerve_pain_2", "slots_requirement": 25 }
+    ]
   },
   {
     "id": "foot_l",
@@ -323,7 +363,11 @@
     "smash_message": "You kick down the %s, smashing it.",
     "safe_bionic_slots": 4,
     "max_bionic_slots": 7,
-    "faults": [ { "effect": "open_skin", "slots_requirement": 4 } ]
+    "faults": [
+      { "effect": "open_skin", "slots_requirement": 4 },
+      { "effect": "nerve_pain", "slots_requirement": 5 },
+      { "effect": "nerve_pain_2", "slots_requirement": 6 }
+    ]
   },
   {
     "id": "foot_r",
@@ -352,6 +396,10 @@
     "smash_message": "You kick down the %s, smashing it.",
     "safe_bionic_slots": 4,
     "max_bionic_slots": 7,
-    "faults": [ { "effect": "open_skin", "slots_requirement": 4 } ]
+    "faults": [
+      { "effect": "open_skin", "slots_requirement": 4 },
+      { "effect": "nerve_pain", "slots_requirement": 5 },
+      { "effect": "nerve_pain_2", "slots_requirement": 6 }
+    ]
   }
 ]

--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -24,7 +24,9 @@
     "base_hp": 60,
     "drench_capacity": 40,
     "smash_message": "You smash the %s with a powerful shoulder-check.",
-    "bionic_slots": 80
+    "safe_bionic_slots": 40,
+    "max_bionic_slots": 80,
+    "faults": [ { "effect": "open_skin", "slots_requirement": 40 } ]
   },
   {
     "id": "head",
@@ -52,7 +54,9 @@
     "drench_capacity": 7,
     "smash_message": "You smash the %s with a firm headbutt.",
     "smash_efficiency": 0.25,
-    "bionic_slots": 18
+    "safe_bionic_slots": 9,
+    "max_bionic_slots": 18,
+    "faults": [ { "effect": "open_skin", "slots_requirement": 9 } ]
   },
   {
     "id": "eyes",
@@ -76,7 +80,9 @@
     "flags": [ "IGNORE_TEMP" ],
     "smash_message": "You use your flippin' face to smash the %s.  EXTREME.",
     "smash_efficiency": 0.25,
-    "bionic_slots": 4
+    "safe_bionic_slots": 2,
+    "max_bionic_slots": 4,
+    "faults": [ { "effect": "open_skin", "slots_requirement": 2 } ]
   },
   {
     "id": "mouth",
@@ -101,7 +107,9 @@
     "drench_capacity": 1,
     "smash_message": "You use your flippin' face to smash the %s.  EXTREME.",
     "smash_efficiency": 0.25,
-    "bionic_slots": 4
+    "safe_bionic_slots": 2,
+    "max_bionic_slots": 4,
+    "faults": [ { "effect": "open_skin", "slots_requirement": 2 } ]
   },
   {
     "id": "arm_l",
@@ -131,7 +139,9 @@
     "base_hp": 60,
     "drench_capacity": 10,
     "smash_message": "You elbow-smash the %s.",
-    "bionic_slots": 20
+    "safe_bionic_slots": 10,
+    "max_bionic_slots": 20,
+    "faults": [ { "effect": "open_skin", "slots_requirement": 10 } ]
   },
   {
     "id": "arm_r",
@@ -160,7 +170,9 @@
     "base_hp": 60,
     "drench_capacity": 10,
     "smash_message": "You elbow-smash the %s.",
-    "bionic_slots": 20
+    "safe_bionic_slots": 10,
+    "max_bionic_slots": 20,
+    "faults": [ { "effect": "open_skin", "slots_requirement": 10 } ]
   },
   {
     "id": "hand_l",
@@ -187,7 +199,9 @@
     "base_hp": 60,
     "drench_capacity": 3,
     "smash_message": "You smash the %s with your fist.",
-    "bionic_slots": 5
+    "safe_bionic_slots": 3,
+    "max_bionic_slots": 5,
+    "faults": [ { "effect": "open_skin", "slots_requirement": 3 } ]
   },
   {
     "id": "hand_r",
@@ -214,7 +228,9 @@
     "base_hp": 60,
     "drench_capacity": 3,
     "smash_message": "You smash the %s with your fist.",
-    "bionic_slots": 5
+    "safe_bionic_slots": 3,
+    "max_bionic_slots": 5,
+    "faults": [ { "effect": "open_skin", "slots_requirement": 3 } ]
   },
   {
     "id": "leg_l",
@@ -244,7 +260,9 @@
     "base_hp": 60,
     "drench_capacity": 11,
     "smash_message": "You bring your knee down on the %s, smashing it.",
-    "bionic_slots": 30
+    "safe_bionic_slots": 15,
+    "max_bionic_slots": 30,
+    "faults": [ { "effect": "open_skin", "slots_requirement": 15 } ]
   },
   {
     "id": "leg_r",
@@ -274,7 +292,9 @@
     "base_hp": 60,
     "drench_capacity": 11,
     "smash_message": "You bring your knee down on the %s, smashing it.",
-    "bionic_slots": 30
+    "safe_bionic_slots": 15,
+    "max_bionic_slots": 30,
+    "faults": [ { "effect": "open_skin", "slots_requirement": 15 } ]
   },
   {
     "id": "foot_l",
@@ -301,7 +321,9 @@
     "base_hp": 60,
     "drench_capacity": 3,
     "smash_message": "You kick down the %s, smashing it.",
-    "bionic_slots": 7
+    "safe_bionic_slots": 4,
+    "max_bionic_slots": 7,
+    "faults": [ { "effect": "open_skin", "slots_requirement": 4 } ]
   },
   {
     "id": "foot_r",
@@ -328,6 +350,8 @@
     "base_hp": 60,
     "drench_capacity": 3,
     "smash_message": "You kick down the %s, smashing it.",
-    "bionic_slots": 7
+    "safe_bionic_slots": 4,
+    "max_bionic_slots": 7,
+    "faults": [ { "effect": "open_skin", "slots_requirement": 4 } ]
   }
 ]

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2393,6 +2393,13 @@
   },
   {
     "type": "effect_type",
+    "id": "open_skin",
+    "name": [ "Open Skin" ],
+    "desc": [ "Your bionics are crowded and not everything is quite sealed, leaving room for infection." ],
+    "base_mods": { "infection_chance": [ 1 ], "infection_tick": [ 86, 400 ] }
+  },
+  {
+    "type": "effect_type",
     "id": "hunger_full",
     "name": [ "Full" ],
     "desc": [ "You feel quite full, and a bit sluggish." ],

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2400,6 +2400,20 @@
   },
   {
     "type": "effect_type",
+    "id": "nerve_pain",
+    "name": [ "Nerve Pain" ],
+    "desc": [ "Your bionics are interfering with your nerves causing pain." ],
+    "base_mods": { "pain_chance": [ 512 ], "pain_min": [ 2 ], "pain_max": [ 8 ] }
+  },
+  {
+    "type": "effect_type",
+    "id": "nerve_pain_2",
+    "name": [ "Nerve Pain" ],
+    "desc": [ "Your bionics are interfering with your nerves causing a lot of pain." ],
+    "base_mods": { "pain_chance": [ 512 ], "pain_min": [ 20 ], "pain_max": [ 40 ] }
+  },
+  {
+    "type": "effect_type",
     "id": "hunger_full",
     "name": [ "Full" ],
     "desc": [ "You feel quite full, and a bit sluggish." ],

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1121,7 +1121,7 @@ bool Character::deactivate_bionic( int b, bool eff_only )
 
     // Recalculate stats (strength, mods from pain etc.) that could have been affected
     calc_encumbrance();
-    //Possibly size or slots used changed? 
+    //Possibly size or slots used changed?
     update_bionic_faults();
     reset();
     if( !bio.id->enchantments.empty() ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1121,6 +1121,8 @@ bool Character::deactivate_bionic( int b, bool eff_only )
 
     // Recalculate stats (strength, mods from pain etc.) that could have been affected
     calc_encumbrance();
+    //Possibly size or slots used changed? 
+    update_bionic_faults();
     reset();
     if( !bio.id->enchantments.empty() ) {
         recalculate_enchantment_cache();

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2384,7 +2384,27 @@ bool Character::install_bionics( const itype &type, player &installer, bool auto
     const int difficulty = type.bionic->difficulty;
     int pl_skill = installer.bionics_pl_skill( autodoc, skill_level );
     int chance_of_success = bionic_success_chance( autodoc, skill_level, difficulty, installer );
+    bool bonus = false;
+    bool penalty = false;
 
+    // If all parts have no bionics give bonus.  If any parts have more than safe slots used apply penalty.
+    for( const std::pair<const bodypart_str_id, size_t> &bp : bioid->occupied_bodyparts ) {
+        if( get_used_bionics_slots( bp.first ) == 0 ) {
+            bonus = true;
+        } else if( get_used_bionics_slots( bp.first ) > bp.first->safe_bionic_slots() ) {
+            bonus = false;
+            penalty = true;
+            break;
+        } else {
+            bonus = false;
+        }
+    }
+    //TODO make this scale and balanced
+    if( penalty ) {
+        chance_of_success -= 30;
+    } else if( bonus ) {
+        chance_of_success += 30;
+    }
     // Practice skills only if conducting manual installation
     if( !autodoc ) {
         installer.practice( skill_electronics, static_cast<int>( ( 100 - chance_of_success ) * 1.5 ) );

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -385,11 +385,9 @@ static void draw_description( const catacurses::window &win, const bionic &bio,
     ypos += 1 + fold_and_print( win, point( 0, ypos ), width, c_light_blue, "%s", bio.id->description );
 
     // TODO: Unhide when enforcing limits
-    if( get_option < bool >( "CBM_SLOTS_ENABLED" ) ) {
-        const bool each_bp_on_new_line = ypos + num_of_bp + 1 < getmaxy( win );
-        fold_and_print( win, point( 0, ypos ), width, c_light_gray, list_occupied_bps( bio.id,
-                        _( "This bionic occupies the following body parts:" ), each_bp_on_new_line ) );
-    }
+    const bool each_bp_on_new_line = ypos + num_of_bp + 1 < getmaxy( win );
+    fold_and_print( win, point( 0, ypos ), width, c_light_gray, list_occupied_bps( bio.id,
+                    _( "This bionic occupies the following body parts:" ), each_bp_on_new_line ) );
     wnoutrefresh( win );
 }
 
@@ -405,7 +403,7 @@ static void draw_connectors( const catacurses::window &win, const point &start,
             pos_and_num.emplace_back( static_cast<int>( pos->second ) + LIST_START_Y, elem.second );
         }
     }
-    if( pos_and_num.empty() || !get_option < bool >( "CBM_SLOTS_ENABLED" ) ) {
+    if( pos_and_num.empty() ) {
         return;
     }
 
@@ -655,10 +653,8 @@ void avatar::power_bionics()
             max_width = std::max( max_width, utf8_width( s ) );
         }
         const int pos_x = WIDTH - 2 - max_width;
-        if( get_option < bool >( "CBM_SLOTS_ENABLED" ) ) {
-            for( size_t i = 0; i < bps.size(); ++i ) {
-                mvwprintz( wBio, point( pos_x, i + list_start_y ), c_light_gray, bps[i] );
-            }
+        for( size_t i = 0; i < bps.size(); ++i ) {
+            mvwprintz( wBio, point( pos_x, i + list_start_y ), c_light_gray, bps[i] );
         }
 
         if( current_bionic_list->empty() ) {
@@ -685,7 +681,7 @@ void avatar::power_bionics()
                                                                 *( *current_bionic_list )[i] ).c_str() );
                 trim_and_print( wBio, point( 2, list_start_y + i - scroll_position ), WIDTH - 3, col,
                                 desc );
-                if( is_highlighted && menu_mode != EXAMINING && get_option < bool >( "CBM_SLOTS_ENABLED" ) ) {
+                if( is_highlighted && menu_mode != EXAMINING ) {
                     const bionic_id bio_id = ( *current_bionic_list )[i]->id;
                     draw_connectors( wBio, point( utf8_width( desc ) + 3, list_start_y + i - scroll_position ),
                                      pos_x - 2, bio_id, bp_to_pos );

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -239,8 +239,17 @@ void body_part_type::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "stylish_bonus", stylish_bonus, 0 );
     optional( jo, was_loaded, "squeamish_penalty", squeamish_penalty, 0 );
 
-    optional( jo, was_loaded, "bionic_slots", bionic_slots_, 0 );
-
+    optional( jo, was_loaded, "safe_bionic_slots", safe_bionic_slots_, 0 );
+    optional( jo, was_loaded, "max_bionic_slots", max_bionic_slots_, 0 );
+    if( safe_bionic_slots_ > max_bionic_slots_ ) {
+        jo.throw_error( "safe slots cannot exceed max slots." );
+    }
+    for( JsonObject fault : jo.get_array( "faults" ) ) {
+        bp_bionic_fault new_fault;
+        mandatory( fault, was_loaded, "effect", new_fault.effect );
+        mandatory( fault, was_loaded, "slots_requirement", new_fault.slots_requirement );
+        faults_.push_back( new_fault );
+    }
     optional( jo, was_loaded, "flags", flags );
 
     part_side = jo.get_enum_value<side>( "side" );

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -307,6 +307,12 @@ void body_part_type::check() const
         debugmsg( "Bodypart %s has inconsistent opposite part!", id.str() );
     }
 
+    for( const bp_bionic_fault &fault : faults_ ) {
+        if( !fault.effect.is_valid() ) {
+            debugmsg( "Fault has invalid effect %s", fault.effect.str() );
+        }
+    }
+
     // Check that connected_to leads eventually to the root bodypart (currently always head),
     // without any loops
     std::unordered_set<bodypart_str_id> visited = { id };

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -15,6 +15,7 @@
 #include "int_id.h"
 #include "string_id.h"
 #include "translations.h"
+#include "type_id.h"
 
 class JsonIn;
 class JsonObject;
@@ -106,6 +107,11 @@ struct stat_hp_mods {
     void deserialize( JsonIn &jsin );
 };
 
+struct bp_bionic_fault {
+    efftype_id effect;
+    int slots_requirement;
+};
+
 struct body_part_type {
     public:
         bodypart_str_id id;
@@ -180,11 +186,19 @@ struct body_part_type {
         // Verifies that body parts make sense
         static void check_consistency();
 
-        int bionic_slots() const {
-            return bionic_slots_;
+        int max_bionic_slots() const {
+            return max_bionic_slots_;
+        }
+        int safe_bionic_slots() const {
+            return safe_bionic_slots_;
+        }
+        std::vector<bp_bionic_fault> faults() const {
+            return faults_;
         }
     private:
-        int bionic_slots_ = 0;
+        int max_bionic_slots_ = 0;
+        int safe_bionic_slots_ = 0;
+        std::vector<bp_bionic_fault> faults_;
 };
 
 struct layer_details {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -12171,6 +12171,12 @@ void Character::process_one_effect( effect &it, bool is_new )
         }
     }
 
+    // Handle infection
+    mod = 1;
+    val = 0;
+    if( it.activated( calendar::turn, "INFECTION", val, reduced, mod ) ) {
+        add_effect( effect_infected, 25_minutes, bp, true );
+    }
     // Speed and stats are handled in recalc_speed_bonus and reset_stats respectively
 }
 

--- a/src/character.h
+++ b/src/character.h
@@ -1266,6 +1266,7 @@ class Character : public Creature, public visitable<Character>
         int get_used_bionics_slots( const bodypart_id &bp ) const;
         int get_total_bionics_slots( const bodypart_id &bp ) const;
         int get_free_bionics_slots( const bodypart_id &bp ) const;
+        void update_bionic_faults();
 
         /**Has enough anesthetic for surgery*/
         bool has_enough_anesth( const itype &cbm, player &patient );

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -393,6 +393,12 @@ bool effect_type::load_mod_data( const JsonObject &jo, const std::string &member
         extract_effect( j, mod_data, "cut_mod",    member, "CUT",  "min" );
         extract_effect( j, mod_data, "size_mod",    member, "SIZE",  "min" );
 
+        // Then infection chance
+        extract_effect( j, mod_data, "infection_chance",     member, "INFECTION",    "chance_top" );
+        extract_effect( j, mod_data, "infection_chance_bot", member, "INFECTION",    "chance_bot" );
+        extract_effect( j, mod_data, "infection_tick",       member, "INFECTION",    "tick" );
+
+
         return true;
     } else {
         return false;
@@ -654,6 +660,9 @@ std::string effect::disp_desc( bool reduced ) const
     val = get_avg_mod( "SLEEP", reduced );
     values.push_back( desc_freq( get_percentage( "SLEEP", val, reduced ), val, _( "blackouts" ),
                                  _( "blackouts" ) ) );
+    val = get_avg_mod( "INFECTION", reduced );
+    values.push_back( desc_freq( get_percentage( "INFECTION", val, reduced ), val, _( "infection" ),
+                                 _( "infection" ) ) );
 
     for( auto &i : values ) {
         if( i.val > 0 ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3391,8 +3391,7 @@ void item::bionic_info( std::vector<iteminfo> &info, const iteminfo_query *parts
     }
 
     // TODO: Unhide when enforcing limits
-    if( get_option < bool >( "CBM_SLOTS_ENABLED" )
-        && parts->test( iteminfo_parts::DESCRIPTION_CBM_SLOTS ) ) {
+    if( parts->test( iteminfo_parts::DESCRIPTION_CBM_SLOTS ) ) {
         info.push_back( iteminfo( "DESCRIPTION", list_occupied_bps( type->bionic->id,
                                   _( "This bionic is installed in the following body "
                                      "part(s):" ) ) ) );

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -629,6 +629,8 @@ int mutation_branch::bionic_slot_bonus( const bodypart_str_id &part ) const
     if( restricts_gear_iter != restricts_gear.end() ) {
         total_bonus --;
     }
+
+    return total_bonus;
 }
 
 std::string mutation_branch::spawn_item_message() const

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -588,7 +588,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
 
 int mutation_branch::bionic_slot_bonus( const bodypart_str_id &part ) const
 {
-    //TODO Possibly add field to mutations for bp affected and use it rather than all these    
+    //TODO Possibly add field to mutations for bp affected and use it rather than all these
     int total_bonus = 0;
     const auto slot_iter = bionic_slot_bonuses.find( part );
     if( slot_iter != bionic_slot_bonuses.end() ) {

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -588,11 +588,46 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
 
 int mutation_branch::bionic_slot_bonus( const bodypart_str_id &part ) const
 {
-    const auto iter = bionic_slot_bonuses.find( part );
-    if( iter == bionic_slot_bonuses.end() ) {
-        return 0;
-    } else {
-        return iter->second;
+    //TODO Possibly add field to mutations for bp affected and use it rather than all these    
+    int total_bonus = 0;
+    const auto slot_iter = bionic_slot_bonuses.find( part );
+    if( slot_iter != bionic_slot_bonuses.end() ) {
+        total_bonus += slot_iter->second;
+    }
+
+    const auto armor_iter = armor.find( part );
+    if( armor_iter != armor.end() ) {
+        total_bonus --;
+    }
+
+    const auto lumination_iter = lumination.find( part );
+    if( lumination_iter != lumination.end() ) {
+        total_bonus --;
+    }
+
+    const auto protection_iter = protection.find( part );
+    if( protection_iter != protection.end() ) {
+        total_bonus --;
+    }
+
+    const auto encumbrance_always_iter = encumbrance_always.find( part );
+    if( encumbrance_always_iter != encumbrance_always.end() ) {
+        total_bonus --;
+    }
+
+    const auto encumbrance_covered_iter = encumbrance_covered.find( part );
+    if( encumbrance_covered_iter != encumbrance_covered.end() ) {
+        total_bonus --;
+    }
+
+    const auto encumbrance_multiplier_always_iter = encumbrance_multiplier_always.find( part );
+    if( encumbrance_multiplier_always_iter != encumbrance_multiplier_always.end() ) {
+        total_bonus --;
+    }
+
+    const auto restricts_gear_iter = restricts_gear.find( part );
+    if( restricts_gear_iter != restricts_gear.end() ) {
+        total_bonus --;
     }
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
Features "Adjust bionic slots for first step of rework"
<!-- This section should consist of exactly one line, formatted like this:

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
First part of #28273
Begin rework of bionics to use max and safe slots and faults for overuse
With the exodites coming next version to shake up cbms, it will be the perfect time to flesh them out more.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
This needs balancing/feedback but it sets up much of the linked issues framework.

- Adds the concepts of maximum and safe slots for each body part.    Right now all max values are unchanged and all safe vals are 50% of them.
- CBM installation chances are affected by going over safe slot usage. Right now a 30% bonus is applied if no affected parts have bionics and a 30% penalty is applied if any parts are over safe limit before install.
- Adds faults.  For each body part you define in json a list of faults, which are an effect id and a number of slots.  When you use that number of slots or more on that body part you will have that effect on the body part.  Right now there are 3 faults for all body parts: open_skin which has a chance of infection, and nerve_pain and nerve_pain_2 which both add pain. These need balance/tweaking.
- Each body parts maximum slot number will be lowered by mutations affecting it.  Right now this is using existing bp tags in mutation but in the future will need new trait tags to fully capture.
- Added ability for effects to cause infections, as this was needed for open skin.
- Removes the option of not using cbm slots mode.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
