### PR TITLE
Only inform about enemies regenerating if the player can see it

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -483,7 +483,7 @@ static void damage_targets( const spell &sp, Creature &caster,
             cr->deal_projectile_attack( &caster, atk, true );
         } else if( sp.damage() < 0 ) {
             sp.heal( target );
-            add_msg( m_good, _( "%s wounds are closing up!" ), cr->disp_name( true ) );
+            add_msg_if_player_sees( cr->pos(), m_good, _( "%s wounds are closing up!" ), cr->disp_name( true ) );
         }
         // TODO: randomize hit location
         cr->add_damage_over_time( sp.damage_over_time( { body_part_torso } ) );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -483,7 +483,8 @@ static void damage_targets( const spell &sp, Creature &caster,
             cr->deal_projectile_attack( &caster, atk, true );
         } else if( sp.damage() < 0 ) {
             sp.heal( target );
-            add_msg_if_player_sees( cr->pos(), m_good, _( "%s wounds are closing up!" ), cr->disp_name( true ) );
+            add_msg_if_player_sees( cr->pos(), m_good, _( "%s wounds are closing up!" ),
+                                    cr->disp_name( true ) );
         }
         // TODO: randomize hit location
         cr->add_damage_over_time( sp.damage_over_time( { body_part_torso } ) );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Only inform about enemies regenerating if the player can see it"

#### Purpose of change

You would know about swamp creature slowly regenerating while walking in the tunnels at z-level -5.

#### Describe the solution

Only display the message if the player can see the relevant entity.

#### Describe alternatives you've considered

None

#### Testing

Hurt Mox Elder, put on a blindfold, didn't get any messages, took it off and it was fully healed.
