### PR TITLE
Move more of the Nanofabricator functionality to json

### DIFF
--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -453,7 +453,7 @@
     "color": "dark_gray",
     "move_cost": 0,
     "coverage": 65,
-    "flags": [ "PLACE_ITEM" ],
+    "flags": [ "PLACE_ITEM", "NANOFAB_TABLE" ],
     "bash": {
       "str_min": 120,
       "str_max": 150,
@@ -481,6 +481,7 @@
     "name": "nanofabricator control panel",
     "symbol": "&",
     "description": "A small computer panel attached to a nanofabricator.  It has a single slot for reading templates.",
+    "allowed_template_ids": [ "standard_template_construct", "debug_template" ],
     "color": "red",
     "looks_like": "f_console",
     "move_cost": 0,

--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -80,6 +80,12 @@
   },
   {
     "type": "item_group",
+    "id": "debug_template_item",
+    "subtype": "distribution",
+    "entries": [ { "item": "standard_template_construct", "prob": 10 } ]
+  },
+  {
+    "type": "item_group",
     "id": "nanofab_recipes",
     "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
     "magazine": 100,

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -1605,10 +1605,21 @@
     "price_postapoc": 1000,
     "material": [ "steel", "plastic" ],
     "nanofab_template_group": "nanofab_recipes",
+    "template_requirements": "nanofabricator",
     "weight": "317 g",
     "volume": "250 ml",
     "to_hit": -1,
     "flags": [ "NANOFAB_TEMPLATE", "TRADER_AVOID" ]
+  },
+  {
+    "type": "GENERIC",
+    "id": "debug_template",
+    "copy-from": "standard_template_construct",
+    "color": "yellow",
+    "name": { "str": "nanofabricator template" },
+    "description": "A state-of-the-art optical storage system, containing the instruction set to replicate itself.",
+    "nanofab_template_group": "debug_template_item",
+    "template_requirements": "copper_scrap_equivalent"
   },
   {
     "type": "GENERIC",

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -307,7 +307,7 @@ void iexamine::nanofab( player &p, const tripoint &examp )
             return e.typeId() == itid;
         } );
     }, _( "Introduce a compatible template." ), PICKUP_RANGE,
-    _( "You don't have any usable templates.\n\nCompatible templates are: " + name_list ) );
+    _( "You don't have any usable templates.\n\nCompatible templates are: " ) + name_list );
 
     if( !nanofab_template ) {
         return;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2937,6 +2937,10 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         def.nanofab_template_group = item_group_id( jo.get_string( "nanofab_template_group" ) );
     }
 
+    if( jo.has_string( "template_requirements" ) ) {
+        def.template_requirements = requirement_id( jo.get_string( "template_requirements" ) );
+    }
+
     JsonArray jarr = jo.get_array( "min_skills" );
     if( !jarr.empty() ) {
         def.min_skills.clear();

--- a/src/itype.h
+++ b/src/itype.h
@@ -1000,6 +1000,8 @@ struct itype {
         // itemgroup used to generate the recipes within nanofabricator templates.
         item_group_id nanofab_template_group;
 
+        requirement_id template_requirements;
+
     private:
         /** Can item be combined with other identical items? */
         bool stackable_ = false;

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1223,6 +1223,8 @@ void ter_t::load( const JsonObject &jo, const std::string &src )
         set_connects( jo.get_string( "connects_to" ) );
     }
 
+    optional( jo, was_loaded, "allowed_template_ids", allowed_template_id );
+
     optional( jo, was_loaded, "open", open, ter_str_id::NULL_ID() );
     optional( jo, was_loaded, "close", close, ter_str_id::NULL_ID() );
     optional( jo, was_loaded, "transforms_into", transforms_into, ter_str_id::NULL_ID() );

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -373,6 +373,7 @@ struct ter_t : map_data_common_t {
     trap_id trap; // The id of the trap located at this terrain. Limit one trap per tile currently.
 
     std::set<emit_id> emissions;
+    std::set<itype_id> allowed_template_id;
 
     ter_t();
 


### PR DESCRIPTION
#### Summary

SUMMARY: Content "Move more of the Nanofabricator functionality to json"

#### Purpose of change

Unhardcode more nanofab functionality, making them more versatile. This mostly  preliminary work to make nano fabricators more common within Aftershock.

#### Describe the solution

Nanofabricator templates must now specify the material requirements that must be provided for printing. 

The nanofabricator terrain can now specify what templates it accepts, allowing the creation of differentiated fabricators. You can now create a medical printer that only prints medical templates, or a civiliant variant that can only print common consumer goods.




