### PR TITLE
Snow: Part 1

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -1225,6 +1225,20 @@
     "phase": "gas"
   },
   {
+    "id": "fd_snow",
+    "type": "field_type",
+    "//": "1 < 10mm (0.39\"); 2 ≈ 10mm-160mm (6.3\");  3 ≈ 160mm-810mm (31.9\"); see map::actualize_snow_in_submap for details.",
+    "intensity_levels": [
+      { "name": "shallow snow", "sym": "*", "color": "white", "convection_temperature_mod": -2 },
+      { "name": { "ctxt": "noun", "str": "snow" }, "color": "white" },
+      { "name": "deep snow" }
+    ],
+    "priority": -1,
+    "phase": "solid",
+    "display_items": true,
+    "display_field": true
+  },
+  {
     "id": "fd_cold_air2",
     "type": "field_type",
     "legacy_enum_id": 42,

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -1229,8 +1229,8 @@
     "type": "field_type",
     "//": "1 < 10mm (0.39\"); 2 ≈ 10mm-160mm (6.3\");  3 ≈ 160mm-810mm (31.9\"); see map::actualize_snow_in_submap for details.",
     "intensity_levels": [
-      { "name": "shallow snow", "sym": "*", "color": "white", "convection_temperature_mod": -2 },
-      { "name": { "ctxt": "noun", "str": "snow" }, "color": "white" },
+      { "name": "shallow snow", "color": "light_gray", "convection_temperature_mod": -2 },
+      { "name": "snow" },
       { "name": "deep snow" }
     ],
     "priority": -1,

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -976,8 +976,8 @@
         "thunder",
         "lightning",
         "flurries",
-        "snowing",
-        "snowstorm"
+        "snowstorm",
+        "snowing"
       ]
     },
     "overmap_feature_flag_settings": { "clear_blacklist": false, "blacklist": [  ], "clear_whitelist": false, "whitelist": [  ] }

--- a/data/json/weather_type.json
+++ b/data/json/weather_type.json
@@ -244,12 +244,13 @@
     "dangerous": false,
     "precip": "light",
     "rains": false,
+    "snows": true,
     "acidic": false,
     "tiles_animation": "weather_snowflake",
     "weather_animation": { "factor": 0.01, "color": "white", "sym": "." },
     "sound_category": "flurries",
     "sun_intensity": "light",
-    "requirements": { "temperature_max": 33, "required_weathers": [ "drizzle" ] }
+    "requirements": { "temperature_max": 33, "required_weathers": [ "light_drizzle", "drizzle" ] }
   },
   {
     "id": "snowing",
@@ -265,6 +266,7 @@
     "dangerous": false,
     "precip": "heavy",
     "rains": false,
+    "snows": true,
     "acidic": false,
     "effects": [ { "must_be_outside": true, "wet": 10 } ],
     "tiles_animation": "weather_snowflake",
@@ -287,12 +289,13 @@
     "dangerous": false,
     "precip": "heavy",
     "rains": false,
+    "snows": true,
     "acidic": false,
     "effects": [ { "must_be_outside": true, "wet": 40 } ],
     "tiles_animation": "weather_snowflake",
     "weather_animation": { "factor": 0.04, "color": "white", "sym": "*" },
     "sound_category": "snowstorm",
     "sun_intensity": "none",
-    "requirements": { "temperature_max": 33, "windpower_min": 15, "required_weathers": [ "thunder", "lightning" ] }
+    "requirements": { "temperature_max": 33, "windpower_min": 15, "required_weathers": [ "rain", "thunder", "lightning" ] }
   }
 ]

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -566,6 +566,7 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - ```NO_SIGHT``` Creature on this tile have their sight reduced to one tile
 - ```NO_SCENT``` This tile cannot have scent values, which prevents scent diffusion through this tile
 - ```NO_SHOOT``` Terrain with this flag cannot be damaged by ranged attacks, and ranged attacks will not pass through it.
+- ```NO_SNOW```  This terrain cannot support snow (e.g. water, lava)
 - ```OPENCLOSE_INSIDE``` If it's a door (with an 'open' or 'close' field), it can only be opened or closed if you're inside.
 - ```PAINFUL``` May cause a small amount of pain.
 - ```PERMEABLE``` Permeable for gases.

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -128,8 +128,7 @@ int field_entry::get_field_intensity() const
 int field_entry::set_field_intensity( int new_intensity )
 {
     is_alive = new_intensity > 0;
-    return intensity = std::max( std::min( new_intensity, get_max_field_intensity() ), 1 );
-
+    return intensity = clamp( new_intensity, 1, get_max_field_intensity() );
 }
 
 void field_entry::mod_field_intensity( int mod )
@@ -234,12 +233,16 @@ bool field::add_field( const field_type_id &field_type_to_add, const int new_int
         it->second.set_field_intensity( it->second.get_field_intensity() + new_intensity );
         return false;
     }
-    if( !_displayed_field_type ||
-        field_type_to_add.obj().priority >= _displayed_field_type.obj().priority ) {
-        _displayed_field_type = field_type_to_add;
+    if( new_intensity > 0 ) {
+        if( !_displayed_field_type ||
+            field_type_to_add.obj().priority >= _displayed_field_type.obj().priority ) {
+            _displayed_field_type = field_type_to_add;
+        }
+        _field_type_list[field_type_to_add] = field_entry(
+                field_type_to_add, std::min( new_intensity, field_type_to_add->get_max_intensity() ), new_age );
+        return true;
     }
-    _field_type_list[field_type_to_add] = field_entry( field_type_to_add, new_intensity, new_age );
-    return true;
+    return false;
 }
 
 bool field::remove_field( const field_type_id &field_to_remove )

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -13,6 +13,7 @@
 
 const field_type_str_id fd_null = field_type_str_id::NULL_ID();
 const field_type_str_id fd_fire( "fd_fire" );
+const field_type_str_id fd_snow( "fd_snow" );
 const field_type_str_id fd_blood( "fd_blood" );
 const field_type_str_id fd_bile( "fd_bile" );
 const field_type_str_id fd_extinguisher( "fd_extinguisher" );

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -111,6 +111,7 @@ struct field_intensity_level {
 const field_type_id INVALID_FIELD_TYPE_ID = field_type_id( -1 );
 extern const field_type_str_id fd_null;
 extern const field_type_str_id fd_fire;
+extern const field_type_str_id fd_snow;
 extern const field_type_str_id fd_blood;
 extern const field_type_str_id fd_bile;
 extern const field_type_str_id fd_extinguisher;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1583,6 +1583,10 @@ bool game::do_turn()
     // consider a stripped down cache just for monsters.
     m.build_map_cache( levz, true );
     monmove();
+    double snow_level = get_weather().snow_level;
+    if( calendar::once_every( 1_minutes ) ) {
+        m.actualize_snow( snow_level );
+    }
     if( calendar::once_every( 5_minutes ) ) {
         overmap_npc_move();
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7070,11 +7070,11 @@ void map::actualize_snow_in_submap( const tripoint &gridp, float new_snow_lvl, b
     const auto level_to_intensity = [&]( float level_mm ) -> float {
         return level_mm < eps ? 0 :
         level_mm <= 10.f ? 1.f :
-        std::powf( level_mm / 10.f, 1.f / 4 );
+        std::pow( level_mm / 10.f, 1.f / 4 );
     };
     // Convert snow level in mm to the index of the pseudorandom tiling sequence
     const auto level_to_idx = [&]( float level_mm ) {
-        return static_cast<int>( std::ceilf( level_to_intensity( level_mm ) * SEEX * SEEY ) );
+        return static_cast<int>( std::ceil( level_to_intensity( level_mm ) * SEEX * SEEY ) );
     };
     const auto remove_snow = [&]( field & f ) {
         if( f.remove_field( fd_snow ) ) {

--- a/src/map.h
+++ b/src/map.h
@@ -1548,11 +1548,11 @@ class map
 
     protected:
         void saven( const tripoint &grid );
-        void loadn( const tripoint &grid, bool update_vehicles, bool _actualize = true );
-        void loadn( const point &grid, bool update_vehicles, bool _actualize = true ) {
+        void loadn( const tripoint &grid, bool update_vehicles );
+        void loadn( const point &grid, bool update_vehicles ) {
             if( zlevels ) {
                 for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
-                    loadn( tripoint( grid, gridz ), update_vehicles, _actualize );
+                    loadn( tripoint( grid, gridz ), update_vehicles );
                 }
 
                 // Note: we want it in a separate loop! It is a post-load cleanup
@@ -1561,7 +1561,7 @@ class map
                     add_roofs( tripoint( grid, gridz ) );
                 }
             } else {
-                loadn( tripoint( grid, abs_sub.z ), update_vehicles, _actualize );
+                loadn( tripoint( grid, abs_sub.z ), update_vehicles );
             }
         }
         /**
@@ -1569,6 +1569,8 @@ class map
          * This is used to rot and remove rotten items, grow plants, fill funnels etc.
          */
         void actualize( const tripoint &grid );
+        // actualized all submaps
+        void actualize();
         /**
          * Hacks in missing roofs. Should be removed when 3D mapgen is done.
          */
@@ -1630,6 +1632,20 @@ class map
         // fills lm with sunlight. pzlev is current player's zlevel
         void build_sunlight_cache( int pzlev );
     public:
+        /**
+         * Adds or removes snow in all submaps
+         * @param new_snow_lvl new snow level in mm
+         * @see actualize_snow_in_submap
+         */
+        void actualize_snow( float new_snow_lvl );
+        /**
+        * Adds or removes snow to match new_snow_lvl. See implementation for more extensive description.
+        * @param gridp submap position in grid coordinates
+        * @param new_snow_lvl new snow level in mm
+        * @param from_scratch if true, removes snow first and then adds it from scratch
+        */
+        void actualize_snow_in_submap( const tripoint &gridp, float new_snow_lvl, bool from_scratch );
+
         void build_outside_cache( int zlev );
         // Get a bitmap indicating which layers are potentially visible from the target layer.
         std::bitset<OVERMAP_LAYERS> get_inter_level_visibility( int origin_zlevel )const ;

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -182,7 +182,8 @@ static const std::unordered_map<std::string, ter_bitflags> ter_bitflags_map = { 
         { "THIN_OBSTACLE",            TFLAG_THIN_OBSTACLE },  // Passable by players and monsters. Vehicles destroy it.
         { "Z_TRANSPARENT",            TFLAG_Z_TRANSPARENT },  // Doesn't block vision passing through the z-level
         { "SMALL_PASSAGE",            TFLAG_SMALL_PASSAGE },   // A small passage, that large or huge things cannot pass through
-        { "SUN_ROOF_ABOVE",           TFLAG_SUN_ROOF_ABOVE }   // This furniture has a "fake roof" above, that blocks sunlight (see #44421).
+        { "SUN_ROOF_ABOVE",           TFLAG_SUN_ROOF_ABOVE },  // This furniture has a "fake roof" above, that blocks sunlight (see #44421).
+        { "NO_SNOW",                  TFLAG_NO_SNOW }          // This terrain cannot support snow (e.g. water, lava)
     }
 };
 

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -217,6 +217,7 @@ enum ter_bitflags : int {
     TFLAG_SMALL_PASSAGE,
     TFLAG_Z_TRANSPARENT,
     TFLAG_SUN_ROOF_ABOVE,
+    TFLAG_NO_SNOW,
 
     NUM_TERFLAGS
 };

--- a/src/rng.h
+++ b/src/rng.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_RNG_H
 #define CATA_SRC_RNG_H
 
+#include <algorithm>
 #include <array>
 #include <functional>
 #include <iosfwd>

--- a/src/rng.h
+++ b/src/rng.h
@@ -196,12 +196,9 @@ class pseudo_random_matrix_tiling
 
     public:
         pseudo_random_matrix_tiling( uint64_t seed ) {
-            for( size_t i = 0; i < w; ++i ) {
-                w_arr[i] = i;
-            }
-            for( size_t i = 0; i < h; ++i ) {
-                h_arr[i] = i;
-            }
+            std::iota( w_arr.begin(), w_arr.end(), 0 );
+            std::iota( h_arr.begin(), h_arr.end(), 0 );
+            // NOLINTNEXTLINE(cata-determinism)
             cata_default_random_engine eng( seed );
             std::shuffle( w_arr.begin(), w_arr.end(), eng );
             std::shuffle( h_arr.begin(), h_arr.end(), eng );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1162,7 +1162,7 @@ void game::unserialize_master( std::istream &fin )
             } else if( name == "seed" ) {
                 jsin.read( seed );
             } else if( name == "weather" ) {
-                weather_manager::unserialize_all( jsin );
+                get_weather().unserialize_all( jsin );
             } else {
                 // silently ignore anything else
                 jsin.skip_value();
@@ -1182,15 +1182,28 @@ void mission::serialize_all( JsonOut &json )
     json.end_array();
 }
 
+void weather_manager::serialize_all( JsonOut &json )
+{
+    json.member( "lightning", lightning_active );
+    json.member( "weather_id", weather_id );
+    json.member( "next_weather", nextweather );
+    json.member( "temperature", temperature );
+    json.member( "winddirection", winddirection );
+    json.member( "windspeed", windspeed );
+    json.member( "snow_level", snow_level );
+}
+
 void weather_manager::unserialize_all( JsonIn &jsin )
 {
     JsonObject w = jsin.get_object();
-    w.read( "lightning", get_weather().lightning_active );
-    w.read( "weather_id", get_weather().weather_id );
-    w.read( "next_weather", get_weather().nextweather );
-    w.read( "temperature", get_weather().temperature );
-    w.read( "winddirection", get_weather().winddirection );
-    w.read( "windspeed", get_weather().windspeed );
+    w.read( "lightning", lightning_active );
+    w.read( "weather_id", weather_id );
+    w.read( "next_weather", nextweather );
+    w.read( "temperature", temperature );
+    w.read( "winddirection", winddirection );
+    w.read( "windspeed", windspeed );
+    snow_level = 0;
+    w.read( "snow_level", snow_level );
 }
 
 void game::serialize_master( std::ostream &fout )
@@ -1211,12 +1224,7 @@ void game::serialize_master( std::ostream &fout )
 
         json.member( "weather" );
         json.start_object();
-        json.member( "lightning", weather.lightning_active );
-        json.member( "weather_id", weather.weather_id );
-        json.member( "next_weather", weather.nextweather );
-        json.member( "temperature", weather.temperature );
-        json.member( "winddirection", weather.winddirection );
-        json.member( "windspeed", weather.windspeed );
+        weather.serialize_all( json );
         json.end_object();
 
         json.end_object();

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3826,6 +3826,7 @@ void submap::store( JsonOut &jsout ) const
 {
     jsout.member( "turn_last_touched", last_touched );
     jsout.member( "temperature", temperature );
+    jsout.member( "snow_level", snow_level );
 
     // Terrain is saved using a simple RLE scheme.  Legacy saves don't have
     // this feature but the algorithm is backward compatible.
@@ -4048,6 +4049,8 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version )
         last_touched = time_point( jsin.get_int() );
     } else if( member_name == "temperature" ) {
         temperature = jsin.get_int();
+    } else if( member_name == "snow_level" ) {
+        snow_level = jsin.get_float();
     } else if( member_name == "terrain" ) {
         // TODO: try block around this to error out if we come up short?
         jsin.start_array();

--- a/src/submap.h
+++ b/src/submap.h
@@ -249,6 +249,10 @@ class submap : maptile_soa<SEEX, SEEY>
         std::map<tripoint, partial_con> partial_constructions;
         std::unique_ptr<basecamp> camp;  // only allowing one basecamp per submap
 
+        // avg actualized snow level, in mm (see map::actualize_snow_in_submap)
+        float snow_level = 0;
+        // a flag that is reset during loading and set during actualization
+        bool actualized = false;
     private:
         std::map<point, computer> computers;
         std::unique_ptr<computer> legacy_computer;

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -1064,7 +1064,7 @@ const weather_generator &weather_manager::get_cur_weather_gen() const
  * @param duration melting period
  * @return snow melt in mm. Could be negative. Negative values are used to offset snow melt from sun radiation.
  */
-double snowmelt_temp( double temp_C, time_duration duration )
+static double snowmelt_temp( double temp_C, time_duration duration )
 {
     /* https://directives.sc.egov.usda.gov/OpenNonWebContent.aspx?content=17753.wba
      The degree-day method is a temperature index approach that equates the total daily melt to a coefficient
@@ -1089,7 +1089,7 @@ double snowmelt_temp( double temp_C, time_duration duration )
  * @param sunlight_percent
  * @return Direct normal radiation, in W/m²
  */
-double sunlight_to_watts_per_m_sq( double sunlight_percent )
+static double sunlight_to_watts_per_m_sq( double sunlight_percent )
 {
     // for New England yearly total GHI (Global Horizontal Irradiance) is ≈1387 kWh/m²
     // cumulative "sunlight_percent" for one year, returned by `sum_conditions` is 1.64339e+09
@@ -1104,7 +1104,7 @@ double sunlight_to_watts_per_m_sq( double sunlight_percent )
  * @param period, melting period
  * @return snow melt in mm (non-negative)
  */
-double snowmelt_sun( double incident_sunlight_percent, time_duration period )
+static double snowmelt_sun( double incident_sunlight_percent, time_duration period )
 {
     // 1 langley = 41.84 kJ/m² (kWs/m²)
     // 1 langley/day =  41.84 / (3600 * 24) kW

--- a/src/weather.h
+++ b/src/weather.h
@@ -53,6 +53,7 @@ struct rl_vec2d;
 struct trap;
 
 double precip_mm_per_hour( precip_class p );
+double snow_mm_per_hour( precip_class p );
 void handle_weather_effects( const weather_type_id &w );
 
 /**
@@ -78,7 +79,6 @@ struct weather_sum {
     int rain_amount = 0;
     int acid_amount = 0;
     float sunlight = 0.0f;
-    int wind_amount = 0;
 };
 
 weather_type_id get_bad_weather();
@@ -162,8 +162,12 @@ class weather_manager
     public:
         weather_manager();
         const weather_generator &get_cur_weather_gen() const;
+        weather_type_id current_weather( const tripoint &location, const time_point &t );
         // Updates the temperature and weather patten
         void update_weather();
+        // Update snow level
+        void update_snow_level( const weather_type_id &weather, const time_point &t, time_duration period );
+        static double get_snowfall_mm( const weather_type_id &weather,  time_duration period );
         // The air temperature
         int temperature = 0;
         bool lightning_active = false;
@@ -171,6 +175,8 @@ class weather_manager
         weather_type_id weather_id = WEATHER_NULL;
         int winddirection = 0;
         int windspeed = 0;
+        // current snow level, in mm
+        double snow_level = 0;
         // Cached weather data
         pimpl<w_point> weather_precise;
         cata::optional<int> wind_direction_override;
@@ -188,9 +194,8 @@ class weather_manager
         // Returns outdoor or indoor temperature of given location
         int get_temperature( const tripoint_abs_omt &location );
         void clear_temp_cache();
-        void on_load();
-        static void serialize_all( JsonOut &json );
-        static void unserialize_all( JsonIn &jsin );
+        void serialize_all( JsonOut &json );
+        void unserialize_all( JsonIn &jsin );
 };
 
 weather_manager &get_weather();

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -172,6 +172,7 @@ void weather_type::load( const JsonObject &jo, const std::string & )
     mandatory( jo, was_loaded, "dangerous", dangerous );
     mandatory( jo, was_loaded, "precip", precip );
     mandatory( jo, was_loaded, "rains", rains );
+    optional( jo, was_loaded, "snows", snows, false );
     optional( jo, was_loaded, "acidic", acidic, false );
     optional( jo, was_loaded, "tiles_animation", tiles_animation, "" );
     optional( jo, was_loaded, "sound_category", sound_category, weather_sound_category::silent );

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -172,6 +172,8 @@ struct weather_type {
         precip_class precip = precip_class::none;
         // Whether said precipitation falls as rain.
         bool rains = false;
+        // Whether said precipitation falls as snow.
+        bool snows = false;
         // Whether said precipitation is acidic.
         bool acidic = false;
         // vector for weather effects.

--- a/tests/rng_test.cpp
+++ b/tests/rng_test.cpp
@@ -92,7 +92,7 @@ static void test_pseudo_random_tiling_test( uint64_t seed )
         CHECK( v.first >= 0 );
         CHECK( v.first < w );
         CHECK( v.second >= 0 );
-        CHECK( v.second <= h );
+        CHECK( v.second < h );
         s1.insert( v );
         vec1.push_back( v );
     }

--- a/tests/rng_test.cpp
+++ b/tests/rng_test.cpp
@@ -124,7 +124,7 @@ static void test_pseudo_random_tiling_test( uint64_t seed )
     }
     INFO( "At least half of the returned values should be different." );
     CHECK( diff >= w * h / 2 );
-};
+}
 
 TEST_CASE( "pseudo_random_tiling_test" )
 {

--- a/tests/submap_load_test.cpp
+++ b/tests/submap_load_test.cpp
@@ -287,9 +287,9 @@ static std::istringstream submap_field_ss(
     "    0, 0, [ \"fd_laser\", 1, 1997 ],\n"
     "    0, 11, [ \"fd_acid\", 2, 2003 ],\n"
     "    11, 0, [ \"fd_web\", 3, 2077 ],\n"
-    "    11, 0, [ \"fd_smoke\", 4, 3004 ],\n"
-    "    11, 11, [ \"fd_electricity\", 5, 1482 ],\n"
-    "    4, 7, [ \"fd_nuke_gas\", 6, 1615 ]\n"
+    "    11, 0, [ \"fd_smoke\", 2, 3004 ],\n"
+    "    11, 11, [ \"fd_electricity\", 3, 1482 ],\n"
+    "    4, 7, [ \"fd_nuke_gas\", 1, 1615 ]\n"
     "  ],\n"
     "  \"cosmetics\": [ ],\n"
     "  \"spawns\": [ ],\n"
@@ -1111,37 +1111,47 @@ TEST_CASE( "submap_field_load", "[submap][load]" )
     REQUIRE( fd_se != nullptr );
     REQUIRE( fd_ra != nullptr );
 
-    // We placed a unique item in a couple of places. Check that those are correct
-    INFO( string_format( "nw: %d %s %d %d %s %d %d", field_nw.field_count(),
-                         fd_nw->get_field_type().id().str(), fd_nw->get_field_intensity(),
-                         to_turns<int>( fd_nw->get_field_age() ), fd_ow->get_field_type().id().str(),
-                         fd_ow->get_field_intensity(),
-                         to_turns<int>( fd_ow->get_field_age() ) ) );
-    INFO( string_format( "ne: %d %s %d %d", field_ne.field_count(),
-                         fd_ne->get_field_type().id().str(), fd_ne->get_field_intensity(),
-                         to_turns<int>( fd_ne->get_field_age() ) ) );
-    INFO( string_format( "sw: %d %s %d %d", field_sw.field_count(),
-                         fd_sw->get_field_type().id().str(), fd_sw->get_field_intensity(),
-                         to_turns<int>( fd_sw->get_field_age() ) ) );
-    INFO( string_format( "se: %d %s %d %d", field_se.field_count(),
-                         fd_se->get_field_type().id().str(), fd_se->get_field_intensity(),
-                         to_turns<int>( fd_se->get_field_age() ) ) );
-    INFO( string_format( "ra: %d %s %d %d", field_ra.field_count(),
-                         fd_ra->get_field_type().id().str(), fd_ra->get_field_intensity(),
-                         to_turns<int>( fd_ra->get_field_age() ) ) );
     // Require to prevent the lower CHECK from being spammy
-    REQUIRE( fd_nw->get_field_intensity() == 3 );
-    REQUIRE( fd_nw->get_field_age() == 2077_seconds );
-    REQUIRE( fd_ow->get_field_intensity() == 4 );
-    REQUIRE( fd_ow->get_field_age() == 3004_seconds );
-    REQUIRE( fd_ne->get_field_intensity() == 1 );
-    REQUIRE( fd_ne->get_field_age() == 1997_seconds );
-    REQUIRE( fd_sw->get_field_intensity() == 5 );
-    REQUIRE( fd_sw->get_field_age() == 1482_seconds );
-    REQUIRE( fd_se->get_field_intensity() == 2 );
-    REQUIRE( fd_se->get_field_age() == 2003_seconds );
-    REQUIRE( fd_ra->get_field_intensity() == 6 );
-    REQUIRE( fd_ra->get_field_age() == 1615_seconds );
+    {
+        INFO( string_format( "nw: %d %s %d %d %s %d %d", field_nw.field_count(),
+                             fd_nw->get_field_type().id().str(), fd_nw->get_field_intensity(),
+                             to_turns<int>( fd_nw->get_field_age() ), fd_ow->get_field_type().id().str(),
+                             fd_ow->get_field_intensity(),
+                             to_turns<int>( fd_ow->get_field_age() ) ) );
+
+        REQUIRE( fd_nw->get_field_intensity() == 3 );
+        REQUIRE( fd_nw->get_field_age() == 2077_seconds );
+        REQUIRE( fd_ow->get_field_intensity() == 2 );
+        REQUIRE( fd_ow->get_field_age() == 3004_seconds );
+    }
+    {
+        INFO( string_format( "ne: %d %s %d %d", field_ne.field_count(),
+                             fd_ne->get_field_type().id().str(), fd_ne->get_field_intensity(),
+                             to_turns<int>( fd_ne->get_field_age() ) ) );
+        REQUIRE( fd_ne->get_field_intensity() == 1 );
+        REQUIRE( fd_ne->get_field_age() == 1997_seconds );
+    }
+    {
+        INFO( string_format( "sw: %d %s %d %d", field_sw.field_count(),
+                             fd_sw->get_field_type().id().str(), fd_sw->get_field_intensity(),
+                             to_turns<int>( fd_sw->get_field_age() ) ) );
+        REQUIRE( fd_sw->get_field_intensity() == 3 );
+        REQUIRE( fd_sw->get_field_age() == 1482_seconds );
+    }
+    {
+        INFO( string_format( "se: %d %s %d %d", field_se.field_count(),
+                             fd_se->get_field_type().id().str(), fd_se->get_field_intensity(),
+                             to_turns<int>( fd_se->get_field_age() ) ) );
+        REQUIRE( fd_se->get_field_intensity() == 2 );
+        REQUIRE( fd_se->get_field_age() == 2003_seconds );
+    }
+    {
+        INFO( string_format( "ra: %d %s %d %d", field_ra.field_count(),
+                             fd_ra->get_field_type().id().str(), fd_ra->get_field_intensity(),
+                             to_turns<int>( fd_ra->get_field_age() ) ) );
+        REQUIRE( fd_ra->get_field_intensity() == 1 );
+        REQUIRE( fd_ra->get_field_age() == 1615_seconds );
+    }
 
     // Also, check we have no other fields
     for( int y = 0; y < SEEY; ++y ) {

--- a/tests/weather_test.cpp
+++ b/tests/weather_test.cpp
@@ -58,7 +58,7 @@ std::ostream &operator<<( std::ostream &os, string_id<T> const &id )
     return os << id.str();
 }
 
-std::ostream &operator<<( std::ostream &os, time_duration const &d )
+static std::ostream &operator<<( std::ostream &os, time_duration const &d )
 {
     return os << to_string( d );
 }

--- a/tests/weather_test.cpp
+++ b/tests/weather_test.cpp
@@ -294,7 +294,7 @@ TEST_CASE( "weather realism", "[weather]" )
         const double at_least_light_precip = proportion_gteq_x(
                 hourly_precip, 1 );
         CHECK( at_least_light_precip >= .025 );
-        CHECK( at_least_light_precip <= .05 );
+        CHECK( at_least_light_precip <= .06 );
 
         // Likewise for heavy precipitation.
         const double heavy_precip = proportion_gteq_x(


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Proper snow simulation. First part: snowfall, snowmelt, tiles support"

#### Purpose of change

Fixes #46354, closes #46328.

Currently CDDA doesn't have snow simulation. The only "snow" currently available is different look of tiles in winter. Snowfall weather doesn't do anything beside animation.  Because of that winter survival in CDDA currently is simulated very poorly.

Previous attempts to add snow simulation (see #28227) stalled because of the large scope and performance problems. Hopefully, this PR will have different fate.


#### Describe the solution

[Youtube demo (subtitles!)](https://youtu.be/fhMGHv0igT0)

This is first part that solves two most challenging snow-related problems:
1. Snow simulation (snowfall, snowmelt)
2. Snow display

Snow added in this PR doesn't (yet) have any mechanics or interactions. If this PR gets merged, more snow-related mechanics (that depend on this PR) will follow.

Technical details:
1. Current "accumulated" snow level (in mm) is a single global number, stored in `weather_manager`
2. This number is updated every 30 (game) seconds:
   * snow-producing weather (flurries, snow, snow storm) increase snow level (based on real-life avg precipitation numbers for corresponding weather)
   * above-freezing temperature and sun radiation melt snow and decrease snow level (again, using real-world models, see `snowmelt_temp` and `snowmelt_sun`)
   * for simplicity, to update the global snow level, weather and temperature is taken from the player's position (note: global map temperature, not the tile temperature)
3. Every 30 game seconds the global snow level is applied to the active map (see `map::actualize_snow_in_submap`)
4. Same snow actualization procedure happens when submap is loaded/generated
    * every submap stores its own "snow level" number and synchronizes it with global number during snow actualization
5. Snow itself is represented by the field `fd_snow` that has three intensity levels (see `map::actualize_snow_in_submap` for details):
   * 1:  < 10mm (0.39")
   * 2: ≈ 10mm-160mm (6.3")
   * 3: ≈ 160mm-810mm (31.9")
6.  `fd_snow` is changed (see `map::actualize_snow_in_submap` for implementation details):
    * added/removed in batch for the whole submap when snow level changes 0->0+  or 0+ -> 0
    * intensity upgraded/downgraded one tile at a time in stable pseudo-random sequence when snow level is increased/decreased


**Rendering:**

1. `fd_snow` is a field, and it has `"display_field": true`, meaning that in curses and by default in tiles it's visible as a white `*` symbol
2. A special case was added for `fd_snow` rendering for tiles build:
    * if a "snow covered" *terrain* (currently only terrain is supported) has a sprite variant with suffix `_with_snow`, e.g. `t_grass_with_snow`, this variant will be rendered, and `fd_snow` field display for this tile is suppressed
    * for multitile, variant id will be, e.g. `..._with_snow_center` (see json example below)

<details> <summary>For example, `t_grass_with_snow` multitile: </summary>

```json
{
  "id": ["t_snow", "t_dirtfloor_with_snow", "t_grass_with_snow" ],
  "fg": [
    "t_snow"
  ],
  "bg": ["t_ice"],
  "rotates": true,
  "multitile": true,
  "additional_tiles": [
    {
      "id": "center",
      "fg": [
        "t_snow_center"
      ],
      "bg": ["t_ice"]
    },
    {
      "id": "corner",
      "fg": [
        "t_snow_corner_1",
        "t_snow_corner_2",
        "t_snow_corner_3",
        "t_snow_corner_4"
      ],
      "bg": ["t_ice"]
    },
    {
      "id": "t_connection",
      "fg": [
        "t_snow_t_connection_1",
        "t_snow_t_connection_2",
        "t_snow_t_connection_3",
        "t_snow_t_connection_4"
      ],
      "bg": ["t_ice"]
    },
    {
      "id": "edge",
      "fg": [
        "t_snow_edge_1",
        "t_snow_edge_2"
      ],
      "bg": ["t_ice"]
    },
    {
      "id": "end_piece",
      "fg": [
        "t_snow_end_piece_1",
        "t_snow_end_piece_2",
        "t_snow_end_piece_3",
        "t_snow_end_piece_4"
      ],
      "bg": ["t_ice"]
    },
    {
      "id": "unconnected",
      "fg": [
        "t_snow_unconnected"
      ],
      "bg": ["t_ice"]
    }
  ]
}
```
</details>


Screenshot:
<img src="https://user-images.githubusercontent.com/2865203/103616993-427d1080-4ee2-11eb-9045-fb531b091596.png" width="300" />
Notice, terrain without `_with_snow` sprite has semi-transparent `fd_snow` overlay, while `t_grass_with_snow` is displayed without such overlay.

Undead people tileset was used for the demo, because `_season_winter` sprites there are green. Here is the modified  tileset that I used for testing with `fd_snow` sprite added and `t_dirtfloor_with_snow`, `t_grass_with_snow` from the json above:
[MSX++UnDead_snow.zip](https://github.com/CleverRaven/Cataclysm-DDA/files/5768640/MSX%2B%2BUnDead_snow.zip)


#### Testing

Added unit tests:
*  realistic snow (4-year simulated weather has similar snowfall, snowmelt and snow days numbers to the real New England)
* snowmelt in different temperatures
* snow actualization behavior 

Playtested:
* Manually waited in winter to see how snow is accumulated, and in spring to see how it melts.
* Debug-cleared patches of snow to see that they are eventually covered.   
* Walked and teleported around to see that snow actualization on submap loading behaves as expected
* modified Undead people tileset with several sprites to test the rendering behavior

<details>
<summary>Profiling</summary>

Snow accumulation during the snowstorm (note: wilderness, nothing to process):
![image](https://user-images.githubusercontent.com/2865203/103618601-1747f080-4ee5-11eb-8d36-f4bb05201738.png)

Waiting in the barren field during snowstorm (monsters killed). Before:
![image](https://user-images.githubusercontent.com/2865203/103619093-f9c75680-4ee5-11eb-979e-051002e5fe2d.png)
After:
![image](https://user-images.githubusercontent.com/2865203/103619103-ff24a100-4ee5-11eb-8a4e-aa3f77fcbd8c.png)
</details>
