### PR TITLE
[Magiclym] Fix Summon Floating Disk duration increment on lvl-up

### DIFF
--- a/data/mods/Magiclysm/Spells/technomancer.json
+++ b/data/mods/Magiclysm/Spells/technomancer.json
@@ -380,7 +380,7 @@
     "range_increment": 1,
     "min_duration": 400000,
     "max_duration": 9600000,
-    "duration_increment": 200
+    "duration_increment": 460000
   },
   {
     "id": "summon_magic_motorcycle",


### PR DESCRIPTION
#### Summary

SUMMARY: Mods "[Magiclym] Fix Summon Floating Disk duration increment on lvl-up"

#### Purpose of change
```json
    "min_duration": 400000,
    "max_duration": 9600000,
    "duration_increment": 200
```

#### Describe the solution
```json
    "duration_increment": 460000
```
( max_duration - min_duration) / max spell level = 460000

#### Describe alternatives you've considered

None

#### Testing

Cast in the game

