### PR TITLE
[Magiclysm] Add longest side to Staff of the Magi

### DIFF
--- a/data/mods/Magiclysm/items/enchanted.json
+++ b/data/mods/Magiclysm/items/enchanted.json
@@ -31,6 +31,7 @@
     },
     "weight": "1400 g",
     "volume": "3 L",
+    "longest_side": "170 cm",
     "bashing": 17,
     "category": "weapons",
     "to_hit": 3
@@ -51,6 +52,7 @@
     },
     "weight": "1400 g",
     "volume": "3 L",
+    "longest_side": "170 cm",
     "bashing": 17,
     "category": "weapons",
     "to_hit": 3
@@ -71,6 +73,7 @@
     },
     "weight": "1400 g",
     "volume": "3 L",
+    "longest_side": "170 cm",
     "bashing": 17,
     "category": "weapons",
     "to_hit": 3


### PR DESCRIPTION
#### Summary

SUMMARY: Mods "[Magiclysm] Add longest-side to Staff of the Magi"

#### Purpose of change

Each one had a length of 14cm.

#### Describe the solution

Other stats are identical so I made all 170cm long, based on comparison with Magus Staff ( which was slightly heavier, bigger, and 175cm long )

#### Describe alternatives you've considered

In addition, making all three variants use copy-from

#### Testing

Spawned items
