### PR TITLE
Fix partial container spawning

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -742,7 +742,7 @@
       [ "water_clean", 30 ],
       [ "water_mineral", 15 ],
       { "group": "softdrinks_canned", "prob": 121 },
-      [ "milk_UHT", 10 ],
+      { "item": "milk_UHT", "prob": 10, "charges": [ 1, 6 ], "sealed": false },
       [ "juice", 31 ],
       [ "pie", 40 ],
       [ "pie_meat", 28 ],

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -639,7 +639,7 @@
       { "item": "colamdew", "prob": 15, "container-item": "bottle_twoliter" },
       { "item": "rootbeer", "prob": 15, "container-item": "bottle_twoliter" },
       { "item": "milk", "prob": 50 },
-      { "item": "milk_UHT", "prob": 5 },
+      { "item": "milk_UHT", "prob": 5, "charges": [ 1, 6 ], "sealed": false },
       { "item": "milk_raw", "prob": 2 },
       { "item": "almond_milk", "prob": 50 },
       { "item": "soy_milk", "prob": 50 },

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -181,7 +181,7 @@ item Single_item_creator::create_single( const time_point &birthday, RecursionLi
         int qty = tmp.charges;
         if( modifier ) {
             qty = rng( modifier->charges.first, modifier->charges.second );
-        } else {
+        } else if( tmp.made_of_from_type( phase_id::LIQUID ) ) {
             qty = item::INFINITE_CHARGES;
         }
         // TODO: change the spawn lists to contain proper references to containers

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -182,7 +182,7 @@ item Single_item_creator::create_single( const time_point &birthday, RecursionLi
         if( modifier ) {
             qty = rng( modifier->charges.first, modifier->charges.second );
         } else {
-          qty = item::INFINITE_CHARGES;
+            qty = item::INFINITE_CHARGES;
         }
         // TODO: change the spawn lists to contain proper references to containers
         tmp = tmp.in_its_container( qty );

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -181,6 +181,8 @@ item Single_item_creator::create_single( const time_point &birthday, RecursionLi
         int qty = tmp.charges;
         if( modifier ) {
             qty = rng( modifier->charges.first, modifier->charges.second );
+        } else {
+          qty = item::INFINITE_CHARGES;
         }
         // TODO: change the spawn lists to contain proper references to containers
         tmp = tmp.in_its_container( qty );


### PR DESCRIPTION
Resolves an issue where containers for spawned liquids would only be partially full if charges were not specified.

#### Summary

SUMMARY: Bugfixes "Resolves a partial item spawn issue"

#### Purpose of change

In locations like grocery stores and liquor stores, it is prior to this fix typical to see things like `plastic gallon jug of milk (1) (rotten)` and `glass bottle of fruit wine (7)`, when these should have 15 and 21 charges, respectively.

#### Resulting solution

This fix causes the item group spawning code to pass the default parameter `item::INFINITE_CHARGES` to the creation code if the number of charges desired is not otherwise specified, causing containers to spawn full.

#### Alternatives considered

The notion of filling out the item groups using things like `{ "item": …, "charges": X }` was considered, but rejected as a massive change that would be essentially impossible to maintain in a satisfactory manner.

#### Testing

For testing that the fix worked as intended, grocery and liquor stores were spawned in with `ITEM_SPAWNRATE` set to 10.00 (so as to nearly guarantee the presence of the tested items), and things like bottles of wine, gallon jugs of milk were inspected for the correct number of charges.

Further, gun stores and pharmacies were spawned in (with the same parameters) and ammunition and drugs were inspected, to ensure that no weirdness with ammo counts or drug charges had occurred.

A quick code analysis was also performed, and the resulting construction `item::in_its_container( item::INFINITE_CHARGES )` is ubiquitous throughout the code. On reading the code, its being missing at the site of edit seems like a simple oversight.
