### PR TITLE
Fixed Chairs and Fridges Not Rotating Correctly 

### DIFF
--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -180,7 +180,7 @@
     "move_cost_mod": -1,
     "coverage": 90,
     "required_str": 10,
-    "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MINEABLE" ],
+    "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MINEABLE", "NO_SELF_CONNECT" ],
     "deconstruct": {
       "items": [
         { "item": "sheet_metal", "count": [ 2, 6 ] },

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3703,12 +3703,19 @@ void cata_tiles::get_tile_values( const int t, const int *tn, int &subtile, int 
 void cata_tiles::get_tile_values_with_ter( const tripoint &p, const int t, const int *tn,
         int &subtile, int &rotation )
 {
-    get_tile_values( t, tn, subtile, rotation );
+    map &here = get_map();
+    //check if furniture should connect to itself
+    if( here.has_flag( "NO_SELF_CONNECT", p ) || here.has_flag( "ALIGN_WORKBENCH", p ) ) {
+        //if we don't ever connect to ourself just return unconnected to be used further
+        get_rotation_and_subtile( 0, rotation, subtile );
+    } else {
+        //if we do connect to ourself (tables, counters etc.) calculate based on neighbours
+        get_tile_values( t, tn, subtile, rotation );
+    }
     // calculate rotation for unconnected tiles based on surrounding walls
     if( subtile == unconnected ) {
         int val = 0;
         bool use_furniture = false;
-        map &here = get_map();
 
         if( here.has_flag( "ALIGN_WORKBENCH", p ) ) {
             for( int i = 0; i < 4; ++i ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Chairs and fridges no longer rotate incorrectly when adjacent"

#### Purpose of change
Fixes #46966

#### Describe the solution

Though there was already code for chairs aligning to tables if two chairs were adjacent this no longer happened. That's because furniture in general wants to connect to other copies of the same furniture (think furniture like tables and countertops) and the table align code only happens to unconnected furniture. So now any item with the "ALIGN_WORKBENCH" flag will ignore checking if its neighbors are the same as it as will anything with the new flag "NO_SELF_CONNECT" making sure these are always "unconnected" which means they will align only to tables and walls. 

#### Describe alternatives you've considered

Do it the other way and make it so only things with a "SELF_CONNECT" flag try to connect to themselves but that seemed like a bunch more json work. 

#### Testing
Loaded up a fresh map and dropped some walls and Research Facility rooms in to make sure fridges were working correctly.

Also built a 3x1 table and successfully added 3 chairs to one side with the correct facing. 

#### Additional context
![image](https://user-images.githubusercontent.com/4514073/106401265-8425ac00-63f9-11eb-8650-6474b3eecc92.png)
