### PR TITLE
Add "TRANSPARENT" flag to birdbaths

### DIFF
--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -143,7 +143,7 @@
     "color": "light_gray",
     "move_cost_mod": -1,
     "required_str": 10,
-    "flags": [ "PLACE_ITEM", "BLOCKSDOOR", "MINEABLE", "LIQUIDCONT" ],
+    "flags": [ "PLACE_ITEM", "BLOCKSDOOR", "MINEABLE", "LIQUIDCONT", "TRANSPARENT" ],
     "bash": {
       "str_min": 16,
       "str_max": 40,


### PR DESCRIPTION
Makes birdbaths transparent, since they're not see-through.

#### Summary

Bugfixes "Add TRANSPARENT flag to birdbaths"

Purpose of change

You can't see through birdbaths, even though they're small enough. Therefore, I made them transparent.

Describe the solution

Editing the furniture-decorative.json file, I added the "TRANSPARENT" flag to the birdbath.

Describe alternatives you've considered

None

Testing

I added the flag, entered the world and the birdbath was indeed transparent now.

Additional context

https://cdn.discordapp.com/attachments/607491164769222687/808796345090965544/unknown.png
Birdbath being actually see-through.
