### PR TITLE
Show actual fuel consumption, not a guess

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3471,7 +3471,7 @@ int vehicle::consumption_per_hour( const itype_id &ftype, fuel_consumption_data 
     }
 
     int average = fcd.total_fuel / fcd.fuel_per_sec.size();
-    //Fuel energy is in 'kJ', consumption is per 's' so multiply by 3600, then divide by 1000
+    //Fuel energy is in 'kJ', consumption is per 's' so multiply by 3600, then divide by 1000 in order to convert kj to ml
     return -36 * average / fuel.fuel_energy() / 10 ;
 }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4629,9 +4629,9 @@ void vehicle::consume_fuel( int load, bool idling )
             }
         } else {
             fcd.total_fuel -= fcd.fuel_per_sec[ fcd.tail ];
-            fcd.tail = ++fcd.tail % 60;
+            fcd.tail = ( fcd.tail + 1 ) % 60;
         }
-        fcd.head = ++fcd.head % 60;
+        fcd.head = ( fcd.head + 1 ) % 60;
         fcd.total_fuel += amnt_precise_j;
         fcd.fuel_per_sec[ fcd.head ] = amnt_precise_j;
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4610,13 +4610,15 @@ double vehicle::drain_energy( const itype_id &ftype, double energy_j )
 void vehicle::consume_fuel( int load, bool idling )
 {
     double st = strain();
+    std::map<itype_id, fuel_consumption_data> fuel_used_tmp;
     for( const auto &fuel_pr : fuel_usage() ) {
         const itype_id &ft = fuel_pr.first;
         if( idling && ft == fuel_type_battery ) {
             continue;
         }
 
-        fuel_consumption_data &fcd = fuel_used[ ft ];
+        fuel_used_tmp[ft] = fuel_used[ ft ];
+        fuel_consumption_data &fcd = fuel_used_tmp[ ft ];
 
         double amnt_precise_j = static_cast<double>( fuel_pr.second );
         amnt_precise_j *= load / 1000.0 * ( 1.0 + st * st * 100.0 );
@@ -4642,6 +4644,7 @@ void vehicle::consume_fuel( int load, bool idling )
     if( idling ) {
         return;
     }
+    fuel_used = fuel_used_tmp;
     Character &player_character = get_player_character();
     if( load > 0 && fuel_left( fuel_type_muscle ) > 0 &&
         player_character.has_effect( effect_winded ) ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3470,10 +3470,9 @@ int vehicle::consumption_per_hour( const itype_id &ftype, fuel_consumption_data 
         return 0;
     }
 
-    int energy_j_per_mL = fuel.fuel_energy() * 1000;
     int average = fcd.total_fuel / fcd.fuel_per_sec.size();
-
-    return -1 * average * 3600 / energy_j_per_mL;
+    //Fuel energy is in 'kJ', consumption is per 's' so multiply by 3600, then divide by 1000
+    return -36 * average / fuel.fuel_energy() / 10 ;
 }
 
 int vehicle::total_power_w( const bool fueled, const bool safe ) const

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -724,13 +724,21 @@ class vehicle
 
         units::volume total_folded_volume() const;
 
+        struct fuel_consumption_data {
+            int head = -1;
+            int tail = -1;
+            std::array<int, 60> fuel_per_sec;
+            int total_fuel = 0;
+        };
+        std::map<itype_id, fuel_consumption_data> fuel_used;
+
         // Vehicle fuel indicator (by fuel)
         void print_fuel_indicator( const catacurses::window &w, const point &p,
                                    const itype_id &fuel_type,
                                    bool verbose = false, bool desc = false );
         void print_fuel_indicator( const catacurses::window &w, const point &p,
                                    const itype_id &fuel_type,
-                                   std::map<itype_id, float> fuel_usages,
+                                   std::map<itype_id, fuel_consumption_data> &fuel_usages,
                                    bool verbose = false, bool desc = false );
 
         // Calculate how long it takes to attempt to start an engine
@@ -1190,7 +1198,8 @@ class vehicle
 
         // fuel consumption of vehicle engines of given type
         int basic_consumption( const itype_id &ftype ) const;
-        int consumption_per_hour( const itype_id &ftype, int fuel_rate ) const;
+
+        int consumption_per_hour( const itype_id &ftype, fuel_consumption_data &fcd ) const;
 
         void consume_fuel( int load, bool idling );
 
@@ -1888,7 +1897,6 @@ class vehicle
         std::set<std::string> tags;        // Properties of the vehicle
         // After fuel consumption, this tracks the remainder of fuel < 1, and applies it the next time.
         std::map<itype_id, float> fuel_remainder;
-        std::map<itype_id, float> fuel_used_last_turn;
         std::unordered_multimap<point, zone_data> loot_zones;
         active_item_cache active_items;
         // a magic vehicle, powered by magic.gif

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -725,9 +725,7 @@ class vehicle
         units::volume total_folded_volume() const;
 
         struct fuel_consumption_data {
-            int head = -1;
-            int tail = -1;
-            std::array<int, 60> fuel_per_sec;
+            std::list<int> fuel_per_sec;
             int total_fuel = 0;
         };
         std::map<itype_id, fuel_consumption_data> fuel_used;

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -381,7 +381,7 @@ void vehicle::print_fuel_indicators( const catacurses::window &win, const point 
 
     for( int i = start_index; i < max_size; i++ ) {
         const itype_id &f = fuels[i];
-        print_fuel_indicator( win, p + point( 0, yofs ), f, fuel_used_last_turn, verbose, desc );
+        print_fuel_indicator( win, p + point( 0, yofs ), f, fuel_used, verbose, desc );
         yofs++;
     }
 
@@ -404,13 +404,13 @@ void vehicle::print_fuel_indicators( const catacurses::window &win, const point 
 void vehicle::print_fuel_indicator( const catacurses::window &win, const point &p,
                                     const itype_id &fuel_type, bool verbose, bool desc )
 {
-    std::map<itype_id, float> fuel_usages;
+    std::map<itype_id, fuel_consumption_data> fuel_usages;
     print_fuel_indicator( win, p, fuel_type, fuel_usages, verbose, desc );
 }
 
 void vehicle::print_fuel_indicator( const catacurses::window &win, const point &p,
                                     const itype_id &fuel_type,
-                                    std::map<itype_id, float> fuel_usages,
+                                    std::map<itype_id, fuel_consumption_data> &fuel_usages,
                                     bool verbose, bool desc )
 {
     const char fsyms[5] = { 'E', '\\', '|', '/', 'F' };


### PR DESCRIPTION
#### Summary
Interface "Show actual fuel consumption, not a guess"

#### Purpose of change

Part of my #46632.
Also, according to @mlangsdorf this function required rewrite anyway.

#### Describe the solution

Make a struct that stores fuel consumption from the last 60 calls of consume_fuel().
Calculate and display average fuel consumption. 
Until now the displayed fuel consumption was calculated based on load, speed, acceleration without regard to actual fuel consumption.

#### Describe alternatives you've considered

I used a solution suggested by Mark.

#### Testing

Drove a few vehicles. Put on a few alternators, crashed in stuff.