### PR TITLE
Tiring dodges

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1698,6 +1698,13 @@ bool Character::is_dead_state() const
     return false;
 }
 
+void Character::on_try_dodge()
+{
+    const int base_burn_rate = get_option<int>( STATIC( "PLAYER_BASE_STAMINA_BURN_RATE" ) );
+    mod_stamina( -base_burn_rate * 6 );
+    increase_activity_level( EXTRA_EXERCISE );
+}
+
 void Character::on_dodge( Creature *source, float difficulty )
 {
     // Each avoided hit consumes an available dodge

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1702,7 +1702,7 @@ void Character::on_try_dodge()
 {
     const int base_burn_rate = get_option<int>( STATIC( "PLAYER_BASE_STAMINA_BURN_RATE" ) );
     mod_stamina( -base_burn_rate * 6 );
-    increase_activity_level( EXTRA_EXERCISE );
+    set_activity_level( EXTRA_EXERCISE );
 }
 
 void Character::on_dodge( Creature *source, float difficulty )

--- a/src/character.h
+++ b/src/character.h
@@ -652,6 +652,7 @@ class Character : public Creature, public visitable
 
         /** Called after the player has successfully dodged an attack */
         void on_dodge( Creature *source, float difficulty ) override;
+        void on_try_dodge() override;
 
         /** Combat getters */
         float get_dodge_base() const override;

--- a/src/creature.h
+++ b/src/creature.h
@@ -496,6 +496,10 @@ class Creature : public viewer
          */
         virtual void on_dodge( Creature *source, float difficulty ) = 0;
         /**
+         * Invoked when the creature attempts to dodge, regardless of success or failure.
+         */
+        virtual void on_try_dodge() = 0;
+        /**
          * This creature just got hit by an attack - possibly special/ranged attack - from source.
          * Players should train dodge, possibly counter-attack somehow.
          */

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1174,7 +1174,7 @@ float Character::get_dodge() const
     //Dodge decreases linearly to 0 when below 50% stamina.
     const float stamina_ratio = static_cast<float>( get_stamina() ) / get_stamina_max();
     if( stamina_ratio <= .5 ) {
-        ret *= 2 * stamina_ratio;
+        ret *= 2.0f * stamina_ratio;
     }
 
     // Reaction score of limbs influences dodge chances

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1172,10 +1172,23 @@ float Character::get_dodge() const
     }
 
     //Dodge decreases linearly to 0 when below 50% stamina.
-    const float stamina_ratio = static_cast<float>( get_stamina() ) / get_stamina_max();
-    if( stamina_ratio <= .5 ) {
-        ret *= 2.0f * stamina_ratio;
+    //const float stamina_ratio = static_cast<float>( get_stamina() ) / get_stamina_max();
+    const double stamina = get_stamina();
+    const double stamina_min = get_stamina_max() * 0.1;
+    const double stamina_max = get_stamina_max() * 0.9;
+    const double stamina_logistic = 1.0 - logarithmic_range( stamina_min, stamina_max, stamina );
+    if( stamina_logistic <= 0.1 ) {
+        //Don't attempt to dodge if stamina too low, to avoid getting locked in
+        return 0.0f;
     }
+    ret *= stamina_logistic;
+    /*
+    if( stamina_ratio < 0.1 ) {
+    return 0.0f;
+    }
+    if( stamina_ratio <= .5 ) {
+    ret *= 2.0f * stamina_ratio;
+    }*/
 
     // Reaction score of limbs influences dodge chances
     ret *= get_limb_score( limb_score_reaction );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -753,7 +753,7 @@ bool mattack::acid_barf( monster *z )
                                        _( "The %s barfs acid at <npcname>, but they dodge!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2 );
         return true;
     }
 
@@ -1245,8 +1245,7 @@ bool mattack::smash( monster *z )
         target->add_msg_player_or_npc( _( "The %s takes a powerful swing at you, but you dodge it!" ),
                                        _( "The %s takes a powerful swing at <npcname>, who dodges it!" ),
                                        z->name() );
-
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2 );
         return true;
     }
 
@@ -2224,7 +2223,7 @@ bool mattack::impale( monster *z )
                                        _( "The %s lunges at <npcname>, but they dodge!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2);
         return true;
     }
 
@@ -2799,7 +2798,7 @@ bool mattack::ranged_pull( monster *z )
                                        _( "The %s's arms fly out at <npcname>, but they dodge!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2 );
         return true;
     }
 
@@ -2921,7 +2920,7 @@ bool mattack::grab( monster *z )
                                        _( "The %s gropes at <npcname>, but they dodge!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2 );
         return true;
     }
 
@@ -4443,7 +4442,7 @@ bool mattack::stretch_bite( monster *z )
                                        _( "The %s's head extends to bite <npcname>, but they dodge and the head sails past!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2 );
         return true;
     }
 
@@ -5203,7 +5202,7 @@ bool mattack::evolve_kill_strike( monster *z )
                                        _( "The %s lunges at <npcname>, but they dodge!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2 );
         target->add_msg_player_or_npc( msg_type, _( "The %s lunges at you, but you dodge!" ),
                                        _( "The %s lunges at <npcname>, but they dodge!" ),
                                        z->name() );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2223,7 +2223,7 @@ bool mattack::impale( monster *z )
                                        _( "The %s lunges at <npcname>, but they dodge!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill * 2);
+        target->on_dodge( z, z->type->melee_skill * 2 );
         return true;
     }
 
@@ -6138,12 +6138,12 @@ bool mattack::dodge_check( monster *z, Creature *target )
     }
 
     const float dodge_ability = target->get_dodge();
-    if( dodge_ability > 0.0 ) {
+    if( dodge_ability > 0.8f ) {
         target->on_try_dodge();
     }
-    ///\EFFECT_DODGE increases chance of dodging, vs their melee skill
-    float dodge = std::max( dodge_ability - rng( 0, z->get_hit() ), 0.0f );
-    return dodge > 0.0 && rng( 0, 10000 ) < 10000 / ( 1 + 99 * std::exp( -.6 * dodge ) );
+
+    float attack_roll = z->get_hit() + rng_normal( 0, 5 );
+    return dodge_ability > attack_roll;
 }
 
 bool mattack::speaker( monster *z )

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -6138,8 +6138,12 @@ bool mattack::dodge_check( monster *z, Creature *target )
         return true;
     }
 
+    const float dodge_ability = target->get_dodge();
+    if( dodge_ability > 0.0 ) {
+        target->on_try_dodge();
+    }
     ///\EFFECT_DODGE increases chance of dodging, vs their melee skill
-    float dodge = std::max( target->get_dodge() - rng( 0, z->get_hit() ), 0.0f );
+    float dodge = std::max( dodge_ability - rng( 0, z->get_hit() ), 0.0f );
     return dodge > 0.0 && rng( 0, 10000 ) < 10000 / ( 1 + 99 * std::exp( -.6 * dodge ) );
 }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1245,7 +1245,7 @@ bool mattack::smash( monster *z )
         target->add_msg_player_or_npc( _( "The %s takes a powerful swing at you, but you dodge it!" ),
                                        _( "The %s takes a powerful swing at <npcname>, who dodges it!" ),
                                        z->name() );
-        target->on_dodge( z, z->type->melee_skill * 2 );
+        target->on_dodge( z, z->type->melee_skill );
         return true;
     }
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -409,6 +409,7 @@ class monster : public Creature
         float stability_roll() const override;
         // We just dodged an attack from something
         void on_dodge( Creature *source, float difficulty ) override;
+        void on_try_dodge() override {}
         // Something hit us (possibly null source)
         void on_hit( Creature *source, bodypart_id bp_hit,
                      float difficulty = INT_MIN, dealt_projectile_attack const *proj = nullptr ) override;

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -38,6 +38,39 @@ units::angle random_direction()
     return rng_float( 0_pi_radians, 2_pi_radians );
 }
 
+// Returns the area under a curve with provided standard deviation and center
+// from difficulty to positive infinity. That is, the chance that a normal roll on
+// said curve will return a value of difficulty or greater.
+float normal_roll_chance( float center, float stddev, float difficulty )
+{
+    cata_assert( stddev >= 0.f );
+    // We're going to be using them a lot, so let's name our variables.
+    // M = the given "center" of the curve
+    // S = the given standard deviation of the curve
+    // A = the difficulty
+    // So, the equation of the normal curve is...
+    // y = (1.f/(S*std::sqrt(2 * M_PI))) * exp(-(std::pow(x - M, 2))/(2 * std::pow(S, 2)))
+    // Thanks to wolfram alpha, we know the integral of that from A to B to be
+    // 0.5 * (erf((M-A)/(std::sqrt(2) * S)) - erf((M-B)/(std::sqrt(2) * S)))
+    // And since we know B to be infinity, we can simplify that to
+    // 0.5 * (erfc((A-m)/(std::sqrt(2)* S))+sgn(S)-1) (as long as S != 0)
+    // Wait a second, what are erf, erfc and sgn?
+    // Oh, those are the error function, complementary error function, and sign function
+    // Luckily, erf() is provided to us in math.h, and erfc is just 1 - erf
+    // Sign is pretty obvious x > 0 ? x == 0 ? 0 : 1 : -1;
+    // Since we know S will always be > 0, that term vanishes.
+
+    // With no standard deviation, we will always return center
+    if( stddev == 0.f ) {
+        return ( center > difficulty ) ? 1.f : 0.f;
+    }
+
+    float numerator = difficulty - center;
+    float denominator = std::sqrt( 2 ) * stddev;
+    float compl_erf = 1.f - std::erf( numerator / denominator );
+    return 0.5 * compl_erf;
+}
+
 double normal_roll( double mean, double stddev )
 {
     static std::normal_distribution<double> rng_normal_dist;

--- a/src/rng.h
+++ b/src/rng.h
@@ -71,6 +71,8 @@ inline double rng_normal( double hi )
     return rng_normal( 0.0, hi );
 }
 
+float normal_roll_chance( float center, float stddev, float difficulty );
+
 double normal_roll( double mean, double stddev );
 
 double rng_exponential( double min, double mean );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I noticed dodges are inexplicably "free" from a stamina point of view, so decided to add a stamina cost.
While I was looking at the code, I also noticed that the special attack code inexplicably doubles the skill cap for dodge training.

#### Describe the solution
Removed skill cap doubling for dodge training.
Added a small stamina cost when attempting to dodge.

#### Describe alternatives you've considered
I still need to fine tune the stamina cost, and add a weariness level increase. (DONE)

#### Testing
Spawn a monster with a frequently firing special attack, set dodge skill high, allow it to attack you repeatedly, and see if skill continues training.
Spawn a monster that attacks, wait near it to allow it to attack you, and check that stamina drops slowly.