### PR TITLE
[Magiclysm] Can't cast if Stunned

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1487,7 +1487,7 @@ static bool assign_spellcasting( Character &you, spell &sp, bool fake_spell )
         return false;
     }
 
-    if( you.has_effect( effect_stunned ) ) {
+    if( !sp.has_flag( spell_flag::NO_HANDS ) && you.has_effect( effect_stunned ) ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
                  _( "You can't focus enough to cast spell." ) );
         return false;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -107,6 +107,7 @@ static const efftype_id effect_alarm_clock( "alarm_clock" );
 static const efftype_id effect_incorporeal( "incorporeal" );
 static const efftype_id effect_laserlocked( "laserlocked" );
 static const efftype_id effect_relax_gas( "relax_gas" );
+static const efftype_id effect_stunned( "stunned" );
 
 static const itype_id itype_radiocontrol( "radiocontrol" );
 static const itype_id itype_shoulder_strap( "shoulder_strap" );
@@ -1483,6 +1484,12 @@ static bool assign_spellcasting( Character &you, spell &sp, bool fake_spell )
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
                  _( "You don't have enough %s to cast the spell." ),
                  sp.energy_string() );
+        return false;
+    }
+
+    if( you.has_effect( effect_stunned ) ) {
+        add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
+                 _( "You can't focus enough to cast spell." ) );
         return false;
     }
 


### PR DESCRIPTION
#### Summary
Mods "[Magiclysm] Can't cast if Stunned"

#### Purpose of change

After being hit by a riot control platform you can't move in a straight line but can cast high difficulty lighting bolts and teleports?

#### Describe the solution

Check if the character is stunned before casting a spell if it requires hands
It's a compromise since most mutation spells like Dragon's Breath etc. have this flag and I consider them to be rather instinctual.

#### Describe alternatives you've considered

Trying to decide what spells are "instinctual" vs "trained"

#### Testing

Can't cast a spell if stunned
Can use magic items
Can cast a no-hands spell
