### PR TITLE
Vehicle sprites to show accumulated blood spatter

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2782,9 +2782,23 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         // Gets the visible part, should work fine once tileset vp_ids are updated to work
         // with the vehicle part json ids
         // get the vpart_id
+        //
+        // part_mod number guide
+        //          no blood   light blood   heavy blood
+        // normal      0            3            6
+        // open        1            4            7
+        // broken      2            5            8
         char part_mod = 0;
         const std::string &vp_id = veh.part_id_string( veh_part, part_mod );
-        const int subtile = part_mod == 1 ? open_ : part_mod == 2 ? broken : 0;
+        const int subtile = part_mod == 1 ? open_
+                            : part_mod == 2 ? broken
+                            : part_mod == 3 ? lb
+                            : part_mod == 4 ? lb_open_
+                            : part_mod == 5 ? lb_broken
+                            : part_mod == 6 ? hb
+                            : part_mod == 7 ? hb_open_
+                            : part_mod == 8 ? hb_broken
+                            : 0;
         const int rotation = std::round( to_degrees( veh.face.dir() ) );
         const std::string vpname = "vp_" + vp_id;
         avatar &you = get_avatar();
@@ -2812,7 +2826,15 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         const vpart_id &vp2 = std::get<0>( override->second );
         if( vp2 ) {
             const char part_mod = std::get<1>( override->second );
-            const int subtile = part_mod == 1 ? open_ : part_mod == 2 ? broken : 0;
+            const int subtile = part_mod == 1 ? open_
+                                : part_mod == 2 ? broken
+                                : part_mod == 3 ? lb
+                                : part_mod == 4 ? lb_open_
+                                : part_mod == 5 ? lb_broken
+                                : part_mod == 6 ? hb
+                                : part_mod == 7 ? hb_open_
+                                : part_mod == 8 ? hb_broken
+                                : 0;
             const units::angle rotation = std::get<2>( override->second );
             const int draw_highlight = std::get<3>( override->second );
             const std::string vpname = "vp_" + vp2.str();

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -78,7 +78,7 @@ static const itype_id itype_corpse( "corpse" );
 static const std::string ITEM_HIGHLIGHT( "highlight_item" );
 static const std::string ZOMBIE_REVIVAL_INDICATOR( "zombie_revival_indicator" );
 
-static const std::array<std::string, 8> multitile_keys = {{
+static const std::array<std::string, 12> multitile_keys = {{
         "center",
         "corner",
         "edge",
@@ -86,7 +86,11 @@ static const std::array<std::string, 8> multitile_keys = {{
         "end_piece",
         "unconnected",
         "open",
-        "broken"
+        "broken",
+        "blooded_open",
+        "blooded_broken",
+        "lightblood",
+        "heavyblood"
     }
 };
 
@@ -2785,19 +2789,17 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         //
         // part_mod number guide
         //          no blood   light blood   heavy blood
-        // normal      0            3            6
-        // open        1            4            7
-        // broken      2            5            8
+        // normal      0            5            6
+        // open        1            3            3
+        // broken      2            4            4
         char part_mod = 0;
         const std::string &vp_id = veh.part_id_string( veh_part, part_mod );
         const int subtile = part_mod == 1 ? open_
                             : part_mod == 2 ? broken
-                            : part_mod == 3 ? lightblood
-                            : part_mod == 4 ? lightblood_open_
-                            : part_mod == 5 ? lightblood_broken
+                            : part_mod == 3 ? blooded_open_
+                            : part_mod == 4 ? blooded_broken
+                            : part_mod == 5 ? lightblood
                             : part_mod == 6 ? heavyblood
-                            : part_mod == 7 ? heavyblood_open_
-                            : part_mod == 8 ? heavyblood_broken
                             : 0;
         const int rotation = std::round( to_degrees( veh.face.dir() ) );
         const std::string vpname = "vp_" + vp_id;
@@ -2828,12 +2830,10 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             const char part_mod = std::get<1>( override->second );
             const int subtile = part_mod == 1 ? open_
                                 : part_mod == 2 ? broken
-                                : part_mod == 3 ? lightblood
-                                : part_mod == 4 ? lightblood_open_
-                                : part_mod == 5 ? lightblood_broken
+                                : part_mod == 3 ? blooded_open_
+                                : part_mod == 4 ? blooded_broken
+                                : part_mod == 5 ? lightblood
                                 : part_mod == 6 ? heavyblood
-                                : part_mod == 7 ? heavyblood_open_
-                                : part_mod == 8 ? heavyblood_broken
                                 : 0;
             const units::angle rotation = std::get<2>( override->second );
             const int draw_highlight = std::get<3>( override->second );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2792,12 +2792,12 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         const std::string &vp_id = veh.part_id_string( veh_part, part_mod );
         const int subtile = part_mod == 1 ? open_
                             : part_mod == 2 ? broken
-                            : part_mod == 3 ? lb
-                            : part_mod == 4 ? lb_open_
-                            : part_mod == 5 ? lb_broken
-                            : part_mod == 6 ? hb
-                            : part_mod == 7 ? hb_open_
-                            : part_mod == 8 ? hb_broken
+                            : part_mod == 3 ? lightblood
+                            : part_mod == 4 ? lightblood_open_
+                            : part_mod == 5 ? lightblood_broken
+                            : part_mod == 6 ? heavyblood
+                            : part_mod == 7 ? heavyblood_open_
+                            : part_mod == 8 ? heavyblood_broken
                             : 0;
         const int rotation = std::round( to_degrees( veh.face.dir() ) );
         const std::string vpname = "vp_" + vp_id;
@@ -2828,12 +2828,12 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             const char part_mod = std::get<1>( override->second );
             const int subtile = part_mod == 1 ? open_
                                 : part_mod == 2 ? broken
-                                : part_mod == 3 ? lb
-                                : part_mod == 4 ? lb_open_
-                                : part_mod == 5 ? lb_broken
-                                : part_mod == 6 ? hb
-                                : part_mod == 7 ? hb_open_
-                                : part_mod == 8 ? hb_broken
+                                : part_mod == 3 ? lightblood
+                                : part_mod == 4 ? lightblood_open_
+                                : part_mod == 5 ? lightblood_broken
+                                : part_mod == 6 ? heavyblood
+                                : part_mod == 7 ? heavyblood_open_
+                                : part_mod == 8 ? heavyblood_broken
                                 : 0;
             const units::angle rotation = std::get<2>( override->second );
             const int draw_highlight = std::get<3>( override->second );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -55,6 +55,12 @@ enum MULTITILE_TYPE {
     unconnected,
     open_,
     broken,
+    lb,
+    hb,
+    lb_open_,
+    lb_broken,
+    hb_open_,
+    hb_broken,
     num_multitile_types
 };
 // Make sure to change TILE_CATEGORY_IDS if this changes!

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -55,12 +55,12 @@ enum MULTITILE_TYPE {
     unconnected,
     open_,
     broken,
-    lb,
-    hb,
-    lb_open_,
-    lb_broken,
-    hb_open_,
-    hb_broken,
+    lightblood,
+    heavyblood,
+    lightblood_open_,
+    lightblood_broken,
+    heavyblood_open_,
+    heavyblood_broken,
     num_multitile_types
 };
 // Make sure to change TILE_CATEGORY_IDS if this changes!

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -55,12 +55,10 @@ enum MULTITILE_TYPE {
     unconnected,
     open_,
     broken,
+    blooded_open_,
+    blooded_broken,
     lightblood,
     heavyblood,
-    lightblood_open_,
-    lightblood_broken,
-    heavyblood_open_,
-    heavyblood_broken,
     num_multitile_types
 };
 // Make sure to change TILE_CATEGORY_IDS if this changes!

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -66,9 +66,9 @@ char vehicle::part_sym( const int p, const bool exact ) const
 // during draw_vpart vector returns at least 1 element, max of 2 elements. If 2 elements the
 // second denotes if it is open or damaged and bloodstained level
 //          no blood   light blood   heavy blood
-// normal      0            3            6
-// open        1            4            7
-// broken      2            5            8
+// normal      0            5            6
+// open        1            3            3
+// broken      2            4            4
 std::string vehicle::part_id_string( const int p, char &part_mod ) const
 {
 
@@ -86,34 +86,28 @@ std::string vehicle::part_id_string( const int p, char &part_mod ) const
     const vehicle_part &vp = parts.at( displayed_part );
 
     if( part_flag( displayed_part, VPFLAG_OPENABLE ) && vp.open ) {
-        if( parts[displayed_part].blood > 200 ) {
-            // open and heavy blood
-            part_mod = 7;
-        } else if( parts[displayed_part].blood > 0 ) {
-            // open and light blood
-            part_mod = 4;
+        if( vp.blood > 0 ) {
+            // open and blooded
+            part_mod = 3;
         } else {
             // open
             part_mod = 1;
         }
     } else if( vp.is_broken() ) {
-        if( parts[displayed_part].blood > 200 ) {
-            // broken and heavy blood
-            part_mod = 8;
-        } else if( parts[displayed_part].blood > 0 ) {
-            // broken and light blood
-            part_mod = 5;
+        if( vp.blood > 0 ) {
+            // broken and blooded
+            part_mod = 4;
         } else {
             // broken
             part_mod = 2;
         }
     } else {
-        if( parts[displayed_part].blood > 200 ) {
+        if( vp.blood > 200 ) {
             // normal and heavy blood
             part_mod = 6;
-        } else if( parts[displayed_part].blood > 0 ) {
+        } else if( vp.blood > 0 ) {
             // normal and light blood
-            part_mod = 3;
+            part_mod = 5;
         }
     }
 

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -64,9 +64,14 @@ char vehicle::part_sym( const int p, const bool exact ) const
 
 // similar to part_sym(int p) but for use when drawing SDL tiles. Called only by cata_tiles
 // during draw_vpart vector returns at least 1 element, max of 2 elements. If 2 elements the
-// second denotes if it is open or damaged
+// second denotes if it is open or damaged and bloodstained level
+//          no blood   light blood   heavy blood
+// normal      0            3            6
+// open        1            4            7
+// broken      2            5            8
 std::string vehicle::part_id_string( const int p, char &part_mod ) const
 {
+
     part_mod = 0;
     if( p < 0 || p >= static_cast<int>( parts.size() ) || parts[p].removed ) {
         return "";
@@ -81,11 +86,35 @@ std::string vehicle::part_id_string( const int p, char &part_mod ) const
     const vehicle_part &vp = parts.at( displayed_part );
 
     if( part_flag( displayed_part, VPFLAG_OPENABLE ) && vp.open ) {
-        // open
-        part_mod = 1;
+        if( parts[displayed_part].blood > 200 ) {
+            // open and heavy blood
+            part_mod = 7;
+        } else if( parts[displayed_part].blood > 0 ) {
+            // open and light blood
+            part_mod = 4;
+        } else {
+            // open
+            part_mod = 1;
+        }
     } else if( vp.is_broken() ) {
-        // broken
-        part_mod = 2;
+        if( parts[displayed_part].blood > 200 ) {
+            // broken and heavy blood
+            part_mod = 8;
+        } else if( parts[displayed_part].blood > 0 ) {
+            // broken and light blood
+            part_mod = 5;
+        } else {
+            // broken
+            part_mod = 2;
+        }
+    } else {
+        if( parts[displayed_part].blood > 200 ) {
+            // normal and heavy blood
+            part_mod = 6;
+        } else if( parts[displayed_part].blood > 0 ) {
+            // normal and light blood
+            part_mod = 3;
+        }
     }
 
     return vp.id.str() + ( vp.variant.empty() ?  "" : "_" + vp.variant );


### PR DESCRIPTION
#### Summary
Features "vehicle sprites to show accumulated blood spatter"

#### Purpose of change

The already fleshed out blood spatter system was only used in ASCII mode and vehicle inspection mode.  Why should tileset players miss out on all the excitement of spraying viscera onto your car?

This change introduces four new multitile metadata entries to tileset json files to allow vehicle sprites to render blood state.

#### Describe the solution

The tile drawing function asked the vehicle system for details on each part so it knows what to pass to the sprite drawing function.  This function used to collect only two states - Is the part open or broken?  I expanded this function to also collect information on how much blood is on the part.  It passes this information onto the sub-tile metadata so the tile drawing function can read whether or not the part has the multitile string, there are 4 new strings now for this.

    center
    corner
    edge
    t_connection
    end_piece
    unconnected
    open
    broken
    blooded_open -> for vehicle doors that get bloodied
    blooded_broken -> for vehicle parts that get broken and bloodied
    lightblood -> for any vehicle parts that get bloodied a little
    heavyblood -> for any vehicle parts that get bloodied a lot

The last 4 ids are only used for vehicle parts.  Since the subtitle id for the first 8 are unmodified, all existing multitile data should function as normally.

I created a tileset branch of UltiCa to test the blood sprite functionality, and will include a link at the bottom - it will be pushed to the main tileset repository in the event of this pr being merged.

https://imgur.com/a/zWHwC3Q
Video of bloodspatter in action.  Highly recommend watching to see how it works in action.

![image](https://user-images.githubusercontent.com/34361592/119547590-34466880-bd8d-11eb-93d7-4e31434602a3.png)

Extra sprites that I created :

![blood tileset](https://user-images.githubusercontent.com/34361592/119684814-b80b5e00-be3c-11eb-8b24-c2b21ced7379.jpg)

In this initial tileset the blood is used as an overlay much like cracks and dents are.  More committed tileset creators can create more detailed blood parts if they want to.

#### Describe alternatives you've considered

#### Testing

I did a lot of hit-and-run testing in vehicles, and while the rest of the game looks normal...  This edits multitile functionality of tile sprites so I do need to do more testing to confirm all other multitile usage remains intact. ( Such as doors, building wall connections, and so on)

#### Additional context

Tilesets WILL have to all be updated as this will break any vehicle tiles that have blood and multitile json data using the current system.  They will display unbroken, if they are actually broken and bloodied. I have made a UltiCa revision that updates windshields, quarterpanels, panels and doors that will show blood parts.  The only other thing that is necessary for UltiCa tileset to be completed is for all other vehicle parts to add a blooded_broken multitile state.

The two changes all tileset creators would have to do at a minimum is ;

            Add a new multitile for all "open" vehicle sprites to also declare "blooded_open" with same value as "open"
            Add a new multitile for all "broken" vehicle sprites to also declare "blooded_broken" with same value as "broken"

Any blood sprite inclusion is optional for tilesets.  Only the above changes would be required for tilesets to function as normally without blood sprites.

This is the PR for the Ultica tileset that contains the blood sprites necessary for this pr to work ;

     https://github.com/I-am-Erk/CDDA-Tilesets/pull/630 

Any tileset system that uses the Ultica vehicle tileset style and naming as a base should have little difficulty copying the blood and jsons over to convert their tile system to get a working blood sprite set.
