### PR TITLE
Implement Rummage pocket activity actor

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -1005,5 +1005,15 @@
     "no_resume": true,
     "refuel_fires": false,
     "auto_needs": false
+	},
+  {
+    "id": "ACT_RUMMAGE_POCKET",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "rummaging pocket",
+    "based_on": "speed",
+    "no_resume": true
   }
+  
+  
 ]

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -27,6 +27,7 @@
 #include "craft_command.h"
 #include "debug.h"
 #include "enums.h"
+#include "enum_conversions.h"
 #include "event.h"
 #include "event_bus.h"
 #include "flag.h"
@@ -4077,6 +4078,105 @@ std::unique_ptr<activity_actor> haircut_activity_actor::deserialize( JsonIn & )
     return haircut_activity_actor().clone();
 }
 
+void rummage_pocket_activity_actor::start(player_activity& act, Character& who)
+{
+    //TODO: Items that are in containers not held by character
+    //need to be moved to inventory like item_location::obtain
+    const int moves = item_loc.obtain_cost(who);
+    act.moves_total = moves;
+    act.moves_left = moves;
+}
+
+void rummage_pocket_activity_actor::do_turn(player_activity&, Character& who)
+{
+    who.add_msg_if_player(_("You rummage your pockets for the item"));
+}
+
+void rummage_pocket_activity_actor::finish(player_activity& act, Character& who)
+{
+    who.add_msg_if_player(m_good, _("You rummaged your pockets to find the item"));
+    // some function calls in the switch block spawn activities e.g.
+    // avatar::read spawns an ACT_READ activity, so we need to set
+    // this one to null before calling them
+    act.set_to_null();
+    switch (kind) {
+    case action::read: {
+        avatar& u = g->u;
+        if (item_loc->type->can_use("learn_spell")) {
+            item spell_book = *item_loc.get_item();
+            spell_book.get_use("learn_spell")->call(
+                u, spell_book, spell_book.active, u.pos());
+        }
+        else {
+            u.read(*item_loc);
+        }
+        return;
+    }
+    case action::wear: {
+        avatar& u = g->u;
+        u.wear(*item_loc);
+        return;
+    }
+    case action::wield:
+        g->wield(item_loc);
+        return;
+    default:
+        debugmsg("Unexpected action kind in rummage_pocket_activity_actor::finish");
+        return;
+    }
+}
+
+void rummage_pocket_activity_actor::serialize(JsonOut& jsout) const
+{
+    jsout.start_object();
+
+    jsout.member("item_loc", item_loc);
+    jsout.member_as_string("action", kind);
+
+    jsout.end_object();
+}
+
+std::unique_ptr<activity_actor> rummage_pocket_activity_actor::deserialize(JsonIn& jsin)
+{
+    rummage_pocket_activity_actor actor(item_location{}, action::none);
+
+    JsonObject data = jsin.get_object();
+
+    data.read("item_loc", actor.item_loc);
+    const action k = data.get_enum_value<action>("action");
+    actor.kind = k;
+
+    return actor.clone();
+}
+
+namespace io
+{
+    template<>
+    std::string enum_to_string<rummage_pocket_activity_actor::action>(
+        const rummage_pocket_activity_actor::action kind)
+    {
+        switch (kind) {
+        case rummage_pocket_activity_actor::action::none:
+            return "none";
+        case rummage_pocket_activity_actor::action::read:
+            return "read";
+        case rummage_pocket_activity_actor::action::wear:
+            return "wear";
+        case rummage_pocket_activity_actor::action::wield:
+            return "wield";
+        case rummage_pocket_activity_actor::action::last:
+            break;
+        }
+        debugmsg("Invalid rummage_pocket_activity_actor::action");
+        abort();
+    }
+} //namespace io
+
+template<>
+struct enum_traits<rummage_pocket_activity_actor::action> {
+    static constexpr rummage_pocket_activity_actor::action last =
+        rummage_pocket_activity_actor::action::last;
+};
 namespace activity_actors
 {
 
@@ -4112,6 +4212,7 @@ deserialize_functions = {
     { activity_id( "ACT_PLAY_WITH_PET" ), &play_with_pet_activity_actor::deserialize },
     { activity_id( "ACT_READ" ), &read_activity_actor::deserialize },
     { activity_id( "ACT_RELOAD" ), &reload_activity_actor::deserialize },
+    { activity_id("ACT_RUMMAGE_POCKET"), &rummage_pocket_activity_actor::deserialize },
     { activity_id( "ACT_SHAVE" ), &shave_activity_actor::deserialize },
     { activity_id( "ACT_SHEARING" ), &shearing_activity_actor::deserialize },
     { activity_id( "ACT_STASH" ), &stash_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1363,4 +1363,37 @@ class haircut_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonIn & );
 };
 
+class rummage_pocket_activity_actor : public activity_actor
+{
+public:
+    enum class action : int {
+        none,
+        read,
+        wear,
+        wield,
+        last
+    };
+private:
+    item_location item_loc;
+    action kind;
+
+public:
+    rummage_pocket_activity_actor(const item_location& i_loc, action act_kind) :
+        item_loc(i_loc), kind(act_kind) {}
+
+    activity_id get_type() const override {
+        return activity_id("ACT_RUMMAGE_POCKET");
+    }
+
+    void start(player_activity& act, Character&) override;
+    void do_turn(player_activity&, Character&) override;
+    void finish(player_activity& act, Character&) override;
+
+    std::unique_ptr<activity_actor> clone() const override {
+        return std::make_unique<rummage_pocket_activity_actor>(*this);
+    }
+
+    void serialize(JsonOut& jsout) const override;
+    static std::unique_ptr<activity_actor> deserialize(JsonIn& jsin);
+};
 #endif // CATA_SRC_ACTIVITY_ACTOR_DEFINITIONS_H

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1365,35 +1365,42 @@ class haircut_activity_actor : public activity_actor
 
 class rummage_pocket_activity_actor : public activity_actor
 {
-public:
-    enum class action : int {
-        none,
-        read,
-        wear,
-        wield,
-        last
-    };
-private:
-    item_location item_loc;
-    action kind;
+    public:
+        enum class action : int {
+            activate,
+            drop,
+            empty,
+            none,
+            read,
+            wear,
+            wield,
+            last
+        };
+    private:
+        using item_locations = drop_locations;
+        item_locations item_loc;
+        action kind;
+        tripoint target;
 
-public:
-    rummage_pocket_activity_actor(const item_location& i_loc, action act_kind) :
-        item_loc(i_loc), kind(act_kind) {}
+    public:
+        rummage_pocket_activity_actor( const item_locations &iloc, action act_kind, const tripoint &tgt ) :
+            item_loc( iloc ), kind( act_kind ), target( tgt ) {}
+        rummage_pocket_activity_actor( const item_location &iloc, const action kind,
+                                       const tripoint &tgt = tripoint_zero );
 
-    activity_id get_type() const override {
-        return activity_id("ACT_RUMMAGE_POCKET");
-    }
+        activity_id get_type() const override {
+            return activity_id( "ACT_RUMMAGE_POCKET" );
+        }
 
-    void start(player_activity& act, Character&) override;
-    void do_turn(player_activity&, Character&) override;
-    void finish(player_activity& act, Character&) override;
+        void start( player_activity &act, Character & ) override;
+        void do_turn( player_activity &, Character & ) override;
+        void finish( player_activity &act, Character & ) override;
 
-    std::unique_ptr<activity_actor> clone() const override {
-        return std::make_unique<rummage_pocket_activity_actor>(*this);
-    }
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<rummage_pocket_activity_actor>( *this );
+        }
 
-    void serialize(JsonOut& jsout) const override;
-    static std::unique_ptr<activity_actor> deserialize(JsonIn& jsin);
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonIn &jsin );
 };
 #endif // CATA_SRC_ACTIVITY_ACTOR_DEFINITIONS_H

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9435,7 +9435,14 @@ void game::wield()
     item_location loc = game_menus::inv::wield( u );
 
     if( loc ) {
-        wield( loc );
+        if (loc.where() == item_location::type::container) {
+            u.assign_activity(player_activity(rummage_pocket_activity_actor(
+                loc, rummage_pocket_activity_actor::action::wield
+            )));
+        }
+        else {
+            wield(loc);
+        }
     } else {
         add_msg( _( "Never mind." ) );
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8584,13 +8584,15 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
 
 void game::drop()
 {
-    u.drop( game_menus::inv::multidrop( u ), u.pos() );
+    u.assign_activity(player_activity(rummage_pocket_activity_actor(game_menus::inv::multidrop(u),
+        rummage_pocket_activity_actor::action::drop, u.pos())));
 }
 
 void game::drop_in_direction()
 {
     if( const cata::optional<tripoint> pnt = choose_adjacent( _( "Drop where?" ) ) ) {
-        u.drop( game_menus::inv::multidrop( u ), *pnt );
+        u.assign_activity(player_activity(rummage_pocket_activity_actor(game_menus::inv::multidrop(u),
+            rummage_pocket_activity_actor::action::drop, *pnt)));
     }
 }
 

--- a/src/game.h
+++ b/src/game.h
@@ -16,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+#include "activity_actor.h"
 #include "calendar.h"
 #include "character_id.h"
 #include "coordinates.h"
@@ -166,6 +167,7 @@ class game
         friend scent_map &get_scent();
         friend timed_event_manager &get_timed_events();
         friend memorial_logger &get_memorial();
+        friend void rummage_pocket_activity_actor::finish(player_activity&, Character&);
     public:
         game();
         ~game();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1274,7 +1274,14 @@ static void wear()
     item_location loc = game_menus::inv::wear( player_character );
 
     if( loc ) {
-        player_character.wear( loc );
+        if (loc.where() == item_location::type::container) {
+            player_character.assign_activity(player_activity(rummage_pocket_activity_actor(
+                loc, rummage_pocket_activity_actor::action::wear
+            )));
+        }
+        else {
+            player_character.wear(loc);
+        }
     } else {
         add_msg( _( "Never mind." ) );
     }
@@ -1299,13 +1306,18 @@ static void read()
     item_location loc = game_menus::inv::read( player_character );
 
     if( loc ) {
-        if( loc->type->can_use( "learn_spell" ) ) {
-            item spell_book = *loc.get_item();
-            spell_book.get_use( "learn_spell" )->call( player_character, spell_book,
-                    spell_book.active, player_character.pos() );
+        if (loc.where() == item_location::type::container) {
+            player_character.assign_activity(player_activity(rummage_pocket_activity_actor(
+                loc, rummage_pocket_activity_actor::action::read
+            )));
         } else {
-            loc = loc.obtain( player_character );
-            player_character.read( loc );
+            if (loc->type->can_use("learn_spell")) {
+                item spell_book = *loc.get_item();
+                spell_book.get_use("learn_spell")->call(player_character, spell_book, spell_book.active, player_character.pos());
+            }
+            else {
+                player_character.read(loc);
+            }
         }
     } else {
         add_msg( _( "Never mind." ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfix "Implement Rummage pocket activity actor"
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The intention is to solve #40163. This is a continuation of the work of @rsulli55 in PR #40413.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I intend to fully implement this activity. I started by copying @rsulli55 work and then implementing the case for the `drop` action. I don't really like my implementation because it assumes that we'll be looking for each item one at a time, which could be better simulated. I'll probably work on the `use_item` action now and see if I can get it to work. In the meantime, I request your opinions on how to better simulate the `drop` action.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Running far away and never look back.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I've run in-game tests to see if everything was working and it worked, but I will need to be more rigorous after this draft is complete.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
rsulli55 was unsure if his (de)serialization code for `enums` was the suggested way of doing things and I have no idea what that code is, to be honest.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
