### PR TITLE
Create no_fungal_growth mod

### DIFF
--- a/data/mods/no_fungal_growth/modinfo.json
+++ b/data/mods/no_fungal_growth/modinfo.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "no_fungal_growth",
+    "name": "No Fungal Growth",
+    "authors": [ "eltank" ],
+    "description": "Removes the exponential growth ability of fungaloids.",
+    "category": "rebalance",
+    "dependencies": [ "dda" ]
+  },
+  {
+    "id": "mon_spore",
+    "copy-from": "mon_spore",
+    "type": "MONSTER",
+    "name": { "str": "spore cloud" },
+    "upgrades": false,
+    "special_attacks": [ [ "DISAPPEAR", 10 ] ],
+    "delete": { "special_attacks": [ "PLANT" ] }
+  }
+]


### PR DESCRIPTION
#### Summary
Balance "Create No Fungal Growth mod"

#### Purpose of change

Provides an alternative to simply removing all fungus from the game for players who are fed up with the fungal exponential growth.

#### Describe the solution

New mod.
Remove the spores' ability to spawn fungaloids. Spores just disappear on death.

#### Describe alternatives you've considered


#### Testing

New world with the mod enabled.
![image](https://user-images.githubusercontent.com/8000047/132150950-8b48c158-46e3-47dc-9211-d09f77efca1e.png)

Spawn a fungaloid. It starts poufing but that doesn't do anything except create fungal terrain.

![image](https://user-images.githubusercontent.com/8000047/132150983-47fb79bb-eec4-4712-a9fa-98e65a5d8049.png)

Wait 24 hours. The fungaloid does a good job of planting fungus all over the place, but no additional fungaloids are created.

![image](https://user-images.githubusercontent.com/8000047/132151167-a9f2df47-acd8-47c5-aea0-41863c0d704b.png)


#### Additional context

For comparison, here is what a single fungaloid can do in 24 hours without the mod. That's 161 visible fungaloids; there are more outside the viewable area.
![image](https://user-images.githubusercontent.com/8000047/133349521-a104055e-dea3-48b5-aebe-85c1c1a7c1a9.png)

I-am-erk suggested that this mod could be on by default. I'd like to make sure there are no issues with it first (based on player feedback) but if others agree that change is easy to make in a follow-up PR. [Edit: done in #51620]
