### PR TITLE
Bugfixes: Companion mission ui hotkey failing due to too many companions

### DIFF
--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -2000,7 +2000,7 @@ npc_ptr talk_function::companion_choose( const std::map<skill_id, int> &required
                 }
             }
         }
-        uilist_entry npc_entry = uilist_entry( x, can_do, x, npc_desc );
+        uilist_entry npc_entry = uilist_entry( x, can_do, -1, npc_desc );
         npc_menu.push_back( npc_entry );
         x++;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Companion mission ui hotkey failing due to too many companions"
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When you have more than 10 companions, the current method of assigning hotkeys fails because it starts to auto-assign tab and enter.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change the uilist_entry hotkey from x which iterates from 0, to the automated method of -1.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None as the automated method already exists and seems to avoid the enter key.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Did a before and after, and after the fix, I was able to select non Darrell npcs.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Before the fix - Darrell is assigned the hotkey of Enter so no other companions will ever be able to be selected.
![image](https://user-images.githubusercontent.com/3409545/135640525-ba6f7463-072a-42a9-b969-0bfc0cdd7634.png)

After the fix - 
![image](https://user-images.githubusercontent.com/3409545/135640630-eaa54032-1bb3-4f2d-9053-f886d88baf6d.png)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
