### PR TITLE
Bugfixes Using the firearm repair kit to cut metal uses the battery

### DIFF
--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -886,7 +886,7 @@
       [ "CHISEL", 3 ],
       [ "CHISEL_WOOD", 3 ]
     ],
-    "use_action": [ "GUN_REPAIR", [ "CROWBAR", 0 ], [ "HAMMER", 0 ] ],
+    "use_action": [ "GUN_REPAIR", [ "CROWBAR", 0 ], [ "HAMMER", 0 ], [ "HACKSAW", 0] ],
     "flags": [ "ALLOWS_REMOTE_USE" ],
     "pocket_data": [
       {

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -886,7 +886,7 @@
       [ "CHISEL", 3 ],
       [ "CHISEL_WOOD", 3 ]
     ],
-    "use_action": [ "GUN_REPAIR", [ "CROWBAR", 0 ], [ "HAMMER", 0 ], [ "HACKSAW", 0] ],
+    "use_action": [ "GUN_REPAIR", [ "CROWBAR", 0 ], [ "HAMMER", 0 ], [ "HACKSAW", 0 ] ],
     "flags": [ "ALLOWS_REMOTE_USE" ],
     "pocket_data": [
       {

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -1552,6 +1552,7 @@
     "description": "Test hacksaw which uses batteries.",
     "charges_per_use": 1,
     "ammo": [ "battery" ],
+    "use_action": [ [ "HACKSAW", 1 ] ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1052,6 +1052,8 @@ void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
 
 void hacksaw_activity_actor::do_turn( player_activity &/*act*/, Character &who )
 {
+    std::string method = "HACKSAW";
+
     if( tool->ammo_sufficient( &who, method ) ) {
         int ammo_consumed = tool->ammo_required();
         std::map<std::string, float>::const_iterator iter = tool->type->ammo_scale.find( method );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1052,8 +1052,14 @@ void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
 
 void hacksaw_activity_actor::do_turn( player_activity &/*act*/, Character &who )
 {
-    if( tool->ammo_sufficient( &who ) ) {
-        tool->ammo_consume( tool->ammo_required(), tool.position(), &who );
+    if( tool->ammo_sufficient( &who, method ) ) {
+        int ammo_consumed = tool->ammo_required();
+        std::map<std::string, float>::const_iterator iter = tool->type->ammo_scale.find( method );
+        if( iter != tool->type->ammo_scale.end() ) {
+            ammo_consumed *= iter->second;
+        }
+
+        tool->ammo_consume( ammo_consumed, tool.position(), &who );
         sfx::play_activity_sound( "tool", "hacksaw", sfx::get_heard_volume( target ) );
         if( calendar::once_every( 1_minutes ) ) {
             //~ Sound of a metal sawing tool at work!

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -308,7 +308,6 @@ class hacksaw_activity_actor : public activity_actor
     private:
         tripoint target;
         item_location tool;
-        std::string method = "HACKSAW";
 
         bool can_resume_with_internal( const activity_actor &other,
                                        const Character &/*who*/ ) const override {

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -308,6 +308,7 @@ class hacksaw_activity_actor : public activity_actor
     private:
         tripoint target;
         item_location tool;
+        std::string method = "HACKSAW";
 
         bool can_resume_with_internal( const activity_actor &other,
                                        const Character &/*who*/ ) const override {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Using the firearm repair kit to cut metal uses the battery"
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Makes it so that the firearm repair kit does not need a battery and does not consume battery charges when cutting metal.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The hacksaw activity got jsonized recently but the hacking_activity_actor used the older tool->ammo_sufficient( &who ) and tool->ammo_required() which doesn't account for per-second ammo consumption.  This change just makes it so that the activity uses the new ammo_scaled parameter.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
I used the ammo_scaled method because that is also the method being used to display the charge cost on the use item menu.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Did a before and after with the regular hacksaw and a firearm repair kit.  Both worked as expected - hacksaw works the same, and firearm repair kit can now hacksaw without a battery, and without using battery charges.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/30137

Before trying to cut the shelf with the firearm repair kit there is 400 battery charges.
![image](https://user-images.githubusercontent.com/3409545/135696582-a5e739e0-f714-4f7e-a441-407a73b51462.png)

When trying to cut, 5 second elapses and I see the no charges remaining, meaning it took 100 charge per 1 second which would be the regular firearm repair kit use cost.
![image](https://user-images.githubusercontent.com/3409545/135696586-728702af-7238-48a6-82e9-c4bef55beb7c.png)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
