### PR TITLE
Consistent naming of mutation categories

### DIFF
--- a/data/json/mutations/mutation_category.json
+++ b/data/json/mutations/mutation_category.json
@@ -102,7 +102,7 @@
   {
     "type": "mutation_category",
     "id": "URSINE",
-    "name": "Bear",
+    "name": "Ursine",
     "threshold_mut": "THRESH_URSINE",
     "mutagen_message": "You feel an urge to… patrol?  the forests?",
     "iv_message": "You feel yourself quite equipped for wilderness survival.",
@@ -120,7 +120,7 @@
   {
     "type": "mutation_category",
     "id": "LUPINE",
-    "name": "Wolf",
+    "name": "Lupine",
     "threshold_mut": "THRESH_LUPINE",
     "mutagen_message": "You feel an urge to mark your territory.  But then it passes.",
     "iv_message": "As the mutagen hits you, your ears twitch and you stifle a yipe.",
@@ -250,7 +250,7 @@
   {
     "type": "mutation_category",
     "id": "ELFA",
-    "name": "Fey",
+    "name": "Elf-A",
     "threshold_mut": "THRESH_ELFA",
     "mutagen_message": "Nature is becoming one with you…",
     "iv_message": "Everything goes green for a second.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Changed the 'name' string of URSINE, LUPINE and ELFA mutation categories to match the internal ID"
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There are only three mutation categories (LUPINE, URSINE and ELFA) where the "name" field does not match the internal ID, while every other category does. To my knowledge, this information is not exposed to the player anywhere, but I noticed it thanks to the new [mutation catalogue](https://nornagon.github.io/cdda-guide/#/mutation) on the HHG, and it just seemed needlessly confusing.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed the names of those categories to match their internal ID.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Could've done it the other way around, but then I would've had to find-and-replace every instance of the category ID.

Honestly, the naming conventions of mutation categories are a little inconsistent in general, so I suppose I could've undertaken a wholesale restructuring, but that's a lot of work for something fairly inconsequential. Plus mutations are undergoing reworks and getting new documentation anyway, so I'd rather fix this small inconsistency and get on with my life.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
As far as I know, this is an entirely cosmetic internal change, so there's nothing to test.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->