### PR TITLE
Allow disabling use of gold linker when LTO is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,14 @@ ifndef PCH
   PCH = 1
 endif
 
+ifndef GOLD
+ifeq ($(LTO), 1)
+  GOLD = 1
+else
+  GOLD = 0
+endif
+endif
+
 # Auto-detect MSYS2
 ifdef MSYSTEM
   MSYS2 = 1
@@ -371,7 +379,9 @@ ifeq ($(RELEASE), 1)
         LTOFLAGS += -flto=full
       endif
     else
-      LDFLAGS += -fuse-ld=gold # This breaks in OS X because gold can only produce ELF binaries, not Mach
+      ifeq ($(GOLD), 1)
+        LDFLAGS += -fuse-ld=gold # This breaks in OS X because gold can only produce ELF binaries, not Mach
+      endif
     endif
 
     ifneq ($(CLANG), 0)
@@ -484,7 +494,7 @@ ifeq ($(NATIVE), linux64)
   CXXFLAGS += -m64
   LDFLAGS += -m64
   TARGETSYSTEM=LINUX
-  ifdef GOLD
+  ifeq ($(GOLD), 1)
     CXXFLAGS += -fuse-ld=gold
     LDFLAGS += -fuse-ld=gold -Wl,--detect-odr-violations
   endif
@@ -494,7 +504,7 @@ else
     CXXFLAGS += -m32
     LDFLAGS += -m32
     TARGETSYSTEM=LINUX
-    ifdef GOLD
+    ifeq ($(GOLD), 1)
       CXXFLAGS += -fuse-ld=gold
       LDFLAGS += -fuse-ld=gold -Wl,--detect-odr-violations
     endif


### PR DESCRIPTION
#### Summary
Build  "Make use of gold linker optional for LTO builds"

#### Purpose of change

gold is not / no longer needed to link binaries with LTO.
As gold is not available on every architecture, allow building
CDDA with the default linker, even when LTO is enabled.

Because of the automatic gold usage, CDDA is currently not
building on some architectures on the Debian and Ubuntu build servers (e.g. riscv64):
https://buildd.debian.org/status/logs.php?pkg=cataclysm-dda&ver=0.F-3-1

#### Describe the solution

Allow building with `GOLD=0` even when LTO is enabled (`LTO=1`) by setting the existing GOLD variable only if it's not already defined.
The default behavior is not changed.

#### Describe alternatives you've considered

- don't build with LTO on Debian/Ubuntu
- keep building with LTO, but keep builds failing on architectures without gold

#### Testing

I built once with `LTO=1 GOLD=0` and once with `LTO=1 GOLD=1` and checked the presence of the `-fuse-ld=gold` switch in the command line.