### PR TITLE
Rework on_death effect for slimes

### DIFF
--- a/data/json/monster_special_attacks/monster_deaths.json
+++ b/data/json/monster_special_attacks/monster_deaths.json
@@ -110,7 +110,9 @@
     "valid_targets": [ "ground", "self" ],
     "flags": [ "SILENT", "HOSTILE_SUMMON", "PERMANENT", "SPAWN_WITH_DEATH_DROPS" ],
     "shape": "blast",
-    "effect": "slime_split"
+    "effect": "slime_split",
+    "min_aoe": 1,
+    "max_aoe": 1
   },
   {
     "id": "death_blobsplit",
@@ -120,7 +122,9 @@
     "valid_targets": [ "ground", "self" ],
     "flags": [ "SILENT", "HOSTILE_SUMMON", "PERMANENT", "SPAWN_WITH_DEATH_DROPS" ],
     "shape": "blast",
-    "effect": "slime_split"
+    "effect": "slime_split",
+    "min_aoe": 1,
+    "max_aoe": 1
   },
   {
     "id": "death_blobsplit_brain",
@@ -130,7 +134,9 @@
     "valid_targets": [ "ground", "self" ],
     "flags": [ "SILENT", "HOSTILE_SUMMON", "PERMANENT", "SPAWN_WITH_DEATH_DROPS" ],
     "shape": "blast",
-    "effect": "slime_split"
+    "effect": "slime_split",
+    "min_aoe": 1,
+    "max_aoe": 1
   },
   {
     "id": "death_blob_brain",

--- a/data/json/monster_special_attacks/monster_deaths.json
+++ b/data/json/monster_special_attacks/monster_deaths.json
@@ -108,14 +108,9 @@
     "name": { "str": "Death Blobsplit Large" },
     "description": "A large blob splits in half",
     "valid_targets": [ "ground", "self" ],
-    "min_damage": 2,
-    "max_damage": 2,
     "flags": [ "SILENT", "HOSTILE_SUMMON", "PERMANENT", "SPAWN_WITH_DEATH_DROPS" ],
     "shape": "blast",
-    "effect": "summon",
-    "effect_str": "mon_blob",
-    "min_aoe": 2,
-    "max_aoe": 2
+    "effect": "slime_split"
   },
   {
     "id": "death_blobsplit",
@@ -123,14 +118,9 @@
     "name": { "str": "Death Blobsplit" },
     "description": "A blob splits in half",
     "valid_targets": [ "ground", "self" ],
-    "min_damage": 2,
-    "max_damage": 2,
     "flags": [ "SILENT", "HOSTILE_SUMMON", "PERMANENT", "SPAWN_WITH_DEATH_DROPS" ],
     "shape": "blast",
-    "effect": "summon",
-    "effect_str": "mon_blob_small",
-    "min_aoe": 2,
-    "max_aoe": 2
+    "effect": "slime_split"
   },
   {
     "id": "death_blobsplit_brain",
@@ -138,14 +128,9 @@
     "name": { "str": "Death Blobsplit Brain" },
     "description": "A blob brain splits in half",
     "valid_targets": [ "ground", "self" ],
-    "min_damage": 3,
-    "max_damage": 3,
     "flags": [ "SILENT", "HOSTILE_SUMMON", "PERMANENT", "SPAWN_WITH_DEATH_DROPS" ],
     "shape": "blast",
-    "effect": "summon",
-    "effect_str": "mon_blob_large",
-    "min_aoe": 2,
-    "max_aoe": 2
+    "effect": "slime_split"
   },
   {
     "id": "death_blob_brain",

--- a/src/magic.h
+++ b/src/magic.h
@@ -713,6 +713,7 @@ void emit( const spell &sp, Creature &caster, const tripoint &target );
 void fungalize( const spell &sp, Creature &caster, const tripoint &target );
 void effect_on_condition( const spell &sp, Creature &caster, const tripoint &target );
 void none( const spell &sp, Creature &, const tripoint &target );
+void slime_split_on_death( const spell &sp, Creature &, const tripoint &target );
 
 static const std::map<spell_shape, std::function<std::set<tripoint>
 ( const override_parameters &, const tripoint &, const tripoint & )>> shape_map = {
@@ -758,6 +759,7 @@ effect_map{
     { "emit", spell_effect::emit },
     { "fungalize", spell_effect::fungalize },
     { "effect_on_condition", spell_effect::effect_on_condition },
+    { "slime_split", spell_effect::slime_split_on_death },
     { "none", spell_effect::none }
 };
 } // namespace spell_effect

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -72,9 +72,14 @@ static const json_character_flag json_flag_PRED2( "PRED2" );
 static const json_character_flag json_flag_PRED3( "PRED3" );
 static const json_character_flag json_flag_PRED4( "PRED4" );
 
+static const mtype_id mon_blob( "mon_blob" );
+static const mtype_id mon_blob_brain( "mon_blob_brain" );
+static const mtype_id mon_blob_large( "mon_blob_large" );
+static const mtype_id mon_blob_small( "mon_blob_small" );
 static const mtype_id mon_generator( "mon_generator" );
 
 static const species_id species_HALLUCINATION( "HALLUCINATION" );
+static const species_id species_SLIME( "SLIME" );
 
 static const trait_id trait_KILLER( "KILLER" );
 static const trait_id trait_PACIFIST( "PACIFIST" );
@@ -1541,6 +1546,77 @@ void spell_effect::effect_on_condition( const spell &sp, Creature &caster, const
             eoc->activate( d );
         } else {
             debugmsg( "Must use an activation eoc for a spell.  If you don't want the effect_on_condition to happen on its own (without the spell being cast), remove the recurrence min and max.  Otherwise, create a non-recurring effect_on_condition for this spell with its condition and effects, then have a recurring one queue it." );
+        }
+    }
+}
+
+void spell_effect::slime_split_on_death( const spell &sp, Creature &caster, const tripoint &target )
+{
+    sp.make_sound( target );
+    int mass = caster.get_speed_base();
+    monster *caster_monster = dynamic_cast<monster *>( &caster );
+    if( caster_monster && caster_monster->type->id == mon_blob_brain ) {
+        mass += mass;
+    }
+    const time_duration summon_time = sp.duration_turns();
+    std::vector<tripoint> pts = closest_points_first( caster.pos(), 1 );
+    std::vector<monster *> summoned_slimes;
+    // Make sure the creature has enough mass to create new slimes
+    int last_mass = mass;
+    while( mass > 35 ) {
+        for( const tripoint &dest : pts ) {
+            // Fall back to small slimes if no bigger smile is chosen
+            mtype_id slime_id = mon_blob_small;
+            if( mass > mon_blob_large->speed + 20 && one_in( 3 ) ) {
+                // 33% chance of spawning a big slime if enough mass
+                slime_id = mon_blob_large;
+            } else if( mass > mon_blob->speed + 20 && one_in( 2 ) ) {
+                // 50% chance of spawning a slime if enough mass
+                slime_id = mon_blob;
+            }
+
+            shared_ptr_fast<monster> mon = make_shared_fast<monster>( slime_id );
+            mon->ammo = mon->type->starting_ammo;
+            if( mon->will_move_to( dest ) ) {
+                if( monster *const blob = g->place_critter_around( mon, dest, 0 ) ) {
+                    if( caster_monster ) {
+                        blob->make_ally( *caster_monster );
+                    }
+                    mass -= slime_id->speed - 15;
+                    blob->set_speed_base( slime_id->speed - 15 );
+                    blob->no_extra_death_drops = !sp.has_flag( spell_flag::SPAWN_WITH_DEATH_DROPS );
+                    summoned_slimes.push_back( mon.get() );
+                }
+            }
+        }
+        if( last_mass <= mass ) {
+            break;
+        }
+        last_mass = mass;
+    }
+
+    // Divide remaining mass between summoned slimes
+    if( mass > 0 && !summoned_slimes.empty() ) {
+        const int mass_per_mob = mass / summoned_slimes.size();
+        for( monster *slime : summoned_slimes ) {
+            slime->set_speed_base( slime->get_speed_base() + mass_per_mob );
+            mass -= mass_per_mob;
+        }
+    }
+
+    // Last resort: Find a slime nearby that will absorb part of this mass
+    if( mass > 3 ) {
+        std::vector<tripoint> pts = closest_points_first( caster.pos(), 1 );
+        for( const tripoint &dest : pts ) {
+            if( monster *mon = get_creature_tracker().creature_at<monster>( dest ) ) {
+                if( mon->type->in_species( species_SLIME ) ) {
+                    // The mass discarded here should prevent issues when surrounded
+                    // by big blobs that keep trading mass and spawning medium slimes
+                    // over and over.
+                    mon->set_speed_base( mon->get_speed_base() + mass - 3 );
+                    return;
+                }
+            }
         }
     }
 }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1558,7 +1558,6 @@ void spell_effect::slime_split_on_death( const spell &sp, Creature &caster, cons
     if( caster_monster && caster_monster->type->id == mon_blob_brain ) {
         mass += mass;
     }
-    const time_duration summon_time = sp.duration_turns();
     std::vector<tripoint> pts = closest_points_first( caster.pos(), 1 );
     std::vector<monster *> summoned_slimes;
     // Make sure the creature has enough mass to create new slimes

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1561,8 +1561,7 @@ void spell_effect::slime_split_on_death( const spell &sp, Creature &caster, cons
     std::vector<tripoint> pts = closest_points_first( caster.pos(), 1 );
     std::vector<monster *> summoned_slimes;
     // Make sure the creature has enough mass to create new slimes
-    int last_mass = mass;
-    while( mass > 35 ) {
+    if( mass >= mon_blob_small->speed / 2 ) {
         for( const tripoint &dest : pts ) {
             // Fall back to small slimes if no bigger smile is chosen
             mtype_id slime_id = mon_blob_small;
@@ -1581,17 +1580,17 @@ void spell_effect::slime_split_on_death( const spell &sp, Creature &caster, cons
                     if( caster_monster ) {
                         blob->make_ally( *caster_monster );
                     }
-                    mass -= slime_id->speed - 15;
-                    blob->set_speed_base( slime_id->speed - 15 );
+                    const int used_mass = std::min( mass, slime_id->speed - 15 );
+                    mass -= used_mass;
+                    blob->set_speed_base( used_mass );
                     blob->no_extra_death_drops = !sp.has_flag( spell_flag::SPAWN_WITH_DEATH_DROPS );
                     summoned_slimes.push_back( mon.get() );
+                    if( mass < mon_blob_small->speed / 2 ) {
+                        break;
+                    }
                 }
             }
         }
-        if( last_mass <= mass ) {
-            break;
-        }
-        last_mass = mass;
     }
 
     // Divide remaining mass between summoned slimes

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2371,25 +2371,47 @@ bool mattack::formblob( monster *z )
 
         monster &othermon = *( dynamic_cast<monster *>( critter ) );
         // Hit a monster.  If it's a blob, give it our speed.  Otherwise, blobify it?
-        if( z->get_speed_base() > 40 && othermon.type->in_species( species_SLIME ) ) {
+        if( othermon.type->in_species( species_SLIME ) ) {
             if( othermon.type->id == mon_blob_brain ) {
                 // Brain blobs don't get sped up, they heal at the cost of the other blob.
                 // But only if they are hurt badly.
-                if( othermon.get_hp() < othermon.get_hp_max() / 2 ) {
-                    othermon.heal( z->get_speed_base(), true );
-                    z->set_hp( 0 );
-                    return true;
+                const int othermon_half_hp = othermon.get_hp_max() / 2;
+                if( othermon.get_hp() < othermon_half_hp ) {
+                    const int heal_value = std::min( z->get_speed_base(), othermon_half_hp - othermon.get_hp() );
+                    othermon.heal( heal_value, true );
+                    if( heal_value >= z->get_speed_base() ) {
+                        z->set_speed_base( 0 );
+                        z->set_hp( 0 );
+                        return true;
+                    } else {
+                        didit = true;
+                        z->set_speed_base( z->get_speed_base() - heal_value );
+                    }
                 }
                 continue;
             }
-            didit = true;
-            othermon.set_speed_base( othermon.get_speed_base() + 5 );
-            z->set_speed_base( z->get_speed_base() - 5 );
-            if( othermon.type->id == mon_blob_small &&
-                othermon.get_speed_base() >= mon_blob_small->speed + 10 ) {
-                poly_keep_speed( othermon, mon_blob );
-            } else if( othermon.type->id == mon_blob && othermon.get_speed_base() >= mon_blob->speed + 10 ) {
-                poly_keep_speed( othermon, mon_blob_large );
+
+            if( z->get_speed_base() > 40 ) {
+                didit = true;
+                othermon.set_speed_base( othermon.get_speed_base() + 5 );
+                z->set_speed_base( z->get_speed_base() - 5 );
+                if( othermon.type->id == mon_blob_small &&
+                    othermon.get_speed_base() >= mon_blob_small->speed + 10 ) {
+                    poly_keep_speed( othermon, mon_blob );
+                } else if( othermon.type->id == mon_blob && othermon.get_speed_base() >= mon_blob->speed + 10 ) {
+                    poly_keep_speed( othermon, mon_blob_large );
+                }
+            } else if( one_in( z->get_speed_base() ) ) {
+                othermon.set_speed_base( othermon.get_speed_base() + z->get_speed_base() );
+                z->set_speed_base( 0 );
+                z->set_hp( 0 );
+                if( othermon.type->id == mon_blob_small &&
+                    othermon.get_speed_base() >= mon_blob_small->speed + 10 ) {
+                    poly_keep_speed( othermon, mon_blob );
+                } else if( othermon.type->id == mon_blob && othermon.get_speed_base() >= mon_blob->speed + 10 ) {
+                    poly_keep_speed( othermon, mon_blob_large );
+                }
+                return true;
             }
         } else if( ( othermon.made_of( material_flesh ) ||
                      othermon.made_of( material_veggy ) ||


### PR DESCRIPTION
#### Summary
Bugfixes "Rework on_death effect for slimes"

#### Purpose of change
As pointed out in #53565 the fix provided didn't work in all scenarios.

Slimes had a fixed on_death effect and bigger slimes were always splitting into two smaller ones with full mass. The combined mass of the newly spawned slimes was (in most cases) higher than the mass of the donating (dead) slime. This extra mass in turn helped the slimes grow into bigger versions and split into new smaller slimes. This loop made them replicate indefinitely unless you focused on killing the smaller ones (which don't spawn new slimes on death).

This problem was observed and documented by @Balthasar-eu in a test where a skitterbot kept killing slimes over and over creating new ones in the process, until the whole area was filled by slimes.

#### Describe the solution
The generic approach with summon spells isn't good enough for the splitting mechanic so I created a new spell for the slime on_death effect specifically.

This new effect tries to create new slimes (of random sizes and reduced mass) up to the total mass of the dead slime, avoiding the main issue. If there is no room to place new slimes around, the remaining mass is transferred to a nearby slime as if it was absorbed. I added a failsafe to this new mechanic so that some of the mass is lost on transfer. This should prevent infinite loops where dead slimes keep transferring all their mass to other slimes and/or creating medium+ sized slimes that feed each other without a chance to kill the smaller ones to finally get rid of them.

The new effect is limited to a size 1 radius which prevents slimes from being created on the other side of walls. The radius can be increased to 2 if a check for passability/reachability between the source and target tile is added, but I went with the radius 1 approach. It's an easy change though if anyone wants to implement it at some point.

I also added a new behavior so very small slimes have a chance to fully merge with a nearby slime. Otherwise at some point most slimes became too small to donate mass or split.

#### Describe alternatives you've considered
None.

#### Testing

![SlimeVsSkitterbot](https://user-images.githubusercontent.com/1606943/146768404-ec55395c-dc58-439c-b71a-1c210929e219.gif)

![SlimeVsSkitterbot2](https://user-images.githubusercontent.com/1606943/146768411-4cf802f8-9d7f-4f38-b95e-938792ee5d1b.gif)

![SlimeVsSkitterbot3](https://user-images.githubusercontent.com/1606943/146768428-eefa8e9b-2a72-46b6-8c14-5487bfaa4259.gif)
