### PR TITLE
Fix .desktop filename in appdata file

### DIFF
--- a/data/xdg/org.cataclysmdda.CataclysmDDA.appdata.xml
+++ b/data/xdg/org.cataclysmdda.CataclysmDDA.appdata.xml
@@ -56,7 +56,7 @@
   <url type="translate">
     https://www.transifex.com/cataclysm-dda-translators/cataclysm-dda/
   </url>
-  <launchable type="desktop-id">cataclysm-dda.desktop</launchable>
+  <launchable type="desktop-id">org.cataclysmdda.CataclysmDDA.desktop</launchable>
   <provides>
     <binary>cataclysm-tiles</binary>
   </provides>


### PR DESCRIPTION
#### Summary

Infrastructure "Fix filename of .desktop file in AppData"

#### Purpose of change

The AppData file still pointed to the old .desktop file that got renamed some time ago.