### PR TITLE
Make melee weapons only wear down when hit is successful

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -866,7 +866,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
         cur_weapon->unset_flag( flag_UNARMED_WEAPON );
     }
 
-    if( !t.is_hallucination() ) {
+    if( hits && !t.is_hallucination() ) {
         handle_melee_wear( *cur_weapon );
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Make melee weapons only wear down when hit was successful"
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Wearing melee weapons on miss does not make sense.
Fixes #53527
Fixes #52803
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Check that attack actually hit before applying wear to a melee weapon.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
* Set `wear_modifier` to high value for testing
* Try hitting a monster
* See that weapon it not wearing on miss anymore

Before the fix:
![before-fix](https://user-images.githubusercontent.com/2339406/149615305-c0521c4b-9412-436d-ae3e-c0251869311a.png)
After the fix:
![after-fix](https://user-images.githubusercontent.com/2339406/149615312-8818b748-8e45-4bff-8295-85b6c5827eaf.png)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
