### PR TITLE
Add conditional bodypart flags

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -651,12 +651,14 @@ For information about tools with option to export ASCII art in format ready to b
 | `stat_hp_mods`         | (_optional_) Values modifying hp_max of this part following this formula: `hp_max += int_mod*int_max + dex_mod*dex_max + str_mod*str_max + per_mod*per_max + health_mod*get_healthy()` with X_max being the unmodified value of the X stat and get_healthy() being the hidden health stat of the character.
 | `heal_bonus`           | (_optional_) Innate amount of HP the bodypart heals every healing roll ( 5 minutes, currently ).
 | `mend_rate`            | (_optional_) Innate mending rate of the limb, should it get broken. Default `1.0`, used as a multiplier on the healing factor after other factors are calculated. 
+| `health_limit`         | (_optional_) Amount of limb HP necessary for the limb to provide its melee `techniques` and `conditional_flags`.  Defaults to 1, meaning broken limbs don't contribute.
 | `bionic_slots`         | (_optional_) How many bionic slots does this part have.
 | `is_limb`              | (_optional_) Is this bodypart a limb and capable of breaking. (default: `false`)
 | `smash_message`        | (_optional_) The message displayed when using that part to smash something.
 | `smash_efficiency`     | (_optional_) Modifier applied to your smashing strength when using this part to smash terrain or furniture unarmed. (default: `0.5`)
 | `flags`                | (_optional_) List of bodypart flags.  These are considered character flags, similar to bionic/trait/effect flags.
-| `techniques`           | (_optional_) List of melee techniques granted by this limb.  The chance for the technique to be included in each attack's tech list is dependent on limb encumbrance. ( `!x_in_y(current encumbrance / technique_encumbrance_limit`)
+| `conditional_flags`    | (_optional_) List of character flags this limb provides as long as it's above `health_limit` HP.
+| `techniques`           | (_optional_) List of melee techniques granted by this limb as long as it's above its `health_limit` HP.  The chance for the technique to be included in each attack's tech list is dependent on limb encumbrance. ( `!x_in_y(current encumbrance / technique_encumbrance_limit`)
 | `technique_encumbrance_limit` | (_optional_) Level of encumbrance that disables the given techniques for this limb completely, lower encumbrance still reduces the chances of the technique being chosen (see above).
 | `limb_scores`          | (_optional_) List of arrays defining limb scores. Each array contains 2 mandatory values and 1 optional value. Value 1 is a reference to a `limb_score` id. Value 2 is a float defining the limb score's value. (optional) Value 3 is a float defining the limb score's maximum value (mostly just used for manipulator score).
 | `unarmed_damage`       | (_optional_) An array of objects, each detailing the amount of unarmed damage the bodypart contributes to unarmed attacks and their armor penetration. The unarmed damages of each limb are summed and added to the base unarmed damage. Should be used for limbs the character is expected to *always* attack with, for special attacks use a dedicated technique.

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -606,7 +606,8 @@ bool bodypart::is_limb_overencumbered() const
 
 bool bodypart::has_conditional_flag( const json_character_flag &flag ) const
 {
-    return id->conditional_flags.count( flag ) > 0 && hp_cur > id->health_limit;
+    return id->conditional_flags.count( flag ) > 0 && hp_cur > id->health_limit &&
+           !is_limb_overencumbered();
 }
 
 std::set<matec_id> bodypart::get_limb_techs() const

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -351,9 +351,11 @@ void body_part_type::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "bionic_slots", bionic_slots_, 0 );
 
     optional( jo, was_loaded, "flags", flags );
+    optional( jo, was_loaded, "conditional_flags", conditional_flags );
 
     optional( jo, was_loaded, "encumbrance_threshold", encumbrance_threshold, 0 );
     optional( jo, was_loaded, "encumbrance_limit", encumbrance_limit, 100 );
+    optional( jo, was_loaded, "health_limit", health_limit, 1 );
     optional( jo, was_loaded, "techniques", techniques );
     optional( jo, was_loaded, "technique_encumbrance_limit", technique_enc_limit, 50 );
 
@@ -602,10 +604,16 @@ bool bodypart::is_limb_overencumbered() const
     return get_encumbrance_data().encumbrance >= id->encumbrance_limit;
 }
 
+bool bodypart::has_conditional_flag( const json_character_flag &flag ) const
+{
+    return id->conditional_flags.count( flag ) > 0 && hp_cur > id->health_limit;
+}
+
 std::set<matec_id> bodypart::get_limb_techs() const
 {
     std::set<matec_id> result;
-    if( !x_in_y( get_encumbrance_data().encumbrance, id->technique_enc_limit ) ) {
+    if( !x_in_y( get_encumbrance_data().encumbrance, id->technique_enc_limit  &&
+                 hp_cur > id->health_limit ) ) {
         result.insert( id->techniques.begin(), id->techniques.end() );
     }
     return result;

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -216,6 +216,8 @@ struct body_part_type {
         int encumbrance_threshold = 0;
         // Limit of encumbrance, after reaching this point the limb contributes no scores
         int encumbrance_limit = 0;
+        // Health at which the limb stops contributing its conditional flags / techs
+        int health_limit = 0;
 
         // If true, extra encumbrance on this limb affects dodge effectiveness
         bool encumb_impacts_dodge = false;
@@ -254,6 +256,7 @@ struct body_part_type {
         // Wetness morale bonus/malus of the limb
         int wet_morale = 0;
         cata::flat_set<json_character_flag> flags;
+        cata::flat_set<json_character_flag> conditional_flags;
         bool has_flag( const json_character_flag &flag ) const;
 
         // Limb-specific attacks
@@ -467,6 +470,7 @@ class bodypart
         int get_encumbrance_threshold() const;
         // Check if we're above our encumbrance limit
         bool is_limb_overencumbered() const;
+        bool has_conditional_flag( const json_character_flag &flag ) const;
 
         // Get our limb attacks
         std::set<matec_id> get_limb_techs() const;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10162,6 +10162,9 @@ bool Character::has_bodypart_with_flag( const json_character_flag &flag ) const
         if( bp->has_flag( flag ) ) {
             return true;
         }
+        if( get_part( bp )->has_conditional_flag( flag ) ) {
+            return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Character flags are just the best, so I've been busy shoveling a lot of limb functionality into them. However, they are also pretty much unchangeable, and you flying (or at least not falling) with your broken wings isn't very realistic.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
- Add `conditional_flags`, a list of flags that get checked by `has_flag` but only return true if the limb in question is above its `health_limit` and isn't above its `encumbrance_limit`
- Add `health_limit` (default 1, so broken limbs don't contribute)
- Have limb techs check for `health_limit` (they have their own tech encumbrance check)

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Turn *all* flags conditional, but a broken antenna doesn't lose its `LIMB_UPPER`ness.
Include the same random element as with the limb tech encumbrance check, but that felt a bit unnecessarily cruel.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Mutated limbified bird wings, jumped off a cliff, fluttered gracefully down. Set all HP to 1 ( wings have a pretty restrictive `health_limit`), splatted on the concrete.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
`body_part_type` vs `body_part` strikes again. I'm sure I'll cause some nightmares for whatever poor programmer will refactor bodypart.cpp down the line, but hey it works!