### PR TITLE
Load tileset on a background thread to speedup game load times.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -650,6 +650,9 @@ void DynamicDataLoader::finalize_loaded_data( loading_ui &ui )
 
     using named_entry = std::pair<std::string, std::function<void()>>;
     const std::vector<named_entry> entries = {{
+#if defined(TILES)
+            { _( "Background load tileset" ), &start_background_load_tileset },
+#endif
             { _( "Flags" ), &json_flag::finalize_all },
             { _( "Body parts" ), &body_part_type::finalize_all },
             { _( "Sub body parts" ), &sub_body_part_type::finalize_all },
@@ -707,7 +710,7 @@ void DynamicDataLoader::finalize_loaded_data( loading_ui &ui )
             { _( "Achievements" ), &achievement::finalize },
             { _( "Widgets" ), &widget::finalize },
 #if defined(TILES)
-            { _( "Tileset" ), &load_tileset },
+            { _( "Finish background load tileset" ), &sync_background_load_tileset },
 #endif
         }
     };

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -45,6 +45,8 @@ extern int fontwidth;
 // may be displayed. Actually, this is supposed to be called from init.cpp,
 // and only from there.
 void load_tileset();
+void start_background_load_tileset();
+void sync_background_load_tileset();
 void rescale_tileset( int size );
 bool save_screenshot( const std::string &file_path );
 void toggle_fullscreen_window();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Loading the tileset can involve a lot of gpu operations and cpu time spent doing something that has no external dependency on any other part of the load process. Since it's a completely isolated operation, and easily runs as long as the rest of the finalization step, it's an obvious choice to move to a background thread to take advantage of the fact that, with near certainly, most devices running cataclysm have more than one core available, and even that microscopic amount that don't can probably interleave blocking gpu operations and other cpu work at the kernel level.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Split `load_tileset()` into two functions, one which does the actual work but in a thread, and the other which syncs on the result from the thread. The output is an optional `std::exception_ptr` in case the loading operation threw an exception, so we can
rethrow it at an appropriate time for display purposes.
TODO:
- [ ] Add option to enable/disable this in case of mysterious explosions.
- [ ] Slice background work at a level guaranteed not to do things like call `dbgmsg` or other unlocked core infra.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
On Windows, loaded a game, walked around, saved, reloaded it, changed the tileset in game, saved, reloaded it, no errors and everything seemed to work right.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
These flame graphs show the cpu cost moving. These aren't a strictly chronological ordering of events because you can't flatten multiple threads together sensibly, but it shows the relative cost and how it compares to the rest of the work it was serialized on before.
Before:
![before](https://user-images.githubusercontent.com/667719/152232658-e533bc21-b0c1-4e9c-9b4c-4f00c0606fd8.png)

After:
![after](https://user-images.githubusercontent.com/667719/152232706-c758d99e-d5b2-44ab-bdc6-434a34bf9d9c.PNG)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


