### PR TITLE
Lazy create level cache layers to reduce load path cpu ~8% (and slow tests 15-20s)

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -2024,7 +2024,7 @@ class map
         /**
          * Holds caches for visibility, light, transparency and vehicles
          */
-        std::array< std::unique_ptr<level_cache>, OVERMAP_LAYERS > caches;
+        mutable std::array< std::unique_ptr<level_cache>, OVERMAP_LAYERS > caches;
 
         mutable std::array< std::unique_ptr<pathfinding_cache>, OVERMAP_LAYERS > pathfinding_caches;
         /**
@@ -2039,7 +2039,15 @@ class map
 
         // Note: no bounds check
         level_cache &get_cache( int zlev ) const {
-            return *caches[zlev + OVERMAP_DEPTH];
+            std::unique_ptr<level_cache> &cache = caches[zlev + OVERMAP_DEPTH];
+            if( !cache ) {
+                cache = std::make_unique<level_cache>();
+            }
+            return *cache;
+        }
+
+        level_cache *get_cache_lazy( int zlev ) const {
+            return caches[zlev + OVERMAP_DEPTH].get();
         }
 
         pathfinding_cache &get_pathfinding_cache( int zlev ) const;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
One of the big outliers in the load path is an incredible amount of cpu time spent in memset clearing memory for these level caches in map objects. They are only being created as part of creating a fake map for some load time validation which doesn't even need them. If we switch to lazily initializing them, we exchange an incredibly minor amount of future cpu cost in exchange for a strictly faster load, and possibly even better savings because future map instantiations also won't need these caches created until they're accessed.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Instead of creating the `level_cache`s in the constructor, wrap accesses around a simple check to see if the desired `level_cache` exists or not, and created it on demand if needed. There's also a bunch of places that iterate all zlevels and 'do something' if there's something in the cache at that level... but if the cache is freshly created, there won't be anything in it, so we can skip that work, but only if we detect the cache hasn't been created yet. Manually go through finding those and fixing them until the `overmap_terrain_coverage` test stops forcibly initializing the caches as based on measurements.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Somehow allocating the caches but not zeroing them, or finding a 'free zeroed' memory source. Neither seems as likely to consistently work as just not allocating the memory at all.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load a game, profiling loading before/after the changes. At 5k samples/second, approximately 10-11k samples are eliminated from a given load (sampling error +- ~1k samples across a few measurements). <400 samples are new in `map::get_cache` in the after trace, representing how much of that original 10k was actually needed. 5k is directly attributed to `memset`, the other 5k is inlined and attributed directly to `level_cache::level_cache`.

---
Before:
![level_cache_before](https://user-images.githubusercontent.com/667719/152253156-833228d9-a3f5-40cb-8ba5-21f24802bcd9.png)

After (total 108k samples):
![level_cache_after](https://user-images.githubusercontent.com/667719/152253168-261d4424-0a78-4698-ab19-b37de70fd433.PNG)

---
`overmap_terrain_coverage` runtime reduced 15s, 20s total including test startup time improvement.
Before:
![overmap_coverage_before](https://user-images.githubusercontent.com/667719/152442855-586c3edf-aefa-4839-becd-e36f297dde08.PNG)

After:
![image](https://user-images.githubusercontent.com/667719/152442781-7c5651eb-bbcc-4467-b480-b59814a8858c.png)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
---

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
