### PR TITLE
JSONify weariness text widget

### DIFF
--- a/data/json/ui/weariness.json
+++ b/data/json/ui/weariness.json
@@ -30,7 +30,43 @@
     "type": "widget",
     "label": "Weariness",
     "style": "text",
-    "var": "weariness_text",
-    "//": "Uses display::weariness_text_color"
+    "clauses": [
+      {
+        "id": "fresh",
+        "text": "Fresh",
+        "color": "green",
+        "condition": { "compare_int": [ { "u_val": "weariness_level" }, "==", { "const": 0 } ] }
+      },
+      {
+        "id": "light",
+        "text": "Light",
+        "color": "yellow",
+        "condition": { "compare_int": [ { "u_val": "weariness_level" }, "==", { "const": 1 } ] }
+      },
+      {
+        "id": "moderate",
+        "text": "Moderate",
+        "color": "light_red",
+        "condition": { "compare_int": [ { "u_val": "weariness_level" }, "==", { "const": 2 } ] }
+      },
+      {
+        "id": "weary",
+        "text": "Weary",
+        "color": "light_red",
+        "condition": { "compare_int": [ { "u_val": "weariness_level" }, "==", { "const": 3 } ] }
+      },
+      {
+        "id": "very",
+        "text": "Very",
+        "color": "red",
+        "condition": { "compare_int": [ { "u_val": "weariness_level" }, "==", { "const": 4 } ] }
+      },
+      {
+        "id": "extreme",
+        "text": "Extreme",
+        "color": "red",
+        "condition": { "compare_int": [ { "u_val": "weariness_level" }, ">=", { "const": 5 } ] }
+      }
+    ]
   }
 ]

--- a/data/mods/TEST_DATA/widgets.json
+++ b/data/mods/TEST_DATA/widgets.json
@@ -997,6 +997,50 @@
     "copy-from": "test_fatigue_clause_template"
   },
   {
+    "id": "test_weariness_clauses",
+    "type": "widget",
+    "label": "Weariness",
+    "style": "text",
+    "clauses": [
+      {
+        "id": "fresh",
+        "text": "Fresh",
+        "color": "green",
+        "condition": { "compare_int": [ { "u_val": "weariness_level" }, "==", { "const": 0 } ] }
+      },
+      {
+        "id": "light",
+        "text": "Light",
+        "color": "yellow",
+        "condition": { "compare_int": [ { "u_val": "weariness_level" }, "==", { "const": 1 } ] }
+      },
+      {
+        "id": "moderate",
+        "text": "Moderate",
+        "color": "light_red",
+        "condition": { "compare_int": [ { "u_val": "weariness_level" }, "==", { "const": 2 } ] }
+      },
+      {
+        "id": "weary",
+        "text": "Weary",
+        "color": "light_red",
+        "condition": { "compare_int": [ { "u_val": "weariness_level" }, "==", { "const": 3 } ] }
+      },
+      {
+        "id": "very",
+        "text": "Very",
+        "color": "red",
+        "condition": { "compare_int": [ { "u_val": "weariness_level" }, "==", { "const": 4 } ] }
+      },
+      {
+        "id": "extreme",
+        "text": "Extreme",
+        "color": "red",
+        "condition": { "compare_int": [ { "u_val": "weariness_level" }, ">=", { "const": 5 } ] }
+      }
+    ]
+  },
+  {
     "id": "test_hp_head_graph",
     "type": "widget",
     "label": "HEAD",

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -988,6 +988,7 @@ Example | Description
 `"u_val": "age"` | Current age in years.
 `"u_val": "bmi_permil"` | Current BMI per mille (Body Mass Index x 1000)
 `"u_val": "height"` | Current height in cm. When setting there is a range for your character size category. Setting it too high or low will use the limit instead. For tiny its 58, and 87. For small its 88 and 144. For medium its 145 and 200. For large its 201 and 250. For huge its 251 and 320.
+`"u_val": "weariness_level"` | Current weariness level from 0-5
 `"distance": []` | Distance between two targets. Valid targets are: "u","npc" and an object with a variable name.
 `"hour"` | Hours since midnight.
 `"moon"` | Phase of the moon. MOON_NEW =0, WAXING_CRESCENT =1, HALF_MOON_WAXING =2, WAXING_GIBBOUS =3, FULL =4, WANING_GIBBOUS =5, HALF_MOON_WANING =6, WANING_CRESCENT =7

--- a/doc/WIDGETS.md
+++ b/doc/WIDGETS.md
@@ -837,7 +837,6 @@ Some vars refer to text descriptors. These must use style "text". Examples:
 | `veh_azimuth_text`      | Heading of vehicle in degrees
 | `veh_cruise_text`       | Target and actual cruising velocity, positive or negative
 | `veh_fuel_text`         | Percentage of fuel remaining for current vehicle engine
-| `weariness_text`        | Weariness level - "Fresh", "Light", "Moderate", "Weary" etc.
 | `weary_malus_text`      | Percentage penalty affecting speed due to weariness
 | `weather_text`          | Weather conditions - "Sunny", "Cloudy", "Drizzle", "Portal Storm" etc.
 | `wielding_text`         | Name of current weapon or wielded item

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1582,6 +1582,10 @@ std::function<int( const T & )> conditional_t<T>::get_get_int( const JsonObject 
             return [is_npc]( const T & d ) {
                 return d.actor( is_npc )->get_npc_anger();
             };
+        } else if( checked_value == "weariness_level" ) {
+            return [is_npc]( const T & d ) {
+                return d.actor( is_npc )->get_weariness_level();
+            };
         }
     } else if( jo.has_member( "moon" ) ) {
         return []( const T & ) {

--- a/src/talker.h
+++ b/src/talker.h
@@ -379,6 +379,9 @@ class talker
         virtual int get_fatigue() const {
             return 0;
         }
+        virtual int get_weariness_level() const {
+            return 0;
+        }
         virtual int get_hunger() const {
             return 0;
         }

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -383,6 +383,11 @@ int talker_character_const::get_fatigue() const
     return me_chr_const->get_fatigue();
 }
 
+int talker_character_const::get_weariness_level() const
+{
+    return me_chr_const->weariness_level();
+}
+
 int talker_character_const::get_hunger() const
 {
     return me_chr_const->get_hunger();

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -97,6 +97,7 @@ class talker_character_const: public talker
         bool is_mounted() const override;
         int get_activity_level() const override;
         int get_fatigue() const override;
+        int get_weariness_level() const override;
         int get_hunger() const override;
         int get_thirst() const override;
         int get_stored_kcal() const override;

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -149,8 +149,6 @@ std::string enum_to_string<widget_var>( widget_var data )
             return "veh_cruise_text";
         case widget_var::veh_fuel_text:
             return "veh_fuel_text";
-        case widget_var::weariness_text:
-            return "weariness_text";
         case widget_var::weary_malus_text:
             return "weary_malus_text";
         case widget_var::weather_text:
@@ -843,7 +841,6 @@ bool widget::uses_text_function()
         case widget_var::veh_azimuth_text:
         case widget_var::veh_cruise_text:
         case widget_var::veh_fuel_text:
-        case widget_var::weariness_text:
         case widget_var::weary_malus_text:
         case widget_var::weather_text:
         case widget_var::wielding_text:
@@ -934,9 +931,6 @@ std::string widget::color_text_function_string( const avatar &ava, unsigned int 
             break;
         case widget_var::veh_fuel_text:
             desc = display::vehicle_fuel_percent_text_color( ava );
-            break;
-        case widget_var::weariness_text:
-            desc = display::weariness_text_color( ava );
             break;
         case widget_var::weary_malus_text:
             desc = display::weary_malus_text_color( ava );

--- a/src/widget.h
+++ b/src/widget.h
@@ -60,7 +60,6 @@ enum class widget_var : int {
     veh_azimuth_text, // Azimuth or heading in degrees, string
     veh_cruise_text, // Current/target cruising speed in vehicle, color string
     veh_fuel_text,  // Current/total fuel for active vehicle engine, color string
-    weariness_text, // Weariness description text, color string
     weary_malus_text, // Weariness malus or penalty
     weather_text,   // Weather/sky conditions (if visible), color string
     wielding_text,  // Currently wielded weapon or item name

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -40,9 +40,6 @@ static const dig_activity_actor dig_actor( move_25h, tripoint_zero, "t_pit", tri
 
 static const activity_id ACT_PLANT_SEED( "ACT_PLANT_SEED" );
 
-static const activity_schedule task_dig( dig_actor, 5_minutes );
-static const activity_schedule task_plant( ACT_PLANT_SEED, 5_minutes );
-
 static const efftype_id effect_bandaged( "bandaged" );
 static const efftype_id effect_bite( "bite" );
 static const efftype_id effect_bleed( "bleed" );
@@ -57,6 +54,9 @@ static const efftype_id effect_hunger_satisfied( "hunger_satisfied" );
 static const efftype_id effect_hunger_starving( "hunger_starving" );
 static const efftype_id effect_hunger_very_hungry( "hunger_very_hungry" );
 static const efftype_id effect_infected( "infected" );
+
+static const activity_schedule task_dig( dig_actor, 5_minutes );
+static const activity_schedule task_plant( ACT_PLANT_SEED, 5_minutes );
 
 static const flag_id json_flag_SPLINT( "SPLINT" );
 const static flag_id json_flag_W_DISABLED_WHEN_EMPTY( "W_DISABLED_WHEN_EMPTY" );

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -36,10 +36,9 @@ namespace cata_curses_test
 #endif
 
 static const int move_25h = to_seconds<int>( 25_hours ) * 100;
+static const dig_activity_actor dig_actor( move_25h, tripoint_zero, "t_pit", tripoint_zero, 0, "" );
 
 static const activity_id ACT_PLANT_SEED( "ACT_PLANT_SEED" );
-
-static const dig_activity_actor dig_actor( move_25h, tripoint_zero, "t_pit", tripoint_zero, 0, "" );
 
 static const activity_schedule task_dig( dig_actor, 5_minutes );
 static const activity_schedule task_plant( ACT_PLANT_SEED, 5_minutes );

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -35,8 +35,7 @@ namespace cata_curses_test
 #include "cursesport.h"
 #endif
 
-static const int move_25h = to_seconds<int>( 25_hours ) * 100;
-static const dig_activity_actor dig_actor( move_25h, tripoint_zero, "t_pit", tripoint_zero, 0, "" );
+// ------------ String IDs ------------
 
 static const activity_id ACT_PLANT_SEED( "ACT_PLANT_SEED" );
 
@@ -54,9 +53,6 @@ static const efftype_id effect_hunger_satisfied( "hunger_satisfied" );
 static const efftype_id effect_hunger_starving( "hunger_starving" );
 static const efftype_id effect_hunger_very_hungry( "hunger_very_hungry" );
 static const efftype_id effect_infected( "infected" );
-
-static const activity_schedule task_dig( dig_actor, 5_minutes );
-static const activity_schedule task_plant( ACT_PLANT_SEED, 5_minutes );
 
 static const flag_id json_flag_SPLINT( "SPLINT" );
 const static flag_id json_flag_W_DISABLED_WHEN_EMPTY( "W_DISABLED_WHEN_EMPTY" );
@@ -146,6 +142,14 @@ static const widget_id widget_test_weather_text( "test_weather_text" );
 static const widget_id widget_test_weather_text_height5( "test_weather_text_height5" );
 static const widget_id widget_test_weight_clauses_fun( "test_weight_clauses_fun" );
 static const widget_id widget_test_weight_clauses_normal( "test_weight_clauses_normal" );
+
+// ------------ Not String IDs ------------
+static const int move_25h = to_seconds<int>( 25_hours ) * 100;
+static const dig_activity_actor dig_actor( move_25h, tripoint_zero, "t_pit", tripoint_zero, 0, "" );
+
+static const activity_schedule task_dig( dig_actor, 5_minutes );
+static const activity_schedule task_plant( ACT_PLANT_SEED, 5_minutes );
+
 
 // dseguin 2022 - Ugly hack to scrape content from the window object.
 // Scrapes the window w at origin, reading the number of cols and rows.


### PR DESCRIPTION
#### Summary

Features "JSONify weariness text widget"


#### Purpose of change

Contribute to #55076 


#### Describe the solution

- [x] Add a `get_weariness_level` wrapper to the `talker` and `talker_character` classes used by conditions, and a `u_val` for `weariness_level`.
- [x] Add a widget using "clauses" to show weariness text based on weariness level condition.
- [x] Add test case for weariness level number and some clauses
- [x] Remove `weariness_text` widget variable


#### Describe alternatives you've considered

We'll want to remove the `display::weariness_text_color` functions after all the classic/legacy sidebars are replaced with widget versions in #54191 and its follow-ups, but I am leaving them in place for now.



#### Testing

Get a shovel and dig some holes to get tired. See the widget change.


#### Additional context

Don't mind the misleading branch name in this PR; I started out thinking I would do weight first, but did weariness instead and forgot to rename it.
