### PR TITLE
Making jeans less encumbering and motorcycle pants more accurate to their jean roots.

### DIFF
--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -680,23 +680,68 @@
   },
   {
     "id": "motorbike_pants",
-    "repairs_like": "survivor_suit",
+    "repairs_like": "jeans",
     "type": "ARMOR",
-    "name": { "str": "motorcycle pants", "str_pl": "pairs of motorcycle pants" },
-    "description": "A pair of pants designed for dirt bikers and motorcyclists.",
+    "name": { "str": "motorcycle jeans", "str_pl": "pairs of motorcycle jeans" },
+    "description": "A pair of thick jeans interwoven with kevlar for added durability and sporting integrated kneepads and flank protection, typically worn by motorcyclists to protect from road rash.",
     "weight": "1340 g",
-    "volume": "750 ml",
+    "volume": "2500 ml",
     "price": 10000,
     "price_postapoc": 750,
-    "material": [ "kevlar", "cotton" ],
+    "material": [ "kevlar", "cotton", "plastic" ],
     "symbol": "[",
-    "looks_like": "pants_leather",
+    "looks_like": "jeans",
     "color": "dark_gray",
-    "warmth": 35,
-    "material_thickness": 1.5,
+    "warmth": 15,
+    "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF" ],
-    "armor": [ { "encumbrance": 20, "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
+    "flags": [ "VARSIZE", "WATERPROOF", "POCKETS" ],
+    "armor": [
+      {
+        "material": [ { "type": "kevlar", "covered_by_mat": 100, "thickness": 0.25 }, { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 } ],
+        "encumbrance": [10, 14],
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_upper_l", "leg_lower_l", "leg_hip_r", "leg_upper_r", "leg_lower_r" ]
+      },
+      {
+        "material": [ { "type": "kevlar", "covered_by_mat": 100, "thickness": 0.25 }, { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 }, { "type": "plastic", "covered_by_mat": 100, "thickness": 4 } ],
+        "encumbrance": [0, 0],
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_knee_l", "leg_knee_r" ]
+      }
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1250 ml",
+        "max_contains_weight": "4 kg",
+        "max_item_length": "19 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1250 ml",
+        "max_contains_weight": "4 kg",
+        "max_item_length": "19 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1080 ml",
+        "max_contains_weight": "4 kg",
+        "max_item_length": "165 mm",
+        "moves": 100
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1080 ml",
+        "max_contains_weight": "4 kg",
+        "max_item_length": "165 mm",
+        "moves": 100
+      }
+	]
   },
   {
     "id": "trousers_eod",

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -698,15 +698,22 @@
     "flags": [ "VARSIZE", "WATERPROOF", "POCKETS" ],
     "armor": [
       {
-        "material": [ { "type": "kevlar", "covered_by_mat": 100, "thickness": 0.25 }, { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 } ],
-        "encumbrance": [10, 14],
+        "material": [
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 0.25 },
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 }
+        ],
+        "encumbrance": [ 10, 14 ],
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_upper_l", "leg_lower_l", "leg_hip_r", "leg_upper_r", "leg_lower_r" ]
       },
       {
-        "material": [ { "type": "kevlar", "covered_by_mat": 100, "thickness": 0.25 }, { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 }, { "type": "plastic", "covered_by_mat": 100, "thickness": 4 } ],
-        "encumbrance": [0, 0],
+        "material": [
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 0.25 },
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 4 }
+        ],
+        "encumbrance": [ 0, 0 ],
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_knee_l", "leg_knee_r" ]
@@ -741,7 +748,7 @@
         "max_item_length": "165 mm",
         "moves": 100
       }
-	]
+    ]
   },
   {
     "id": "trousers_eod",

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -228,7 +228,7 @@
         "text": "An old pair of blue jeans.  You are not sure if they are faded through age or stone washed."
       }
     ],
-    "armor": [ { "encumbrance": [ 6, 10 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 7, 11 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "jeans_red",
@@ -278,7 +278,7 @@
     "warmth": 10,
     "material_thickness": 0.25,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "armor": [ { "encumbrance": [ 12, 16 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 7, 11 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "kilt",

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -228,7 +228,7 @@
         "text": "An old pair of blue jeans.  You are not sure if they are faded through age or stone washed."
       }
     ],
-    "armor": [ { "encumbrance": [ 12, 16 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 6, 10 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "jeans_red",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change

Jeans (unless they're ill-fitting) aren't really that encumbering: Speaking from personal experience, it's not too hard to run or even wrestle in jeans (I'm a dumbass who kept showing up to sports practice without a change of clothes). Even skinny jeans nowadays are made with stretch fabrics that make them move pretty easily.

As for the Motorcycle Pants, the more I looked into them, the more it was clear they were basically just jeans. A bit thicker, and often the denim was woven with kevlar to some degree, and sporting kneepads, but at their heart they were just reinforced jeans. The old motorcycle pants were *far* too encumbering (and warm) for something that can easily be worn as regular day jeans.

#### Describe the solution

For jeans (and the red jeans) themselves, all I've done is lower the encumbrance from 12/16 to 7/11 to match the khaki pants (I've also done sports in khakis because I have terminal smooth brain and they're about the same, although khakis chafed more honestly).

For motorcycle pants, I've essentially gutted them entirely and remade them to more accurately resemble the jeans they really are. I changed their name to "motorcycle jeans" and their description to make them more clear, massively lowered the encumbrance (to 10/14) and warmth (from a huge 35 down to a more reasonable 15) to both be just a bit above regular jeans, but also lowered their thickness so they're overall less protective. Only 0.5 for cotton and 0.25 for kevlar rather than 0.75 for both. I've also added plastic kneepads to them, since that seems to be common in all the motorcycle pants I could find.

#### Describe alternatives you've considered

Like all clothing, motorcycle jeans vary. Some are just pure denim instead of denim woven with kevlar and their only protection are the kneepads and maybe some flank reinforcement.

#### Testing

There *is* a current UI bug with them, where the UI in-game acts as if the entire pant is made of the rubber kneepads. BombasticSlacks has assured me this is purely a UI bug and that he'll have this fixed though. The actual values for the non-padded part is 0.75 bash 1.25 cut and 1.75 ballistic. Enough to take the edge off some lighter hits but not going to completely stop much.

#### Additional context

I know anecdotes aren't rigorously scientific or anything, but I don't have a much better way to determine encumbrance. I just read from prowling forums and the like that motorcycle jeans really aren't that much harder to move in than regular jeans, and my dirtbiker buddy used to even do parkour in them and would wear them when doing regular work.