### PR TITLE
[CR] [WIP] New SIMPLE_MATERIAL flag for better disassembly

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -716,6 +716,10 @@
     "type": "json_flag"
   },
   {
+    "id": "SIMPLE_MATERIAL",
+    "type": "json_flag"
+  },
+  {
     "id": "REVIVE_SPECIAL",
     "type": "json_flag"
   },

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -176,6 +176,7 @@
     "price": 100,
     "price_postapoc": 10,
     "material": [ "rubber" ],
+    "flags": [ "SIMPLE_MATERIAL" ],
     "symbol": "=",
     "color": "dark_gray"
   },
@@ -191,6 +192,7 @@
     "price": 500,
     "price_postapoc": 50,
     "material": [ "rubber" ],
+    "flags": [ "SIMPLE_MATERIAL" ],
     "symbol": "=",
     "color": "dark_gray"
   },

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -723,7 +723,7 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```REDUCED_BASHING``` ... Gunmod flag; reduces the item's bashing damage by 50%.
 - ```REDUCED_WEIGHT``` ... Gunmod flag; reduces the item's base weight by 25%.
 - ```REQUIRES_TINDER``` ... Requires tinder to be present on the tile this item tries to start a fire on.
-  ```SIMPLE_MATERIAL``` ... Allows for the material to be salvaged from parent components when the parent fails salvaging via disassembly.
+- ```SIMPLE_MATERIAL``` ... Allows for the material to be salvaged from parent components when the parent fails salvaging via disassembly.
 - ```SLEEP_AID``` ... This item helps in sleeping.
 - ```SLEEP_AID_CONTAINER``` ... This item allows sleep aids inside of it to help in sleeping. (E.g. this is a pillowcase).
 - ```SLEEP_IGNORE``` ... This item is not shown as before-sleep warning.

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -723,6 +723,7 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```REDUCED_BASHING``` ... Gunmod flag; reduces the item's bashing damage by 50%.
 - ```REDUCED_WEIGHT``` ... Gunmod flag; reduces the item's base weight by 25%.
 - ```REQUIRES_TINDER``` ... Requires tinder to be present on the tile this item tries to start a fire on.
+  ```SIMPLE_MATERIAL``` ... Allows for the material to be salvaged from parent components when the parent fails salvaging via disassembly.
 - ```SLEEP_AID``` ... This item helps in sleeping.
 - ```SLEEP_AID_CONTAINER``` ... This item allows sleep aids inside of it to help in sleeping. (E.g. this is a pillowcase).
 - ```SLEEP_IGNORE``` ... This item is not shown as before-sleep warning.

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -275,6 +275,7 @@ const flag_id flag_ROLLER_QUAD( "ROLLER_QUAD" );
 const flag_id flag_SAFECRACK( "SAFECRACK" );
 const flag_id flag_SEMITANGIBLE( "SEMITANGIBLE" );
 const flag_id flag_SHRUB( "SHRUB" );
+const flag_id flag_SIMPLE_MATERIAL( "SIMPLE_MATERIAL" );
 const flag_id flag_SKINNED( "SKINNED" );
 const flag_id flag_SKINTIGHT( "SKINTIGHT" );
 const flag_id flag_SLEEP_AID( "SLEEP_AID" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Failed disassembled components now yield their simple parts"
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #53014
When disassembling damaged items, the sub-components of the lost components are completely lost. There are items that are simple enough to be partially recovered from failed disassembles. 

This new JSON flag will mark items as "SIMPLE_MATERIAL" and will be detected by a traversal of the failed sub-components during disassembly.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Ideally, this PR will add the JSON flags required to all applicable items and will also add the required code to traverse the components of our failed parts (all the way down the tree, checking for "SIMPLE_MATERIAL"). The recovered simple components would be based on the damage level of the parent component. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Alternatives considered for json flag name (RECURSIVE_RECOVERY, SIMPLE, SIMPLE_RECOVERY)

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
None yet.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I made an attempt to parse the C++ side of the disassembly code, but I lack the knowledge required to make a meaningful contribution. While I can read the code, it would be much better off being written/handled by someone more experienced.

I roughly understand that the logic needs to happen in crafting.cpp inside the complete_disassemble function. Where it would traverse all of the components all the way down the tree, make a list of simple components, and return and appropriate amount based on the damage level of their parents (which would be based on the damage level of the initial item).

If I can find someone willing to write the logic, I can make a pass at applying this new flag to all the applicable items, although it would probably take quite a long time. I'm open to suggestions on narrowing down what items would be compatible, as there are likely categories of items that would never be simple.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
