### PR TITLE
Revert "Raise the proportional AP value of handloaded 5.7mm (#49593)"

### DIFF
--- a/data/json/items/ammo/57.json
+++ b/data/json/items/ammo/57.json
@@ -30,7 +30,7 @@
     "description": "5.7x28mm ammunition with 31gr AP FMJ bullets.  The 5.7x28mm cartridge was designed by FN Herstal to replace the 9x19mm round in NATO use.  Although the project to replace 9x19mm Parabellum was effectively canceled the 5.7x28mm round has seen action in many conflicts and has proven to be reliable.  It has very low recoil but no usual armor penetration due to using simple lead bullets rather than proper factory-made penetrator projectiles.",
     "proportional": {
       "price": 0.3,
-      "damage": { "damage_type": "bullet", "amount": 0.56, "armor_penetration": 0.4 },
+      "damage": { "damage_type": "bullet", "amount": 0.56, "armor_penetration": 0.1 },
       "recoil": 0.56,
       "dispersion": 1.2
     },
@@ -43,7 +43,7 @@
     "type": "AMMO",
     "name": { "str_sp": "5.7x28mm, reloaded" },
     "description": "5.7x28mm ammunition with 31gr AP FMJ bullets.  The 5.7x28mm cartridge was designed by FN Herstal to replace the 9x19mm round in NATO use.  Although the project to replace 9x19mm Parabellum was effectively canceled the 5.7x28mm round has seen action in many conflicts and has proven to be reliable.  It has very low recoil but no usual armor penetration due to using simple lead bullets rather than proper factory-made penetrator projectiles.",
-    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9, "armor_penetration": 0.7 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9, "armor_penetration": 0.2 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
   }


### PR DESCRIPTION
#### Summary
None

Reverts CleverRaven/Cataclysm-DDA#49593

The reason 5.7mm has the high AP value that it does is a steel penetratior within the bullet. This is not something a survivor can hand-load in a meaningful capacity, and this is true for both 5.7mm and the comparable 4.6mm caliber. 

Seeing as the justification for the previous PR seems to be a balance one not grounded in how things actually work IRL, I consider it reasonable to revert the change. 

This can naturally be superseded if more accurate data about the hand-loading of complex bullets or the ballistic properties of monolithic 5.7mm bullets comes to light.