### PR TITLE
Martial Arts Variable Moves Per Weapon (and reach techniques)

### DIFF
--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -223,7 +223,6 @@
     "copy-from": "inter_bayonet",
     "description": "The weapon's integrated bayonet has been folded for storage.",
     "longest_side": "22 cm",
-    "cutting": 0,
     "integral_longest_side": "0 cm",
     "use_action": {
       "type": "transform",

--- a/data/json/items/tool/knives.json
+++ b/data/json/items/tool/knives.json
@@ -59,6 +59,7 @@
     "qualities": [ [ "CUT", 2 ], [ "PRY", 1 ], [ "BUTCHER", 15 ] ],
     "use_action": [ "CROWBAR" ],
     "flags": [ "SHEATH_KNIFE" ],
+    "damage_blacklist": [ "stab" ],
     "weapon_category": [ "KNIVES" ]
   },
   {

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -95,7 +95,7 @@
     "id": "SLASH",
     "name": "Slashing",
     "melee_allowed": true,
-    "used_damage": ["cut"],
+    "used_damage": [ "cut" ],
     "messages": [ "You slash at the %s", "<npcname> slashes at the %s" ],
     "attack_vectors": [ "WEAPON" ]
   },
@@ -104,7 +104,7 @@
     "id": "STAB",
     "name": "Stabbing",
     "melee_allowed": true,
-    "used_damage": ["stab"],
+    "used_damage": [ "stab" ],
     "messages": [ "You stab at the %s", "<npcname> stabs at the %s" ],
     "attack_vectors": [ "WEAPON" ]
   },
@@ -113,7 +113,7 @@
     "id": "BASH",
     "name": "Bashing",
     "melee_allowed": true,
-    "used_damage": ["bash"],
+    "used_damage": [ "bash" ],
     "messages": [ "You hilt bash the %s", "<npcname> hilt bashes the %s" ],
     "attack_vectors": [ "WEAPON" ]
   },

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -75,6 +75,23 @@
   },
   {
     "type": "technique",
+    "id": "POKE",
+    "name": "Ranged Strike",
+    "melee_allowed": true,
+    "crit_ok": true,
+    "reach_attack": true,
+    "mult_bonuses": [
+      { "stat": "movecost", "scale": 0.9 },
+      { "stat": "damage", "type": "bash", "scale": 0.01 },
+      { "stat": "damage", "type": "cut", "scale": 0.01 },
+      { "stat": "damage", "type": "stab", "scale": 1 }
+    ],
+    "messages": [ "You jab at the %s from a distance", "<npcname> jabs at %s" ],
+    "description": "Ranged, pierce damage only",
+    "attack_vectors": [ "WEAPON" ]
+  },
+  {
+    "type": "technique",
     "id": "IMPALE",
     "name": "Impaling Strike",
     "melee_allowed": true,

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -92,6 +92,33 @@
   },
   {
     "type": "technique",
+    "id": "SLASH",
+    "name": "Slashing",
+    "melee_allowed": true,
+    "used_damage": ["cut"],
+    "messages": [ "You slash at the %s", "<npcname> slashes at the %s" ],
+    "attack_vectors": [ "WEAPON" ]
+  },
+  {
+    "type": "technique",
+    "id": "STAB",
+    "name": "Stabbing",
+    "melee_allowed": true,
+    "used_damage": ["stab"],
+    "messages": [ "You stab at the %s", "<npcname> stabs at the %s" ],
+    "attack_vectors": [ "WEAPON" ]
+  },
+  {
+    "type": "technique",
+    "id": "BASH",
+    "name": "Bashing",
+    "melee_allowed": true,
+    "used_damage": ["bash"],
+    "messages": [ "You hilt bash the %s", "<npcname> hilt bashes the %s" ],
+    "attack_vectors": [ "WEAPON" ]
+  },
+  {
+    "type": "technique",
     "id": "IMPALE",
     "name": "Impaling Strike",
     "melee_allowed": true,

--- a/data/json/weapon_categories.json
+++ b/data/json/weapon_categories.json
@@ -77,7 +77,8 @@
   {
     "type": "weapon_category",
     "id": "POLEARMS",
-    "name": "POLEARMS"
+    "name": "POLEARMS",
+    "default_techniques": [ "POKE" ]
   },
   {
     "type": "weapon_category",

--- a/data/json/weapon_categories.json
+++ b/data/json/weapon_categories.json
@@ -12,7 +12,8 @@
   {
     "type": "weapon_category",
     "id": "KNIVES",
-    "name": "KNIVES"
+    "name": "KNIVES",
+    "default_techniques": [ "STAB", "SLASH" ]
   },
   {
     "type": "weapon_category",
@@ -38,7 +39,7 @@
     "type": "weapon_category",
     "id": "LONG_SWORDS",
     "name": "LONG SWORDS",
-    "default_techniques": [ "BASH", "POKE", "SLASH" ]
+    "default_techniques": [ "BASH", "STAB", "SLASH" ]
   },
   {
     "type": "weapon_category",

--- a/data/json/weapon_categories.json
+++ b/data/json/weapon_categories.json
@@ -37,7 +37,8 @@
   {
     "type": "weapon_category",
     "id": "LONG_SWORDS",
-    "name": "LONG SWORDS"
+    "name": "LONG SWORDS",
+    "default_techniques": [ "BASH", "POKE", "SLASH" ]
   },
   {
     "type": "weapon_category",

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -80,6 +80,7 @@ int Character::get_armor_type( damage_type dt, bodypart_id bp ) const
         }
         case damage_type::NONE:
         case damage_type::NUM:
+        case damage_type::RAW:
             // Let it error below
             break;
     }
@@ -131,6 +132,7 @@ std::map<bodypart_id, int> Character::get_all_armor_type( damage_type dt,
             }
             case damage_type::NONE:
             case damage_type::NUM:
+            case damage_type::RAW:
                 debugmsg( "Invalid damage type: %d", dt );
                 return ret;
         }

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -37,6 +37,7 @@ std::string enum_to_string<damage_type>( damage_type data )
         case damage_type::COLD: return "cold";
         case damage_type::ELECTRIC: return "electric";
         case damage_type::BULLET: return "bullet";
+        case damage_type::RAW: return "raw";
             // *INDENT-ON*
         case damage_type::NUM:
             break;

--- a/src/damage.h
+++ b/src/damage.h
@@ -30,6 +30,7 @@ enum class damage_type : int {
     COLD, // e.g. heatdrain, cryogrenades
     ELECTRIC, // e.g. electrical discharge
     BULLET, // bullets and other fast moving projectiles
+    RAW, // fake damage value for scaling other damage types
     NUM
 };
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5032,7 +5032,8 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
 {
     const std::string space = "  ";
 
-    int dmg_raw = damage_melee( damage_type::RAW );
+    // BASH PIERCE and CUT are all inferred from RAW
+    int dmg_raw = damage_melee( damage_type::BASH );
 
     Character &player_character = get_player_character();
 
@@ -9373,6 +9374,9 @@ float item::damage_resist( damage_type dt, bool to_self, const bodypart_id &bp, 
             return fire_resist( to_self, 0, bp );
         case damage_type::BULLET:
             return bullet_resist( to_self, bp, roll );
+        case damage_type::RAW:
+            // Nothing is damaged by RAW directly it will be converted to other weapons
+            return std::numeric_limits<float>::max();
         default:
             debugmsg( "Invalid damage type: %d", dt );
     }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -684,9 +684,9 @@ void Item_factory::finalize_post( itype &obj )
             if( !dtype.is_valid() ) {
                 debugmsg( "contamination in %s contains invalid diseasetype_id %s.",
                           obj.id.str(), dtype.str() );
-                        }
-                    }
-                }
+            }
+        }
+    }
     // go through any weapons and add their base category moves
     for( const weapon_category_id &cat : obj.weapon_category ) {
         for( const matec_id &ma : cat.obj().get_default_moves() ) {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -42,6 +42,7 @@
 #include "iuse_actor.h"
 #include "json.h"
 #include "material.h"
+#include "martialarts.h"
 #include "optional.h"
 #include "options.h"
 #include "proficiency.h"
@@ -676,15 +677,23 @@ void Item_factory::finalize_post( itype &obj )
         pocket.name = obj.name;
     }
 
+
     if( obj.comestible ) {
         for( const std::pair<const diseasetype_id, int> &elem : obj.comestible->contamination ) {
             const diseasetype_id dtype = elem.first;
             if( !dtype.is_valid() ) {
                 debugmsg( "contamination in %s contains invalid diseasetype_id %s.",
                           obj.id.str(), dtype.str() );
-            }
+                        }
+                    }
+                }
+    // go through any weapons and add their base category moves
+    for( const weapon_category_id &cat : obj.weapon_category ) {
+        for( const matec_id &ma : cat.obj().get_default_moves() ) {
+            obj.techniques.insert( ma );
         }
     }
+
 
     // if we haven't set what the item can be repaired with calculate it now
     if( obj.repairs_with.empty() ) {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -222,6 +222,29 @@ void Item_factory::finalize_pre( itype &obj )
                    obj.melee[static_cast<int>( damage_type::STAB )] );
     }
 
+    // if the item has a cutting or bashing or pierce entry then combine for PURE damage which will be scaled later
+    int bash = obj.melee[static_cast<int>( damage_type::BASH )];
+    int cut = obj.melee[static_cast<int>( damage_type::CUT )];
+    int stab = obj.melee[static_cast<int>( damage_type::STAB )];
+    obj.melee[static_cast<int>( damage_type::RAW )] = cut + bash + stab;
+
+    // if no default damage is defined then infer it from old style damage input
+    if( obj.default_damage == damage_type::NONE && bash + cut + stab > 0 ) {
+        // only stab or cut are gonna be a value at any time
+        if( bash >= stab + cut ) {
+            obj.default_damage = damage_type::BASH;
+        } else if( stab > cut ) {
+            obj.default_damage = damage_type::STAB;
+        } else {
+            obj.default_damage = damage_type::CUT;
+        }
+    }
+
+    // remove split damage from the weapon it should all be RAW until getting to moves later
+    obj.melee[static_cast<int>( damage_type::BASH )] = 0;
+    obj.melee[static_cast<int>( damage_type::CUT )] = 0;
+    obj.melee[static_cast<int>( damage_type::STAB )] = 0;
+
     // add usage methods (with default values) based upon qualities
     // if a method was already set the specific values remain unchanged
     for( const auto &q : obj.qualities ) {

--- a/src/itype.h
+++ b/src/itype.h
@@ -1202,6 +1202,8 @@ struct itype {
         std::set<emit_id> emits;
 
         std::set<matec_id> techniques;
+        std::set<matec_id> techniques_blacklist;
+        std::vector<damage_type> damage_blacklist;
 
         // Minimum stat(s) or skill(s) to use the item
         std::map<skill_id, int> min_skills;

--- a/src/itype.h
+++ b/src/itype.h
@@ -1315,6 +1315,9 @@ struct itype {
         /** Damage output in melee for zero or more damage types */
         std::array<int, static_cast<int>( damage_type::NUM )> melee;
 
+        // default damage type if a move doesn't specify it
+        damage_type default_damage = damage_type::NONE;
+
         bool default_container_sealed = true;
 
         // Should the item explode when lit on fire

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -85,6 +85,7 @@ void weapon_category::reset()
 void weapon_category::load( const JsonObject &jo, const std::string & )
 {
     mandatory( jo, was_loaded, "name", name_ );
+    optional( jo, was_loaded, "default_techniques", default_techniques );
 }
 
 const std::vector<weapon_category> &weapon_category::get_all()
@@ -236,6 +237,7 @@ void ma_technique::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "stunned_target", stunned_target, false );
     optional( jo, was_loaded, "wall_adjacent", wall_adjacent, false );
     optional( jo, was_loaded, "human_target", human_target, false );
+    optional( jo, was_loaded, "reach_attack", reach_attack, false );
 
     optional( jo, was_loaded, "needs_ammo", needs_ammo, false );
 
@@ -1859,6 +1861,10 @@ std::string ma_technique::get_description() const
 
     if( human_target ) {
         dump += _( "* Only works on a <info>humanoid</info> target" ) + std::string( "\n" );
+    }
+
+    if( reach_attack ) {
+        dump += _( "* Only works as a <info>reach attack</info>" ) + std::string( "\n" );
     }
 
     if( powerful_knockback ) {

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -269,6 +269,8 @@ void ma_technique::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "attack_vectors", attack_vectors, {} );
     optional( jo, was_loaded, "attack_vectors_random", attack_vectors_random, {} );
 
+    optional( jo, was_loaded, "used_damage", used_damage );
+
     for( JsonValue jv : jo.get_array( "eocs" ) ) {
         eocs.push_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
     }

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -45,6 +45,10 @@ class weapon_category
             return name_;
         }
 
+        const std::vector<matec_id> &get_default_moves() const {
+            return default_techniques;
+        }
+
     private:
         friend class generic_factory<weapon_category>;
         friend struct mod_tracker;
@@ -54,6 +58,8 @@ class weapon_category
         bool was_loaded = false;
 
         translation name_;
+
+        std::vector<matec_id> default_techniques;
 };
 
 matype_id martial_art_learned_from( const itype & );
@@ -185,6 +191,7 @@ class ma_technique
         bool stunned_target = false;// only works on stunned enemies
         bool wall_adjacent = false; // only works near a wall
         bool human_target = false;  // only works on humanoid enemies
+        bool reach_attack = false;  // only works as a reach attack
 
         bool needs_ammo = false;    // technique only works if the item is loaded with ammo
 

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -200,6 +200,9 @@ class ma_technique
 
         std::vector<tech_effect_data> tech_effects;
 
+        // the damage types the technique uses, converts PURE to them for further scaling (with melee weapons)
+        std::vector<damage_type> used_damage;
+
         float damage_bonus( const Character &u, damage_type type ) const;
         float damage_multiplier( const Character &u, damage_type type ) const;
         float move_cost_multiplier( const Character &u ) const;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -119,6 +119,7 @@ static const limb_score_id limb_score_block( "block" );
 static const limb_score_id limb_score_grip( "grip" );
 static const limb_score_id limb_score_reaction( "reaction" );
 
+static const matec_id no_technique_id( "" );
 static const matec_id WBLOCK_1( "WBLOCK_1" );
 static const matec_id WBLOCK_2( "WBLOCK_2" );
 static const matec_id WBLOCK_3( "WBLOCK_3" );
@@ -463,7 +464,6 @@ static void melee_train( Character &you, int lo, int hi, const item &weap,
 
 bool Character::melee_attack( Creature &t, bool allow_special )
 {
-    static const matec_id no_technique_id( "" );
     return melee_attack( t, allow_special, no_technique_id );
 }
 
@@ -935,7 +935,8 @@ int Character::get_total_melee_stamina_cost( const item *weap ) const
 
 void Character::reach_attack( const tripoint &p )
 {
-    matec_id force_technique = tec_none;
+    //reach attacks can have special attacks now
+    matec_id force_technique = no_technique_id;
     /** @EFFECT_MELEE >5 allows WHIP_DISARM technique */
     if( weapon.has_flag( flag_WHIP ) && ( get_skill_level( skill_melee ) > 5 ) && one_in( 3 ) ) {
         force_technique = WHIP_DISARM;
@@ -1000,7 +1001,7 @@ void Character::reach_attack( const tripoint &p )
     }
 
     reach_attacking = true;
-    melee_attack_abstract( *critter, false, force_technique, false );
+    melee_attack_abstract( *critter, true, force_technique, false );
     reach_attacking = false;
 }
 
@@ -1651,6 +1652,16 @@ matec_id Character::pick_technique( Creature &t, const item_location &weap, bool
 
         // skip wall adjacent techniques if not next to a wall
         if( tec.wall_adjacent && !wall_adjacent ) {
+            continue;
+        }
+
+        // skip non reach moves if reach attacking
+        if( !tec.reach_attack && reach_attacking ) {
+            continue;
+        }
+
+        // skip reach moves if not reach attacking
+        if( tec.reach_attack && !reach_attacking ) {
             continue;
         }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -119,7 +119,6 @@ static const limb_score_id limb_score_block( "block" );
 static const limb_score_id limb_score_grip( "grip" );
 static const limb_score_id limb_score_reaction( "reaction" );
 
-static const matec_id no_technique_id( "" );
 static const matec_id WBLOCK_1( "WBLOCK_1" );
 static const matec_id WBLOCK_2( "WBLOCK_2" );
 static const matec_id WBLOCK_3( "WBLOCK_3" );
@@ -464,6 +463,7 @@ static void melee_train( Character &you, int lo, int hi, const item &weap,
 
 bool Character::melee_attack( Creature &t, bool allow_special )
 {
+    static const matec_id no_technique_id( "" );
     return melee_attack( t, allow_special, no_technique_id );
 }
 
@@ -936,7 +936,7 @@ int Character::get_total_melee_stamina_cost( const item *weap ) const
 void Character::reach_attack( const tripoint &p )
 {
     //reach attacks can have special attacks now
-    matec_id force_technique = no_technique_id;
+    matec_id force_technique = matec_id( "" );
     /** @EFFECT_MELEE >5 allows WHIP_DISARM technique */
     if( weapon.has_flag( flag_WHIP ) && ( get_skill_level( skill_melee ) > 5 ) && one_in( 3 ) ) {
         force_technique = WHIP_DISARM;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1926,6 +1926,50 @@ void Character::perform_technique( const ma_technique &technique, Creature &t, d
         di.clear();
     }
 
+    // if using a weapon
+    if( cur_weapon ) {
+        // if the technique doesn't have damage types described default to the damage from the weapon
+        bool use_cut = false;
+        bool use_bash = false;
+        bool use_stab = false;
+        if( technique.used_damage.empty() ) {
+            damage_type used_damage_type = cur_weapon.get_item()->type->default_damage;
+            if( used_damage_type == damage_type::BASH ) {
+                use_bash = true;
+            }
+            if( used_damage_type == damage_type::CUT ) {
+                use_cut = true;
+            }
+            if( used_damage_type == damage_type::STAB ) {
+                use_stab = true;
+            }
+
+        } else {
+            // populate the damage array with the base damage
+            for( const damage_type &used_damage_type : technique.used_damage ) {
+                if( used_damage_type == damage_type::BASH ) {
+                    use_bash = true;
+                }
+                if( used_damage_type == damage_type::CUT ) {
+                    use_cut = true;
+                }
+                if( used_damage_type == damage_type::STAB ) {
+                    use_stab = true;
+                }
+            }
+        }
+
+        if( !use_bash ) {
+            di.mult_type_damage( 0, damage_type::BASH );
+        }
+        if( !use_cut ) {
+            di.mult_type_damage( 0, damage_type::CUT );
+        }
+        if( !use_stab ) {
+            di.mult_type_damage( 0, damage_type::STAB );
+        }
+    }
+
     std::map<std::string, damage_type> dt_map = get_dt_map();
     for( const std::pair<const std::string, damage_type> &dt : dt_map ) {
         damage_type type = dt.second;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2217,6 +2217,7 @@ int monster::get_armor_type( damage_type dt, bodypart_id bp ) const
             return worn_armor + static_cast<int>( type->armor_elec );
         case damage_type::NONE:
         case damage_type::NUM:
+        case damage_type::RAW:
             // Let it error below
             break;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Martial Arts Variable Moves Per Weapon (and reach techniques)"
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
_**This will be extended next release into a larger standardizing of melee**_

fixes #59585

As discussed on discord a way to do split moves would be to add techniques to the weapons themselves with different damage techniques.

This is just a proof of concept and the POKE example should be removed before this can be merged since it currently breaks stuff like the halberd that only does cut damage.


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This is the basics of the infrastructure required to do this overhaul well and easily. 

IN THIS PR:
- Unhardcode no reach techniques 
- Set all techniques to default to non reaching
- When selecting techniques filter selection based on if reach attacking 
- Weapon categories can have default techniques added to all weapons in the category
- Adds example polearm technique POKE which does only pierce damage

TODO (But out of scope for me right now)
- Weapons need a generalized *damage*/*weighting* value (maybe derived from just weight / descriptors) that techniques can scale and transform the damage type of for this to really work
- Pierce should probably stop being a flag
- Someone needs to make the techniques for all the weapons
- Someone needs to add them to the weapon_categories
- Someone needs to do a pass on weapons that don't have categories (like the Lucern Hammer)

**TLDR bunch of JSON needs to be done with more care than I'm willing to put in, and whoever does it needs to decide how they want to derive their core value this is all based on for melee weapons**

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![image](https://user-images.githubusercontent.com/4514073/158416163-a4cb14a0-8a36-4651-bc10-fcdc6546f30d.png)

![image](https://user-images.githubusercontent.com/4514073/158416220-24b4741c-82c9-4cd0-9b0c-c5d41eb2528c.png)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Leaving this up as a proof of concept someone can adopt.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
