### PR TITLE
Leaping from the dash spell effect handled better

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9560,25 +9560,25 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
         std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
         if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "ALWAYS" &&
             !prompt_dangerous_tile( dest_loc ) ) {
-            return true;
+            return false;
         } else if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "RUNNING" &&
                    ( !u.is_running() || !prompt_dangerous_tile( dest_loc ) ) ) {
             add_msg( m_warning,
                      _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ),
                      enumerate_as_string( harmful_stuff ) );
-            return true;
+            return false;
         } else if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "CROUCHING" &&
                    ( !u.is_crouching() || !prompt_dangerous_tile( dest_loc ) ) ) {
             add_msg( m_warning,
                      _( "Stepping into that %1$s looks risky.  Crouch and move into it if you wish to enter anyway." ),
                      enumerate_as_string( harmful_stuff ) );
-            return true;
+            return false;
         } else if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "NEVER" &&
                    !u.is_running() ) {
             add_msg( m_warning,
                      _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ),
                      enumerate_as_string( harmful_stuff ) );
-            return true;
+            return false;
         }
     }
     // Used to decide whether to print a 'moving is slow message

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9340,7 +9340,8 @@ bool game::prompt_dangerous_tile( const tripoint &dest_loc, const bool leaping )
     return true;
 }
 
-std::vector<std::string> game::get_dangerous_tile( const tripoint &dest_loc, const bool leaping ) const
+std::vector<std::string> game::get_dangerous_tile( const tripoint &dest_loc,
+        const bool leaping ) const
 {
     if( u.is_blind() ) {
         return {}; // blinded players don't see dangerous tiles
@@ -9357,7 +9358,7 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint &dest_loc, con
         if( !u.is_dangerous_field( e.second ) ) {
             continue;
         }
-        
+
         if( leaping && e.second.get_field_type().obj().phase == phase_id::LIQUID ) {
             continue;
         }
@@ -9443,7 +9444,8 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint &dest_loc, con
     return harmful_stuff;
 }
 
-bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool furniture_move, const bool leaping )
+bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool furniture_move,
+                      const bool leaping )
 {
     if( m.has_flag_ter( ter_furn_flag::TFLAG_SMALL_PASSAGE, dest_loc ) ) {
         if( u.get_size() > creature_size::medium ) {
@@ -9519,7 +9521,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
         add_msg( m_warning, _( "Can't find grabbed object." ) );
         u.grab( object_type::NONE );
     }
-    if( leaping && grabbed ){
+    if( leaping && grabbed ) {
         add_msg( m_bad, _( "You cannot leap while grabbing." ) );
         return false;
     }
@@ -9634,7 +9636,8 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
 
     if( !leaping ) {
         // Print a message if movement is slow
-        const int mcost_to = leaping ? 0 : m.move_cost( dest_loc ); //calculate this _after_ calling grabbed_move
+        const int mcost_to = leaping ? 0 : m.move_cost(
+                                 dest_loc ); //calculate this _after_ calling grabbed_move
         const bool fungus = m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FUNGUS, u.pos() ) ||
                             m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FUNGUS,
                                     dest_loc ); //fungal furniture has no slowing effect on Mycus characters
@@ -9817,7 +9820,8 @@ point game::place_player( const tripoint &dest_loc, const bool leaping )
         u.remove_effect( effect_no_sight );
     }
 
-    if( !leaping && m.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, dest_loc ) && u.has_effect( effect_onfire ) ) {
+    if( !leaping && m.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, dest_loc ) &&
+        u.has_effect( effect_onfire ) ) {
         add_msg( _( "The water puts out the flames!" ) );
         u.remove_effect( effect_onfire );
         if( u.is_mounted() ) {
@@ -9985,7 +9989,7 @@ point game::place_player( const tripoint &dest_loc, const bool leaping )
     if( vp1.part_with_feature( "BOARDABLE", true ) && !u.is_mounted() ) {
         m.board_vehicle( u.pos(), &u );
     }
-    
+
     if( !leaping ) {
         //Autopickup
         if( !u.is_mounted() && get_option<bool>( "AUTO_PICKUP" ) && !u.is_hauling() &&

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9401,14 +9401,16 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint &dest_loc,
         harmful_stuff.push_back( e.second.name() );
     }
 
-    const trap &tr = m.tr_at( dest_loc );
-    // HACK: Hack for now, later ledge should stop being a trap
-    if( tr == tr_ledge && !leaping ) {
-        if( !veh_dest ) {
+    if( !leaping ) {
+        const trap &tr = m.tr_at( dest_loc );
+        // HACK: Hack for now, later ledge should stop being a trap
+        if( tr == tr_ledge ) {
+            if( !veh_dest ) {
+                harmful_stuff.emplace_back( tr.name() );
+            }
+        } else if( tr.can_see( dest_loc, u ) && !tr.is_benign() && !veh_dest ) {
             harmful_stuff.emplace_back( tr.name() );
         }
-    } else if( tr.can_see( dest_loc, u ) && !tr.is_benign() && !veh_dest ) {
-        harmful_stuff.emplace_back( tr.name() );
     }
 
     static const std::set< bodypart_str_id > sharp_bps = {

--- a/src/game.h
+++ b/src/game.h
@@ -761,7 +761,8 @@ class game
         bool phasing_move( const tripoint &dest, bool via_ramp = false );
         bool can_move_furniture( tripoint fdest, const tripoint &dp );
         // Regular movement. Returns false if it failed for any reason
-        bool walk_move( const tripoint &dest, bool via_ramp = false, bool furniture_move = false, bool leaping = false );
+        bool walk_move( const tripoint &dest, bool via_ramp = false, bool furniture_move = false,
+                        bool leaping = false );
         void on_move_effects();
     private:
         // Game-start procedures

--- a/src/game.h
+++ b/src/game.h
@@ -761,7 +761,7 @@ class game
         bool phasing_move( const tripoint &dest, bool via_ramp = false );
         bool can_move_furniture( tripoint fdest, const tripoint &dp );
         // Regular movement. Returns false if it failed for any reason
-        bool walk_move( const tripoint &dest, bool via_ramp = false, bool furniture_move = false );
+        bool walk_move( const tripoint &dest, bool via_ramp = false, bool furniture_move = false, bool leaping = false );
         void on_move_effects();
     private:
         // Game-start procedures
@@ -834,7 +834,7 @@ class game
         void reload_wielded( bool prompt = false );
         void reload_weapon( bool try_everything = true ); // Reload a wielded gun/tool  'r'
         // Places the player at the specified point; hurts feet, lists items etc.
-        point place_player( const tripoint &dest );
+        point place_player( const tripoint &dest, bool leaping = false );
         void place_player_overmap( const tripoint_abs_omt &om_dest, bool move_player = true );
 
         unsigned int get_seed() const;
@@ -845,9 +845,9 @@ class game
         void set_critter_died();
         void mon_info_update( );    //Update seen monsters information
         void cleanup_dead();     // Delete any dead NPCs/monsters
-        bool is_dangerous_tile( const tripoint &dest_loc ) const;
-        std::vector<std::string> get_dangerous_tile( const tripoint &dest_loc ) const;
-        bool prompt_dangerous_tile( const tripoint &dest_loc ) const;
+        bool is_dangerous_tile( const tripoint &dest_loc, bool leaping = false ) const;
+        std::vector<std::string> get_dangerous_tile( const tripoint &dest_loc, bool leaping = false ) const;
+        bool prompt_dangerous_tile( const tripoint &dest_loc, bool leaping = false ) const;
         // Pick up items from the given point
         void pickup( const tripoint &p );
     private:

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1572,17 +1572,15 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint &targ
     for( const tripoint &local_point : trajectory_local ) {
         trajectory.push_back( here.getabs( local_point ) );
     }
-    creature_tracker &creatures = get_creature_tracker();
     for( auto walk_point : trajectory ) {
-        if( creatures.creature_at( here.getlocal( walk_point ) ) ||
-            !g->walk_move( here.getlocal( walk_point ), false, false, true ) ) {
+        if( !g->walk_move( here.getlocal( walk_point ), false, false, true ) ) {
             break;
         } else {
             sp.create_field( here.getlocal( walk_point ) );
             g->draw_ter();
         }
     }
-    g->place_player( caster.pos() );
+    g->place_player( caster.pos(), false );
     tripoint far_target;
     calc_ray_end( coord_to_angle( source, target ), sp.aoe(), here.getlocal( caster.pos() ),
                   far_target );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1572,7 +1572,7 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint &targ
     for( const tripoint &local_point : trajectory_local ) {
         trajectory.push_back( here.getabs( local_point ) );
     }
-    for( auto walk_point : trajectory ) {
+    for( tripoint walk_point : trajectory ) {
         if( !g->walk_move( here.getlocal( walk_point ), false, false, true ) ) {
             break;
         } else {

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1560,8 +1560,7 @@ void spell_effect::bash( const spell &sp, Creature &caster, const tripoint &targ
 void spell_effect::dash( const spell &sp, Creature &caster, const tripoint &target )
 {
     avatar *caster_you = caster.as_avatar();
-    if( caster_you == nullptr || !g->prompt_dangerous_tile( target, false ) )
-    {
+    if( caster_you == nullptr || !g->prompt_dangerous_tile( target, false ) ) {
         return;
     }
     const tripoint source = caster.pos();
@@ -1576,7 +1575,7 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint &targ
     creature_tracker &creatures = get_creature_tracker();
     for( auto walk_point : trajectory ) {
         if( creatures.creature_at( here.getlocal( walk_point ) ) ||
-            !g->walk_move( here.getlocal( walk_point ), false, false, true) ) {
+            !g->walk_move( here.getlocal( walk_point ), false, false, true ) ) {
             break;
         } else {
             sp.create_field( here.getlocal( walk_point ) );
@@ -1585,7 +1584,8 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint &targ
     }
     g->place_player( caster.pos() );
     tripoint far_target;
-    calc_ray_end( coord_to_angle( source, target ), sp.aoe(), here.getlocal( caster.pos() ), far_target );
+    calc_ray_end( coord_to_angle( source, target ), sp.aoe(), here.getlocal( caster.pos() ),
+                  far_target );
     spell_effect::override_parameters params( sp );
     params.range = sp.aoe();
     const std::set<tripoint> hit_area = spell_effect_cone_range_override( params, source, far_target );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Leaping from dash spells behaves more rationally"
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Previously, a dash spell would prompt safety checks for every tile that would be passed through- and simply pressing No would make you ignore the traps and other effects, while saying Yes would cause irrational effects like falling from every ledge you passed through.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Leaping is now a boolean variable for movement, which prevents the player from falling, being hit by liquid fields or other ground effects, or outputting most terrain descriptions (ie, the messages from walking over an item), at least until the tile they land on.
Dash spells will warn if anything dangerous is present at the final location, or if there is a danger that cannot be avoided by leaping.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Jumped around, walked around, jumped over some gaps and acid.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
