### PR TITLE
Begin getting the refugees to improve their lot in life.

### DIFF
--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Boris_Borichenko.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Boris_Borichenko.json
@@ -97,6 +97,16 @@
         "condition": { "not": { "u_has_var": "Boris_mission_1", "type": "mission", "context": "completed", "value": "yes" } }
       },
       {
+        "text": "Now that you've got your tools, what are you going to do next?",
+        "topic": "TALK_BORIS_MISSION_LIST",
+        "condition": {
+          "and": [
+            { "u_has_var": "Boris_mission_2", "type": "mission", "context": "completed", "value": "yes" },
+            { "not": { "npc_has_var": "Boris_upgrade_mission_1", "value": "done" } }
+          ]
+        }
+      },
+      {
         "text": "Got anything else I can help out with?",
         "topic": "TALK_MISSION_LIST",
         "condition": {
@@ -477,10 +487,18 @@
       "effect": [
         { "u_spawn_item": "FMCNote", "count": 5 },
         { "u_add_var": "Boris_mission_2", "type": "mission", "context": "completed", "value": "yes" },
-        { "u_adjust_var": "refugee_happiness", "type": "counter", "context": "refugee_center", "adjustment": 2 }
+        { "u_adjust_var": "refugee_happiness", "type": "counter", "context": "refugee_center", "adjustment": 2 },
+        { "mapgen_update": "boris_setup_workshop", "om_terrain": "evac_center_8" }
       ]
-    },
-    "//": "TK add update mapgen."
+    }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "boris_setup_workshop",
+    "method": "json",
+    "object": {
+      "//": "I should probably do some work before I start mapping."
+    }
   },
   {
     "id": "MISSION_REFUGEE_Boris_LAPTOP",

--- a/data/json/npcs/refugee_center/surface_refugees/center_upgrades.json
+++ b/data/json/npcs/refugee_center/surface_refugees/center_upgrades.json
@@ -1,0 +1,41 @@
+[  
+  {
+    "type": "talk_topic",
+    "id": "TALK_BORIS_MISSION_LIST",
+    "dynamic_line": { "and": [ 
+      "Oh, my friend.  Yes, I have many plans.  My family is joining me, to work with me, but even others have seen what we can do, and now I think we have a chance",
+      "npc_has_var": "Boris_upgrade_mission_1", "value": "done",
+      "no": ".  For a start, I am just working on talking to my fellows about what is next.  I think we need bedrooms, not to sleep in the shared open.  I can do this, easily!  I have some wood, but of course I will need more.  Also I would like to show some others my plans, so we can all agree on how to use the space we have.",
+      "yes": ".  However, for the moment, I need some time to think, because I have not been written to have more answers yet."
+    "responses": [
+      { "text": "I think I know the other people here pretty well now.  Want me to ask around for you?", "topic": "TALK_BORIS_MISSION_UPGRADE1_askaround" },
+      { "text": "Hi Boris, nice to meet you.  I gotta go though.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "MISSION_REFUGEE_UPGRADE1_askaround",
+    "type": "mission_definition",
+    "name": { "str": "Help Boris get opinions on upgrades." },
+    "difficulty": 1,
+    "value": 0,
+    "goal": "MGOAL_",
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "dialogue": {
+      "describe": ".",
+      "offer": "",
+      "accepted": "You are a kind soul.",
+      "rejected": "Ah well.  I can ask around myself, perhaps.",
+      "advice": ".",
+      "inquire": ".",
+      "success": ".",
+      "success_lie": "I see…",
+      "failure": "Oh well.  Let me know if you want to try again."
+    },
+    "end": {
+      "effect": [
+        { "npc_add_var": "Boris_upgrade_mission_1", "value": "done" },
+        { "u_adjust_var": "refugee_happiness", "type": "counter", "context": "refugee_center", "adjustment": 1 }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Adds missions for free merchant refugees to start building a real home."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The surface refugees now have some blank quests implying that they want to improve their lives, and some quests getting started with it, but they don't follow through. 

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This will begin adding the missions, and possibly some of the mapgen, for refugees to fix up their new home.

Ideally I hope to make some of these missions auto-complete on a timer whether or not you get involved, but you can help speed them up. I don't consider that a high initial priority because of how much additional JSON it requires, but I plan to write them with the assumption that could happen, at least. If someone has a good thought for how to do it concisely with EoCs I'm all ears.

I'm listing *all* my goals here, not just what I hope to do this PR. I'll probably carry these forward to future PRs because I'm sure it will be too much for this one.

##### GOALS:
BORIS MISSIONS
Note: I might see if I can have multiple "working" NPCs offer these missions, with different dialogue depending on who you ask.
- [ ] Boris sets up his workshop in the clear back bay
- [ ] Mission 1: Help Boris get a layout for the bedroom area that everyone can agree on, either by taking a survey around yourself or convincing someone else to do it.
- - Auto-completion time: 1 week, without your help.
- [ ] Mission 2: Help Boris secure scrap wood either by bringing it to him or by discussing it with Tacoma
- - Note: can be done concurrent to mission 1; does not require that mission to be completed first.
- - Auto-completion time: 3 weeks after mission 1 completed, without your help.
- [ ] Mission 3: Help Boris work on the new bedroom layout
- - Auto-completion time: 1 week, without your help.
- [ ] Update mapgen: rearrange the furniture in the refugee space, move the refugees around, and add walls
- [ ] Mission 4: Convince a merchant to bring some comfortable furniture and decorations for the new area. Can be done by talking to any random encounter merchant from the refugee center. The teamster says they're already aware and are just trying to find someone - so talking to the teamster isn't an option.
- - Auto-completion time: 3 weeks, without your help.
- [ ] Update mapgen: add creature comforts to the bedroom area.

GENERAL DIALOGUE AND IMMERSION
- [ ] Boris, Sam, Garry, John, Gunny, and Aleesha head to the back bay during the daytime, and we get occasional text snippets about how they're working in there.
- [ ] Add context dialogue to the refugees that start working in the new workshop, talking about what they're doing there
- [ ] Add context dialogue after Mission 1 to the other refugees, commenting on all the work. Vanessa complains about the noise, Rhyzaea talks about the positivity, Alonso is excited to have privacy, etc.
- [ ] Add context dialogue after Mission 3 and 4 to all refugees to talk about their new living quarters and the huge qol change
- [ ] Add a "player assistance" tracker to these and a few other missions: if the player has sufficiently helped the refugees, they will offer you a space of your own in their area.

To come later:
- gunny should have a follow up mission series to work on designing and upgrading the common area
- Rhyzaea, Sam, and Aleesha should have a follow up mission series to add first a library and then a gym and laundry room to the back bay.
- Vanessa will seek your help in getting a hair salon set up
- There will be some debate over how to use the office area in the old back bay, which you can resolve as an outside party (counselling office, massage parlor, mini-theater/games den, or player's personal office are options, the latter requires you to have been an enormous help to the refugees.)


#### Describe alternatives you've considered
There is no alternative but stagnation and death.

#### Testing
Nope. Not yet.

#### Additional context
This is ambitious and I have no idea how far I'll get, but Haveric is helping so we've got a chance!
