### PR TITLE
Charcoal forge and clay kiln can use coal

### DIFF
--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -108,7 +108,7 @@
     "coverage": 40,
     "required_str": -1,
     "crafting_pseudo_item": "fake_forge",
-    "flags": [ "TRANSPARENT", "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT" ],
+    "flags": [ "TRANSPARENT", "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "AMMOTYPE_RELOAD" ],
     "deconstruct": { "items": [ { "item": "char_forge", "count": 1 } ] },
     "examine_action": "reload_furniture",
     "bash": {
@@ -131,7 +131,7 @@
     "coverage": 40,
     "required_str": -1,
     "crafting_pseudo_item": "fake_forge",
-    "flags": [ "TRANSPARENT", "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT" ],
+    "flags": [ "TRANSPARENT", "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "AMMOTYPE_RELOAD" ],
     "deconstruct": { "items": [ { "item": "char_forge", "count": 1 } ] },
     "examine_action": "reload_furniture",
     "bash": {
@@ -154,7 +154,7 @@
     "coverage": 40,
     "required_str": -1,
     "crafting_pseudo_item": "fake_forge",
-    "flags": [ "TRANSPARENT", "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT" ],
+    "flags": [ "TRANSPARENT", "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "AMMOTYPE_RELOAD" ],
     "deconstruct": { "items": [ { "item": "char_forge", "count": 1 } ] },
     "examine_action": "reload_furniture",
     "bash": {
@@ -500,7 +500,7 @@
     "coverage": 40,
     "required_str": -1,
     "crafting_pseudo_item": "fake_forge",
-    "flags": [ "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "MINEABLE" ],
+    "flags": [ "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "MINEABLE", "AMMOTYPE_RELOAD" ],
     "deconstruct": { "items": [ { "item": "rock", "count": 40 } ] },
     "examine_action": "reload_furniture",
     "bash": {
@@ -523,7 +523,7 @@
     "coverage": 40,
     "required_str": -1,
     "crafting_pseudo_item": "fake_clay_kiln",
-    "flags": [ "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "MINEABLE" ],
+    "flags": [ "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "MINEABLE", "AMMOTYPE_RELOAD" ],
     "deconstruct": { "items": [ { "item": "rock", "count": 40 } ] },
     "examine_action": "reload_furniture",
     "bash": {

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -565,6 +565,7 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - ```ALIGN_WORKBENCH``` (only for furniture) A hint to the tiles display that the sprite for this furniture should face toward any adjacent tile with a workbench quality.
 - ```ALLOW_FIELD_EFFECT``` Apply field effects to items inside `SEALED` terrain/furniture.
 - ```ALLOW_ON_OPEN_AIR``` Don't warn when this furniture is placed on `t_open_air` or similar 'open air' terrains which lack a floor.
+- ```AMMOTYPE_RELOAD``` Furniture reloads by ammotype so player can choose from more than one fuel type.
 - ```AUTO_WALL_SYMBOL``` (only for terrain) The symbol of this terrain will be one of the line drawings (corner, T-intersection, straight line etc.) depending on the adjacent terrains.
 
     Example: `-` and `|` are both terrain with the `CONNECT_TO_WALL` flag. `O` does not have the flag, while `X` and `Y` have the `AUTO_WALL_SYMBOL` flag.

--- a/src/character.h
+++ b/src/character.h
@@ -1572,7 +1572,8 @@ class Character : public Creature, public visitable
                                          bool empty = true ) const;
 
         /** Select ammo from the provided options */
-        item::reload_option select_ammo( const item &base, std::vector<item::reload_option> opts ) const;
+        item::reload_option select_ammo( const item &base, std::vector<item::reload_option> opts,
+                                         const std::string name_override = std::string() ) const;
 
         void process_items();
         /** Search surrounding squares for traps (and maybe other things in the future). */

--- a/src/character_ammo.cpp
+++ b/src/character_ammo.cpp
@@ -109,17 +109,18 @@ bool Character::list_ammo( const item &base, std::vector<item::reload_option> &a
 }
 
 item::reload_option Character::select_ammo( const item &base,
-        std::vector<item::reload_option> opts ) const
+        std::vector<item::reload_option> opts, const std::string name_override ) const
 {
     if( opts.empty() ) {
         add_msg_if_player( m_info, _( "Never mind." ) );
         return item::reload_option();
     }
 
+    std::string name = name_override.empty() ? base.tname() : name_override;
     uilist menu;
     menu.text = string_format( base.is_watertight_container() ? _( "Refill %s" ) :
                                base.has_flag( flag_RELOAD_AND_SHOOT ) ? _( "Select ammo for %s" ) : _( "Reload %s" ),
-                               base.tname() );
+                               name );
 
     // Construct item names
     std::vector<std::string> names;
@@ -164,10 +165,12 @@ item::reload_option Character::select_ammo( const item &base,
     std::vector<std::string> destination;
     std::transform( opts.begin(), opts.end(),
     std::back_inserter( destination ), [&]( const item::reload_option & e ) {
+        name = name_override.empty() ? e.target->tname( 1, false, 0, false ) :
+               name_override;
         if( e.target == e.getParent() ) {
-            return e.target->tname( 1, false, 0, false );
+            return name;
         } else {
-            return e.target->tname( 1, false, 0, false ) + " in " + e.getParent()->tname( 1, false, 0, false );
+            return name + " in " + e.getParent()->tname( 1, false, 0, false );
         }
     } );
     // Pads elements to match longest member and return length
@@ -203,7 +206,7 @@ item::reload_option Character::select_ammo( const item &base,
     menu.text += _( "| Moves   " );
 
     // We only show ammo statistics for guns and magazines
-    if( base.is_gun() || base.is_magazine() ) {
+    if( ( base.is_gun() || base.is_magazine() ) && !base.is_tool() ) {
         menu.text += _( "| Damage  | Pierce  " );
     }
 
@@ -214,7 +217,7 @@ item::reload_option Character::select_ammo( const item &base,
                                 sel.ammo->is_ammo_container() ) ? " %-7d |" : "         |", sel.qty() );
         row += string_format( " %-7d ", sel.moves() );
 
-        if( base.is_gun() || base.is_magazine() ) {
+        if( ( base.is_gun() || base.is_magazine() ) && !base.is_tool() ) {
             const itype *ammo = sel.ammo->is_ammo_container() ? sel.ammo->first_ammo().ammo_data() :
                                 sel.ammo->ammo_data();
             if( ammo ) {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4082,6 +4082,14 @@ const itype *furn_t::crafting_ammo_item_type() const
     return nullptr;
 }
 
+/**
+* Finds the number of charges of the first item that matches type.
+*
+* @param type       Search target.
+* @param items      Stack of items. Search stops at first match.
+*
+* @return           Number of charges.
+* */
 static int count_charges_in_list( const itype *type, const map_stack &items )
 {
     for( const auto &candidate : items ) {
@@ -4092,25 +4100,48 @@ static int count_charges_in_list( const itype *type, const map_stack &items )
     return 0;
 }
 
+/**
+* Finds the number of charges of the first item that matches ammotype.
+*
+* @param ammotype   Search target.
+* @param items      Stack of items. Search stops at first match.
+* @param [out] item_type Matching type.
+*
+* @return           Number of charges.
+* */
+static int count_charges_in_list( const ammotype *ammotype, const map_stack &items,
+                                  itype_id &item_type )
+{
+    for( const auto &candidate : items ) {
+        if( candidate.is_ammo() && candidate.type->ammo->type == *ammotype ) {
+            item_type = candidate.typeId();
+            return candidate.charges;
+        }
+    }
+    return 0;
+}
+
 static void reload_furniture( Character &you, const tripoint &examp, bool allow_unload )
 {
     map &here = get_map();
     const furn_t &f = here.furn( examp ).obj();
-    const itype *type = f.crafting_pseudo_item_type();
+    const itype *pseudo_type = f.crafting_pseudo_item_type();
     const itype *ammo = f.crafting_ammo_item_type();
-    if( type == nullptr || ammo == nullptr || !ammo->ammo ) {
+    bool use_ammotype = f.has_flag( ter_furn_flag::TFLAG_AMMOTYPE_RELOAD );
+    if( pseudo_type == nullptr || ammo == nullptr || !ammo->ammo ) {
         add_msg( m_info, _( "This %s can not be reloaded!" ), f.name() );
         return;
     }
-    map_stack items_here = here.i_at( examp );
-    const int amount_in_furn = count_charges_in_list( ammo, items_here );
-    const int amount_in_inv = you.crafting_inventory().charges_of( ammo->get_id() );
+    itype_id ammo_itypeID( ammo->get_id() );
+    int amount_in_furn = use_ammotype ?
+                         count_charges_in_list( &ammo->ammo->type, here.i_at( examp ), ammo_itypeID ) :
+                         count_charges_in_list( ammo, here.i_at( examp ) );
     if( allow_unload && amount_in_furn > 0 ) {
         if( you.query_yn( _( "The %1$s contains %2$d %3$s.  Unload?" ), f.name(), amount_in_furn,
-                          ammo->nname( amount_in_furn ) ) ) {
+                          ammo_itypeID->nname( amount_in_furn ) ) ) {
             map_stack items = here.i_at( examp );
             for( auto &itm : items ) {
-                if( itm.type == ammo ) {
+                if( itm.typeId() == ammo_itypeID ) {
                     you.assign_activity( player_activity( pickup_activity_actor(
                     { item_location( map_cursor( examp ), &itm ) }, { 0 }, you.pos(), false ) ) );
                     return;
@@ -4119,21 +4150,38 @@ static void reload_furniture( Character &you, const tripoint &examp, bool allow_
         }
     }
 
-    const int max_amount_in_furn = item( type ).ammo_capacity( ammo->ammo->type );
+    const int max_amount_in_furn = item( pseudo_type ).ammo_capacity( ammo->ammo->type );
     const int max_reload_amount = max_amount_in_furn - amount_in_furn;
     if( max_reload_amount <= 0 ) {
         return;
     }
-    if( amount_in_inv == 0 ) {
+    item pseudo( f.crafting_pseudo_item_type() );
+    std::vector<item::reload_option> ammo_list;
+    for( item_location &ammo : you.find_ammo( pseudo, false, PICKUP_RANGE ) ) {
+        // Only allow the same type to reload if partially loaded.
+        if( ( amount_in_furn > 0 || !use_ammotype ) && ammo_itypeID != ammo.get_item()->typeId() ) {
+            continue;
+        }
+        if( pseudo.can_reload_with( *ammo, true ) ) {
+            ammo_list.emplace_back( &you, &pseudo, &pseudo, std::move( ammo ) );
+        }
+    }
+
+    if( ammo_list.empty() ) {
         //~ Reloading or restocking a piece of furniture, for example a forge.
         add_msg( m_info, _( "You need some %1$s to reload this %2$s." ), ammo->nname( 2 ),
                  f.name() );
         return;
     }
-    const int max_amount = std::min( amount_in_inv, max_reload_amount );
-    //~ Loading fuel or other items into a piece of furniture.
+
+    item::reload_option opt = you.select_ammo( pseudo, std::move( ammo_list ), f.name() );
+    if( !opt ) {
+        return;
+    }
+    const itype *opt_type = opt.ammo->type;
+    const int max_amount = std::min( opt.qty(), max_reload_amount );
     const std::string popupmsg = string_format( _( "Put how many of the %1$s into the %2$s?" ),
-                                 ammo->nname( max_amount ), f.name() );
+                                 opt_type->nname( max_amount ), f.name() );
     int amount = string_input_popup()
                  .title( popupmsg )
                  .width( 20 )
@@ -4144,8 +4192,7 @@ static void reload_furniture( Character &you, const tripoint &examp, bool allow_
         return;
     }
 
-    std::list<item> moved = you.consume_items( { { ammo->get_id(), amount } } );
-    auto place_item = [&]( const item & it ) {
+    auto place_item = [&here, &examp]( const item & it ) {
         for( item &e : here.i_at( examp ) ) {
             if( e.merge_charges( it ) ) {
                 return;
@@ -4155,16 +4202,20 @@ static void reload_furniture( Character &you, const tripoint &examp, bool allow_
         here.add_item( examp, it );
     };
 
-    for( const item &m : moved ) {
-        // We can't use map::add_item_or_charges here since the furniture has NO_ITEM
-        place_item( m );
-        you.mod_moves( -you.item_handling_cost( m ) );
+    item moved( opt_type, opt.ammo.get_item()->birthday(), amount );
+    place_item( moved );
+    you.mod_moves( -you.item_handling_cost( moved ) );
+    std::list<item>used;
+    if( opt.ammo.get_item()->use_charges( opt_type->get_id(), amount, used,
+                                          opt.ammo.position() ) ) {
+        opt.ammo.remove_item();
     }
 
-    const int amount_in_furn_after_placing = count_charges_in_list( ammo, here.i_at( examp ) );
+    const int amount_in_furn_after_placing = count_charges_in_list( opt_type,
+            here.i_at( examp ) );
     //~ %1$s - furniture, %2$d - number, %3$s items.
     add_msg( _( "The %1$s contains %2$d %3$s." ), f.name(), amount_in_furn_after_placing,
-             ammo->nname( amount_in_furn_after_placing ) );
+             opt_type->nname( amount_in_furn_after_placing ) );
 
     add_msg( _( "You reload the %s." ), here.furnname( examp ) );
 

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -19,6 +19,7 @@
 #include "inventory_ui.h" // auto inventory blocking
 #include "item_pocket.h"
 #include "item_stack.h"
+#include "itype.h"
 #include "map.h"
 #include "map_iterator.h"
 #include "mapdata.h"
@@ -441,6 +442,27 @@ static int count_charges_in_list( const itype *type, const map_stack &items )
     return 0;
 }
 
+/**
+* Finds the number of charges of the first item that matches ammotype.
+*
+* @param ammotype   Search target.
+* @param items      Stack of items. Search stops at first match.
+* @param [out] item_type Matching type.
+*
+* @return           Number of charges.
+* */
+static int count_charges_in_list( const ammotype *ammotype, const map_stack &items,
+                                  itype_id &item_type )
+{
+    for( const auto &candidate : items ) {
+        if( candidate.is_ammo() && candidate.type->ammo->type == *ammotype ) {
+            item_type = candidate.typeId();
+            return candidate.charges;
+        }
+    }
+    return 0;
+}
+
 void inventory::form_from_map( const tripoint &origin, int range, const Character *pl,
                                bool assign_invlet,
                                bool clear_path )
@@ -494,7 +516,16 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
             const itype *ammo = f.crafting_ammo_item_type();
             if( furn_item->has_pocket_type( item_pocket::pocket_type::MAGAZINE ) ) {
                 // NOTE: This only works if the pseudo item has a MAGAZINE pocket, not a MAGAZINE_WELL!
-                item furn_ammo( ammo, calendar::turn, count_charges_in_list( ammo, m.i_at( p ) ) );
+                const bool using_ammotype = f.has_flag( ter_furn_flag::TFLAG_AMMOTYPE_RELOAD );
+                int amount = 0;
+                itype_id ammo_id = ammo->get_id();
+                // Some furniture can consume more than one item type.
+                if( using_ammotype ) {
+                    amount = count_charges_in_list( &ammo->ammo->type, m.i_at( p ), ammo_id );
+                } else {
+                    amount = count_charges_in_list( ammo, m.i_at( p ) );
+                }
+                item furn_ammo( ammo_id, calendar::turn, amount );
                 furn_item->put_in( furn_ammo, item_pocket::pocket_type::MAGAZINE );
             }
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5239,10 +5239,15 @@ static void use_charges_from_furn( const furn_t &f, const itype_id &type, int &q
     const itype *itt = f.crafting_pseudo_item_type();
     if( itt != nullptr && itt->tool && !itt->tool->ammo_id.empty() ) {
         const itype_id ammo = ammotype( *itt->tool->ammo_id.begin() )->default_ammotype();
+        const bool using_ammotype = f.has_flag( ter_furn_flag::TFLAG_AMMOTYPE_RELOAD );
         map_stack stack = m->i_at( p );
         auto iter = std::find_if( stack.begin(), stack.end(),
-        [ammo]( const item & i ) {
-            return i.typeId() == ammo;
+        [ammo, using_ammotype]( const item & i ) {
+            if( using_ammotype ) {
+                return i.type->ammo->type == ammo->ammo->type;
+            } else {
+                return i.typeId() == ammo;
+            }
         } );
         if( iter != stack.end() ) {
             item furn_item( itt, calendar::turn_zero );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -251,6 +251,7 @@ std::string enum_to_string<ter_furn_flag>( ter_furn_flag data )
         case ter_furn_flag::TFLAG_NO_SELF_CONNECT: return "NO_SELF_CONNECT";
         case ter_furn_flag::TFLAG_BURROWABLE: return "BURROWABLE";
         case ter_furn_flag::TFLAG_MURKY: return "MURKY";
+        case ter_furn_flag::TFLAG_AMMOTYPE_RELOAD: return "AMMOTYPE_RELOAD";
 
         // *INDENT-ON*
         case ter_furn_flag::NUM_TFLAG_FLAGS:

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -296,6 +296,7 @@ enum class ter_furn_flag : int {
     TFLAG_NO_SELF_CONNECT,
     TFLAG_BURROWABLE,
     TFLAG_MURKY,
+    TFLAG_AMMOTYPE_RELOAD,
 
     NUM_TFLAG_FLAGS
 };


### PR DESCRIPTION
#### Summary
Bugfixes "Charcoal forge and clay kiln can use coal"

#### Purpose of change

Fixes #57216

Furniture versions of charcoal forge and clay kiln could only burn charcoal as fuel. Coal was usable in the portable versions however. This adds the option of loading items that match the default ammotype - coal can be loaded and used in the charcoal forge and clay kiln.

#### Describe the solution

Added a flag to the furniture json to allow loading by ammotype. Added the flag to the charcoal forges and the charcoal clay kiln.

Source code to support the `AMMOTYPE_RELOAD` flag. Furniture reloading and crafting affected.

Also some code changes to improve the UI when reloading with pseudo items.

#### Describe alternatives you've considered

Reloading only allows one source stack at a time. It could be changed to choose from more than one stack, but would not be as clean or simple as how this is working. I opted for the simpler approach.

#### Testing

Reloaded with coal and charcoal on the ground, a vehicle, player inventory, and on a shelf. Charge and item deletion working as expected. Also did same tests with smoking rack.

Reloading while partially loaded only allows the existing type. Working as intended.

Unloading the furniture moves the item stack to player - same as before. 

Crafting with forge / clay kiln loaded with coal or charcoal: craft completes and proper amount of charge is deducted.

#### Additional context

The pseudo item is messing with the tool name being displayed in the crafting menu. For example a charcoal forge is displayed as _basecamp forge_ instead of its actual name _forge_. This is the same behavior as in the master branch; it is not affecting anything other than being a display issue. This PR does not address this problem.

Forge name is displaying correctly when reloading.
![image](https://user-images.githubusercontent.com/30374490/167027769-a3d40d80-2397-4163-8f84-8dd37846434e.png)
