### PR TITLE
Fix pseudo item scanning

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -704,12 +704,14 @@ void basecamp::form_crafting_inventory( map &target_map )
     }
 
     //  We're potentially adding the same item multiple times if present in multiple expansions,
-    //  but we're already that with the resources above. The resources are stored in expansions
+    //  but we're already doing that with the resources above. The resources are stored in expansions
     //  rather than in a common pool to allow them to apply only to their respective expansion
     //  in the future.
     for( auto &expansion : expansions ) {
         for( itype_id &it : expansion.second.available_pseudo_items ) {
-            _inv.add_item( item( it ) );
+            item camp_item( it, calendar::turn_zero );
+            camp_item.set_flag( STATIC( flag_id( "PSEUDO" ) ) );
+            _inv.add_item( camp_item );
         }
     }
 }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1895,12 +1895,14 @@ void basecamp::abandon_camp()
 
 void basecamp::scan_pseudo_items()
 {
+    tinymap expansion_map;
+
     for( auto &expansion : expansions ) {
         expansion.second.available_pseudo_items.clear();
         tripoint_abs_omt tile = tripoint_abs_omt( omt_pos.x() + expansion.first.x,
                                 omt_pos.y() + expansion.first.y, omt_pos.z() );
-        tinymap expansion_map;
-        expansion_map.load( project_to<coords::sm>( tile ), false );
+//        expansion_map.load( project_to<coords::sm>( tile ), false );
+        expansion_map.peek_load(project_to<coords::sm>(tile));
 
         tripoint mapmin = tripoint( 0, 0, omt_pos.z() );
         tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_pos.z() );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1901,8 +1901,7 @@ void basecamp::scan_pseudo_items()
         expansion.second.available_pseudo_items.clear();
         tripoint_abs_omt tile = tripoint_abs_omt( omt_pos.x() + expansion.first.x,
                                 omt_pos.y() + expansion.first.y, omt_pos.z() );
-//        expansion_map.load( project_to<coords::sm>( tile ), false );
-        expansion_map.peek_load(project_to<coords::sm>(tile));
+        expansion_map.peek_load( project_to<coords::sm>( tile ) );
 
         tripoint mapmin = tripoint( 0, 0, omt_pos.z() );
         tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_pos.z() );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6848,7 +6848,7 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle,
 
 void map::peek_load( const tripoint_abs_sm &w )
 {
-    map &main_map = get_map();
+    get_map();
     set_abs_sub( w );
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6846,6 +6846,12 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle,
     }
 }
 
+void map::peek_load(const tripoint_abs_sm& w)
+{
+    map& main_map = get_map();
+    set_abs_sub(w);
+}
+
 void map::shift_traps( const tripoint &shift )
 {
     // Offset needs to have sign opposite to shift direction

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6846,10 +6846,10 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle,
     }
 }
 
-void map::peek_load(const tripoint_abs_sm& w)
+void map::peek_load( const tripoint_abs_sm &w )
 {
-    map& main_map = get_map();
-    set_abs_sub(w);
+    map &main_map = get_map();
+    set_abs_sub( w );
 }
 
 void map::shift_traps( const tripoint &shift )

--- a/src/map.h
+++ b/src/map.h
@@ -526,6 +526,7 @@ class map
          */
         void load( const tripoint_abs_sm &w, bool update_vehicles,
                    bool pump_events = false );
+        void peek_load(const tripoint_abs_sm& w);
         /**
          * Shift the map along the vector s.
          * This is like loading the map with coordinates derived from the current

--- a/src/map.h
+++ b/src/map.h
@@ -526,7 +526,12 @@ class map
          */
         void load( const tripoint_abs_sm &w, bool update_vehicles,
                    bool pump_events = false );
-        void peek_load(const tripoint_abs_sm& w);
+        /**
+        * Loads submaps without touching any caches. It's intended to be used to view
+        * static map information in locations that overlap the primary map without
+        * scrambling the caches used by the primary map (as 'load' does).
+        */
+        void peek_load( const tripoint_abs_sm &w );
         /**
          * Shift the map along the vector s.
          * This is like loading the map with coordinates derived from the current


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #57439
The scanned pseudo items weren't created completely, with a need to add the PSEUDO flag afterwards.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Initiate the scanned items in the same way the resource items were.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Verified that the bugged save worked correctly when accessing the bulletin board between lighting the smoking racks and checking on them after sleeping.

Edit: Also tested to construct a couple of appliances to verify that they were still picked up. An oven and an electric forge were placed in a newly surveyed workshop modified to provide some cooking and blacksmithing recipes immediately upon survey. Once the appliances were placed in a basecamp supply zone they were picked up as available for boiling eggs (oven) and crafting a hatchet (forge).
Verified that boiling an egg reduced the storage battery charges by 2.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Thanks to @andrei8l  for looking at the save and figuring out what caused smoking to be stalled.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
