### PR TITLE
Add carving proficiency to knitting needles

### DIFF
--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -430,6 +430,7 @@
     "time": "3 m",
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 2 } ],
+    "proficiencies": [ { "proficiency": "prof_carving" } ],
     "components": [ [ [ "skewer_bone", 2 ], [ "splinter", 2 ] ] ]
   },
   {


### PR DESCRIPTION

#### Summary
none

#### Purpose of change
Your carving something to have a pointy but not sharp end, strait sides to not catch the yarn and  a place to hold on to well.  Items with similar tool quality, level requirement, and material to craft require carving like wood and bone needles, flutes and hooks.