### PR TITLE
Remove FIRE_CONTAINER flag from 'f_oven'

### DIFF
--- a/data/core/tips.json
+++ b/data/core/tips.json
@@ -7,7 +7,7 @@
   {
     "type": "snippet",
     "category": "tip",
-    "text": [ "Even without electricity, ovens can be useful fire containers." ]
+    "text": [ "Careful, ovens can't contain a fire. Maybe a brazier instead?" ]
   },
   {
     "type": "snippet",

--- a/data/core/tips.json
+++ b/data/core/tips.json
@@ -7,7 +7,7 @@
   {
     "type": "snippet",
     "category": "tip",
-    "text": [ "Ovens won't contain a fire. Try a brazier instead." ]
+    "text": [ "Ovens won't contain a fire.  Try a brazier instead." ]
   },
   {
     "type": "snippet",

--- a/data/core/tips.json
+++ b/data/core/tips.json
@@ -7,7 +7,7 @@
   {
     "type": "snippet",
     "category": "tip",
-    "text": [ "Careful, ovens can't contain a fire. Maybe a brazier instead?" ]
+    "text": [ "Ovens won't contain a fire. Try a brazier instead." ]
   },
   {
     "type": "snippet",

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -355,8 +355,7 @@
     "coverage": 60,
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "oven" },
-    "//": "TODO: Replace FIRE_CONTAINER with some flag choking out small files",
-    "flags": [ "PLACE_ITEM", "TRANSPARENT", "EASY_DECONSTRUCT", "FIRE_CONTAINER", "CONTAINER", "BLOCKSDOOR", "MOUNTABLE" ],
+    "flags": [ "PLACE_ITEM", "TRANSPARENT", "EASY_DECONSTRUCT", "CONTAINER", "BLOCKSDOOR", "MOUNTABLE" ],
     "deconstruct": { "items": [ { "item": "oven", "count": 1 } ] },
     "max_volume": "120 L",
     "bash": {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #56343
Removes FIRE_CONTAINER flag from 'f_oven' due to the fact that electric ovens can't realistically contain fire. 

#### Describe the solution

#### Describe alternatives you've considered

None

#### Testing

It builds and runs :P

#### Additional context

Nothing
