### PR TITLE
Parametric basecamp expansions

### DIFF
--- a/data/json/mapgen/basecamps/base/modular_hub/version_2/modular_field_generic.json
+++ b/data/json/mapgen/basecamps/base/modular_hub/version_2/modular_field_generic.json
@@ -1,16 +1,21 @@
 [
   {
+    "type": "palette",
+    "id": "fbmh_2_any_palette",
+    "parameters": {
+      "fbmh_2_generic_palette": {
+        "type": "palette_id",
+        "scope": "omt",
+        "default": { "distribution": [ "fbmh_2_log_palette", "fbmh_2_migo_resin_palette" ] }
+      }
+    },
+    "palettes": [ { "param": "fbmh_2_generic_palette" } ]
+  },
+  {
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "fbmh_2_generic_room_1_1",
     "object": {
-      "parameters": {
-        "fbmh_2_generic_palette": {
-          "type": "palette_id",
-          "scope": "omt",
-          "default": { "distribution": [ "fbmh_2_log_palette", "fbmh_2_migo_resin_palette" ] }
-        }
-      },
       "mapgensize": [ 6, 6 ],
       "rows": [
         "  wwww",
@@ -20,7 +25,7 @@
         "      ",
         "      "
       ],
-      "palettes": [ { "param": "fbmh_2_generic_palette" } ]
+      "palettes": [ "fbmh_2_any_palette" ]
     }
   },
   {

--- a/data/json/mapgen/basecamps/base/modular_hub/version_2/modular_field_generic.json
+++ b/data/json/mapgen/basecamps/base/modular_hub/version_2/modular_field_generic.json
@@ -1,0 +1,32 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbmh_2_generic_room_1_1",
+    "object": {
+      "parameters": {
+        "fbmh_2_generic_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": { "distribution": [ "fbmh_2_log_palette", "fbmh_2_migo_resin_palette" ] }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "  wwww",
+        "  ...w",
+        "    .w",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ { "param": "fbmh_2_generic_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "fbmh_2_generic_room_NE_1",
+    "method": "json",
+    "object": { "place_nested": [ { "chunks": [ "fbmh_2_generic_room_1_1" ], "x": 18, "y": 0 } ] }
+  }
+]

--- a/data/json/mapgen/basecamps/base/modular_hub/version_2/modular_field_log.json
+++ b/data/json/mapgen/basecamps/base/modular_hub/version_2/modular_field_log.json
@@ -8,29 +8,6 @@
   {
     "type": "mapgen",
     "method": "json",
-    "nested_mapgen_id": "fbmh_2_log_room_1_1",
-    "object": {
-      "mapgensize": [ 6, 6 ],
-      "rows": [
-        "  wwww",
-        "  ...w",
-        "    .w",
-        "      ",
-        "      ",
-        "      "
-      ],
-      "palettes": [ "fbmh_2_log_palette" ]
-    }
-  },
-  {
-    "type": "mapgen",
-    "update_mapgen_id": "fbmh_2_log_room_NE_1",
-    "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbmh_2_log_room_1_1" ], "x": 18, "y": 0 } ] }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
     "nested_mapgen_id": "fbmh_2_log_room_1_2",
     "object": {
       "mapgensize": [ 6, 6 ],

--- a/data/json/mapgen/basecamps/base/modular_hub/version_2/modular_field_migo_resin.json
+++ b/data/json/mapgen/basecamps/base/modular_hub/version_2/modular_field_migo_resin.json
@@ -8,29 +8,6 @@
   {
     "type": "mapgen",
     "method": "json",
-    "nested_mapgen_id": "fbmh_2_resin_room_1_1",
-    "object": {
-      "mapgensize": [ 6, 6 ],
-      "rows": [
-        "  wwww",
-        "  ...w",
-        "    .w",
-        "      ",
-        "      ",
-        "      "
-      ],
-      "palettes": [ "fbmh_2_migo_resin_palette" ]
-    }
-  },
-  {
-    "type": "mapgen",
-    "update_mapgen_id": "fbmh_2_resin_room_NE_1",
-    "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbmh_2_resin_room_1_1" ], "x": 18, "y": 0 } ] }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
     "nested_mapgen_id": "fbmh_2_resin_room_1_2",
     "object": {
       "mapgensize": [ 6, 6 ],

--- a/data/json/recipes/basecamps/base/recipe_modular_hub/version_2/recipe_modular_field_generic.json
+++ b/data/json/recipes/basecamps/base/recipe_modular_hub/version_2/recipe_modular_field_generic.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "fbmh_2_generic_room_1_1",
+    "description": "We need some shelter, so build half of a shack with a roof on the northeast side of the camp",
+    "category": "CC_BUILDING",
+    "subcategory": "CSC_BUILDING_BASES",
+    "autolearn": false,
+    "never_learn": true,
+    "construction_blueprint": "fbmh_2_generic_room_NE_1",
+    "blueprint_name": "northeast shack",
+    "blueprint_parameter_names": {
+      "fbmh_2_generic_palette": { "fbmh_2_log_palette": "Log walls and wooden roof", "fbmh_2_migo_resin_palette": "Mi-go resin walls and roof" }
+    },
+    "blueprint_requires": [ { "id": "fbmh_2" } ],
+    "blueprint_provides": [ { "id": "fbmh_2_room_NE" } ],
+    "blueprint_excludes": [ { "id": "fbmh_2_room_NE" } ]
+  }
+]

--- a/data/json/recipes/basecamps/base/recipe_modular_hub/version_2/recipe_modular_field_log.json
+++ b/data/json/recipes/basecamps/base/recipe_modular_hub/version_2/recipe_modular_field_log.json
@@ -2,21 +2,6 @@
   {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
-    "result": "fbmh_2_log_room_1_1",
-    "description": "We need some shelter, so build half of a log shack with a wooden roof on the northeast side of the camp",
-    "category": "CC_BUILDING",
-    "subcategory": "CSC_BUILDING_BASES",
-    "autolearn": false,
-    "never_learn": true,
-    "construction_blueprint": "fbmh_2_log_room_NE_1",
-    "blueprint_name": "northeast log shack",
-    "blueprint_requires": [ { "id": "fbmh_2" } ],
-    "blueprint_provides": [ { "id": "fbmh_2_room_NE" } ],
-    "blueprint_excludes": [ { "id": "fbmh_2_room_NE" } ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "MODERATE_EXERCISE",
     "result": "fbmh_2_log_room_1_2",
     "description": "We should use logs to expand the shack so we have space for another bed.",
     "category": "CC_BUILDING",

--- a/data/json/recipes/basecamps/base/recipe_modular_hub/version_2/recipe_modular_field_migo_resin.json
+++ b/data/json/recipes/basecamps/base/recipe_modular_hub/version_2/recipe_modular_field_migo_resin.json
@@ -2,21 +2,6 @@
   {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
-    "result": "fbmh_2_resin_room_1_1",
-    "description": "We need some shelter, so build half of a resin shack with a mi-go resin roof on the northeast side of the camp",
-    "category": "CC_BUILDING",
-    "subcategory": "CSC_BUILDING_BASES",
-    "autolearn": false,
-    "never_learn": true,
-    "construction_blueprint": "fbmh_2_resin_room_NE_1",
-    "blueprint_name": "northeast mi-go resin shack",
-    "blueprint_requires": [ { "id": "fbmh_2" } ],
-    "blueprint_provides": [ { "id": "fbmh_2_room_NE" } ],
-    "blueprint_excludes": [ { "id": "fbmh_2_room_NE" } ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "MODERATE_EXERCISE",
     "result": "fbmh_2_resin_room_1_2",
     "description": "We should use mi-go resin to expand the shack so we have space for another bed.",
     "category": "CC_BUILDING",

--- a/data/mods/TEST_DATA/basecamp.json
+++ b/data/mods/TEST_DATA/basecamp.json
@@ -100,5 +100,21 @@
     "//": "This has explicit needs which don't match, so it disables checking",
     "blueprint_needs": {  },
     "check_blueprint_needs": false
+  },
+  {
+    "type": "recipe",
+    "result": "test_base_stove_plus_pipe_4",
+    "description": "Test data only.",
+    "category": "CC_BUILDING",
+    "subcategory": "CSC_BUILDING_BASES",
+    "autolearn": false,
+    "never_learn": true,
+    "time": "20 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "pipe", 2 ], [ "scrap", 1 ] ] ],
+    "construction_blueprint": "test_stove_update",
+    "blueprint_name": "stove",
+    "//": "This doesn't declare blueprint_needs at all, and disables checking, so they are taken exclusively from the recipe needs",
+    "check_blueprint_needs": false
   }
 ]

--- a/doc/BASECAMP.md
+++ b/doc/BASECAMP.md
@@ -10,20 +10,21 @@ A basecamp upgrade path is a series of basecamp upgrade missions that upgrade th
 
 Basecamp upgrade paths are defined by several related files:
 * The recipe JSONs that define what the material, tool, and skill requirements to perform an upgrade mission and the blueprint mapgen, blueprint requirements, blueprint provides, and blueprint resources associated with each upgrade mission.
-* The mapgen_update JSONs that define how the map will change when the upgrade mission is complete.  These may include shared instances of nested mapgen, such a standard room or tent.
-* The recipe_group JSONs that define what recipes can be crafted after completing the upgrade mission and what camps and expansions are available.
+* The mapgen update JSONs that define how the map will change when the upgrade mission is complete.  These may include shared instances of nested mapgen, such a standard room or tent.
+* The `recipe_group` JSONs that define what recipes can be crafted after completing the upgrade mission and what camps and expansions are available.
 
 ## recipe JSONs
 The recipe JSONs are standard recipe JSONs, with the addition of a few fields.
 
 New field | Description
 -- | --
-`"construction_blueprint"` | string, the `"update_mapgen_id"` of the mapgen_update JSON that will be performed when the upgrade mission is complete.
+`"construction_blueprint"` | string, the `"update_mapgen_id"` of the mapgen update JSON that will be performed when the upgrade mission is complete.
 `"construction_name"` | string, a short description/name of the upgrade mission that is displayed in the base camp mission selector.  The recipe's `"description"` field has the extended description that explains why a player might want to have an NPC perform this upgrade mission.
 `"blueprint_provides"` | array of objects, with each object having an `"id"` string and an optional `"amount"` integer.  These are the camp features that are available when the upgrade mission is complete.  Every upgrade mission provides its recipe `"result"` with an amount of 1 automatically and that string does not need to be listed in `"blueprint_provides"`.
 `"blueprint_requires"` | array of objects, with each object having an `"id"` string and an optional `"amount"` integer.  These are the camp features that are required before the upgrade mission can be attempted.
 `"blueprint_excludes"` | array of objects, with each object having an `"id"` string and an optional `"amount"` integer.  These are the camp features that prevent the upgrade mission from being attempted if they exist.
 `"blueprint_resources"` | array of `"itype_id"`s.  Items with those ids will be added to the camp inventory after the upgrade mission is completed and can be used for crafting or additional upgrade missions.
+`"blueprint_needs"` | object which defines the requirements to build this blueprint.  If not given, the game will attempt to autocalculate the needs based on the associated mapgen definition, so usually you need not specify `"blueprint_needs"`.
 
 ### blueprint requires, provides, and excludes
 blueprint requires, blueprint provides, and blueprint excludes are abstract concepts or flags that an upgrade mission requires to start, or that are provided by a previous upgrade mission to satisfy the blueprint requirements of a current upgrade mission, or that prevent an upgrade mission from being available.  Each one has an `"id"` and an `"amount"`.  Multiple requires, provides, or excludes with the same `"id"` sum their `"amount"` if they're on the same basecamp expansion.
@@ -89,11 +90,16 @@ The `"faction_base_camp_8"` upgrade mission can be performed after `"faction_bas
 
 `"blueprint_autocalc": true` could be used instead of `components` to let the cost be calculated automatically from the mapgen\_update data.
 
-## mapgen_update JSON
+## mapgen update JSON
 
-These are standard mapgen_update JSON; see doc/MAPGEN.md for more details.  Each one should change a localized portion of the camp map and should, as much as possible, be independent of any other pieces of mapgen_update for the basecamp upgrade path.  Obviously, some bits are going to expand other bits, in which case their `"blueprint_requires"` should include the `"blueprint_provides"` of the previous upgrade missions.
+These are standard mapgen update JSON; see [the MAPGEN docs](doc/MAPGEN.md) for
+more details.  Each one should change a localized portion of the camp map and
+should, as much as possible, be independent of any other pieces of
+mapgen update for the basecamp upgrade path.  Obviously, some bits are going to
+expand other bits, in which case their `"blueprint_requires"` should include
+the `"blueprint_provides"` of the previous upgrade missions.
 
-### Sample mapgen_update JSON
+### Sample mapgen update JSON
 
 ```json
   {
@@ -143,7 +149,7 @@ There are two special recipe groups, `"all_faction_base_types"` and `"all_factio
 
 Each entry in the `"recipes"` array must be a dictionary with the `"id"`, `"description"`, and `"om_terrains"` fields.  `"id"` is the recipe `"id"` of the recipe that starts that basecamp or basecamp expansion upgrade path, and has to conform to the pattern `"faction_base_X_0"`, where X distinguishes the entry from the others, with the prefix and suffix required by the code.  `"description"` is a short name of the basecamp or basecamp expansion.  `"om_terrains"` is a list of overmap terrain ids which can be used as the basis for the basecamp or basecamp expansion.
 
-All recipes that start an upgrade path or expansion should have a blueprint requirement that can never be met, such as "not_an_upgrade", to prevent them from showing up as available upgrades. Additionally, if you want to add an expansion, you must create an OMT with the same `id` as the expansion's `id`.
+All recipes that start an upgrade path or expansion should have a blueprint requirement that can never be met, such as `"not_an_upgrade"`, to prevent them from showing up as available upgrades. Additionally, if you want to add an expansion, you must create an OMT with the same `id` as the expansion's `id`.
 
 If the player attempts to start a basecamp on an overmap terrain that has two or more valid basecamp expansion paths, she will allowed to choose which path to start.
 
@@ -195,13 +201,13 @@ Modular bases use the following naming scheme for recipes.  Each element is sepa
 * MATERIAL <-- the type of material used in construction, such as metal, wood, brick, or wad (short for wattle-and-daub), _and_
 * AREA <-- the area in the 3x3 grid of the modular camp layout.
 
-blueprint keywords follow a similar scheme, but `"faction_base_modular"` is collapsed into `"fbm"` and the overmap terrain id is collapsed into a short identifier.  ie, `"fbmf"` is the keyword identifier for elements of the modular field base.
+blueprint keywords follow a similar scheme, but `"faction_base_modular"` is collapsed into `"fbm"` and the overmap terrain id is collapsed into a short identifier.  I.e., `"fbmf"` is the keyword identifier for elements of the modular field base.
 
 # Adding basecamp expansions
 
 Basecamp expansion upgrade paths are defined by the corresponding set of files to the basecamps themselves, with two additions (at the end of the list):
 * The recipe JSONs that define what the material, tool, and skill requirements to perform an upgrade mission and the blueprint mapgen, blueprint requirements, blueprint provides, and blueprint resources associated with each upgrade mission.
-* The mapgen_update JSONs that define how the map will change when the upgrade mission is complete.  These may include shared instances of nested mapgen, such a standard room or tent.
-* The recipe_group JSONs that define what recipes can be crafted after completing the upgrade mission and what camps and expansions are available.
-* ../json/overmap/overmap_terrain/overmap_terrain_faction_base.json has to be updated to provide an overmap identifier for each new expansion.
-* ../json/mapgen/faction_buildings.json also has to be updated to introduce an entry for the new expansion.
+* The mapgen update JSONs that define how the map will change when the upgrade mission is complete.  These may include shared instances of nested mapgen, such a standard room or tent.
+* The `recipe_group` JSONs that define what recipes can be crafted after completing the upgrade mission and what camps and expansions are available.
+* `data/json/overmap/overmap_terrain/overmap_terrain_faction_base.json` has to be updated to provide an overmap identifier for each new expansion.
+* `data/json/mapgen/faction_buildings.json` also has to be updated to introduce an entry for the new expansion.

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -111,6 +111,7 @@ struct basecamp_fuel {
 
 struct basecamp_upgrade {
     std::string bldg;
+    mapgen_arguments args;
     translation name;
     bool avail = false;
     bool in_progress = false;
@@ -303,7 +304,8 @@ class basecamp
                                        //  const std::vector<item*>& equipment, //  No support for extracting equipment from recipes currently..
                                        const std::map<skill_id, int> &required_skills = {} );
         void start_upgrade( const mission_id &miss_id );
-        std::string om_upgrade_description( const std::string &bldg, bool trunc = false ) const;
+        std::string om_upgrade_description( const std::string &bldg, const mapgen_arguments &,
+                                            bool trunc = false ) const;
         void start_menial_labor();
         void worker_assignment_ui();
         void job_assignment_ui();
@@ -415,13 +417,15 @@ class basecamp
 class basecamp_action_components
 {
     public:
-        basecamp_action_components( const recipe &making, int batch_size, basecamp & );
+        basecamp_action_components( const recipe &making, const mapgen_arguments &, int batch_size,
+                                    basecamp & );
 
         // Returns true iff all necessary components were successfully chosen
         bool choose_components();
         void consume_components();
     private:
         const recipe &making_;
+        const mapgen_arguments &args_;
         int batch_size_;
         basecamp &base_;
         std::vector<comp_selection<item_comp>> item_selections_;

--- a/src/build_reqs.h
+++ b/src/build_reqs.h
@@ -2,18 +2,39 @@
 #define CATA_SRC_BUILD_REQS_H
 
 #include <map>
+#include <unordered_map>
+#include <vector>
 
 #include "mapdata.h"
+#include "mapgendata.h"
+#include "requirements.h"
 #include "type_id.h"
 
 struct build_reqs {
     std::map<skill_id, int> skills;
-    std::map<requirement_id, int> reqs;
+    std::map<requirement_id, int> raw_reqs;
     int time = 0;
+
+    requirement_data consolidated_reqs;
+
+    template<typename Reqs1, typename Reqs2>
+    void consolidate( const Reqs1 &add_reqs1, const Reqs2 &add_reqs2 ) {
+        consolidated_reqs = requirement_data{ raw_reqs };
+        auto add_reqs = [&]( const auto & r ) {
+            consolidated_reqs = std::accumulate( r.begin(), r.end(), consolidated_reqs );
+        };
+        add_reqs( add_reqs1 );
+        add_reqs( add_reqs2 );
+        consolidated_reqs.consolidate();
+    }
 
     void clear() {
         *this = build_reqs();
     }
+};
+
+struct parameterized_build_reqs {
+    std::unordered_map<mapgen_arguments, build_reqs> reqs_by_parameters;
 };
 
 build_reqs get_build_reqs_for_furn_ter_ids(

--- a/src/cartesian_product.h
+++ b/src/cartesian_product.h
@@ -1,0 +1,51 @@
+#ifndef CATA_SRC_CARTESIAN_PRODUCT_H
+#define CATA_SRC_CARTESIAN_PRODUCT_H
+
+namespace cata
+{
+
+template<typename RangeOfRanges>
+auto cartesian_product( const RangeOfRanges &input )
+-> std::vector<std::vector<typename RangeOfRanges::value_type::value_type>>
+{
+    std::vector<std::vector<typename RangeOfRanges::value_type::value_type>> result;
+    using Iterators = std::vector<typename RangeOfRanges::value_type::const_iterator>;
+    Iterators iterators;
+    iterators.reserve( input.size() );
+    for( const auto &range : input ) {
+        if( range.empty() ) {
+            return result;
+        }
+        iterators.push_back( range.begin() );
+    }
+
+    while( true ) {
+        // Append the new result
+        result.emplace_back();
+        auto &new_list = result.back();
+        new_list.reserve( input.size() );
+        for( typename Iterators::value_type it : iterators ) {
+            new_list.push_back( *it );
+        }
+
+        // Increment the iterators
+        size_t i = 0;
+        for( ; i != input.size(); ++i ) {
+            auto &which_it = iterators[i];
+            const auto &range = input[i];
+            ++which_it;
+            if( which_it == range.end() ) {
+                which_it = range.begin();
+            } else {
+                break;
+            }
+        }
+        if( i == input.size() ) {
+            return result;
+        }
+    }
+}
+
+} // namespace cata
+
+#endif // CATA_SRC_CARTESIAN_PRODUCT_H

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2317,10 +2317,7 @@ build_reqs get_build_reqs_for_furn_ter_ids(
         const construction &build = build_data.first.obj();
         const int count = build_data.second;
         total_reqs.time += build.time * count;
-        if( total_reqs.reqs.find( build.requirements ) == total_reqs.reqs.end() ) {
-            total_reqs.reqs[build.requirements] = 0;
-        }
-        total_reqs.reqs[build.requirements] += count;
+        total_reqs.raw_reqs[build.requirements] += count;
         for( const auto &req_skill : build.required_skills ) {
             auto it = total_reqs.skills.find( req_skill.first );
             if( it == total_reqs.skills.end() || it->second < req_skill.second ) {

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -529,8 +529,6 @@ void basecamp::faction_display( const catacurses::window &fac_w, const int width
     std::string bldg = next_upgrade( base_camps::base_dir, 1 );
     std::string bldg_full = _( "Next Upgrade: " ) + bldg;
     mvwprintz( fac_w, point( width, ++y ), col, bldg_full );
-    std::string requirements = om_upgrade_description( bldg, true );
-    fold_and_print( fac_w, point( width, ++y ), getmaxx( fac_w ) - width - 2, col, requirements );
 }
 
 void faction::faction_display( const catacurses::window &fac_w, const int width ) const

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -693,7 +693,7 @@ void talk_function::start_camp( npc &p )
         }
     }
     const recipe &making = camp_type.obj();
-    if( !run_mapgen_update_func( making.get_blueprint(), omt_pos ) ) {
+    if( !run_mapgen_update_func( making.get_blueprint(), omt_pos, {} ) ) {
         popup( _( "%s failed to start the %s basecamp, perhaps there is a vehicle in the way." ),
                p.disp_name(), making.get_blueprint().str() );
         return;
@@ -751,7 +751,7 @@ void basecamp::add_available_recipes( mission_data &mission_key, mission_kind ki
 {
     const std::string dir_abbr = base_camps::all_directions.at( dir ).bracket_abbr.translated();
     for( const auto &recipe_data : craft_recipes ) {
-        const mission_id miss_id = {kind, recipe_data.first.str(), dir};
+        const mission_id miss_id = {kind, recipe_data.first.str(), {}, dir};
         const std::string &title_e = dir_abbr + recipe_data.second;
         const std::string &entry = craft_description( recipe_data.first );
         const recipe &recp = recipe_data.first.obj();
@@ -771,7 +771,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
 
     {
         // return legacy workers. How old is this legacy?...
-        mission_id miss_id = { Camp_Upgrade, "", dir };
+        mission_id miss_id = { Camp_Upgrade, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id ); // Don't match any blueprints
 
         if( !npc_list.empty() ) {
@@ -789,14 +789,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
 
         for( const basecamp_upgrade &upgrade : upgrades ) {
             miss_id.parameters = upgrade.bldg;
+            miss_id.mapgen_args = upgrade.args;
 
             comp_list npc_list = get_mission_workers( miss_id );
 
             if( npc_list.empty() ) {
-                entry = om_upgrade_description( upgrade.bldg );
-                mission_key.add_start( miss_id,
-                                       name_display_of( miss_id ), entry,
-                                       upgrade.avail );
+                std::string display_name = name_display_of( miss_id );
+                entry = om_upgrade_description( upgrade.bldg, upgrade.args );
+                mission_key.add_start( miss_id, display_name, entry, upgrade.avail );
             } else {
                 entry = action_of( miss_id.id );
                 bool avail = update_time_left( entry, npc_list );
@@ -808,7 +808,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
 
     if( has_provides( "gathering", dir ) ) {
-        const mission_id miss_id = { Camp_Gather_Materials, "", dir };
+        const mission_id miss_id = { Camp_Gather_Materials, "", {}, dir };
         std::string gather_bldg = "null";
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
@@ -832,7 +832,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
         }
     }
     if( has_provides( "firewood", dir ) ) {
-        const mission_id miss_id = { Camp_Collect_Firewood, "", dir };
+        const mission_id miss_id = { Camp_Collect_Firewood, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to gather light brush and stout branches.\n\n"
@@ -855,7 +855,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
         }
     }
     if( has_provides( "sorting", dir ) ) {
-        const mission_id miss_id = { Camp_Menial, "", dir };
+        const mission_id miss_id = { Camp_Menial, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to do low level chores and sort "
@@ -879,7 +879,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
 
     if( has_provides( "logging", dir ) ) {
-        const mission_id miss_id = { Camp_Cut_Logs, "", dir };
+        const mission_id miss_id = { Camp_Cut_Logs, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to a nearby forest to cut logs.\n\n"
@@ -905,7 +905,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
 
     if( has_provides( "logging", dir ) ) {
-        const mission_id miss_id = { Camp_Clearcut, "", dir };
+        const mission_id miss_id = { Camp_Clearcut, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to clear a nearby forest.\n\n"
@@ -931,7 +931,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
 
     if( has_provides( "relaying", dir ) ) {
-        const mission_id miss_id = { Camp_Setup_Hide_Site, "", dir };
+        const mission_id miss_id = { Camp_Setup_Hide_Site, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to build an improvised shelter and stock it "
@@ -956,7 +956,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
 
     if( has_provides( "relaying", dir ) ) {
-        const mission_id miss_id = { Camp_Relay_Hide_Site, "", dir };
+        const mission_id miss_id = { Camp_Relay_Hide_Site, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
                                   "Push gear out to a hide site or bring gear back from one.\n\n"
@@ -982,7 +982,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
 
     if( has_provides( "foraging", dir ) ) {
-        const mission_id miss_id = { Camp_Foraging, "", dir };
+        const mission_id miss_id = { Camp_Foraging, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to forage for edible plants.\n\n"
@@ -1006,7 +1006,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
 
     if( has_provides( "trapping", dir ) ) {
-        const mission_id miss_id = { Camp_Trapping, "", dir };
+        const mission_id miss_id = { Camp_Trapping, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to set traps for small game.\n\n"
@@ -1029,7 +1029,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
 
     if( has_provides( "hunting", dir ) ) {
-        const mission_id miss_id = { Camp_Hunting, "", dir };
+        const mission_id miss_id = { Camp_Hunting, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to hunt large animals.\n\n"
@@ -1052,9 +1052,11 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
 
     if( has_provides( "walls", dir ) ) {
-        mission_id miss_id = { Camp_OM_Fortifications, camp_om_fortifications_trench_parameter, dir };
+        mission_id miss_id = {
+            Camp_OM_Fortifications, camp_om_fortifications_trench_parameter, {}, dir
+        };
         comp_list npc_list = get_mission_workers( miss_id );
-        entry = om_upgrade_description( faction_wall_level_n_0_string );
+        entry = om_upgrade_description( faction_wall_level_n_0_string, {} );
         //  Should add check for materials as well as active mission.
         mission_key.add_start( miss_id, name_display_of( miss_id ),
                                entry, npc_list.empty() );
@@ -1065,7 +1067,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
                                     entry, avail );
         }
 
-        entry = om_upgrade_description( faction_wall_level_n_1_string );
+        entry = om_upgrade_description( faction_wall_level_n_1_string, {} );
         miss_id.parameters = camp_om_fortifications_spiked_trench_parameter;
         npc_list = get_mission_workers( miss_id );
         //  Should add check for materials as well as active mission.
@@ -1094,7 +1096,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
 
     if( has_provides( "recruiting", dir ) ) {
-        const mission_id miss_id = { Camp_Recruiting, "", dir };
+        const mission_id miss_id = { Camp_Recruiting, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = recruit_description( npc_list.size() );
         mission_key.add_start( miss_id, name_display_of( miss_id ), entry,
@@ -1108,7 +1110,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
 
     if( has_provides( "scouting", dir ) ) {
-        const mission_id miss_id = { Camp_Scouting, "", dir };
+        const mission_id miss_id = { Camp_Scouting, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
                                   "Send a companion out into the great unknown.  High survival "
@@ -1134,7 +1136,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
 
     if( has_provides( "patrolling", dir ) ) {
-        const mission_id miss_id = { Camp_Combat_Patrol, "", dir };
+        const mission_id miss_id = { Camp_Combat_Patrol, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to purge the wasteland.  Their goal is to "
@@ -1163,7 +1165,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
 
     if( has_provides( "dismantling",
                       dir ) ) {  //  Obsolete (during 0.E), but we still have to be able to process existing missions.
-        const mission_id miss_id = { Camp_Chop_Shop, "", dir };
+        const mission_id miss_id = { Camp_Chop_Shop, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         if( !npc_list.empty() ) {
             entry = action_of( miss_id.id );
@@ -1174,7 +1176,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
     std::map<recipe_id, translation> craft_recipes = recipe_deck( dir );
     {
-        mission_id miss_id = { Camp_Crafting, "", dir };
+        mission_id miss_id = { Camp_Crafting, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id, true );
         if( npc_list.size() < 3 ) {
             add_available_recipes( mission_key, Camp_Crafting, dir, craft_recipes );
@@ -1231,7 +1233,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
             ( !hidden_missions.empty() &&
               !hidden_missions[size_t( base_camps::all_directions.at( dir ).tab_order )].empty() ) ) {
             {
-                const mission_id miss_id = { Camp_Hide_Mission, "", dir };
+                const mission_id miss_id = { Camp_Hide_Mission, "", {}, dir };
                 entry = string_format( _( "Hide a mission to clean up the UI." ) );
                 mission_key.add( { miss_id, false }, name_display_of( miss_id ),
                                  entry );
@@ -1242,7 +1244,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
                     count = hidden_missions[base_camps::all_directions.at( dir ).tab_order].size();
                 }
 
-                const mission_id miss_id = { Camp_Reveal_Mission, "", dir };
+                const mission_id miss_id = { Camp_Reveal_Mission, "", {}, dir };
                 entry = string_format( _( "Reveal a mission previously hidden.\n"
                                           "Current number of hidden missions: %d" ),
                                        count );
@@ -1254,7 +1256,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
 
     if( has_provides( "farming", dir ) ) {
         size_t plots = 0;
-        const mission_id miss_id = { Camp_Plow, "", dir };
+        const mission_id miss_id = { Camp_Plow, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         if( npc_list.empty() ) {
             entry = _( "Notes:\n"
@@ -1280,7 +1282,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
     if( has_provides( "farming", dir ) ) {
         size_t plots = 0;
-        const mission_id miss_id = { Camp_Plant, "", dir };
+        const mission_id miss_id = { Camp_Plant, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         if( npc_list.empty() ) {
             entry = _( "Notes:\n"
@@ -1309,7 +1311,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
     }
     if( has_provides( "farming", dir ) ) {
         size_t plots = 0;
-        const mission_id miss_id = { Camp_Harvest, "", dir };
+        const mission_id miss_id = { Camp_Harvest, "", {}, dir };
         comp_list npc_list = get_mission_workers( miss_id );
         if( npc_list.empty() ) {
             entry = _( "Notes:\n"
@@ -1347,7 +1349,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
     // Missions that belong exclusively to the central tile
     {
         if( can_expand() ) {
-            const mission_id miss_id = { Camp_Survey_Expansion, "", base_dir };
+            const mission_id miss_id = { Camp_Survey_Expansion, "", {}, base_dir };
             comp_list npc_list = get_mission_workers( miss_id );
             entry = string_format( _( "Notes:\n"
                                       "Your base has become large enough to support an expansion.  "
@@ -1378,7 +1380,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
             // Unless maximum expansions have been reached, show "Expand Base",
             // but in a disabled state, with a message about what is required.
             if( directions.size() < 8 ) {
-                const mission_id miss_id = { Camp_Survey_Expansion, "", base_dir };
+                const mission_id miss_id = { Camp_Survey_Expansion, "", {}, base_dir };
                 entry = _( "You will need more beds before you can expand your base." );
                 mission_key.add_start( miss_id, name_display_of( miss_id ),
                                        entry, false );
@@ -1388,7 +1390,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
 
     if( !by_radio ) {
         {
-            const mission_id miss_id = { Camp_Distribute_Food, "", base_dir };
+            const mission_id miss_id = { Camp_Distribute_Food, "", {}, base_dir };
             entry = string_format( _( "Notes:\n"
                                       "Distribute food to your follower and fill your larders.  "
                                       "Place the food you wish to distribute in the camp food zone.  "
@@ -1410,7 +1412,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
         }
         {
             validate_assignees();
-            const mission_id miss_id = { Camp_Assign_Jobs, "", base_dir };
+            const mission_id miss_id = { Camp_Assign_Jobs, "", {}, base_dir };
             entry = string_format( _( "Notes:\n"
                                       "Assign repeating job duties to NPCs stationed here.\n"
                                       "Difficulty: N/A\n"
@@ -1420,13 +1422,13 @@ void basecamp::get_available_missions( mission_data &mission_key )
             mission_key.add( {miss_id, false}, name_display_of( miss_id ), entry );
         }
         {
-            const mission_id miss_id = { Camp_Assign_Workers, "", base_dir };
+            const mission_id miss_id = { Camp_Assign_Workers, "", {}, base_dir };
             entry = string_format( _( "Notes:\n"
                                       "Assign followers to work at this camp." ) );
             mission_key.add( {miss_id, false}, name_display_of( miss_id ), entry );
         }
         {
-            const mission_id miss_id = { Camp_Abandon, "", base_dir };
+            const mission_id miss_id = { Camp_Abandon, "", {}, base_dir };
             entry = _( "Notes:\nAbandon this camp" );
             mission_key.add( {miss_id, false}, name_display_of( miss_id ), entry );
         }
@@ -1440,7 +1442,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
     }
 
     if( !camp_workers.empty() ) {
-        const mission_id miss_id = { Camp_Emergency_Recall, "", base_dir };
+        const mission_id miss_id = { Camp_Emergency_Recall, "", {}, base_dir };
         entry = string_format( _( "Notes:\n"
                                   "Cancel a current mission and force the immediate return of a "
                                   "companion.  No work will be done on the mission and all "
@@ -1755,15 +1757,18 @@ comp_list basecamp::start_multi_mission( const mission_id &miss_id,
         // const std::vector<item*>& equipment, //  No support for extracting equipment from recipes currently..
         const std::map<skill_id, int> &required_skills )
 {
+    const recipe &making = *recipe_id( miss_id.parameters );
+    auto req_it = making.blueprint_build_reqs().reqs_by_parameters.find( miss_id.mapgen_args );
+    cata_assert( req_it != making.blueprint_build_reqs().reqs_by_parameters.end() );
+    const build_reqs &bld_reqs = req_it->second;
+    time_duration base_time = time_duration::from_moves( bld_reqs.time );
 
-    const recipe &making = recipe_id( miss_id.parameters ).obj();
     comp_list result;
 
     time_duration work_days;
 
     while( true ) { //  We'll break out of the loop when all the workers have been assigned
-        work_days = base_camps::to_workdays( making.batch_duration(
-                get_player_character() ) / ( result.size() + 1 ) );
+        work_days = base_camps::to_workdays( base_time / ( result.size() + 1 ) );
 
         if( must_feed && camp_food_supply() < time_to_food( work_days * ( result.size() + 1 ) ) ) {
             if( result.empty() ) {
@@ -1791,8 +1796,7 @@ comp_list basecamp::start_multi_mission( const mission_id &miss_id,
     if( result.empty() ) {
         return result;
     } else {
-        work_days = base_camps::to_workdays( making.batch_duration(
-                get_player_character() ) / result.size() );
+        work_days = base_camps::to_workdays( base_time / result.size() );
 
         for( npc_ptr &comp : result ) {
             comp->companion_mission_time_ret = calendar::turn + work_days;
@@ -1806,7 +1810,7 @@ comp_list basecamp::start_multi_mission( const mission_id &miss_id,
 
 void basecamp::start_upgrade( const mission_id &miss_id )
 {
-    const recipe &making = recipe_id( miss_id.parameters ).obj();
+    const recipe &making = *recipe_id( miss_id.parameters );
     if( making.get_blueprint().str() == faction_expansion_salt_water_pipe_swamp_N ) {
         start_salt_water_pipe( miss_id );
         return;
@@ -1815,18 +1819,22 @@ void basecamp::start_upgrade( const mission_id &miss_id )
         return;
     }
 
+    auto req_it = making.blueprint_build_reqs().reqs_by_parameters.find( miss_id.mapgen_args );
+    cata_assert( req_it != making.blueprint_build_reqs().reqs_by_parameters.end() );
+    const build_reqs &bld_reqs = req_it->second;
+    const requirement_data &reqs = bld_reqs.consolidated_reqs;
+
     //Stop upgrade if you don't have materials
-    if( making.deduped_requirements().can_make_with_inventory(
-            _inv, making.get_component_filter() ) ) {
+    if( reqs.can_make_with_inventory( _inv, making.get_component_filter() ) ) {
         bool must_feed = !making.has_flag( "NO_FOOD_REQ" );
 
-        basecamp_action_components components( making, 1, *this );
+        basecamp_action_components components( making, miss_id.mapgen_args, 1, *this );
         if( !components.choose_components() ) {
             return;
         }
 
         comp_list comp;
-        if( making.required_skills.empty() ) {
+        if( bld_reqs.skills.empty() ) {
             if( making.skill_used.is_valid() ) {
                 comp = start_multi_mission( miss_id, must_feed,
                                             _( "begins to upgrade the camp…" ),
@@ -1837,7 +1845,7 @@ void basecamp::start_upgrade( const mission_id &miss_id )
             }
         } else {
             comp = start_multi_mission( miss_id, must_feed, _( "begins to upgrade the camp…" ),
-                                        making.required_skills );
+                                        bld_reqs.skills );
         }
         if( comp.empty() ) {
             return;
@@ -2481,7 +2489,7 @@ void basecamp::start_fortifications( const mission_id &miss_id )
         }
 
         const int batch_size = fortify_om.size() * 2 - 2;
-        basecamp_action_components components( making, batch_size, *this );
+        basecamp_action_components components( making, {}, batch_size, *this );
         if( !components.choose_components() ) {
             return;
         }
@@ -2666,7 +2674,7 @@ bool basecamp::common_salt_water_pipe_construction(
         }
     }
 
-    basecamp_action_components components( making, 1, *this );
+    basecamp_action_components components( making, {}, 1, *this );
     if( !components.choose_components() ) {
         return false;
     }
@@ -2971,7 +2979,7 @@ void basecamp::start_crafting( const std::string &type, const mission_id &miss_i
             return;
         }
 
-        basecamp_action_components components( making, batch_size, *this );
+        basecamp_action_components components( making, {}, batch_size, *this );
         if( !components.choose_components() ) {
             return;
         }
@@ -3335,7 +3343,7 @@ bool basecamp::upgrade_return( const mission_id &miss_id )
         return false;
     }
     const tripoint_abs_omt upos = e->second.pos;
-    const recipe &making = recipe_id( bldg ).obj();
+    const recipe &making = *recipe_id( bldg );
 
     comp_list npc_list = get_mission_workers( miss_id );
     if( npc_list.empty() ) {
@@ -3370,8 +3378,8 @@ bool basecamp::upgrade_return( const mission_id &miss_id )
         return salt_water_pipe_return( miss_id, npc_list );
     }
 
-    if( !run_mapgen_update_func( making.get_blueprint(), upos, nullptr, true, mirror_horizontal,
-                                 mirror_vertical, rotation ) ) {
+    if( !run_mapgen_update_func( making.get_blueprint(), upos, miss_id.mapgen_args, nullptr, true,
+                                 mirror_horizontal, mirror_vertical, rotation ) ) {
         popup( _( "%s failed to build the %s upgrade, perhaps there is a vehicle in the way." ),
                companion_list,
                making.get_blueprint().str() );
@@ -3508,12 +3516,12 @@ void basecamp::fortifications_return( const mission_id &miss_id )
         for( size_t pt = 0; pt < build_point.size(); pt++ ) {
             //First point is always at top or west since they are built in a line and sorted
             if( pt == 0 ) {
-                run_mapgen_update_func( build_first, build_point[pt] );
+                run_mapgen_update_func( build_first, build_point[pt], {} );
             } else if( pt == build_point.size() - 1 ) {
-                run_mapgen_update_func( build_second, build_point[pt] );
+                run_mapgen_update_func( build_second, build_point[pt], {} );
             } else {
-                run_mapgen_update_func( build_first, build_point[pt] );
-                run_mapgen_update_func( build_second, build_point[pt] );
+                run_mapgen_update_func( build_first, build_point[pt], {} );
+                run_mapgen_update_func( build_second, build_point[pt], {} );
             }
             if( miss_id.parameters == faction_wall_level_n_0_string ||
                 //  Handling of old format (changed mid 0.F) below
@@ -3619,12 +3627,12 @@ bool basecamp::salt_water_pipe_swamp_return( const mission_id &miss_id,
 
     if( orthogonal ) {
         const update_mapgen_id id{ faction_expansion_salt_water_pipe_swamp_N };
-        run_mapgen_update_func( id, pipe->segments[segment_number].point, nullptr, true, mirror_horizontal,
-                                mirror_vertical, rotation );
+        run_mapgen_update_func( id, pipe->segments[segment_number].point, {}, nullptr, true,
+                                mirror_horizontal, mirror_vertical, rotation );
     } else {
         const update_mapgen_id id{ faction_expansion_salt_water_pipe_swamp_NE };
-        run_mapgen_update_func( id, pipe->segments[segment_number].point, nullptr, true, mirror_horizontal,
-                                mirror_vertical, rotation );
+        run_mapgen_update_func( id, pipe->segments[segment_number].point, {}, nullptr, true,
+                                mirror_horizontal, mirror_vertical, rotation );
     }
 
     pipe->segments[segment_number].finished = true;
@@ -3713,12 +3721,12 @@ bool basecamp::salt_water_pipe_return( const mission_id &miss_id,
 
     if( orthogonal ) {
         const update_mapgen_id id{ faction_expansion_salt_water_pipe_N };
-        run_mapgen_update_func( id, pipe->segments[segment_number].point, nullptr, true, mirror_horizontal,
-                                mirror_vertical, rotation );
+        run_mapgen_update_func( id, pipe->segments[segment_number].point, {}, nullptr, true,
+                                mirror_horizontal, mirror_vertical, rotation );
     } else {
         const update_mapgen_id id{ faction_expansion_salt_water_pipe_NE };
-        run_mapgen_update_func( id, pipe->segments[segment_number].point, nullptr, true, mirror_horizontal,
-                                mirror_vertical, rotation );
+        run_mapgen_update_func( id, pipe->segments[segment_number].point, {}, nullptr, true,
+                                mirror_horizontal, mirror_vertical, rotation );
     }
 
     salt_water_pipe_orientation_adjustment( next_construction_direction, orthogonal, mirror_vertical,
@@ -3726,12 +3734,12 @@ bool basecamp::salt_water_pipe_return( const mission_id &miss_id,
 
     if( orthogonal ) {
         const update_mapgen_id id{ faction_expansion_salt_water_pipe_N };
-        run_mapgen_update_func( id, pipe->segments[segment_number].point, nullptr, true, mirror_horizontal,
-                                mirror_vertical, rotation );
+        run_mapgen_update_func( id, pipe->segments[segment_number].point, {}, nullptr, true,
+                                mirror_horizontal, mirror_vertical, rotation );
     } else {
         const update_mapgen_id id{ faction_expansion_salt_water_pipe_NE };
-        run_mapgen_update_func( id, pipe->segments[segment_number].point, nullptr, true, mirror_horizontal,
-                                mirror_vertical, rotation );
+        run_mapgen_update_func( id, pipe->segments[segment_number].point, {}, nullptr, true,
+                                mirror_horizontal, mirror_vertical, rotation );
     }
 
     pipe->segments[segment_number].finished = true;
@@ -3975,7 +3983,7 @@ bool basecamp::survey_return( const mission_id &miss_id )
         return false;
     }
 
-    if( !run_mapgen_update_func( update_mapgen_id( expansion_type.str() ), where, nullptr, true,
+    if( !run_mapgen_update_func( update_mapgen_id( expansion_type.str() ), where, {}, nullptr, true,
                                  mirror_horizontal, mirror_vertical, rotation ) ) {
         popup( _( "%s failed to add the %s expansion, perhaps there is a vehicle in the way." ),
                comp->disp_name(),
@@ -5114,16 +5122,26 @@ std::string basecamp::name_display_of( const mission_id &miss_id )
         case Camp_Harvest:
             return mission_ui_activity_of( miss_id );
 
-        case Camp_Upgrade:
+        case Camp_Upgrade: {
             upgrades = available_upgrades( miss_id.dir.value() );
 
-            for( basecamp_upgrade &upgrade : upgrades ) {
-                if( upgrade.bldg == miss_id.parameters ) {
-                    return mission_ui_activity_of( miss_id ) + upgrade.name;
-                }
+            auto upgrade_it = std::find_if(
+                                  upgrades.begin(), upgrades.end(),
+            [&]( const basecamp_upgrade & upgrade ) {
+                return upgrade.bldg == miss_id.parameters;
+            } );
+            if( upgrade_it == upgrades.end() ) {
+                return mission_ui_activity_of( miss_id ) + _( "<No longer valid construction>" );
             }
-            return mission_ui_activity_of( miss_id ) + _( "<No longer valid construction>" );
-
+            std::string result = mission_ui_activity_of( miss_id ) + upgrade_it->name;
+            const recipe &rec = *recipe_id( upgrade_it->bldg );
+            for( const std::pair<const std::string, cata_variant> &arg : miss_id.mapgen_args.map ) {
+                result +=
+                    string_format(
+                        " (%s)", rec.blueprint_parameter_ui_string( arg.first, arg.second ) );
+            }
+            return result;
+        }
         case Camp_Crafting: {
             const std::string dir_id = base_camps::all_directions.at( miss_id.dir.value() ).id;
             const std::string dir_abbr = base_camps::all_directions.at(

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -131,7 +131,7 @@ bool cardreader_examine_actor::apply( const tripoint &examp ) const
     map &here = get_map();
     if( map_regen ) {
         tripoint_abs_omt omt_pos( ms_to_omt_copy( here.getabs( examp ) ) );
-        if( !run_mapgen_update_func( mapgen_id, omt_pos, nullptr, false ) ) {
+        if( !run_mapgen_update_func( mapgen_id, omt_pos, {}, nullptr, false ) ) {
             debugmsg( "Failed to apply magen function %s", mapgen_id.str() );
         }
         here.set_seen_cache_dirty( examp );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3985,7 +3985,8 @@ void mapgen_palette::reset()
 
 void mapgen_palette::add( const mapgen_value<std::string> &rh, const add_palette_context &context )
 {
-    std::vector<std::string> possible_values = rh.all_possible_results( *context.parameters );
+    std::vector<std::string> possible_values =
+        rh.all_possible_results( *context.current_parameters );
     if( possible_values.empty() ) {
         if( const std::string *param_name = rh.get_name_if_parameter() ) {
             debugmsg( "Parameter %s used for palette id in %s but has no possible values",
@@ -4002,7 +4003,7 @@ void mapgen_palette::add( const mapgen_value<std::string> &rh, const add_palette
             param_name = *name;
         } else {
             const auto param_it =
-                context.parameters->add_unique_parameter(
+                context.top_level_parameters->add_unique_parameter(
                     "palette_choice_", rh, cata_variant_type::palette_id,
                     mapgen_parameter_scope::overmap_special );
             param_name = param_it->first;
@@ -4040,6 +4041,7 @@ void mapgen_palette::add( const mapgen_palette &rh, const add_palette_context &c
     }
     add_palette_context new_context = context;
     new_context.ancestors.push_back( rh.id );
+    new_context.current_parameters = &rh.parameters;
 
     for( const mapgen_value<std::string> &recursive_palette : rh.palettes_used ) {
         add( recursive_palette, new_context );
@@ -4146,7 +4148,8 @@ mapgen_palette mapgen_palette::load_internal( const JsonObject &jo, const std::s
 mapgen_palette::add_palette_context::add_palette_context(
     const std::string &ctx, mapgen_parameters *params )
     : context( ctx )
-    , parameters( params )
+    , top_level_parameters( params )
+    , current_parameters( params )
 {}
 
 bool mapgen_function_json::setup_internal( const JsonObject &jo )

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3986,8 +3986,15 @@ void mapgen_palette::reset()
 void mapgen_palette::add( const mapgen_value<std::string> &rh, const add_palette_context &context )
 {
     std::vector<std::string> possible_values = rh.all_possible_results( *context.parameters );
-    cata_assert( !possible_values.empty() );
-    if( possible_values.size() == 1 ) {
+    if( possible_values.empty() ) {
+        if( const std::string *param_name = rh.get_name_if_parameter() ) {
+            debugmsg( "Parameter %s used for palette id in %s but has no possible values",
+                      *param_name, context.context );
+        } else {
+            debugmsg( "Mapgen value for used for palette id in %s has no possible values",
+                      context.context );
+        }
+    } else if( possible_values.size() == 1 ) {
         add( palette_id( possible_values.front() ), context );
     } else {
         std::string param_name;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -510,6 +510,24 @@ const nested_mapgen &string_id<nested_mapgen>::obj() const
     return it->second;
 }
 
+template<>
+bool string_id<update_mapgen>::is_valid() const
+{
+    return str() == "null" || update_mapgens.find( *this ) != update_mapgens.end();
+}
+
+template<>
+const update_mapgen &string_id<update_mapgen>::obj() const
+{
+    auto it = update_mapgens.find( *this );
+    if( it == update_mapgens.end() ) {
+        debugmsg( "Using invalid nested_mapgen_id %s", str() );
+        static const update_mapgen null_mapgen;
+        return null_mapgen;
+    }
+    return it->second;
+}
+
 /*
  * setup mapgen_basic_container::weights_ which mapgen uses to diceroll. Also setup mapgen_function_json
  */
@@ -1129,6 +1147,9 @@ class mapgen_value
                 const value_source &, const std::string &context ) const = 0;
             virtual std::vector<StringId> all_possible_results(
                 const mapgen_parameters & ) const = 0;
+            virtual const std::string *get_name_if_parameter() const {
+                return nullptr;
+            }
         };
 
         struct null_source : value_source {
@@ -1256,6 +1277,10 @@ class mapgen_value
                     }
                     return result;
                 }
+            }
+
+            const std::string *get_name_if_parameter() const override {
+                return &param_name;
             }
         };
 
@@ -1446,6 +1471,10 @@ class mapgen_value
             return source_->all_possible_results( params );
         }
 
+        const std::string *get_name_if_parameter() const {
+            return source_->get_name_if_parameter();
+        }
+
         void deserialize( const JsonValue &jsin ) {
             if( jsin.test_object() ) {
                 *this = mapgen_value( jsin.get_object() );
@@ -1603,12 +1632,14 @@ mapgen_arguments mapgen_parameters::get_args(
 {
     std::unordered_map<std::string, cata_variant> result;
     for( const std::pair<const std::string, mapgen_parameter> &p : map ) {
+        const std::string &param_name = p.first;
         const mapgen_parameter &param = p.second;
         if( param.scope() == scope ) {
-            result.emplace( p.first, param.get( md ) );
+            cata_variant value = md.get_arg_or( param_name, param.get( md ) );
+            result.emplace( param_name, value );
         }
     }
-    return { std::move( result ) };
+    return mapgen_arguments{ result };
 }
 
 void mapgen_parameters::check_and_merge( const mapgen_parameters &other,
@@ -3959,11 +3990,16 @@ void mapgen_palette::add( const mapgen_value<std::string> &rh, const add_palette
     if( possible_values.size() == 1 ) {
         add( palette_id( possible_values.front() ), context );
     } else {
-        const auto param_it =
-            context.parameters->add_unique_parameter(
-                "palette_choice_", rh, cata_variant_type::palette_id,
-                mapgen_parameter_scope::overmap_special );
-        const std::string &param_name = param_it->first;
+        std::string param_name;
+        if( const std::string *name = rh.get_name_if_parameter() ) {
+            param_name = *name;
+        } else {
+            const auto param_it =
+                context.parameters->add_unique_parameter(
+                    "palette_choice_", rh, cata_variant_type::palette_id,
+                    mapgen_parameter_scope::overmap_special );
+            param_name = param_it->first;
+        }
         add_palette_context context_with_extra_constraint( context );
         for( const std::string &value : possible_values ) {
             palette_id val_id( value );
@@ -7628,8 +7664,9 @@ bool update_mapgen_function_json::setup_internal( const JsonObject &/*jo*/ )
     return true;
 }
 
-bool update_mapgen_function_json::update_map( const tripoint_abs_omt &omt_pos, const point &offset,
-        mission *miss, bool verify, bool mirror_horizontal, bool mirror_vertical, int rotation ) const
+bool update_mapgen_function_json::update_map(
+    const tripoint_abs_omt &omt_pos, const mapgen_arguments &args, const point &offset,
+    mission *miss, bool verify, bool mirror_horizontal, bool mirror_vertical, int rotation ) const
 {
     if( omt_pos == overmap::invalid_tripoint ) {
         debugmsg( "Mapgen update function called with overmap::invalid_tripoint" );
@@ -7644,7 +7681,8 @@ bool update_mapgen_function_json::update_map( const tripoint_abs_omt &omt_pos, c
     update_tmap.rotate( 4 - rotation );
     update_tmap.mirror( mirror_horizontal, mirror_vertical );
 
-    mapgendata md( omt_pos, update_tmap, 0.0f, calendar::start_of_cataclysm, miss );
+    mapgendata md_base( omt_pos, update_tmap, 0.0f, calendar::start_of_cataclysm, miss );
+    mapgendata md( md_base, args );
 
     bool const u = update_map( md, offset, verify );
     update_tmap.mirror( mirror_horizontal, mirror_vertical );
@@ -7700,7 +7738,7 @@ mapgen_update_func add_mapgen_update_func( const JsonObject &jo, bool &defer )
         const update_mapgen_id mapgen_update_id{ jo.get_string( "mapgen_update_id" ) };
         const auto update_function = [mapgen_update_id]( const tripoint_abs_omt & omt_pos,
         mission * miss ) {
-            run_mapgen_update_func( mapgen_update_id, omt_pos, miss, false );
+            run_mapgen_update_func( mapgen_update_id, omt_pos, {}, miss, false );
         };
         return update_function;
     }
@@ -7714,7 +7752,7 @@ mapgen_update_func add_mapgen_update_func( const JsonObject &jo, bool &defer )
         return null_function;
     }
     const auto update_function = [json_data]( const tripoint_abs_omt & omt_pos, mission * miss ) {
-        json_data.update_map( omt_pos, point_zero, miss );
+        json_data.update_map( omt_pos, {}, point_zero, miss );
     };
     defer = mapgen_defer::defer;
     mapgen_defer::jsi = JsonObject();
@@ -7722,8 +7760,9 @@ mapgen_update_func add_mapgen_update_func( const JsonObject &jo, bool &defer )
 }
 
 bool run_mapgen_update_func(
-    const update_mapgen_id &update_mapgen_id, const tripoint_abs_omt &omt_pos, mission *miss,
-    bool cancel_on_collision, bool mirror_horizontal, bool mirror_vertical, int rotation )
+    const update_mapgen_id &update_mapgen_id, const tripoint_abs_omt &omt_pos,
+    const mapgen_arguments &args, mission *miss, bool cancel_on_collision, bool mirror_horizontal,
+    bool mirror_vertical, int rotation )
 {
     const auto update_function = update_mapgens.find( update_mapgen_id );
 
@@ -7731,8 +7770,8 @@ bool run_mapgen_update_func(
         return false;
     }
     return update_function->second.funcs()[0]->update_map(
-               omt_pos, point_zero, miss, cancel_on_collision, mirror_horizontal, mirror_vertical,
-               rotation );
+               omt_pos, args, point_zero, miss, cancel_on_collision, mirror_horizontal,
+               mirror_vertical, rotation );
 }
 
 bool run_mapgen_update_func( const update_mapgen_id &update_mapgen_id, mapgendata &dat,
@@ -7746,7 +7785,8 @@ bool run_mapgen_update_func( const update_mapgen_id &update_mapgen_id, mapgendat
 }
 
 std::pair<std::map<ter_id, int>, std::map<furn_id, int>> get_changed_ids_from_update(
-            const update_mapgen_id &update_mapgen_id, ter_id const &base_ter )
+            const update_mapgen_id &update_mapgen_id,
+            const mapgen_arguments &mapgen_args, ter_id const &base_ter )
 {
     std::map<ter_id, int> terrains;
     std::map<furn_id, int> furnitures;
@@ -7759,7 +7799,8 @@ std::pair<std::map<ter_id, int>, std::map<furn_id, int>> get_changed_ids_from_up
 
     fake_map tmp_map( base_ter );
 
-    mapgendata fake_md( tmp_map, mapgendata::dummy_settings );
+    mapgendata base_fake_md( tmp_map, mapgendata::dummy_settings );
+    mapgendata fake_md( base_fake_md, mapgen_args );
     fake_md.skip = { mapgen_phase::zones };
 
     if( update_function->second.funcs()[0]->update_map( fake_md ) ) {

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -354,7 +354,8 @@ class mapgen_palette
 
             std::string context;
             std::vector<palette_id> ancestors;
-            mapgen_parameters *parameters;
+            mapgen_parameters *top_level_parameters;
+            const mapgen_parameters *current_parameters;
             std::vector<mapgen_constraint<palette_id>> constraints;
         };
 

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -434,6 +434,10 @@ class mapgen_function_json_base
 
         void add_placement_coords_to( std::unordered_set<point> & ) const;
 
+        const mapgen_parameters &get_parameters() const {
+            return parameters;
+        }
+
     private:
         JsonObject jsobj;
     protected:
@@ -501,9 +505,10 @@ class update_mapgen_function_json : public mapgen_function_json_base
         bool setup_update( const JsonObject &jo );
         void finalize_parameters();
         void check() const;
-        bool update_map( const tripoint_abs_omt &omt_pos, const point &offset,
-                         mission *miss, bool verify = false,
-                         bool mirror_horizontal = false, bool mirror_vertical = false, int rotation = 0 ) const;
+        bool update_map(
+            const tripoint_abs_omt &omt_pos, const mapgen_arguments &, const point &offset,
+            mission *miss, bool verify = false, bool mirror_horizontal = false,
+            bool mirror_vertical = false, int rotation = 0 ) const;
         bool update_map( const mapgendata &md, const point &offset = point_zero,
                          bool verify = false ) const;
 

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -14,6 +14,7 @@
 class map;
 class mapgendata;
 class mission;
+struct mapgen_arguments;
 struct mapgen_parameters;
 struct point;
 struct tripoint;
@@ -74,14 +75,17 @@ void madd_field( map *m, const point &, field_type_id type, int intensity );
 void mremove_fields( map *m, const point & );
 
 mapgen_update_func add_mapgen_update_func( const JsonObject &jo, bool &defer );
-bool run_mapgen_update_func( const update_mapgen_id &, const tripoint_abs_omt &omt_pos,
-                             mission *miss = nullptr, bool cancel_on_collision = true,
-                             bool mirror_horizontal = false, bool mirror_vertical = false, int rotation = 0 );
+bool run_mapgen_update_func(
+    const update_mapgen_id &, const tripoint_abs_omt &omt_pos, const mapgen_arguments &,
+    mission *miss = nullptr, bool cancel_on_collision = true, bool mirror_horizontal = false,
+    bool mirror_vertical = false, int rotation = 0 );
 bool run_mapgen_update_func( const update_mapgen_id &, mapgendata &dat,
                              bool cancel_on_collision = true );
 bool run_mapgen_func( const std::string &mapgen_id, mapgendata &dat );
-std::pair<std::map<ter_id, int>, std::map<furn_id, int>> get_changed_ids_from_update(
-            const update_mapgen_id &, ter_id const &base_ter = t_dirt );
+std::pair<std::map<ter_id, int>, std::map<furn_id, int>>
+        get_changed_ids_from_update(
+            const update_mapgen_id &, const mapgen_arguments &,
+            ter_id const &base_ter = t_dirt );
 mapgen_parameters get_map_special_params( const std::string &mapgen_id );
 
 void resolve_regional_terrain_and_furniture( const mapgendata &dat );

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -2,6 +2,7 @@
 
 #include "all_enum_values.h"
 #include "debug.h"
+#include "hash_utils.h"
 #include "json.h"
 #include "map.h"
 #include "mapdata.h"
@@ -26,6 +27,18 @@ void mapgen_arguments::deserialize( const JsonValue &ji )
 {
     ji.read( map, true );
 }
+
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+namespace std
+{
+
+size_t hash<mapgen_arguments>::operator()( const mapgen_arguments &args ) const noexcept
+{
+    cata::range_hash h;
+    return h( args.map );
+}
+
+} // namespace std
 
 static const regional_settings dummy_regional_settings;
 

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -24,12 +24,42 @@ enum class type : int;
 } // namespace om_direction
 
 struct mapgen_arguments {
+    mapgen_arguments() = default;
+
+    template <
+        typename InputRange,
+        std::enable_if_t <
+            std::is_same <
+                typename InputRange::value_type, std::pair<std::string, cata_variant>
+                >::value ||
+            std::is_same <
+                typename InputRange::value_type, std::pair<const std::string, cata_variant>
+                >::value
+            > * = nullptr >
+    explicit mapgen_arguments( const InputRange &map_ )
+        : map( map_.begin(), map_.end() )
+    {}
+
     std::unordered_map<std::string, cata_variant> map;
+
+    bool operator==( const mapgen_arguments &other ) const {
+        return map == other.map;
+    }
 
     void merge( const mapgen_arguments & );
     void serialize( JsonOut & ) const;
     void deserialize( const JsonValue &ji );
 };
+
+namespace std
+{
+
+template<>
+struct hash<mapgen_arguments> {
+    size_t operator()( const mapgen_arguments & ) const noexcept;
+};
+
+} // namespace std
 
 namespace mapgendata_detail
 {
@@ -44,6 +74,11 @@ template<>
 inline std::string extract_variant_value<std::string>( const cata_variant &v )
 {
     return v.get_string();
+}
+template<>
+inline cata_variant extract_variant_value<cata_variant>( const cata_variant &v )
+{
+    return v;
 }
 
 } // namespace mapgendata_detail

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -133,6 +133,58 @@ struct miss_data {
     std::string serialize_id;  // Serialized string for enum
     translation action;        // Optional extended UI description of task for return.
 };
+namespace io
+{
+
+template<>
+std::string enum_to_string<mission_kind>( mission_kind data )
+{
+    switch( data ) {
+        // *INDENT-OFF*
+        case mission_kind::No_Mission: return "No_Mission";
+        case mission_kind::Scavenging_Patrol_Job: return "Scavenging_Patrol_Job";
+        case mission_kind::Scavenging_Raid_Job: return "Scavenging_Raid_Job";
+        case mission_kind::Hospital_Raid_Job: return "Hospital_Raid_Job";
+        case mission_kind::Menial_Job: return "Menial_Job";
+        case mission_kind::Carpentry_Job: return "Carpentry_Job";
+        case mission_kind::Forage_Job: return "Forage_Job";
+        case mission_kind::Caravan_Commune_Center_Job: return "Caravan_Commune_Center_Job";
+        case mission_kind::Camp_Distribute_Food: return "Camp_Distribute_Food";
+        case mission_kind::Camp_Hide_Mission: return "Camp_Hide_Mission";
+        case mission_kind::Camp_Reveal_Mission: return "Camp_Reveal_Mission";
+        case mission_kind::Camp_Assign_Jobs: return "Camp_Assign_Jobs";
+        case mission_kind::Camp_Assign_Workers: return "Camp_Assign_Workers";
+        case mission_kind::Camp_Abandon: return "Camp_Abandon";
+        case mission_kind::Camp_Upgrade: return "Camp_Upgrade";
+        case mission_kind::Camp_Emergency_Recall: return "Camp_Emergency_Recall";
+        case mission_kind::Camp_Crafting: return "Camp_Crafting";
+        case mission_kind::Camp_Gather_Materials: return "Camp_Gather_Materials";
+        case mission_kind::Camp_Collect_Firewood: return "Camp_Collect_Firewood";
+        case mission_kind::Camp_Menial: return "Camp_Menial";
+        case mission_kind::Camp_Survey_Expansion: return "Camp_Survey_Expansion";
+        case mission_kind::Camp_Cut_Logs: return "Camp_Cut_Logs";
+        case mission_kind::Camp_Clearcut: return "Camp_Clearcut";
+        case mission_kind::Camp_Setup_Hide_Site: return "Camp_Setup_Hide_Site";
+        case mission_kind::Camp_Relay_Hide_Site: return "Camp_Relay_Hide_Site";
+        case mission_kind::Camp_Foraging: return "Camp_Foraging";
+        case mission_kind::Camp_Trapping: return "Camp_Trapping";
+        case mission_kind::Camp_Hunting: return "Camp_Hunting";
+        case mission_kind::Camp_OM_Fortifications: return "Camp_OM_Fortifications";
+        case mission_kind::Camp_Recruiting: return "Camp_Recruiting";
+        case mission_kind::Camp_Scouting: return "Camp_Scouting";
+        case mission_kind::Camp_Combat_Patrol: return "Camp_Combat_Patrol";
+        case mission_kind::Camp_Chop_Shop: return "Camp_Chop_Shop";
+        case mission_kind::Camp_Plow: return "Camp_Plow";
+        case mission_kind::Camp_Plant: return "Camp_Plant";
+        case mission_kind::Camp_Harvest: return "Camp_Harvest";
+        // *INDENT-ON*
+        case mission_kind::last_mission_kind:
+            break;
+    }
+    cata_fatal( "Invalid event_type" );
+}
+
+} // namespace io
 
 static const std::array < miss_data, Camp_Harvest + 1 > miss_info = { {
         {
@@ -300,156 +352,159 @@ bool is_equal( const mission_id &first, const mission_id &second )
 
 void reset_miss_id( mission_id &miss_id )
 {
-    miss_id.id = No_Mission;
-    miss_id.parameters.clear();
-    miss_id.dir.reset();
+    miss_id = {};
 }
 
-std::string string_of( mission_id miss_id )
+void mission_id::serialize( JsonOut &jsout ) const
 {
-    if( miss_id.id == No_Mission ) {
-        return "";  //  Throw exception? Should never happen
-    }
-
-    if( miss_id.dir.has_value() ) {
-        return miss_info[miss_id.id].serialize_id + miss_id.parameters + base_camps::all_directions.at(
-                   miss_id.dir.value() ).id;
-    } else {
-        return miss_info[miss_id.id].serialize_id + miss_id.parameters;
-    }
+    jsout.start_object();
+    jsout.member_as_string( "id", id );
+    jsout.member( "parameters", parameters );
+    jsout.member( "mapgen_args", mapgen_args );
+    jsout.member( "dir", dir );
+    jsout.end_object();
 }
 
-mission_id mission_id_of( const std::string &str )
+void mission_id::deserialize( const JsonValue &val )
 {
-    mission_id result = { No_Mission, "", {}, cata::nullopt };
-    size_t id_size = str.length();
+    *this = { No_Mission, "", {}, cata::nullopt };
+    if( val.test_object() ) {
+        JsonObject obj = val.get_object();
+        obj.read( "id", id );
+        obj.read( "parameters", parameters );
+        obj.read( "mapgen_args", mapgen_args );
+        obj.read( "dir", dir );
+    } else if( val.test_string() ) {
+        // Legacy values are stored as a string where the pieces need to be
+        // parsed out.  Replaced during 0.G.
+        std::string str = val.get_string();
+        size_t id_size = str.length();
 
-    if( id_size == 0 ) {
-        return result;
-    }
-
-    for( const auto &direction : base_camps::all_directions ) {
-        if( string_ends_with( str, direction.second.id ) ) {
-            result.dir = direction.first;
-            id_size = str.length() - direction.second.id.length();
-            break;
+        if( id_size == 0 ) {
+            return;
         }
-    }
 
-    std::string st = str.substr( 0, id_size );
-
-    for( int i = No_Mission + 1; i <= Camp_Harvest; i++ ) {
-        if( st.length() >= miss_info[i].serialize_id.length() &&
-            st.substr( 0, miss_info[i].serialize_id.length() ) == miss_info[i].serialize_id ) {
-            if( st.length() == miss_info[i].serialize_id.length() ) {
-                result.id = static_cast<mission_kind>( i );
-                return result;
-            } else {
-                result.id = static_cast<mission_kind>( i );
-                result.parameters = st.substr( miss_info[i].serialize_id.length() );
-                return result;
+        for( const auto &direction : base_camps::all_directions ) {
+            if( string_ends_with( str, direction.second.id ) ) {
+                dir = direction.first;
+                id_size = str.length() - direction.second.id.length();
+                break;
             }
         }
+
+        std::string st = str.substr( 0, id_size );
+
+        for( int i = No_Mission + 1; i <= Camp_Harvest; i++ ) {
+            if( st.length() >= miss_info[i].serialize_id.length() &&
+                st.substr( 0, miss_info[i].serialize_id.length() ) == miss_info[i].serialize_id ) {
+                if( st.length() == miss_info[i].serialize_id.length() ) {
+                    id = static_cast<mission_kind>( i );
+                    return;
+                } else {
+                    id = static_cast<mission_kind>( i );
+                    parameters = st.substr( miss_info[i].serialize_id.length() );
+                    return;
+                }
+            }
+        }
+
+        // Even older legacy definition matching (replaced during 0.F)
+        if( str == "_scavenging_patrol" ) {
+            id = Scavenging_Patrol_Job;
+        } else if( str == "_scavenging_raid" ) {
+            id = Scavenging_Raid_Job;
+        } else if( str == "_labor" ) {
+            id = Menial_Job;
+        } else if( str == "_carpenter" ) {
+            id = Carpentry_Job;
+        } else if( str == "_forage" ) {
+            id = Forage_Job;
+        } else if( str == "_commune_refugee_caravan" ) {
+            id = Caravan_Commune_Center_Job;
+        }
+        //  The farm field actions do not result in npc missions
+
+        else if( string_ends_with( str, camp_upgrade_npc_string ) ) {  //  blueprint + id
+            id = Camp_Upgrade;
+            parameters = str.substr( 0, str.length() - camp_upgrade_npc_string.length() );
+            dir = base_camps::base_dir;
+        }  //  Camp_Emergency_Recall is an immediate action, and so isn't serialized
+
+        else if( st == "_faction_camp_crafting_" ) { //  id + dir
+            id = Camp_Crafting;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_gathering" ) {
+            id = Camp_Gather_Materials;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_firewood" ) {
+            id = Camp_Collect_Firewood;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_menial" ) {
+            id = Camp_Menial;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_expansion" ) {
+            id = Camp_Survey_Expansion;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_cut_log" ) {
+            id = Camp_Cut_Logs;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_clearcut" ) {
+            id = Camp_Clearcut;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_hide_site" ) {
+            id = Camp_Setup_Hide_Site;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_hide_trans" ) {
+            id = Camp_Relay_Hide_Site;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_foraging" ) {
+            id = Camp_Foraging;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_trapping" ) {
+            id = Camp_Trapping;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_hunting" ) {
+            id = Camp_Hunting;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_om_fortifications" ) {
+            //  This legacy mission version hides the blueprint as a mission role rather than a string component
+            id = Camp_OM_Fortifications;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_recruit_0" ) {
+            id = Camp_Recruiting;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_scout_0" ) {
+            id = Camp_Scouting;
+            dir = base_camps::base_dir;
+        } else if( str == "_faction_camp_combat_0" ) {
+            id = Camp_Combat_Patrol;
+            dir = base_camps::base_dir;
+        } else if( id_size >= camp_upgrade_expansion_npc_string.length() &&
+                   st.substr( id_size - camp_upgrade_expansion_npc_string.length() ) ==
+                   camp_upgrade_expansion_npc_string ) { // blueprint + id + dir
+            id = Camp_Upgrade;
+            parameters = st.substr( 0, id_size - camp_upgrade_expansion_npc_string.length() );
+        } else if( st == "_faction_exp_chop_shop_" ) {        // id + dir
+            id = Camp_Chop_Shop;
+        } else if( st == "_faction_exp_kitchen_cooking_" ||   // id + dir
+                   st == "_faction_exp_blacksmith_crafting_" ||
+                   st == "_faction_exp_farm_crafting_" ) {
+            id = Camp_Crafting;
+        } else if( st == "_faction_exp_plow_" ) {             // id + dir
+            id = Camp_Plow;
+        } else if( st == "_faction_exp_plant_" ) {            // id + dir
+            id = Camp_Plant;
+        } else if( st == "_faction_exp_harvest_" ) {          // id + dir
+            id = Camp_Harvest;
+        }
+
+        if( id == No_Mission ) {
+            debugmsg(
+                "Unrecognized npc mission id string encountered: '%s'", str );
+        }
+    } else {
+        debugmsg( "Mission id in JSON should be either a string or object, but was neither" );
     }
-
-    //  Legacy definition matching (replaced during 0.F)
-    st = str.substr( 0, id_size );
-
-    if( str == "_scavenging_patrol" ) {
-        result.id = Scavenging_Patrol_Job;
-    } else if( str == "_scavenging_raid" ) {
-        result.id = Scavenging_Raid_Job;
-    } else if( str == "_labor" ) {
-        result.id = Menial_Job;
-    } else if( str == "_carpenter" ) {
-        result.id = Carpentry_Job;
-    } else if( str == "_forage" ) {
-        result.id = Forage_Job;
-    } else if( str == "_commune_refugee_caravan" ) {
-        result.id = Caravan_Commune_Center_Job;
-    }
-    //  The farm field actions do not result in npc missions
-
-    else if( string_ends_with( str, camp_upgrade_npc_string ) ) {  //  blueprint + id
-        result.id = Camp_Upgrade;
-        result.parameters = str.substr( 0, str.length() - camp_upgrade_npc_string.length() );
-        result.dir = base_camps::base_dir;
-    }  //  Camp_Emergency_Recall is an immediate action, and so isn't serialized
-
-    else if( st == "_faction_camp_crafting_" ) { //  id + dir
-        result.id = Camp_Crafting;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_gathering" ) {
-        result.id = Camp_Gather_Materials;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_firewood" ) {
-        result.id = Camp_Collect_Firewood;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_menial" ) {
-        result.id = Camp_Menial;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_expansion" ) {
-        result.id = Camp_Survey_Expansion;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_cut_log" ) {
-        result.id = Camp_Cut_Logs;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_clearcut" ) {
-        result.id = Camp_Clearcut;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_hide_site" ) {
-        result.id = Camp_Setup_Hide_Site;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_hide_trans" ) {
-        result.id = Camp_Relay_Hide_Site;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_foraging" ) {
-        result.id = Camp_Foraging;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_trapping" ) {
-        result.id = Camp_Trapping;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_hunting" ) {
-        result.id = Camp_Hunting;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_om_fortifications" ) {
-        //  This legacy mission version hides the blueprint as a mission role rather than a string component
-        result.id = Camp_OM_Fortifications;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_recruit_0" ) {
-        result.id = Camp_Recruiting;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_scout_0" ) {
-        result.id = Camp_Scouting;
-        result.dir = base_camps::base_dir;
-    } else if( str == "_faction_camp_combat_0" ) {
-        result.id = Camp_Combat_Patrol;
-        result.dir = base_camps::base_dir;
-    } else if( id_size >= camp_upgrade_expansion_npc_string.length() &&
-               st.substr( id_size - camp_upgrade_expansion_npc_string.length() ) ==
-               camp_upgrade_expansion_npc_string ) { // blueprint + id + dir
-        result.id = Camp_Upgrade;
-        result.parameters = st.substr( 0, id_size - camp_upgrade_expansion_npc_string.length() );
-    } else if( st == "_faction_exp_chop_shop_" ) {        // id + dir
-        result.id = Camp_Chop_Shop;
-    } else if( st == "_faction_exp_kitchen_cooking_" ||   // id + dir
-               st == "_faction_exp_blacksmith_crafting_" ||
-               st == "_faction_exp_farm_crafting_" ) {
-        result.id = Camp_Crafting;
-    } else if( st == "_faction_exp_plow_" ) {             // id + dir
-        result.id = Camp_Plow;
-    } else if( st == "_faction_exp_plant_" ) {            // id + dir
-        result.id = Camp_Plant;
-    } else if( st == "_faction_exp_harvest_" ) {          // id + dir
-        result.id = Camp_Harvest;
-    }
-
-    if( result.id == No_Mission ) {
-        debugmsg(
-            "Unrecognized npc mission id string encountered: '%s'", str );
-    }
-
-    return result;
 }
 
 bool is_equal( const ui_mission_id &first, const ui_mission_id &second )

--- a/src/mission_companion.h
+++ b/src/mission_companion.h
@@ -10,6 +10,7 @@
 
 #include "calendar.h"
 #include "coordinates.h"
+#include "mapgendata.h"
 #include "memory_fast.h"
 #include "optional.h"
 #include "point.h"
@@ -92,6 +93,7 @@ std::string action_of( mission_kind kind );
 struct mission_id {
     mission_kind id = No_Mission;
     std::string parameters;
+    mapgen_arguments mapgen_args;
     cata::optional<point> dir;
 };
 

--- a/src/mission_companion.h
+++ b/src/mission_companion.h
@@ -74,7 +74,14 @@ enum mission_kind : int {
     Camp_Chop_Shop,  //  Obsolete removed during 0.E
     Camp_Plow,
     Camp_Plant,
-    Camp_Harvest
+    Camp_Harvest,
+
+    last_mission_kind
+};
+
+template<>
+struct enum_traits<mission_kind> {
+    static constexpr mission_kind last = mission_kind::last_mission_kind;
 };
 
 //  Operation to get translated UI strings for the corresponding misison
@@ -95,12 +102,13 @@ struct mission_id {
     std::string parameters;
     mapgen_arguments mapgen_args;
     cata::optional<point> dir;
+
+    void serialize( JsonOut & ) const;
+    void deserialize( const JsonValue & );
 };
 
 bool is_equal( const mission_id &first, const mission_id &second );
 void reset_miss_id( mission_id &miss_id );
-std::string string_of( mission_id miss_id );
-mission_id mission_id_of( const std::string &str );
 
 //  ret determines whether the mission is for the start of a mission or the return of the companion(s).
 //  Used in the UI mission generation process to distinguish active missions from available ones.

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2799,7 +2799,7 @@ void talk_effect_fun_t<T>::set_mapgen_update( const JsonObject &jo, const std::s
 
         } else {
             for( const str_or_var<T> &mapgen_update_id : update_ids ) {
-                run_mapgen_update_func( update_mapgen_id( mapgen_update_id.evaluate( d ) ), omt_pos,
+                run_mapgen_update_func( update_mapgen_id( mapgen_update_id.evaluate( d ) ), omt_pos, {},
                                         d.actor( d.has_beta )->selected_mission() );
             }
             get_map().invalidate_map_cache( omt_pos.z() );

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1213,7 +1213,7 @@ const translation &recipe::blueprint_parameter_ui_string(
     if( arg == translations.end() ) {
         debugmsg( "Argument value %s missing from bp_parameter_names[\"%s\"] in %s",
                   arg_value.get_string(), param_name, ident().str() );
-        static const translation error = to_translation( "[bad arg value]" );
+        static const translation error = to_translation( "[bad argument value]" );
         return error;
     }
 

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -10,6 +10,7 @@
 #include "assign.h"
 #include "cached_options.h"
 #include "calendar.h"
+#include "cartesian_product.h"
 #include "cata_utility.h"
 #include "character.h"
 #include "color.h"
@@ -328,7 +329,7 @@ void recipe::load( const JsonObject &jo, const std::string &src )
     // These cannot be inherited
     bp_autocalc = false;
     check_blueprint_needs = false;
-    blueprint_reqs.reset();
+    bp_build_reqs.reset();
 
     if( type == "recipe" ) {
 
@@ -365,6 +366,7 @@ void recipe::load( const JsonObject &jo, const std::string &src )
         assign( jo, "construction_blueprint", blueprint );
         if( !blueprint.is_empty() ) {
             assign( jo, "blueprint_name", bp_name );
+            assign( jo, "blueprint_parameter_names", bp_parameter_names );
             bp_resources.clear();
             for( const std::string resource : jo.get_array( "blueprint_resources" ) ) {
                 bp_resources.emplace_back( resource );
@@ -386,25 +388,34 @@ void recipe::load( const JsonObject &jo, const std::string &src )
                                           exclude.get_int( "amount", 1 ) ) );
             }
             check_blueprint_needs = jo.get_bool( "check_blueprint_needs", true );
-            if( jo.has_member( "blueprint_needs" ) ) {
-                blueprint_reqs = cata::make_value<build_reqs>();
+            bool has_needs = jo.has_member( "blueprint_needs" );
+            if( has_needs && !bp_parameter_names.empty() ) {
+                debugmsg( "blueprint %s has parameters but also provides explicit needs; "
+                          "these are incompatible", result_.str() );
+            }
+            if( bp_parameter_names.empty() ) {
+                bp_build_reqs = cata::make_value<parameterized_build_reqs>();
+                build_reqs &default_reqs =
+                    bp_build_reqs->reqs_by_parameters.emplace().first->second;
                 const JsonObject jneeds = jo.get_object( "blueprint_needs" );
                 if( jneeds.has_member( "time" ) ) {
-                    blueprint_reqs->time =
+                    default_reqs.time =
                         to_moves<int>( read_from_json_string<time_duration>(
                                            jneeds.get_member( "time" ), time_duration::units ) );
                 }
                 if( jneeds.has_member( "skills" ) ) {
                     std::vector<std::pair<skill_id, int>> blueprint_skills;
                     jneeds.read( "skills", blueprint_skills );
-                    blueprint_reqs->skills = { blueprint_skills.begin(), blueprint_skills.end() };
+                    default_reqs.skills = { blueprint_skills.begin(), blueprint_skills.end() };
                 }
                 if( jneeds.has_member( "inline" ) ) {
                     const requirement_id req_id( "inline_blueprint_" + type + "_" + ident_.str() );
                     requirement_data::load_requirement( jneeds.get_object( "inline" ), req_id );
-                    blueprint_reqs->reqs.emplace( req_id, 1 );
+                    default_reqs.raw_reqs.emplace( req_id, 1 );
                 }
-            } else if( check_blueprint_needs ) {
+            }
+
+            if( check_blueprint_needs && !has_needs ) {
                 bp_autocalc = true;
             }
         }
@@ -447,27 +458,94 @@ void recipe::load( const JsonObject &jo, const std::string &src )
     reqs_internal.emplace_back( req_id, 1 );
 }
 
+static cata::value_ptr<parameterized_build_reqs> calculate_all_blueprint_reqs(
+    const update_mapgen_id &id,
+    const std::map<std::string, std::map<std::string, translation>> &bp_params )
+{
+    cata::value_ptr<parameterized_build_reqs> result = cata::make_value<parameterized_build_reqs>();
+    const std::vector<std::unique_ptr<update_mapgen_function_json>> &funcs = id->funcs();
+    if( funcs.size() != 1 ) {
+        debugmsg( "update_mapgen %s used for blueprint, but has %zu versions, where it should have exactly one",
+                  funcs.size() );
+        return result;
+    }
+
+    const update_mapgen_function_json &json_func = *funcs.front();
+    const mapgen_parameters &mapgen_params = json_func.get_parameters();
+
+    std::vector<std::string> mapgen_param_names;
+    for( const std::pair<const std::string, mapgen_parameter> &mapgen_param : mapgen_params.map ) {
+        mapgen_param_names.push_back( mapgen_param.first );
+    }
+    // NOLINTNEXTLINE(cata-use-localized-sorting)
+    std::sort( mapgen_param_names.begin(), mapgen_param_names.end() );
+
+    std::vector<std::string> bp_param_names;
+    bp_param_names.reserve( bp_params.size() );
+    for( const auto &bp_param : bp_params ) {
+        bp_param_names.push_back( bp_param.first );
+    }
+    cata_assert( std::is_sorted( bp_param_names.begin(), bp_param_names.end() ) );
+
+    if( mapgen_param_names != bp_param_names ) {
+        debugmsg( "parameter names listed in blueprint do not match those from corresponding "
+                  "update_mapgen id %s.\nBlueprint had %s.\nupdate_mapgen had %s.",
+                  id.str(),
+                  enumerate_as_string( bp_param_names ),
+                  enumerate_as_string( mapgen_param_names ) );
+        return result;
+    }
+
+    // Each inner vector is a list of (param_name, param_value) pairs where
+    // every param_name is the same, and each param_value is the set of
+    // possible values for that param_name.  Once these lists are assembled we
+    // will need to iterate over their cartesian product to get all the
+    // possible options for parameter choices.
+    std::vector<std::vector<std::pair<std::string, cata_variant>>> option_lists;
+
+    for( const std::string &param_name : bp_param_names ) {
+        option_lists.emplace_back();
+        const mapgen_parameter &mapgen_param = mapgen_params.map.at( param_name );
+        cata_variant_type param_type = mapgen_param.type();
+
+        for( const std::pair<const std::string, translation> &p : bp_params.at( param_name ) ) {
+            cata_variant param_value =
+                cata_variant::from_string( param_type, std::string( p.first ) );
+            option_lists.back().emplace_back( param_name, param_value );
+        }
+    }
+
+    for( const std::vector<std::pair<std::string, cata_variant>> &chosen_params :
+         cata::cartesian_product( option_lists ) ) {
+        result->reqs_by_parameters.emplace(
+            chosen_params,
+            get_build_reqs_for_furn_ter_ids(
+                get_changed_ids_from_update( id, mapgen_arguments{ chosen_params } ) ) );
+    }
+
+    return result;
+}
+
 void recipe::finalize()
 {
     if( bp_autocalc ) {
-        blueprint_reqs =
-            cata::make_value<build_reqs>( get_build_reqs_for_furn_ter_ids(
-                                              get_changed_ids_from_update( blueprint ) ) );
+        bp_build_reqs = calculate_all_blueprint_reqs( blueprint, bp_parameter_names );
     } else if( test_mode && check_blueprint_needs ) {
         check_blueprint_requirements();
     }
 
-    incorporate_build_reqs();
-    blueprint_reqs.reset();
+    if( !blueprint.is_empty() ) {
+        incorporate_build_reqs();
+    } else {
+        // concatenate both external and inline requirements
+        add_requirements( reqs_external );
+        add_requirements( reqs_internal );
 
-    // concatenate both external and inline requirements
-    add_requirements( reqs_external );
-    add_requirements( reqs_internal );
+        reqs_external.clear();
+        reqs_internal.clear();
 
-    reqs_external.clear();
-    reqs_internal.clear();
-
-    deduped_requirements_ = deduped_requirement_data( requirements_, ident() );
+        deduped_requirements_ = deduped_requirement_data( requirements_, ident() );
+    }
 
     if( contained && container.is_null() ) {
         container = item::find_type( result_ )->default_container.value_or( "null" );
@@ -984,9 +1062,9 @@ std::string recipe::required_skills_string( const Character &c ) const
     return required_skills_as_string( sorted_lex( required_skills ), c );
 }
 
-std::string recipe::required_all_skills_string() const
+std::string recipe::required_all_skills_string( const std::map<skill_id, int> &skills ) const
 {
-    std::vector<std::pair<skill_id, int>> skillList = sorted_lex( required_skills );
+    std::vector<std::pair<skill_id, int>> skillList = sorted_lex( skills );
     // There is primary skill used, add it to the front
     if( skill_used ) {
         skillList.insert( skillList.begin(), std::pair<skill_id, int>( skill_used, difficulty ) );
@@ -1119,6 +1197,29 @@ const translation &recipe::blueprint_name() const
     return bp_name;
 }
 
+const translation &recipe::blueprint_parameter_ui_string(
+    const std::string &param_name, const cata_variant &arg_value ) const
+{
+    auto param = bp_parameter_names.find( param_name );
+    if( param == bp_parameter_names.end() ) {
+        debugmsg( "Parameter name %s missing from bp_parameter_names in %s",
+                  param_name, ident().str() );
+        static const translation error = to_translation( "[bad param name]" );
+        return error;
+    }
+
+    const TranslationMap &translations = param->second;
+    auto arg = translations.find( arg_value.get_string() );
+    if( arg == translations.end() ) {
+        debugmsg( "Argument value %s missing from bp_parameter_names[\"%s\"] in %s",
+                  arg_value.get_string(), param_name, ident().str() );
+        static const translation error = to_translation( "[bad arg value]" );
+        return error;
+    }
+
+    return arg->second;
+}
+
 const std::vector<itype_id> &recipe::blueprint_resources() const
 {
     return bp_resources;
@@ -1139,16 +1240,35 @@ const std::vector<std::pair<std::string, int>>  &recipe::blueprint_excludes() co
     return bp_excludes;
 }
 
+const parameterized_build_reqs &recipe::blueprint_build_reqs() const
+{
+    if( !bp_build_reqs ) {
+        cata_fatal( "Accessing absent blueprint_build_reqs in recipe %s", ident().str() );
+    }
+    return *bp_build_reqs;
+}
+
 void recipe::check_blueprint_requirements()
 {
     build_reqs total_reqs =
-        get_build_reqs_for_furn_ter_ids( get_changed_ids_from_update( blueprint ) );
-    requirement_data req_data_blueprint( blueprint_reqs->reqs );
-    requirement_data req_data_calc( total_reqs.reqs );
+        get_build_reqs_for_furn_ter_ids( get_changed_ids_from_update( blueprint, {} ) );
+    if( bp_build_reqs->reqs_by_parameters.size() != 1 ) {
+        debugmsg( "Cannot check blueprint reqs for blueprints with parameters" );
+        return;
+    }
+    const std::pair<const mapgen_arguments, build_reqs> &no_param_reqs =
+        *bp_build_reqs->reqs_by_parameters.begin();
+    if( !no_param_reqs.first.map.empty() ) {
+        debugmsg( "Cannot check blueprint reqs for blueprints with parameters" );
+        return;
+    }
+    const build_reqs &reqs = no_param_reqs.second;
+    requirement_data req_data_blueprint( reqs.raw_reqs );
+    requirement_data req_data_calc( total_reqs.raw_reqs );
     // do not consolidate req_data_blueprint: it actually changes the meaning of the requirement.
     // instead we enforce specifying the exact consolidated requirement.
     req_data_calc.consolidate();
-    if( blueprint_reqs->time != total_reqs.time || blueprint_reqs->skills != total_reqs.skills
+    if( reqs.time != total_reqs.time || reqs.skills != total_reqs.skills
         || !req_data_blueprint.has_same_requirements_as( req_data_calc ) ) {
         std::ostringstream os;
         JsonOut jsout( os, /*pretty_print=*/true );
@@ -1242,22 +1362,21 @@ int recipe::makes_amount() const
 
 void recipe::incorporate_build_reqs()
 {
-    if( !blueprint_reqs ) {
-        return;
+    if( !bp_build_reqs ) {
+        bp_build_reqs = cata::make_value<parameterized_build_reqs>();
     }
 
-    time += blueprint_reqs->time;
+    for( std::pair<const mapgen_arguments, build_reqs> &p : bp_build_reqs->reqs_by_parameters ) {
+        build_reqs &reqs = p.second;
+        reqs.time += time;
 
-    for( const std::pair<const skill_id, int> &p : blueprint_reqs->skills ) {
-        int &val = required_skills[p.first];
-        val = std::max( val, p.second );
+        for( const std::pair<const skill_id, int> &p : required_skills ) {
+            int &val = reqs.skills[p.first];
+            val = std::max( val, p.second );
+        }
+
+        reqs.consolidate( reqs_internal, reqs_external );
     }
-
-    requirement_data req_data( blueprint_reqs->reqs );
-    req_data.consolidate();
-    const requirement_id req_id( "autocalc_blueprint_" + ident_.str() );
-    requirement_data::save_requirement( req_data, req_id );
-    reqs_internal.emplace_back( req_id, 1 );
 }
 
 void recipe_proficiency::deserialize( const JsonObject &jo )

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -221,7 +221,7 @@ class recipe
         float exertion_level() const;
 
         // This is used by the basecamp bulletin board.
-        std::string required_all_skills_string() const;
+        std::string required_all_skills_string( const std::map<skill_id, int> & ) const;
 
         // Create a string to describe the time savings of batch-crafting, if any.
         // Format: "N% at >M units" or "none"
@@ -264,10 +264,13 @@ class recipe
         bool is_blueprint() const;
         const update_mapgen_id &get_blueprint() const;
         const translation &blueprint_name() const;
+        const translation &blueprint_parameter_ui_string(
+            const std::string &param_name, const cata_variant &arg_value ) const;
         const std::vector<itype_id> &blueprint_resources() const;
         const std::vector<std::pair<std::string, int>> &blueprint_provides() const;
         const std::vector<std::pair<std::string, int>> &blueprint_requires() const;
         const std::vector<std::pair<std::string, int>> &blueprint_excludes() const;
+        const parameterized_build_reqs &blueprint_build_reqs() const;
         /**
          * Calculate blueprint requirements according to changed terrain and furniture
          * tiles, then check the calculated requirements against blueprint requirements
@@ -340,8 +343,13 @@ class recipe
         int result_mult = 1; // used by certain batch recipes that create more than one stack of the result
         update_mapgen_id blueprint;
         translation bp_name;
+        using TranslationMap = std::map<std::string, translation>;
+        std::map<std::string, TranslationMap> bp_parameter_names;
         std::vector<itype_id> bp_resources;
         std::vector<std::pair<std::string, int>> bp_provides;
+        /** bp_requires specifies which other basecamp components need to exist
+         * before this one.  Whereas bp_build_reqs below contains the material
+         * and skills requirements */
         std::vector<std::pair<std::string, int>> bp_requires;
         std::vector<std::pair<std::string, int>> bp_excludes;
 
@@ -350,7 +358,7 @@ class recipe
          * requirements into the standard recipe requirements. */
         bool bp_autocalc = false;
         bool check_blueprint_needs = false;
-        cata::value_ptr<build_reqs> blueprint_reqs;
+        cata::value_ptr<parameterized_build_reqs> bp_build_reqs;
 };
 
 #endif // CATA_SRC_RECIPE_H

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2212,7 +2212,6 @@ void npc::load( const JsonObject &data )
     int classtmp = 0;
     int atttmp = 0;
     std::string facID;
-    std::string comp_miss_id;
     std::string comp_miss_role;
     tripoint_abs_omt comp_miss_pt;
     std::string classid;
@@ -2316,9 +2315,7 @@ void npc::load( const JsonObject &data )
         }
     }
 
-    if( data.read( "comp_mission_id", comp_miss_id ) ) {
-        comp_mission.miss_id = mission_id_of( comp_miss_id );
-    }
+    data.read( "comp_mission_id", comp_mission.miss_id );
 
     if( data.read( "comp_mission_pt", comp_miss_pt ) ) {
         comp_mission.position = comp_miss_pt;
@@ -2432,7 +2429,7 @@ void npc::store( JsonOut &json ) const
         json.member( "real_weapon", real_weapon ); // also saves contents
     }
 
-    json.member( "comp_mission_id", string_of( comp_mission.miss_id ) );
+    json.member( "comp_mission_id", comp_mission.miss_id );
     json.member( "comp_mission_pt", comp_mission.position );
     json.member( "comp_mission_role", comp_mission.role_id );
     json.member( "companion_mission_role_id", companion_mission_role_id );
@@ -4354,13 +4351,13 @@ void basecamp::serialize( JsonOut &json ) const
         json.member( "dumping_spot", dumping_spot );
         json.member( "hidden_missions" );
         json.start_array();
-        for( const auto &list : hidden_missions ) {
+        for( const std::vector<ui_mission_id> &list : hidden_missions ) {
             json.start_object();
             json.member( "dir" );
             json.start_array();
             for( const ui_mission_id &miss_id : list ) {
                 json.start_object();
-                json.member( "mission_id", string_of( miss_id.id ) );
+                json.member( "mission_id", miss_id.id );
                 json.end_object();
             }
             json.end_array();
@@ -4445,10 +4442,8 @@ void basecamp::deserialize( const JsonObject &data )
         list.allow_omitted_members();
         for( JsonObject miss_id_json : list.get_array( "dir" ) ) {
             miss_id_json.allow_omitted_members();
-            std::string miss_id_string;
-            miss_id_json.read( "mission_id", miss_id_string );
             ui_mission_id miss_id;
-            miss_id.id = mission_id_of( miss_id_string );
+            miss_id_json.read( "mission_id", miss_id.id );
             miss_id.ret = false;
             hidden_missions[tab_num].push_back( miss_id );
         }

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -308,8 +308,8 @@ void timed_event::actualize()
             break;
         }
         case timed_event_type::UPDATE_MAPGEN:
-            run_mapgen_update_func( update_mapgen_id( string_id ), project_to<coords::omt>( map_point ),
-                                    nullptr );
+            run_mapgen_update_func(
+                update_mapgen_id( string_id ), project_to<coords::omt>( map_point ), {}, nullptr );
             get_map().invalidate_map_cache( map_point.z() );
             break;
 

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1485,7 +1485,7 @@ bool trapfunc::map_regen( const tripoint &p, Creature *c, item * )
             tripoint_abs_omt omt_pos = you->global_omt_location();
             const update_mapgen_id &regen_mapgen = here.tr_at( p ).map_regen_target();
             here.remove_trap( p );
-            if( !run_mapgen_update_func( regen_mapgen, omt_pos, nullptr, false ) ) {
+            if( !run_mapgen_update_func( regen_mapgen, omt_pos, {}, nullptr, false ) ) {
                 popup( _( "Failed to generate the new map" ) );
                 return false;
             }

--- a/tests/cartesian_product_test.cpp
+++ b/tests/cartesian_product_test.cpp
@@ -1,0 +1,20 @@
+#include "cata_catch.h"
+
+#include "cartesian_product.h"
+
+TEST_CASE( "cartesian_product" )
+{
+    std::vector<int> empty;
+    std::vector<int> singleton = { 0 };
+    std::vector<int> pair = { 1, 2 };
+
+    using Lists = std::vector<std::vector<int>>;
+
+    CHECK( cata::cartesian_product( Lists{} ) == Lists{ {} } );
+    CHECK( cata::cartesian_product( Lists{ empty } ).empty() );
+    CHECK( cata::cartesian_product( Lists{ empty, singleton } ).empty() );
+    CHECK( cata::cartesian_product( Lists{ empty, pair } ).empty() );
+    CHECK( cata::cartesian_product( Lists{ singleton, singleton } ) == Lists{ { 0, 0 } } );
+    CHECK( cata::cartesian_product( Lists{ singleton, pair } ) == Lists{ { 0, 1 }, { 0, 2 } } );
+    CHECK( cata::cartesian_product( Lists{ pair, pair } ) == Lists{ { 1, 1 }, { 2, 1 }, { 1, 2 }, { 2, 2 } } );
+}

--- a/tests/mapgen_helpers.cpp
+++ b/tests/mapgen_helpers.cpp
@@ -20,7 +20,7 @@ void manual_update_mapgen( tripoint_abs_omt const &pos, update_mapgen_id const &
 {
     // make sure we don't rotate the update
     overmap_buffer.ter_set( pos, oter_field.id() );
-    run_mapgen_update_func( id, pos, nullptr, false );
+    run_mapgen_update_func( id, pos, {}, nullptr, false );
 }
 
 void manual_nested_mapgen( tripoint_abs_omt const &pos, nested_mapgen_id const &id )

--- a/tests/recipe_test.cpp
+++ b/tests/recipe_test.cpp
@@ -17,55 +17,81 @@ static std::string reqs_to_json_string( const requirement_data &reqs )
     return os.str();
 }
 
+static const build_reqs &get_default_build_reqs( const recipe_id rec )
+{
+    const std::unordered_map<mapgen_arguments, build_reqs> &all_reqs =
+        rec->blueprint_build_reqs().reqs_by_parameters;
+
+    REQUIRE( all_reqs.size() == 1 );
+    auto it = all_reqs.find( {} );
+    REQUIRE( it != all_reqs.end() );
+    return it->second;
+}
+
 TEST_CASE( "blueprint_autocalc_only", "[recipe][blueprint]" )
 {
-    Character &you = get_player_character();
-
     recipe_id stove_1( "test_base_stove_1" );
     recipe_id stove_2( "test_base_stove_2" );
     recipe_id stove_3( "test_base_stove_3" );
 
-    CHECK( stove_1->time_to_craft( you ) == 1_hours );
-    CHECK( stove_1->time_to_craft( you ) == stove_2->time_to_craft( you ) );
-    CHECK( stove_3->time_to_craft( you ) == 0_hours );
+    const build_reqs &stove_1_reqs = get_default_build_reqs( stove_1 );
+    const build_reqs &stove_2_reqs = get_default_build_reqs( stove_2 );
+    const build_reqs &stove_3_reqs = get_default_build_reqs( stove_3 );
 
-    CHECK( stove_1->required_all_skills_string() ==
+    CHECK( stove_1_reqs.time == to_moves<int>( 1_hours ) );
+    CHECK( stove_1_reqs.time == stove_2_reqs.time );
+    CHECK( stove_3_reqs.time == 0 );
+
+    CHECK( stove_1->required_all_skills_string( stove_1_reqs.skills ) ==
            "<color_white>fabrication (5)</color> and <color_white>mechanics (3)</color>" );
-    CHECK( stove_1->required_all_skills_string() == stove_2->required_all_skills_string() );
-    CHECK( stove_3->required_all_skills_string() == "<color_cyan>none</color>" );
+    CHECK( stove_1->required_all_skills_string( stove_1_reqs.skills ) ==
+           stove_2->required_all_skills_string( stove_2_reqs.skills ) );
+    CHECK( stove_3->required_all_skills_string( stove_3_reqs.skills ) ==
+           "<color_cyan>none</color>" );
 
-    CHECK( reqs_to_json_string( stove_1->simple_requirements() ) ==
+    CHECK( reqs_to_json_string( stove_1_reqs.consolidated_reqs ) ==
            R"({"tools":[],"qualities":[[{"id":"SAW_M"}]],)"
            R"("components":[[["metal_tank",1]],[["pipe",1]]]})" );
-    CHECK( stove_1->simple_requirements().has_same_requirements_as(
-               stove_2->simple_requirements() ) );
-    CHECK( reqs_to_json_string( stove_3->simple_requirements() ) ==
+    CHECK( stove_1_reqs.consolidated_reqs.has_same_requirements_as(
+               stove_2_reqs.consolidated_reqs ) );
+    CHECK( reqs_to_json_string( stove_3_reqs.consolidated_reqs ) ==
            R"({"tools":[],"qualities":[],"components":[]})" );
 }
 
 TEST_CASE( "blueprint_autocalc_with_components", "[recipe][blueprint]" )
 {
-    Character &you = get_player_character();
-
     recipe_id stove_1( "test_base_stove_plus_pipe_1" );
     recipe_id stove_2( "test_base_stove_plus_pipe_2" );
     recipe_id stove_3( "test_base_stove_plus_pipe_3" );
+    recipe_id stove_4( "test_base_stove_plus_pipe_4" );
 
-    CHECK( stove_1->time_to_craft( you ) == 1_hours + 20_minutes );
-    CHECK( stove_1->time_to_craft( you ) == stove_2->time_to_craft( you ) );
-    CHECK( stove_3->time_to_craft( you ) == 20_minutes );
+    const build_reqs &stove_1_reqs = get_default_build_reqs( stove_1 );
+    const build_reqs &stove_2_reqs = get_default_build_reqs( stove_2 );
+    const build_reqs &stove_3_reqs = get_default_build_reqs( stove_3 );
+    const build_reqs &stove_4_reqs = get_default_build_reqs( stove_4 );
 
-    CHECK( stove_1->required_all_skills_string() ==
+    CHECK( stove_1_reqs.time == to_moves<int>( 1_hours + 20_minutes ) );
+    CHECK( stove_1_reqs.time == stove_2_reqs.time );
+    CHECK( stove_3_reqs.time == to_moves<int>( 20_minutes ) );
+    CHECK( stove_4_reqs.time == stove_3_reqs.time );
+
+    CHECK( stove_1->required_all_skills_string( stove_1_reqs.skills ) ==
            "<color_white>fabrication (5)</color> and <color_white>mechanics (3)</color>" );
-    CHECK( stove_1->required_all_skills_string() == stove_2->required_all_skills_string() );
-    CHECK( stove_3->required_all_skills_string() == "<color_cyan>none</color>" );
+    CHECK( stove_1->required_all_skills_string( stove_1_reqs.skills ) ==
+           stove_2->required_all_skills_string( stove_2_reqs.skills ) );
+    CHECK( stove_3->required_all_skills_string( stove_3_reqs.skills ) ==
+           "<color_cyan>none</color>" );
+    CHECK( stove_3->required_all_skills_string( stove_3_reqs.skills ) ==
+           stove_4->required_all_skills_string( stove_4_reqs.skills ) );
 
-    CHECK( reqs_to_json_string( stove_1->simple_requirements() ) ==
+    CHECK( reqs_to_json_string( stove_1_reqs.consolidated_reqs ) ==
            R"({"tools":[],"qualities":[[{"id":"CUT","level":2}],[{"id":"SAW_M"}]],)"
-           R"("components":[[["pipe",2],["scrap",1]],[["metal_tank",1]],[["pipe",1]]]})" );
+           R"("components":[[["metal_tank",1]],[["pipe",3]]]})" );
     CAPTURE( reqs_to_json_string( stove_2->simple_requirements() ) );
-    CHECK( stove_1->simple_requirements().has_same_requirements_as(
-               stove_2->simple_requirements() ) );
-    CHECK( reqs_to_json_string( stove_3->simple_requirements() ) ==
+    CHECK( stove_1_reqs.consolidated_reqs.has_same_requirements_as(
+               stove_2_reqs.consolidated_reqs ) );
+    CHECK( reqs_to_json_string( stove_3_reqs.consolidated_reqs ) ==
            R"({"tools":[],"qualities":[[{"id":"CUT","level":2}]],"components":[[["pipe",2],["scrap",1]]]})" );
+    CHECK( stove_3_reqs.consolidated_reqs.has_same_requirements_as(
+               stove_4_reqs.consolidated_reqs ) );
 }


### PR DESCRIPTION
#### Summary
Features "Parametric basecamp expansion definitions"

#### Purpose of change
We have lots of basecamp expansion definitions that use almost exactly the same layout, but differ only in the materials used.

Currently each requires an entirely separate recipe and mapgen definition.

It would be nice to take advantage of parametric mapgen to consolidate these similar definitions into a single one.  This would dramatically cut down on JSON.

Fixes #45098.

#### Describe the solution
Allow the mapgen definitions for basecamp expansions to use parameters.

The human-readable versions of those parameters must be defined in the recipe to appear in the UI.

The game will consider each possible combination of values for the parameters, and the Cartesian product of these options will appear in the UI.  That has the potential to explode the options, but hopefully people won't abuse it.  I imagine in most cases there will be only a single parameter (which defines the palette).

I chose one pair of similar expansions (`fbmh_2_log_room_1_1` and `fbmh_2_resin_room_1_1`) and consolidated them into a single genericised version (`fbmh_2_generic_room_1_1`) as an example.

A `basecamp_upgrade` object now must contain `mapgen_arguments` to convey the particular choice made by the player.

I also fixed parametric sub-palettes used inside palettes.  This was theoretically supported before, but didn't actually work.

#### Describe alternatives you've considered
The use of recipes to represent basecamp upgrades is a bit of an abuse.  This change is probably making that particular mess worse.  It would be nice to factor out the common functionality and make two separate classes, but that would be a bigger change.

#### Testing
I tried the new upgrades.  They take a reasonable amount of time and consume resources as expected.  But there are a million potential corner cases, so more testing is probably warranted.

@PatrikLundell I believe it was you who was wanting to use this feature.  Are you able to take a look at this approach and see if it seems reasonable to you.  Even better, if you are able to build this branch perhaps you could try using it yourself and see if you run into any problems?

I still haven't written any documentation; feel free to tell me you're going to wait until that's done.

I don't expect this feature to get merged during feature freeze, so there's no particular hurry.

@curstwist I'm also interested in your opinion as our resident mapgen guru.

#### Additional context
Some before-and-after shots of the upgrade UI:
![parametric-basecamp-before](https://user-images.githubusercontent.com/52664/172063589-2a48cd51-2261-490f-bb79-4e80c923a56a.png)
![parametric-basecamp-after](https://user-images.githubusercontent.com/52664/172063587-4ef0cc67-ea5f-41ca-aa66-673677bca702.png)
The UI for the new parametric case could certainly be improved, but that's a problem for a future PR.