### PR TITLE
Add accessibility services warning to Android pre-launch menu

### DIFF
--- a/android/app/src/main/java/com/cleverraven/cataclysmdda/CataclysmDDA_Helpers.java
+++ b/android/app/src/main/java/com/cleverraven/cataclysmdda/CataclysmDDA_Helpers.java
@@ -1,0 +1,29 @@
+package com.cleverraven.cataclysmdda;
+
+import java.util.List;
+
+import android.content.Context;
+import android.view.accessibility.AccessibilityManager;
+import android.accessibilityservice.AccessibilityService;
+import android.accessibilityservice.AccessibilityServiceInfo;
+import android.content.pm.ServiceInfo;
+import android.widget.Toast;
+
+public class CataclysmDDA_Helpers {
+    public static List<AccessibilityServiceInfo> getEnabledAccessibilityServiceInfo(Context context) {
+        AccessibilityManager am = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
+        List<AccessibilityServiceInfo> enabledServicesInfo = am.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK);
+        return enabledServicesInfo;
+    }
+
+    public static String getEnabledAccessibilityServiceNames(Context context) {
+        List<AccessibilityServiceInfo> enabledServicesInfo = getEnabledAccessibilityServiceInfo( context );
+        String service_names = "";
+        for (AccessibilityServiceInfo enabledService : enabledServicesInfo) {
+            ServiceInfo enabledServiceInfo = enabledService.getResolveInfo().serviceInfo;
+            String service_name = enabledServiceInfo.name;
+            service_names = service_names + "\n" + service_name;
+        }
+        return service_names;
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="upgradeTitle">Upgrading game data...</string>
     <string name="helpTitle">Help &amp; Controls</string>
     <string name="helpMessage">"Swipe" for directional movement (hold for virtual joystick). "Tap" to confirm selection in menu or Pause one turn in-game (hold to Pause several turns in-game). "Double tap" to cancel or go back in menus (works like Escape key). "Pinch" to zoom in/out (in-game). Use hardware "Back" button to toggle virtual keyboard (hold to toggle keyboard shortcuts).</string>
+    <string name="accessibilityServicesTitle">Accessibility Services Warning</string>
+    <string name="accessibilityServicesMessage">If swipe commands and shortcuts menus are not working in game, you might want to disable one of the following accessibility services/software that interact with touchscreen (swipe assists, auto-clickers, one-handed mode, etc.):\n%1$s</string>
     <string name="softwareRendering">Software rendering</string>
     <string name="forceFullscreen">Force fullscreen</string>
     <string name="trapBackButton">Trap Back button</string>
@@ -11,6 +13,7 @@
     <string name="settings">Settings</string>
     <string name="startGame">Start game</string>
     <string name="showHelp">Show help</string>
+    <string name="showAccessibilitySettings">Show accessibility settings menu</string>
     <string name="crashAlert">The game did not quit properly last time</string>
     <string name="crashMessage">The crash report located in ./config/crash.log may help developers troubleshoot program errors.</string>
     <string name="yes">Yes</string>


### PR DESCRIPTION
#### Summary
Interface "Add accessibility services warning to Android pre-launch menu"

#### Purpose of change

Some accessibility software on Android devices might interact negatively with CDDA and disallow touchscreen commands and interaction with shortcut menus. While we don't want to disable all of these service programatically, we might warn the users they have one ore more of such accessibility services running, so they would know what they might need to disable.

#### Describe the solution

Add accessibility services warning to Android pre-launch menu

![image](https://user-images.githubusercontent.com/16213433/172798739-ac689312-ea1f-4f34-bb55-3923b233a8c7.png)

#### Testing

1. Launch Android version with enabled accessibility service and see alert dialog with warning.
 
#### Additional context

See https://github.com/CleverRaven/Cataclysm-DDA/issues/45876 and linked issues.


