### PR TITLE
In-place construction and deconstruction of appliances

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -5658,5 +5658,17 @@
     "components": [ [ [ "rock", 30 ] ], [ [ "fire_brick", 10 ] ], [ [ "clay_lump", 15 ] ], [ [ "water", 2 ], [ "water_clean", 2 ] ] ],
     "pre_special": "check_empty",
     "post_terrain": "f_clay_oven"
+  },
+  {
+    "type": "construction",
+    "id": "constr_test_conap",
+    "group": "build_test_conap",
+    "category": "APPLIANCE",
+    "required_skills": [ [ "fabrication", 1 ] ],
+    "time": "1 m",
+    "components": [ [ [ "scrap", 1 ] ], [ [ "e_scrap", 1 ] ] ],
+    "pre_terrain": "f_table",
+    "post_special": "done_appliance",
+    "appliance_base": "test_conap"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1603,5 +1603,10 @@
     "type": "construction_group",
     "id": "build_clay_oven",
     "name": "Build Clay Oven"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_test_conap",
+    "name": "Constructible Appliance Test"
   }
 ]

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -411,6 +411,11 @@
     "info": "This item is impossible to clean."
   },
   {
+    "id": "NO_TAKEDOWN",
+    "type": "json_flag",
+    "//": "Appliance that cannot be simply taken down as a whole item. It may or may not have a deconstruction recipe that can be used instead."
+  },
+  {
     "id": "NUTRIENT_OVERRIDE",
     "type": "json_flag",
     "//": "forces calories and vitamins to be the ones defined in the json, instead of inheriting from ingredients"

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -887,5 +887,27 @@
     ],
     "damage_reduction": { "all": 5 },
     "requirements": { "removal": { "time": "6 m" } }
+  },
+  {
+    "type": "GENERIC",
+    "id": "test_conap",
+    "category": "spare_parts",
+    "name": { "str": "test constructible appliance base item" },
+    "description": "test constructible appliance base item",
+    "volume": "1 ml",
+    "weight": "1 g",
+    "symbol": "?",
+    "color": "white"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ap_test_conap",
+    "name": { "str": "test constructible appliance" },
+    "symbol": "?",
+    "color": "white",
+    "description": "test constructible appliance",
+    "flags": [ "APPLIANCE", "NO_TAKEDOWN" ],
+    "durability": 1,
+    "item": "test_conap"
   }
 ]

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1258,6 +1258,17 @@ bool construct::check_nofloor_above( const tripoint &p )
 bool construct::check_deconstruct( const tripoint &p )
 {
     map &here = get_map();
+
+    optional_vpart_position veh = here.veh_at( p );
+
+    if( veh ) {
+        cata::optional<vpart_reference> vpart = veh->part_with_feature(
+                vpart_bitflags::VPFLAG_APPLIANCE, /*unbroken=*/ false );
+        if( vpart ) {
+            return vpart->info().deconstruct.can_do;
+        }
+    }
+
     if( here.has_furn( p.xy() ) ) {
         return here.furn( p.xy() ).obj().deconstruct.can_do;
     }
@@ -2008,6 +2019,10 @@ void load_construction( const JsonObject &jo )
 
     con.on_display = jo.get_bool( "on_display", true );
     con.dark_craftable = jo.get_bool( "dark_craftable", false );
+
+    if( jo.has_string( "appliance_base" ) ) {
+        con.appliance_base = jo.get_string( "appliance_base" );
+    }
 
     constructions.push_back( con );
     construction_id_map.emplace( con.str_id, con.id );

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1487,17 +1487,29 @@ void construct::done_appliance( const tripoint &p, Character &who )
 {
     map &here = get_map();
     partial_con *pc = here.partial_con_at( p );
-    cata::optional<item> base = cata::nullopt;
-    const vpart_id &vpart = vpart_appliance_from_item( who.lastconsumed );
-    if( pc ) {
-        for( item &obj : pc->components ) {
-            if( obj.typeId() == vpart->base_item ) {
-                base = obj;
-            }
-        }
-    } else {
-        debugmsg( "partial construction not found" );
+
+    if( !pc ) {
+        debugmsg( "partial construction not found (possible cause: appliance construction entry with category other than APPLIANCE)" );
+        return;
     }
+
+    cata::optional<item> base = cata::nullopt;
+
+    itype_id base_item;
+    if( !pc->id.obj().appliance_base.empty() ) {
+        base_item = itype_id( pc->id.obj().appliance_base );
+    } else {
+        base_item = who.lastconsumed;
+    }
+
+    const vpart_id &vpart = vpart_appliance_from_item( base_item );
+
+    for( item &obj : pc->components ) {
+        if( obj.typeId() == vpart->base_item ) {
+            base = obj;
+        }
+    }
+
     here.partial_con_remove( p );
     place_appliance( p, vpart, base );
 }

--- a/src/construction.h
+++ b/src/construction.h
@@ -53,6 +53,8 @@ struct construction {
         std::string pre_terrain;
         // Final terrain after construction
         std::string post_terrain;
+        // Base item of appliance to be constructed (if different from component)
+        std::string appliance_base;
 
         // Item group of byproducts created by the construction on success.
         cata::optional<item_group_id> byproduct_item_group;

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -30,6 +30,7 @@ static const vproto_id vehicle_prototype_none( "none" );
 
 static const std::string flag_APPLIANCE( "APPLIANCE" );
 static const std::string flag_WIRING( "WIRING" );
+static const std::string flag_NO_TAKEDOWN( "NO_TAKEDOWN" );
 
 
 // Width of the entire set of windows. 60 is sufficient for
@@ -421,6 +422,12 @@ void veh_app_interact::remove()
     int const part = veh->part_at( a_point );
     vehicle_part &vp = veh->part( part >= 0 ? part : 0 );
     const vpart_info &vpinfo = vp.info();
+
+    if( vpinfo.has_flag( flag_NO_TAKEDOWN ) ) {
+        popup( _( "This appliance cannot be taken down. It may be possible to deconstruct it instead." ) );
+        return;
+    }
+
     const requirement_data reqs = vpinfo.removal_requirements();
     Character &you = get_player_character();
     const inventory &inv = you.crafting_inventory();

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -199,6 +199,17 @@ std::pair<std::string, std::string> get_vpart_str_variant( const std::string &vp
 std::pair<vpart_id, std::string> get_vpart_id_variant( const vpart_id &vpid );
 std::pair<vpart_id, std::string> get_vpart_id_variant( const std::string &vpid );
 
+struct appliance_deconstruct_info {
+    // Only if true the appliance is deconstructible
+    bool can_do;
+    // items you get when deconstructing
+    item_group_id drop_group;
+    // furniture to leave behind (if any)
+    furn_str_id furn_set;
+    appliance_deconstruct_info();
+    bool load( const JsonObject &jsobj, const std::string &member, const std::string &context );
+};
+
 class vpart_category
 {
     public:
@@ -330,6 +341,8 @@ class vpart_info
         const cata::optional<vpslot_workbench> &get_workbench_info() const;
 
         std::set<std::pair<itype_id, int>> get_pseudo_tools() const;
+
+        appliance_deconstruct_info deconstruct;
     private:
         std::set<std::string> flags;
         // category list for installation ui breakdown

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -718,3 +718,24 @@ std::string vehicle_part::carried_name() const
     }
     return carry_names.top().substr( name_offset );
 }
+
+appliance_deconstruct_info::appliance_deconstruct_info() : can_do( false ),
+    drop_group( item_group_id::NULL_ID() ), furn_set( furn_str_id::NULL_ID() ) {}
+
+bool appliance_deconstruct_info::load( const JsonObject &jsobj, const std::string &member,
+                                       const std::string &context )
+{
+    if( !jsobj.has_object( member ) ) {
+        return false;
+    }
+
+    JsonObject j = jsobj.get_object( member );
+    furn_set = furn_str_id( j.get_string( "furn_set", "f_null" ) );
+
+    can_do = true;
+
+    drop_group = item_group::load_item_group( j.get_member( "items" ), "collection",
+                 "appliance_deconstruct_info for " + context );
+
+    return true;
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Allow in-place construction and deconstruction of appliances"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Although setting up appliances uses the standard construction menu, it is limited to simply placing a ready-made item on an empty spot. Likewise, deconstruction is limited to picking them up. This patch brings appliance construction more in line with terrain and furniture, allowing it to use multiple components and integrate into existing terrain or furniture, and allowing appliances to be directly taken apart into components. Possible use cases include:

* machines too large to reasonably be built on a workbench then set up elsewhere 
* appliances most sensibly made by modifying existing furniture (e.g. a battery rack for connecting many batteries to grid, made by wiring-up regular shelving - I intend to add this later)
* devices assembled from multiple parts (for multi-part appliances in the future)

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- [x] Optional override of appliance base item to allow different/multiple components
- [x] Flag to disallow simple take down of appliance
- [ ] Appliance deconstruction (WIP)
- [ ] Consistency checks for constructible and deconstructible appliances

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

WIP

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

On hold for feature freeze

@Maleclypse You asked to be pinged on this to give it the freeze tag.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
