### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/assign_mission_target_needs_om_special.yml
+++ b/.github/workflows/assign_mission_target_needs_om_special.yml
@@ -2,6 +2,9 @@ name: Detect missions that are missing .start.assign_mission_target.om_special
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   run-the-tool:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-translation.yml
+++ b/.github/workflows/check-translation.yml
@@ -6,6 +6,9 @@ on:
       - 'lang/po/*.po'
       - 'tools/check_po_printf_format.py'
 
+permissions:
+  contents: read
+
 jobs:
   check-po-printf:
     runs-on: ubuntu-20.04

--- a/.github/workflows/cmake-format.yml
+++ b/.github/workflows/cmake-format.yml
@@ -16,6 +16,9 @@ on:
     - '**.cmake'
     - '**.cmake.in'
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -12,6 +12,9 @@ on:
     paths:
     - '**.py'
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,8 +2,14 @@ name: "Pull Request Labeler"
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   triage:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v3

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -58,6 +58,8 @@ jobs:
         with:
           paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "lgtm/**", "msvc-**", "object_creator/**", "tools/**", "utilities/**"]'
   matrix-variables:
+    permissions:
+      contents: none
     continue-on-error: true
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/push-translation-template.yml
+++ b/.github/workflows/push-translation-template.yml
@@ -9,6 +9,9 @@ on:
       - completed
 
 
+permissions:
+  contents: read
+
 jobs:
   push-template:
     runs-on: ubuntu-latest

--- a/.github/workflows/text-changes-analyzer.yml
+++ b/.github/workflows/text-changes-analyzer.yml
@@ -15,6 +15,9 @@ on:
       - '**.json'
 
 
+permissions:
+  contents: read
+
 jobs:
   analyze-text-changes:
     runs-on: ubuntu-20.04

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -5,6 +5,9 @@ on:
     paths:
     - 'doc/JSON_INFO.md'
 name: TOC Generator
+permissions:
+  contents: read
+
 jobs:
   generateTOC:
     if: github.repository == 'CleverRaven/Cataclysm-DDA'


### PR DESCRIPTION

#### Summary
Infrastructure "Restrict the GitHub token permissions only to the required ones" 


#### Purpose of change

Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
