### PR TITLE
remove day one shockers from open sewer

### DIFF
--- a/data/json/mapgen/cs_open_sewer_small.json
+++ b/data/json/mapgen/cs_open_sewer_small.json
@@ -4,7 +4,7 @@
     "name": "GROUP_ZOMBIE_SEWER",
     "monsters": [
       { "monster": "mon_zombie_technician", "weight": 850, "cost_multiplier": 3 },
-      { "monster": "mon_zombie_electric", "weight": 150, "cost_multiplier": 5 }
+      { "monster": "mon_zombie_static", "weight": 150, "cost_multiplier": 5 }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Open sewers initially spawn zapper zombies"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Shocker zombie spawns on day one were massively out of depth which does not generally match the lore of gradual zombie evolution. It is also a particularly salt-inducing enemy for how early it appears (speaking from personal experience)
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Open sewer spawns zappers instead of shockers. These will gradually upgrade over time according to their half-lives and become shockers eventually, but generally not on the first day or two.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Remove the open sewer. Why are there so many open sewers in the cities, often in the middle of major thoroughfares. Why are technicians working on the open sewer in the middle of the zombie apocalypse. This is a particularly bad overmap, but it's also one of the few places to get 7.5kw generators so people may complain if I remove it entirely.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
