### PR TITLE
Adding jury-rigged frames to the game

### DIFF
--- a/data/json/vehicleparts/frames.json
+++ b/data/json/vehicleparts/frames.json
@@ -56,9 +56,28 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m", "using": "vehicle_weld_removal" },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
-    "flags": [ "MOUNTABLE", "INITIAL_PART" ],
+    "flags": [ "MOUNTABLE", "INITIAL_PART", "NO_INSTALL_PLAYER" ],
     "categories": [ "hull" ],
     "damage_reduction": { "all": 20 }
+  },
+   {
+    "id": "jrframe",
+    "type": "vehicle_part",
+    "name": { "str": "jury-rigged frame" },
+    "item": "frame",
+    "location": "structure",
+    "standard_symbols": true,
+    "durability": 250,
+    "description": "A metal framework, haphazardly welded together. It still provides support, but is much less durable than machined frame.",
+    "breaks_into": "ig_vp_frame",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "20 m", "using": [ [ "welding_standard", 10 ] ] },
+      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m", "using": "vehicle_weld_removal" },
+      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
+    },
+    "flags": [ "MOUNTABLE", "INITIAL_PART" ],
+    "categories": [ "hull" ],
+    "damage_reduction": { "all": 15 }
   },
   {
     "id": "frame_wood",
@@ -118,9 +137,29 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "20 m", "using": "vehicle_weld_removal" },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
-    "flags": [ "MOUNTABLE", "INITIAL_PART" ],
+    "flags": [ "MOUNTABLE", "INITIAL_PART", "NO_INSTALL_PLAYER" ],
     "damage_reduction": { "all": 30 }
   },
+  {
+    "id": "jrhdframe",
+    "type": "vehicle_part",
+    "name": { "str": "jury-rigged heavy frame" },
+    "item": "hdframe",
+    "location": "structure",
+    "standard_symbols": true,
+    "categories": [ "hull" ],
+    "color": "dark_gray",
+    "durability": 500,
+    "description": "A heavy metal framework, haphazardly welded together. It still provides support, but is much less durable than machined frame.  Increased mass makes it more resistant to damage in collisions.",
+    "breaks_into": "ig_vp_hdframe",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "40 m", "using": [ [ "welding_standard", 20 ] ] },
+      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "20 m", "using": "vehicle_weld_removal" },
+      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 3 ] ] }
+    },
+    "flags": [ "MOUNTABLE", "INITIAL_PART" ],
+    "damage_reduction": { "all": 20 }
+  },  
   {
     "id": "xlframe",
     "type": "vehicle_part",
@@ -138,7 +177,27 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "12 m", "using": "vehicle_weld_removal" },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "repair_welding_alloys", 1 ] ] }
     },
-    "flags": [ "MOUNTABLE", "INITIAL_PART" ],
+    "flags": [ "MOUNTABLE", "INITIAL_PART", "NO_INSTALL_PLAYER" ],
     "damage_reduction": { "all": 7 }
+  }, 
+  {
+    "id": "jrxlframe",
+    "type": "vehicle_part",
+    "name": { "str": "jury-rigged light frame" },
+    "item": "xlframe",
+    "location": "structure",
+    "standard_symbols": true,
+    "categories": [ "hull" ],
+    "color": "light_gray",
+    "durability": 100,
+    "description": "A light metal framework, haphazardly welded together. It still provides support, but is much less durable than machined frame.",
+    "breaks_into": "ig_vp_xlframe",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "25 m", "using": [ [ "welding_alloys", 10 ] ] },
+      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "12 m", "using": "vehicle_weld_removal" },
+      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "repair_welding_alloys", 1 ] ] }
+    },
+    "flags": [ "MOUNTABLE", "INITIAL_PART" ],
+    "damage_reduction": { "all": 5 }
   }
 ]

--- a/data/json/vehicleparts/frames.json
+++ b/data/json/vehicleparts/frames.json
@@ -60,7 +60,7 @@
     "categories": [ "hull" ],
     "damage_reduction": { "all": 20 }
   },
-   {
+  {
     "id": "jrframe",
     "type": "vehicle_part",
     "name": { "str": "jury-rigged frame" },
@@ -159,7 +159,7 @@
     },
     "flags": [ "MOUNTABLE", "INITIAL_PART" ],
     "damage_reduction": { "all": 20 }
-  },  
+  },
   {
     "id": "xlframe",
     "type": "vehicle_part",
@@ -179,7 +179,7 @@
     },
     "flags": [ "MOUNTABLE", "INITIAL_PART", "NO_INSTALL_PLAYER" ],
     "damage_reduction": { "all": 7 }
-  }, 
+  },
   {
     "id": "jrxlframe",
     "type": "vehicle_part",

--- a/data/json/vehicleparts/frames.json
+++ b/data/json/vehicleparts/frames.json
@@ -68,7 +68,7 @@
     "location": "structure",
     "standard_symbols": true,
     "durability": 250,
-    "description": "A metal framework, haphazardly welded together. It still provides support, but is much less durable than machined frame.",
+    "description": "A metal framework, haphazardly welded together.  It still provides support, but is much less durable than machined frame.",
     "breaks_into": "ig_vp_frame",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "20 m", "using": [ [ "welding_standard", 10 ] ] },
@@ -150,7 +150,7 @@
     "categories": [ "hull" ],
     "color": "dark_gray",
     "durability": 500,
-    "description": "A heavy metal framework, haphazardly welded together. It still provides support, but is much less durable than machined frame.  Increased mass makes it more resistant to damage in collisions.",
+    "description": "A heavy metal framework, haphazardly welded together.  It still provides support, but is much less durable than machined frame.  Increased mass makes it more resistant to damage in collisions.",
     "breaks_into": "ig_vp_hdframe",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 3 ] ], "time": "40 m", "using": [ [ "welding_standard", 20 ] ] },
@@ -190,7 +190,7 @@
     "categories": [ "hull" ],
     "color": "light_gray",
     "durability": 100,
-    "description": "A light metal framework, haphazardly welded together. It still provides support, but is much less durable than machined frame.",
+    "description": "A light metal framework, haphazardly welded together.  It still provides support, but is much less durable than machined frame.",
     "breaks_into": "ig_vp_xlframe",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "25 m", "using": [ [ "welding_alloys", 10 ] ] },

--- a/data/json/vehicleparts/frames.json
+++ b/data/json/vehicleparts/frames.json
@@ -77,7 +77,7 @@
     },
     "flags": [ "MOUNTABLE", "INITIAL_PART" ],
     "categories": [ "hull" ],
-    "damage_reduction": { "all": 15 }
+    "damage_reduction": { "all": 25 }
   },
   {
     "id": "frame_wood",
@@ -158,7 +158,7 @@
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
     "flags": [ "MOUNTABLE", "INITIAL_PART" ],
-    "damage_reduction": { "all": 20 }
+    "damage_reduction": { "all": 40 }
   },
   {
     "id": "xlframe",
@@ -198,6 +198,6 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "repair_welding_alloys", 1 ] ] }
     },
     "flags": [ "MOUNTABLE", "INITIAL_PART" ],
-    "damage_reduction": { "all": 5 }
+    "damage_reduction": { "all": 10 }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Make players unable to install proper frames, instead letting them install less durable variants"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Making it harder for players to create death-mobiles, and forcing them to rely on preexistent frame structures rather than trying to enhance them.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Made players unable to install extra light, heavy duty and normal frames, replacing them with variants that have about 2/3 durability and damage resistance as originals.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Making it possible to install proper frames using something like a car assembly line.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Can repair old frames, can remove them. Installing new frames is only possible via jury-rigging.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
