### PR TITLE
Prevent .38 Super from spawning as on-hand ammo for normal .38 guns.

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_ammo.json
@@ -303,7 +303,7 @@
       { "item": "38_fmj", "prob": 75, "charges": [ 44, 80 ] },
       { "item": "38_special", "prob": 75, "charges": [ 44, 80 ] },
       { "item": "38_fmj", "prob": 30, "charges": [ 88, 160 ] },
-      { "item": "38_special", "prob": 30, "charges": [ 88, 160 ] },
+      { "item": "38_special", "prob": 30, "charges": [ 88, 160 ] }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_ammo.json
@@ -304,7 +304,6 @@
       { "item": "38_special", "prob": 75, "charges": [ 44, 80 ] },
       { "item": "38_fmj", "prob": 30, "charges": [ 88, 160 ] },
       { "item": "38_special", "prob": 30, "charges": [ 88, 160 ] },
-      { "item": "38_super", "prob": 30, "charges": [ 1, 40 ] }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent .38 Super from spawning as on-hand ammo for normal .38 guns."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently, .38 Super is included as a potential spawn in on_hand_38, which is meant for the .38 ammunition type, not the separate .38 Super ammo type. bombasticSlacks confirmed on Discord that this is a bug.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove the .38 Super line of code from the on_hand_38 group. (and remove the comma that preceeds that line, so the code is formatted correctly).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Made sure there weren't any formatting mistakes by loading the game and seeing no errors. Used debug menu to spawn 100 instances of on_hand_38. The normal .38 ammo spawned correctly, and no .38 Super spawned.
![Screenshot (168)](https://user-images.githubusercontent.com/38295275/178083823-3bc62ab9-c213-400a-80b1-2a5effefe7ab.png)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
