### PR TITLE
Add ``mon_dog_death_drops`` to the acid zombie dog

### DIFF
--- a/data/json/monsters/zed_acid.json
+++ b/data/json/monsters/zed_acid.json
@@ -249,6 +249,7 @@
     "dodge": 1,
     "harvest": "zombie",
     "special_attacks": [ { "type": "bite", "attack_upper": false, "cooldown": 5 }, [ "ACID_BARF", 10 ] ],
+    "death_drops": "mon_dog_death_drops",
     "death_function": { "message": "The %s's body leaks acid.", "effect": { "id": "death_acid", "hit_self": true } },
     "upgrades": { "half_life": 12, "into": "mon_zombie_dog_brute_acidic" },
     "flags": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Added the appropriate death drop group to the acid dog"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes a problem that theoretically didn't ever appear outside testing: Acid Zombie Dog and its upgraded form did not have any death drops associated with them. In normal playthroughs, this should not matter as acid dogs would be upgraded versions of zombie dogs and as such carry over their loot, I simply changed this for the sake of consistency and testing.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Simply adds the mon_dog_death_drops to the code of the Acid Zombie Dog, its upgraded variant copies it so it should automatically apply to it as well.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Just leaving it as is since it really doesn't impact normal gameplay, it just confused the hell out of me when trying to test loot drops specifically on acid zombie dogs and figured I may as well patch this up.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned a bunch of acid zombie dogs and killed them with debug mode, many dropped loot associated with zombie dogs such as rubber dog rainsuits, primarily.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Came across this while trying to figure out why one acid zombie dog dropped me a clean rainsuit on my regular save. Still haven't found any possible culprit for that and honestly the more I look into it the more I feel like I must have just imagined it as it's just not possible according to the code.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
