### PR TITLE
Fix AppData inconsistencies

### DIFF
--- a/data/xdg/org.cataclysmdda.CataclysmDDA.appdata.xml
+++ b/data/xdg/org.cataclysmdda.CataclysmDDA.appdata.xml
@@ -287,72 +287,78 @@
       </description>
     </release>
     <release version="0.C Cooper" date="2015-03-09">
-      <p>
-        The Cooper release is named in honor of the new monster
-        infighting system. Now you can sit back and watch as your
-        enemies tear each other to pieces! Don’t get too close though,
-        they’re still out for your blood.
-      </p>
-      <ul>
-        <li>
-          This release also brings the long-requested DeathCam system,
-          which lets you see the aftermath of the glorious fireball or
-          atrocious train wreck that was your demise.
-        </li>
-        <li>
-          Gun users will notice a new aiming menu: you can now spend
-          time to steady your aim. Do you take the shot now, or wait
-          until the zombie gets a little closer?
-        </li>
-        <li>
-          Tailoring-oriented survivors (and who isn’t?) will note the
-          new tailor’s kit item, which lets you add insulation or
-          protective patches to your clothes.
-        </li>
-        <li>
-          Survivors with gigantic death-mobiles may appreciate the new
-          turret options, including being able to enable/disable
-          individual turrets, and being able to fire some turrets
-          manually.
-        </li>
-        <li>
-          Finally, for survivors with, shall we say, “well-stocked”
-          bases, there are massive improvements to performance when
-          there are many thousands of items nearby.
-        </li>
-      </ul>
+      <description>
+        <p>
+          The Cooper release is named in honor of the new monster
+          infighting system. Now you can sit back and watch as your
+          enemies tear each other to pieces! Don’t get too close though,
+          they’re still out for your blood.
+        </p>
+        <ul>
+          <li>
+            This release also brings the long-requested DeathCam system,
+            which lets you see the aftermath of the glorious fireball or
+            atrocious train wreck that was your demise.
+          </li>
+          <li>
+            Gun users will notice a new aiming menu: you can now spend
+            time to steady your aim. Do you take the shot now, or wait
+            until the zombie gets a little closer?
+          </li>
+          <li>
+            Tailoring-oriented survivors (and who isn’t?) will note the
+            new tailor’s kit item, which lets you add insulation or
+            protective patches to your clothes.
+          </li>
+          <li>
+            Survivors with gigantic death-mobiles may appreciate the new
+            turret options, including being able to enable/disable
+            individual turrets, and being able to fire some turrets
+            manually.
+          </li>
+          <li>
+            Finally, for survivors with, shall we say, “well-stocked”
+            bases, there are massive improvements to performance when
+            there are many thousands of items nearby.
+          </li>
+        </ul>
+      </description>
     </release>
     <release version="0.B Brin" date="2014-11-17">
-      <p>
-        The Brin release is named in honor of significant improvements
-        to PC/NPC relations.
-      </p>
-      <p>
-        This release, containing over 9,000 commits (@kevingranade
-        counted) brings an unheard-of amount of new features and
-        content, most of which wants you dead.
-      </p>
-      <p>
-        Start your adventure in a wide variety of different locations,
-        with a selection of different starting scenarios, now with
-        unique character traits. Explore new locations, some of which
-        are ridiculously big (did somebody say ‘mall’?), and some of
-        which have inhabitants that don’t want to eat you for a
-        change. Vehicles have gotten some love, and now form a basis
-        for an electrical network should you desire to build one. If
-        you’ve ever wanted to strap a C4 pack onto an RC car and drive
-        it under a Zombie Hulk, you got your chance.
-      </p>
+      <description>
+        <p>
+          The Brin release is named in honor of significant improvements
+          to PC/NPC relations.
+        </p>
+        <p>
+          This release, containing over 9,000 commits (@kevingranade
+          counted) brings an unheard-of amount of new features and
+          content, most of which wants you dead.
+        </p>
+        <p>
+          Start your adventure in a wide variety of different locations,
+          with a selection of different starting scenarios, now with
+          unique character traits. Explore new locations, some of which
+          are ridiculously big (did somebody say ‘mall’?), and some of
+          which have inhabitants that don’t want to eat you for a
+          change. Vehicles have gotten some love, and now form a basis
+          for an electrical network should you desire to build one. If
+          you’ve ever wanted to strap a C4 pack onto an RC car and drive
+          it under a Zombie Hulk, you got your chance.
+        </p>
+      </description>
     </release>
     <release version="0.A Kaufman" date="2014-03-22">
-      <p>
-        The Kaufman is named in honor of a huge expansion to
-        Cataclysm’s mutation system.  The release, our largest yet
-        also brings innumerable bugfixes, performance enhancements,
-        new items, a long-awaited module manager, new monsters,
-        fullscreen mode, better mouse support, new map tiles and an
-        unheard-of level of stability.
-      </p>
+      <description>
+        <p>
+          The Kaufman is named in honor of a huge expansion to
+          Cataclysm’s mutation system.  The release, our largest yet
+          also brings innumerable bugfixes, performance enhancements,
+          new items, a long-awaited module manager, new monsters,
+          fullscreen mode, better mouse support, new map tiles and an
+          unheard-of level of stability.
+        </p>
+      </description>
     </release>
   </releases>
 </component>

--- a/data/xdg/org.cataclysmdda.CataclysmDDA.appdata.xml
+++ b/data/xdg/org.cataclysmdda.CataclysmDDA.appdata.xml
@@ -140,14 +140,8 @@
           <li>Dinomod added many dino interactions, including farming, riding, butchering, cooking, and special attacks.</li>
           <li>Magiclysm added a huge content update including many new traits called Attunements that switch up gameplay at the endgame.</li>
         </ul>
-        <p>
-          Finally, see the changelog for the more complete (but still
-          not comprehensive) listing of new features and contents -
-          <a href="https://github.com/CleverRaven/Cataclysm-DDA/blob/0.F/data/changelog.txt">
-            https://github.com/CleverRaven/Cataclysm-DDA/blob/0.F/data/changelog.txt
-          </a>
-        </p>
       </description>
+      <url type="details">https://github.com/CleverRaven/Cataclysm-DDA/blob/0.F/data/changelog.txt</url>
     </release>
     <release version="0.E Ellison" date="2020-04-01">
       <description>
@@ -201,14 +195,8 @@
           <li>Crouching movement mode allows hiding.</li>
           <li>Magiclysm and Aftershock mods have first class support within the game.</li>
         </ul>
-        <p>
-          Finally, see the changelog for the more complete (but still
-          not comprehensive) listing of new features and contents -
-          <a href="https://github.com/CleverRaven/Cataclysm-DDA/blob/0.E/data/changelog.txt">
-            https://github.com/CleverRaven/Cataclysm-DDA/blob/0.E/data/changelog.txt
-          </a>
-        </p>
       </description>
+      <url type="details">https://github.com/CleverRaven/Cataclysm-DDA/blob/0.E/data/changelog.txt</url>
     </release>
     <release version="0.D Danny" date="2019-03-08">
       <description>


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

The appstream validator reported a few violations of the metadata spec.
```
$ appstreamcli validate org.cataclysmdda.CataclysmDDA.appdata.xml
W: org.cataclysmdda.CataclysmDDA:143: description-has-plaintext-url p
I: org.cataclysmdda.CataclysmDDA:326: unknown-tag p
I: org.cataclysmdda.CataclysmDDA:290: unknown-tag p
I: org.cataclysmdda.CataclysmDDA:296: unknown-tag ul
I: org.cataclysmdda.CataclysmDDA:348: unknown-tag p
I: org.cataclysmdda.CataclysmDDA:335: unknown-tag p
E: org.cataclysmdda.CataclysmDDA:207: description-para-markup-invalid a
W: org.cataclysmdda.CataclysmDDA:204: description-has-plaintext-url p
I: org.cataclysmdda.CataclysmDDA:330: unknown-tag p
E: org.cataclysmdda.CataclysmDDA:146: description-para-markup-invalid a
```

#### Describe the solution

Tags like `<p>`, `<ul>` can't be used directly in `<release>` sections. This is fixed by placing them into `<description>` tags.

URLs are also not allowed within `<release>`/`<description>` tags, they need to be put into `<url>` tags.

#### Testing

With these changes the validator no longer reports warnings/errors:
```
$ appstreamcli validate org.cataclysmdda.CataclysmDDA.appdata.xml 

✔ Validation was successful: pedantic: 1
```

There is only one pedantic notice left about uppercase spelling of the id:
```
$ appstreamcli validate --pedantic org.cataclysmdda.CataclysmDDA.appdata.xml 
P: org.cataclysmdda.CataclysmDDA:3: cid-contains-uppercase-letter
     org.cataclysmdda.CataclysmDDA

✔ Validation was successful: pedantic: 1
```

#### Additional context

https://appstream.debian.org/sid/main/issues/cataclysm-dda-sdl.html
https://freedesktop.org/software/appstream/docs/chap-Metadata.html
