### PR TITLE
Refactor light levels into their own class light

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1504,8 +1504,8 @@ void Character::burn_fuel( bionic &bio, const auto_toggle_bionic_result &result 
         case auto_toggle_bionic_result::fuel_type_t::perpetual:
             if( result.burnable_fuel_id == fuel_type_sun_light && g->is_in_sunlight( pos() ) ) {
                 const weather_type_id &wtype = current_weather( pos() );
-                const float tick_sunlight = incident_sunlight( wtype, calendar::turn );
-                const double intensity = tick_sunlight / default_daylight_level();
+                const light tick_sunlight = incident_sunlight( wtype, calendar::turn );
+                const float intensity = tick_sunlight / default_daylight_level();
                 mod_power_level( units::from_kilojoule( result.fuel_energy ) * intensity *
                                  result.effective_efficiency );
             } else if( result.burnable_fuel_id == fuel_type_wind ) {
@@ -1568,7 +1568,7 @@ void Character::passive_power_gen( const bionic &bio )
         }
 
         if( fuel == fuel_type_sun_light ) {
-            const double modifier = g->natural_light_level( pos().z ) / default_daylight_level();
+            const float modifier = g->natural_light_level( pos().z ) / default_daylight_level();
             mod_power_level( units::from_kilojoule( fuel_energy ) * modifier * effective_passive_efficiency );
         } else if( fuel == fuel_type_wind ) {
             int vehwindspeed = 0;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -81,6 +81,7 @@
 #include "vpart_position.h"
 #include "weather.h"
 #include "weather_gen.h"
+#include "light.h"
 
 static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 
@@ -1505,7 +1506,7 @@ void Character::burn_fuel( bionic &bio, const auto_toggle_bionic_result &result 
             if( result.burnable_fuel_id == fuel_type_sun_light && g->is_in_sunlight( pos() ) ) {
                 const weather_type_id &wtype = current_weather( pos() );
                 const light tick_sunlight = incident_sunlight( wtype, calendar::turn );
-                const float intensity = tick_sunlight / default_daylight_level();
+                const float intensity = tick_sunlight / LIGHT_DAY;
                 mod_power_level( units::from_kilojoule( result.fuel_energy ) * intensity *
                                  result.effective_efficiency );
             } else if( result.burnable_fuel_id == fuel_type_wind ) {
@@ -1568,7 +1569,7 @@ void Character::passive_power_gen( const bionic &bio )
         }
 
         if( fuel == fuel_type_sun_light ) {
-            const float modifier = g->natural_light_level( pos().z ) / default_daylight_level();
+            const float modifier = g->natural_light_level( pos().z ) / LIGHT_DAY;
             mod_power_level( units::from_kilojoule( fuel_energy ) * modifier * effective_passive_efficiency );
         } else if( fuel == fuel_type_wind ) {
             int vehwindspeed = 0;

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -45,11 +45,6 @@ static constexpr units::angle nautical_dawn = -12_degrees;
 static constexpr units::angle civil_dawn = -6_degrees;
 static constexpr units::angle sunrise_angle = -1_degrees;
 
-light default_daylight_level()
-{
-    return light( 100.0f );
-}
-
 time_duration lunar_month()
 {
     return 29.530588853 * 1_days;

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -610,8 +610,6 @@ bool is_day( const time_point &p );
 bool is_dusk( const time_point &p );
 /** Returns true if it's currently dawn - between sunrise and twilight_duration after sunrise. */
 bool is_dawn( const time_point &p );
-/** How much light is provided in full daylight */
-light default_daylight_level();
 /** Returns the current sunlight.
  *  Based entirely on astronomical circumstances; does not account for e.g.
  *  weather.

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "units_fwd.h"
+#include "light.h"
 
 class JsonIn;
 class JsonOut;
@@ -610,19 +611,19 @@ bool is_dusk( const time_point &p );
 /** Returns true if it's currently dawn - between sunrise and twilight_duration after sunrise. */
 bool is_dawn( const time_point &p );
 /** How much light is provided in full daylight */
-double default_daylight_level();
+light default_daylight_level();
 /** Returns the current sunlight.
  *  Based entirely on astronomical circumstances; does not account for e.g.
  *  weather.
  *  For most situations you actually want to call the below function which also
  *  includes moonlight. */
-float sun_light_at( const time_point &p );
+light sun_light_at( const time_point &p );
 /** Returns the current sunlight plus moonlight level.
  *  Based entirely on astronomical circumstances; does not account for e.g.
  *  weather. */
-float sun_moon_light_at( const time_point &p );
+light sun_moon_light_at( const time_point &p );
 /** How much light is provided at the solar noon nearest to given time */
-double sun_moon_light_at_noon_near( const time_point &p );
+light sun_moon_light_at_noon_near( const time_point &p );
 
 std::pair<units::angle, units::angle> sun_azimuth_altitude( time_point );
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1520,11 +1520,11 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
             if( g->display_overlay_state( ACTION_DISPLAY_LIGHTING ) ) {
                 if( g->displaying_lighting_condition == 0 ) {
-                    const float light = here.ambient_light_at( {x, y, center.z} );
                     // note: lighting will be constrained in the [1.0, 11.0] range.
+                    const light amb_light = here.ambient_light_at( {x, y, center.z} );
                     int intensity =
-                        static_cast<int>( std::max( 1.0, LIGHT_AMBIENT_LIT - light + 1.0 ) ) - 1;
-                    draw_debug_tile( intensity, string_format( "%.1f", light ) );
+                        static_cast<int>( std::max( 1.0f, LIGHT_AMBIENT_LIT.value - amb_light.value + 1.0f ) ) - 1;
+                    draw_debug_tile( intensity, string_format( "%.1f", amb_light.value ) );
                 }
             }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1084,7 +1084,7 @@ double Character::aim_per_move( const item &gun, double recoil,
 int Character::sight_range( light light_level ) const
 {
     light threshold = get_vision_threshold();
-    return std::min( sight_max, light_level.sight_range(threshold));
+    return std::min( unimpaired_range(), light_level.sight_range(threshold));
 }
 
 int Character::unimpaired_range() const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9120,7 +9120,7 @@ bool Character::sees_with_infrared( const Creature &critter ) const
     map &here = get_map();
     // Use range based on default daylight, not actual current light, since
     // we're seeing in infra red not via light.
-    int range = sight_range( default_daylight_level() );
+    int range = sight_range( LIGHT_DAY );
 
     if( is_avatar() || critter.is_avatar() ) {
         // Players should not use map::sees

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1083,7 +1083,7 @@ double Character::aim_per_move( const item &gun, double recoil,
 
 int Character::sight_range( light light_level ) const
 {
-    light threshold = get_vision_threshold( get_map().ambient_light_at( pos() ) );
+    light threshold = get_vision_threshold();
     return std::min( sight_max, light_level.sight_range(threshold));
 }
 
@@ -2289,8 +2289,9 @@ static float threshold_for_range( float range )
     return LIGHT_AMBIENT_MINIMAL.value / std::exp( range * LIGHT_TRANSPARENCY_OPEN_AIR ) - epsilon;
 }
 
-light Character::get_vision_threshold( light light_level ) const
+light Character::get_vision_threshold() const
 {
+    light light_level = get_map().ambient_light_at( pos() );
     if( vision_mode_cache[DEBUG_NIGHTVISION] ) {
         // Debug vision always works with absurdly little light.
         return light( 0.01f );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1083,26 +1083,8 @@ double Character::aim_per_move( const item &gun, double recoil,
 
 int Character::sight_range( light light_level ) const
 {
-    if( static_cast<int>( light_level.value ) == 0 ) {
-        return 1;
-    }
-    /* Via Beer-Lambert we have:
-     * light_level * (1 / exp( LIGHT_TRANSPARENCY_OPEN_AIR * distance) ) <= LIGHT_AMBIENT_LOW
-     * Solving for distance:
-     * 1 / exp( LIGHT_TRANSPARENCY_OPEN_AIR * distance ) <= LIGHT_AMBIENT_LOW / light_level
-     * 1 <= exp( LIGHT_TRANSPARENCY_OPEN_AIR * distance ) * LIGHT_AMBIENT_LOW / light_level
-     * light_level <= exp( LIGHT_TRANSPARENCY_OPEN_AIR * distance ) * LIGHT_AMBIENT_LOW
-     * log(light_level) <= LIGHT_TRANSPARENCY_OPEN_AIR * distance + log(LIGHT_AMBIENT_LOW)
-     * log(light_level) - log(LIGHT_AMBIENT_LOW) <= LIGHT_TRANSPARENCY_OPEN_AIR * distance
-     * log(LIGHT_AMBIENT_LOW / light_level) <= LIGHT_TRANSPARENCY_OPEN_AIR * distance
-     * log(LIGHT_AMBIENT_LOW / light_level) * (1 / LIGHT_TRANSPARENCY_OPEN_AIR) <= distance
-     */
     light threshold = get_vision_threshold( get_map().ambient_light_at( pos() ) );
-    int range = static_cast<int>( -std::log( threshold / light_level ) *
-                                  ( 1.0f / LIGHT_TRANSPARENCY_OPEN_AIR ) );
-
-    // Clamp to [1, sight_max].
-    return clamp( range, 1, sight_max );
+    return std::min( sight_max, light_level.sight_range(threshold));
 }
 
 int Character::unimpaired_range() const

--- a/src/character.h
+++ b/src/character.h
@@ -57,6 +57,7 @@
 #include "visitable.h"
 #include "weakpoint.h"
 #include "weighted_list.h"
+#include "light.h"
 
 class Character;
 class JsonIn;
@@ -649,13 +650,13 @@ class Character : public Creature, public visitable
         float get_hit_base() const override;
 
         /** Returns the player's sight range */
-        int sight_range( int light_level ) const override;
+        int sight_range( light light_level ) const override;
         /** Returns the player maximum vision range factoring in mutations, diseases, and other effects */
         int  unimpaired_range() const;
         /** Returns true if overmap tile is within player line-of-sight */
         bool overmap_los( const tripoint_abs_omt &omt, int sight_points ) const;
         /** Returns the distance the player can see on the overmap */
-        int  overmap_sight_range( int light_level ) const;
+        int  overmap_sight_range( light light_level ) const;
         /** Returns the distance the player can see through walls */
         int  clairvoyance() const;
         /** Returns true if the player has some form of impaired sight */
@@ -806,7 +807,7 @@ class Character : public Creature, public visitable
         int visibility( bool check_color = false, int stillness = 0 ) const;
 
         /** Returns character luminosity based on the brightest active item they are carrying */
-        float active_light() const;
+        light active_light() const;
 
         bool sees_with_specials( const Creature &critter ) const;
 
@@ -880,7 +881,7 @@ class Character : public Creature, public visitable
          * This is adjusted by the light level at the *character's* position
          * to simulate glare, etc, night vision only works if you are in the dark.
          */
-        float get_vision_threshold( float light_level ) const;
+        light get_vision_threshold( light light_level ) const;
         /**
          * Flag encumbrance for updating.
         */

--- a/src/character.h
+++ b/src/character.h
@@ -881,7 +881,7 @@ class Character : public Creature, public visitable
          * This is adjusted by the light level at the *character's* position
          * to simulate glare, etc, night vision only works if you are in the dark.
          */
-        light get_vision_threshold( light light_level ) const;
+        light get_vision_threshold() const;
         /**
          * Flag encumbrance for updating.
         */

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -61,6 +61,7 @@
 #include "value_ptr.h"
 #include "vehicle.h"
 #include "vpart_position.h"
+#include "light.h"
 
 struct mutation_branch;
 
@@ -426,7 +427,7 @@ bool Creature::sees( const tripoint &t, bool is_avatar, int range_mod ) const
 
     map &here = get_map();
     const int range_cur = sight_range( here.ambient_light_at( t ) );
-    const int range_day = sight_range( default_daylight_level() );
+    const int range_day = sight_range( LIGHT_DAY );
     const int range_night = sight_range( light( 0.0f ) );
     const int range_max = std::max( range_day, range_night );
     const int range_min = std::min( range_cur, range_max );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -427,7 +427,7 @@ bool Creature::sees( const tripoint &t, bool is_avatar, int range_mod ) const
     map &here = get_map();
     const int range_cur = sight_range( here.ambient_light_at( t ) );
     const int range_day = sight_range( default_daylight_level() );
-    const int range_night = sight_range( 0 );
+    const int range_night = sight_range( light( 0.0f ) );
     const int range_max = std::max( range_day, range_night );
     const int range_min = std::min( range_cur, range_max );
     const int wanted_range = rl_dist( pos(), t );

--- a/src/creature.h
+++ b/src/creature.h
@@ -26,6 +26,7 @@
 #include "units_fwd.h"
 #include "viewer.h"
 #include "weakpoint.h"
+#include "light.h"
 
 class monster;
 class translation;
@@ -383,7 +384,7 @@ class Creature : public viewer
          * How far the creature sees under the given light. Places outside this range can
          * @param light_level See @ref game::light_level.
          */
-        virtual int sight_range( int light_level ) const = 0;
+        virtual int sight_range( light light_level ) const = 0;
 
         /** Returns an approximation of the creature's strength. */
         virtual float power_rating() const = 0;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -313,7 +313,7 @@ std::string display::sundial_text_color( const Character &u, int width )
     std::pair<units::angle, units::angle> sun_pos = sun_azimuth_altitude( calendar::turn );
     const int h = hour_of_day<int>( calendar::turn );
     const int h_dawn = hour_of_day<int>( sunset( calendar::turn ) ) - 12;
-    const float light = sun_light_at( calendar::turn );
+    const light light = sun_light_at( calendar::turn );
     float azm = to_degrees( normalize( sun_pos.first + 90_degrees ) );
     if( azm > 270.f ) {
         azm -= 360.f;
@@ -349,7 +349,7 @@ std::string display::sundial_text_color( const Character &u, int width )
                     clr = n_glyphs[glyph].second;
                 }
             }
-            if( light > l_dist ) {
+            if( light.value > l_dist ) {
                 clr = hilite( clr );
             }
             ret += colorize( ch, clr );
@@ -1247,7 +1247,7 @@ std::pair<std::string, nc_color> display::overmap_tile_symbol_color( const avata
     // Show hordes on minimap, leaving a one-tile space around the player
     if( std::abs( u_loc.x() - omt.x() ) > 1 || std::abs( u_loc.y() - omt.y() ) > 1 ) {
         const int horde_size = overmap_buffer.get_horde_size( omt );
-        const int sight_points = u.overmap_sight_range( g->light_level( u.posz() ) );
+        const int sight_points = u.overmap_sight_range( g->incorrect_light_level( u.posz() ) );
         if( horde_size >= HORDE_VISIBILITY_SIZE && overmap_buffer.seen( omt ) &&
             u.overmap_los( omt, sight_points ) ) {
             // Draw green Z or z

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -751,7 +751,7 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     mvwprintw( w_info, point( 1, off++ ), _( "dist: %d u_see: %s veh: %s scent: %d" ),
                rl_dist( player_character.pos(), target ), u_see_msg, veh_msg, get_scent().get( target ) );
     mvwprintw( w_info, point( 1, off++ ), _( "sight_range: %d, noon_sight_range: %d," ),
-               player_character.sight_range( g->light_level( player_character.posz() ) ),
+               player_character.sight_range( g->incorrect_light_level( player_character.posz() ) ),
                player_character.sight_range( sun_moon_light_at_noon_near( calendar::turn ) ) );
     mvwprintw( w_info, point( 1, off++ ), _( "cache{transp:%.4f seen:%.4f cam:%.4f}" ),
                map_cache.transparency_cache[target.x][target.y],
@@ -769,7 +769,7 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     mvwprintw( w_info, point( 1, off++ ), _( "light_at: %s" ),
                map_cache.lm[target.x][target.y].to_string() );
     mvwprintw( w_info, point( 1, off++ ), _( "apparent light: %.5f (%d)" ),
-               al.apparent_light, apparent_light );
+               al.apparent_light.value, apparent_light );
     std::string extras;
     if( vp ) {
         extras += _( " [vehicle]" );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5959,8 +5959,7 @@ void game::print_terrain_info( const tripoint &lp, const catacurses::window &w_l
     }
 
     // Print light level on the selected tile.
-    std::pair<std::string, nc_color> ll = get_light_level( std::max( light( 1.0f ),
-                                          LIGHT_AMBIENT_LIT - m.ambient_light_at( lp ) + light( 1.0f ) ) );
+    std::pair<std::string, nc_color> ll = get_light_level( m.ambient_light_at( lp ) );
     mvwprintz( w_look, point( column, ++line ), c_light_gray, _( "Lighting: " ) );
     mvwprintz( w_look, point( column + utf8_width( _( "Lighting: " ) ), line ), ll.second, ll.first );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9648,10 +9648,10 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
         }
     }
 
-    const float dest_light_level = get_map().ambient_light_at( dest_loc );
+    const light dest_light_level = get_map().ambient_light_at( dest_loc );
 
     // Allow players with nyctophobia to move freely through cloudy and dark tiles
-    const float nyctophobia_threshold = LIGHT_AMBIENT_LIT - 3.0f;
+    const light nyctophobia_threshold = LIGHT_AMBIENT_LIT - light(3.0f);
 
     // Forbid players from moving through very dark tiles, unless they are running or took xanax
     if( u.has_flag( json_flag_NYCTOPHOBIA ) && !u.has_effect( effect_took_xanax ) && !u.is_running() &&

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1174,7 +1174,7 @@ static int veh_lumi( vehicle &veh )
         }
     }
     // Calculation: see lightmap.cpp
-    return ( veh_luminance * 3 ).range_in_air();
+    return ( veh_luminance * 3 ).sight_range();
 }
 
 void game::calc_driving_offset( vehicle *veh )
@@ -3868,13 +3868,13 @@ light game::natural_light_level( const int zlev ) const
 light game::incorrect_light_level( const int zlev ) const
 {
     const light nat_light = natural_light_level( zlev );
-    return light( nat_light.range_in_air() );
+    return light( nat_light.sight_range() );
 }
 
 int game::light_level( const int zlev ) const
 {
     const light light = natural_light_level( zlev );
-    return light.range_in_air();
+    return light.sight_range();
 }
 
 void game::reset_light_level()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -183,6 +183,7 @@
 #include "weather.h"
 #include "weather_type.h"
 #include "worldfactory.h"
+#include "light.h"
 
 class computer;
 
@@ -3846,7 +3847,7 @@ light game::natural_light_level( const int zlev ) const
     }
     if( timed_events.queued( timed_event_type::ARTIFACT_LIGHT ) ) {
         // timed_event_type::ARTIFACT_LIGHT causes everywhere to become as bright as day.
-        mod_ret = std::max( ret, default_daylight_level() );
+        mod_ret = std::max( ret, LIGHT_DAY );
     }
     if( const timed_event *e = timed_events.get( timed_event_type::CUSTOM_LIGHT_LEVEL ) ) {
         mod_ret = light( e->strength );
@@ -9650,12 +9651,10 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
 
     const light dest_light_level = get_map().ambient_light_at( dest_loc );
 
-    // Allow players with nyctophobia to move freely through cloudy and dark tiles
-    const light nyctophobia_threshold = LIGHT_AMBIENT_LIT - light(3.0f);
-
     // Forbid players from moving through very dark tiles, unless they are running or took xanax
+    // Allow players with nyctophobia to move freely through cloudy and dark tiles
     if( u.has_flag( json_flag_NYCTOPHOBIA ) && !u.has_effect( effect_took_xanax ) && !u.is_running() &&
-        dest_light_level < nyctophobia_threshold ) {
+        dest_light_level < LIGHT_AMBIENT_CLOUDY ) {
         add_msg( m_bad,
                  _( "It's so dark and scary in there!  You can't force yourself to walk into this tile.  Switch to running movement mode to move there." ) );
         return false;

--- a/src/game.h
+++ b/src/game.h
@@ -556,11 +556,12 @@ class game
         void fling_creature( Creature *c, const units::angle &dir, float flvel,
                              bool controlled = false );
 
-        float natural_light_level( int zlev ) const;
+        light natural_light_level( int zlev ) const;
         /** Returns coarse number-of-squares of visibility at the current light level.
          * Used by monster and NPC AI.
          */
-        unsigned char light_level( int zlev ) const;
+        light incorrect_light_level( int zlev ) const;
+        int light_level( int zlev ) const;
         void reset_light_level();
         character_id assign_npc_id();
         Creature *is_hostile_nearby();

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8987,10 +8987,11 @@ cata::optional<int> iuse::lux_meter( Character *p, item *, bool, const tripoint 
         const units::angle altitude = sun_azimuth_altitude( calendar::turn ).second;
         p->add_msg_if_player( m_neutral,
                               "The illumination is %.1f, Sun illumination %.1f, Sun altitude %.1f.",
-                              g->natural_light_level( pos.z ), sun_light_at( calendar::turn ), to_degrees( altitude ) );
+                              g->natural_light_level( pos.z ).value, sun_light_at( calendar::turn ).value,
+                              to_degrees( altitude ) );
     } else {
         p->add_msg_if_player( m_neutral, _( "The illumination is %.1f." ),
-                              g->natural_light_level( pos.z ) );
+                              g->natural_light_level( pos.z ).value );
     }
 
     return 0;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1335,10 +1335,10 @@ float firestarter_actor::light_mod( const tripoint &pos ) const
         return 1.0f;
     }
 
-    const float light_level = g->natural_light_level( pos.z );
+    const light light_level = g->natural_light_level( pos.z );
     if( get_weather().weather_id->sun_intensity >= sun_intensity_type::normal &&
-        light_level >= 60.0f && !get_map().has_flag( ter_furn_flag::TFLAG_INDOORS, pos ) ) {
-        return std::pow( light_level / 80.0f, 8 );
+        light_level >= light( 60.0f ) && !get_map().has_flag( ter_furn_flag::TFLAG_INDOORS, pos ) ) {
+        return std::pow( light_level / light( 80.0f ), 8 );
     }
 
     return 0.0f;
@@ -1401,7 +1401,7 @@ cata::optional<int> firestarter_actor::use( Character &p, item &it, bool t,
     p.assign_activity( ACT_START_FIRE, moves, potential_skill_gain,
                        0, it.tname() );
     p.activity.targets.emplace_back( p, &it );
-    p.activity.values.push_back( g->natural_light_level( pos.z ) );
+    p.activity.values.push_back( g->natural_light_level( pos.z ).value );
     p.activity.placement = pos;
     // charges to use are handled by the activity
     return 0;

--- a/src/level_cache.cpp
+++ b/src/level_cache.cpp
@@ -11,7 +11,8 @@ level_cache::level_cache()
     constexpr four_quadrants four_zeros( 0.0f );
     std::fill_n( &lm[0][0], map_dimensions, four_zeros );
     std::fill_n( &sm[0][0], map_dimensions, 0.0f );
-    std::fill_n( &light_source_buffer[0][0], map_dimensions, 0.0f );
+    // TODO should be unnecessary due to default constructor
+    std::fill_n( &light_source_buffer[0][0], map_dimensions, light( 0.0f ) );
     std::fill_n( &outside_cache[0][0], map_dimensions, false );
     std::fill_n( &floor_cache[0][0], map_dimensions, false );
     std::fill_n( &transparency_cache[0][0], map_dimensions, 0.0f );

--- a/src/level_cache.h
+++ b/src/level_cache.h
@@ -14,6 +14,7 @@
 #include "reachability_cache.h"
 #include "shadowcasting.h"
 #include "value_ptr.h"
+#include "light.h"
 
 class vehicle;
 
@@ -34,10 +35,10 @@ struct level_cache {
         float sm[MAPSIZE_X][MAPSIZE_Y];
         // To prevent redundant ray casting into neighbors: precalculate bulk light source positions.
         // This is only valid for the duration of generate_lightmap
-        float light_source_buffer[MAPSIZE_X][MAPSIZE_Y];
+        light light_source_buffer[MAPSIZE_X][MAPSIZE_Y];
 
         // Cache of natural light level is useful if it needs to be in sync with the light cache.
-        float natural_light_level_cache;
+        light natural_light_level_cache;
 
         // if false, means tile is under the roof ("inside"), true means tile is "outside"
         // "inside" tiles are protected from sun, rain, etc. (see ter_furn_flag::TFLAG_INDOORS flag)

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -1,0 +1,10 @@
+#include "light.h"
+
+int light::range_in_air() const
+{
+    if( this->value <= LIGHT_AMBIENT_LOW.value ) {
+        return 0;
+    }
+    return static_cast<int>( -std::log( LIGHT_AMBIENT_LOW.value / this->value ) * ( 1.0 /
+                             LIGHT_TRANSPARENCY_OPEN_AIR ) );
+}

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -1,10 +1,21 @@
 #include "light.h"
 
-int light::range_in_air() const
+/* Via Beer-Lambert we have:
+* light_level * (1 / exp( transparency * distance) ) <= threshold
+* Solving for distance:
+* 1 / exp( transparency * distance ) <= threshold / light_level
+* 1 <= exp( transparency * distance ) * threshold / light_level
+* light_level <= exp( transparency * distance ) * threshold
+* log(light_level) <= transparency * distance + log(threshold)
+* log(light_level) - log(threshold) <= transparency * distance
+* - log(threshold / light_level) <= transparency * distance
+* - log(threshold / light_level) / transparency <= distance
+*/
+int light::sight_range(light threshold, float transparency) const
 {
-    if( this->value <= LIGHT_AMBIENT_LOW.value ) {
-        return 0;
+    // We always see at least one tile so we can see ourselves
+    if( *this <= threshold ) {
+        return 1;
     }
-    return static_cast<int>( -std::log( LIGHT_AMBIENT_LOW.value / this->value ) * ( 1.0 /
-                             LIGHT_TRANSPARENCY_OPEN_AIR ) );
+    return static_cast<int>( -std::log( threshold / *this ) / transparency);
 }

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -19,3 +19,13 @@ int light::sight_range(light threshold, float transparency) const
     }
     return static_cast<int>( -std::log( threshold / *this ) / transparency);
 }
+
+// Factoring out the distance from Beer-Lambert results in:
+// 1 / (exp(a1*a2*a3*...*an)*l)
+// We merge all of the absorption values by taking their cumulative average.
+// TODO rename
+// TODO should this return a light?
+// TODO sometimes float argument as distance
+float sight_calc(const float &numerator, const float &transparency, const int &distance) {
+    return numerator / std::exp( transparency * distance );
+}

--- a/src/light.h
+++ b/src/light.h
@@ -55,20 +55,16 @@ class light
         void operator+=( const light &other ) {
             value += other.value;
         }
-        light operator*( const light &other ) const {
-            return light( value * other.value );
+        friend light operator*( const light &l, const float x ) {
+            return light( l.value * x );
         }
-        light operator*( const float x ) const {
-            return light( value * x );
+        friend light operator*( const float x, const light &l ) {
+            return light( l.value * x );
         }
-        friend light operator*( const float x, const light &other ) {
-            return light( other.value * x );
-        }
+
+        // Relative brightness as a fraction
         float operator/( const light &other ) const {
             return value / other.value;
-        }
-        light operator-( const light &other ) const {
-            return light( value - other.value );
         }
 
         bool operator<=( const light &other ) const {

--- a/src/light.h
+++ b/src/light.h
@@ -107,14 +107,22 @@ class light
 static light LIGHT_SOURCE_LOCAL = light( 0.1f );
 static light LIGHT_SOURCE_BRIGHT = light( 10.0f );
 
-// Just enough light that you can see the current and adjacent squares with normal vision.
-static light LIGHT_AMBIENT_MINIMAL = light( 3.7f );
+// Absolute darkness. All lights are brighter than this threshold.
+static light LIGHT_AMBIENT_PITCH_BLACK = light( 0.0f );
 // The threshold between not being able to see anything and things appearing shadowy.
 static light LIGHT_AMBIENT_LOW = light( 3.5f );
+// Just enough light that you can see the current and adjacent squares with normal vision.
+static light LIGHT_AMBIENT_MINIMAL = light( 3.7f );
 // The lower threshold for seeing well enough to do detail work such as reading or crafting.
 static light LIGHT_AMBIENT_DIM = light( 5.0f );
+// The threshold between dim and cloudy.
+// Also used by nyctophobia
+static light LIGHT_AMBIENT_CLOUDY = light( 7.0f );
 // The threshold between things being shadowed and being brightly lit.
 static light LIGHT_AMBIENT_LIT = light( 10.0f );
+// How much light is provided in full daylight
+// TODO As previously defined by calendar.h. Check for consistency
+static light LIGHT_DAY = light( 100.0f );
 
 
 #endif // CATA_SRC_LIGHT_H

--- a/src/light.h
+++ b/src/light.h
@@ -124,5 +124,6 @@ static light LIGHT_AMBIENT_LIT = light( 10.0f );
 // TODO As previously defined by calendar.h. Check for consistency
 static light LIGHT_DAY = light( 100.0f );
 
+float sight_calc(const float &numerator, const float &transparency, const int &distance);
 
 #endif // CATA_SRC_LIGHT_H

--- a/src/light.h
+++ b/src/light.h
@@ -45,7 +45,9 @@ class light
         light() : value( 0.0f ) {};
         explicit light( float value ) : value( value ) {};
 
-        int range_in_air() const;
+        // Sight range at a given transparency
+        // default threshold corresponds to AMBIENT_LIGHT_LOW defined below
+        int sight_range(light threshold = light( 3.5f ), float transparency = LIGHT_TRANSPARENCY_OPEN_AIR) const;
 
         light operator+( const light &other ) const {
             return light( value + other.value );

--- a/src/light.h
+++ b/src/light.h
@@ -1,0 +1,118 @@
+#pragma once
+#ifndef CATA_SRC_LIGHT_H
+#define CATA_SRC_LIGHT_H
+
+#include <cmath>
+#include <ostream>
+
+
+// Compacter representation
+enum class lit_level : int {
+    DARK = 0,
+    LOW, // Hard to see
+    BRIGHT_ONLY, // bright but indistinct
+    LIT,
+    BRIGHT, // Probably only for light sources
+    MEMORIZED, // Not a light level but behaves similarly
+    BLANK // blank space, not an actual light level
+};
+
+class light
+{
+    public:
+        float value;
+        light() : value( 0.0f ) {};
+        explicit light( float value ) : value( value ) {};
+
+        int range_in_air() const;
+
+        light operator+( const light &other ) const {
+            return light( value + other.value );
+        }
+        void operator+=( const light &other ) {
+            value += other.value;
+        }
+        light operator*( const light &other ) const {
+            return light( value * other.value );
+        }
+        light operator*( const float x ) const {
+            return light( value * x );
+        }
+        friend light operator*( const float x, const light &other ) {
+            return light( other.value * x );
+        }
+        float operator/( const light &other ) const {
+            return value / other.value;
+        }
+        light operator-( const light &other ) const {
+            return light( value - other.value );
+        }
+
+        bool operator<=( const light &other ) const {
+            return value <= other.value;
+        }
+        bool operator>=( const light &other ) const {
+            return value >= other.value;
+        }
+        bool operator==( const light &other ) const {
+            return value == other.value;
+        }
+        bool operator<( const light &other ) const {
+            return value < other.value;
+        }
+        bool operator>( const light &other ) const {
+            return value > other.value;
+        }
+        bool operator<=( const lit_level other ) const {
+            return value <= static_cast<float>( other );
+        }
+        bool operator>=( const lit_level other ) const {
+            return value >= static_cast<float>( other );
+        }
+        bool operator<( const lit_level other ) const {
+            return value < static_cast<float>( other );
+        }
+        bool operator>( const lit_level other ) const {
+            return value > static_cast<float>( other );
+        }
+
+        friend std::ostream &operator<<( std::ostream &os, const light &light ) {
+            return os << light.value;
+        }
+};
+
+static light LIGHT_SOURCE_LOCAL = light( 0.1f );
+static light LIGHT_SOURCE_BRIGHT = light( 10.0f );
+
+// Just enough light that you can see the current and adjacent squares with normal vision.
+static light LIGHT_AMBIENT_MINIMAL = light( 3.7f );
+// The threshold between not being able to see anything and things appearing shadowy.
+static light LIGHT_AMBIENT_LOW = light( 3.5f );
+// The lower threshold for seeing well enough to do detail work such as reading or crafting.
+static light LIGHT_AMBIENT_DIM = light( 5.0f );
+// The threshold between things being shadowed and being brightly lit.
+static light LIGHT_AMBIENT_LIT = light( 10.0f );
+
+/**
+ * Transparency 101:
+ * Transparency usually ranges between 0.038 (open air) and 0.38 (regular smoke).
+ * The bigger the value, the more opaque it is (less light goes through).
+ * To make sense of the specific value:
+ * For transparency t, vision becomes "obstructed" (see map::apparent_light_helper) after
+ *   ≈ (2.3 / t) consequent tiles of transparency `t`  ( derived from 1 / e^(dist * t) = 0.1 )
+ *   e.g. for smoke with effective transparency 0.38  it's 2.3/0.38 ≈ 6 tiles
+ *  for clean air with t=0.038  dist = 2.3/0.038 ≈ 60 tiles
+ *
+ * Note:  LIGHT_TRANSPARENCY_SOLID=0 is a special case (it indicates completely opaque tile)
+ * */
+static constexpr float LIGHT_TRANSPARENCY_SOLID = 0.0f;
+// Calculated to run out at 60 squares.
+// Cumulative transparency should drop to 0.1 or lower over 60 squares,
+// Bright sunlight should drop to LIGHT_AMBIENT_LOW over 60 squares.
+static constexpr float LIGHT_TRANSPARENCY_OPEN_AIR = 0.038376418216f;
+
+// indicates starting (full) visibility (for seen_cache)
+static constexpr float VISIBILITY_FULL = 1.0f;
+
+
+#endif // CATA_SRC_LIGHT_H

--- a/src/light.h
+++ b/src/light.h
@@ -17,6 +17,27 @@ enum class lit_level : int {
     BLANK // blank space, not an actual light level
 };
 
+/**
+ * Transparency 101:
+ * Transparency usually ranges between 0.038 (open air) and 0.38 (regular smoke).
+ * The bigger the value, the more opaque it is (less light goes through).
+ * To make sense of the specific value:
+ * For transparency t, vision becomes "obstructed" (see map::apparent_light_helper) after
+ *   ≈ (2.3 / t) consequent tiles of transparency `t`  ( derived from 1 / e^(dist * t) = 0.1 )
+ *   e.g. for smoke with effective transparency 0.38  it's 2.3/0.38 ≈ 6 tiles
+ *  for clean air with t=0.038  dist = 2.3/0.038 ≈ 60 tiles
+ *
+ * Note:  LIGHT_TRANSPARENCY_SOLID=0 is a special case (it indicates completely opaque tile)
+ * */
+static constexpr float LIGHT_TRANSPARENCY_SOLID = 0.0f;
+// Calculated to run out at 60 squares.
+// Cumulative transparency should drop to 0.1 or lower over 60 squares,
+// Bright sunlight should drop to LIGHT_AMBIENT_LOW over 60 squares.
+static constexpr float LIGHT_TRANSPARENCY_OPEN_AIR = 0.038376418216f;
+
+// indicates starting (full) visibility (for seen_cache)
+static constexpr float VISIBILITY_FULL = 1.0f;
+
 class light
 {
     public:
@@ -92,27 +113,6 @@ static light LIGHT_AMBIENT_LOW = light( 3.5f );
 static light LIGHT_AMBIENT_DIM = light( 5.0f );
 // The threshold between things being shadowed and being brightly lit.
 static light LIGHT_AMBIENT_LIT = light( 10.0f );
-
-/**
- * Transparency 101:
- * Transparency usually ranges between 0.038 (open air) and 0.38 (regular smoke).
- * The bigger the value, the more opaque it is (less light goes through).
- * To make sense of the specific value:
- * For transparency t, vision becomes "obstructed" (see map::apparent_light_helper) after
- *   ≈ (2.3 / t) consequent tiles of transparency `t`  ( derived from 1 / e^(dist * t) = 0.1 )
- *   e.g. for smoke with effective transparency 0.38  it's 2.3/0.38 ≈ 6 tiles
- *  for clean air with t=0.038  dist = 2.3/0.038 ≈ 60 tiles
- *
- * Note:  LIGHT_TRANSPARENCY_SOLID=0 is a special case (it indicates completely opaque tile)
- * */
-static constexpr float LIGHT_TRANSPARENCY_SOLID = 0.0f;
-// Calculated to run out at 60 squares.
-// Cumulative transparency should drop to 0.1 or lower over 60 squares,
-// Bright sunlight should drop to LIGHT_AMBIENT_LOW over 60 squares.
-static constexpr float LIGHT_TRANSPARENCY_OPEN_AIR = 0.038376418216f;
-
-// indicates starting (full) visibility (for seen_cache)
-static constexpr float VISIBILITY_FULL = 1.0f;
 
 
 #endif // CATA_SRC_LIGHT_H

--- a/src/light.h
+++ b/src/light.h
@@ -6,7 +6,7 @@
 #include <ostream>
 
 
-// Compacter representation
+// More compact representation
 enum class lit_level : int {
     DARK = 0,
     LOW, // Hard to see

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -227,18 +227,12 @@ void map::apply_character_light( Character &p )
 {
     if( p.has_effect( effect_onfire ) ) {
         apply_light_source( p.pos(), light( 8.0f ) );
-    } else if( p.has_effect( effect_haslight ) ) {
-        apply_light_source( p.pos(), light( 4.0f ) );
     }
 
     const light held_luminance = p.active_light();
-    if( held_luminance > LIGHT_AMBIENT_LOW ) {
-        apply_light_source( p.pos(), held_luminance );
-    }
-
-    if( held_luminance >= light( 4.0f ) &&
-        held_luminance > ambient_light_at( p.pos() ) - light( 0.5f ) ) {
+    if( held_luminance >= LIGHT_AMBIENT_LOW ) {
         p.add_effect( effect_haslight, 1_turns );
+        apply_light_source( p.pos(), held_luminance );
     }
 }
 

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -795,10 +795,8 @@ bool map::pl_sees( const tripoint &t, const int max_range ) const
     }
 
     const apparent_light_info a = apparent_light_helper( map_cache, t );
-    const light light_at_player = light(
-                                      map_cache.lm[player_character.posx()][player_character.posy()].max() );
     return !a.obstructed &&
-           ( a.apparent_light >= player_character.get_vision_threshold( light_at_player ) ||
+           ( a.apparent_light >= player_character.get_vision_threshold() ||
              map_cache.sm[t.x][t.y] > 0.0 );
 }
 

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -5,57 +5,7 @@
 #include <cmath>
 #include <ostream>
 
-static constexpr float LIGHT_SOURCE_LOCAL = 0.1f;
-static constexpr float LIGHT_SOURCE_BRIGHT = 10.0f;
-
-// Just enough light that you can see the current and adjacent squares with normal vision.
-static constexpr float LIGHT_AMBIENT_MINIMAL = 3.7f;
-// The threshold between not being able to see anything and things appearing shadowy.
-static constexpr float LIGHT_AMBIENT_LOW = 3.5f;
-// The lower threshold for seeing well enough to do detail work such as reading or crafting.
-static constexpr float LIGHT_AMBIENT_DIM = 5.0f;
-// The threshold between things being shadowed and being brightly lit.
-static constexpr float LIGHT_AMBIENT_LIT = 10.0f;
-
-/**
- * Transparency 101:
- * Transparency usually ranges between 0.038 (open air) and 0.38 (regular smoke).
- * The bigger the value, the more opaque it is (less light goes through).
- * To make sense of the specific value:
- * For transparency t, vision becomes "obstructed" (see map::apparent_light_helper) after
- *   ≈ (2.3 / t) consequent tiles of transparency `t`  ( derived from 1 / e^(dist * t) = 0.1 )
- *   e.g. for smoke with effective transparency 0.38  it's 2.3/0.38 ≈ 6 tiles
- *  for clean air with t=0.038  dist = 2.3/0.038 ≈ 60 tiles
- *
- * Note:  LIGHT_TRANSPARENCY_SOLID=0 is a special case (it indicates completely opaque tile)
- * */
-static constexpr float LIGHT_TRANSPARENCY_SOLID = 0.0f;
-// Calculated to run out at 60 squares.
-// Cumulative transparency should drop to 0.1 or lower over 60 squares,
-// Bright sunlight should drop to LIGHT_AMBIENT_LOW over 60 squares.
-static constexpr float LIGHT_TRANSPARENCY_OPEN_AIR = 0.038376418216f;
-
-// indicates starting (full) visibility (for seen_cache)
-static constexpr float VISIBILITY_FULL = 1.0f;
-
-constexpr inline int LIGHT_RANGE( float b )
-{
-    if( b <= LIGHT_AMBIENT_LOW ) {
-        return 0;
-    }
-    return static_cast<int>( -std::log( LIGHT_AMBIENT_LOW / b ) * ( 1.0 /
-                             LIGHT_TRANSPARENCY_OPEN_AIR ) );
-}
-
-enum class lit_level : int {
-    DARK = 0,
-    LOW, // Hard to see
-    BRIGHT_ONLY, // bright but indistinct
-    LIT,
-    BRIGHT, // Probably only for light sources
-    MEMORIZED, // Not a light level but behaves similarly
-    BLANK // blank space, not an actual light level
-};
+#include "light.h"
 
 template<typename T>
 constexpr inline bool operator>( const T &lhs, const lit_level &rhs )

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6119,10 +6119,7 @@ void map::update_visibility_cache( const int zlev )
     Character &player_character = get_player_character();
     visibility_variables_cache.variables_set = true; // Not used yet
     visibility_variables_cache.g_light_level = static_cast<int>( g->light_level( zlev ) );
-    visibility_variables_cache.vision_threshold = player_character.get_vision_threshold(
-                light(
-                    get_cache_ref(
-                        player_character.posz() ).lm[player_character.posx()][player_character.posy()].max() ) );
+    visibility_variables_cache.vision_threshold = player_character.get_vision_threshold();
 
     visibility_variables_cache.u_clairvoyance = player_character.clairvoyance();
     visibility_variables_cache.u_sight_impaired = player_character.sight_impaired();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6120,8 +6120,9 @@ void map::update_visibility_cache( const int zlev )
     visibility_variables_cache.variables_set = true; // Not used yet
     visibility_variables_cache.g_light_level = static_cast<int>( g->light_level( zlev ) );
     visibility_variables_cache.vision_threshold = player_character.get_vision_threshold(
-                get_cache_ref(
-                    player_character.posz() ).lm[player_character.posx()][player_character.posy()].max() );
+                light(
+                    get_cache_ref(
+                        player_character.posz() ).lm[player_character.posx()][player_character.posy()].max() ) );
 
     visibility_variables_cache.u_clairvoyance = player_character.clairvoyance();
     visibility_variables_cache.u_sight_impaired = player_character.sight_impaired();
@@ -7930,7 +7931,7 @@ void map::spawn_monsters_submap_group( const tripoint &gp, mongroup &group,
 {
     Character &player_character = get_player_character();
     const int s_range = std::min( HALF_MAPSIZE_X,
-                                  player_character.sight_range( g->light_level( player_character.posz() ) ) );
+                                  player_character.sight_range( g->incorrect_light_level( player_character.posz() ) ) );
     int pop = group.population;
     std::vector<tripoint> locations;
     if( !ignore_sight ) {

--- a/src/map.h
+++ b/src/map.h
@@ -41,6 +41,7 @@
 #include "type_id.h"
 #include "units.h"
 #include "value_ptr.h"
+#include "light.h"
 
 struct scent_block;
 
@@ -121,7 +122,7 @@ struct visibility_variables {
     // Cached values for map visibility calculations
     int g_light_level = 0;
     int u_clairvoyance = 0;
-    float vision_threshold = 0.0f;
+    light vision_threshold = light( 0.0f );
     cata::optional<field_type_id> clairvoyance_field;
 };
 
@@ -384,7 +385,7 @@ class map
 
         struct apparent_light_info {
             bool obstructed;
-            float apparent_light;
+            light apparent_light;
         };
         /** Helper function for light calculation; exposed here for map editor
          */
@@ -1628,7 +1629,7 @@ class map
         // Assumes 0,0 is light map center
         lit_level light_at( const tripoint &p ) const;
         // Raw values for tilesets
-        float ambient_light_at( const tripoint &p ) const;
+        light ambient_light_at( const tripoint &p ) const;
         /**
          * Returns whether the tile at `p` is transparent(you can look past it).
          */
@@ -1952,13 +1953,13 @@ class map
 
         int determine_wall_corner( const tripoint &p ) const;
         // apply a circular light pattern immediately, however it's best to use...
-        void apply_light_source( const tripoint &p, float luminance );
+        void apply_light_source( const tripoint &p, light luminance );
         // ...this, which will apply the light after at the end of generate_lightmap, and prevent redundant
         // light rays from causing massive slowdowns, if there's a huge amount of light.
-        void add_light_source( const tripoint &p, float luminance );
+        void add_light_source( const tripoint &p, light luminance );
         // Handle just cardinal directions and 45 deg angles.
-        void apply_directional_light( const tripoint &p, int direction, float luminance );
-        void apply_light_arc( const tripoint &p, const units::angle &angle, float luminance,
+        void apply_directional_light( const tripoint &p, int direction, light luminance );
+        void apply_light_arc( const tripoint &p, const units::angle &angle, light luminance,
                               const units::angle &wideangle = 30_degrees );
         void apply_light_ray( bool lit[MAPSIZE_X][MAPSIZE_Y],
                               const tripoint &s, const tripoint &e, float luminance );

--- a/src/monster.h
+++ b/src/monster.h
@@ -26,6 +26,7 @@
 #include "units_fwd.h"
 #include "value_ptr.h"
 #include "weakpoint.h"
+#include "light.h"
 
 class Character;
 class JsonObject;
@@ -171,7 +172,7 @@ class monster : public Creature
         bool swims() const;
         // Returns false if the monster is stunned, has 0 moves or otherwise wouldn't act this turn
         bool can_act() const;
-        int sight_range( int light_level ) const override;
+        int sight_range( light light_level ) const override;
         bool made_of( const material_id &m ) const override; // Returns true if it's made of m
         bool made_of_any( const std::set<material_id> &ms ) const override;
         bool made_of( phase_id p ) const; // Returns true if its phase is p

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2239,7 +2239,7 @@ std::pair<std::string, nc_color> get_stamina_bar( int cur_stam, int max_stam )
     return get_bar( cur_stam, max_stam, 5, true, { c_cyan, c_light_cyan, c_yellow, c_light_red, c_red } );
 }
 
-std::pair<std::string, nc_color> get_light_level( const float light )
+std::pair<std::string, nc_color> get_light_level( const light light )
 {
     using pair_t = std::pair<std::string, nc_color>;
     static const std::array<pair_t, 6> strings {
@@ -2254,7 +2254,8 @@ std::pair<std::string, nc_color> get_light_level( const float light )
     };
     // Avoid magic number
     static const int maximum_light_level = static_cast< int >( strings.size() ) - 1;
-    const int light_level = clamp( static_cast< int >( std::ceil( light ) ), 0, maximum_light_level );
+    const int light_level = clamp( static_cast< int >( std::ceil( light.value ) ), 0,
+                                   maximum_light_level );
     const size_t array_index = static_cast< size_t >( light_level );
     return pair_t{ _( strings[array_index].first ), strings[array_index].second };
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2239,25 +2239,26 @@ std::pair<std::string, nc_color> get_stamina_bar( int cur_stam, int max_stam )
     return get_bar( cur_stam, max_stam, 5, true, { c_cyan, c_light_cyan, c_yellow, c_light_red, c_red } );
 }
 
-std::pair<std::string, nc_color> get_light_level( const light light )
+std::pair<std::string, nc_color> get_light_level( const light level )
 {
-    using pair_t = std::pair<std::string, nc_color>;
-    static const std::array<pair_t, 6> strings {
+    using triple_t = std::tuple<light, std::string, nc_color>;
+    static const std::array<triple_t, 6> strings {
         {
-            pair_t {translate_marker( "unknown" ), c_pink},
-            pair_t {translate_marker( "bright" ), c_yellow},
-            pair_t {translate_marker( "cloudy" ), c_white},
-            pair_t {translate_marker( "shady" ), c_light_gray},
-            pair_t {translate_marker( "dark" ), c_dark_gray},
-            pair_t {translate_marker( "very dark" ), c_black_white}
+            triple_t {LIGHT_AMBIENT_LIT, translate_marker( "bright" ), c_yellow},
+            triple_t {LIGHT_AMBIENT_DIM, translate_marker( "cloudy" ), c_white},
+            triple_t {LIGHT_AMBIENT_MINIMAL, translate_marker( "shady" ), c_light_gray},
+            triple_t {LIGHT_AMBIENT_LOW, translate_marker( "dark" ), c_dark_gray},
+            triple_t {LIGHT_AMBIENT_PITCH_BLACK, translate_marker( "very dark" ), c_black_white}
         }
     };
-    // Avoid magic number
-    static const int maximum_light_level = static_cast< int >( strings.size() ) - 1;
-    const int light_level = clamp( static_cast< int >( std::ceil( light.value ) ), 0,
-                                   maximum_light_level );
-    const size_t array_index = static_cast< size_t >( light_level );
-    return pair_t{ _( strings[array_index].first ), strings[array_index].second };
+    for(const auto &entry : strings) {
+        if(level >= std::get<0>(entry)) {
+            return std::pair<std::string, nc_color>{ _(std::get<1>(entry)), std::get<2>(entry)};
+        }
+    }
+
+    debugmsg("Negative light level found.");
+    return std::pair<std::string, nc_color>{ _("very dark"), c_pink};
 }
 
 std::pair<std::string, nc_color> rad_badge_color( const int rad )

--- a/src/output.h
+++ b/src/output.h
@@ -31,6 +31,7 @@
 #include "string_formatter.h"
 #include "translations.h"
 #include "units_fwd.h"
+#include "light.h"
 
 struct input_event;
 
@@ -612,7 +613,7 @@ std::pair<std::string, nc_color> get_hp_bar( int cur_hp, int max_hp, bool is_mon
 
 std::pair<std::string, nc_color> get_stamina_bar( int cur_stam, int max_stam );
 
-std::pair<std::string, nc_color> get_light_level( float light );
+std::pair<std::string, nc_color> get_light_level( light light );
 
 std::pair<std::string, nc_color> rad_badge_color( int rad );
 

--- a/src/output.h
+++ b/src/output.h
@@ -613,7 +613,7 @@ std::pair<std::string, nc_color> get_hp_bar( int cur_hp, int max_hp, bool is_mon
 
 std::pair<std::string, nc_color> get_stamina_bar( int cur_stam, int max_stam );
 
-std::pair<std::string, nc_color> get_light_level( light light );
+std::pair<std::string, nc_color> get_light_level( light level );
 
 std::pair<std::string, nc_color> rad_badge_color( int rad );
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -542,7 +542,7 @@ static void draw_ascii(
     const bool has_debug_vision = player_character.has_trait( trait_DEBUG_NIGHTVISION );
     // sight_points is hoisted for speed reasons.
     const int sight_points = !has_debug_vision ?
-                             player_character.overmap_sight_range( g->light_level( player_character.posz() ) ) :
+                             player_character.overmap_sight_range( g->incorrect_light_level( player_character.posz() ) ) :
                              100;
     // Whether showing hordes is currently enabled
     const bool showhordes = uistate.overmap_show_hordes;
@@ -1012,7 +1012,7 @@ static void draw_om_sidebar(
     const bool has_debug_vision = player_character.has_trait( trait_DEBUG_NIGHTVISION );
     // sight_points is hoisted for speed reasons.
     const int sight_points = !has_debug_vision ?
-                             player_character.overmap_sight_range( g->light_level( player_character.posz() ) ) :
+                             player_character.overmap_sight_range( g->incorrect_light_level( player_character.posz() ) ) :
                              100;
     const bool center_seen = has_debug_vision || overmap_buffer.seen( center );
     const tripoint_abs_omt target = player_character.get_active_mission_target();

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -200,7 +200,7 @@ void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const 
     const int start_x = start_input.x;
     const point mid( width / 2, height / 2 );
     map &here = get_map();
-    const int sight_points = you.overmap_sight_range( g->light_level( you.posz() ) );
+    const int sight_points = you.overmap_sight_range( g->incorrect_light_level( you.posz() ) );
 
     // i scans across width, with 0 in the middle(ish)
     //     -(w/2) ... w-(w/2)-1

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -999,7 +999,7 @@ static void eff_fun_sleep( Character &u, effect &it )
         here.is_outside( u.pos() ) ) {
         if( u.has_trait( trait_CHLOROMORPH ) ) {
             // Hunger and thirst fall before your Chloromorphic physiology!
-            if( g->natural_light_level( u.posz() ) >= 12 &&
+            if( g->natural_light_level( u.posz() ) >= light( 12.0f ) &&
                 get_weather().weather_id->sun_intensity >= sun_intensity_type::light ) {
                 if( u.has_active_mutation( trait_CHLOROMORPH ) && ( u.get_fatigue() <= 25 ) ) {
                     u.set_fatigue( 25 );
@@ -1082,7 +1082,7 @@ static void eff_fun_sleep( Character &u, effect &it )
         if( !u.has_flag( json_flag_SEESLEEP ) ) {
             if( u.has_trait( trait_HEAVYSLEEPER2 ) && !u.has_trait( trait_HIBERNATE ) ) {
                 // So you can too sleep through noon
-                if( ( tirednessVal * 1.25 ) < here.ambient_light_at( u.pos() ) && ( u.get_fatigue() < 10 ||
+                if( ( tirednessVal * 1.25 ) < here.ambient_light_at( u.pos() ).value && ( u.get_fatigue() < 10 ||
                         one_in( u.get_fatigue() / 2 ) ) ) {
                     u.add_msg_if_player( _( "It's too bright to sleep." ) );
                     // Set ourselves up for removal
@@ -1091,14 +1091,14 @@ static void eff_fun_sleep( Character &u, effect &it )
                 }
                 // Ursine hibernators would likely do so indoors.  Plants, though, might be in the sun.
             } else if( u.has_trait( trait_HIBERNATE ) ) {
-                if( ( tirednessVal * 5 ) < here.ambient_light_at( u.pos() ) && ( u.get_fatigue() < 10 ||
+                if( ( tirednessVal * 5 ) < here.ambient_light_at( u.pos() ).value && ( u.get_fatigue() < 10 ||
                         one_in( u.get_fatigue() / 2 ) ) ) {
                     u.add_msg_if_player( _( "It's too bright to sleep." ) );
                     // Set ourselves up for removal
                     it.set_duration( 0_turns );
                     woke_up = true;
                 }
-            } else if( tirednessVal < here.ambient_light_at( u.pos() ) && ( u.get_fatigue() < 10 ||
+            } else if( tirednessVal < here.ambient_light_at( u.pos() ).value && ( u.get_fatigue() < 10 ||
                        one_in( u.get_fatigue() / 2 ) ) ) {
                 u.add_msg_if_player( _( "It's too bright to sleep." ) );
                 // Set ourselves up for removal

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1480,17 +1480,17 @@ Target_attributes::Target_attributes( tripoint src, tripoint target )
            target_critter->ranged_target_size() :
            get_map().ranged_target_size( target );
     size_in_moa = target_size_in_moa( range, size ) ;
-    light = get_map().ambient_light_at( target );
+    ilum = get_map().ambient_light_at( target );
     visible = shooter->sees( target );
 
 }
-Target_attributes::Target_attributes( int rng, double target_size, float light_target,
+Target_attributes::Target_attributes( int rng, double target_size, light light_target,
                                       bool can_see )
 {
     range = rng;
     size = target_size;
     size_in_moa = target_size_in_moa( range, size );
-    light = light_target;
+    ilum = light_target;
     visible = can_see;
 }
 

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "point.h"
+#include "light.h"
 
 class aim_activity_actor;
 class avatar;
@@ -77,11 +78,11 @@ struct Target_attributes {
     int range = 1;
     double size = 0.5;
     double size_in_moa = 10800.0;
-    float light = 0.0f;
+    light ilum = light( 0.0f );
     bool visible = true;
     explicit Target_attributes() = default;
     explicit Target_attributes( tripoint src, tripoint target );
-    explicit Target_attributes( int rng, double size, float l, bool can_see );
+    explicit Target_attributes( int rng, double size, light, bool can_see );
 };
 
 #endif // CATA_SRC_RANGED_H

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -471,7 +471,7 @@ void relic::try_recharge( item &parent, Character *carrier, const tripoint &pos 
         }
         case relic_recharge_type::SOLAR_SUNNY: {
             if( can_recharge_solar( parent, carrier, pos ) &&
-                get_weather().weather_id->light_modifier >= 0 ) {
+                get_weather().weather_id->light_modifier >= 0.0f ) {
                 charge.accumulate_charge( parent );
             }
             return;
@@ -485,7 +485,7 @@ void relic::try_recharge( item &parent, Character *carrier, const tripoint &pos 
         }
         case relic_recharge_type::SOLAR_CLOUDY: {
             if( can_recharge_solar( parent, carrier, pos ) &&
-                get_weather().weather_id->light_modifier < 0 ) {
+                get_weather().weather_id->light_modifier < 0.0f ) {
                 charge.accumulate_charge( parent );
             }
             return;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -855,7 +855,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     const bool has_debug_vision = you.has_trait( trait_DEBUG_NIGHTVISION );
     // sight_points is hoisted for speed reasons.
     const int sight_points = !has_debug_vision ?
-                             you.overmap_sight_range( g->light_level( you.posz() ) ) :
+                             you.overmap_sight_range( g->incorrect_light_level( you.posz() ) ) :
                              100;
     const bool showhordes = uistate.overmap_show_hordes;
     const bool viewing_weather = uistate.overmap_debug_weather || uistate.overmap_visible_weather;

--- a/src/shadowcasting.h
+++ b/src/shadowcasting.h
@@ -86,15 +86,6 @@ struct four_quadrants {
     }
 };
 
-// Hoisted to header and inlined so the test in tests/shadowcasting_test.cpp can use it.
-// Beer-Lambert law says attenuation is going to be equal to
-// 1 / (e^al) where a = coefficient of absorption and l = length.
-// Factoring out length, we get 1 / (e^((a1*a2*a3*...*an)*l))
-// We merge all of the absorption values by taking their cumulative average.
-inline float sight_calc( const float &numerator, const float &transparency, const int &distance )
-{
-    return numerator / std::exp( transparency * distance );
-}
 inline bool sight_check( const float &transparency, const float &/*intensity*/ )
 {
     return transparency > LIGHT_TRANSPARENCY_SOLID;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1659,7 +1659,7 @@ void suffer::from_pain( Character &you )
 void suffer::from_nyctophobia( Character &you )
 {
     std::vector<tripoint> dark_places;
-    const float nyctophobia_threshold = LIGHT_AMBIENT_LIT - 3.0f;
+    const light nyctophobia_threshold = LIGHT_AMBIENT_LIT - light(3.0f);
 
     for( const tripoint &dark_place : points_in_radius( you.pos(), 5 ) ) {
         if( !you.sees( dark_place ) || get_map().ambient_light_at( dark_place ) >= nyctophobia_threshold ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1659,7 +1659,7 @@ void suffer::from_pain( Character &you )
 void suffer::from_nyctophobia( Character &you )
 {
     std::vector<tripoint> dark_places;
-    const light nyctophobia_threshold = LIGHT_AMBIENT_LIT - light(3.0f);
+    const light nyctophobia_threshold = LIGHT_AMBIENT_CLOUDY;
 
     for( const tripoint &dark_place : points_in_radius( you.pos(), 5 ) ) {
         if( !you.sees( dark_place ) || get_map().ambient_light_at( dark_place ) >= nyctophobia_threshold ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4779,8 +4779,8 @@ int vehicle::total_solar_epower_w() const
     // Weather doesn't change much across the area of the vehicle, so just
     // sample it once.
     weather_type_id wtype = current_weather( global_pos3() );
-    const float tick_sunlight = incident_sunlight( wtype, calendar::turn );
-    double intensity = tick_sunlight / default_daylight_level();
+    const light tick_sunlight = incident_sunlight( wtype, calendar::turn );
+    float intensity = tick_sunlight / default_daylight_level();
     return epower_w * intensity;
 }
 
@@ -7239,7 +7239,8 @@ void vehicle::update_time( const time_point &update_to )
 
             epower_w += part_epower_w( part );
         }
-        double intensity = accum_weather.sunlight / default_daylight_level() / to_turns<double>( elapsed );
+        float intensity = light( accum_weather.sunlight ) / default_daylight_level() / to_turns<double>
+                          ( elapsed );
         int energy_bat = power_to_energy_bat( epower_w * intensity, elapsed );
         if( energy_bat > 0 ) {
             add_msg_debug( debugmode::DF_VEHICLE, "%s got %d kJ energy from solar panels", name, energy_bat );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4780,7 +4780,7 @@ int vehicle::total_solar_epower_w() const
     // sample it once.
     weather_type_id wtype = current_weather( global_pos3() );
     const light tick_sunlight = incident_sunlight( wtype, calendar::turn );
-    float intensity = tick_sunlight / default_daylight_level();
+    float intensity = tick_sunlight / LIGHT_DAY;
     return epower_w * intensity;
 }
 
@@ -7239,7 +7239,7 @@ void vehicle::update_time( const time_point &update_to )
 
             epower_w += part_epower_w( part );
         }
-        float intensity = light( accum_weather.sunlight ) / default_daylight_level() / to_turns<double>
+        float intensity = light( accum_weather.sunlight ) / LIGHT_DAY / to_turns<double>
                           ( elapsed );
         int energy_bat = power_to_energy_bat( epower_w * intensity, elapsed );
         if( energy_bat > 0 ) {

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -131,9 +131,9 @@ void glare( const weather_type_id &w )
 
 ////// food vs weather
 
-int incident_sunlight( const weather_type_id &wtype, const time_point &t )
+light incident_sunlight( const weather_type_id &wtype, const time_point &t )
 {
-    return std::max<float>( 0.0f, sun_light_at( t ) + wtype->light_modifier );
+    return std::max( light( 0.0f ), sun_light_at( t ) + light( wtype->light_modifier ) );
 }
 
 static void proc_weather_sum( const weather_type_id &wtype, weather_sum &data,
@@ -162,7 +162,7 @@ static void proc_weather_sum( const weather_type_id &wtype, weather_sum &data,
     }
 
     // TODO: Change this sunlight "sampling" here into a proper interpolation
-    const float tick_sunlight = incident_sunlight( wtype, t );
+    const float tick_sunlight = incident_sunlight( wtype, t ).value;
     data.sunlight += tick_sunlight * to_turns<int>( tick_size );
 }
 

--- a/src/weather.h
+++ b/src/weather.h
@@ -156,8 +156,8 @@ void glare( const weather_type_id &w );
  * Amount of sunlight incident at the ground, taking weather and time of day
  * into account.
  */
-int incident_sunlight( const weather_type_id &wtype,
-                       const time_point &t = calendar::turn );
+light incident_sunlight( const weather_type_id &wtype,
+                         const time_point &t = calendar::turn );
 
 void weather_sound( const translation &sound_message, const std::string &sound_effect );
 

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -16,6 +16,7 @@
 #include "optional.h"
 #include "translations.h"
 #include "type_id.h"
+#include "light.h"
 
 class JsonObject;
 template <typename E> struct enum_traits;

--- a/tests/char_sight_test.cpp
+++ b/tests/char_sight_test.cpp
@@ -63,7 +63,7 @@ TEST_CASE( "light and fine_detail_vision_mod", "[character][sight][light][vision
         here.build_map_cache( 0, false );
         REQUIRE( g->is_in_sunlight( dummy.pos() ) );
         // ambient_light_at is ~100.0 at this time of day (this fails if lightmap cache is not built)
-        REQUIRE( here.ambient_light_at( dummy.pos() ) == Approx( 100.0f ).margin( 1 ) );
+        REQUIRE( here.ambient_light_at( dummy.pos() ).value == Approx( 100.0f ).margin( 1 ) );
 
         // 1.0 is LIGHT_AMBIENT_LIT or brighter
         CHECK( dummy.fine_detail_vision_mod() == Approx( 1.0f ) );
@@ -72,7 +72,7 @@ TEST_CASE( "light and fine_detail_vision_mod", "[character][sight][light][vision
     SECTION( "wielding a bright lamp" ) {
         item lamp( "atomic_lamp" );
         dummy.wield( lamp );
-        REQUIRE( dummy.active_light() == Approx( 15.0f ) );
+        REQUIRE( dummy.active_light().value == Approx( 15.0f ) );
 
         // 1.0 is LIGHT_AMBIENT_LIT or brighter
         CHECK( dummy.fine_detail_vision_mod() == Approx( 1.0f ) );
@@ -86,7 +86,7 @@ TEST_CASE( "light and fine_detail_vision_mod", "[character][sight][light][vision
         calendar::turn = calendar::turn_zero;
         here.build_map_cache( 0, false );
         REQUIRE_FALSE( g->is_in_sunlight( dummy.pos() ) );
-        REQUIRE( here.ambient_light_at( dummy.pos() ) == Approx( LIGHT_AMBIENT_MINIMAL ) );
+        REQUIRE( here.ambient_light_at( dummy.pos() ).value == Approx( LIGHT_AMBIENT_MINIMAL.value ) );
 
         // 7.3 is LIGHT_AMBIENT_MINIMAL, a dark cloudy night, unlit indoors
         CHECK( dummy.fine_detail_vision_mod() == Approx( 7.3f ) );
@@ -213,7 +213,7 @@ TEST_CASE( "ursine vision", "[character][ursine][vision]" )
     clear_map();
     g->reset_light_level();
 
-    float light_here = 0.0f;
+    light light_here = light( 0.0f );
 
     GIVEN( "character with ursine eyes and no eyeglasses" ) {
         dummy.toggle_trait( trait_URSINE_EYE );
@@ -226,13 +226,13 @@ TEST_CASE( "ursine vision", "[character][ursine][vision]" )
             calendar::turn = calendar::turn_zero;
             here.build_map_cache( 0, false );
             light_here = here.ambient_light_at( dummy.pos() );
-            REQUIRE( light_here == Approx( LIGHT_AMBIENT_MINIMAL ) );
+            REQUIRE( light_here.value == Approx( LIGHT_AMBIENT_MINIMAL.value ) );
 
-            THEN( "unimpaired sight, with 4 tiles of range" ) {
+            THEN( "unimpaired sight, with 7 tiles of range" ) {
                 dummy.recalc_sight_limits();
                 CHECK_FALSE( dummy.sight_impaired() );
                 CHECK( dummy.unimpaired_range() == 60 );
-                CHECK( dummy.sight_range( light_here ) == 4 );
+                CHECK( dummy.sight_range( light_here ) == 7 );
             }
         }
 
@@ -240,7 +240,7 @@ TEST_CASE( "ursine vision", "[character][ursine][vision]" )
             calendar::turn = calendar::turn_zero + 7_days;
             here.build_map_cache( 0, false );
             light_here = here.ambient_light_at( dummy.pos() );
-            REQUIRE( light_here == Approx( LIGHT_AMBIENT_DIM ).margin( 1.0f ) );
+            REQUIRE( light_here.value == Approx( LIGHT_AMBIENT_DIM.value ).margin( 1.0f ) );
 
             THEN( "unimpaired sight, with 8 tiles of range" ) {
                 dummy.recalc_sight_limits();
@@ -254,7 +254,7 @@ TEST_CASE( "ursine vision", "[character][ursine][vision]" )
             calendar::turn = calendar::turn_zero + 14_days;
             here.build_map_cache( 0, false );
             light_here = here.ambient_light_at( dummy.pos() );
-            REQUIRE( light_here == Approx( 7 ) );
+            REQUIRE( light_here.value == Approx( 7 ) );
 
             THEN( "unimpaired sight, with 27 tiles of range" ) {
                 dummy.recalc_sight_limits();
@@ -269,7 +269,7 @@ TEST_CASE( "ursine vision", "[character][ursine][vision]" )
             here.build_map_cache( 0, false );
             light_here = here.ambient_light_at( dummy.pos() );
             REQUIRE( g->is_in_sunlight( dummy.pos() ) );
-            REQUIRE( light_here == Approx( 100.0f ).margin( 1 ) );
+            REQUIRE( light_here.value == Approx( 100.0f ).margin( 1 ) );
 
             THEN( "impaired sight, with 12 tiles of range" ) {
                 dummy.recalc_sight_limits();

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -190,8 +190,8 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
     you.setpos( target_location );
     const tripoint_abs_ms abs_target_location = you.get_location();
     reset_caches( target_location.z, target_location.z );
-    REQUIRE( g->natural_light_level( 0 ) > 50.0 );
-    CHECK( here.ambient_light_at( target_location ) > 50.0 );
+    REQUIRE( g->natural_light_level( 0 ) > light( 50.0f ) );
+    CHECK( here.ambient_light_at( target_location ) > light( 50.0f ) );
     const std::string monster_type = "mon_feral_human_pipe";
     for( int distance = 2; distance <= 5; ++distance ) {
         float expected_damage = expected_average_damage_at_range[ distance ];

--- a/tests/moon_test.cpp
+++ b/tests/moon_test.cpp
@@ -217,9 +217,9 @@ TEST_CASE( "moonlight at dawn and dusk", "[calendar][moon][moonlight][dawn][dusk
         time_point new_noon = new_midnight + 12_hours;
 
         // Daylight level should be ~100 at first new moon
-        float daylight_level = sun_moon_light_at( new_noon );
+        float daylight_level = sun_moon_light_at( new_noon ).value;
         CHECK( daylight_level == Approx( 110 ).margin( 10 ) );
-        float moonlight_level = 1.0f;
+        light moonlight_level = light( 1.0f );
 
         THEN( "at night, light is only moonlight" ) {
             CHECK( sun_moon_light_at( new_sunset + 2_hours ) == moonlight_level );
@@ -242,9 +242,9 @@ TEST_CASE( "moonlight at dawn and dusk", "[calendar][moon][moonlight][dawn][dusk
         time_point full_noon = full_midnight + 12_hours;
 
         // Daylight level is higher, later in the season (~104 at first full moon)
-        float daylight_level = sun_moon_light_at( full_noon );
+        float daylight_level = sun_moon_light_at( full_noon ).value;
         CHECK( daylight_level == Approx( 120 ).margin( 10 ) );
-        float moonlight_level = 7.0f;
+        light moonlight_level = light( 7.0f );
 
         THEN( "at night, light is only moonlight" ) {
             CHECK( sun_moon_light_at( full_sunset + 2_hours ) == moonlight_level );
@@ -295,7 +295,7 @@ static float phase_moonlight( const float phase_scale, const moon_phase expect_p
                expect_phase_enum ) );
 
     // Finally, get the amount of moonlight
-    return sun_moon_light_at( this_night );
+    return sun_moon_light_at( this_night ).value;
 }
 
 // Moonlight level varies with moon phase, from 1.0 at new moon to 10.0 at full moon.

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -129,7 +129,7 @@ static dispersion_sources get_dispersion( npc &shooter, const int aim_time, int 
     shooter.moves = aim_time;
     shooter.recoil = MAX_RECOIL;
     // Aim as well as possible within the provided time.
-    shooter.aim( Target_attributes( range, 0.5, 0.0f, true ) );
+    shooter.aim( Target_attributes( range, 0.5, light( 0.0f ), true ) );
     if( aim_time > 0 ) {
         REQUIRE( shooter.recoil < MAX_RECOIL );
     }

--- a/tests/sun_test.cpp
+++ b/tests/sun_test.cpp
@@ -139,47 +139,47 @@ TEST_CASE( "sunlight and moonlight", "[sun][sunlight][moonlight]" )
 
     // Expected numbers below assume 110.0f maximum daylight level
     // (maximum daylight is different at other times of year - see [daylight] tests)
-    REQUIRE( 100.0f == default_daylight_level() );
+    REQUIRE( 100.0f == default_daylight_level().value );
 
     SECTION( "sunlight" ) {
         // Before dawn
-        CHECK( 1.0f == sun_moon_light_at( midnight ) );
+        CHECK( 1.0f == sun_moon_light_at( midnight ).value );
         // Dawn
-        CHECK( sun_moon_light_at( today_sunrise - 2_hours ) == 1.0f );
-        CHECK( sun_moon_light_at( today_sunrise - 1_hours ) == Approx( 5 ).margin( 2 ) );
-        CHECK( sun_moon_light_at( today_sunrise ) == Approx( 60 ).margin( 1 ) );
+        CHECK( sun_moon_light_at( today_sunrise - 2_hours ).value == 1.0f );
+        CHECK( sun_moon_light_at( today_sunrise - 1_hours ).value == Approx( 5 ).margin( 2 ) );
+        CHECK( sun_moon_light_at( today_sunrise ).value == Approx( 60 ).margin( 1 ) );
         // Light gets brighter towards noon
         CHECK( sun_moon_light_at( today_sunrise + 2_hours ) >
                sun_moon_light_at( today_sunrise + 1_hours ) );
         CHECK( sun_moon_light_at( today_sunrise + 3_hours ) >
                sun_moon_light_at( today_sunrise + 2_hours ) );
         // Noon
-        CHECK( sun_moon_light_at( noon ) == Approx( 110 ).margin( 10 ) );
+        CHECK( sun_moon_light_at( noon ).value == Approx( 110 ).margin( 10 ) );
         CHECK( sun_moon_light_at( noon + 1_hours ) <
                sun_moon_light_at( noon ) );
         CHECK( sun_moon_light_at( noon + 2_hours ) <
                sun_moon_light_at( noon + 1_hours ) );
         // Dusk begins
-        CHECK( sun_moon_light_at( today_sunset - 1_hours ) ==
-               Approx( sun_moon_light_at( today_sunrise + 1_hours ) ).margin( 1 ) );
-        CHECK( sun_moon_light_at( today_sunset ) ==
-               Approx( sun_moon_light_at( today_sunrise ) ).margin( 1 ) );
-        CHECK( sun_moon_light_at( today_sunset + 1_hours ) ==
-               Approx( sun_moon_light_at( today_sunrise - 1_hours ) ).margin( 1 ) );
+        CHECK( sun_moon_light_at( today_sunset - 1_hours ).value ==
+               Approx( sun_moon_light_at( today_sunrise + 1_hours ).value ).margin( 1 ) );
+        CHECK( sun_moon_light_at( today_sunset ).value ==
+               Approx( sun_moon_light_at( today_sunrise ).value ).margin( 1 ) );
+        CHECK( sun_moon_light_at( today_sunset + 1_hours ).value ==
+               Approx( sun_moon_light_at( today_sunrise - 1_hours ).value ).margin( 1 ) );
 
         // Eternal night
         calendar::set_eternal_night( true );
-        CHECK( sun_moon_light_at( midnight ) == 1.0f );
-        CHECK( sun_moon_light_at( today_sunset ) == 1.0f );
-        CHECK( sun_moon_light_at( today_sunrise ) == 1.0f );
-        CHECK( sun_moon_light_at( noon ) == 1.0f );
+        CHECK( sun_moon_light_at( midnight ).value == 1.0f );
+        CHECK( sun_moon_light_at( today_sunset ).value == 1.0f );
+        CHECK( sun_moon_light_at( today_sunrise ).value == 1.0f );
+        CHECK( sun_moon_light_at( noon ).value == 1.0f );
         calendar::set_eternal_night( false );
         // Eternal day
         calendar::set_eternal_day( true );
-        CHECK( sun_moon_light_at( midnight ) == Approx( 126 ).margin( 5 ) );
-        CHECK( sun_moon_light_at( today_sunset ) == Approx( 126 ).margin( 5 ) );
-        CHECK( sun_moon_light_at( today_sunrise ) == Approx( 126 ).margin( 5 ) );
-        CHECK( sun_moon_light_at( noon ) == Approx( 126 ).margin( 5 ) );
+        CHECK( sun_moon_light_at( midnight ).value == Approx( 126 ).margin( 5 ) );
+        CHECK( sun_moon_light_at( today_sunset ).value == Approx( 126 ).margin( 5 ) );
+        CHECK( sun_moon_light_at( today_sunrise ).value == Approx( 126 ).margin( 5 ) );
+        CHECK( sun_moon_light_at( noon ).value == Approx( 126 ).margin( 5 ) );
         calendar::set_eternal_day( false );
     }
 
@@ -196,14 +196,14 @@ TEST_CASE( "sunlight and moonlight", "[sun][sunlight][moonlight]" )
         WHEN( "the moon is new" ) {
             REQUIRE( get_moon_phase( new_moon ) == MOON_NEW );
             THEN( "moonlight is 1.0" ) {
-                CHECK( 1.0f == sun_moon_light_at( new_moon ) );
+                CHECK( 1.0f == sun_moon_light_at( new_moon ).value );
             }
         }
 
         WHEN( "the moon is full" ) {
             REQUIRE( get_moon_phase( full_moon_midnight ) == MOON_FULL );
             THEN( "moonlight is 7.0" ) {
-                CHECK( 7.0f == sun_moon_light_at( full_moon_midnight ) );
+                CHECK( 7.0f == sun_moon_light_at( full_moon_midnight ).value );
             }
         }
     }
@@ -219,38 +219,38 @@ TEST_CASE( "noon sunlight levels", "[sun][daylight][equinox][solstice]" )
     const time_point winter = autumn + one_season;
 
     SECTION( "baseline 110 daylight on the spring and autumn equinoxes" ) {
-        float spring_light = sun_light_at( spring + 12_hours );
+        float spring_light = sun_light_at( spring + 12_hours ).value;
         CHECK( spring_light == Approx( 110.0f ).margin( 10 ) );
-        CHECK( sun_light_at( autumn + 12_hours ) == Approx( spring_light ).margin( 1 ) );
+        CHECK( sun_light_at( autumn + 12_hours ).value == Approx( spring_light ).margin( 1 ) );
     }
 
     SECTION( "125 daylight on the summer solstice" ) {
-        CHECK( sun_light_at( summer + 12_hours ) == 125.0f );
+        CHECK( sun_light_at( summer + 12_hours ).value == 125.0f );
     }
 
     SECTION( "90 daylight on the winter solstice" ) {
-        CHECK( sun_light_at( winter + 12_hours ) == Approx( 87.0f ).margin( 10 ) );
+        CHECK( sun_light_at( winter + 12_hours ).value == Approx( 87.0f ).margin( 10 ) );
     }
 
     // Many other times of day have peak daylight level, but noon is for sure
     SECTION( "noon is peak daylight level" ) {
-        CHECK( sun_moon_light_at( spring + 12_hours ) ==
-               Approx( sun_moon_light_at_noon_near( spring ) ).margin( 3 ) );
-        CHECK( sun_moon_light_at( summer + 12_hours ) ==
-               Approx( sun_moon_light_at_noon_near( summer ) ).margin( 3 ) );
-        CHECK( sun_moon_light_at( autumn + 12_hours ) ==
-               Approx( sun_moon_light_at_noon_near( autumn ) ).margin( 3 ) );
-        CHECK( sun_moon_light_at( winter + 12_hours ) ==
-               Approx( sun_moon_light_at_noon_near( winter ) ).margin( 3 ) );
+        CHECK( sun_moon_light_at( spring + 12_hours ).value ==
+               Approx( sun_moon_light_at_noon_near( spring ).value ).margin( 3 ) );
+        CHECK( sun_moon_light_at( summer + 12_hours ).value ==
+               Approx( sun_moon_light_at_noon_near( summer ).value ).margin( 3 ) );
+        CHECK( sun_moon_light_at( autumn + 12_hours ).value ==
+               Approx( sun_moon_light_at_noon_near( autumn ).value ).margin( 3 ) );
+        CHECK( sun_moon_light_at( winter + 12_hours ).value ==
+               Approx( sun_moon_light_at_noon_near( winter ).value ).margin( 3 ) );
     }
 
     SECTION( "Eternal day" ) {
         // locked sunlight when eternal day id due
         calendar::set_eternal_day( true );
-        CHECK( sun_light_at( spring + 12_hours ) == 125.0f );
-        CHECK( sun_light_at( summer + 12_hours ) == 125.0f );
-        CHECK( sun_light_at( autumn + 12_hours ) == 125.0f );
-        CHECK( sun_light_at( winter + 12_hours ) == 125.0f );
+        CHECK( sun_light_at( spring + 12_hours ).value == 125.0f );
+        CHECK( sun_light_at( summer + 12_hours ).value == 125.0f );
+        CHECK( sun_light_at( autumn + 12_hours ).value == 125.0f );
+        CHECK( sun_light_at( winter + 12_hours ).value == 125.0f );
         calendar::set_eternal_day( false );
     }
 }

--- a/tests/sun_test.cpp
+++ b/tests/sun_test.cpp
@@ -139,7 +139,7 @@ TEST_CASE( "sunlight and moonlight", "[sun][sunlight][moonlight]" )
 
     // Expected numbers below assume 110.0f maximum daylight level
     // (maximum daylight is different at other times of year - see [daylight] tests)
-    REQUIRE( 100.0f == default_daylight_level().value );
+    REQUIRE( 100.0f == LIGHT_DAY.value );
 
     SECTION( "sunlight" ) {
         // Before dawn


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The handling of brightness/light levels is inconsistent. The original idea sparked from #59062 which addresses some of the issues but does not go far enough in my opinion.
Issues:
- A formula incorrectly assumes that the maximum light level is 100 (fixed in #59062)
- The type used is inconsistent (int/float/double) (partially fixed in #59062). This leads to confusion about the supposed meaning of functions, e.g. [game::light_level](https://github.com/CleverRaven/Cataclysm-DDA/blob/5fd62948a3e4fcfd252eec0c5b1c7318167b0754/src/game.cpp#L3871-L3875) does not compute a light level but a view range at a given light level. This is then consumed by other functions expecting light levels but due to implicit int->float casts that was never detected.
- Addition of floats does not correspond to the perceived increased brightness for multiple light sources. This is incorrectly addressed by an iteration that depends on the order and does not use the correct formula in [game::veh_lumi](https://github.com/CleverRaven/Cataclysm-DDA/blob/5fd62948a3e4fcfd252eec0c5b1c7318167b0754/src/game.cpp#L1162-L1178) (also duplicated code. This same iteration is used elsewhere)
- Some operations make no real sense for light levels, e.g. subtraction or multiplication with another light level. This is especially problematic with inconsistent upper/lower bounds on brightness as this can result in negative light levels.


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This PR extracts the light level into its own class, called light (though brightness might be a better name). Most places that used floats to represent brightness now use that class instead. This is a very literal translation for ease of review. Changes made are mostly limited to:
- float/double -> light
- static_cast<int or float> removed as they are no longer necessary
- light.value whereever an actual float is needed, light(x) whereever a light is constructed from a float. These are temporary as they should rarely (if ever) be necessary.
- Use game::incorrect_light_level instead of game::light_level which does not do what is inteded but might be relied upon by other code. Also temporary.

One test expects a view range of 4 at night, this was changed to 7 due to removing the rounding error. That was also encountered by #59062.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Doing more stuff in one PR/commit. As that is already a quite sizable PR I've limited myself to transitioning to a light class. Rounding was removed which might influence some results.
Name the light class brightness. Actually, I've only considered this while typing this up. Seems to be a far better name.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tests run through. Besides rounding (which was checked by one test) no real changes were made to the code. There might be a low performance impact but I doubt it as the class has only a single member, a float, and functions that operate on it. On higher optimizations at least that should be completely negated. Caches aren't touched by this PR yet so RAM usage should be identical even without optimizations.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
The first commit is focussed on easy reviewability. Changes I intend to do, either in this PR or separately:
- Remove game::incorrect_light_level
- Change light + light to an logarithmic addition that corresponds to the physical brightness of two light sources. In general, I would transition brightness to a logarithmic scale but I first need to look up how bad that is for performance and what units are used in the real world (candela, lumen, lux, some more?).
- Unify transparency calculations. Beer-Lambert is mentioned at three different places but that's not necessary.
- Remove weird constants. At one point M_SQRT2 is used as the brightness of a light source. Why? Why not 1 or 2?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Note that the changes made by #59062 conflict with these here somewhat. I guess it's best if that PR is merged first and I fix any conflicts here.