### PR TITLE
[WIP] Try to enable ASan on Mingw cross build

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -164,6 +164,7 @@ jobs:
             release: 0
             cmake: 0
             native:
+            sanitize: address
             tiles: 1
             sound: 1
             localize: 1

--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -23,6 +23,8 @@
 #include "platform_win.h"
 #endif
 #include <dbghelp.h>
+#else
+#include <unistd.h>
 #endif
 
 #include "debug.h"
@@ -55,6 +57,17 @@ extern "C" {
         // reasons, including the memory allocations and the SDL message box.
         // But it should usually work in practice, unless for example the
         // program segfaults inside malloc.
+
+        // Do a signal-safe write to stderr first just so we know we're in this
+        // function even if something after this crashes
+        const char *const header = "\n====== [log_crash] ======\n";
+#if defined(_WIN32)
+        HANDLE stderr_handle = GetStdHandle( STD_ERROR_HANDLE );
+        WriteFile( stderr_handle, header, strlen( header ), nullptr, nullptr );
+#else
+        ssize_t bytes_written = write( 2, header, strlen( header ) );
+        static_cast<void>( bytes_written );
+#endif
 #if defined(_WIN32)
         dump_to( ".core" );
 #endif


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The Mingw cross compile build is segfaulting with no useful stack trace or other crash reporting.  From what I've been able to determine based on the minimal crash dump info we do get I think the issue is some kind of heap overflow or other heap misuse.

#### Describe the solution
In the hopes of getting some additional information from it, enable Address Sanitizer which might be able to report something useful on a future CI job where the same issue occurs.

#### Describe alternatives you've considered
Trying to reproduce the issue locally, but cross-compiling is hard.

#### Testing
Needs to be tested on CI, so opening as a draft.

#### Additional context
[Here](https://github.com/CleverRaven/Cataclysm-DDA/runs/7593592238?check_suite_focus=true) and [here](https://github.com/CleverRaven/Cataclysm-DDA/runs/7591045798?check_suite_focus=true) are examples of CI jobs failing in this way.