### PR TITLE
Fix NPC gun time penalty

### DIFF
--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -439,7 +439,7 @@ int npc_attack_gun::base_time_penalty( const npc &source ) const
 {
     const item &weapon = *gunmode;
     int time_penalty = 0;
-    if( source.is_wielding( weapon ) ) {
+    if( !source.is_wielding( weapon ) ) {
         time_penalty += npc_attack_constants::base_time_penalty;
     }
     // we want the need to reload a gun cumulative with needing to wield the gun


### PR DESCRIPTION
#### Summary
Bugfixes "Fix NPC gun time penalty"

#### Purpose of change

Based on this:
```cpp
int npc_attack_melee::base_time_penalty( const npc &source ) const
{
    return source.is_wielding( weapon ) ? 0 : npc_attack_constants::base_time_penalty;
}
```
And this:
```cpp
// we want the need to reload a gun cumulative with needing to wield the gun
if( !weapon.ammo_sufficient( &source ) ) {
    time_penalty += npc_attack_constants::base_time_penalty;
}
```
I believe the current code for `npc_attack_gun::base_time_penalty` is backwards on the `is_wielding` check. Please correct me if I'm wrong.

#### Describe the solution

I made it un-backwards.

#### Describe alternatives you've considered

I'm misunderstanding the code.

#### Testing

I am currently trying to determine the circumstances under which an NPC would choose to hit with a gun instead of shoot it, to test before and after the change.
