### PR TITLE
[WIP] Bonus crafting speed on optional requirements

### DIFF
--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -865,6 +865,18 @@ bool requirement_data::can_make_with_inventory( const read_only_visitable &craft
     return retval;
 }
 
+float requirement_data::get_tool_bonus_speed_with_inventory( const read_only_visitable
+        &crafting_inv,
+        const std::function<bool( const item & )> &filter, int batch, craft_flags flags ) const
+{
+
+    float tool_bonus = 1.0f;
+    // has_comps( crafting_inv, components, filter, batch );
+    // TODO: Iterate reqs and calculate bonus
+
+    return tool_bonus;
+}
+
 template<typename T>
 bool requirement_data::has_comps( const read_only_visitable &crafting_inv,
                                   const std::vector< std::vector<T> > &vec,

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -344,6 +344,14 @@ struct requirement_data {
         bool can_make_with_inventory( const read_only_visitable &crafting_inv,
                                       const std::function<bool( const item & )> &filter, int batch = 1,
                                       craft_flags = craft_flags::none ) const;
+        /**
+        * Returns the speed multiplier for optional tools fulfilled by the filtered inventory
+        * @param filter should be recipe::get_component_filter() if used with a recipe
+        * or is_crafting_component otherwise.
+        */
+        float get_tool_bonus_speed_with_inventory( const read_only_visitable &crafting_inv,
+                const std::function<bool( const item & )> &filter, int batch = 1,
+                craft_flags = craft_flags::none ) const;
 
         /** @param filter see @ref can_make_with_inventory */
         std::vector<std::string> get_folded_components_list( int width, nc_color col,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add optional requirements to crafting recipes to increase crafting speed"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently if we want to add a new tool to improve a current recipe, we need to duplicate and edit the current recipe.
This results in bloated crafting GUI and repeated JSON data. See #54015 for example.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add optional requirements (tools or components) that would increase crafting speed.
This could be achieved by:
- [ ] Add optional requirements to requirement structure
- [ ] Include bonus crafting speed in crafting process
- [ ] Add optional requirements to crafting GUI
  - [ ] Prompt the player when consuming optional requirements (charges, etc)
- [ ] Audit and Modify current recipes that may benefit from this change

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Add speed multiplier to tools: This is lot less flexible and wouldn't work well with all the tools and qualities needed for crafting
- Add speed multiplier to increased tool qualities: Would work well for some crafting recipes but is still limited to some degree and would require a lot of rebalance/audit of current recipes
- Add optional proficiencies which would be learnt by using optional tools (for ex. Sewing machine prof. Activated when using said tool): This would take more work to implement, but can be added easier after getting optional requirements working.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
WIP
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
The purpose of this Draft is to get feedback on this feature before committing to develop it fully
Lots of improvements would be possible with the optional requirements, including the usage of machine tools (appliances), like power hammers, power lathes, sewing machines.
A similar objective is mentioned in #42556 
It would also fix #45157
and enable #54348 

