### PR TITLE
Exodii Mission 1 dialogue

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_missions.json
+++ b/data/json/npcs/exodii/exodii_merchant_missions.json
@@ -20,5 +20,127 @@
       "failure": "Fine an' fine.  Come back to this'n if you like to try again."
     },
     "end": { "effect": [ { "u_add_var": "anusfetick", "type": "mission", "context": "completed", "value": "yes" } ] }
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_1_intro",
+    "type": "talk_topic",
+    "dynamic_line": "Them as offer as can, an it be so. Aye, there's summat the old Scythy been larkin' up Rubik's tailpipe.  B'ain't tass right for a clanker like this'n, but a pop-an-work like you'n, maybe well and suited.",
+    "//~": "Just because you asked, I think we can work something out.  Yes, the Scythean has been bugging me about something.  It's not something a cyborg like me can do, but a mercenary would probably fit the bill.",
+    "responses": [
+      { "text": "What's \"the ol' Scythy\"?", "topic": "TALK_EXODII_MERCHANT_Scythean" },
+      { "text": "Why can't one of you do this?", "topic": "TALK_EXODII_MERCHANT_mission_1_explain" },
+      { "text": "Tell me more about this job that you can't do.", "topic": "TALK_EXODII_MERCHANT_mission_1_intro1" },
+      { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
+      { "text": "I've gotta go.  See you later, Rubik.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_1_explain",
+    "type": "talk_topic",
+    "dynamic_line": "Hat ye kennt our great clanks an' stompers?  There be many a thing we can do right good, but for the supple an' smooth, we b'ain't.  Wish'n we to make a meet-cute, must we first lay out the hempen mats.",
+    "//~": "Have you seen our big stompy quads?  There's a lot of things we're good at, but sneaky and subtle we aren't.  If we want a meet cute, first we've got to lay out the hempen mats.",
+    "responses": [
+      { "text": "Hold up, did you just say \"meet cute\"?", "topic": "TALK_EXODII_MERCHANT_Meetcute" },
+      {
+        "text": "I am guessing it doesn't matter, but what do you mean about hempen mats?",
+        "effect": { "u_add_var": "rubik_personal_questions", "value": "hempen_mats" },
+        "topic": "TALK_EXODII_MERCHANT_Hempen1"
+      },
+      {
+        "text": "OK, fine.  Tell me more about this job that you can't do.",
+        "topic": "TALK_EXODII_MERCHANT_mission_1_intro1"
+      },
+      { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
+      { "text": "I've gotta go.  See you later, Rubik.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_1_intro1",
+    "type": "talk_topic",
+    "dynamic_line": "It be a right coddle to yark, but ol' Rubik'll do as can.  Them as we send a'far, what I'd assert as 'escolts'… explorers?  They's escolted a place with a mite o' promise, an I'm ken.  A wall o' crete-stone, abreast a rattlin' clunker… a 'bunker'.  Not so odd in a deadlands alas, but this'n gots the comin's and goin's.  Sommat's still in there, an' ol' Rubik wonders who.  Be they friend or foe?  What say ye t'helpin' with a mite o' escoltin' y'self?",
+    "//~": "It's a bit hard to explain, but I'll do my best.  The forces we send far out, what I'd call 'escolts'… explorers?  They've scouted a place with a bit of promise, as far as I can tell.  A wall of concrete around a bunker.  That's not so odd in a place like this, but this one has people coming and going.  There's something still in there, and I wonder who.  Are they friendly or not?  What would you think about doing some scouting yourself?",
+    "responses": [
+      { "text": "Why can't one of you do this?", "topic": "TALK_EXODII_MERCHANT_mission_1_explain" },
+      {
+        "text": "Well, today's your lucky day, my metal friend.  I already know the place quite well.",
+        "condition": "already met hub",
+        "topic": "TALK_EXODII_MERCHANT_mission_1_met_hub"
+      },
+      {
+        "text": "What exactly do you want me to do?  Scout out this bunker and contact the people in it?",
+        "topic": "TALK_EXODII_MERCHANT_mission_1_intro2"
+      },
+      { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
+      { "text": "I've gotta go.  See you later, Rubik.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_1_intro2",
+    "type": "talk_topic",
+    "dynamic_line": "No, me fruit gum, no!  Make no contact, y'ken?  This be covert.  If ye kennit be safe, traipse along an' for a kennabout, but upon the chimes, speak none and tarry little.",
+    "//~": "No, my friend, no!  Don't make contact, understand?  This is a covert op.  If you see that it's safe you can go in closer and look around, but for goodness' sake, don't talk to anyone and don't linger.",
+    "responses": [
+      {
+        "text": "I get the impression this is important, but I don't know what you mean.",
+        "topic": "TALK_EXODII_MERCHANT_mission_1_intro2_translate"
+      },
+      {
+        "text": "This sounds insanely dangerous.  They could just shoot me on sight.",
+        "topic": "TALK_EXODII_MERCHANT_mission_1_intro3"
+      },
+      {
+        "text": "So you want me to go there, see what's inside the walls, look around a little, and then let you know if I see anything, but if someone tries to talk to me, not mention you or your people?",
+        "topic": "TALK_EXODII_MERCHANT_mission_1_understood"
+      },
+      { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
+      { "text": "I'm gonna need to think on this one.  See you later, Rubik.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_1_intro2_translate",
+    "type": "talk_topic",
+    "dynamic_line": "*pauses for a moment, and lets out a slow sigh, speaking hesitantly as they catch themselves in idioms.  \"Make no contact.  We ken… we think the abroad o'… the outside o' the bunker be safe an'… be safe to explore, for one such as ye, who harks as from this'n land.  A wander in and escolt… a look around we ken as no… no risk.  If ye think ye been spotted, wave along and make no mention of ol' Rubik and the Exodii.  Not afore we be razzed some more o' this rattlin'… this bunker.",
+    "responses": [
+      {
+        "text": "How can you know that it's safe?  What if I'm shot on sight?",
+        "topic": "TALK_EXODII_MERCHANT_mission_1_intro3"
+      },
+      {
+        "text": "So you want me to go there, see what's inside the walls, look around a little, and then let you know if I see anything, but if someone tries to talk to me, not mention you or your people?",
+        "topic": "TALK_EXODII_MERCHANT_mission_1_understood"
+      },
+      { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
+      { "text": "I'm gonna need to think on this one.  See you later, Rubik.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_1_intro3",
+    "type": "talk_topic",
+    "dynamic_line": "Them as we've escolted seems a fair kin, an' we've eyed a scav or two wanderin' the premise unscathed.  If'n the scavs o' the dust can make it in an' out, so should ye be.",
+    "//~": "Our scouts have seen people who look like you wandering in the area safely.  If the scavengers can make it in and out, you should be fine.",
+    "responses": [
+      {
+        "text": "So you want me to go there, see what's inside the walls, look around a little, and then let you know if I see anything, but if someone tries to talk to me, not mention you or your people?",
+        "topic": "TALK_EXODII_MERCHANT_mission_1_understood"
+      },
+      { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
+      { "text": "I'm gonna need to think on this one.  See you later, Rubik.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_1_understood",
+    "type": "talk_topic",
+    "dynamic_line": "Aye, ye kennit well.",
+    "responses": [
+      {
+        "text": "This is insane.  I can't tell if you're leading me into a trap or not.  What's in it for me?",
+        "topic": "TALK_EXODII_MERCHANT_mission_1_pay_skeptic"
+      },
+      {
+        "text": "Sure.  Don't know what good it'll do you, but I might be willing.  What are you paying?",
+        "topic": "TALK_EXODII_MERCHANT_pay_nice"
+      },
+      { "text": "I'm gonna need to think on this one.  See you later, Rubik.", "topic": "TALK_DONE" }
+    ]
   }
 ]

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -1021,5 +1021,58 @@
       { "text": "I've got some stuff I'd like to install.", "topic": "TALK_DONE", "effect": "bionic_install" },
       { "text": "Would you be able to take out one of my implants?", "topic": "TALK_DONE", "effect": "bionic_remove" }
     ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Scythean",
+    "type": "talk_topic",
+    "dynamic_line": "Ha!  A new string and beans, an I'm ken.  Latched and keyed in the bright shine o' the deadland afore this'n.  He be a thing o' fire and bronze, an' the node appreciates his grit.  \"A cnight of old, clade in shining steel, leading the hoste onward to glorie,\" as 'twere.  This'n finds him an apt one to give rede.  To command in battle, that's t'yark.",
+    "//~": "Ha!  A new part of our crew.  Signed up early on in the world we were in before.  He's a really tough guy, and the node appreciates his grit.  <recites some poetry>, as 'twere.  I think he's pretty good as a military commander.",
+    "responses": [
+      {
+        "text": "You know, every so often you talk normally and I realize you could probably drop the whole accent if you wanted to.",
+        "topic": "TALK_EXODII_MERCHANT_Anglic_Tease"
+      },
+      { "text": "What was it you were saying before?", "topic": "TALK_NONE" },
+      {
+        "text": "I think I've had about enough of trying to figure out what you're talking about, see you later.",
+        "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Anglic_Tease",
+    "type": "talk_topic",
+    "dynamic_line": "Mayhap, but where'd be the fun in that?  Asides, quoth poetry is one thing, but changin' this'n's whole yark for always takes a lot o' practice.",
+    "//~": "Maybe, but where's the fun in that?  Besides, quoting poetry is one thing, but changing the way I speak all the time takes a lot of practice.",
+    "responses": [
+      {
+        "text": "What was it you were saying before, about the mission you had for me?",
+        "topic": "TALK_EXODII_MERCHANT_mission_1_intro"
+      },
+      { "text": "Well, a person can get sick of trying to piece it together.  See you later.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Meetcute",
+    "type": "talk_topic",
+    "dynamic_line": "Aye.  Ye kennit, when two of a sort happen upon each other as per chance, an' find a liking to another?  'Tis a bit o' Anglic yark.",
+    "//~": "Right.  You see, it's when two compatible people randomly happen into each other and take a liking to one another.  It's a bit of Anglic slang.",
+    "responses": [
+      {
+        "text": "Yeah, that's what I thought it meant, just… nevermind.  What were you saying about the job?",
+        "topic": "TALK_EXODII_MERCHANT_mission_1_intro"
+      },
+      { "text": "I don't know what kind of game you're playing, but I'm out for a bit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Hempen1",
+    "type": "talk_topic",
+    "dynamic_line": "*seems to become wistful for a moment.  \"Harks this'n yonder, right so.  'Tis a bit o' t'ol' King's Landing right there, kennit, yarkin' from back when Rubik were nigh smaller than a kelpie.  It…\"  Rubik's gravelly voice falters.  \"Ah, 'tis mightily tassed to harken back yonder.  Mayhap another time.",
+    "//~": "That takes me way back.  That's a bit of the old King's Landing right there, you know, calling back from when I was just little.  It… ah, it's really hard for me to think about those old days.  Maybe another time.",
+    "responses": [
+      { "text": "Maybe later then.  What were you saying about the job?", "topic": "TALK_EXODII_MERCHANT_mission_1_intro" },
+      { "text": "You know, I think it'd be best if I just got going.", "topic": "TALK_DONE" }
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary
Content "Adds dialogue for exodii mission 1"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
See https://github.com/CleverRaven/Cataclysm-DDA/issues/59900 and https://github.com/CleverRaven/Cataclysm-DDA/issues/59901

#### Describe the solution
This adds the dialogue for Rubik's side of the first exodii quest.

If I get this done before bedtime, I'll likely also add the mission portion. However I might also just add the empty dialogue, unlinked and hanging there, like a tempting morsel of delicious bacon hoping someone will add the quest and fall into my trap to become the person who helps me finish up this stuff.

#### Describe alternatives you've considered
See linked issues.

#### Testing
not yet.

#### Additional context
I got tired of writing. I still hope to find an accomplice for ongoing efforts.
