### PR TITLE
Check for duplicate vehicle part defs

### DIFF
--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -358,6 +358,7 @@ void vpart_info::load_workbench( cata::optional<vpslot_workbench> &wbptr, const 
 void vpart_info::load( const JsonObject &jo, const std::string &src )
 {
     vpart_info def;
+    mod_tracker::assign_src( def, src );
 
     if( jo.has_string( "copy-from" ) ) {
         const auto base = vpart_info_all.find( vpart_id( jo.get_string( "copy-from" ) ) );
@@ -535,6 +536,9 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
     if( jo.has_string( "abstract" ) ) {
         abstract_parts[def.id] = def;
     } else {
+        if( vpart_info_all.count( def.id ) != 0 ) {
+            mod_tracker::check_duplicate_entries( def, vpart_info_all[def.id] );
+        }
         vpart_info_all[def.id] = def;
     }
 }

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -352,6 +352,8 @@ class vpart_info
 
         /** Unique identifier for this part */
         vpart_id id;
+        std::vector<std::pair<vpart_id, mod_id>> src;
+        friend struct mod_tracker;
 
         /** Name from vehicle part definition which if set overrides the base item name */
         translation name_;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/59947 fixes a bug where a vehicle part has two overwriting definitions.
Catch those automatically.

#### Describe the solution
Add source tracking to `vpart_info`.

#### Describe alternatives you've considered
Make `vpart_info` use `generic_factory`, but that's a bigger task.

#### Testing
`./build-scripts/get_all_mods.py | xargs -I{} tests/cata_test --mods={} '~*'`

#### Additional context
This will not pass the tests until the above PR is merged.