### PR TITLE
Cardio overhaul; divorce BMR from cardio and fix health, athletics, and traits effects on cardio

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -25,7 +25,7 @@
     "name": "PLAYER_CARDIOFIT_STAMINA_SCALING",
     "info": "Sets the effect of cardio on maximum stamina.",
     "stype": "int",
-    "value": 3
+    "value": 5
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1508,20 +1508,27 @@ void avatar::update_cardio_acc()
     // This function should be called once every 24 hours,
     // before the front of the calorie diary is reset for the next day.
 
-    // Daily gain or loss is the square root of the difference between
-    // current cardio fitness and the kcals spent in the previous 24 hours.
-    const int cardio_fit = get_cardiofit();
+    // Cardio goal is 1000 times the ratio of kcals spent versus bmr,
+    // giving a default of 1000 for no extra activity.
+    const int bmr = get_bmr();
     const int last_24h_kcal = calorie_diary.front().spent;
 
-    // If we burned kcals beyond our current fitness level, gain some cardio.
-    // Or, if we burned fewer kcals than current fitness, lose some cardio.
+    const int cardio_goal = ( last_24h_kcal * 1000 ) / bmr;
+
+    // If cardio accumulator is below cardio goal, gain some cardio.
+    // Or, if cardio accumulator is above cardio goal, lose some cardio.
+    const int cardio_accum = get_cardio_acc();
     int adjustment = 0;
-    if( cardio_fit > last_24h_kcal ) {
-        adjustment = -std::sqrt( cardio_fit - last_24h_kcal );
-    } else if( last_24h_kcal > cardio_fit ) {
-        adjustment = std::sqrt( last_24h_kcal - cardio_fit );
+    if( cardio_accum > cardio_goal ) {
+        adjustment = -std::sqrt( cardio_accum - cardio_goal );
+    } else if( cardio_goal > cardio_accum ) {
+        adjustment = std::sqrt( cardio_goal - cardio_accum );
     }
-    set_cardio_acc( get_cardio_acc() + adjustment );
+
+    // Set a large sane upper limit to cardio fitness. This could be done 
+    // asymptotically instead of as a sharp cutoff, but the gradual growth 
+    // rate of cardio_acc should accomplish that naturally.
+    set_cardio_acc( clamp( cardio_accum + adjustment, 1000, 3000 ) );
 }
 
 void avatar::advance_daily_calories()

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1525,10 +1525,11 @@ void avatar::update_cardio_acc()
         adjustment = std::sqrt( cardio_goal - cardio_accum );
     }
 
-    // Set a large sane upper limit to cardio fitness. This could be done 
-    // asymptotically instead of as a sharp cutoff, but the gradual growth 
+    // Set a large sane upper limit to cardio fitness. This could be done
+    // asymptotically instead of as a sharp cutoff, but the gradual growth
     // rate of cardio_acc should accomplish that naturally.
-    set_cardio_acc( clamp( cardio_accum + adjustment, get_cardio_acc_base(), get_cardio_acc_base() * 3 ) );
+    set_cardio_acc( clamp( cardio_accum + adjustment, get_cardio_acc_base(),
+                           get_cardio_acc_base() * 3 ) );
 }
 
 void avatar::advance_daily_calories()

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1513,7 +1513,7 @@ void avatar::update_cardio_acc()
     const int bmr = get_bmr();
     const int last_24h_kcal = calorie_diary.front().spent;
 
-    const int cardio_goal = ( last_24h_kcal * 1000 ) / bmr;
+    const int cardio_goal = ( last_24h_kcal * get_cardio_acc_base() ) / bmr;
 
     // If cardio accumulator is below cardio goal, gain some cardio.
     // Or, if cardio accumulator is above cardio goal, lose some cardio.
@@ -1528,7 +1528,7 @@ void avatar::update_cardio_acc()
     // Set a large sane upper limit to cardio fitness. This could be done 
     // asymptotically instead of as a sharp cutoff, but the gradual growth 
     // rate of cardio_acc should accomplish that naturally.
-    set_cardio_acc( clamp( cardio_accum + adjustment, 1000, 3000 ) );
+    set_cardio_acc( clamp( cardio_accum + adjustment, get_cardio_acc_base(), get_cardio_acc_base() * 3 ) );
 }
 
 void avatar::advance_daily_calories()

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6389,7 +6389,7 @@ int Character::get_cardiofit() const
 {
     if( is_npc() ) {
         // No point in doing a bunch of checks on NPCs for now since they can't use cardio.
-        return 2000;
+        return 2 * get_cardio_acc_base();
     }
 
     const int cardio_base = get_cardio_acc();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -547,6 +547,7 @@ Character::Character() :
     pkill = 0;
     // 55 Mcal or 55k kcal
     healthy_calories = 55'000'000;
+    base_cardio_acc = 1000;
     // this makes sure characters start with normal bmi
     stored_calories = healthy_calories - 1'000'000;
     initialize_stomach_contents();
@@ -6327,7 +6328,7 @@ void Character::update_stamina( int turns )
     // Your stamina regen rate works as a function of how fit you are compared to your body size.
     // This allows it to scale more quickly than your stamina, so that at higher fitness levels you
     // recover stamina faster.
-    const float effective_regen_rate = base_regen_rate * get_cardiofit() / 1000;
+    const float effective_regen_rate = base_regen_rate * get_cardiofit() / get_cardio_acc_base();
     const int current_stim = get_stim();
     // Mutations can affect stamina regen via stamina_regen_modifier (0.0 is normal)
     // Values above or below normal will increase or decrease stamina regen
@@ -6428,7 +6429,12 @@ void Character::set_cardio_acc( int ncardio_acc )
 
 void Character::reset_cardio_acc()
 {
-    set_cardio_acc( 1000 );
+    set_cardio_acc( get_cardio_acc_base() );
+}
+
+int Character::get_cardio_acc_base() const
+{
+    return base_cardio_acc;
 }
 
 bool Character::invoke_item( item *used )

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6395,7 +6395,7 @@ int Character::get_cardiofit() const
     const int cardio_base = get_cardio_acc();
 
     // Mut mod contains the base 1.0f for all modifiers
-    const float mut_mod = mutation_value("cardio_multiplier");
+    const float mut_mod = mutation_value( "cardio_multiplier" );
     // 1 point of athletics skill = 1% more cardio, up to 10% cardio
     const float athletics_mod = get_skill_level( skill_swimming ) / 100.0f;
     // At some point we might have proficiencies that affect this.
@@ -6404,7 +6404,7 @@ int Character::get_cardiofit() const
     float health_mod = get_lifestyle() / 1000.0f;
 
     // Negative effects of health are doubled, up to 40% cardio
-    if ( health_mod < 0.0f ) {
+    if( health_mod < 0.0f ) {
         health_mod *= 2.0f;
     }
 

--- a/src/character.h
+++ b/src/character.h
@@ -2652,6 +2652,7 @@ class Character : public Creature, public visitable
         int get_cardio_acc() const;
         void set_cardio_acc( int ncardio_acc );
         void reset_cardio_acc();
+        int get_cardio_acc_base() const;
         virtual void update_cardio_acc() = 0;
 
         /** Returns true if a gun misfires, jams, or has other problems, else returns false */
@@ -3515,6 +3516,7 @@ class Character : public Creature, public visitable
         int stamina;
 
         int cardio_acc;
+        int base_cardio_acc;
 
         // All indices represent the percentage compared to normal.
         // i.e. a value of 1.1 means 110% of normal.

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -291,7 +291,7 @@ void Character::update_body( const time_point &from, const time_point &to )
                 mod_daily_health( -1, -200 );
             }
         }
-        if( cardio_accumultor >= 1000 ) {
+        if( cardio_accumultor >= get_cardio_acc_base() ) {
             mod_daily_health( 2, 200 );
         }
     }

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -291,7 +291,7 @@ void Character::update_body( const time_point &from, const time_point &to )
                 mod_daily_health( -1, -200 );
             }
         }
-        if( cardio_accumultor >= get_bmr() / 2 ) {
+        if( cardio_accumultor >= 1000 ) {
             mod_daily_health( 2, 200 );
         }
     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4662,7 +4662,7 @@ void vehicle::consume_fuel( int load, bool idling )
         const int base_staminaRegen = static_cast<int>
                                       ( get_option<float>( "PLAYER_BASE_STAMINA_REGEN_RATE" ) );
         const int actual_staminaRegen = static_cast<int>( base_staminaRegen *
-                                        player_character.get_cardiofit() / player_character.base_bmr() );
+                                        player_character.get_cardiofit() / 1000 );
         int base_burn = actual_staminaRegen - 3;
         base_burn = std::max( eff_load / 3, base_burn );
         //charge bionics when using muscle engine

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4662,7 +4662,7 @@ void vehicle::consume_fuel( int load, bool idling )
         const int base_staminaRegen = static_cast<int>
                                       ( get_option<float>( "PLAYER_BASE_STAMINA_REGEN_RATE" ) );
         const int actual_staminaRegen = static_cast<int>( base_staminaRegen *
-                                        player_character.get_cardiofit() / 1000 );
+                                        player_character.get_cardiofit() / player_character.get_cardio_acc_base() );
         int base_burn = actual_staminaRegen - 3;
         base_burn = std::max( eff_load / 3, base_burn );
         //charge bionics when using muscle engine

--- a/tests/cardio_test.cpp
+++ b/tests/cardio_test.cpp
@@ -197,7 +197,7 @@ TEST_CASE( "cardio is and isn't affected by certain traits", "[cardio][traits]" 
     // Body Size has no effect on running distance.
     SECTION( "Traits affecting body size" ) {
         check_trait_cardio_stamina_run( they, "SMALL2", base_cardio, base_stamina, 81 );
-        check_trait_cardio_stamina_run( they, "SMALL", base_cardio, base_stamina, 81 ); 
+        check_trait_cardio_stamina_run( they, "SMALL", base_cardio, base_stamina, 81 );
         check_trait_cardio_stamina_run( they, "LARGE", base_cardio, base_stamina, 81 );
         check_trait_cardio_stamina_run( they, "HUGE", base_cardio, base_stamina, 81 );
     }

--- a/tests/cardio_test.cpp
+++ b/tests/cardio_test.cpp
@@ -15,14 +15,14 @@
 // For player characters, cardio fitness is derived from a combination of several attributes:
 //
 //   (
-//     [ 1/2 BMR ]                    // Basal Metabolic Rate, varies with activity and body size
-//     + [ Health ]                   // Hidden health modifier, -200..+200
+//       [ Trait modifiers ]          // Good/bad cardio mutations like Languorous and Hyperactive
+//                                    // Trait modifers defaults to 1.0f, so it is the baseline
+//     + [ Health ] / 1000            // Hidden health modifier, -200..+200
 //     + [ Proficiency modifiers ]    // NOT IMPLEMENTED
-//     + [ Cardio_Accumulator ]       // Adjustment based on daily activity, starting at 1/2 BMR
-//     + 10 * [ Athletics skill ]     // Formerly swimming skill, now more versatile and valuable
-//   ) * [ Trait modifiers ]          // Good/bad cardio mutations like Languorous and Hyperactive
+//     + [ Athletics skill ] / 100    // Formerly swimming skill, now more versatile and valuable
+//   ) * [ Cardio_Accumulator ]       // Adjustment based on daily activity, starting at 1000
 //
-// For NPCs (having no cardio), the formula is simply 2 * BMR.
+// For NPCs (having no cardio), it's 2000.
 //
 // Important functions:
 // - Character::get_stamina
@@ -37,12 +37,11 @@ static const move_mode_id move_mode_run( "run" );
 
 static const skill_id skill_swimming( "swimming" );
 
-// Base BMR for default character
-static const int base_bmr = 1738;
-static const int base_cardio = base_bmr;
+// Base cardio for default character
+static const int base_cardio = 1000;
 // Base stamina
-// MAX_STAMINA_BASE + CARDIOFIT_STAMINA_SCALING * base_bmr == 3500 + 3*1738
-static const int base_stamina = 8714;
+// MAX_STAMINA_BASE + CARDIOFIT_STAMINA_SCALING * base_cardio == 3500 + 5*1000
+static const int base_stamina = 8500;
 
 // Ensure the configured options from game_balance.json are what the tests assume they are
 static void verify_default_cardio_options()
@@ -50,7 +49,7 @@ static void verify_default_cardio_options()
     const int max_stamina_base = get_option<int>( "PLAYER_MAX_STAMINA_BASE" );
     const int cardiofit_stamina_scaling = get_option<int>( "PLAYER_CARDIOFIT_STAMINA_SCALING" );
     REQUIRE( max_stamina_base == 3500 );
-    REQUIRE( cardiofit_stamina_scaling == 3 );
+    REQUIRE( cardiofit_stamina_scaling == 5 );
 }
 
 // Count the number of steps (tiles) until character runs out of stamina or becomes winded.
@@ -150,10 +149,8 @@ TEST_CASE( "base cardio", "[cardio][base]" )
     // Ensure no initial effects that would affect cardio
     REQUIRE( they.get_lifestyle() == 0 );
     REQUIRE( they.get_skill_level( skill_swimming ) == 0 );
-    // Ensure base_bmr and starting cardio are what we expect
-    REQUIRE( they.base_bmr() == base_bmr );
-    REQUIRE( they.get_cardiofit() == base_cardio );
-    REQUIRE( 2 * they.get_cardio_acc() == base_bmr );
+    // Ensure starting cardio are what we expect
+    REQUIRE( they.get_cardiofit() == 1000 );
 
     SECTION( "Base character with no traits" ) {
         // pre-Cardio, could run 96 steps
@@ -165,14 +162,7 @@ TEST_CASE( "base cardio", "[cardio][base]" )
 
 // Trait Modifiers
 // ---------------
-// Mutations/traits can influence cardio fitness level in a few ways:
-//
-// - Mutation affecting total body size, which affects base BMR and thus cardio
-//   - Little / Tiny: Smaller body has lower BMR, less cardio, cannot run as far
-//   - Large / Huge: Larger body has higher BMR, more cardio, can run further
-// - metabolism_modifier: Affects metabolic_rate_base
-//   - Heat Dependent / Cold Blooded: Decreased BMR and cardio, less running
-//   - Fast/Rapid/Extreme Metabolism: Increased BMR and cardio, more running
+// Mutations/traits can influence cardio fitness level in a two ways:
 //
 // Some traits affect cardio fitness directly:
 //
@@ -185,7 +175,7 @@ TEST_CASE( "base cardio", "[cardio][base]" )
 // - stamina_regen_modifier
 //   - Fast Metabolism, Persistence Hunter: Increased stamina regeneration
 //
-TEST_CASE( "cardio is affected by certain traits", "[cardio][traits]" )
+TEST_CASE( "cardio is and isn't affected by certain traits", "[cardio][traits]" )
 {
     verify_default_cardio_options();
     Character &they = get_player_character();
@@ -196,31 +186,28 @@ TEST_CASE( "cardio is affected by certain traits", "[cardio][traits]" )
     // Ensure no initial effects that would affect cardio
     REQUIRE( they.get_lifestyle() == 0 );
     REQUIRE( they.get_skill_level( skill_swimming ) == 0 );
-    // Ensure base_bmr and starting cardio are what we expect
-    REQUIRE( they.base_bmr() == base_bmr );
-    REQUIRE( they.get_cardiofit() == base_cardio );
-    REQUIRE( 2 * they.get_cardio_acc() == base_bmr );
+    // Ensure starting cardio are what we expect
+    REQUIRE( they.get_cardiofit() == 1000 );
 
     // Values trailing after check //123 are pre-Cardio in-game running distances, a high-level
     // metric for balancing traits relative to how they were before cardio. Some traits were buffed
     // by the change to cardio; the fast metabolism, persistence hunger, and cold-blooded traits got
     // a 20-30% boost in total running distance. The old values are preserved here for possible
     // future rebalancing and comparison.
+    // Addenum: Many of these pre-cardio values are completely wrong, where mutations that give bonus
+    // stamina/regen have worse running speed than base characters. I wouldn't put much faith in them.
 
     SECTION( "Base character with no traits" ) {
         // pre-Cardio, could run 96 steps
-        check_trait_cardio_stamina_run( they, "", base_cardio, base_stamina, 83 ); //96
+        check_trait_cardio_stamina_run( they, "", base_cardio, base_stamina, 81 ); //96
     }
 
-    // Sprint distance for each body size is only slightly different than it was before cardio
+    // Body Size has no effect on running distance.
     SECTION( "Traits affecting body size" ) {
-        // Body size determines BMR, which affects base cardio fitness
-        // Pre-Cardio, body size did not affect how many steps you could run
-        check_trait_cardio_stamina_run( they, "SMALL2", 1088, 6764, 84 ); //97
-        // FIXME: But why the heck can SMALL2 run further than SMALL?
-        check_trait_cardio_stamina_run( they, "SMALL", 1376, 7628, 78 ); //97
-        check_trait_cardio_stamina_run( they, "LARGE", 2162, 9986, 93 ); //97
-        check_trait_cardio_stamina_run( they, "HUGE", 2663, 11489, 106 ); //97
+        check_trait_cardio_stamina_run( they, "SMALL2", base_cardio, base_stamina, 81 ); //97
+        check_trait_cardio_stamina_run( they, "SMALL", base_cardio, base_stamina, 81 ); //97
+        check_trait_cardio_stamina_run( they, "LARGE", base_cardio, base_stamina, 81 ); //97
+        check_trait_cardio_stamina_run( they, "HUGE", base_cardio, base_stamina, 81 ); //97
     }
 
     SECTION( "Traits with cardio_multiplier" ) {
@@ -228,37 +215,37 @@ TEST_CASE( "cardio is affected by certain traits", "[cardio][traits]" )
         // maximum stamina. Now that cardio fitness is actually implemented, these traits
         // directly affect total cardio fitness, and thus maximum stamina (and running distance).
         // Languorous
-        check_trait_cardio_stamina_run( they, "BADCARDIO", 0.7 * base_cardio, 7148, 66 ); //70
+        check_trait_cardio_stamina_run( they, "BADCARDIO", 0.7 * base_cardio, 7000, 66 ); //70
         // Indefatigable
-        check_trait_cardio_stamina_run( they, "GOODCARDIO", 1.3 * base_cardio, 10277, 103 ); //126
+        check_trait_cardio_stamina_run( they, "GOODCARDIO", 1.3 * base_cardio, 10000, 103 ); //126
         // Hyperactive
-        check_trait_cardio_stamina_run( they, "GOODCARDIO2", 1.6 * base_cardio, 11840, 125 ); //145
+        check_trait_cardio_stamina_run( they, "GOODCARDIO2", 1.6 * base_cardio, 11500, 121 ); //145
     }
 
-    // FIXME: These traits need a significant nerf (-8 to -32) to reach their pre-Cardio balance
+    // Fast and v.fast metabolism apparently had worse run distance than a default character pre cardio?
     SECTION( "Traits with metabolism_modifier AND stamina_regen_modifier" ) {
         // Fast Metabolism
-        check_trait_cardio_stamina_run( they, "HUNGER", 2173, 10019, 95 ); //76
+        check_trait_cardio_stamina_run( they, "HUNGER", base_cardio, base_stamina, 83 ); //76
         // Very Fast Metabolism
-        check_trait_cardio_stamina_run( they, "HUNGER2", 2608, 11324, 108 ); //87
+        check_trait_cardio_stamina_run( they, "HUNGER2", base_cardio, base_stamina, 85 ); //87
         // Extreme Metabolism
-        check_trait_cardio_stamina_run( they, "HUNGER3", 3477, 13931, 133 ); //107
+        check_trait_cardio_stamina_run( they, "HUNGER3", base_cardio, base_stamina, 88 ); //107
     }
 
-    // FIXME: These traits need a significant nerf (-20) to reach their pre-Cardio balance
+    // These pre-cardio numbers make literally no sense, why are they lower than a default character?
     SECTION( "Traits with ONLY stamina_regen_modifier" ) {
-        check_trait_cardio_stamina_run( they, "PERSISTENCE_HUNTER", base_cardio, base_stamina, 85 ); //68
-        check_trait_cardio_stamina_run( they, "PERSISTENCE_HUNTER2", base_cardio, base_stamina, 86 ); //69
+        check_trait_cardio_stamina_run( they, "PERSISTENCE_HUNTER", base_cardio, base_stamina, 83 ); //68
+        check_trait_cardio_stamina_run( they, "PERSISTENCE_HUNTER2", base_cardio, base_stamina, 84 ); //69
     }
 
-    // FIXME: These traits need a significant nerf (-20) to reach their pre-Cardio balance
+    // Pretty sure none of these traits affected stamina pre-cardio
     SECTION( "Traits with ONLY metabolism_modifier" ) {
-        check_trait_cardio_stamina_run( they, "COLDBLOOD", 1449, 7847, 78 ); //63
-        check_trait_cardio_stamina_run( they, "COLDBLOOD2", 1304, 7412, 77 ); //62
-        check_trait_cardio_stamina_run( they, "COLDBLOOD3", 1304, 7412, 81 ); //62
-        check_trait_cardio_stamina_run( they, "COLDBLOOD4", 1304, 7412, 81 ); //62
-        check_trait_cardio_stamina_run( they, "LIGHTEATER", 1449, 7847, 78 ); //63
-        check_trait_cardio_stamina_run( they, "MET_RAT", 2028, 9584, 90 ); //72
+        check_trait_cardio_stamina_run( they, "COLDBLOOD", base_cardio, base_stamina, 81 ); //63
+        check_trait_cardio_stamina_run( they, "COLDBLOOD2", base_cardio, base_stamina, 81 ); //62
+        check_trait_cardio_stamina_run( they, "COLDBLOOD3", base_cardio, base_stamina, 81 ); //62
+        check_trait_cardio_stamina_run( they, "COLDBLOOD4", base_cardio, base_stamina, 81 ); //62
+        check_trait_cardio_stamina_run( they, "LIGHTEATER", base_cardio, base_stamina, 81 ); //63
+        check_trait_cardio_stamina_run( they, "MET_RAT", base_cardio, base_stamina, 81 ); //72
     }
 }
 
@@ -287,7 +274,7 @@ TEST_CASE( "cardio is affected by activity level each day", "[cardio][activity]"
     // Then their cardio should increase slightly
 }
 
-TEST_CASE( "cardio is affected by character height", "[cardio][height]" )
+TEST_CASE( "cardio isn't affected by character height", "[cardio][height]" )
 {
     verify_default_cardio_options();
     Character &they = get_player_character();
@@ -295,13 +282,13 @@ TEST_CASE( "cardio is affected by character height", "[cardio][height]" )
 
     REQUIRE( they.size_class == creature_size::medium );
 
-    SECTION( "Within a size class, greater height means greater cardio" ) {
+    SECTION( "No difference in cardio between heights" ) {
         they.set_base_height( Character::default_height( they.size_class ) );
-        CHECK( they.get_cardiofit() == base_cardio ); //1739
+        CHECK( they.get_cardiofit() == base_cardio );
         they.set_base_height( Character::max_height( they.size_class ) );
-        CHECK( they.get_cardiofit() == Approx( base_cardio + 196 ).margin( 5 ) ); //1935
+        CHECK( they.get_cardiofit() == base_cardio );
         they.set_base_height( Character::min_height( they.size_class ) );
-        CHECK( they.get_cardiofit() == Approx( base_cardio - 214 ).margin( 5 ) ); //1525
+        CHECK( they.get_cardiofit() == base_cardio );
     }
 }
 
@@ -320,9 +307,9 @@ TEST_CASE( "cardio is affected by character health", "[cardio][health]" )
         they.set_lifestyle( 0 );
         CHECK( they.get_cardiofit() == base_cardio );
         they.set_lifestyle( 200 );
-        CHECK( they.get_cardiofit() == base_cardio + 200 );
+        CHECK( they.get_cardiofit() == static_cast<int>( base_cardio * 1.20f ) );
         they.set_lifestyle( -200 );
-        CHECK( they.get_cardiofit() == base_cardio - 200 );
+        CHECK( they.get_cardiofit() == static_cast<int>( base_cardio * 0.60f ) );
     }
 }
 
@@ -336,24 +323,24 @@ TEST_CASE( "cardio is affected by athletics skill", "[cardio][athletics]" )
         they.set_skill_level( skill_swimming, 0 );
         CHECK( they.get_cardiofit() == base_cardio );
         they.set_skill_level( skill_swimming, 1 );
-        CHECK( they.get_cardiofit() == base_cardio + 10 );
+        CHECK( they.get_cardiofit() == static_cast<int>( base_cardio * 1.01f ) );
         they.set_skill_level( skill_swimming, 2 );
-        CHECK( they.get_cardiofit() == base_cardio + 20 );
+        CHECK( they.get_cardiofit() == static_cast<int>( base_cardio * 1.02f ) );
         they.set_skill_level( skill_swimming, 3 );
-        CHECK( they.get_cardiofit() == base_cardio + 30 );
+        CHECK( they.get_cardiofit() == static_cast<int>( base_cardio * 1.03f ) );
         they.set_skill_level( skill_swimming, 4 );
-        CHECK( they.get_cardiofit() == base_cardio + 40 );
+        CHECK( they.get_cardiofit() == static_cast<int>( base_cardio * 1.04f ) );
         they.set_skill_level( skill_swimming, 5 );
-        CHECK( they.get_cardiofit() == base_cardio + 50 );
+        CHECK( they.get_cardiofit() == static_cast<int>( base_cardio * 1.05f ) );
         they.set_skill_level( skill_swimming, 6 );
-        CHECK( they.get_cardiofit() == base_cardio + 60 );
+        CHECK( they.get_cardiofit() == static_cast<int>( base_cardio * 1.06f ) );
         they.set_skill_level( skill_swimming, 7 );
-        CHECK( they.get_cardiofit() == base_cardio + 70 );
+        CHECK( they.get_cardiofit() == static_cast<int>( base_cardio * 1.07f ) );
         they.set_skill_level( skill_swimming, 8 );
-        CHECK( they.get_cardiofit() == base_cardio + 80 );
+        CHECK( they.get_cardiofit() == static_cast<int>( base_cardio * 1.08f ) );
         they.set_skill_level( skill_swimming, 9 );
-        CHECK( they.get_cardiofit() == base_cardio + 90 );
+        CHECK( they.get_cardiofit() == static_cast<int>( base_cardio * 1.09f ) );
         they.set_skill_level( skill_swimming, 10 );
-        CHECK( they.get_cardiofit() == base_cardio + 100 );
+        CHECK( they.get_cardiofit() == static_cast<int>( base_cardio * 1.10f ) );
     }
 }

--- a/tests/cardio_test.cpp
+++ b/tests/cardio_test.cpp
@@ -189,25 +189,17 @@ TEST_CASE( "cardio is and isn't affected by certain traits", "[cardio][traits]" 
     // Ensure starting cardio are what we expect
     REQUIRE( they.get_cardiofit() == 1000 );
 
-    // Values trailing after check //123 are pre-Cardio in-game running distances, a high-level
-    // metric for balancing traits relative to how they were before cardio. Some traits were buffed
-    // by the change to cardio; the fast metabolism, persistence hunger, and cold-blooded traits got
-    // a 20-30% boost in total running distance. The old values are preserved here for possible
-    // future rebalancing and comparison.
-    // Addenum: Many of these pre-cardio values are completely wrong, where mutations that give bonus
-    // stamina/regen have worse running speed than base characters. I wouldn't put much faith in them.
-
     SECTION( "Base character with no traits" ) {
         // pre-Cardio, could run 96 steps
-        check_trait_cardio_stamina_run( they, "", base_cardio, base_stamina, 81 ); //96
+        check_trait_cardio_stamina_run( they, "", base_cardio, base_stamina, 81 );
     }
 
     // Body Size has no effect on running distance.
     SECTION( "Traits affecting body size" ) {
-        check_trait_cardio_stamina_run( they, "SMALL2", base_cardio, base_stamina, 81 ); //97
-        check_trait_cardio_stamina_run( they, "SMALL", base_cardio, base_stamina, 81 ); //97
-        check_trait_cardio_stamina_run( they, "LARGE", base_cardio, base_stamina, 81 ); //97
-        check_trait_cardio_stamina_run( they, "HUGE", base_cardio, base_stamina, 81 ); //97
+        check_trait_cardio_stamina_run( they, "SMALL2", base_cardio, base_stamina, 81 );
+        check_trait_cardio_stamina_run( they, "SMALL", base_cardio, base_stamina, 81 ); 
+        check_trait_cardio_stamina_run( they, "LARGE", base_cardio, base_stamina, 81 );
+        check_trait_cardio_stamina_run( they, "HUGE", base_cardio, base_stamina, 81 );
     }
 
     SECTION( "Traits with cardio_multiplier" ) {
@@ -215,37 +207,34 @@ TEST_CASE( "cardio is and isn't affected by certain traits", "[cardio][traits]" 
         // maximum stamina. Now that cardio fitness is actually implemented, these traits
         // directly affect total cardio fitness, and thus maximum stamina (and running distance).
         // Languorous
-        check_trait_cardio_stamina_run( they, "BADCARDIO", 0.7 * base_cardio, 7000, 66 ); //70
+        check_trait_cardio_stamina_run( they, "BADCARDIO", 0.7 * base_cardio, 7000, 66 );
         // Indefatigable
-        check_trait_cardio_stamina_run( they, "GOODCARDIO", 1.3 * base_cardio, 10000, 103 ); //126
+        check_trait_cardio_stamina_run( they, "GOODCARDIO", 1.3 * base_cardio, 10000, 103 );
         // Hyperactive
-        check_trait_cardio_stamina_run( they, "GOODCARDIO2", 1.6 * base_cardio, 11500, 121 ); //145
+        check_trait_cardio_stamina_run( they, "GOODCARDIO2", 1.6 * base_cardio, 11500, 121 );
     }
 
-    // Fast and v.fast metabolism apparently had worse run distance than a default character pre cardio?
     SECTION( "Traits with metabolism_modifier AND stamina_regen_modifier" ) {
         // Fast Metabolism
-        check_trait_cardio_stamina_run( they, "HUNGER", base_cardio, base_stamina, 83 ); //76
+        check_trait_cardio_stamina_run( they, "HUNGER", base_cardio, base_stamina, 83 );
         // Very Fast Metabolism
-        check_trait_cardio_stamina_run( they, "HUNGER2", base_cardio, base_stamina, 85 ); //87
+        check_trait_cardio_stamina_run( they, "HUNGER2", base_cardio, base_stamina, 85 );
         // Extreme Metabolism
-        check_trait_cardio_stamina_run( they, "HUNGER3", base_cardio, base_stamina, 88 ); //107
+        check_trait_cardio_stamina_run( they, "HUNGER3", base_cardio, base_stamina, 88 );
     }
 
-    // These pre-cardio numbers make literally no sense, why are they lower than a default character?
     SECTION( "Traits with ONLY stamina_regen_modifier" ) {
-        check_trait_cardio_stamina_run( they, "PERSISTENCE_HUNTER", base_cardio, base_stamina, 83 ); //68
-        check_trait_cardio_stamina_run( they, "PERSISTENCE_HUNTER2", base_cardio, base_stamina, 84 ); //69
+        check_trait_cardio_stamina_run( they, "PERSISTENCE_HUNTER", base_cardio, base_stamina, 83 );
+        check_trait_cardio_stamina_run( they, "PERSISTENCE_HUNTER2", base_cardio, base_stamina, 84 );
     }
 
-    // Pretty sure none of these traits affected stamina pre-cardio
     SECTION( "Traits with ONLY metabolism_modifier" ) {
-        check_trait_cardio_stamina_run( they, "COLDBLOOD", base_cardio, base_stamina, 81 ); //63
-        check_trait_cardio_stamina_run( they, "COLDBLOOD2", base_cardio, base_stamina, 81 ); //62
-        check_trait_cardio_stamina_run( they, "COLDBLOOD3", base_cardio, base_stamina, 81 ); //62
-        check_trait_cardio_stamina_run( they, "COLDBLOOD4", base_cardio, base_stamina, 81 ); //62
-        check_trait_cardio_stamina_run( they, "LIGHTEATER", base_cardio, base_stamina, 81 ); //63
-        check_trait_cardio_stamina_run( they, "MET_RAT", base_cardio, base_stamina, 81 ); //72
+        check_trait_cardio_stamina_run( they, "COLDBLOOD", base_cardio, base_stamina, 81 );
+        check_trait_cardio_stamina_run( they, "COLDBLOOD2", base_cardio, base_stamina, 81 );
+        check_trait_cardio_stamina_run( they, "COLDBLOOD3", base_cardio, base_stamina, 81 );
+        check_trait_cardio_stamina_run( they, "COLDBLOOD4", base_cardio, base_stamina, 81 );
+        check_trait_cardio_stamina_run( they, "LIGHTEATER", base_cardio, base_stamina, 81 );
+        check_trait_cardio_stamina_run( they, "MET_RAT", base_cardio, base_stamina, 81 );
     }
 }
 

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -637,7 +637,7 @@ TEST_CASE( "weapon attack ratings and moves", "[iteminfo][weapon]" )
         CHECK( item_info_str( halligan, stam ) ==
                "--\n"
                "<color_c_white>Stamina use</color>:"
-               " Costs about <color_c_yellow>3.10</color>%"
+               " Costs about <color_c_yellow>3.20</color>%"
                " stamina to swing.\n" );
 
         CHECK( item_info_str( mr_pointy, stam ) ==
@@ -649,7 +649,7 @@ TEST_CASE( "weapon attack ratings and moves", "[iteminfo][weapon]" )
         CHECK( item_info_str( arrow, stam ) ==
                "--\n"
                "<color_c_white>Stamina use</color>:"
-               " Costs about <color_c_yellow>0.70</color>%"
+               " Costs about <color_c_yellow>0.80</color>%"
                " stamina to swing.\n" );
     }
 


### PR DESCRIPTION
#### Summary
Balance "Divorces BMR from cardio. Fixes health, athletics, and traits effects on cardio"

#### Purpose of change

- Cardiofit trended towards kcal spent per day, inevitably ignoring all other variables.
- BMR had a massive effect on cardio, making things like fast metabolism, being overweight, being tall give you absurd amounts of stamina.
- Morbidly obese characters gained a butt ton of stamina, and the health modifier in cardio fit was functionally irrelevant.
- Drastic changes in BMR had ridiculous effects, a default character going tiny increased their stamina regen from 20 to 50.
- Health, athletics, and traits (indefatigable and hyperactive) had no effect on cardio in the long run, due how the cardio accumulator was updated.

#### Describe the solution

Fixes all problems listed above by;

Refactored how cardio fitness and the cardio accumulator works. Cardio accumulator is now a number representing the ratio of your average activity (kcal burned each day/BMR). Cardio accumulator starts at 1000 (1/1 ratio) and goes up to 3000 max (3/1 ratio of kcal burned a day to bmr). Health, athletics, and traits are multipliers of cardio a that stack additively, increasing (or decreasing, if you have negative health) your cardio fitness. BMR, and things that affect it (height, age, obesity, etc) have no effect on stamina any more.

- Health -200 to 200 -> -40% cardio to +20% cardio
- Athletics 0 to 10 -> +0% cardio to +10% cardio
- Indefatigable and hyperactive work as intended (+30% and +60% cardio)

I changed these from additive bonuses to multipliers because it seemed to make more sense to me. Technical cardio skill via athletics or a proficiency would be proportionally beneficial to both someone with high physical endurance and someone with low physical endurance. Traits have always been multipliers anyways. Health being a multiplier helps it maintain relevance (especially as a penalty for messing up your health stat), but I could see it as an additive effect, though it would be the odd one out at that point.

#### Describe alternatives you've considered

Changing around the numbers a bit. Indefatigable and hyperactive seem rather high powered now that they don't get eaten by the cardio accumulator over time.

#### Testing

Compiled and ran game, checked to make sure everything (cardio accumulator, health, athletics, and traits) had the expected effect on both stamina regen and max stamina. Re-configured the cardio test and made sure it produced sensible results.

#### Additional context

- I tried to keep cardio accumulator to about the same value as before to prevent messing up current characters.
- Base stamina is slightly lowered to 8500 from 8714
- The checks in character body relating to health and cardio accumulator were a bit wonky, and I didn't change their functionality.
