### PR TITLE
Human skulls can be broken down into bones.

### DIFF
--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -213,5 +213,15 @@
     "time": "10 s",
     "components": [ [ [ "bag_canvas", 1 ] ], [ [ "material_soil", 3 ] ] ],
     "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "skull_human",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "skill_used": "fabrication",
+    "time": "10 s",
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "bone_human", 4 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Human skulls can now be disassembled into bones"


#### Purpose of change

Human skulls have a single use ingame, and that is to craft skull bowls - a heavier plastic bottle that can't store liquid in bags - which essentially makes the skull a useless item. Seeing as skulls are made of bone it only makes sense you should be able to make glue or bone meal with them, just like the rest of the skeleton.

#### Describe the solution

Skulls now have an uncraft recipe which lets you break them down if you have a hammering tool of 1 or higher. It nets you four bones, since a bone ingame is 0.23 kg and the skull itself is a kilogram.

#### Describe alternatives you've considered

cutting out the middleman and adding human skulls as a possible ingredient to it's recipes, or creating a separate recipe that uses the skull and creates more of the material.
#### Testing

None done.
#### Additional context

Need to consider more uses for the skull, probably something bone seer related.
