### PR TITLE
Dampen telefrag behavior for player in particular

### DIFF
--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -190,19 +190,17 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
             teleport( *poor_soul );
         }
     }
-    if( critter ) {
-        critter.setpos( target );
-        //player and npc exclusive teleporting effects
-        if( p ) {
-            g->place_player( p->pos() );
-            if( add_teleglow ) {
-                p->add_effect( effect_teleglow, 30_minutes );
-            }
+    critter.setpos( target );
+    //player and npc exclusive teleporting effects
+    if( p ) {
+        g->place_player( p->pos() );
+        if( add_teleglow ) {
+            p->add_effect( effect_teleglow, 30_minutes );
         }
-        if( c_is_u ) {
-            g->update_map( *p );
-        }
-        critter.remove_effect( effect_grabbed );
     }
+    if( c_is_u ) {
+        g->update_map( *p );
+    }
+    critter.remove_effect( effect_grabbed );
     return true;
 }

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -111,8 +111,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
     int tfrag_attempts = 5;
     bool collision = false;
     int collision_angle = 0;
-    while( ( Creature *const poor_soul = get_creature_tracker().creature_at<Creature>( target ) ) &&
-           ( !collision ) ) {
+    while( ( Creature *const poor_soul = get_creature_tracker().creature_at<Creature>( target ) ) && ( !collision ) ) {
         //Fail if we run out of telefrag attempts
         if( tfrag_attempts-- < 1 ) {
             if( p && display_message ) {

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -139,10 +139,10 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
                 g->place_player_overmap( project_to<coords::omt>( avatar_pos ), false );
             }
             return false;
-        } else if( !resonance( poor_soul, 1, 1, true, true ) ) {
+        } else if( !resonance( poor_soul, 2, 2, false, true ) ) {
             const bool poor_soul_is_u = poor_soul->is_avatar();
             if( poor_soul_is_u && display_message ) {
-                add_msg( m_bad, _( "…" ) );
+                add_msg( m_bad, _( "You're blasted with strange energy!" ) );
                 add_msg( m_bad, _( "You explode into thousands of fragments." ) );
             }
             if( p ) {
@@ -167,7 +167,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
         } else {
             const bool poor_soul_is_u = poor_soul->is_avatar();
             if( poor_soul_is_u && display_message ) {
-                add_msg( m_bad, _( "" ) );
+                add_msg( m_bad, _( "You're blasted with strange energy!" ) );
                 add_msg( m_bad, _( "You're violently forced out of the way!" ) );
             }
             if( p ) {

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -156,23 +156,25 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
             //don't splatter. instead get thrown in a random direction painfully.
             collision = true;
             collision_angle = rng( 0, 360 );
-            g->fling_creature( poor_soul, collision_angle, 50 );
+            g->fling_creature( poor_soul, units::from_degrees( collision_angle - 180 ), 50 );
             poor_soul->remove_effect( effect_grabbed );
             poor_soul->apply_damage( nullptr, bodypart_id( "arm_l" ), rng( 5, 10 ) );
             poor_soul->apply_damage( nullptr, bodypart_id( "arm_r" ), rng( 5, 10 ) );
             poor_soul->apply_damage( nullptr, bodypart_id( "leg_l" ), rng( 7, 12 ) );
             poor_soul->apply_damage( nullptr, bodypart_id( "leg_r" ), rng( 7, 12 ) );
             poor_soul->apply_damage( nullptr, bodypart_id( "torso" ), rng( 5, 15 ) );
+            poor_soul->check_dead_state();
         }
     }
     critter.setpos( target );
     if( collision ) {
-        g->fling_creature( *critter, collision_angle - 180, 50 );
+        g->fling_creature( critter, units::from_degrees( collision_angle - 180 ), 50 );
         critter.apply_damage( nullptr, bodypart_id( "arm_l" ), rng( 5, 10 ) );
         critter.apply_damage( nullptr, bodypart_id( "arm_r" ), rng( 5, 10 ) );
         critter.apply_damage( nullptr, bodypart_id( "leg_l" ), rng( 7, 12 ) );
         critter.apply_damage( nullptr, bodypart_id( "leg_r" ), rng( 7, 12 ) );
         critter.apply_damage( nullptr, bodypart_id( "torso" ), rng( 5, 15 ) );
+        critter.check_dead_state();
     }
     //player and npc exclusive teleporting effects
     if( p ) {

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -218,16 +218,17 @@ bool teleport::resonance( Creature &critter, int min_distance, int max_distance,
         return false;
     }
     int tries = 0;
+    int rangle = rng( 0, 360 );
     tripoint origin = critter.pos();
     tripoint new_pos = origin;
     map &here = get_map();
     do {
-        int rangle = rng( 0, 360 );
         int rdistance = rng( min_distance, max_distance );
         new_pos.x = origin.x + rdistance * std::cos( rangle );
         new_pos.y = origin.y + rdistance * std::sin( rangle );
+        rangle+= 15;
         tries++;
-    } while( here.impassable( new_pos ) && get_creature_tracker().creature_at<Creature>( new_pos ) && tries < 999 );
+    } while( here.impassable( new_pos ) && get_creature_tracker().creature_at<Creature>( new_pos ) && tries < 100 );
     if ( here.impassable( new_pos ) || get_creature_tracker().creature_at<Creature>( new_pos ) ) {
         return false;
     } else {

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -23,7 +23,6 @@
 #include "viewer.h"
 #include "map_iterator.h"
 
-static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_teleglow( "teleglow" );
 
@@ -157,7 +156,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
             //don't splatter. instead get thrown in a random direction painfully.
             collision = true;
             collision_angle = rng( 0, 360 );
-            g->fling_creature( *poor_soul, collision_angle, 50 );
+            g->fling_creature( poor_soul, collision_angle, 50 );
             poor_soul->remove_effect( effect_grabbed );
             poor_soul->apply_damage( nullptr, bodypart_id( "arm_l" ), rng( 5, 10 ) );
             poor_soul->apply_damage( nullptr, bodypart_id( "arm_r" ), rng( 5, 10 ) );
@@ -168,7 +167,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
     }
     critter.setpos( target );
     if( collision ) {
-        g->fling_creature( critter, collision_angle - 180, 50 );
+        g->fling_creature( *critter, collision_angle - 180, 50 );
         critter.apply_damage( nullptr, bodypart_id( "arm_l" ), rng( 5, 10 ) );
         critter.apply_damage( nullptr, bodypart_id( "arm_r" ), rng( 5, 10 ) );
         critter.apply_damage( nullptr, bodypart_id( "leg_l" ), rng( 7, 12 ) );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -13,6 +13,7 @@
 #include "enums.h"
 #include "event.h"
 #include "event_bus.h"
+#include "explosion.h"
 #include "game.h"
 #include "map.h"
 #include "messages.h"
@@ -157,12 +158,14 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
             collision = true;
             collision_angle = rng( 0, 360 );
             g->fling_creature( poor_soul, units::from_degrees( collision_angle - 180 ), 50 );
+            explosion_handler::explosion( target, 25 );
             poor_soul->remove_effect( effect_grabbed );
             poor_soul->apply_damage( nullptr, bodypart_id( "arm_l" ), rng( 5, 10 ) );
             poor_soul->apply_damage( nullptr, bodypart_id( "arm_r" ), rng( 5, 10 ) );
             poor_soul->apply_damage( nullptr, bodypart_id( "leg_l" ), rng( 7, 12 ) );
             poor_soul->apply_damage( nullptr, bodypart_id( "leg_r" ), rng( 7, 12 ) );
             poor_soul->apply_damage( nullptr, bodypart_id( "torso" ), rng( 5, 15 ) );
+            poor_soul->apply_damage( nullptr, bodypart_id( "head" ), rng( 2, 8 ) );
             poor_soul->check_dead_state();
         }
     }
@@ -174,6 +177,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
         critter.apply_damage( nullptr, bodypart_id( "leg_l" ), rng( 7, 12 ) );
         critter.apply_damage( nullptr, bodypart_id( "leg_r" ), rng( 7, 12 ) );
         critter.apply_damage( nullptr, bodypart_id( "torso" ), rng( 5, 15 ) );
+        critter.apply_damage( nullptr, bodypart_id( "head" ), rng( 2, 8 ) );
         critter.check_dead_state();
     }
     //player and npc exclusive teleporting effects

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -168,7 +168,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
     }
     critter.setpos( target );
     if( collision ) {
-        g->fling_creature( *critter, units::from_degrees( collision_angle - 180 ), 50 );
+        g->fling_creature( critter, units::from_degrees( collision_angle - 180 ), 50 );
         critter.apply_damage( nullptr, bodypart_id( "arm_l" ), rng( 5, 10 ) );
         critter.apply_damage( nullptr, bodypart_id( "arm_r" ), rng( 5, 10 ) );
         critter.apply_damage( nullptr, bodypart_id( "leg_l" ), rng( 7, 12 ) );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -168,7 +168,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
     }
     critter.setpos( target );
     if( collision ) {
-        g->fling_creature( critter, units::from_degrees( collision_angle - 180 ), 50 );
+        g->fling_creature( get_creature_tracker().creature_at<Creature>( target ), units::from_degrees( collision_angle - 180 ), 50 );
         critter.apply_damage( nullptr, bodypart_id( "arm_l" ), rng( 5, 10 ) );
         critter.apply_damage( nullptr, bodypart_id( "arm_r" ), rng( 5, 10 ) );
         critter.apply_damage( nullptr, bodypart_id( "leg_l" ), rng( 7, 12 ) );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -168,7 +168,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
     }
     critter.setpos( target );
     if( collision ) {
-        g->fling_creature( get_creature_tracker().creature_at<Creature>( target ), units::from_degrees( collision_angle - 180 ), 50 );
+        g->fling_creature( &critter, units::from_degrees( collision_angle - 180 ), 50 );
         critter.apply_damage( nullptr, bodypart_id( "arm_l" ), rng( 5, 10 ) );
         critter.apply_damage( nullptr, bodypart_id( "arm_r" ), rng( 5, 10 ) );
         critter.apply_damage( nullptr, bodypart_id( "leg_l" ), rng( 7, 12 ) );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -178,7 +178,6 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
                                               _( "<npcname> teleports into the same place as %s, and they are forcibly teleported away to make room for them." ),
                                               poor_soul->disp_name() );
                 }
-                get_event_bus().send<event_type::telefrags_creature>( p->getID(), poor_soul->get_name() );
             } else {
                 if( get_player_view().sees( *poor_soul ) ) {
                     if( display_message ) {

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -111,8 +111,8 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
     int tfrag_attempts = 5;
     bool collision = false;
     int collision_angle = 0;
-    while( !collision &&
-           Creature *const poor_soul = get_creature_tracker().creature_at<Creature>( target ) ) {
+    while( ( Creature *const poor_soul = get_creature_tracker().creature_at<Creature>( target ) ) &&
+           ( !collision ) ) {
         //Fail if we run out of telefrag attempts
         if( tfrag_attempts-- < 1 ) {
             if( p && display_message ) {

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -111,7 +111,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
     int tfrag_attempts = 5;
     bool collision = false;
     int collision_angle = 0;
-    while( Creature *const poor_soul = get_creature_tracker().creature_at<Creature>( target ) ) {
+    while( Creature *const poor_soul = get_creature_tracker().creature_at<Creature>( target ) && !collision ) {
         //Fail if we run out of telefrag attempts
         if( tfrag_attempts-- < 1 ) {
             if( p && display_message ) {

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -140,7 +140,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
                 g->place_player_overmap( project_to<coords::omt>( avatar_pos ), false );
             }
             return false;
-        } else if( !( resonance( poor_soul, 2, 2, false, true ) ) ) {
+        } else if( !( resonance( *poor_soul, 2, 2, false, true ) ) ) {
             const bool poor_soul_is_u = poor_soul->is_avatar();
             if( poor_soul_is_u && display_message ) {
                 add_msg( m_bad, _( "You're blasted with strange energy!" ) );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -139,7 +139,8 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
                 g->place_player_overmap( project_to<coords::omt>( avatar_pos ), false );
             }
             return false;
-        } else if( ( !poor_player && one_in( 2 ) ) || ( poor_player && one_in( 2 ) && poor_soul->has_effect( effect_teleglow ) ) ){
+        } else if( ( !poor_player && one_in( 2 ) ) || ( poor_player && one_in( 2 ) &&
+                   poor_soul->has_effect( effect_teleglow ) ) ) {
             const bool poor_soul_is_u = poor_soul->is_avatar();
             if( poor_soul_is_u && display_message ) {
                 add_msg( m_bad, _( "…" ) );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -120,7 +120,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
             }
             return false;
         }
-        Character *const poor_player = dynamic_cast<Character *>( poor_soul );
+        //Character *const poor_player = dynamic_cast<Character *>( poor_soul );
         if( force ) {
             poor_soul->apply_damage( nullptr, bodypart_id( "torso" ), 9999 );
             poor_soul->check_dead_state();
@@ -168,7 +168,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
     }
     critter.setpos( target );
     if( collision ) {
-        g->fling_creature( critter, units::from_degrees( collision_angle - 180 ), 50 );
+        g->fling_creature( *critter, units::from_degrees( collision_angle - 180 ), 50 );
         critter.apply_damage( nullptr, bodypart_id( "arm_l" ), rng( 5, 10 ) );
         critter.apply_damage( nullptr, bodypart_id( "arm_r" ), rng( 5, 10 ) );
         critter.apply_damage( nullptr, bodypart_id( "leg_l" ), rng( 7, 12 ) );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -227,7 +227,7 @@ bool teleport::resonance( Creature &critter, int min_distance, int max_distance,
         int rdistance = rng( min_distance, max_distance );
         new_pos.x = origin.x + rdistance * std::cos( rangle );
         new_pos.y = origin.y + rdistance * std::sin( rangle );
-        rangle+= 15;
+        rangle += 15;
         tries++;
     } while( here.impassable( new_pos ) && get_creature_tracker().creature_at<Creature>( new_pos ) &&
              tries < 100 );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -229,8 +229,9 @@ bool teleport::resonance( Creature &critter, int min_distance, int max_distance,
         new_pos.y = origin.y + rdistance * std::sin( rangle );
         rangle+= 15;
         tries++;
-    } while( here.impassable( new_pos ) && get_creature_tracker().creature_at<Creature>( new_pos ) && tries < 100 );
-    if ( here.impassable( new_pos ) || get_creature_tracker().creature_at<Creature>( new_pos ) ) {
+    } while( here.impassable( new_pos ) && get_creature_tracker().creature_at<Creature>( new_pos ) &&
+             tries < 100 );
+    if( here.impassable( new_pos ) || get_creature_tracker().creature_at<Creature>( new_pos ) ) {
         return false;
     } else {
         return teleport_to_point( critter, new_pos, safe, add_teleglow );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -111,7 +111,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
     int tfrag_attempts = 5;
     bool collision = false;
     int collision_angle = 0;
-    while( Creature *const poor_soul = get_creature_tracker().creature_at<Creature>( target ) && !collision ) {
+    while( !collision && Creature *const poor_soul = get_creature_tracker().creature_at<Creature>( target ) ) {
         //Fail if we run out of telefrag attempts
         if( tfrag_attempts-- < 1 ) {
             if( p && display_message ) {

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -111,7 +111,8 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
     int tfrag_attempts = 5;
     bool collision = false;
     int collision_angle = 0;
-    while( !collision && Creature *const poor_soul = get_creature_tracker().creature_at<Creature>( target ) ) {
+    while( !collision &&
+           Creature *const poor_soul = get_creature_tracker().creature_at<Creature>( target ) ) {
         //Fail if we run out of telefrag attempts
         if( tfrag_attempts-- < 1 ) {
             if( p && display_message ) {

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -148,7 +148,8 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
             } else {
                 if( get_player_view().sees( *poor_soul ) ) {
                     if( display_message ) {
-                        add_msg( m_good, _( "%1$s collides with %2$s mid teleport, and they are both knocked away by a violent explosion of energy!" ),
+                        add_msg( m_good,
+                                 _( "%1$s collides with %2$s mid teleport, and they are both knocked away by a violent explosion of energy!" ),
                                  critter.disp_name(), poor_soul->disp_name() );
                     }
                 }

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -190,17 +190,19 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
             teleport( *poor_soul );
         }
     }
-    critter.setpos( target );
-    //player and npc exclusive teleporting effects
-    if( p ) {
-        g->place_player( p->pos() );
-        if( add_teleglow ) {
-            p->add_effect( effect_teleglow, 30_minutes );
+    if( critter ){
+        critter.setpos( target );
+        //player and npc exclusive teleporting effects
+        if( p ) {
+            g->place_player( p->pos() );
+            if( add_teleglow ) {
+                p->add_effect( effect_teleglow, 30_minutes );
+            }
         }
+        if( c_is_u ) {
+            g->update_map( *p );
+        }
+        critter.remove_effect( effect_grabbed );
     }
-    if( c_is_u ) {
-        g->update_map( *p );
-    }
-    critter.remove_effect( effect_grabbed );
     return true;
 }

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -190,7 +190,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
             teleport( *poor_soul );
         }
     }
-    if( critter ){
+    if( critter ) {
         critter.setpos( target );
         //player and npc exclusive teleporting effects
         if( p ) {

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -23,6 +23,7 @@
 #include "viewer.h"
 #include "map_iterator.h"
 
+static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_teleglow( "teleglow" );
 
@@ -139,7 +140,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
                 g->place_player_overmap( project_to<coords::omt>( avatar_pos ), false );
             }
             return false;
-        } else if( !resonance( poor_soul, 2, 2, false, true ) ) {
+        } else if( !( resonance( poor_soul, 2, 2, false, true ) ) ) {
             const bool poor_soul_is_u = poor_soul->is_avatar();
             if( poor_soul_is_u && display_message ) {
                 add_msg( m_bad, _( "You're blasted with strange energy!" ) );

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -13,6 +13,9 @@ namespace teleport
 bool teleport( Creature &critter, int min_distance = 2, int max_distance = 12,
                bool safe = false,
                bool add_teleglow = true );
+bool resonance( Creature &critter, int min_distance = 2, int max_distance = 2,
+               bool safe = false,
+               bool add_teleglow = true );
 bool teleport_to_point( Creature &critter, tripoint target, bool safe, bool add_teleglow,
                         bool display_message = true, bool force = false );
 } // namespace teleport

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -13,9 +13,6 @@ namespace teleport
 bool teleport( Creature &critter, int min_distance = 2, int max_distance = 12,
                bool safe = false,
                bool add_teleglow = true );
-bool resonance( Creature &critter, int min_distance = 2, int max_distance = 2,
-                bool safe = false,
-                bool add_teleglow = true );
 bool teleport_to_point( Creature &critter, tripoint target, bool safe, bool add_teleglow,
                         bool display_message = true, bool force = false );
 } // namespace teleport

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -14,8 +14,8 @@ bool teleport( Creature &critter, int min_distance = 2, int max_distance = 12,
                bool safe = false,
                bool add_teleglow = true );
 bool resonance( Creature &critter, int min_distance = 2, int max_distance = 2,
-               bool safe = false,
-               bool add_teleglow = true );
+                bool safe = false,
+                bool add_teleglow = true );
 bool teleport_to_point( Creature &critter, tripoint target, bool safe, bool add_teleglow,
                         bool display_message = true, bool force = false );
 } // namespace teleport


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Don't telefrag the player in most cases"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Telefrags-on-player suck ass. It's not a fun mechanic, it's just "did you not have an active anchor? here's a chance to instantly die in a single turn lol" which we've been moving away from - among other "!FUN!" elements such as tankbots, lava rifts, chicken walkers, flaming eyes, and so on.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Any time an entity would be fragged, there is a 50% chance they will be teleported away instead of being fragged. If the player would be fragged, there is a 100% chance they will be teleported away unless they have teleglow, in which case they have the same 50% chance to frag or be teleported that every other entity has.

This makes playing with portals still dangerous and incentivizes using an anchor - a random teleport is really unsafe and if you don't take it as a warning to GTFO you run the risk of getting fragged. Therefore there is counterplay instead of just instantly dying no matter the character. This also preserves the lore element of telefrags - telefrags are established as things that can happen in multiple lore snippets, and the random chance element helps explain why the player isn't just magically immune by virtue of being the player - they're just getting lucky. But for the average player who doesn't dive code, it should be a convincing magic trick.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
make the player entirely immune no matter what
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled successfully, spawned the tindalos lab finale and equipped power armor. Sat still a very long time until something would have fragged me, at which point I was teleported away instead of being fragged. Observed enemies occasionally getting fragged and occasionally getting teleported. Due to the extreme rarity of telefrags it's a difficult subject to test so I can't guarantee this is working 100% correctly. There is probably also a very very small chance that something that would get fragged by a teleporter gets teleported to the teleporter's space instead and counter-frags them before they can teleport but I have not observed this phenomenon and have no idea what would happen if it occurred. I don't want to make the teleport SAFE because there is a chance it could fail if it doesn't find a valid destination, instead it could be replaced with a function that loops safe teleports until it makes a successful one.  If someone feels this is necessary I can do that too (I think)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
