### PR TITLE
Split conditional_names COMPONENT_ID_SUBSTRING from COMPONENT_ID

### DIFF
--- a/data/json/items/comestibles/alcohol.json
+++ b/data/json/items/comestibles/alcohol.json
@@ -822,11 +822,7 @@
     "looks_like": "cola",
     "name": { "str_sp": "rum & cola" },
     "conditional_names": [
-      { "type": "COMPONENT_ID", "condition": "whiskey", "name": { "str_sp": "whiskey and cola" } },
-      { "type": "COMPONENT_ID", "condition": "single_malt_whiskey", "name": { "str_sp": "whiskey and cola" } },
-      { "type": "COMPONENT_ID", "condition": "single_pot_whiskey", "name": { "str_sp": "whiskey and cola" } },
-      { "type": "COMPONENT_ID", "condition": "cheap_whiskey", "name": { "str_sp": "whiskey and cola" } },
-      { "type": "COMPONENT_ID", "condition": "canadian_whiskey", "name": { "str_sp": "whiskey and cola" } },
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "whiskey", "name": { "str_sp": "whiskey and cola" } },
       { "type": "COMPONENT_ID", "condition": "sake_filtered", "name": { "str_sp": "sake and cola" } }
     ],
     "weight": "252 g",
@@ -887,11 +883,7 @@
     "looks_like": "rum",
     "name": { "str_sp": "pina colada" },
     "conditional_names": [
-      { "type": "COMPONENT_ID", "condition": "whiskey", "name": { "str_sp": "Scotsman colada" } },
-      { "type": "COMPONENT_ID", "condition": "single_malt_whiskey", "name": { "str_sp": "Scotsman colada" } },
-      { "type": "COMPONENT_ID", "condition": "single_pot_whiskey", "name": { "str_sp": "Scotsman colada" } },
-      { "type": "COMPONENT_ID", "condition": "cheap_whiskey", "name": { "str_sp": "Scotsman colada" } },
-      { "type": "COMPONENT_ID", "condition": "canadian_whiskey", "name": { "str_sp": "Scotsman colada" } },
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "whiskey", "name": { "str_sp": "Scotsman colada" } },
       { "type": "COMPONENT_ID", "condition": "vodka", "name": { "str_sp": "chi chi" } },
       { "type": "COMPONENT_ID", "condition": "tequila", "name": { "str_sp": "tequila colada" } }
     ],

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -674,7 +674,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "jerk jerky" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "talking animal jerky" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "monster jerky" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "monster jerky" } }
     ],
     "description": "Salty dried meat that lasts for a long time, but will make you thirsty.",
     "primary_material": "cured_meat",
@@ -734,7 +734,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "smoked sucker" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "smoked Narnian" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
     ],
     "description": "Tasty meat that has been heavily smoked for preservation.  It could be further smoked to dehydrate it completely.",
     "color": "brown",
@@ -1772,7 +1772,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "fried fool" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "fried familiar" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
     ],
     "description": "Delicious oil-fried meat.",
     "color": "brown",

--- a/data/json/items/comestibles/junkfood.json
+++ b/data/json/items/comestibles/junkfood.json
@@ -859,7 +859,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "niño nachos" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "nibelung nachos" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "nachos con chupacabra" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "nachos con chupacabra" } }
     ],
     "weight": "150 g",
     "color": "yellow",
@@ -886,7 +886,11 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "niño nachos with cheese" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "nibelung nachos with cheese" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "cheese and chupacabra nachos" } }
+      {
+        "type": "COMPONENT_ID_SUBSTRING",
+        "condition": "mutant",
+        "name": { "str_sp": "cheese and chupacabra nachos" }
+      }
     ],
     "weight": "250 g",
     "color": "yellow",

--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -6,7 +6,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": "raw Mannwurst" },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": "raw killbasa" },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "sinister %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "sinister %s" } }
     ],
     "weight": "148 g",
     "color": "red",
@@ -33,7 +33,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": "smoked Mannwurst" },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": "smoked killbasa" },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "sinister %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "sinister %s" } }
     ],
     "copy-from": "sausage_raw",
     "parasites": 0,
@@ -50,7 +50,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": "cooked Mannwurst" },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": "cooked killbasa" },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "sinister %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "sinister %s" } }
     ],
     "copy-from": "sausage_raw",
     "parasites": 0,
@@ -68,7 +68,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "con confit" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "birdman confit" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "twisted confit" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "twisted confit" } }
     ],
     "weight": "351 g",
     "color": "brown",
@@ -91,7 +91,7 @@
     "type": "COMESTIBLE",
     "id": "sweet_sausage",
     "name": { "str": "sweet sausage" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "sinister %s" } } ],
+    "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "sinister %s" } } ],
     "weight": "148 g",
     "color": "brown",
     "spoils_in": "2 days",
@@ -114,7 +114,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": "Menschenblutwurst" },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": "Mein teil" },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "baleful %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "baleful %s" } }
     ],
     "weight": "100 g",
     "color": "brown",
@@ -140,7 +140,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": "Mannbrat" },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": "frankenfurter" },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "baleful %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "baleful %s" } }
     ],
     "weight": "100 g",
     "color": "brown",
@@ -278,7 +278,7 @@
     "type": "COMESTIBLE",
     "id": "glazed_tenderloin",
     "name": { "str_sp": "glazed tenderloins" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "grisly %s" } } ],
+    "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "grisly %s" } } ],
     "weight": "205 g",
     "color": "brown",
     "spoils_in": "2 days 8 hours",
@@ -326,7 +326,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "cheapskate %s" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "confusing %s" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "bloodcurdling %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "bloodcurdling %s" } }
     ],
     "weight": "85 g",
     "color": "red",
@@ -351,7 +351,7 @@
     "id": "meat_aspic",
     "name": { "str": "aspic" },
     "conditional_names": [
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "abomination %s" } },
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "abomination %s" } },
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "amoral %s" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "Orwell's %s" } }
     ],
@@ -552,7 +552,7 @@
     "type": "COMESTIBLE",
     "id": "lunchmeat",
     "name": { "str": "lunch meat" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "loathsome %s" } } ],
+    "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "loathsome %s" } } ],
     "weight": "56 g",
     "color": "red",
     "spoils_in": "2 days 12 hours",
@@ -575,7 +575,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "brat %s" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "Tumnis %s" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "bleak %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "bleak %s" } }
     ],
     "weight": "56 g",
     "//": "Rebalanced: the recipe looks to easily make two pounds.",
@@ -680,7 +680,7 @@
         "condition": "STRICT_HUMANITARIANISM",
         "name": { "str": "killbasa gravy", "str_pl": "killbasa gravies" }
       },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "ghastly %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "ghastly %s" } }
     ],
     "weight": "60 g",
     "color": "light_gray",
@@ -705,7 +705,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "prepper %s" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "Orley %s" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "pernicious %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "pernicious %s" } }
     ],
     "weight": "106 g",
     "color": "brown",
@@ -730,7 +730,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "hobo helper" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "halfling helper" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "heinous %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "heinous %s" } }
     ],
     "weight": "170 g",
     "color": "red",
@@ -781,7 +781,7 @@
         "name": { "str": "chili con Sindar", "str_pl": "chilis con Sindar" }
       },
       {
-        "type": "COMPONENT_ID",
+        "type": "COMPONENT_ID_SUBSTRING",
         "condition": "mutant",
         "name": { "str": "chili con chupacabra", "str_pl": "chilis con chupacabra" }
       }
@@ -928,8 +928,8 @@
     "id": "can_chowder",
     "name": { "str": "clam chowder" },
     "conditional_names": [
-      { "type": "COMPONENT_ID", "condition": "meat", "name": "meat chowder" },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": "monster chowder" }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "meat", "name": "meat chowder" },
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": "monster chowder" }
     ],
     "weight": "253 g",
     "color": "white",
@@ -953,7 +953,7 @@
     "type": "COMESTIBLE",
     "id": "deluxe_beans",
     "name": { "str_sp": "baked beans" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "ork and beans" } } ],
+    "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "ork and beans" } } ],
     "weight": "293 g",
     "color": "brown",
     "spoils_in": "15 days",
@@ -975,7 +975,7 @@
     "type": "COMESTIBLE",
     "id": "deluxe_rice",
     "name": { "str_sp": "meat fried rice" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "mutant fried rice" } } ],
+    "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "mutant fried rice" } } ],
     "weight": "187 g",
     "color": "yellow",
     "spoils_in": "15 days",
@@ -997,7 +997,7 @@
     "type": "COMESTIBLE",
     "id": "deluxe_beansnrice",
     "name": { "str_sp": "deluxe beans and rice" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "\"deluxe\" beans and rice" } } ],
+    "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "\"deluxe\" beans and rice" } } ],
     "weight": "312 g",
     "color": "brown",
     "spoils_in": "15 days",
@@ -1021,7 +1021,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "prick pie" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "talking animal pie" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "malignant %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "malignant %s" } }
     ],
     "weight": "189 g",
     "color": "brown",
@@ -1048,7 +1048,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "poser pizza" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "protesting pizza" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "miserable %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "miserable %s" } }
     ],
     "weight": "230 g",
     "color": "light_red",
@@ -1089,7 +1089,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "deluxe scrambled eggheads" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "birdman's scrambled eggs" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "\"deluxe\" scrambled eggs" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "\"deluxe\" scrambled eggs" } }
     ],
     "weight": "198 g",
     "color": "yellow",
@@ -1114,7 +1114,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "soylent slice" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "sapient slice" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
     ],
     "copy-from": "meat_cooked",
     "color": "red",
@@ -1134,7 +1134,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "salted simpleton slice" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "salted sapient slice" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
     ],
     "copy-from": "meat_cooked",
     "color": "red",
@@ -1156,7 +1156,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "scoundrel spaghetti" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "speaking spaghetti" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "gnarly %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "gnarly %s" } }
     ],
     "weight": "150 g",
     "color": "red",
@@ -1181,7 +1181,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "Luigi %s" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "Lab %s" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "monster %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "monster %s" } }
     ],
     "weight": "255 g",
     "color": "red",
@@ -1221,7 +1221,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "chump %s" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "elf %s" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "chilling %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "chilling %s" } }
     ],
     "weight": "333 g",
     "color": "brown",
@@ -1247,7 +1247,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "chump %s" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "elf %s" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "chilling %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "chilling %s" } }
     ],
     "weight": "333 g",
     "color": "brown",
@@ -1303,7 +1303,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "bobburger" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "Moreauburger" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "horrible %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "horrible %s" } }
     ],
     "weight": "300 g",
     "color": "brown",
@@ -1328,7 +1328,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "wheat-free bobburger" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "wheat-free Moreauburger" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "horrible %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "horrible %s" } }
     ],
     "weight": "300 g",
     "color": "brown",
@@ -1357,7 +1357,7 @@
         "condition": "STRICT_HUMANITARIANISM",
         "name": { "str": "manfriendwich", "str_pl": "manfriendwiches" }
       },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "suspicious %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "suspicious %s" } }
     ],
     "weight": "313 g",
     "color": "brown",
@@ -1390,7 +1390,7 @@
         "condition": "STRICT_HUMANITARIANISM",
         "name": { "str": "wheat-free manfriendwich", "str_pl": "wheat-free manfriendwiches" }
       },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "suspicious %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "suspicious %s" } }
     ],
     "weight": "313 g",
     "color": "brown",
@@ -1415,7 +1415,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "tio %s" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "talking %s" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "terrifying %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "terrifying %s" } }
     ],
     "weight": "102 g",
     "color": "yellow",
@@ -1440,7 +1440,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "pickled punk" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "pickled anthro" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
     ],
     "copy-from": "meat_cooked",
     "color": "pink",
@@ -1459,7 +1459,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "%s, human" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "%s, demihuman" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
     ],
     "copy-from": "meat_cooked",
     "weight": "85 g",
@@ -1481,7 +1481,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "%s, human" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "%s, demihuman" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
     ],
     "copy-from": "meat_cooked",
     "color": "light_red",
@@ -1539,7 +1539,7 @@
     "type": "COMESTIBLE",
     "id": "sushi_meatroll",
     "name": { "str_sp": "meat temaki" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "troubling %s" } } ],
+    "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "troubling %s" } } ],
     "weight": "273 g",
     "color": "green",
     "spoils_in": "1 day",
@@ -1591,7 +1591,7 @@
     "type": "COMESTIBLE",
     "id": "pelmeni",
     "name": { "str": "pelmeni" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "perilous %s" } } ],
+    "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "perilous %s" } } ],
     "weight": "151 g",
     "color": "light_red",
     "spoils_in": "2 days",
@@ -1613,7 +1613,7 @@
     "type": "COMESTIBLE",
     "id": "homemade_burrito",
     "name": { "str": "homemade burrito" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": "bone-chilling burrito" } ],
+    "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": "bone-chilling burrito" } ],
     "weight": "142 g",
     "color": "brown",
     "spoils_in": "1 days 4 hours",
@@ -1638,7 +1638,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": "raw manball" },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": "raw murderball" },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "sinister %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "sinister %s" } }
     ],
     "weight": "85g",
     "color": "pink",
@@ -1662,7 +1662,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": "manball" },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": "murderball" },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "sinister %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "sinister %s" } }
     ],
     "copy-from": "meatball_raw",
     "parasites": 0,
@@ -1676,7 +1676,7 @@
     "type": "COMESTIBLE",
     "id": "paella_valenciana",
     "name": { "str_sp": "valencian paella" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "\"deluxe\" beans and rice" } } ],
+    "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "\"deluxe\" beans and rice" } } ],
     "weight": "110 g",
     "color": "brown",
     "spoils_in": "15 days",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -251,7 +251,7 @@
     "id": "gelatin_fresh",
     "name": { "str_sp": "fresh gelatin" },
     "conditional_names": [
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "abomination %s" } },
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "abomination %s" } },
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "amoral %s" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "Orwell's %s" } }
     ],

--- a/data/json/items/comestibles/protein.json
+++ b/data/json/items/comestibles/protein.json
@@ -7,7 +7,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "soylent green drink" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "sapient green drink" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
     ],
     "description": "A thin slurry of refined protein mixed with water.  While quite nutritious, it is not particularly tasty.",
     "weight": "278 g",
@@ -35,7 +35,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "soylent green powder" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "sapient green powder" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
     ],
     "description": "Raw, refined protein.  While quite nutritious, it is impossible to enjoy in its pure form, try adding water.",
     "//": "1 g of protein powder is 0.959 ml, 1 serving is 28g and 27ml",
@@ -83,7 +83,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "soylent green shake" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "sapient green shake" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
     ],
     "description": "A thick and tasty beverage made from pure refined protein and nutritious fruit.",
     "material": [ "fruit" ],
@@ -102,7 +102,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "fortified soylent green shake" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "fortified sapient green shake" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
     ],
     "description": "A thick and tasty beverage made from pure refined protein and nutritious fruit.  It has been supplemented with extra vitamins and minerals.",
     "relative": { "vitamins": [ [ "calcium", 5 ], [ "iron", 5 ], [ "vitC", 5 ] ] }
@@ -115,7 +115,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "soylent milk" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "sapient-enhanced milk" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "freaky %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "freaky %s" } }
     ],
     "description": "Milk enriched with protein powder, it's extra healthy and doesn't taste too bad.",
     "weight": "286 g",
@@ -143,7 +143,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "soylent smoothie" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "sapient green smoothie" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
     ],
     "description": "A thick and tasty smoothie made from pure refined protein and nutritious fruit mixed into milk.",
     "material": [ "fruit", "milk" ],

--- a/data/json/items/comestibles/sandwich.json
+++ b/data/json/items/comestibles/sandwich.json
@@ -69,7 +69,7 @@
     "name": { "str": "deluxe sandwich", "str_pl": "deluxe sandwiches" },
     "conditional_names": [
       {
-        "type": "COMPONENT_ID",
+        "type": "COMPONENT_ID_SUBSTRING",
         "condition": "mutant",
         "name": { "str": "\"deluxe\" sandwich", "str_pl": "\"deluxe\" sandwiches" }
       }
@@ -98,7 +98,7 @@
     "name": { "str": "reuben sandwich", "str_pl": "reuben sandwiches" },
     "conditional_names": [
       {
-        "type": "COMPONENT_ID",
+        "type": "COMPONENT_ID_SUBSTRING",
         "condition": "mutant",
         "name": { "str": "\"fauxben\" sandwich", "str_pl": "\"fauxben\" sandwiches" }
       }
@@ -310,7 +310,7 @@
         "condition": "STRICT_HUMANITARIANISM",
         "name": { "str": "satyr sandwich", "str_pl": "satyr sandwiches" }
       },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "mutant %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "mutant %s" } }
     ],
     "weight": "203 g",
     "color": "light_gray",
@@ -509,7 +509,7 @@
     "name": { "str": "wheat-free deluxe sandwich", "str_pl": "wheat-free deluxe sandwiches" },
     "conditional_names": [
       {
-        "type": "COMPONENT_ID",
+        "type": "COMPONENT_ID_SUBSTRING",
         "condition": "mutant",
         "name": { "str": "wheat-free \"deluxe\" sandwich", "str_pl": "wheat-free \"deluxe\" sandwiches" }
       }
@@ -538,7 +538,7 @@
     "name": { "str": "wheat-free reuben sandwich", "str_pl": "wheat-free reuben sandwiches" },
     "conditional_names": [
       {
-        "type": "COMPONENT_ID",
+        "type": "COMPONENT_ID_SUBSTRING",
         "condition": "mutant",
         "name": { "str": "wheat-free \"fauxben\" sandwich", "str_pl": "wheat-free \"fauxben\" sandwiches" }
       }
@@ -753,7 +753,7 @@
         "condition": "STRICT_HUMANITARIANISM",
         "name": { "str": "wheat-free satyr sandwich", "str_pl": "wheat-free satyr sandwiches" }
       },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "mutant %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "mutant %s" } }
     ],
     "weight": "203 g",
     "color": "light_gray",

--- a/data/json/items/comestibles/soup.json
+++ b/data/json/items/comestibles/soup.json
@@ -84,7 +84,7 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "sap soup" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "goblin soup" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "mutant %s" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "mutant %s" } }
     ],
     "weight": "253 g",
     "color": "red",
@@ -158,7 +158,13 @@
     "id": "curry_meat",
     "looks_like": "soup_meat",
     "name": { "str": "curry with meat", "str_pl": "curries with meat" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str": "creature curry", "str_pl": "creature curries" } } ],
+    "conditional_names": [
+      {
+        "type": "COMPONENT_ID_SUBSTRING",
+        "condition": "mutant",
+        "name": { "str": "creature curry", "str_pl": "creature curries" }
+      }
+    ],
     "weight": "289 g",
     "color": "red",
     "spoils_in": "5 days",
@@ -183,7 +189,7 @@
     "id": "soup_woods",
     "looks_like": "soup_veggy",
     "name": { "str": "woods meat soup" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": "Mirkwood soup" } ],
+    "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": "Mirkwood soup" } ],
     "weight": "250 g",
     "color": "red",
     "spoils_in": "5 days",
@@ -208,7 +214,7 @@
     "id": "soup_woods_egg",
     "looks_like": "soup_woods",
     "name": { "str": "woods egg soup" },
-    "conditional_names": [ { "type": "COMPONENT_ID", "condition": "mutant", "name": "Mirkwood soup" } ],
+    "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": "Mirkwood soup" } ],
     "weight": "250 g",
     "color": "red",
     "spoils_in": "5 days",

--- a/data/mods/Xedra_Evolved/items/carnivore.json
+++ b/data/mods/Xedra_Evolved/items/carnivore.json
@@ -119,8 +119,8 @@
     "conditional_names": [
       { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "smoked sucker" } },
       { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "smoked Narnian" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "%s, mutant" } },
-      { "type": "COMPONENT_ID", "condition": "fae", "name": { "str_sp": "smoked fae" } }
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "%s, mutant" } },
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "fae", "name": { "str_sp": "smoked fae" } }
     ],
     "description": "Tasty meat that has been heavily smoked for preservation.  It could be further smoked to dehydrate it completely.",
     "color": "brown",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13688,7 +13688,17 @@ std::string item::type_name( unsigned int quantity ) const
 
     // Apply conditional names, in order.
     for( const conditional_name &cname : type->conditional_names ) {
-        // Lambda for recursively searching for a item ID among all components.
+        // Lambda for searching for a item ID among all components.
+        std::function<bool( std::list<item> )> component_id_equals =
+        [&]( const std::list<item> &components ) {
+            for( const item &component : components ) {
+                if( component.typeId().str() == cname.condition ) {
+                    return true;
+                }
+            }
+            return false;
+        };
+        // Lambda for recursively searching for a item ID substring among all components.
         std::function<bool ( std::list<item> )> component_id_contains =
         [&]( const std::list<item> &components ) {
             for( const item &component : components ) {
@@ -13706,6 +13716,11 @@ std::string item::type_name( unsigned int quantity ) const
                 }
                 break;
             case condition_type::COMPONENT_ID:
+                if( component_id_equals( components ) ) {
+                    ret_name = string_format( cname.name.translated( quantity ), ret_name );
+                }
+                break;
+            case condition_type::COMPONENT_ID_SUBSTRING:
                 if( component_id_contains( components ) ) {
                     ret_name = string_format( cname.name.translated( quantity ), ret_name );
                 }

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -38,6 +38,8 @@ std::string enum_to_string<condition_type>( condition_type data )
             return "FLAG";
         case condition_type::COMPONENT_ID:
             return "COMPONENT_ID";
+        case condition_type::COMPONENT_ID_SUBSTRING:
+            return "COMPONENT_ID_SUBSTRING";
         case condition_type::VAR:
             return "VAR";
         case condition_type::SNIPPET_ID:

--- a/src/itype.h
+++ b/src/itype.h
@@ -1040,6 +1040,7 @@ struct islot_seed {
 enum condition_type {
     FLAG,
     COMPONENT_ID,
+    COMPONENT_ID_SUBSTRING,
     VAR,
     SNIPPET_ID,
     num_condition_types


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Separate the use cases where you want to match a sub string of an ID from those where you want an exact match.

Mentioned in comment to #60599, but doesn't address the main issue.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Introduced the new identifier COMPONENT_ID_SUBSTRING that takes on the behavior of the previous COMPONENT_ID, i.e. matches any ID that has the given substring as part of its identifier.
- Changed the existing COMPONENT_ID to require an exact match of the string to the ID to actually be considered a match.
- Went through all instances of "conditional_names" in the JSON files and changed all the instances where COMPONENT_ID was matched with "mutant" (plus one instance of "fae" in a mod).
- Changed two cases of whiskey matching to use substrings, retaining the original behavior, as it probably is the desired behavior. Also removed the redundant entries that contained that substring.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

There is some uncertainty as to how alcoholic beverages should be treated. There is the case of "whiskey" being one entry followed by entries of various variants of whiskey that all result in the same result. With the original implementation, all of them should be caught by the "whiskey" entry, with the rest being redundant. This indicates that the intention was for an exact match, rather than a substring one. Regardless, I went for the substring matching and removal of the redundant entries, as that not only matches the previous behavior, but also would automatically treat any new variants of whiskey the same as the current ones for the purpose of mixing those drinks.

There are cases with "gin", "rum", and "vodka", but as far as I can tell there are no variants of those, so switching to an exact match should not result in any change.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Verified that dehydrating pineapple resulted in "dehydrated fruit, apple, pineapple (fresh) (10)", i.e. matching both apple and pineapple.
- Changed the code.
- Verified that the "apple" match disappeared when dehydrating pineapples.
- Verified that meat jerky made out of mutant meat was described as "meat jerky", rather than indicating its mutant origin.
- Changed the JSON recipe for meat jerky to use COMPONENT_ID_SUBSTRING.
- Verified that meat jerky made out of mutant meat now (again) indicates its suspect ingredient.
- Went through all the "conditional_names" instances of all the JSON files and changed all the mutant ones.
- Did the same with the mods sub directory.
- Linted the JSON files.
- Started the game and made jerky out of mutant meat again, verifying that it still gave the expected result, but primarily verified that there weren't any complaints about the JSON modifications.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

While chugging through the conditional_names entries, I noticed that the fruit drink sections are shorter than the fruit dish ones, indicating that they should be updated to contain entries for the fruit added to the dish section fairly recently. This would be in addition to adding the native plant stuff that's missing in both sections that would take care of #60599.

Also noted that it's inconsistent whether humanitarian and cannibal flags are accompanied by a mutant substring match or not. I have no idea whether this is intentional or accidental.

Edit: Comment to @Maleclypse (who I assume has been "requested to review" due to Xedra Evolved):
There are a LOT of mutant recipe matches in the base game. If you want to do "fae" matches for all of them you've got a bit of copy-paste work ahead of you.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
