### PR TITLE
Update blade trap to use the small electric motor instead of the norm…

### DIFF
--- a/data/json/items/tool/traps.json
+++ b/data/json/items/tool/traps.json
@@ -31,7 +31,7 @@
     "type": "TOOL",
     "name": { "str": "blade trap" },
     "description": "This is a machete attached laterally to a motor, with a tripwire controlling its throttle.  When the tripwire is pulled, the blade is swung around with great force.  The trap forms a 3x3 area of effect.",
-    "weight": "2381 g",
+    "weight": "6142 g",
     "volume": "4500 ml",
     "price": 5000,
     "price_postapoc": 1500,

--- a/data/json/recipes/recipe_traps.json
+++ b/data/json/recipes/recipe_traps.json
@@ -180,7 +180,7 @@
     "proficiencies": [ { "proficiency": "prof_traps" } ],
     "book_learn": [ [ "manual_mechanics", 3 ], [ "manual_traps", 3 ], [ "howto_traps", 3 ], [ "book_icef", 4 ] ],
     "qualities": [ { "id": "WRENCH", "level": 1 } ],
-    "components": [ [ [ "motor", 1 ] ], [ [ "blade", 2 ] ], [ [ "cordage", 1, "LIST" ] ] ]
+    "components": [ [ [ "motor_small", 1 ] ], [ [ "blade", 2 ] ], [ [ "cordage", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -365,7 +365,7 @@
     "difficulty": 2,
     "trap_radius": 1,
     "action": "none",
-    "drops": [ "motor", "blade", "blade", "string_36" ]
+    "drops": [ "motor_small", "blade", "blade", "string_36" ]
   },
   {
     "type": "trap",


### PR DESCRIPTION
…al sized electric motor.  Update blade trap weight to match components used.  Update blade trap disarm to give back small electric motor.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Update the blade trap to be more consistent with materials used"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Replace the electric motor used in the blade trap with the small electric motor.  The reason I think this is more appropriate is that the electric chainsaw and the electric jackhammer both use this motor.  It would be much more appropriate than the electric motor used in electric vehicles.

I've also updated the weight to 6.142 kg so that it would match the materials used.  I thought about updating the volume, but simply adding the materials used may not be appropriate, so I left that alone.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I updated the blade trap to use the small electric motor.

I summed up the materials used and set that as the new weight.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Updated json, created the trap, disassembled the trap.  Created a new trap, set the trap, and then disarmed the trap to verify the correct materials.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
