### PR TITLE
Update get_melee_hit_base to account for unarmed attacks having melee…

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10497,12 +10497,12 @@ gun_type_type item::gun_type() const
 
 skill_id item::melee_skill() const
 {
-    if( !is_melee() ) {
-        return skill_id::NULL_ID();
+    if (is_unarmed_weapon()) {
+        return skill_unarmed;
     }
 
-    if( has_flag( flag_UNARMED_WEAPON ) ) {
-        return skill_unarmed;
+    if( !is_melee() ) {
+        return skill_id::NULL_ID();
     }
 
     int hi = 0;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10497,7 +10497,7 @@ gun_type_type item::gun_type() const
 
 skill_id item::melee_skill() const
 {
-    if (is_unarmed_weapon()) {
+    if( is_unarmed_weapon() ) {
         return skill_unarmed;
     }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -345,9 +345,11 @@ float Character::get_hit_weapon( const item &weap ) const
 float Character::get_melee_hit_base() const
 {
     float hit_weapon = 0.0f;
-    if( used_weapon() ) {
-        hit_weapon = get_hit_weapon( *used_weapon() );
-    }
+
+    item_location cur_weapon = used_weapon();
+    item cur_weap = cur_weapon ? *cur_weapon : null_item_reference();
+
+    hit_weapon = get_hit_weapon(cur_weap);
 
     // Character::get_hit_base includes stat calculations already
     return Character::get_hit_base() + hit_weapon + mabuff_tohit_bonus();

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -349,7 +349,7 @@ float Character::get_melee_hit_base() const
     item_location cur_weapon = used_weapon();
     item cur_weap = cur_weapon ? *cur_weapon : null_item_reference();
 
-    hit_weapon = get_hit_weapon(cur_weap);
+    hit_weapon = get_hit_weapon( cur_weap );
 
     // Character::get_hit_base includes stat calculations already
     return Character::get_hit_base() + hit_weapon + mabuff_tohit_bonus();


### PR DESCRIPTION
… skill bonus.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Wearing unarmed weapons is not counted as a weapon in calculations and does not get melee skill bonus."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #60369
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I updated get_melee_hit_base to use a similar method for checking weapon usage that was added to account for worn weapons or body slots.  If that is null, then the unarmed skill is used.

I've also updated melee_skill in item.cpp so that the unarmed weapon check goes before the melee check.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A - the recent changes made it so that worn unarmed weapons never use the melee skill in the attack calculations.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Do item checking, but that solution would explicitly exclude plain fists with no armor which seems odd.
#### Testing
I've been playing with this fix for a week or so and no crashes so far.  When stepping through the hit calculations, I get the +10 melee skill that my character has.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Unarmed is still rather weak due to weak raw damage.  It is slightly balanced by the fact that unarmed attacks act roughly equivalent to a +5 weapon.  Previously without the melee skill addition your attack rolls would be the same whether you were 0 melee skill or 10 melee skill.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
