### PR TITLE
Add ability to merge appliance into grid

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1689,6 +1689,20 @@
   },
   {
     "type": "keybinding",
+    "id": "UNPLUG",
+    "category": "APP_INTERACT",
+    "name": "Unplug power connections",
+    "bindings": [ { "input_method": "keyboard_any", "key": "u" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "MERGE",
+    "category": "APP_INTERACT",
+    "name": "Merge power grids",
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "INSTALL",
     "category": "VEH_INTERACT",
     "name": "Install part",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1123,8 +1123,14 @@ std::optional<tripoint> choose_direction( const std::string &message, const bool
 
 std::optional<tripoint> choose_adjacent( const std::string &message, const bool allow_vertical )
 {
+    return choose_adjacent( get_player_character().pos(), message, allow_vertical );
+}
+
+std::optional<tripoint> choose_adjacent( const tripoint &pos, const std::string &message,
+        bool allow_vertical )
+{
     const std::optional<tripoint> dir = choose_direction( message, allow_vertical );
-    return dir ? *dir + get_player_character().pos() : dir;
+    return dir ? *dir + pos : dir;
 }
 
 std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
@@ -1141,11 +1147,18 @@ std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
         const std::string &failure_message, const std::function<bool ( const tripoint & )> &allowed,
         const bool allow_vertical, const bool allow_autoselect )
 {
+    return choose_adjacent_highlight( get_avatar().pos(), message, failure_message, allowed,
+                                      allow_vertical, allow_autoselect );
+}
+
+std::optional<tripoint> choose_adjacent_highlight( const tripoint &pos, const std::string &message,
+        const std::string &failure_message, const std::function<bool( const tripoint & )> &allowed,
+        bool allow_vertical, bool allow_autoselect )
+{
     std::vector<tripoint> valid;
-    avatar &player_character = get_avatar();
     map &here = get_map();
     if( allowed ) {
-        for( const tripoint &pos : here.points_in_radius( player_character.pos(), 1 ) ) {
+        for( const tripoint &pos : here.points_in_radius( pos, 1 ) ) {
             if( allowed( pos ) ) {
                 valid.emplace_back( pos );
             }
@@ -1170,5 +1183,5 @@ std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
         g->add_draw_callback( hilite_cb );
     }
 
-    return choose_adjacent( message, allow_vertical );
+    return choose_adjacent( pos, message, allow_vertical );
 }

--- a/src/action.h
+++ b/src/action.h
@@ -462,6 +462,8 @@ bool can_action_change_worldstate( action_id act );
  * @param[in] allow_vertical Allows player to select tiles above/below them if true
  */
 std::optional<tripoint> choose_adjacent( const std::string &message, bool allow_vertical = false );
+std::optional<tripoint> choose_adjacent( const tripoint &pos, const std::string &message,
+        bool allow_vertical = false );
 
 /**
  * Request player input of a direction, possibly including vertical component
@@ -515,6 +517,9 @@ std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
  * @param[in] allow_autoselect Automatically select location if there's only one valid option and the appropriate setting is enabled
  */
 std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
+        const std::string &failure_message, const std::function<bool( const tripoint & )> &allowed,
+        bool allow_vertical = false, bool allow_autoselect = true );
+std::optional<tripoint> choose_adjacent_highlight( const tripoint &pos, const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint & )> &allowed,
         bool allow_vertical = false, bool allow_autoselect = true );
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1432,12 +1432,6 @@ void construct::done_vehicle( const tripoint_bub_ms &p, Character & )
 void construct::done_wiring( const tripoint_bub_ms &p, Character &/*who*/ )
 {
     get_map().partial_con_remove( p );
-<<<<<<< HEAD
-
-    place_appliance( p.raw(), vpart_from_item( STATIC( itype_id( "wall_wiring" ) ) ) );
-}
-=======
->>>>>>> 1fede075a0 (post rebase fixes)
 
     place_appliance( p.raw(), vpart_from_item( itype_wall_wiring ) );
 }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1435,6 +1435,38 @@ void construct::done_wiring( const tripoint_bub_ms &p, Character &/*who*/ )
     place_appliance( p.raw(), vpart_from_item( STATIC( itype_id( "wall_wiring" ) ) ) );
 }
 
+    for( const tripoint_bub_ms &trip : here.points_in_radius( p, 1 ) ) {
+        const optional_vpart_position vp = here.veh_at( trip );
+        if( !vp ) {
+            continue;
+        }
+        const vehicle &veh_target = vp->vehicle();
+        if( veh_target.is_appliance() || veh_target.has_tag( flag_WIRING ) ) {
+            if( connected_vehicles.find( &veh_target ) == connected_vehicles.end() ) {
+                // TODO: fix point types
+                veh->connect( p.raw(), trip.raw() );
+                connected_vehicles.insert( &veh_target );
+            }
+        }
+    }
+}
+
+    for( const tripoint_bub_ms &trip : here.points_in_radius( p, 1 ) ) {
+        const optional_vpart_position vp = here.veh_at( trip );
+        if( !vp ) {
+            continue;
+        }
+        const vehicle &veh_target = vp->vehicle();
+        if( veh_target.is_appliance() || veh_target.has_tag( flag_WIRING ) ) {
+            if( connected_vehicles.find( &veh_target ) == connected_vehicles.end() ) {
+                // TODO: fix point types
+                veh->connect( p.raw(), trip.raw() );
+                connected_vehicles.insert( &veh_target );
+            }
+        }
+    }
+}
+
 void construct::done_appliance( const tripoint_bub_ms &p, Character & )
 {
     map &here = get_map();

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -90,6 +90,7 @@ static const itype_id itype_nail( "nail" );
 static const itype_id itype_sheet( "sheet" );
 static const itype_id itype_stick( "stick" );
 static const itype_id itype_string_36( "string_36" );
+static const itype_id itype_wall_wiring( "wall_wiring" );
 
 static const mon_flag_str_id mon_flag_HUMAN( "HUMAN" );
 
@@ -1431,40 +1432,14 @@ void construct::done_vehicle( const tripoint_bub_ms &p, Character & )
 void construct::done_wiring( const tripoint_bub_ms &p, Character &/*who*/ )
 {
     get_map().partial_con_remove( p );
+<<<<<<< HEAD
 
     place_appliance( p.raw(), vpart_from_item( STATIC( itype_id( "wall_wiring" ) ) ) );
 }
+=======
+>>>>>>> 1fede075a0 (post rebase fixes)
 
-    for( const tripoint_bub_ms &trip : here.points_in_radius( p, 1 ) ) {
-        const optional_vpart_position vp = here.veh_at( trip );
-        if( !vp ) {
-            continue;
-        }
-        const vehicle &veh_target = vp->vehicle();
-        if( veh_target.is_appliance() || veh_target.has_tag( flag_WIRING ) ) {
-            if( connected_vehicles.find( &veh_target ) == connected_vehicles.end() ) {
-                // TODO: fix point types
-                veh->connect( p.raw(), trip.raw() );
-                connected_vehicles.insert( &veh_target );
-            }
-        }
-    }
-}
-
-    for( const tripoint_bub_ms &trip : here.points_in_radius( p, 1 ) ) {
-        const optional_vpart_position vp = here.veh_at( trip );
-        if( !vp ) {
-            continue;
-        }
-        const vehicle &veh_target = vp->vehicle();
-        if( veh_target.is_appliance() || veh_target.has_tag( flag_WIRING ) ) {
-            if( connected_vehicles.find( &veh_target ) == connected_vehicles.end() ) {
-                // TODO: fix point types
-                veh->connect( p.raw(), trip.raw() );
-                connected_vehicles.insert( &veh_target );
-            }
-        }
-    }
+    place_appliance( p.raw(), vpart_from_item( itype_wall_wiring ) );
 }
 
 void construct::done_appliance( const tripoint_bub_ms &p, Character & )

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -116,6 +116,10 @@ void place_appliance( const tripoint &p, const vpart_id &vpart, const std::optio
 
     veh->last_update = calendar::turn;
 
+    if( veh->is_powergrid() ) {
+        veh->add_tag( flag_CANT_DRAG );
+    }
+
     // Update the vehicle cache immediately,
     // or the appliance will be invisible for the first couple of turns.
     here.add_vehicle_to_cache( veh );
@@ -353,6 +357,19 @@ bool veh_app_interact::can_siphon()
     return false;
 }
 
+bool veh_app_interact::can_unplug()
+{
+    vehicle_part_range vpr = veh->get_all_parts();
+    return std::any_of( vpr.begin(), vpr.end(), []( const vpart_reference & ref ) {
+        return ref.info().has_flag( "POWER_TRANSFER" );
+    } );
+}
+
+bool veh_app_interact::can_merge()
+{
+    return veh->is_powergrid();
+}
+
 // Helper function for selecting a part in the parts list.
 // If only one part is available, don't prompt the player.
 static vehicle_part *pick_part( const std::vector<vehicle_part *> &parts,
@@ -571,6 +588,20 @@ void veh_app_interact::populate_app_actions()
     imenu.addentry( -1, true, ctxt.keys_bound_to( "PLUG" ).front(),
                     ctxt.get_action_name( "PLUG" ) );
 
+    // Unplug
+    app_actions.emplace_back( [this]() {
+        unplug();
+    } );
+    imenu.addentry( -1, can_unplug(), ctxt.keys_bound_to( "UNPLUG" ).front(),
+                    ctxt.get_action_name( "UNPLUG" ) );
+
+    // Merge
+    app_actions.emplace_back( [this]() {
+        merge();
+    } );
+    imenu.addentry( -1, can_merge(), ctxt.keys_bound_to( "MERGE" ).front(),
+                    ctxt.get_action_name( "MERGE" ) );
+
     /*************** Get part-specific actions ***************/
     veh_menu menu( veh, "IF YOU SEE THIS IT IS A BUG" );
     veh->build_interact_menu( menu, veh->mount_to_tripoint( a_point ), false );
@@ -582,6 +613,34 @@ void veh_app_interact::populate_app_actions()
         app_actions.emplace_back( it._on_submit );
     }
     imenu.setup();
+}
+
+void veh_app_interact::merge()
+{
+    const cata::optional<tripoint> dir = choose_direction(
+            _( "Merge the appliance into which grid?" ) );
+    if( !dir ) {
+        return;
+    }
+
+    const tripoint target_pos = get_player_character().pos() + *dir;
+    map &here = get_map();
+    const optional_vpart_position target_vp = here.veh_at( target_pos );
+    if( !target_vp ) {
+        return;
+    }
+    vehicle &target_veh = target_vp->vehicle();
+    if( !target_veh.has_tag( flag_APPLIANCE ) ) {
+        popup( _( "Target must be an appliance." ) );
+        return;
+    }
+    if( !target_veh.is_powergrid() ) {
+        popup( _( "A power grid must be wires, power generation or batteries." ) );
+        return;
+    }
+    veh->merge_appliance_into_grid( target_veh );
+
+    return;
 }
 
 shared_ptr_fast<ui_adaptor> veh_app_interact::create_or_get_ui_adaptor()

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -132,7 +132,7 @@ void place_appliance( const tripoint &p, const vpart_id &vpart, const std::optio
             continue;
         }
         vehicle &veh_target = vp->vehicle();
-        if( veh_target.has_tag( flag_APPLIANCE ) || veh_target.has_tag( flag_WIRING ) ) {
+        if( veh_target.has_tag( flag_APPLIANCE ) ) {
             if( veh->is_powergrid() && veh_target.is_powergrid() ) {
                 veh->merge_appliance_into_grid( veh_target );
                 continue;

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -541,6 +541,10 @@ void veh_app_interact::merge()
 
 void veh_app_interact::populate_app_actions()
 {
+
+    int const part = veh->part_at( a_point );
+    const vehicle_part &vp = veh->part( part >= 0 ? part : 0 );
+
     const std::string ctxt_letters = ctxt.get_available_single_char_hotkeys();
     imenu.entries.clear();
     app_actions.clear();
@@ -568,7 +572,7 @@ void veh_app_interact::populate_app_actions()
     app_actions.emplace_back( [this]() {
         remove();
     } );
-    imenu.addentry( -1, true, ctxt.keys_bound_to( "REMOVE" ).front(),
+    imenu.addentry( -1, veh->can_unmount( vp ).success(), ctxt.keys_bound_to( "REMOVE" ).front(),
                     ctxt.get_action_name( "REMOVE" ) );
     // Plug
     app_actions.emplace_back( [this]() {

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -639,8 +639,6 @@ void veh_app_interact::merge()
         return;
     }
     veh->merge_appliance_into_grid( target_veh );
-
-    return;
 }
 
 shared_ptr_fast<ui_adaptor> veh_app_interact::create_or_get_ui_adaptor()

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -328,14 +328,6 @@ bool veh_app_interact::can_siphon()
     return false;
 }
 
-bool veh_app_interact::can_unplug()
-{
-    vehicle_part_range vpr = veh->get_all_parts();
-    return std::any_of( vpr.begin(), vpr.end(), []( const vpart_reference & ref ) {
-        return ref.info().has_flag( "POWER_TRANSFER" );
-    } );
-}
-
 bool veh_app_interact::can_merge()
 {
     return veh->is_powergrid();
@@ -584,13 +576,6 @@ void veh_app_interact::populate_app_actions()
     } );
     imenu.addentry( -1, true, ctxt.keys_bound_to( "PLUG" ).front(),
                     ctxt.get_action_name( "PLUG" ) );
-
-    // Unplug
-    app_actions.emplace_back( [this]() {
-        unplug();
-    } );
-    imenu.addentry( -1, can_unplug(), ctxt.keys_bound_to( "UNPLUG" ).front(),
-                    ctxt.get_action_name( "UNPLUG" ) );
 
     // Merge
     app_actions.emplace_back( [this]() {

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -127,8 +127,12 @@ void place_appliance( const tripoint &p, const vpart_id &vpart, const std::optio
         if( !vp ) {
             continue;
         }
-        const vehicle &veh_target = vp->vehicle();
-        if( veh_target.is_appliance() || veh_target.has_tag( flag_WIRING ) ) {
+        vehicle &veh_target = vp->vehicle();
+        if( veh_target.has_tag( flag_APPLIANCE ) || veh_target.has_tag( flag_WIRING ) ) {
+            if( veh->is_powergrid() && veh_target.is_powergrid() ) {
+                veh->merge_appliance_into_grid( veh_target );
+                continue;
+            }
             if( connected_vehicles.find( &veh_target ) == connected_vehicles.end() ) {
                 veh->connect( p, trip );
                 connected_vehicles.insert( &veh_target );

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -38,8 +38,6 @@ static const std::string flag_CANT_DRAG( "CANT_DRAG" );
 static const std::string flag_WIRING( "WIRING" );
 static const std::string flag_HALF_CIRCLE_LIGHT( "HALF_CIRCLE_LIGHT" );
 
-static const int MAX_WIRE_VEHICLE_SIZE = 24;
-
 // Width of the entire set of windows. 60 is sufficient for
 // all tested cases while remaining within the 80x24 limit.
 // TODO: make this dynamic in the future.

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -103,12 +103,6 @@ class veh_app_interact
          * can be disconnected by the player.
          * @returns True if the appliance can be unplugged.
         */
-        bool can_unplug();
-        /**
-         * Checks whether the current appliance is considered a "power grid"
-         * that could be merged with another power grid.
-         * @returns True if the appliance can be merged.
-        */
         bool can_merge();
         /**
          * Function associated with the "MERGE" action.

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -105,6 +105,17 @@ class veh_app_interact
         */
         bool can_unplug();
         /**
+         * Checks whether the current appliance is considered a "power grid"
+         * that could be merged with another power grid.
+         * @returns True if the appliance can be merged.
+        */
+        bool can_merge();
+        /**
+         * Function associated with the "MERGE" action.
+         * Merge power grid elements together into a single appliance
+         */
+        void merge();
+        /**
          * Function associated with the "REFILL" action.
          * Checks all appliance parts for a watertight container to refill. If multiple
          * parts are eligible, the player is prompted to select one. A refill activity

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3330,7 +3330,7 @@ void veh_interact::complete_vehicle( Character &you )
             // Remove any leftover power cords from the appliance
             if( appliance_removal && veh.part_count() >= 2 ) {
                 veh.shed_loose_parts( trinary::ALL );
-                veh.find_and_split_vehicles( here, { vehicle_part } );
+                veh.find_and_split_vehicles( here, { vp_index } );
                 veh.part_removal_cleanup();
                 //always stop after removing an appliance
                 you.activity.set_to_null();

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3330,6 +3330,7 @@ void veh_interact::complete_vehicle( Character &you )
             // Remove any leftover power cords from the appliance
             if( appliance_removal && veh.part_count() >= 2 ) {
                 veh.shed_loose_parts( trinary::ALL );
+                veh.find_and_split_vehicles( here, { vehicle_part } );
                 veh.part_removal_cleanup();
                 //always stop after removing an appliance
                 you.activity.set_to_null();

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1797,8 +1797,6 @@ void vehicle::merge_appliance_into_grid( vehicle &veh_target )
         return;
     }
 
-    bool has_wires = has_tag( flag_WIRING ) || veh_target.has_tag( flag_WIRING );
-
     bounding_box vehicle_box = get_bounding_box( false );
     point size;
     size.x = std::abs( ( vehicle_box.p2 - vehicle_box.p1 ).x ) + 1;
@@ -1818,14 +1816,11 @@ void vehicle::merge_appliance_into_grid( vehicle &veh_target )
             //The grid needs to stay undraggable
             add_tag( flag_CANT_DRAG );
             name = _( "power grid" );
-            if( has_wires ) {
-                add_tag( flag_WIRING );
-            }
         }
     }
 }
 
-bool vehicle::is_powergrid()
+bool vehicle::is_powergrid() const
 {
     if( !has_tag( flag_APPLIANCE ) ) {
         return false;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -124,6 +124,7 @@ static const std::string flag_E_COMBUSTION( "E_COMBUSTION" );
 
 static const std::string flag_APPLIANCE( "APPLIANCE" );
 static const std::string flag_CANT_DRAG( "CANT_DRAG" );
+static const std::string flag_WIRING( "WIRING" );
 
 static bool is_sm_tile_outside( const tripoint &real_global_pos );
 static bool is_sm_tile_over_water( const tripoint &real_global_pos );
@@ -1816,6 +1817,16 @@ void vehicle::merge_appliance_into_grid( vehicle &veh_target )
             add_tag( flag_CANT_DRAG );
         }
     }
+}
+
+bool vehicle::is_powergrid()
+{
+    if( !has_tag( flag_APPLIANCE ) ) {
+        return false;
+    }
+
+    return  !solar_panels.empty() || !reactors.empty() || !wind_turbines.empty() ||
+            !water_wheels.empty() || !alternators.empty() || !batteries.empty() || has_tag( flag_WIRING );
 }
 
 /**

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2274,8 +2274,8 @@ bool vehicle::split_vehicles( map &here,
         point mnt_offset;
 
         // if one part is an appliance it means we're dealing with a power grid
-        bool is_appliance = part_info( split_part0 ).has_flag( flag_APPLIANCE );
-        bool is_wiring = part_info( split_part0 ).base_item == itype_wall_wiring;
+        bool is_appliance = parts[split_part0].info().has_flag( flag_APPLIANCE );
+        bool is_wiring = parts[split_part0].info().base_item == itype_wall_wiring;
 
         decltype( labels ) new_labels;
         decltype( loot_zones ) new_zones;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7428,7 +7428,6 @@ const std::set<tripoint> &vehicle::get_points( const bool force_refresh, const b
         for( const std::pair<const point, std::vector<int>> &part_location : relative_parts ) {
             if( no_fake && part( part_location.second.front() ).is_fake ) {
                 continue;
-
             }
             occupied_points.insert( global_part_pos3( part_location.second.front() ) );
         }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1825,8 +1825,15 @@ void vehicle::merge_appliance_into_grid( vehicle &veh_target )
         } else {
             //The grid needs to stay undraggable
             add_tag( flag_CANT_DRAG );
+
+            //Keep wall wiring sections from losing their flag
+            //A grid with only wires needs this flag to count as a powergrid
+            //But it's not a problem if a grid without any has this flag, thus we can add it without issue
+            add_tag( flag_WIRING );
             name = _( "power grid" );
         }
+    } else {
+        add_msg( m_bad, _( "Can't merge into %s, the resulting grid would be too big." ), veh_target.name );
     }
 }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1797,6 +1797,8 @@ void vehicle::merge_appliance_into_grid( vehicle &veh_target )
         return;
     }
 
+    bool has_wires = has_tag( flag_WIRING ) || veh_target.has_tag( flag_WIRING );
+
     bounding_box vehicle_box = get_bounding_box( false );
     point size;
     size.x = std::abs( ( vehicle_box.p2 - vehicle_box.p1 ).x ) + 1;
@@ -1815,6 +1817,10 @@ void vehicle::merge_appliance_into_grid( vehicle &veh_target )
         } else {
             //The grid needs to stay undraggable
             add_tag( flag_CANT_DRAG );
+            name = _( "power grid" );
+            if( has_wires ) {
+                add_tag( flag_WIRING );
+            }
         }
     }
 }
@@ -1833,7 +1839,7 @@ bool vehicle::is_powergrid()
  * Mark a part as removed from the vehicle.
  * @return bool true if the vehicle's 0,0 point shifted.
  */
-bool vehicle::remove_part(vehicle_part& vp)
+bool vehicle::remove_part( vehicle_part &vp )
 {
     DefaultRemovePartHandler handler;
     return remove_part( vp, handler );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1800,6 +1800,10 @@ void vehicle::merge_appliance_into_grid( vehicle &veh_target )
     if( &veh_target == this ) {
         return;
     }
+    //Reset both grid turn_dir to prevent rotation on merge
+    turn_dir = 0_degrees;
+    veh_target.turn_dir = 0_degrees;
+
     veh_target.shift_parts( get_map(), veh_target.pivot_displacement() );
 
     bounding_box vehicle_box = get_bounding_box( true, true );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1776,6 +1776,9 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
 bool vehicle::merge_vehicle_parts( vehicle *veh )
 {
     for( const vehicle_part &part : veh->parts ) {
+        if( part.is_fake || part.removed ) {
+            continue;
+        }
         point part_loc = veh->mount_to_tripoint( part.mount ).xy();
 
         parts.push_back( part );
@@ -1796,13 +1799,14 @@ void vehicle::merge_appliance_into_grid( vehicle &veh_target )
     if( &veh_target == this ) {
         return;
     }
+    veh_target.shift_parts( get_map(), veh_target.pivot_displacement() );
 
-    bounding_box vehicle_box = get_bounding_box( false );
+    bounding_box vehicle_box = get_bounding_box( true, true );
     point size;
     size.x = std::abs( ( vehicle_box.p2 - vehicle_box.p1 ).x ) + 1;
     size.y = std::abs( ( vehicle_box.p2 - vehicle_box.p1 ).y ) + 1;
 
-    bounding_box target_vehicle_box = veh_target.get_bounding_box( false );
+    bounding_box target_vehicle_box = veh_target.get_bounding_box( true, true );
 
     point target_size;
     target_size.x = std::abs( ( target_vehicle_box.p2 - target_vehicle_box.p1 ).x ) + 1;
@@ -7394,7 +7398,7 @@ bool vehicle::restore_folded_parts( const item &it )
     return true;
 }
 
-const std::set<tripoint> &vehicle::get_points( const bool force_refresh ) const
+const std::set<tripoint> &vehicle::get_points( const bool force_refresh, const bool no_fake ) const
 {
     if( force_refresh || occupied_cache_pos != global_pos3() ||
         occupied_cache_direction != face.dir() ) {
@@ -7402,6 +7406,10 @@ const std::set<tripoint> &vehicle::get_points( const bool force_refresh ) const
         occupied_cache_direction = face.dir();
         occupied_points.clear();
         for( const std::pair<const point, std::vector<int>> &part_location : relative_parts ) {
+            if( no_fake && part( part_location.second.front() ).is_fake ) {
+                continue;
+
+            }
             occupied_points.insert( global_part_pos3( part_location.second.front() ) );
         }
     }
@@ -7718,7 +7726,7 @@ void vehicle::calc_mass_center( bool use_precalc ) const
     }
 }
 
-bounding_box vehicle::get_bounding_box( bool use_precalc )
+bounding_box vehicle::get_bounding_box( bool use_precalc, bool no_fake )
 {
     int min_x = INT_MAX;
     int max_x = INT_MIN;
@@ -7729,7 +7737,7 @@ bounding_box vehicle::get_bounding_box( bool use_precalc )
 
     precalc_mounts( 0, turn_dir, point() );
 
-    for( const tripoint &p : get_points( true ) ) {
+    for( const tripoint &p : get_points( true, no_fake ) ) {
         point pt;
         if( use_precalc ) {
             const int i_use = 0;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1781,6 +1781,7 @@ bool vehicle::merge_vehicle_parts( vehicle *veh )
         }
         point part_loc = veh->mount_to_tripoint( part.mount ).xy();
 
+        remove_fake_parts();
         parts.push_back( part );
         vehicle_part &copied_part = parts.back();
         copied_part.mount = part_loc - global_pos3().xy();

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -123,9 +123,12 @@ static const zone_type_id zone_type_VEHICLE_PATROL( "VEHICLE_PATROL" );
 static const std::string flag_E_COMBUSTION( "E_COMBUSTION" );
 
 static const std::string flag_APPLIANCE( "APPLIANCE" );
+static const std::string flag_CANT_DRAG( "CANT_DRAG" );
 
 static bool is_sm_tile_outside( const tripoint &real_global_pos );
 static bool is_sm_tile_over_water( const tripoint &real_global_pos );
+
+static const int MAX_WIRE_VEHICLE_SIZE = 24;
 
 void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
 {
@@ -1787,7 +1790,39 @@ bool vehicle::merge_vehicle_parts( vehicle *veh )
     return true;
 }
 
-bool vehicle::remove_part( vehicle_part &vp )
+void vehicle::merge_appliance_into_grid( vehicle &veh_target )
+{
+    if( &veh_target == this ) {
+        return;
+    }
+
+    bounding_box vehicle_box = get_bounding_box( false );
+    point size;
+    size.x = std::abs( ( vehicle_box.p2 - vehicle_box.p1 ).x ) + 1;
+    size.y = std::abs( ( vehicle_box.p2 - vehicle_box.p1 ).y ) + 1;
+
+    bounding_box target_vehicle_box = veh_target.get_bounding_box( false );
+
+    point target_size;
+    target_size.x = std::abs( ( target_vehicle_box.p2 - target_vehicle_box.p1 ).x ) + 1;
+    target_size.y = std::abs( ( target_vehicle_box.p2 - target_vehicle_box.p1 ).y ) + 1;
+    //Make sur the resulting vehicle would not be too large
+    if( size.x + target_size.x <= MAX_WIRE_VEHICLE_SIZE &&
+        size.y + target_size.y <= MAX_WIRE_VEHICLE_SIZE ) {
+        if( !merge_vehicle_parts( &veh_target ) ) {
+            debugmsg( "failed to merge vehicle parts" );
+        } else {
+            //The grid needs to stay undraggable
+            add_tag( flag_CANT_DRAG );
+        }
+    }
+}
+
+/**
+ * Mark a part as removed from the vehicle.
+ * @return bool true if the vehicle's 0,0 point shifted.
+ */
+bool vehicle::remove_part(vehicle_part& vp)
 {
     DefaultRemovePartHandler handler;
     return remove_part( vp, handler );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -109,7 +109,7 @@ static const itype_id fuel_type_plutonium_cell( "plut_cell" );
 static const itype_id fuel_type_wind( "wind" );
 static const itype_id itype_battery( "battery" );
 static const itype_id itype_plut_cell( "plut_cell" );
-static const itype_id itype_wall_wiring("wall_wiring");
+static const itype_id itype_wall_wiring( "wall_wiring" );
 static const itype_id itype_water( "water" );
 static const itype_id itype_water_clean( "water_clean" );
 static const itype_id itype_water_faucet( "water_faucet" );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1042,6 +1042,7 @@ class vehicle
         bool merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int> &rack_parts );
         // merges vehicles together by copying parts, does not account for any vehicle complexities
         bool merge_vehicle_parts( vehicle *veh );
+        void merge_appliance_into_grid( vehicle &veh_target );
 
         /**
          * @param handler A class that receives various callbacks, e.g. for placing items.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1899,7 +1899,8 @@ class vehicle
         bool assign_seat( vehicle_part &pt, const npc &who );
 
         // Update the set of occupied points and return a reference to it
-        const std::set<tripoint> &get_points( bool force_refresh = false ) const;
+        const std::set<tripoint> &get_points( const bool force_refresh = false,
+                                              const bool no_fake = false ) const;
 
         /**
         * Consumes specified charges (or fewer) from the vehicle part
@@ -2045,7 +2046,7 @@ class vehicle
         // Called by map.cpp to make sure the real position of each zone_data is accurate
         bool refresh_zones();
 
-        bounding_box get_bounding_box( bool use_precalc = true );
+        bounding_box get_bounding_box( bool use_precalc = true, bool no_fake = false );
         // Retroactively pass time spent outside bubble
         // Funnels, solar panels
         void update_time( const time_point &update_to );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1044,6 +1044,8 @@ class vehicle
         bool merge_vehicle_parts( vehicle *veh );
         void merge_appliance_into_grid( vehicle &veh_target );
 
+        bool is_powergrid() const;
+
         /**
          * @param handler A class that receives various callbacks, e.g. for placing items.
          * This handler is different when called during mapgen (when items need to be placed

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1899,8 +1899,7 @@ class vehicle
         bool assign_seat( vehicle_part &pt, const npc &who );
 
         // Update the set of occupied points and return a reference to it
-        const std::set<tripoint> &get_points( const bool force_refresh = false,
-                                              const bool no_fake = false ) const;
+        const std::set<tripoint> &get_points( bool force_refresh = false, bool no_fake = false ) const;
 
         /**
         * Consumes specified charges (or fewer) from the vehicle part

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -562,6 +562,7 @@ void vehicle::plug_in( const tripoint &pos )
     if( cord.get_use( "link_up" ) ) {
         cord.type->get_use( "link_up" )->call( &get_player_character(), cord, pos );
     }
+
 }
 
 void vehicle::connect( const tripoint &source_pos, const tripoint &target_pos )

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -562,7 +562,6 @@ void vehicle::plug_in( const tripoint &pos )
     if( cord.get_use( "link_up" ) ) {
         cord.type->get_use( "link_up" )->call( &get_player_character(), cord, pos );
     }
-
 }
 
 void vehicle::connect( const tripoint &source_pos, const tripoint &target_pos )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Add ability to merge appliance into grid"

#### Purpose of change

For performance purposes it would make sense to merge powergen and battery appliances into the grid to reduce the number of vehicles the code has to walk through

#### Describe the solution

- [x] Encapsulate code to merge appliances
- [x] Add menu to merge an appliance into a grid
- [x] Limit the option to powergen and batteries
- [x] Only merge adjacent appliances, no gap in the grid 
- [x] Prevent rotation of the grid upon merging
- [x] Make sure `Take down appliance` still works properly
- [x] Forbig taking down appliances that would split the grid
- [x] Reset `turn_dir` before merge to prevent rotation

- is_powergen() aplliance that make power, are reactores, batteries or wire
- if an appliance returns true on is_powergen() upon being installed it's made undraggable, that way it's rotation can't change and it won't mess things up when merging it
- only powergrid elements have the merging option


#### Describe alternatives you've considered


#### Testing

- spawn some wall wirings
- intall storage batteries, solar panels and generators around 
- can't drag them
- can merge them
- no rotation issues
- Place a standing lamp > can drag it around > can't merge it

To test rotation
- Allow dragging solar panel
- spawn a bunch 
- drag them around
- merge into wall grid > no issue
- merge wall grid into panel > no issue
- do it on a different wall > no issue
- make a different grid of dragged around panels and merge that into existing grid > no problem


#### Additional context

The merge option could probably be removed after next stable since the powergen appliances can't be dragged, can only be merged into adjacent appliences and will merge atuomatically upon being put down.