### PR TITLE
[WIP] Aftershock exosuit inventory fix proposal

### DIFF
--- a/data/mods/Aftershock/items/armor/exosuit/exosuit_frame.json
+++ b/data/mods/Aftershock/items/armor/exosuit/exosuit_frame.json
@@ -337,7 +337,7 @@
       "PARTIAL_DEAF",
       "SUN_GLASSES",
       "FLASH_PROTECTION",
-	  "MUNDANE"
+      "MUNDANE"
     ],
     "weight_capacity_bonus": "20 kg",
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "STRENGTH", "add": 10 } ] } ] },

--- a/data/mods/Aftershock/items/armor/exosuit/exosuit_frame.json
+++ b/data/mods/Aftershock/items/armor/exosuit/exosuit_frame.json
@@ -304,7 +304,7 @@
       }
     ],
     "ammo": "battery",
-    "flags": [ "USE_UPS", "STURDY", "WATERPROOF", "ELECTRIC_IMMUNE", "COMBAT_TOGGLEABLE", "OUTER", "DEAF" ],
+    "flags": [ "USE_UPS", "STURDY", "WATERPROOF", "ELECTRIC_IMMUNE", "COMBAT_TOGGLEABLE", "OUTER", "DEAF", "MUNDANE" ],
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "STRENGTH", "add": 10 } ] } ] },
     "use_action": [
       {
@@ -336,7 +336,8 @@
       "CLIMATE_CONTROL",
       "PARTIAL_DEAF",
       "SUN_GLASSES",
-      "FLASH_PROTECTION"
+      "FLASH_PROTECTION",
+	  "MUNDANE"
     ],
     "weight_capacity_bonus": "20 kg",
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "STRENGTH", "add": 10 } ] } ] },

--- a/data/mods/Aftershock/items/armor/exosuit/exosuit_underlayers.json
+++ b/data/mods/Aftershock/items/armor/exosuit/exosuit_underlayers.json
@@ -28,7 +28,7 @@
       }
     ],
     "warmth": 10,
-    "flags": [ "EXO_UNDERLAYER", "CANT_WEAR", "SKINTIGHT", "WATERPROOF", "POWERARMOR_COMPATIBLE", "SOFT", "CLIMATE_CONTROL" ],
+    "flags": [ "EXO_UNDERLAYER", "CANT_WEAR", "SKINTIGHT", "WATERPROOF", "POWERARMOR_COMPATIBLE", "SOFT", "CLIMATE_CONTROL", "MUNDANE" ],
     "relic_data": {
       "passive_effects": [
         {
@@ -76,7 +76,7 @@
       }
     ],
     "warmth": 10,
-    "flags": [ "EXO_UNDERLAYER", "CANT_WEAR", "SKINTIGHT", "WATERPROOF", "POWERARMOR_COMPATIBLE", "SOFT", "CLIMATE_CONTROL" ],
+    "flags": [ "EXO_UNDERLAYER", "CANT_WEAR", "SKINTIGHT", "WATERPROOF", "POWERARMOR_COMPATIBLE", "SOFT", "CLIMATE_CONTROL", "MUNDANE" ],
     "relic_data": {
       "passive_effects": [
         {
@@ -185,7 +185,8 @@
       "GAS_PROOF",
       "RAD_RESIST",
       "RAINPROOF",
-      "CLIMATE_CONTROL"
+      "CLIMATE_CONTROL",
+	  "MUNDANE"
     ],
     "relic_data": {
       "passive_effects": [

--- a/data/mods/Aftershock/items/armor/exosuit/exosuit_underlayers.json
+++ b/data/mods/Aftershock/items/armor/exosuit/exosuit_underlayers.json
@@ -28,7 +28,16 @@
       }
     ],
     "warmth": 10,
-    "flags": [ "EXO_UNDERLAYER", "CANT_WEAR", "SKINTIGHT", "WATERPROOF", "POWERARMOR_COMPATIBLE", "SOFT", "CLIMATE_CONTROL", "MUNDANE" ],
+    "flags": [
+      "EXO_UNDERLAYER",
+      "CANT_WEAR",
+      "SKINTIGHT",
+      "WATERPROOF",
+      "POWERARMOR_COMPATIBLE",
+      "SOFT",
+      "CLIMATE_CONTROL",
+      "MUNDANE"
+    ],
     "relic_data": {
       "passive_effects": [
         {
@@ -76,7 +85,16 @@
       }
     ],
     "warmth": 10,
-    "flags": [ "EXO_UNDERLAYER", "CANT_WEAR", "SKINTIGHT", "WATERPROOF", "POWERARMOR_COMPATIBLE", "SOFT", "CLIMATE_CONTROL", "MUNDANE" ],
+    "flags": [
+      "EXO_UNDERLAYER",
+      "CANT_WEAR",
+      "SKINTIGHT",
+      "WATERPROOF",
+      "POWERARMOR_COMPATIBLE",
+      "SOFT",
+      "CLIMATE_CONTROL",
+      "MUNDANE"
+    ],
     "relic_data": {
       "passive_effects": [
         {
@@ -186,7 +204,7 @@
       "RAD_RESIST",
       "RAINPROOF",
       "CLIMATE_CONTROL",
-	  "MUNDANE"
+      "MUNDANE"
     ],
     "relic_data": {
       "passive_effects": [

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2309,7 +2309,7 @@ cata::optional<int> iuse::manage_exosuit( Character *p, item *it, bool, const tr
         add_msg( m_warning, _( "Your %s does not have any pockets to contain modules." ), it->tname() );
         return cata::nullopt;
     }
-    p->moves -= exosuit_interact::run( it );
+    exosuit_interact::run( it );
     return 0;
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix for exosuit users being unable to access an exosuit's nested containers"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

With exosuits as they currently stand, users are unable to reasonably access an exosuit's nested containers. This PR is intended to fix that.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adding the `MUNDANE` flag to the frame and its underlayer suits fixes this problem as best I can tell but introduces a new problem: every time a player moves the exosuit management screen is opened up, sometimes repeatedly, thus necessitating the change I made to `iuse::manage_exosuit()`

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

~~Not opening this PR~~

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Compile game, load game with this PR's changes, debug spawn in exosuit, underlayer, storage items and some misc items to test if nested containers can be accessed. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

The reason this PR is marked as a draft is due to my uncertainty over precisely what the `MUNDANE` flag does, as well as uncertainty over any knock-on effects changing `iuse::manage_exosuit()` might have that my limited testing didn't reveal.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
