### PR TITLE
Insect mutation tweaks

### DIFF
--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -788,6 +788,31 @@
     ]
   },
   {
+    "id": "integrated_shell4",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "sleek shell" },
+    "description": "You have a sturdy shell that fits your exoskeleton snugly.",
+    "weight": "8650 g",
+    "volume": "9 L",
+    "price": 0,
+    "price_postapoc": 0,
+    "material": [ "sclerotin" ],
+    "symbol": "x",
+    "color": "magenta",
+    "warmth": 5,
+    "environmental_protection": 10,
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "WATERPROOF", "PADDED" ],
+    "armor": [
+      {
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 9 } ],
+        "covers": [ "torso" ],
+        "coverage": 100,
+        "encumbrance": 5
+      }
+    ]
+  },
+  {
     "id": "armor_bio_eyes",
     "//": "These do not preclude wearing glasses, but you'll get double-up penalties.  If you really needed to you could likely still situate the lenses in front of them.  You should probably just augment your eyes though.",
     "type": "ARMOR",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6878,7 +6878,7 @@
     "prereqs": [ "CHITIN", "THICKSKIN" ],
     "cancels": [ "CHITIN3" ],
     "changes_to": [ "SHELL2", "SHELL4" ],
-    "category": [ "CEPHALOPOD", "GASTROPOD", "INSECT"  ],
+    "category": [ "CEPHALOPOD", "GASTROPOD", "INSECT" ],
     "wet_protection": [ { "part": "torso", "ignored": 26 } ],
     "integrated_armor": [ "integrated_shell" ]
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5750,6 +5750,7 @@
     "purifiable": false,
     "prereqs": [ "MANDIBLES" ],
     "category": [ "INSECT" ],
+    "threshreq": [ "THRESH_INSECT" ],
     "active": true,
     "restricts_gear": [ "mouth" ]
   },
@@ -6876,8 +6877,8 @@
     "types": [ "TORSO_ARMOR" ],
     "prereqs": [ "CHITIN", "THICKSKIN" ],
     "cancels": [ "CHITIN3" ],
-    "changes_to": [ "SHELL2" ],
-    "category": [ "CEPHALOPOD", "GASTROPOD" ],
+    "changes_to": [ "SHELL2", "SHELL4" ],
+    "category": [ "CEPHALOPOD", "GASTROPOD", "INSECT"  ],
     "wet_protection": [ { "part": "torso", "ignored": 26 } ],
     "integrated_armor": [ "integrated_shell" ]
   },
@@ -6919,6 +6920,23 @@
     "wet_protection": [ { "part": "torso", "ignored": 45 } ],
     "active": true,
     "integrated_armor": [ "integrated_shell3" ]
+  },
+  {
+    "type": "mutation",
+    "id": "SHELL4",
+    "name": { "str": "Sleek Shell" },
+    "points": -1,
+    "visibility": 10,
+    "ugliness": 1,
+    "mixed_effect": true,
+    "description": "Your protective shell has toughened considerably and become better shaped to the contours of your body.  Backpacks won't cause you trouble now.",
+    "types": [ "TORSO_ARMOR" ],
+    "prereqs": [ "SHELL2" ],
+    "threshreq": [ "THRESH_INSECT" ],
+    "category": [ "INSECT" ],
+    "wet_protection": [ { "part": "torso", "ignored": 26 } ],
+    "active": true,
+    "integrated_armor": [ "integrated_shell4" ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3192,6 +3192,7 @@
     "thirst_modifier": 0.75,
     "types": [ "THIRST" ],
     "leads_to": [ "BOMBADIER_BLAST" ],
+    "threshreq": [ "THRESH_INSECT" ],
     "category": [ "INSECT" ]
   },
   {
@@ -6925,13 +6926,12 @@
     "type": "mutation",
     "id": "SHELL4",
     "name": { "str": "Sleek Shell" },
-    "points": -1,
+    "points": 1,
     "visibility": 10,
     "ugliness": 1,
-    "mixed_effect": true,
     "description": "Your protective shell has toughened considerably and become better shaped to the contours of your body.  Backpacks won't cause you trouble now.",
     "types": [ "TORSO_ARMOR" ],
-    "prereqs": [ "SHELL2" ],
+    "prereqs": [ "SHELL" ],
     "threshreq": [ "THRESH_INSECT" ],
     "category": [ "INSECT" ],
     "wet_protection": [ { "part": "torso", "ignored": 26 } ],

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5528,7 +5528,6 @@
     "category": [
       "FISH",
       "CATTLE",
-      "INSECT",
       "CEPHALOPOD",
       "FELINE",
       "LUPINE",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "tweaks to insect mutations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Insects often have shells (beetles for example) so it felt fitting to give them shells, then that led to a bunch of other changes.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Shell was added to Insect.
- There is a new Shell variant that is post thresh Insect, Sleek Shell. It offers 9mm of sclerotin (compared to 10mm of light chitin for the standard shell) and is only OUTER rather than BELTED. 
- 
Doing this exposed an underlying issue with Insect that it had way more than 90 thresh breach power. So I had to lower it a bit.

- Proboscis was moved back to being post-threshold.
- Bulging Reservoir was moved to post-threshold.
- At this point Insect still had 91 breach power so I got rid of Deformed and left them with just Ugly. This seemed like the least consequential way to get them within acceptable bounds.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Different shifting of pre threshold stuff.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Confirmed no errors and could successfully stack shell on top of a chitin carapace through mutation.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
![image](https://user-images.githubusercontent.com/56016372/193384482-5936eef8-3c1a-44fa-8893-9eea920f730c.png)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
