### PR TITLE
MilComp repairs

### DIFF
--- a/data/json/items/vehicle/plating.json
+++ b/data/json/items/vehicle/plating.json
@@ -135,6 +135,7 @@
     "category": "veh_parts",
     "price": 16000,
     "price_postapoc": 750,
+    "flags": [ "NO_REPAIR" ],
     "qualities": [ [ "COOK", 1 ] ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Makes MilComp item unrepairable"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
An oversight with making military composite plating unrepairable meant that it could be repaired by uninstalling it from the vehicle, repairing the item, and then reinstalling it on the vehicle. This A) should not work and B) is extremely tedious for the player taking advantage of it.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds "NO_REPAIR" to the military composite item.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned item, confirmed it shows as not repairable.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I understand the desire to repair military composite armor and the frustration it creates to not be able to do so. Realistically, the repair of such plating is to completely replace the piece of armor if it is damaged beyond a certain point, the piece is then recycled. Simple welds cannot restore the ceramic (which is what makes this **composite**) armor. It may be possible to create new ceramic sheets or at least a ceramic coating on metal armor, but those are extremely advanced processes and generally do not scale down to the creation of one single plate.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
