### PR TITLE
No sawing off (the most demanding) recoil operated guns' barrels

### DIFF
--- a/data/json/items/gun/50.json
+++ b/data/json/items/gun/50.json
@@ -91,10 +91,10 @@
       "volume": "-1500 ml",
       "price": -1210000,
       "ranged_damage": { "damage_type": "bullet", "amount": -4 },
-      "dispersion": 60,
-      "barrel_volume": "-250 ml"
+      "dispersion": 60
     },
     "blackpowder_tolerance": 24,
+    "barrel_volume": "1000 ml",
     "longest_side": "130 cm",
     "flags": [ "RELOAD_EJECT" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "50": 1 } } ]

--- a/data/json/items/gun/50.json
+++ b/data/json/items/gun/50.json
@@ -21,7 +21,6 @@
     "dispersion": 130,
     "durability": 8,
     "min_cycle_recoil": 23625,
-    "barrel_volume": "1250 ml",
     "default_mods": [ "bipod", "rifle_scope", "muzzle_brake" ],
     "flags": [ "NEVER_JAMS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "m107a1mag" ] } ]
@@ -47,7 +46,6 @@
     "durability": 8,
     "min_cycle_recoil": 23625,
     "reload": 400,
-    "barrel_volume": "1250 ml",
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 3 ] ],
     "valid_mod_locations": [
       [ "accessories", 4 ],


### PR DESCRIPTION
#### Summary
Bugfixes "Removes Sawable Barrel Volume from M2HB, M107"

#### Purpose of change

The M107 and M2HB are both recoil operated .50BMG guns, in which the barrel reciprocates as part of the action to delay the opening of the breech until pressures drop to safe levels. Having less mass as part of the action means it opens earlier, and is harder on the system. Without knowing how much can be safely taken off, removal is the best option.

#### Describe the solution
Deletes the defined barrel volumes for the M2 and M107.

#### Describe alternatives you've considered

Implementing a NO_SAW flag, but the game already has a "you can't saw that!" condition.

#### Testing

![image](https://user-images.githubusercontent.com/7764202/193937062-a5e88255-fd1c-4475-98a0-521ad17cd7e5.png)

#### Additional context

None
