### PR TITLE
2 new mutations for post thresh bear.

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5683,7 +5683,7 @@
     "attacks": {
       "attack_text_u": "You bite %s",
       "attack_text_npc": "%1$s bites %2$s",
-      "blocker_mutations": [ "FANGS" ],
+      "blocker_mutations": [ "FANGS", "CRUSHING_FANGS"   ],
       "body_part": "mouth",
       "chance": 20,
       "base_damage": { "damage_type": "cut", "amount": 5 }

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6110,7 +6110,7 @@
   {
     "type": "mutation",
     "id": "PAWS_HUGE",
-    "name": { "str": "Crushing Paws" },
+    "name": { "str": "Ursine Paws" },
     "points": 2,
     "visibility": 6,
     "ugliness": 3,
@@ -6135,7 +6135,7 @@
     "threshreq": [ "THRESH_URSINE" ],
     "prereqs": [ "PAWS_LARGE" ],
     "cancels": [ "TALONS" ],
-    "category": [ "BEAST", "URSINE" ]
+    "category": [ "URSINE" ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5680,24 +5680,14 @@
     "prereqs": [ "SNOUT" ],
     "category": [ "URSINE" ],
     "restricts_gear": [ "mouth" ],
-    "attacks": [
-      {
-        "attack_text_u": "You bite %s",
-        "attack_text_npc": "%1$s bites %2$s",
-        "blocker_mutations": [ "FANGS", "CRUSHING_FANGS" ],
-        "body_part": "mouth",
-        "chance": 20,
-        "base_damage": { "damage_type": "cut", "amount": 5 }
-      },
-      {
-        "attack_text_u": "You bite into %s with your crushing fangs",
-        "attack_text_npc": "%1$s bites %2$s with their crushing fangs",
-        "body_part": "mouth",
-        "required_mutations": [ "CRUSHING_FANGS" ],
-        "chance": 20,
-        "base_damage": [ { "damage_type": "cut", "amount": 10 }, { "damage_type": "bash", "amount": 10 } ]
-      }
-    ]
+    "attacks": {
+      "attack_text_u": "You bite %s",
+      "attack_text_npc": "%1$s bites %2$s",
+      "blocker_mutations": [ "FANGS" ],
+      "body_part": "mouth",
+      "chance": 20,
+      "base_damage": { "damage_type": "cut", "amount": 5 }
+    }
   },
   {
     "type": "mutation",
@@ -6158,7 +6148,15 @@
     "types": [ "TEETH" ],
     "prereqs": [ "MUZZLE_BEAR" ],
     "threshreq": [ "THRESH_URSINE" ],
-    "category": [ "URSINE" ]
+    "category": [ "URSINE" ],
+    "attacks": {
+      "attack_text_u": "You bite a chunk out of %s",
+      "attack_text_npc": "%1$s bites a chunk out of %2$s",
+      "blocker_mutations": [ "FANGS" ],
+      "body_part": "mouth",
+      "chance": 20,
+      "base_damage": [ { "damage_type": "stab", "amount": 10 }, { "damage_type": "bash", "amount": 10 } ]
+    }
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6132,6 +6132,7 @@
     "bash_dmg_bonus": 15,
     "flags": [ "UNARMED_BONUS" ],
     "types": [ "HANDS" ],
+    "threshreq": [ "THRESH_URSINE" ],
     "prereqs": [ "PAWS_LARGE" ],
     "cancels": [ "TALONS" ],
     "category": [ "BEAST", "URSINE" ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5683,7 +5683,7 @@
     "attacks": {
       "attack_text_u": "You bite %s",
       "attack_text_npc": "%1$s bites %2$s",
-      "blocker_mutations": [ "FANGS" ],
+      "blocker_mutations": [ "FANGS", "CRUSHING_FANGS" ],
       "body_part": "mouth",
       "chance": 20,
       "base_damage": { "damage_type": "cut", "amount": 5 }
@@ -6110,8 +6110,8 @@
   {
    "type": "mutation",
     "id": "PAWS_HUGE",
-    "name": { "str": "Broad Paws" },
-    "points": -4,
+    "name": { "str": "Crushing Paws" },
+    "points": 2,
     "visibility": 6,
     "ugliness": 3,
     "mixed_effect": true,
@@ -6136,6 +6136,26 @@
     "prereqs": [ "PAWS_LARGE" ],
     "cancels": [ "TALONS" ],
     "category": [ "BEAST", "URSINE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "CRUSHING_FANGS",
+    "name": { "str": "Crushing Fangs" },
+    "points": 4,
+    "visibility": 3,
+    "ugliness": 3,
+    "description": "Your big teeth have grown in.  You can easily tear meat apart.",
+    "types": [ "TEETH" ],
+    "prereqs": [ "MUZZLE_BEAR" ],
+    "threshreq": [ "THRESH_URSINE" ],
+    "category": [ "URSINE" ],
+    "attacks": {
+      "attack_text_u": "You bite into %s with your crushing fangs",
+      "attack_text_npc": "%1$s bites %2$s with their crushing fangs",
+      "body_part": "mouth",
+      "chance": 20,
+      "base_damage": [ { "damage_type": "cut", "amount": 10 }, { "damage_type": "bash", "amount": 10 } ]
+    }
   },
   { 
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5680,14 +5680,23 @@
     "prereqs": [ "SNOUT" ],
     "category": [ "URSINE" ],
     "restricts_gear": [ "mouth" ],
-    "attacks": {
-      "attack_text_u": "You bite %s",
-      "attack_text_npc": "%1$s bites %2$s",
-      "blocker_mutations": [ "FANGS", "CRUSHING_FANGS" ],
-      "body_part": "mouth",
-      "chance": 20,
-      "base_damage": { "damage_type": "cut", "amount": 5 }
-    }
+    "attacks": [
+      {
+        "attack_text_u": "You bite %s",
+        "attack_text_npc": "%1$s bites %2$s",
+        "blocker_mutations": [ "FANGS", "CRUSHING_FANGS" ],
+        "body_part": "mouth",
+        "chance": 20,
+        "base_damage": { "damage_type": "cut", "amount": 5 }
+      },
+      {
+        "attack_text_u": "You bite into %s with your crushing fangs",
+        "attack_text_npc": "%1$s bites %2$s with their crushing fangs",
+        "body_part": "mouth",
+        "chance": 20,
+        "base_damage": [ { "damage_type": "cut", "amount": 10 }, { "damage_type": "bash", "amount": 10 } ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -6108,7 +6117,7 @@
     "category": [ "BEAST", "URSINE" ]
   },
   {
-   "type": "mutation",
+    "type": "mutation",
     "id": "PAWS_HUGE",
     "name": { "str": "Crushing Paws" },
     "points": 2,
@@ -6148,16 +6157,9 @@
     "types": [ "TEETH" ],
     "prereqs": [ "MUZZLE_BEAR" ],
     "threshreq": [ "THRESH_URSINE" ],
-    "category": [ "URSINE" ],
-    "attacks": {
-      "attack_text_u": "You bite into %s with your crushing fangs",
-      "attack_text_npc": "%1$s bites %2$s with their crushing fangs",
-      "body_part": "mouth",
-      "chance": 20,
-      "base_damage": [ { "damage_type": "cut", "amount": 10 }, { "damage_type": "bash", "amount": 10 } ]
-    }
+    "category": [ "URSINE" ]
   },
-  { 
+  {
     "type": "mutation",
     "id": "BEAK",
     "name": { "str": "Beak" },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5693,6 +5693,7 @@
         "attack_text_u": "You bite into %s with your crushing fangs",
         "attack_text_npc": "%1$s bites %2$s with their crushing fangs",
         "body_part": "mouth",
+        "required_mutations": [ "CRUSHING_FANGS" ],
         "chance": 20,
         "base_damage": [ { "damage_type": "cut", "amount": 10 }, { "damage_type": "bash", "amount": 10 } ]
       }

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3814,7 +3814,7 @@
     "points": 10,
     "purifiable": false,
     "description": "Your tough paws allow you to dig through dirt and rubble with ease.",
-    "prereqs": [ "PAWS", "PAWS_LARGE" ],
+    "prereqs": [ "PAWS", "PAWS_LARGE", "PAWS_HUGE" ],
     "threshreq": [ "THRESH_LUPINE", "THRESH_URSINE" ],
     "category": [ "LUPINE", "URSINE" ],
     "active": true
@@ -6104,9 +6104,39 @@
     "types": [ "HANDS" ],
     "prereqs": [ "PAWS" ],
     "cancels": [ "TALONS" ],
+    "changes_to": [ "PAWS_HUGE" ],
     "category": [ "BEAST", "URSINE" ]
   },
   {
+   "type": "mutation",
+    "id": "PAWS_HUGE",
+    "name": { "str": "Broad Paws" },
+    "points": -4,
+    "visibility": 6,
+    "ugliness": 3,
+    "mixed_effect": true,
+    "description": "Your broad paws are much larger now.  Manual dexterity is severely lower: permanent hand encumbrance of 40, serious problems crafting, and no gloves.  In return, though, you can swim better, and your hands can crush skulls.",
+    "craft_skill_bonus": [
+      [ "electronics", -6 ],
+      [ "tailor", -6 ],
+      [ "mechanics", -6 ],
+      [ "firstaid", -4 ],
+      [ "computer", -4 ],
+      [ "traps", -4 ],
+      [ "fabrication", -4 ],
+      [ "cooking", -4 ],
+      [ "survival", -4 ]
+    ],
+    "encumbrance_always": [ [ "hand_l", 40 ], [ "hand_r", 40 ] ],
+    "restricts_gear": [ "hand_l", "hand_r" ],
+    "bash_dmg_bonus": 15,
+    "flags": [ "UNARMED_BONUS" ],
+    "types": [ "HANDS" ],
+    "prereqs": [ "PAWS_LARGE" ],
+    "cancels": [ "TALONS" ],
+    "category": [ "BEAST", "URSINE" ]
+  },
+  { 
     "type": "mutation",
     "id": "BEAK",
     "name": { "str": "Beak" },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5683,7 +5683,7 @@
     "attacks": {
       "attack_text_u": "You bite %s",
       "attack_text_npc": "%1$s bites %2$s",
-      "blocker_mutations": [ "FANGS", "CRUSHING_FANGS"   ],
+      "blocker_mutations": [ "FANGS", "CRUSHING_FANGS" ],
       "body_part": "mouth",
       "chance": 20,
       "base_damage": { "damage_type": "cut", "amount": 5 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Added two new post thresh bear mutations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I figured that bear could use some more variety and added some mutations for unarmed styles on top of making them actually feel like a bear when they complete the transformation.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added Ursine paws: 15 bash unarmed bonus at the cost of even more hands encumbrance and debuffs to crafting. Grizzly bears can have a paw swipe force up to 25,200 lb. -ft./s (about 783 pounds of force), which is between two to five times stronger than the punch force of the average, untrained human. Average punching damage ingame is between 4~6 bash with 10 strength. However lacks of thumbs suck so that will impact them harder.

Added Crushing fangs: 10 bash 10 stab bite attacks to be in line with similar damaging bite attacks. Polar Bears have the strongest bite force of all bears, with a bite force of 1200 PSI. The Grizzly Bear comes in a close second with a bite force of about 1160 PSI. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Add more requirements or downsides. Maybe dexterity debuff to crushing paws? But i guess the hand encumbrance already takes care of that. or a Strong requirement for crushing paws.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Logged and everything seems to be working with the mutations.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
