### PR TITLE
Balance and tweaks to relic procgen

### DIFF
--- a/data/json/artifact/relic_procgen_data.json
+++ b/data/json/artifact/relic_procgen_data.json
@@ -13,36 +13,36 @@
       }
     ],
     "active_procgen_values": [
-      { "weight": 100, "spell_id": "AEA_ADRENALINE", "base_power": 150 },
-      { "weight": 100, "spell_id": "AEA_BLOOD", "base_power": 50 },
-      { "weight": 100, "spell_id": "AEA_HEAL", "base_power": 250 },
+      { "weight": 100, "spell_id": "AEA_ADRENALINE", "base_power": 250 },
+      { "weight": 100, "spell_id": "AEA_BLOOD", "base_power": 0 },
+      { "weight": 100, "spell_id": "AEA_HEAL", "base_power": 500 },
       { "weight": 100, "spell_id": "AEA_CONFUSED", "base_power": 250 },
       { "weight": 100, "spell_id": "AEA_PAIN", "base_power": -150 },
-      { "weight": 100, "spell_id": "AEA_TELEPORT", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_ATTENTION", "base_power": -50 },
-      { "weight": 100, "spell_id": "AEA_TELEGLOW", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_TELEPORT", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_ATTENTION", "base_power": -100 },
+      { "weight": 100, "spell_id": "AEA_TELEGLOW", "base_power": -150 },
       { "weight": 100, "spell_id": "AEA_VOMIT", "base_power": -50 },
-      { "weight": 100, "spell_id": "AEA_SHADOWS", "base_power": 500 },
+      { "weight": 100, "spell_id": "AEA_SHADOWS", "base_power": 25 },
       { "weight": 100, "spell_id": "AEA_STAMINA_EMPTY", "base_power": -250 },
       { "weight": 100, "spell_id": "AEA_RADIATION", "base_power": -250 },
-      { "weight": 100, "spell_id": "AEA_HURTALL", "base_power": -250 },
-      { "weight": 100, "spell_id": "AEA_ACIDBALL", "base_power": 500 },
-      { "weight": 100, "spell_id": "AEA_BUGS", "base_power": 250 },
-      { "weight": 100, "spell_id": "AEA_NOISE", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_LIGHT", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_DIM", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_FATIGUE", "base_power": -100 },
-      { "weight": 100, "spell_id": "AEA_FIREBALL", "base_power": 500 },
-      { "weight": 100, "spell_id": "AEA_FLASH", "base_power": 250 },
+      { "weight": 100, "spell_id": "AEA_HURTALL", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_ACIDBALL", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_BUGS", "base_power": 200 },
+      { "weight": 100, "spell_id": "AEA_NOISE", "base_power": -25 },
+      { "weight": 100, "spell_id": "AEA_LIGHT", "base_power": -25 },
+      { "weight": 100, "spell_id": "AEA_DIM", "base_power": 0 },
+      { "weight": 100, "spell_id": "AEA_FATIGUE", "base_power": -300 },
+      { "weight": 100, "spell_id": "AEA_FIREBALL", "base_power": -500 },
+      { "weight": 100, "spell_id": "AEA_FLASH", "base_power": 150 },
       { "weight": 100, "spell_id": "AEA_PARALYZE", "base_power": -250 },
       { "weight": 100, "spell_id": "AEA_MAP", "base_power": 500 },
-      { "weight": 100, "spell_id": "AEA_FIRESTORM", "base_power": 1000 },
+      { "weight": 100, "spell_id": "AEA_FIRESTORM", "base_power": -500 },
       { "weight": 100, "spell_id": "AEA_FUN", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_MUTATE", "base_power": 150 },
-      { "weight": 100, "spell_id": "AEA_STORM", "base_power": 1000 },
-      { "weight": 100, "spell_id": "AEA_ENTRANCE", "base_power": 1000 },
-      { "weight": 100, "spell_id": "AEA_SCREAM", "base_power": -150 },
-      { "weight": 100, "spell_id": "AEA_PULSE", "base_power": 250 }
+      { "weight": 100, "spell_id": "AEA_MUTATE", "base_power": -150 },
+      { "weight": 100, "spell_id": "AEA_STORM", "base_power": -100 },
+      { "weight": 100, "spell_id": "AEA_ENTRANCE", "base_power": 500 },
+      { "weight": 100, "spell_id": "AEA_SCREAM", "base_power": -75 },
+      { "weight": 100, "spell_id": "AEA_PULSE", "base_power": 75 }
     ],
     "passive_mult_procgen_values": [
       { "weight": 100, "min_value": -0.5, "max_value": 1, "type": "METABOLISM", "increment": 0.1, "power_per_increment": -50 },
@@ -60,7 +60,7 @@
         "max_value": 1,
         "type": "CARRY_WEIGHT",
         "increment": 0.1,
-        "power_per_increment": 250
+        "power_per_increment": 75
       },
       {
         "weight": 100,
@@ -68,7 +68,7 @@
         "max_value": 2,
         "type": "MAX_HP",
         "increment": 0.1,
-        "power_per_increment": 250
+        "power_per_increment": 100
       },
       {
         "weight": 100,
@@ -76,7 +76,7 @@
         "max_value": 2,
         "type": "REGEN_HP",
         "increment": 0.1,
-        "power_per_increment": 250
+        "power_per_increment": 50
       },
       {
         "weight": 100,
@@ -84,7 +84,7 @@
         "max_value": 2,
         "type": "SHOUT_NOISE",
         "increment": 0.2,
-        "power_per_increment": 100
+        "power_per_increment": 10
       },
       {
         "weight": 100,
@@ -92,7 +92,7 @@
         "max_value": 1,
         "type": "ARMOR_ACID",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -125
       },
       {
         "weight": 100,
@@ -100,23 +100,7 @@
         "max_value": 1,
         "type": "ARMOR_BASH",
         "increment": 0.1,
-        "power_per_increment": -500
-      },
-      {
-        "weight": 100,
-        "min_value": -0.2,
-        "max_value": 1,
-        "type": "ARMOR_BIO",
-        "increment": 0.1,
-        "power_per_increment": -500
-      },
-      {
-        "weight": 100,
-        "min_value": -0.2,
-        "max_value": 1,
-        "type": "ARMOR_COLD",
-        "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 100,
@@ -124,7 +108,7 @@
         "max_value": 1,
         "type": "ARMOR_CUT",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 100,
@@ -132,7 +116,7 @@
         "max_value": 1,
         "type": "ARMOR_ELEC",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -125
       },
       {
         "weight": 100,
@@ -140,7 +124,7 @@
         "max_value": 1,
         "type": "ARMOR_HEAT",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -125
       },
       {
         "weight": 100,
@@ -148,7 +132,7 @@
         "max_value": 1,
         "type": "ARMOR_STAB",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 100,
@@ -156,7 +140,7 @@
         "max_value": 1,
         "type": "ARMOR_BULLET",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 50,
@@ -164,7 +148,7 @@
         "max_value": 0.2,
         "type": "MOVE_COST",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 100,
@@ -172,7 +156,39 @@
         "max_value": 0.5,
         "type": "ATTACK_SPEED",
         "increment": 0.1,
-        "power_per_increment": 500
+        "power_per_increment": -200
+      },
+      {
+        "weight": 75,
+        "min_value": -0.75,
+        "max_value": 2.5,
+        "type": "FOOTSTEP_NOISE",
+        "increment": 0.25
+        "power_per_increment": -50
+      },
+      {
+        "weight": 50,
+        "min_value": -0.5,
+        "max_value": 1.0,
+        "type": "REGEN_STAMINA",
+        "increment": 0.1
+        "power_per_increment": 100
+      },
+      {
+        "weight": 25,
+        "min_value": -0.5,
+        "max_value": 1.0,
+        "type": "RECOIL_MODIFIER",
+        "increment": 0.1
+        "power_per_increment": -50
+      },
+      {
+        "weight": 35,
+        "min_value": -0.75,
+        "max_value": 0.5,
+        "type": "WEAPON_DISPERSION",
+        "increment": 0.05
+        "power_per_increment": -50
       }
     ],
     "passive_add_procgen_values": [
@@ -207,15 +223,15 @@
         "max_value": 20,
         "type": "SPEED",
         "increment": 5,
-        "power_per_increment": 200
+        "power_per_increment": 250
       },
       {
         "weight": 50,
-        "min_value": -50,
-        "max_value": 20,
+        "min_value": -20,
+        "max_value": 50,
         "type": "ATTACK_SPEED",
         "increment": 5,
-        "power_per_increment": 250
+        "power_per_increment": -150
       },
       {
         "weight": 50,
@@ -223,7 +239,7 @@
         "max_value": 10000,
         "type": "MAX_STAMINA",
         "increment": 250,
-        "power_per_increment": 125
+        "power_per_increment": 50
       },
       {
         "weight": 50,
@@ -231,7 +247,15 @@
         "max_value": 20000,
         "type": "CARRY_WEIGHT",
         "increment": 1000,
-        "power_per_increment": 250
+        "power_per_increment": 25
+      },
+      {
+        "weight": 10,
+        "min_value": -10,
+        "max_value": 10,
+        "type": "EFFECTIVE_HEALTH_MOD",
+        "increment": 2,
+        "power_per_increment": 100
       }
     ],
     "type_weights": [
@@ -273,36 +297,35 @@
       }
     ],
     "active_procgen_values": [
-      { "weight": 100, "spell_id": "AEA_ADRENALINE", "base_power": 150 },
-      { "weight": 100, "spell_id": "AEA_BLOOD", "base_power": 50 },
-      { "weight": 100, "spell_id": "AEA_HEAL", "base_power": 250 },
+      { "weight": 100, "spell_id": "AEA_BLOOD", "base_power": -25 },
+      { "weight": 100, "spell_id": "AEA_HEAL", "base_power": 500 },
       { "weight": 100, "spell_id": "AEA_CONFUSED", "base_power": 250 },
       { "weight": 100, "spell_id": "AEA_PAIN", "base_power": -150 },
-      { "weight": 100, "spell_id": "AEA_TELEPORT", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_ATTENTION", "base_power": -50 },
-      { "weight": 100, "spell_id": "AEA_TELEGLOW", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_TELEPORT", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_ATTENTION", "base_power": -100 },
+      { "weight": 100, "spell_id": "AEA_TELEGLOW", "base_power": -150 },
       { "weight": 100, "spell_id": "AEA_VOMIT", "base_power": -50 },
-      { "weight": 100, "spell_id": "AEA_SHADOWS", "base_power": 500 },
+      { "weight": 100, "spell_id": "AEA_SHADOWS", "base_power": 25 },
       { "weight": 100, "spell_id": "AEA_STAMINA_EMPTY", "base_power": -250 },
       { "weight": 100, "spell_id": "AEA_RADIATION", "base_power": -250 },
-      { "weight": 100, "spell_id": "AEA_HURTALL", "base_power": -250 },
-      { "weight": 100, "spell_id": "AEA_ACIDBALL", "base_power": 500 },
-      { "weight": 100, "spell_id": "AEA_BUGS", "base_power": 250 },
-      { "weight": 100, "spell_id": "AEA_NOISE", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_LIGHT", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_DIM", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_FATIGUE", "base_power": -100 },
-      { "weight": 100, "spell_id": "AEA_FIREBALL", "base_power": 500 },
-      { "weight": 100, "spell_id": "AEA_FLASH", "base_power": 250 },
+      { "weight": 100, "spell_id": "AEA_HURTALL", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_ACIDBALL", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_BUGS", "base_power": 200 },
+      { "weight": 100, "spell_id": "AEA_NOISE", "base_power": -25 },
+      { "weight": 100, "spell_id": "AEA_LIGHT", "base_power": -25 },
+      { "weight": 100, "spell_id": "AEA_DIM", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_FATIGUE", "base_power": -300 },
+      { "weight": 100, "spell_id": "AEA_FIREBALL", "base_power": -500 },
+      { "weight": 100, "spell_id": "AEA_FLASH", "base_power": 150 },
       { "weight": 100, "spell_id": "AEA_PARALYZE", "base_power": -250 },
       { "weight": 100, "spell_id": "AEA_MAP", "base_power": 500 },
-      { "weight": 100, "spell_id": "AEA_FIRESTORM", "base_power": 1000 },
+      { "weight": 100, "spell_id": "AEA_FIRESTORM", "base_power": -500 },
       { "weight": 100, "spell_id": "AEA_FUN", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_MUTATE", "base_power": 150 },
-      { "weight": 100, "spell_id": "AEA_STORM", "base_power": 1000 },
-      { "weight": 100, "spell_id": "AEA_ENTRANCE", "base_power": 1000 },
-      { "weight": 100, "spell_id": "AEA_SCREAM", "base_power": -150 },
-      { "weight": 100, "spell_id": "AEA_PULSE", "base_power": 250 }
+      { "weight": 100, "spell_id": "AEA_MUTATE", "base_power": -150 },
+      { "weight": 100, "spell_id": "AEA_STORM", "base_power": -100 },
+      { "weight": 100, "spell_id": "AEA_ENTRANCE", "base_power": 500 },
+      { "weight": 100, "spell_id": "AEA_SCREAM", "base_power": -75 },
+      { "weight": 100, "spell_id": "AEA_PULSE", "base_power": 75 }
     ],
     "passive_mult_procgen_values": [
       { "weight": 100, "min_value": -0.5, "max_value": 1, "type": "METABOLISM", "increment": 0.1, "power_per_increment": -50 },
@@ -320,7 +343,7 @@
         "max_value": 1,
         "type": "CARRY_WEIGHT",
         "increment": 0.1,
-        "power_per_increment": 250
+        "power_per_increment": 75
       },
       {
         "weight": 100,
@@ -328,7 +351,7 @@
         "max_value": 2,
         "type": "MAX_HP",
         "increment": 0.1,
-        "power_per_increment": 250
+        "power_per_increment": 100
       },
       {
         "weight": 100,
@@ -336,7 +359,7 @@
         "max_value": 2,
         "type": "REGEN_HP",
         "increment": 0.1,
-        "power_per_increment": 250
+        "power_per_increment": 50
       },
       {
         "weight": 100,
@@ -344,7 +367,7 @@
         "max_value": 2,
         "type": "SHOUT_NOISE",
         "increment": 0.2,
-        "power_per_increment": 100
+        "power_per_increment": 10
       },
       {
         "weight": 100,
@@ -352,7 +375,7 @@
         "max_value": 1,
         "type": "ARMOR_ACID",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -125
       },
       {
         "weight": 100,
@@ -360,23 +383,7 @@
         "max_value": 1,
         "type": "ARMOR_BASH",
         "increment": 0.1,
-        "power_per_increment": -500
-      },
-      {
-        "weight": 100,
-        "min_value": -0.2,
-        "max_value": 1,
-        "type": "ARMOR_BIO",
-        "increment": 0.1,
-        "power_per_increment": -500
-      },
-      {
-        "weight": 100,
-        "min_value": -0.2,
-        "max_value": 1,
-        "type": "ARMOR_COLD",
-        "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 100,
@@ -384,7 +391,7 @@
         "max_value": 1,
         "type": "ARMOR_CUT",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 100,
@@ -392,7 +399,7 @@
         "max_value": 1,
         "type": "ARMOR_ELEC",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -125
       },
       {
         "weight": 100,
@@ -400,7 +407,7 @@
         "max_value": 1,
         "type": "ARMOR_HEAT",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -125
       },
       {
         "weight": 100,
@@ -408,7 +415,7 @@
         "max_value": 1,
         "type": "ARMOR_STAB",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 100,
@@ -416,7 +423,7 @@
         "max_value": 1,
         "type": "ARMOR_BULLET",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 50,
@@ -424,7 +431,7 @@
         "max_value": 0.2,
         "type": "MOVE_COST",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 100,
@@ -432,7 +439,39 @@
         "max_value": 0.5,
         "type": "ATTACK_SPEED",
         "increment": 0.1,
-        "power_per_increment": 500
+        "power_per_increment": -200
+      },
+      {
+        "weight": 75,
+        "min_value": -0.75,
+        "max_value": 2.5,
+        "type": "FOOTSTEP_NOISE",
+        "increment": 0.25
+        "power_per_increment": -50
+      },
+      {
+        "weight": 50,
+        "min_value": -0.5,
+        "max_value": 1.0,
+        "type": "REGEN_STAMINA",
+        "increment": 0.1
+        "power_per_increment": 100
+      },
+      {
+        "weight": 25,
+        "min_value": -0.5,
+        "max_value": 1.0,
+        "type": "RECOIL_MODIFIER",
+        "increment": 0.1
+        "power_per_increment": -50
+      },
+      {
+        "weight": 35,
+        "min_value": -0.75,
+        "max_value": 0.5,
+        "type": "WEAPON_DISPERSION",
+        "increment": 0.05
+        "power_per_increment": -50
       }
     ],
     "passive_add_procgen_values": [
@@ -467,15 +506,15 @@
         "max_value": 20,
         "type": "SPEED",
         "increment": 5,
-        "power_per_increment": 200
+        "power_per_increment": 250
       },
       {
         "weight": 50,
-        "min_value": -50,
-        "max_value": 20,
+        "min_value": -20,
+        "max_value": 50,
         "type": "ATTACK_SPEED",
         "increment": 5,
-        "power_per_increment": 250
+        "power_per_increment": -150
       },
       {
         "weight": 50,
@@ -483,7 +522,7 @@
         "max_value": 10000,
         "type": "MAX_STAMINA",
         "increment": 250,
-        "power_per_increment": 125
+        "power_per_increment": 50
       },
       {
         "weight": 50,
@@ -491,7 +530,15 @@
         "max_value": 20000,
         "type": "CARRY_WEIGHT",
         "increment": 1000,
-        "power_per_increment": 250
+        "power_per_increment": 25
+      },
+      {
+        "weight": 10,
+        "min_value": -10,
+        "max_value": 10,
+        "type": "EFFECTIVE_HEALTH_MOD",
+        "increment": 2,
+        "power_per_increment": 100
       }
     ],
     "type_weights": [
@@ -533,36 +580,36 @@
       }
     ],
     "active_procgen_values": [
-      { "weight": 100, "spell_id": "AEA_ADRENALINE", "base_power": 150 },
-      { "weight": 100, "spell_id": "AEA_BLOOD", "base_power": 50 },
-      { "weight": 100, "spell_id": "AEA_HEAL", "base_power": 250 },
-      { "weight": 100, "spell_id": "AEA_CONFUSED", "base_power": 250 },
+      { "weight": 100, "spell_id": "AEA_ADRENALINE", "base_power": 250 },
+      { "weight": 100, "spell_id": "AEA_BLOOD", "base_power": -25 },
+      { "weight": 100, "spell_id": "AEA_HEAL", "base_power": 400 },
+      { "weight": 100, "spell_id": "AEA_CONFUSED", "base_power": 200 },
       { "weight": 100, "spell_id": "AEA_PAIN", "base_power": -150 },
-      { "weight": 100, "spell_id": "AEA_TELEPORT", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_ATTENTION", "base_power": -50 },
-      { "weight": 100, "spell_id": "AEA_TELEGLOW", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_TELEPORT", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_ATTENTION", "base_power": -100 },
+      { "weight": 100, "spell_id": "AEA_TELEGLOW", "base_power": -150 },
       { "weight": 100, "spell_id": "AEA_VOMIT", "base_power": -50 },
-      { "weight": 100, "spell_id": "AEA_SHADOWS", "base_power": 500 },
+      { "weight": 100, "spell_id": "AEA_SHADOWS", "base_power": 25 },
       { "weight": 100, "spell_id": "AEA_STAMINA_EMPTY", "base_power": -250 },
       { "weight": 100, "spell_id": "AEA_RADIATION", "base_power": -250 },
-      { "weight": 100, "spell_id": "AEA_HURTALL", "base_power": -250 },
-      { "weight": 100, "spell_id": "AEA_ACIDBALL", "base_power": 500 },
-      { "weight": 100, "spell_id": "AEA_BUGS", "base_power": 250 },
-      { "weight": 100, "spell_id": "AEA_NOISE", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_LIGHT", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_DIM", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_FATIGUE", "base_power": -100 },
-      { "weight": 100, "spell_id": "AEA_FIREBALL", "base_power": 500 },
-      { "weight": 100, "spell_id": "AEA_FLASH", "base_power": 250 },
+      { "weight": 100, "spell_id": "AEA_HURTALL", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_ACIDBALL", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_BUGS", "base_power": 200 },
+      { "weight": 100, "spell_id": "AEA_NOISE", "base_power": -25 },
+      { "weight": 100, "spell_id": "AEA_LIGHT", "base_power": -25 },
+      { "weight": 100, "spell_id": "AEA_DIM", "base_power": -50 },
+      { "weight": 100, "spell_id": "AEA_FATIGUE", "base_power": -300 },
+      { "weight": 100, "spell_id": "AEA_FIREBALL", "base_power": -500 },
+      { "weight": 100, "spell_id": "AEA_FLASH", "base_power": 150 },
       { "weight": 100, "spell_id": "AEA_PARALYZE", "base_power": -250 },
       { "weight": 100, "spell_id": "AEA_MAP", "base_power": 500 },
-      { "weight": 100, "spell_id": "AEA_FIRESTORM", "base_power": 1000 },
+      { "weight": 100, "spell_id": "AEA_FIRESTORM", "base_power": -750 },
       { "weight": 100, "spell_id": "AEA_FUN", "base_power": 100 },
-      { "weight": 100, "spell_id": "AEA_MUTATE", "base_power": 150 },
-      { "weight": 100, "spell_id": "AEA_STORM", "base_power": 1000 },
-      { "weight": 100, "spell_id": "AEA_ENTRANCE", "base_power": 1000 },
-      { "weight": 100, "spell_id": "AEA_SCREAM", "base_power": -150 },
-      { "weight": 100, "spell_id": "AEA_PULSE", "base_power": 250 }
+      { "weight": 100, "spell_id": "AEA_MUTATE", "base_power": -150 },
+      { "weight": 100, "spell_id": "AEA_STORM", "base_power": -100 },
+      { "weight": 100, "spell_id": "AEA_ENTRANCE", "base_power": 500 },
+      { "weight": 100, "spell_id": "AEA_SCREAM", "base_power": -75 },
+      { "weight": 100, "spell_id": "AEA_PULSE", "base_power": 75 }
     ],
     "passive_mult_procgen_values": [
       { "weight": 100, "min_value": -0.5, "max_value": 1, "type": "METABOLISM", "increment": 0.1, "power_per_increment": -50 },
@@ -580,7 +627,7 @@
         "max_value": 1,
         "type": "CARRY_WEIGHT",
         "increment": 0.1,
-        "power_per_increment": 250
+        "power_per_increment": 75
       },
       {
         "weight": 100,
@@ -588,7 +635,7 @@
         "max_value": 2,
         "type": "MAX_HP",
         "increment": 0.1,
-        "power_per_increment": 250
+        "power_per_increment": 100
       },
       {
         "weight": 100,
@@ -596,7 +643,7 @@
         "max_value": 2,
         "type": "REGEN_HP",
         "increment": 0.1,
-        "power_per_increment": 250
+        "power_per_increment": 50
       },
       {
         "weight": 100,
@@ -604,7 +651,7 @@
         "max_value": 2,
         "type": "SHOUT_NOISE",
         "increment": 0.2,
-        "power_per_increment": 100
+        "power_per_increment": 10
       },
       {
         "weight": 100,
@@ -612,7 +659,7 @@
         "max_value": 1,
         "type": "ARMOR_ACID",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -125
       },
       {
         "weight": 100,
@@ -620,23 +667,7 @@
         "max_value": 1,
         "type": "ARMOR_BASH",
         "increment": 0.1,
-        "power_per_increment": -500
-      },
-      {
-        "weight": 100,
-        "min_value": -0.2,
-        "max_value": 1,
-        "type": "ARMOR_BIO",
-        "increment": 0.1,
-        "power_per_increment": -500
-      },
-      {
-        "weight": 100,
-        "min_value": -0.2,
-        "max_value": 1,
-        "type": "ARMOR_COLD",
-        "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 100,
@@ -644,7 +675,7 @@
         "max_value": 1,
         "type": "ARMOR_CUT",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 100,
@@ -652,7 +683,7 @@
         "max_value": 1,
         "type": "ARMOR_ELEC",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -125
       },
       {
         "weight": 100,
@@ -660,7 +691,7 @@
         "max_value": 1,
         "type": "ARMOR_HEAT",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -125
       },
       {
         "weight": 100,
@@ -668,7 +699,7 @@
         "max_value": 1,
         "type": "ARMOR_STAB",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 100,
@@ -676,7 +707,7 @@
         "max_value": 1,
         "type": "ARMOR_BULLET",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 50,
@@ -684,7 +715,7 @@
         "max_value": 0.2,
         "type": "MOVE_COST",
         "increment": 0.1,
-        "power_per_increment": -500
+        "power_per_increment": -250
       },
       {
         "weight": 100,
@@ -692,7 +723,39 @@
         "max_value": 0.5,
         "type": "ATTACK_SPEED",
         "increment": 0.1,
-        "power_per_increment": 500
+        "power_per_increment": -200
+      },
+      {
+        "weight": 75,
+        "min_value": -0.75,
+        "max_value": 2.5,
+        "type": "FOOTSTEP_NOISE",
+        "increment": 0.25
+        "power_per_increment": -50
+      },
+      {
+        "weight": 50,
+        "min_value": -0.5,
+        "max_value": 1.0,
+        "type": "REGEN_STAMINA",
+        "increment": 0.1
+        "power_per_increment": 100
+      },
+      {
+        "weight": 25,
+        "min_value": -0.5,
+        "max_value": 1.0,
+        "type": "RECOIL_MODIFIER",
+        "increment": 0.1
+        "power_per_increment": -50
+      },
+      {
+        "weight": 35,
+        "min_value": -0.75,
+        "max_value": 0.5,
+        "type": "WEAPON_DISPERSION",
+        "increment": 0.05
+        "power_per_increment": -50
       }
     ],
     "passive_add_procgen_values": [
@@ -727,15 +790,15 @@
         "max_value": 20,
         "type": "SPEED",
         "increment": 5,
-        "power_per_increment": 200
+        "power_per_increment": 250
       },
       {
         "weight": 50,
-        "min_value": -50,
-        "max_value": 20,
+        "min_value": -20,
+        "max_value": 50,
         "type": "ATTACK_SPEED",
         "increment": 5,
-        "power_per_increment": 250
+        "power_per_increment": -150
       },
       {
         "weight": 50,
@@ -743,7 +806,7 @@
         "max_value": 10000,
         "type": "MAX_STAMINA",
         "increment": 250,
-        "power_per_increment": 125
+        "power_per_increment": 50
       },
       {
         "weight": 50,
@@ -751,7 +814,15 @@
         "max_value": 20000,
         "type": "CARRY_WEIGHT",
         "increment": 1000,
-        "power_per_increment": 250
+        "power_per_increment": 25
+      },
+      {
+        "weight": 10,
+        "min_value": -10,
+        "max_value": 10,
+        "type": "EFFECTIVE_HEALTH_MOD",
+        "increment": 2,
+        "power_per_increment": 100
       }
     ],
     "type_weights": [
@@ -875,34 +946,34 @@
       }
     ],
     "active_procgen_values": [
-      { "weight": 100, "spell_id": "AO_FRIENDLY_VORTEX", "base_power": 250 },
+      { "weight": 100, "spell_id": "AO_FRIENDLY_VORTEX", "base_power": 100 },
       { "weight": 100, "spell_id": "AO_CALL_OF_TINDALOS", "base_power": -500 },
-      { "weight": 100, "spell_id": "AO_FORCE_PULL", "base_power": 250 },
+      { "weight": 100, "spell_id": "AO_FORCE_PULL", "base_power": 200 },
       { "weight": 100, "spell_id": "AO_TELEPORTITIS", "base_power": -500 },
       { "weight": 100, "spell_id": "AO_SLOW", "base_power": -150 },
       { "weight": 100, "spell_id": "AO_TIME_STOP", "base_power": 1000 },
       { "weight": 100, "spell_id": "AO_DARKNESS_EFFECT", "base_power": -50 },
       { "weight": 100, "spell_id": "AO_LIFE_DRAIN", "base_power": -150 },
-      { "weight": 100, "spell_id": "AEA_ATTENTION", "base_power": -50 },
-      { "weight": 100, "spell_id": "AEA_FLASH", "base_power": 250 },
-      { "weight": 100, "spell_id": "AEA_HEAL", "base_power": 250 },
-      { "weight": 100, "spell_id": "AEA_FATIGUE", "base_power": -100 },
+      { "weight": 100, "spell_id": "AEA_ATTENTION", "base_power": -100 },
+      { "weight": 100, "spell_id": "AEA_FLASH", "base_power": 150 },
+      { "weight": 100, "spell_id": "AEA_HEAL", "base_power": 400 },
+      { "weight": 100, "spell_id": "AEA_FATIGUE", "base_power": -500 },
       { "weight": 100, "spell_id": "AEA_PAIN", "base_power": -150 },
-      { "weight": 100, "spell_id": "AEA_SHADOWS", "base_power": 500 },
+      { "weight": 100, "spell_id": "AEA_SHADOWS", "base_power": -50 },
       { "weight": 100, "spell_id": "AEA_LIGHT", "base_power": 100 },
       { "weight": 100, "spell_id": "AEA_DIM", "base_power": 100 },
       { "weight": 100, "spell_id": "AEA_SCREAM", "base_power": -50 },
-      { "weight": 100, "spell_id": "AEA_PULSE", "base_power": 250 }
+      { "weight": 100, "spell_id": "AEA_PULSE", "base_power": 150 }
     ],
     "passive_add_procgen_values": [
-      { "weight": 100, "min_value": -20, "max_value": 20, "type": "SPEED", "increment": 5, "power_per_increment": 200 },
+      { "weight": 100, "min_value": -20, "max_value": 20, "type": "SPEED", "increment": 5, "power_per_increment": 250 },
       {
         "weight": 50,
-        "min_value": -50,
-        "max_value": 20,
+        "min_value": -20,
+        "max_value": 50,
         "type": "ATTACK_SPEED",
         "increment": 5,
-        "power_per_increment": 250
+        "power_per_increment": -150
       }
     ],
     "type_weights": [ { "weight": 10, "value": "passive_enchantment_add" }, { "weight": 100, "value": "active_enchantment" } ],

--- a/data/json/artifact/relic_procgen_data.json
+++ b/data/json/artifact/relic_procgen_data.json
@@ -163,7 +163,7 @@
         "min_value": -0.75,
         "max_value": 2.5,
         "type": "FOOTSTEP_NOISE",
-        "increment": 0.25
+        "increment": 0.25,
         "power_per_increment": -50
       },
       {
@@ -171,7 +171,7 @@
         "min_value": -0.5,
         "max_value": 1.0,
         "type": "REGEN_STAMINA",
-        "increment": 0.1
+        "increment": 0.1,
         "power_per_increment": 100
       },
       {
@@ -179,7 +179,7 @@
         "min_value": -0.5,
         "max_value": 1.0,
         "type": "RECOIL_MODIFIER",
-        "increment": 0.1
+        "increment": 0.1,
         "power_per_increment": -50
       },
       {
@@ -187,7 +187,7 @@
         "min_value": -0.75,
         "max_value": 0.5,
         "type": "WEAPON_DISPERSION",
-        "increment": 0.05
+        "increment": 0.05,
         "power_per_increment": -50
       }
     ],
@@ -446,7 +446,7 @@
         "min_value": -0.75,
         "max_value": 2.5,
         "type": "FOOTSTEP_NOISE",
-        "increment": 0.25
+        "increment": 0.25,
         "power_per_increment": -50
       },
       {
@@ -454,7 +454,7 @@
         "min_value": -0.5,
         "max_value": 1.0,
         "type": "REGEN_STAMINA",
-        "increment": 0.1
+        "increment": 0.1,
         "power_per_increment": 100
       },
       {
@@ -462,7 +462,7 @@
         "min_value": -0.5,
         "max_value": 1.0,
         "type": "RECOIL_MODIFIER",
-        "increment": 0.1
+        "increment": 0.1,
         "power_per_increment": -50
       },
       {
@@ -470,7 +470,7 @@
         "min_value": -0.75,
         "max_value": 0.5,
         "type": "WEAPON_DISPERSION",
-        "increment": 0.05
+        "increment": 0.05,
         "power_per_increment": -50
       }
     ],
@@ -730,7 +730,7 @@
         "min_value": -0.75,
         "max_value": 2.5,
         "type": "FOOTSTEP_NOISE",
-        "increment": 0.25
+        "increment": 0.25,
         "power_per_increment": -50
       },
       {
@@ -738,7 +738,7 @@
         "min_value": -0.5,
         "max_value": 1.0,
         "type": "REGEN_STAMINA",
-        "increment": 0.1
+        "increment": 0.1,
         "power_per_increment": 100
       },
       {
@@ -746,7 +746,7 @@
         "min_value": -0.5,
         "max_value": 1.0,
         "type": "RECOIL_MODIFIER",
-        "increment": 0.1
+        "increment": 0.1,
         "power_per_increment": -50
       },
       {
@@ -754,7 +754,7 @@
         "min_value": -0.75,
         "max_value": 0.5,
         "type": "WEAPON_DISPERSION",
-        "increment": 0.05
+        "increment": 0.05,
         "power_per_increment": -50
       }
     ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "edits to relic progen for better cohesion"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Relic progen was a little wonky, something I noticed after they were assigned resonance.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fixes include:
- ATTACK_SPEED was inverted - negative attack speed was being seen as "bad" and positive attack speed was being treated as "good" when in reality the opposite was the case. This has been corrected.
- some active effects have been changed. A few "bad" actives are worth less negative points, and a few "good" actives are now bad (FIRESTORM was worth 1000 points when it's really the most negative effect by far). Some really strong actives like healing and adrenaline are worth more points.
- Carryweight and stamina were worth way too many points, an artifact with 20kg carryweight had a ridiculous 6,000 resonance. Cut those down substantially (the same artifact has only 600 now) 
- ARMOR_BIO and ARMOR_COLD were removed from the pools because these are not used at all in the base game, so they were wholly superfluous effects. HEAT, ACID and ELEC were made to be worth less than CUT, STAB, BULLET and BASH. An artifact that makes you twice as weak to shocks is not as bad as an artifact that makes you twice as weak to bullets.
- Added relic effects for FOOTSTEP_NOISE, WEAPON_DISPERSION, RECOIL_MODIFIER, REGEN_STAMINA and EFFECTIVE_HEALTH_MOD. 
- A few passive relic effects like shout noise are worth less power., A few passive effects such as speed are worth more value.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Balance is hard to nail down and not necessarily even good in this context, but I wanted to fix the obviously wacko stuff at the very least.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
There are basic build test failures but I don't *think* they're mine. Will be trying this in game.
Edit: have tested this for a bit and it seems to work fine. The only thing I might change is spawning more passive properties on spawned artifacts since they self-balance.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
