### PR TITLE
Update suits_protection.json

### DIFF
--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -991,7 +991,7 @@
     "copy-from": "armor_lc_plate",
     "material": [ "qt_steel", "qt_steel_chain" ],
     "name": { "str": "tempered plate armor" },
-    "description": "A suit of plate armor with a 4mm thick chestpiece.  The medium steel has been quenched and tempered, offering top-of-the-line-protection.",
+    "description": "A suit of plate armor with a 4mm thick chestpiece.  The medium steel has been quenched and tempered, offering top-of-the-line protection.",
     "armor": [
       {
         "material": [
@@ -1244,7 +1244,7 @@
     "copy-from": "armor_lc_heavyplate",
     "material": [ "qt_steel", "qt_steel_chain" ],
     "name": { "str": "tempered heavy plate armor" },
-    "description": "A heavy suit of plate armor with a 6mm thick chestpiece.  The medium steel has been quenched and tempered, offering top of the line protection.",
+    "description": "A heavy suit of plate armor with a 6mm thick chestpiece.  The medium steel has been quenched and tempered, offering top-of-the-line protection.",
     "armor": [
       {
         "material": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Fixes typos in the flavor text of the item descriptions for 'Tempered Steel Armor' and its variants (Light, Normal and Heavy). The item descriptions are all similar to one another, but have small deviations in the hyphenation. They currently read as: "... top-of-the-line protection.", "... top of the line protection." and "... top-of-the-line-protection.". This fix standardizes all three of these texts as "... top-of-the-line protection.".

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Fixed the item description text for "Tempered Plate Armor" and "Tempered Heavy Plate Armor" to read as the same as the item description text for "Tempered Light Plate Armor", which reads as: "... top-of-the-line protection.".

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Each type of plate armor could have its own unique description, but given there are 3 types (Light, Normal and Heavy) and three sizes (XS, Normal and XL) and that their descriptions and functions are more similar than different, I felt it was more appropriate to bring all the items descriptions in-line with one another than to deviate further. I think that having wildly different descriptions, for so many similar items may be more confusing to new players than it would be beneficial, so I decided against this.


#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Loaded up a test world and checked the new descriptions with debug menu. It worked!

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
![new](https://user-images.githubusercontent.com/115378524/194736317-5b1e8e10-286e-40f9-86af-d865e75c206e.jpg)
