### PR TITLE
Implement scrolling for world menu

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -236,18 +236,38 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
         return;
     }
 
-    const point top_left( bottom_left + point( 0, -( sub_opts.size() + 1 ) ) );
-    catacurses::window w_sub = catacurses::newwin( sub_opts.size() + 2, xlen + 4, top_left );
+    point top_left( bottom_left + point( 0, -( sub_opts.size() + 1 ) ) );
+    int height = sub_opts.size();
+    if( top_left.y < 0 ) {
+        height -= abs( top_left.y ); // abs unnecessary but more clear
+        top_left.y = 0;
+    } else {
+        sub_opt_off = 0;
+    }
+
+    if( sel2 - 1 < sub_opt_off ) {
+        sub_opt_off = sel2;
+    } else if( sel2 + 1 > sub_opt_off + height ) {
+        sub_opt_off = sel2 - height + 1;
+    }
+
+    catacurses::window w_sub = catacurses::newwin( height + 2, xlen + 4, top_left );
     werase( w_sub );
     draw_border( w_sub, c_white );
-    for( int y = 0; static_cast<size_t>( y ) < sub_opts.size(); y++ ) {
-        std::string opt = ( sel2 == y ? "» " : "  " ) + sub_opts[y];
+
+    for( int y = 0; y < height; y++ ) {
+        std::string opt = ( sel2 == y + sub_opt_off ? "» " : "  " ) + sub_opts[y + sub_opt_off];
         int padding = ( xlen + 2 ) - utf8_width( opt, true );
         opt.append( padding, ' ' );
-        nc_color clr = sel2 == y ? hilite( c_white ) : c_white;
+        nc_color clr = sel2 == y + sub_opt_off ? hilite( c_white ) : c_white;
         trim_and_print( w_sub, point( 1, y + 1 ), xlen + 2, clr, opt );
-        inclusive_rectangle<point> rec( top_left + point( 1, y + 1 ), top_left + point( xlen + 2, y + 1 ) );
+        inclusive_rectangle<point> rec( top_left + point( 1, y  + 1 ),
+                                        top_left + point( xlen + 2, y + 1 ) );
         main_menu_sub_button_map.emplace_back( rec, std::pair<int, int> { sel, y } );
+    }
+    if( static_cast<size_t>( height ) != sub_opts.size() ) {
+        draw_scrollbar( w_sub, sel2, height, sub_opts.size(), point_south, c_white,
+                        false );
     }
     wnoutrefresh( w_sub );
 }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -239,7 +239,7 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
     point top_left( bottom_left + point( 0, -( sub_opts.size() + 1 ) ) );
     int height = sub_opts.size();
     if( top_left.y < 0 ) {
-        height -= abs( top_left.y ); // abs unnecessary but more clear
+        height += top_left.y;
         top_left.y = 0;
     } else {
         sub_opt_off = 0;

--- a/src/main_menu.h
+++ b/src/main_menu.h
@@ -72,6 +72,7 @@ class main_menu
         input_context ctxt;
         int sel1 = 1;
         int sel2 = 1;
+        int sub_opt_off = 0;
         point LAST_TERM;
         catacurses::window w_open;
         point menu_offset;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Implement scrolling for world menu (and other main menu sub-menus)"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #61369. Small terminal sizes, coupled with lots of worlds causes the whole world menu to disappear. This occurs at the smallest terminal size (24) with 17 worlds; this is a _very_ rare edge case (#61369 was playing on android). 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Implemented scrolling for all the sub-menus including for `[World]` and `[Load]`. Note that existing behavior (and visuals) for people on standard screens/ terminals is unchanged.  We use a extra variable to keep track of where the top of the menu is, relative to the scrolling: `sub_opt_off`. I'm not sure if this could have been better done with existing scrolling architectures and overall `main_menu.cpp` needs a refactor to unify all the different implementations of scrolling, menu drawing etc.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Try and understand a way to do this with other scrolling logic in `main_menu.cpp`: Too difficult, other code solves a slightly different problem and this is best addressed by a proper refactor.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Opened game, created excessive number of worlds, all scrollbars and logic is working as intended. Also successfully tested resizing the terminal with the menu open.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I'm reasonably new to this codebase and might not have done this in the optimal way.
