### PR TITLE
Fixed regenerating zombie mutating into a crawler + rewrote medical zombie descriptions

### DIFF
--- a/data/json/monsters/zed-medical.json
+++ b/data/json/monsters/zed-medical.json
@@ -13,7 +13,7 @@
     "id": "mon_zombie_medical_brute",
     "type": "MONSTER",
     "name": { "str": "medical horror" },
-    "description": "This enormous shambling corpse is dressed like a medical professional.  Its entire body bulges with distended muscles and swollen, festering wounds.",
+    "description": "A former doctor of some sort, though its uniform has been torn apart.  You assume the oversized muscles that cover it to be the culprit.",
     "copy-from": "mon_zombie_brute",
     "death_drops": "mon_zombie_medical_death_drops",
     "color": "blue"
@@ -21,8 +21,8 @@
   {
     "id": "mon_zombie_medical_regenerating",
     "type": "MONSTER",
-    "name": { "str": "regenerating zombie medic" },
-    "description": "This hairless corpse is dressed like a medical professional.  Its pale, pinkish flesh appears to be squirming and moving across its body, quickly covering and fixing any wounds received.",
+    "name": { "str": "miracle lurker" },
+    "description": "The zombified remains of a practitioner of medicine, you aren't certain what field - your focus is instead drawn to the way that its pink flesh snakes all over it, weaving its way over wounds and injuries.",
     "copy-from": "mon_zombie_regenerating",
     "death_drops": "mon_zombie_medical_death_drops",
     "upgrades": { "half_life": 30, "into_group": "GROUP_MEDICAL_CRAWLER_UPGRADE" }
@@ -31,7 +31,7 @@
     "id": "mon_skeleton_medical",
     "type": "MONSTER",
     "name": { "str_sp": "sawbones" },
-    "description": "An overgrowth of ossified tissue has replaced this former medical professional's rotting skin with an organic armor of dense bone.  Large clumps of black goo seep from its joints as it shambles aimlessly, with sickening crackling sounds filling the surrounding air.",
+    "description": "A malformed armor of misshapen bone has grown over this zombie, having pushed what remains of the skin out of the way.  The clothes of a medical worker is still draped over it.",
     "copy-from": "mon_skeleton",
     "death_drops": "zombie_medical_clothes",
     "color": "blue"
@@ -40,7 +40,7 @@
     "id": "mon_zombie_medical_acidic",
     "type": "MONSTER",
     "name": { "str_sp": "doctor burns" },
-    "description": "This is the pale, shuffling corpse of a medical professional.  Its skin looks especially thin, with a sticky, yellow fluid flowing through the clearly visible veins.",
+    "description": "This is the body of a doctor or nurse of some kind.  It's hard to tell now that most of its clothing has corroded away from whatever vile acid its secreting.",
     "copy-from": "mon_zombie_acidic",
     "death_drops": "mon_zombie_medical_death_drops"
   },

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1129,7 +1129,6 @@
     "death_drops": "default_zombie_death_drops",
     "regenerates": 12,
     "burn_into": "mon_zombie_scorched",
-    "upgrades": { "half_life": 28, "into_group": "GROUP_ZOMBIE_CRAWLER_UPGRADE" },
     "flags": [
       "SEES",
       "HEARS",


### PR DESCRIPTION
#### Summary
Content "Removed regenerating zombie mutating into crawlers + rewrote some medical zombie's descriptions"

#### Purpose of change

The descriptions of the medical zombies from #48669 were very barebones, simply reading variations of "A zombie dressed like a medical professional" followed by a snippet from the description of whatever it's based on. Underwhelming considering they all have unique and creative names, except the regenerating variant (though I've fixed that as well.)

Speaking of, I noticed the regenerating zombie I made in #47089 mutates into a crawler or a pupating crawler, which I don't think is intentional. It could explain why it appears so little ingame.

#### Describe the solution

Rewrote the descriptions to help them stand out, as well as removed the line that evolves the regenerating zombie

#### Describe alternatives you've considered

In the future I'll add evolved forms of the regenerating zombie.

#### Testing

none done
