### PR TITLE
Improve display of reasons an NPC won't trade an item

### DIFF
--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -130,7 +130,7 @@
   {
     "id": "robofac_blacklist",
     "type": "shopkeeper_blacklist",
-    "entries": [ { "group": "NC_ROBOFAC_gear", "message": "Hub 01 will not buy back their own gear" } ]
+    "entries": [ { "group": "NC_ROBOFAC_gear", "message": "Will not buy back their own gear" } ]
   },
   {
     "type": "mapgen",

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3598,12 +3598,15 @@ void inventory_multiselector::toggle_entries( int &count, const toggle_mode mode
     }
 
     if( selected.empty() || !selected.front()->is_selectable() ) {
-        if( !selected.front()->is_selectable() && mode == toggle_mode::SELECTED ) {
+        if( !selected.front()->is_selectable() && mode == toggle_mode::SELECTED &&
+            selected.front()->is_item() ) {
             const std::string denial = preset.get_denial( selected.front()->any_item() );
             if( !denial.empty() ) {
+                const std::string assembled = selected.front()->any_item().get_item()->display_name() + ":\n"
+                                              + colorize( denial, c_red );
                 query_popup()
-                .message( "%s", denial )
-                .option( "CONTINUE" )
+                .message( "%s", assembled )
+                .option( "QUIT" )
                 .query();
             }
         }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1671,7 +1671,7 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
 
             if( denial_width > 0 ) {
 	      // Print from right rather than trim_and_print to avoid improper positioning of wide characters
-	      right_print( win, yy, 1, c_red, trim_by_length( denial, denial_width ) );
+	      right_print( win, yy, 1, c_red, trim_by_length( selected ? hilite_string( colorize( denial, c_red ) ) : denial, denial_width ) );
             }
         }
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1670,8 +1670,9 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
                                                   true ) ) );
 
             if( denial_width > 0 ) {
-	      // Print from right rather than trim_and_print to avoid improper positioning of wide characters
-	      right_print( win, yy, 1, c_red, trim_by_length( selected ? hilite_string( colorize( denial, c_red ) ) : denial, denial_width ) );
+                // Print from right rather than trim_and_print to avoid improper positioning of wide characters
+                right_print( win, yy, 1, c_red, trim_by_length( selected ? hilite_string( colorize( denial,
+                             c_red ) ) : denial, denial_width ) );
             }
         }
 
@@ -3599,19 +3600,19 @@ void inventory_multiselector::toggle_entries( int &count, const toggle_mode mode
     // Deal with entries that can be highlighted but not selected (e.g. items too large to pick up)
     inventory_entry &highlighted_entry = get_active_column().get_highlighted();
     if( !highlighted_entry.is_selectable() && highlighted_entry.is_item() ) {
-	cata_assert( highlighted_entry.denial.has_value() );
-	const std::string &denial = *highlighted_entry.denial;
+        cata_assert( highlighted_entry.denial.has_value() );
+        const std::string &denial = *highlighted_entry.denial;
 
-	if( !denial.empty() ) {
-	  const std::string assembled = highlighted_entry.any_item().get_item()->display_name() + ":\n"
-	    + colorize( denial, c_red );
-	  query_popup()
-	    .message( "%s", assembled )
-	    .option( "QUIT" )
-	    .query();
-	}
-	count = 0;
-	return;
+        if( !denial.empty() ) {
+            const std::string assembled = highlighted_entry.any_item().get_item()->display_name() + ":\n"
+                                          + colorize( denial, c_red );
+            query_popup()
+            .message( "%s", assembled )
+            .option( "QUIT" )
+            .query();
+        }
+        count = 0;
+        return;
     }
 
     // Deal with anything else that can't be selected

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -30,6 +30,7 @@
 #include "options.h"
 #include "output.h"
 #include "point.h"
+#include "popup.h"
 #include "ret_val.h"
 #include "sdltiles.h"
 #include "localized_comparator.h"
@@ -3597,6 +3598,15 @@ void inventory_multiselector::toggle_entries( int &count, const toggle_mode mode
     }
 
     if( selected.empty() || !selected.front()->is_selectable() ) {
+        if( !selected.front()->is_selectable() && mode == toggle_mode::SELECTED ) {
+            const std::string denial = preset.get_denial( selected.front()->any_item() );
+            if( !denial.empty() ) {
+                query_popup()
+                .message( "%s", denial )
+                .option( "CONTINUE" )
+                .query();
+            }
+        }
         count = 0;
         return;
     }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1660,8 +1660,11 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
         const std::string &denial = *entry.denial;
 
         if( !denial.empty() ) {
+            // Determine the width available for the first cell to print, then use that to trim the denial
+            const size_t first_cell_width = std::min( get_entry_cell_width( entry, 0 ),
+                                            x2 + cells[0].current_width - min_denial_gap );
             const size_t max_denial_width = std::max( static_cast<int>( get_width() - ( min_denial_gap +
-                                            get_entry_cell_width( entry, 0 ) ) ), 0 );
+                                            first_cell_width ) ), 0 );
             const size_t denial_width = std::min( max_denial_width, static_cast<size_t>( utf8_width( denial,
                                                   true ) ) );
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3596,7 +3596,12 @@ void inventory_multiselector::toggle_entries( int &count, const toggle_mode mode
         }
     }
 
-    if( selected.empty() || !selected.front()->is_selectable() ) {
+    if( selected.empty() ) {
+        count = 0;
+        return;
+    }
+
+    if( !selected.front()->is_selectable() ) {
         if( !selected.front()->is_selectable() && mode == toggle_mode::SELECTED &&
             selected.front()->is_item() ) {
             const std::string denial = preset.get_denial( selected.front()->any_item() );
@@ -3609,8 +3614,8 @@ void inventory_multiselector::toggle_entries( int &count, const toggle_mode mode
                 .query();
             }
         }
-        count = 0;
-        return;
+	count = 0;
+	return;
     }
 
     // No amount entered, select all

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3596,26 +3596,28 @@ void inventory_multiselector::toggle_entries( int &count, const toggle_mode mode
         }
     }
 
+    // Deal with entries that can be highlighted but not selected (e.g. items too large to pick up)
+    inventory_entry &highlighted_entry = get_active_column().get_highlighted();
+    if( !highlighted_entry.is_selectable() && highlighted_entry.is_item() ) {
+	cata_assert( highlighted_entry.denial.has_value() );
+	const std::string &denial = *highlighted_entry.denial;
+
+	if( !denial.empty() ) {
+	  const std::string assembled = highlighted_entry.any_item().get_item()->display_name() + ":\n"
+	    + colorize( denial, c_red );
+	  query_popup()
+	    .message( "%s", assembled )
+	    .option( "QUIT" )
+	    .query();
+	}
+	count = 0;
+	return;
+    }
+
+    // Deal with anything else that can't be selected
     if( selected.empty() ) {
         count = 0;
         return;
-    }
-
-    if( !selected.front()->is_selectable() ) {
-        if( !selected.front()->is_selectable() && mode == toggle_mode::SELECTED &&
-            selected.front()->is_item() ) {
-            const std::string denial = preset.get_denial( selected.front()->any_item() );
-            if( !denial.empty() ) {
-                const std::string assembled = selected.front()->any_item().get_item()->display_name() + ":\n"
-                                              + colorize( denial, c_red );
-                query_popup()
-                .message( "%s", assembled )
-                .option( "QUIT" )
-                .query();
-            }
-        }
-	count = 0;
-	return;
     }
 
     // No amount entered, select all

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1670,9 +1670,8 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
                                                   true ) ) );
 
             if( denial_width > 0 ) {
-                trim_and_print( win, point( p.x + get_width() - denial_width, yy ),
-                                denial_width,
-                                c_red, denial );
+	      // Print from right rather than trim_and_print to avoid improper positioning of wide characters
+	      right_print( win, yy, 1, c_red, trim_by_length( denial, denial_width ) );
             }
         }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1983,7 +1983,7 @@ ret_val<void> npc::wants_to_sell( const item_location &it, int at_price ) const
         is_worn( *it ) ||
         ( ( !myclass->sells_belongings || it->has_flag( flag_TRADER_KEEP_EQUIPPED ) ) &&
           it.held_by( *this ) ) ) {
-        return ret_val<void>::make_failure( _( "<npcname> will never sell this" ) );
+        return ret_val<void>::make_failure( _( "Won't sell their own equipment" ) );
     }
 
     for( const shopkeeper_item_group &ig : myclass->get_shopkeeper_items() ) {
@@ -2016,11 +2016,11 @@ ret_val<void> npc::wants_to_buy( const item &it, int at_price ) const
     }
 
     if( it.has_flag( flag_TRADER_AVOID ) || it.has_var( VAR_TRADE_IGNORE ) ) {
-        return ret_val<void>::make_failure( _( "<npcname> will never buy this" ) );
+        return ret_val<void>::make_failure( _( "Will never buy this" ) );
     }
 
     if( !is_shopkeeper() && has_trait( trait_SQUEAMISH ) && it.is_filthy() ) {
-        return ret_val<void>::make_failure( _( "<npcname> will not buy filthy items" ) );
+        return ret_val<void>::make_failure( _( "Will not buy filthy items" ) );
     }
 
     icg_entry const *bl = myclass->get_shopkeeper_blacklist().matches( it, *this );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Improve display of reasons an NPC won't trade an item"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
If an NPC is unwilling to buy or sell an item, the player should have some idea why.  The Trade UI tries to fit this in, but there are a couple of issues with how it does so:
1] For long item names, the trade denial message is shrunk to fit the _untrimmed_ item name.  Note the trimming on the "duffel bag" line.  When the screen is two characters narrower, it will produce an error message as in #61597.
![Before--Improper_trimming](https://user-images.githubusercontent.com/89038572/196045822-fd5a4c85-5495-4533-9b30-0c7a21347827.png)

Fixes #61597 

2] There's no way to scroll through the entry, so on small screen sizes, the full denial message is unavailable.  So, the player might not know why they can't buy/sell an item
3] On languages with wide characters, there's a minor display issue where the denial message is shifted to the left:
![Before--Improper_positioning--Chinese](https://user-images.githubusercontent.com/89038572/196045942-5b60db11-a0a6-41f7-8c81-a859f583f321.png)

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1] Trim the denial message to fit with the trimmed item name, ensuring there's always at least something indicating that this trade is unavailable.
![After--Proper_trimming](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/73fff0df-4a62-4a63-8252-682d6632b55c)
2] When attempting to select an untradeable item for trade, display a popup with the full item name and the reason it cannot be traded
![After--Denial_popup--English](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/8d59b389-6c5e-4a88-b607-c14fe108c0cf)
3] Change form trim_and_print() to right_print(trim_by_length()) to right-justify the denial message, even on languages with wide characters

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
1. Adding the ability to scroll through the text in a given inventory_selector line
This seemed like it would be a nightmare to control
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested at a variety of screen sizes:

https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/30bda7af-6c6f-4bdf-af43-d311c4b035c7

https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/cfa2a7f7-423e-4635-bd04-73c5271409e9


Tested in several different languages:
![After--Denial_popup--Spanish](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/0fe906ef-2069-4260-9f17-561e7e94e47b)

https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/aa59114d-94a0-40bf-ac82-28aac660ef5e


Tested trading with Hub 01:
![After--Hub01_trading](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/595387b4-aee8-42f1-907e-fade53d154a8)


Tested pickup screen denial popup (Portuguese shown):
![After--Pickup_screen_denial--Portuguese](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/17184e76-12fe-41b8-a102-be5c2887dfe5)

Tested wear item/disassembly screens to ensure I didn't break display of denial messages on other inventory_selector screens.
If there's a way to get a denial message on comparison `I` or drop `D`, that should probably be tested, but I didn't see a way to do it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
- It might be useful to add the popup denial message to other inventory_selector types.  In some languages it doesn't seem like there's a lot of room to describe, e.g., the tools required for disassembly:
![After--Disassembly--Polish](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/27bbc33c-4a28-4c24-8e97-0dfaae3204aa)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
