### PR TITLE
fix ads cost

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -14,8 +14,8 @@
     "description": "A thin forcefield surrounds your body, continually draining power.  Everything loses velocity when penetrating this field, which results in reduced amount of dealt damage at the cost of your bionic energy.  Bullets and stabbing attacks will lose more velocity than cutting attacks and those in turn more than bashing attacks.",
     "occupied_bodyparts": [ [ "torso", 10 ], [ "head", 1 ], [ "arm_l", 1 ], [ "arm_r", 1 ], [ "leg_l", 2 ], [ "leg_r", 2 ] ],
     "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
-    "act_cost": 10,
-    "react_cost": 10,
+    "act_cost": "10 J",
+    "react_cost": "10 J",
     "trigger_cost": "25kJ",
     "time": "1 s"
   },

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -323,7 +323,9 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 // Taking muzzle energy of 5.56mm ammo as a reference, 1936 J is equal to 44 damage
                 // Having this in mind, let's make 2500 J equal to 50 damage, which will be the maximum damage ADS can absorb
                 const int max_absorption = 50;
-
+                // costs energy equal to the square of the base damage, before it is reduced, regardless of how much it is reduced.
+                // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 144j.
+                units::energy power_cost = units::from_joule ( elem.amount * elem.amount * -1 );
                 // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
                 // Otherwise, divide the damage by X times, depending on damage type
                 if( elem.type == damage_type::BASH ) {
@@ -333,7 +335,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 } else if( elem.type == damage_type::STAB || elem.type == damage_type::BULLET ) {
                     elem.amount = elem.amount > max_absorption ? elem.amount - max_absorption : elem.amount / 4;
                 }
-                mod_power_level( -bio_ads->power_trigger );
+                mod_power_level( power_cost );
                 add_msg_if_player( m_good,
                                    _( "The defensive forcefield surrounding your body ripples as it reduces velocity of incoming attack." ) );
             }

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -325,7 +325,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 // costs energy equal to the square of the base damage, before it is reduced, regardless of how much it is reduced
                 // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 144j
                 const int max_absorption = 50;
-                units::energy power_cost = units::from_joule( std::max( -2500, ( elem.amount * elem.amount * -1 ) ) );
+                units::energy power_cost = units::from_joule( std::max( -2500, elem.amount * elem.amount * -1 ) );
 
                 // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
                 // Otherwise, divide the damage by X times, depending on damage type

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -322,11 +322,11 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 // Assuming it absorbs damage at 10% efficiency, it can absorb at most 2500 J of energy
                 // Taking muzzle energy of 5.56mm ammo as a reference, 1936 J is equal to 44 damage
                 // Having this in mind, let's make 2500 J equal to 50 damage, which will be the maximum damage ADS can absorb
-                // costs energy equal to the square of the base damage, before it is reduced, regardless of how much it is reduced
-                // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 144j
+                // costs energy equal to the 10x damage^2, before it is reduced, regardless of how much it is reduced
+                // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 1440j
                 const int max_absorption = 50;
-                units::energy power_cost = units::from_joule( std::max( -2500.0f,
-                                           elem.amount * elem.amount * -1 ) );
+                units::energy power_cost = units::from_joule( std::max( -25000.0f,
+                                           elem.amount * elem.amount * -10 ) );
 
                 // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
                 // Otherwise, divide the damage by X times, depending on damage type

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -325,7 +325,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 const int max_absorption = 50;
                 // costs energy equal to the square of the base damage, before it is reduced, regardless of how much it is reduced.
                 // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 144j.
-                units::energy power_cost = units::from_joule( elem.amount * elem.amount * -1 );
+                units::energy power_cost = units::from_joule( std::max( -2500, ( elem.amount * elem.amount * -1 ) );
                 // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
                 // Otherwise, divide the damage by X times, depending on damage type
                 if( elem.type == damage_type::BASH ) {

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -323,11 +323,13 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 // Taking muzzle energy of 5.56mm ammo as a reference, 1936 J is equal to 44 damage
                 // Having this in mind, let's make 2500 J equal to 50 damage, which will be the maximum damage ADS can absorb
                 const int max_absorption = 50;
+
                 // costs energy equal to the square of the base damage, before it is reduced, regardless of how much it is reduced.
                 // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 144j.
                 units::energy power_cost = units::from_joule( std::max( -2500, ( elem.amount * elem.amount * -1 ) );
-                                           // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
-                                           // Otherwise, divide the damage by X times, depending on damage type
+
+                // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
+                // Otherwise, divide the damage by X times, depending on damage type
                 if( elem.type == damage_type::BASH ) {
                     elem.amount = elem.amount > max_absorption ? elem.amount - max_absorption : elem.amount / 2;
                 } else if( elem.type == damage_type::CUT ) {

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -322,10 +322,9 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 // Assuming it absorbs damage at 10% efficiency, it can absorb at most 2500 J of energy
                 // Taking muzzle energy of 5.56mm ammo as a reference, 1936 J is equal to 44 damage
                 // Having this in mind, let's make 2500 J equal to 50 damage, which will be the maximum damage ADS can absorb
+                // costs energy equal to the square of the base damage, before it is reduced, regardless of how much it is reduced
+                // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 144j
                 const int max_absorption = 50;
-
-                // costs energy equal to the square of the base damage, before it is reduced, regardless of how much it is reduced.
-                // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 144j.
                 units::energy power_cost = units::from_joule( std::max( -2500, ( elem.amount * elem.amount * -1 ) );
 
                 // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -325,7 +325,8 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 // costs energy equal to the square of the base damage, before it is reduced, regardless of how much it is reduced
                 // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 144j
                 const int max_absorption = 50;
-                units::energy power_cost = units::from_joule( std::max( -2500.0f, elem.amount * elem.amount * -1 ) );
+                units::energy power_cost = units::from_joule( std::max( -2500.0f,
+                                           elem.amount * elem.amount * -1 ) );
 
                 // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
                 // Otherwise, divide the damage by X times, depending on damage type

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -325,7 +325,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 const int max_absorption = 50;
                 // costs energy equal to the square of the base damage, before it is reduced, regardless of how much it is reduced.
                 // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 144j.
-                units::energy power_cost = units::from_joule ( elem.amount * elem.amount * -1 );
+                units::energy power_cost = units::from_joule( elem.amount * elem.amount * -1 );
                 // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
                 // Otherwise, divide the damage by X times, depending on damage type
                 if( elem.type == damage_type::BASH ) {

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -325,7 +325,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 // costs energy equal to the square of the base damage, before it is reduced, regardless of how much it is reduced
                 // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 144j
                 const int max_absorption = 50;
-                units::energy power_cost = units::from_joule( std::max( -2500, ( elem.amount * elem.amount * -1 ) );
+                units::energy power_cost = units::from_joule( std::max( -2500, ( elem.amount * elem.amount * -1 ) ) );
 
                 // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
                 // Otherwise, divide the damage by X times, depending on damage type

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -325,7 +325,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 // costs energy equal to the square of the base damage, before it is reduced, regardless of how much it is reduced
                 // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 144j
                 const int max_absorption = 50;
-                units::energy power_cost = units::from_joule( std::max( -2500, elem.amount * elem.amount * -1 ) );
+                units::energy power_cost = units::from_joule( std::max( -2500.0f, elem.amount * elem.amount * -1 ) );
 
                 // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
                 // Otherwise, divide the damage by X times, depending on damage type

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -326,8 +326,8 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 // costs energy equal to the square of the base damage, before it is reduced, regardless of how much it is reduced.
                 // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 144j.
                 units::energy power_cost = units::from_joule( std::max( -2500, ( elem.amount * elem.amount * -1 ) );
-                // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
-                // Otherwise, divide the damage by X times, depending on damage type
+                                           // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
+                                           // Otherwise, divide the damage by X times, depending on damage type
                 if( elem.type == damage_type::BASH ) {
                     elem.amount = elem.amount > max_absorption ? elem.amount - max_absorption : elem.amount / 2;
                 } else if( elem.type == damage_type::CUT ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
bugfixes "ads uses 10J, not 10kJ"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#60631 intended the cost to be 10 j but misunderstood what "react_cost": 10 meant, that defaults to kJ and not a lower unit of measurement. @Night-Pryanik if I'm wrong on this let me know.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
"_cost": 10 ->"_cost": "10 J"
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Also, I found that the CBM deducted 25kJ no matter how much damage was dealt, and not only that, it also deducted 25kJ per damage type the enemy had! So an attack that did 2 cut damage and 12 bash damage actually took up a whole 50 kJ. If a feral biker shot you with its shotgun, it would deduct 25kJ *per pellet*. Now it is just the ten times the square of the damage in joules, so the aforementioned 2 cut, 12 bash attack would cost a total of 1480j to absorb, being halved. Meanwhile, a 44 damage 5.56 bullet from a CROWS would cost 19360J, being quartered. The energy cost is the base damage of the attack before being reduced.

#### Describe alternatives you've considered
personally I don't like the gameplay that ADS creates because it is a lot of micromanagement turning it on and off in between combats in order to save power, and I'd personally rather increase its trigger cost in exchange for having no upkeep cost but NP didn't want to do that.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Also, it could be good to make the power cost the square of the damage reduction rather than a flat 25kJ, as it is still rather useless if it drains that much power every time a zombie punches you. I can do that also. Edit: did this.
#### Testing
Tested in game, confirmed that it is operational. A secubot shot me with its m16 for 11-12 damage. feral humans threw rocks for up to 6 damage. power cost was correctly deducted per attack, with higher damage attacks incurring exponentially more cost. did not have any errors or weirdness.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
