### PR TITLE
make KitchenMaster use pseudo_water_purifier instead of water_purifier

### DIFF
--- a/data/mods/BlazeIndustries/vehicleparts/blaze_other_parts.json
+++ b/data/mods/BlazeIndustries/vehicleparts/blaze_other_parts.json
@@ -163,7 +163,7 @@
       { "id": "pan" },
       { "id": "chemistry_set", "hotkey": "h" },
       { "id": "electrolysis_kit" },
-      { "id": "water_purifier", "hotkey": "p" }
+      { "id": "pseudo_water_purifier", "hotkey": "p" }
     ],
     "breaks_into": [
       { "item": "steel_lump", "count": [ 9, 18 ] },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Blazeindustries' KitchenMaster uses "water_purifier", because of this it lacks the option to purify water directly from a vehicle's tank.

#### Describe the solution
Making the KitchenMaster use "pseudo_water_purfier" fixes this issue allowing it to purify water from a vehicle's tank.

#### Describe alternatives you've considered
None

#### Testing
Tested the updated KitchenMaster's purifier and it behaves like the FOODCO kitchen buddy's one as expected. No issues found.

