### PR TITLE
Mop up liquids when placing furniture

### DIFF
--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -105,6 +105,7 @@
     "techniques": [ "WBLOCK_1" ],
     "weapon_category": [ "QUARTERSTAVES" ],
     "use_action": [ "MOP" ],
+    "qualities": [ [ "MOP", 1 ] ],
     "flags": [ "MOP" ]
   },
   {
@@ -125,6 +126,7 @@
     "looks_like": "mop",
     "weapon_category": [ "QUARTERSTAVES" ],
     "flags": [ "FRAGILE_MELEE", "MOP" ],
+    "qualities": [ [ "MOP", 1 ] ],
     "use_action": [ "MOP" ]
   },
   {

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -397,5 +397,10 @@
     "type": "tool_quality",
     "id": "CUT_GLASS",
     "name": { "str": "glass cutting" }
+  },
+  {
+    "type": "tool_quality",
+    "id": "MOP",
+    "name": { "str": "mopping" }
   }
 ]

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1078,12 +1078,7 @@ cata::optional<int> deploy_furn_actor::use( Character &p, item &it, bool,
         p.add_msg_if_player( m_info, _( "There is already furniture at that location." ) );
         return cata::nullopt;
     }
-    
-    if( here.mop_spills( tripoint_bub_ms( pnt ) ) ) {
-        p.add_msg_if_player( m_info, _( "You moped up the spill when deploying furniture." ) );
-        p.moves -= 35;
-    }
-    
+    here.mop_spills( tripoint_bub_ms( pnt ) )
     here.furn_set( pnt, furn_type );
     it.spill_contents( pnt );
     p.mod_moves( -to_moves<int>( 2_seconds ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1081,7 +1081,7 @@ cata::optional<int> deploy_furn_actor::use( Character &p, item &it, bool,
     }
     
     if( here.terrain_moppable( tripoint_bub_ms( pnt ) ) ) {
-        if( get_avatar().crafting_inventory().has_quality( qual_MOP ) ){
+        if( get_avatar().crafting_inventory().has_quality( qual_MOP ) ) {
             here.mop_spills( tripoint_bub_ms( pnt ) );
             p.add_msg_if_player( m_info, _( "You moped up the spill when deploying furniture." ) );
             p.moves -= 15;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1078,7 +1078,12 @@ cata::optional<int> deploy_furn_actor::use( Character &p, item &it, bool,
         p.add_msg_if_player( m_info, _( "There is already furniture at that location." ) );
         return cata::nullopt;
     }
-    here.mop_spills( tripoint_bub_ms( pnt ) )
+    
+    if( here.mop_spills( tripoint_bub_ms( pnt ) ) ) {
+        p.add_msg_if_player( m_info, _( "The liquid on the floor slowly evaporates away." ) );
+        p.moves -= 15;
+    }
+    
     here.furn_set( pnt, furn_type );
     it.spill_contents( pnt );
     p.mod_moves( -to_moves<int>( 2_seconds ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -131,6 +131,7 @@ static const proficiency_id proficiency_prof_wound_care( "prof_wound_care" );
 static const proficiency_id proficiency_prof_wound_care_expert( "prof_wound_care_expert" );
 
 static const quality_id qual_DIG( "DIG" );
+static const quality_id qual_MOP( "MOP" );
 
 static const skill_id skill_fabrication( "fabrication" );
 static const skill_id skill_firstaid( "firstaid" );
@@ -1079,9 +1080,15 @@ cata::optional<int> deploy_furn_actor::use( Character &p, item &it, bool,
         return cata::nullopt;
     }
     
-    if( here.mop_spills( tripoint_bub_ms( pnt ) ) ) {
-        p.add_msg_if_player( m_info, _( "The liquid on the floor slowly evaporates away." ) );
-        p.moves -= 15;
+    if( here.terrain_moppable( tripoint_bub_ms( pnt ) ) ) {
+        if( get_avatar().crafting_inventory().has_quality( qual_MOP ) ){
+            here.mop_spills( tripoint_bub_ms( pnt ) );
+            p.add_msg_if_player( m_info, _( "You moped up the spill when deploying furniture." ) );
+            p.moves -= 15;
+        } else {
+            p.add_msg_if_player( m_info, _( "You need a mop to clean up liquids before deploying furniture." ) );
+            return cata::nullopt;
+        }
     }
     
     here.furn_set( pnt, furn_type );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1083,7 +1083,7 @@ cata::optional<int> deploy_furn_actor::use( Character &p, item &it, bool,
     if( here.terrain_moppable( tripoint_bub_ms( pnt ) ) ) {
         if( get_avatar().crafting_inventory().has_quality( qual_MOP ) ) {
             here.mop_spills( tripoint_bub_ms( pnt ) );
-            p.add_msg_if_player( m_info, _( "You moped up the spill when deploying furniture." ) );
+            p.add_msg_if_player( m_info, _( "You mopped up the spill when deploying furniture." ) );
             p.moves -= 15;
         } else {
             p.add_msg_if_player( m_info,

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1079,18 +1079,19 @@ cata::optional<int> deploy_furn_actor::use( Character &p, item &it, bool,
         p.add_msg_if_player( m_info, _( "There is already furniture at that location." ) );
         return cata::nullopt;
     }
-    
+
     if( here.terrain_moppable( tripoint_bub_ms( pnt ) ) ) {
         if( get_avatar().crafting_inventory().has_quality( qual_MOP ) ) {
             here.mop_spills( tripoint_bub_ms( pnt ) );
             p.add_msg_if_player( m_info, _( "You moped up the spill when deploying furniture." ) );
             p.moves -= 15;
         } else {
-            p.add_msg_if_player( m_info, _( "You need a mop to clean up liquids before deploying furniture." ) );
+            p.add_msg_if_player( m_info,
+                                _( "You need a mop to clean up liquids before deploying furniture." ) );
             return cata::nullopt;
         }
     }
-    
+
     here.furn_set( pnt, furn_type );
     it.spill_contents( pnt );
     p.mod_moves( -to_moves<int>( 2_seconds ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1078,10 +1078,12 @@ cata::optional<int> deploy_furn_actor::use( Character &p, item &it, bool,
         p.add_msg_if_player( m_info, _( "There is already furniture at that location." ) );
         return cata::nullopt;
     }
-    if( here.has_items( pnt ) ) {
-        p.add_msg_if_player( m_info, _( "Before deploying furniture, you need to clear the tile." ) );
-        return cata::nullopt;
+    
+    if( here.mop_spills( tripoint_bub_ms( pnt ) ) ) {
+        p.add_msg_if_player( m_info, _( "You moped up the spill when deploying furniture." ) );
+        p.moves -= 35;
     }
+    
     here.furn_set( pnt, furn_type );
     it.spill_contents( pnt );
     p.mod_moves( -to_moves<int>( 2_seconds ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1087,7 +1087,7 @@ cata::optional<int> deploy_furn_actor::use( Character &p, item &it, bool,
             p.moves -= 15;
         } else {
             p.add_msg_if_player( m_info,
-                                _( "You need a mop to clean up liquids before deploying furniture." ) );
+                                 _( "You need a mop to clean up liquids before deploying furniture." ) );
             return cata::nullopt;
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

Features "Mop up liquids when deploying furniture instead of interrupting the placement of furniture."

#### Purpose of change

The method of https://github.com/CleverRaven/Cataclysm-DDA/pull/53724 (checking for items on tiles when placing furniture) is simple and effective, but I feel that the detection is too broad and rough, and breaks some existing or future gameplay mechanics that will be implemented, such as simple item hiding (to avoid NPCs taking supplies at will), or using the planting system to simulate regular output actions such as beekeeping, composting or other no-agricultural actions(which would have to be directly masked by the deploy_furniture function to avoid letting the player get the seeds), etc.

Secondly, in reality, quite a lot of furniture is placed without damaging items on the floor (unless you just smash them down), such as tables, beds (which often have a lot of space near the floor), chairs, etc. However, liquids generally evaporate and disappear, so I chose to make them disappear in the game via the mop_spills() function, without destroying the original PR's target.

In addition, this change will reduce the amount of manipulation required when placing furniture, and we all know that the need for too much manipulation can be a hindrance to the player's play.

#### Describe the solution

~~Use the mop_spills() function instead of the has_items() function for the purpose of checking only liquids and ignoring other items.~~
Use tool_qualities to detect the presence of a mop within a certain range when placing furniture. If there is, the mop is used to remove the liquid from the floor; if not, the player is prompted that a mop is missing.
In order to avoid players stealing NPC items by using cardboard boxes and other furnishable homes, the determination of the ownership of items on the ground has been added. If there are items on the ground that do not belong to the player, it will stop the deployment of furniture and prompt the player.

#### Describe alternatives you've considered

Selective removal of liquid items using the item's liquid flag (a more complex implementation than the above method)

#### Testing

1. Change the code
2. Compiling CDDA with MSYS2
3. Separately place 8 liquid items and other items on the ground
4. Then use the "folded butter churn" to place the furniture on top of all the items separately
5. Use the map function in the debug menu to check if items on the ground have disappeared
6. Eventually all 8 liquid items were found to have disappeared and the other 8 other items were still there

#### Additional context

