### PR TITLE
Add bodypart on-hit effects, unhardcode bleeding / blinding on damage, allow effects to modify limb scores

### DIFF
--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -65,21 +65,21 @@
         "max_duration": 15
       },
       {
-        "id": "staggered",
+        "id": "staggered_character",
         "dmg_type": "bash",
         "dmg_threshold": 5,
         "dmg_scale_increment": 5,
-        "chance": 10,
+        "chance": 20,
         "chance_dmg_scaling": 10,
         "duration": 5,
         "duration_dmg_scaling": 2,
         "max_duration": 15
       },
       {
-        "id": "staggered",
+        "id": "staggered_character",
         "dmg_threshold": 15,
         "dmg_scale_increment": 5,
-        "chance": 10,
+        "chance": 20,
         "chance_dmg_scaling": 10,
         "duration": 5,
         "duration_dmg_scaling": 2,
@@ -323,6 +323,27 @@
         "duration": 60,
         "duration_dmg_scaling": 60,
         "max_duration": 1800
+      },
+      {
+        "id": "staggered_character",
+        "dmg_type": "bash",
+        "dmg_threshold": 5,
+        "dmg_scale_increment": 5,
+        "chance": 20,
+        "chance_dmg_scaling": 10,
+        "duration": 5,
+        "duration_dmg_scaling": 2,
+        "max_duration": 15
+      },
+      {
+        "id": "staggered_character",
+        "dmg_threshold": 10,
+        "dmg_scale_increment": 5,
+        "chance": 20,
+        "chance_dmg_scaling": 10,
+        "duration": 5,
+        "duration_dmg_scaling": 2,
+        "max_duration": 15
       }
     ],
     "sub_parts": [ "arm_shoulder_l", "arm_upper_l", "arm_elbow_l", "arm_lower_l" ]
@@ -384,6 +405,27 @@
         "duration": 60,
         "duration_dmg_scaling": 60,
         "max_duration": 1800
+      },
+      {
+        "id": "staggered_character",
+        "dmg_type": "bash",
+        "dmg_threshold": 5,
+        "dmg_scale_increment": 5,
+        "chance": 20,
+        "chance_dmg_scaling": 10,
+        "duration": 5,
+        "duration_dmg_scaling": 2,
+        "max_duration": 15
+      },
+      {
+        "id": "staggered_character",
+        "dmg_threshold": 10,
+        "dmg_scale_increment": 5,
+        "chance": 20,
+        "chance_dmg_scaling": 10,
+        "duration": 5,
+        "duration_dmg_scaling": 2,
+        "max_duration": 15
       }
     ],
     "sub_parts": [ "arm_shoulder_r", "arm_upper_r", "arm_elbow_r", "arm_lower_r" ]

--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -56,6 +56,15 @@
         "duration_dmg_scaling": 60
       },
       {
+        "id": "winded",
+        "dmg_type": "bash",
+        "dmg_threshold": 10,
+        "dmg_scale_increment": 5,
+        "chance": 10,
+        "chance_dmg_scaling": 2,
+        "max_duration": 15
+      },
+      {
         "id": "staggered",
         "dmg_type": "bash",
         "dmg_threshold": 5,
@@ -67,8 +76,28 @@
         "max_duration": 15
       },
       {
+        "id": "staggered",
+        "dmg_threshold": 15,
+        "dmg_scale_increment": 5,
+        "chance": 10,
+        "chance_dmg_scaling": 10,
+        "duration": 5,
+        "duration_dmg_scaling": 2,
+        "max_duration": 15
+      },
+      {
         "id": "downed",
-        "dmg_threshold": 20,
+        "dmg_type": "bash",
+        "dmg_threshold": 15,
+        "dmg_scale_increment": 10,
+        "chance": 5,
+        "chance_dmg_scaling": 20,
+        "duration": 2,
+        "duration_dmg_scaling": 0.5
+      },
+      {
+        "id": "downed",
+        "dmg_threshold": 25,
         "dmg_scale_increment": 10,
         "chance": 5,
         "chance_dmg_scaling": 20,
@@ -152,6 +181,16 @@
         "dmg_type": "bash",
         "dmg_threshold": 10,
         "dmg_scale_increment": 5,
+        "chance": 10,
+        "chance_dmg_scaling": 10,
+        "duration": 1,
+        "duration_dmg_scaling": 0.5,
+        "max_duration": 4
+      },
+      {
+        "id": "stunned",
+        "dmg_threshold": 30,
+        "dmg_scale_increment": 10,
         "chance": 10,
         "chance_dmg_scaling": 10,
         "duration": 1,
@@ -468,11 +507,29 @@
         "max_duration": 1800
       },
       {
+        "id": "bouldering",
+        "dmg_threshold": 5,
+        "dmg_scale_increment": 3,
+        "chance": 20,
+        "chance_dmg_scaling": 2,
+        "duration": 3,
+        "max_duration": 15
+      },
+      {
         "id": "downed",
         "dmg_type": "bash",
         "dmg_threshold": 10,
         "dmg_scale_increment": 10,
         "chance": 5,
+        "chance_dmg_scaling": 15,
+        "duration": 1,
+        "duration_dmg_scaling": 0.5
+      },
+      {
+        "id": "downed",
+        "dmg_threshold": 25,
+        "dmg_scale_increment": 10,
+        "chance": 15,
         "chance_dmg_scaling": 15,
         "duration": 1,
         "duration_dmg_scaling": 0.5
@@ -543,11 +600,29 @@
         "max_duration": 1800
       },
       {
+        "id": "bouldering",
+        "dmg_threshold": 5,
+        "dmg_scale_increment": 3,
+        "chance": 20,
+        "chance_dmg_scaling": 2,
+        "duration": 3,
+        "max_duration": 15
+      },
+      {
         "id": "downed",
         "dmg_type": "bash",
         "dmg_threshold": 10,
         "dmg_scale_increment": 10,
         "chance": 5,
+        "chance_dmg_scaling": 15,
+        "duration": 1,
+        "duration_dmg_scaling": 0.5
+      },
+      {
+        "id": "downed",
+        "dmg_threshold": 25,
+        "dmg_scale_increment": 10,
+        "chance": 15,
         "chance_dmg_scaling": 15,
         "duration": 1,
         "duration_dmg_scaling": 0.5

--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -29,6 +29,53 @@
     "drench_capacity": 4000,
     "smash_message": "You smash the %s with a powerful shoulder-check.",
     "bionic_slots": 80,
+    "effects_on_hit": [
+      {
+        "id": "bleed",
+        "dmg_type": "cut",
+        "dmg_threshold": 3,
+        "dmg_scale_increment": 2,
+        "duration": 60,
+        "duration_dmg_scaling": 45,
+        "max_duration": 1800
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "stab",
+        "dmg_threshold": 1,
+        "dmg_scale_increment": 1.5,
+        "duration": 60,
+        "duration_dmg_scaling": 60
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "bullet",
+        "dmg_threshold": 1,
+        "dmg_scale_increment": 1,
+        "duration": 60,
+        "duration_dmg_scaling": 60
+      },
+      {
+        "id": "staggered",
+        "dmg_type": "bash",
+        "dmg_threshold": 5,
+        "dmg_scale_increment": 5,
+        "chance": 10,
+        "chance_dmg_scaling": 10,
+        "duration": 5,
+        "duration_dmg_scaling": 2,
+        "max_duration": 15
+      },
+      {
+        "id": "downed",
+        "dmg_threshold": 20,
+        "dmg_scale_increment": 10,
+        "chance": 5,
+        "chance_dmg_scaling": 20,
+        "duration": 2,
+        "duration_dmg_scaling": 0.5
+      }
+    ],
     "sub_parts": [ "torso_upper", "torso_neck", "torso_lower", "torso_hanging_front", "torso_hanging_back", "torso_waist" ]
   },
   {
@@ -72,6 +119,45 @@
       { "weight": "2200 g", "encumbrance": 50 },
       { "weight": "5600 g", "encumbrance": 80 },
       { "weight": "10000 g", "encumbrance": 160 }
+    ],
+    "effects_on_hit": [
+      {
+        "id": "bleed",
+        "dmg_type": "cut",
+        "dmg_threshold": 5,
+        "dmg_scale_increment": 2,
+        "duration": 60,
+        "duration_dmg_scaling": 30,
+        "max_duration": 960
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "stab",
+        "dmg_threshold": 1,
+        "dmg_scale_increment": 1.5,
+        "duration": 60,
+        "duration_dmg_scaling": 60,
+        "max_duration": 1200
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "bullet",
+        "dmg_threshold": 1,
+        "dmg_scale_increment": 1,
+        "duration": 60,
+        "duration_dmg_scaling": 60
+      },
+      {
+        "id": "stunned",
+        "dmg_type": "bash",
+        "dmg_threshold": 10,
+        "dmg_scale_increment": 5,
+        "chance": 10,
+        "chance_dmg_scaling": 10,
+        "duration": 1,
+        "duration_dmg_scaling": 0.5,
+        "max_duration": 4
+      }
     ]
   },
   {
@@ -99,7 +185,18 @@
     "smash_message": "You use your flippin' face to smash the %s.  EXTREME.",
     "smash_efficiency": 0.25,
     "bionic_slots": 4,
-    "sub_parts": [ "eyes_left", "eyes_right" ]
+    "sub_parts": [ "eyes_left", "eyes_right" ],
+    "effects_on_hit": [
+      {
+        "id": "blind",
+        "dmg_threshold": 3,
+        "dmg_scale_increment": 3,
+        "chance": 50,
+        "chance_dmg_scaling": 5,
+        "duration": 1,
+        "duration_dmg_scaling": 0.5
+      }
+    ]
   },
   {
     "id": "mouth",
@@ -160,6 +257,35 @@
     "drench_capacity": 1000,
     "smash_message": "You elbow-smash the %s.",
     "bionic_slots": 20,
+    "effects_on_hit": [
+      {
+        "id": "bleed",
+        "dmg_type": "cut",
+        "dmg_threshold": 5,
+        "dmg_scale_increment": 2,
+        "duration": 60,
+        "duration_dmg_scaling": 30,
+        "max_duration": 1500
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "stab",
+        "dmg_threshold": 3,
+        "dmg_scale_increment": 2,
+        "duration": 60,
+        "duration_dmg_scaling": 60,
+        "max_duration": 1800
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "bullet",
+        "dmg_threshold": 3,
+        "dmg_scale_increment": 1,
+        "duration": 60,
+        "duration_dmg_scaling": 60,
+        "max_duration": 1800
+      }
+    ],
     "sub_parts": [ "arm_shoulder_l", "arm_upper_l", "arm_elbow_l", "arm_lower_l" ]
   },
   {
@@ -192,6 +318,35 @@
     "drench_capacity": 1000,
     "smash_message": "You elbow-smash the %s.",
     "bionic_slots": 20,
+    "effects_on_hit": [
+      {
+        "id": "bleed",
+        "dmg_type": "cut",
+        "dmg_threshold": 5,
+        "dmg_scale_increment": 2,
+        "duration": 60,
+        "duration_dmg_scaling": 30,
+        "max_duration": 1500
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "stab",
+        "dmg_threshold": 3,
+        "dmg_scale_increment": 2,
+        "duration": 60,
+        "duration_dmg_scaling": 60,
+        "max_duration": 1800
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "bullet",
+        "dmg_threshold": 3,
+        "dmg_scale_increment": 1,
+        "duration": 60,
+        "duration_dmg_scaling": 60,
+        "max_duration": 1800
+      }
+    ],
     "sub_parts": [ "arm_shoulder_r", "arm_upper_r", "arm_elbow_r", "arm_lower_r" ]
   },
   {
@@ -284,6 +439,45 @@
     "drench_capacity": 1100,
     "smash_message": "You bring your knee down on the %s, smashing it.",
     "bionic_slots": 30,
+    "effects_on_hit": [
+      {
+        "id": "bleed",
+        "dmg_type": "cut",
+        "dmg_threshold": 5,
+        "dmg_scale_increment": 2.5,
+        "duration": 60,
+        "duration_dmg_scaling": 45,
+        "max_duration": 1800
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "stab",
+        "dmg_threshold": 3,
+        "dmg_scale_increment": 2,
+        "duration": 60,
+        "duration_dmg_scaling": 60,
+        "max_duration": 1800
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "bullet",
+        "dmg_threshold": 3,
+        "dmg_scale_increment": 2,
+        "duration": 60,
+        "duration_dmg_scaling": 60,
+        "max_duration": 1800
+      },
+      {
+        "id": "downed",
+        "dmg_type": "bash",
+        "dmg_threshold": 10,
+        "dmg_scale_increment": 10,
+        "chance": 5,
+        "chance_dmg_scaling": 15,
+        "duration": 1,
+        "duration_dmg_scaling": 0.5
+      }
+    ],
     "sub_parts": [ "leg_hip_l", "leg_upper_l", "leg_knee_l", "leg_lower_l", "leg_draped_l" ],
     "flags": [ "LIMB_LOWER" ]
   },
@@ -320,6 +514,45 @@
     "smash_message": "You bring your knee down on the %s, smashing it.",
     "bionic_slots": 30,
     "sub_parts": [ "leg_hip_r", "leg_upper_r", "leg_knee_r", "leg_lower_r", "leg_draped_r" ],
+    "effects_on_hit": [
+      {
+        "id": "bleed",
+        "dmg_type": "cut",
+        "dmg_threshold": 5,
+        "dmg_scale_increment": 2.5,
+        "duration": 60,
+        "duration_dmg_scaling": 45,
+        "max_duration": 1800
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "stab",
+        "dmg_threshold": 3,
+        "dmg_scale_increment": 2,
+        "duration": 60,
+        "duration_dmg_scaling": 60,
+        "max_duration": 1800
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "bullet",
+        "dmg_threshold": 3,
+        "dmg_scale_increment": 2,
+        "duration": 60,
+        "duration_dmg_scaling": 60,
+        "max_duration": 1800
+      },
+      {
+        "id": "downed",
+        "dmg_type": "bash",
+        "dmg_threshold": 10,
+        "dmg_scale_increment": 10,
+        "chance": 5,
+        "chance_dmg_scaling": 15,
+        "duration": 1,
+        "duration_dmg_scaling": 0.5
+      }
+    ],
     "flags": [ "LIMB_LOWER" ]
   },
   {

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -605,6 +605,17 @@
   },
   {
     "type": "effect_type",
+    "id": "staggered_character",
+    "name": [ "Staggered" ],
+    "desc": [ "You've been knocked off-balance by an attack." ],
+    "apply_message": "You're staggered off-balance.",
+    "rating": "bad",
+    "limb_score_mods": [ { "limb_score": "balance", "modifier": 0.8 }, { "limb_score": "reaction", "modifier": 0.8 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ],
+    "show_in_info": true
+  },
+  {
+    "type": "effect_type",
     "id": "poison",
     "name": [ "Poisoned" ],
     "desc": [ "You have been poisoned!" ],

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -395,7 +395,22 @@
     "rating": "bad",
     "resist_traits": [ "GASTROPOD_FOOT" ],
     "show_in_info": true,
-    "flags": [ "DISABLE_FLIGHT" ]
+    "flags": [ "DISABLE_FLIGHT", "EFFECT_LIMB_SCORE_MOD" ],
+    "limb_score_mods": [
+      {
+        "limb_score": "balance",
+        "modifier": 0.1,
+        "resist_modifier": 0.8
+      },
+      {
+        "limb_score": "reaction",
+        "modifier": 0.5
+      },
+      {
+        "limb_score": "blocking",
+        "modifier": 0.5
+      }
+    ]
   },
   {
     "type": "effect_type",
@@ -440,7 +455,30 @@
       "pain_min": [ 1 ],
       "pain_chance": [ 1 ],
       "pain_max_val": [ 20 ]
-    }
+    },
+    "limb_score_mods": [
+      {
+        "limb_score": "reaction",
+        "modifier": 0.5
+      },
+      {
+        "limb_score": "lift",
+        "modifier": 0.75
+      },
+      {
+        "limb_score": "blocking",
+        "modifier": 0.75
+      },
+      {
+        "limb_score": "manip",
+        "modifier": 0.5
+      },
+      {
+        "limb_score": "swim",
+        "modifier": 0.3
+      }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -2216,7 +2254,8 @@
       "pkill_max_val": [ 30 ],
       "stamina_chance": [ 2 ],
       "stamina_min": [ -2 ]
-    }
+    },
+    "flags": [ "EFFECT_LIMB_SCORE_MOD_LOCAL" ]
   },
   {
     "type": "effect_type",
@@ -2656,7 +2695,15 @@
       "sleep_chance": [ 501 ],
       "pkill_max_val": [ 10 ],
       "pkill_tick": [ -10 ]
-    }
+    },
+    "limb_score_mods": [
+      {
+        "limb_score": "night_vis",
+        "modifier": 3.0,
+        "scaling": 1.0
+      }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD"]
   },
   {
     "type": "effect_type",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -463,7 +463,7 @@
     "rating": "bad",
     "resist_traits": [ "PER_SLIME_OK" ],
     "limb_score_mods": [
-      { "limb_score": "vision", "modifier": 0.0, "resist_modifier": 1.0 },
+      { "limb_score": "vision", "modifier": 0.5, "resist_modifier": 1.0 },
       { "limb_score": "night_vis", "modifier": 0.1, "resist_modifier": 1.0 }
     ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
@@ -3066,7 +3066,7 @@
       { "limb_score": "block", "modifier": 0.7, "scaling": -0.1 },
       { "limb_score": "breathing", "modifier": 0.8, "scaling": -0.1 },
       { "limb_score": "reaction", "modifier": 0.9, "scaling": -0.1 },
-      { "limb_score": "balance", "modifier": 0.75, "scaling": -0.05 },
+      { "limb_score": "balance", "modifier": 0.655, "scaling": -0.07 },
       { "limb_score": "swim", "modifier": 0.8, "scaling": -0.2 }
     ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ]

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -539,7 +539,7 @@
     "apply_message": "You try to keep your balance.",
     "resist_traits": [ "GASTROPOD_BALANCE" ],
     "rating": "bad",
-    "limb_score_mods": [ { "limb_score": "balance", "modifier": 0.75 }, { "limb_score": "footing", "modifier": 0.2 } ],
+    "limb_score_mods": [ { "limb_score": "balance", "modifier": 0.75 }, { "limb_score": "footing", "modifier": 0.4 } ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -397,19 +397,9 @@
     "show_in_info": true,
     "flags": [ "DISABLE_FLIGHT", "EFFECT_LIMB_SCORE_MOD" ],
     "limb_score_mods": [
-      {
-        "limb_score": "balance",
-        "modifier": 0.1,
-        "resist_modifier": 0.8
-      },
-      {
-        "limb_score": "reaction",
-        "modifier": 0.5
-      },
-      {
-        "limb_score": "blocking",
-        "modifier": 0.5
-      }
+      { "limb_score": "balance", "modifier": 0.1, "resist_modifier": 0.8 },
+      { "limb_score": "reaction", "modifier": 0.5 },
+      { "limb_score": "block", "modifier": 0.5 }
     ]
   },
   {
@@ -457,26 +447,11 @@
       "pain_max_val": [ 20 ]
     },
     "limb_score_mods": [
-      {
-        "limb_score": "reaction",
-        "modifier": 0.5
-      },
-      {
-        "limb_score": "lift",
-        "modifier": 0.75
-      },
-      {
-        "limb_score": "blocking",
-        "modifier": 0.75
-      },
-      {
-        "limb_score": "manip",
-        "modifier": 0.5
-      },
-      {
-        "limb_score": "swim",
-        "modifier": 0.3
-      }
+      { "limb_score": "reaction", "modifier": 0.5 },
+      { "limb_score": "lift", "modifier": 0.75 },
+      { "limb_score": "block", "modifier": 0.75 },
+      { "limb_score": "manip", "modifier": 0.5 },
+      { "limb_score": "swim", "modifier": 0.3 }
     ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
@@ -485,7 +460,13 @@
     "id": "darkness",
     "apply_message": "Your vision flickers and goes gray!",
     "remove_message": "The world flickers back to normality.",
-    "rating": "bad"
+    "rating": "bad",
+    "resist_traits": [ "PER_SLIME_OK" ],
+    "limb_score_mods": [
+      { "limb_score": "vision", "modifier": 0.0, "resist_modifier": 1.0 },
+      { "limb_score": "night_vis", "modifier": 0.1, "resist_modifier": 1.0 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -495,7 +476,8 @@
     "apply_message": "You're stunned!",
     "rating": "bad",
     "show_in_info": true,
-    "flags": [ "DISABLE_FLIGHT" ]
+    "limb_score_mods": [ { "limb_score": "balance", "modifier": 0.2 }, { "limb_score": "reaction", "modifier": 0.0 } ],
+    "flags": [ "DISABLE_FLIGHT", "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -516,9 +498,14 @@
     "max_intensity": 10,
     "max_duration": "10 m",
     "int_add_val": 2,
-    "base_mods": { "per_mod": [ -5 ], "dex_mod": [ -2 ] },
     "scaling_mods": { "speed_mod": [ -3 ] },
-    "show_in_info": true
+    "show_in_info": true,
+    "limb_score_mods": [
+      { "limb_score": "balance", "modifier": 0.5 },
+      { "limb_score": "reaction", "modifier": 0.35 },
+      { "limb_score": "vision", "modifier": 0.75 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -526,7 +513,9 @@
     "name": [ "Riding" ],
     "desc": [ "You are riding an animal." ],
     "apply_message": "You mount your steed.",
-    "rating": "good"
+    "rating": "good",
+    "limb_score_mods": [ { "limb_score": "balance", "modifier": 0.8 }, { "limb_score": "reaction", "modifier": 0.75 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -549,7 +538,9 @@
     "desc": [ "Your footing is unstable.  It's more difficult to fight while standing here." ],
     "apply_message": "You try to keep your balance.",
     "resist_traits": [ "GASTROPOD_BALANCE" ],
-    "rating": "bad"
+    "rating": "bad",
+    "limb_score_mods": [ { "limb_score": "balance", "modifier": 0.75 }, { "limb_score": "footing", "modifier": 0.2 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -561,14 +552,21 @@
     "remove_message": "Your sight returns!",
     "rating": "bad",
     "show_in_info": true,
-    "flags": [ "BLIND" ]
+    "limb_score_mods": [
+      { "limb_score": "vision", "modifier": 0.0 },
+      { "limb_score": "night_vis", "modifier": 0.0 },
+      { "limb_score": "reaction", "modifier": 0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD", "BLIND" ]
   },
   {
     "type": "effect_type",
     "id": "earphones",
     "name": [ "Wearing Earphones" ],
     "desc": [ "You are wearing earphones and can't hear much from outside world." ],
-    "rating": "bad"
+    "rating": "bad",
+    "limb_score_mods": [ { "limb_score": "reaction", "modifier": 0.9 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -585,7 +583,9 @@
     "max_intensity": 3,
     "int_dur_factor": "100 s",
     "base_mods": { "pain_min": [ 1 ], "pain_chance": [ -50 ], "pain_chance_bot": [ 1000 ] },
-    "scaling_mods": { "pain_max_val": [ 5 ], "pain_chance": [ 150 ] }
+    "scaling_mods": { "pain_max_val": [ 5 ], "pain_chance": [ 150 ] },
+    "limb_score_mods": [ { "limb_score": "reaction", "modifier": 0.9, "scaling": -0.2 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -676,6 +676,8 @@
       "cough_chance": [ 10 ]
     },
     "show_in_info": true,
+    "limb_score_mods": [ { "limb_score": "breathing", "modifier": 0.6 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ],
     "blood_analysis_description": "Unknown Organic Toxin"
   },
   {
@@ -745,7 +747,16 @@
       "stamina_min": [ -0.351, -0.151 ],
       "stamina_chance": [ -0.021, -0.051 ],
       "speed_mod": [ -0.31, -0.21 ]
-    }
+    },
+    "limb_score_mods": [
+      { "limb_score": "manip", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "lift", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "grip", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "block", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "reaction", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.025 },
+      { "limb_score": "balance", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -765,7 +776,13 @@
     "int_decay_remove": true,
     "resist_traits": [ "ELFA_NV" ],
     "base_mods": { "per_mod": [ -3, 0 ] },
-    "scaling_mods": { "per_mod": [ -2, -1 ] }
+    "scaling_mods": { "per_mod": [ -2, -1 ] },
+    "limb_score_mods": [
+      { "limb_score": "vision", "modifier": 0.75, "resist_modifier": 1.0, "scaling": -0.25, "resist_scaling": -0.1 },
+      { "limb_score": "night_vis", "modifier": 1.0, "resist_modifier": 1.0, "scaling": 0.0, "resist_scaling": 0.0 },
+      { "limb_score": "reaction", "modifier": 1.0, "resist_modifier": 1.0, "scaling": 0.0, "resist_scaling": 0.0 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD_LOCAL" ]
   },
   {
     "type": "effect_type",
@@ -836,6 +853,37 @@
     "int_decay_tick": 600,
     "base_mods": { "dex_mod": [ -0.34, -0.17 ], "speed_mod": [ -5, -3 ] },
     "scaling_mods": { "dex_mod": [ -0.34, -0.17 ], "speed_mod": [ -5, -3 ] },
+    "limb_score_mods": [
+      {
+        "//": "Worse for fine manipulation than large movements",
+        "limb_score": "manip",
+        "modifier": 0.8,
+        "resist_modifier": 1.0,
+        "scaling": -0.1,
+        "resist_scaling": -0.025
+      },
+      { "limb_score": "lift", "modifier": 0.9, "resist_modifier": 1.0, "scaling": -0.05, "resist_scaling": -0.00125 },
+      { "limb_score": "grip", "modifier": 0.8, "resist_modifier": 1.0, "scaling": -0.1, "resist_scaling": -0.025 },
+      { "limb_score": "block", "modifier": 0.9, "resist_modifier": 1.0, "scaling": -0.05, "resist_scaling": -0.00125 },
+      {
+        "limb_score": "breathing",
+        "modifier": 0.9,
+        "resist_modifier": 1.0,
+        "scaling": -0.05,
+        "resist_scaling": -0.00125
+      },
+      {
+        "limb_score": "move_speed",
+        "modifier": 0.9,
+        "resist_modifier": 1.0,
+        "scaling": -0.05,
+        "resist_scaling": -0.00125
+      },
+      { "limb_score": "balance", "modifier": 0.8, "resist_modifier": 1.0, "scaling": -0.1, "resist_scaling": -0.025 },
+      { "limb_score": "swim", "modifier": 0.9, "resist_modifier": 1.0, "scaling": -0.05, "resist_scaling": -0.00125 },
+      { "limb_score": "crawl", "modifier": 0.9, "resist_modifier": 1.0, "scaling": -0.05, "resist_scaling": -0.00125 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ],
     "show_in_info": true,
     "blood_analysis_description": "Paralyzing Poison"
   },
@@ -1641,7 +1689,14 @@
     "desc": [ "The sun is in your eyes." ],
     "apply_message": "The sunlight's glare makes it hard to see.",
     "rating": "bad",
-    "base_mods": { "per_mod": [ -1 ] }
+    "base_mods": { "per_mod": [ -1 ] },
+    "//": "No night vision for you",
+    "limb_score_mods": [
+      { "limb_score": "vision", "modifier": 0.5 },
+      { "limb_score": "night_vis", "modifier": 0.0 },
+      { "limb_score": "reaction", "modifier": 0.75 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD_LOCAL" ]
   },
   {
     "type": "effect_type",
@@ -1650,7 +1705,13 @@
     "desc": [ "The sunlight is reflecting off the snow." ],
     "apply_message": "The sunlight reflecting off the snow makes it hard to see.",
     "rating": "bad",
-    "base_mods": { "per_mod": [ -1 ] }
+    "base_mods": { "per_mod": [ -1 ] },
+    "limb_score_mods": [
+      { "limb_score": "vision", "modifier": 0.5 },
+      { "limb_score": "night_vis", "modifier": 0.0 },
+      { "limb_score": "reaction", "modifier": 0.75 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD_LOCAL" ]
   },
   {
     "type": "effect_type",
@@ -1692,6 +1753,13 @@
     "harmful_cough": true,
     "max_duration": "30 m",
     "base_mods": { "str_mod": [ -2 ], "dex_mod": [ -2 ], "per_mod": [ -5 ], "speed_mod": [ -10 ], "cough_chance": [ 5 ] },
+    "limb_score_mods": [
+      { "limb_score": "vision", "modifier": 0.5 },
+      { "limb_score": "night_vis", "modifier": 0.5 },
+      { "limb_score": "reaction", "modifier": 0.75 },
+      { "limb_score": "breathing", "modifier": 0.3 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ],
     "show_in_info": true
   },
   {
@@ -1701,7 +1769,13 @@
     "desc": [ "Range of Sight: 1; You are covered in magenta bile!" ],
     "apply_message": "You're covered in bile!",
     "rating": "bad",
-    "base_mods": { "per_mod": [ -3 ], "vomit_chance": [ 500 ] }
+    "base_mods": { "per_mod": [ -3 ], "vomit_chance": [ 500 ] },
+    "limb_score_mods": [
+      { "limb_score": "vision", "modifier": 0.1 },
+      { "limb_score": "night_vis", "modifier": 0.0 },
+      { "limb_score": "reaction", "modifier": 0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -1797,7 +1871,13 @@
     "name": [ "Poor Sight" ],
     "desc": [ "You can't see very far from this spot." ],
     "apply_message": "Your sight distance is impaired.",
-    "rating": "bad"
+    "rating": "bad",
+    "limb_score_mods": [
+      { "limb_score": "vision", "modifier": 0.1 },
+      { "limb_score": "night_vis", "modifier": 0.0 },
+      { "limb_score": "reaction", "modifier": 0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -1859,6 +1939,13 @@
     "int_add_val": 1,
     "base_mods": { "speed_mod": [ -20 ] },
     "scaling_mods": { "speed_mod": [ -5 ] },
+    "limb_score_mods": [
+      { "limb_score": "lift", "modifier": 0.8, "scaling": -0.15 },
+      { "limb_score": "block", "modifier": 0.8, "scaling": -0.15 },
+      { "limb_score": "breathing", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "balance", "modifier": 8, "scaling": -0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ],
     "show_in_info": true,
     "show_intensity": false
   },
@@ -1871,6 +1958,12 @@
     "rating": "bad",
     "miss_messages": [ [ "The sludge restricts your movement.", 4 ] ],
     "max_intensity": 3,
+    "limb_score_mods": [
+      { "limb_score": "move_speed", "modifier": 0.8, "scaling": -0.15 },
+      { "limb_score": "footing", "modifier": 0.8, "scaling": -0.15 },
+      { "limb_score": "balance", "modifier": 8, "scaling": -0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ],
     "show_in_info": true
   },
   {
@@ -2059,7 +2152,14 @@
     "int_add_val": 1,
     "int_dur_factor": "5 m",
     "base_mods": { "speed_mod": [ -20 ], "str_mod": [ 0 ], "dex_mod": [ -1 ], "per_mod": [ -2 ], "vomit_chance": [ 20 ] },
-    "scaling_mods": { "speed_mod": [ -10 ], "int_mod": [ -2 ], "str_mod": [ -1 ], "dex_mod": [ -1 ], "per_mod": [ -2 ] }
+    "scaling_mods": { "speed_mod": [ -10 ], "int_mod": [ -2 ], "str_mod": [ -1 ], "dex_mod": [ -1 ], "per_mod": [ -2 ] },
+    "limb_score_mods": [
+      { "limb_score": "reaction", "modifier": 0.8, "scaling": -0.2 },
+      { "limb_score": "block", "modifier": 0.8, "scaling": -0.2 },
+      { "limb_score": "vision", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "night_vis", "modifier": 0.9, "scaling": -0.1 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -2072,6 +2172,11 @@
     "desc": [ "You can't trust everything that you see." ],
     "rating": "bad",
     "base_mods": { "int_mod": [ -2 ], "dex_mod": [ -1 ], "per_mod": [ -4 ] },
+    "limb_score_mods": [
+      { "limb_score": "reaction", "modifier": 0.8, "scaling": -0.2 },
+      { "limb_score": "block", "modifier": 0.8, "scaling": -0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ],
     "blood_analysis_description": "Hallucinations"
   },
   {
@@ -2106,7 +2211,14 @@
     "miss_messages": [ [ "You tremble.", 4 ] ],
     "base_mods": { "str_mod": [ -1 ], "dex_mod": [ -4 ] },
     "max_duration": 7200,
-    "dur_add_perc": 30
+    "dur_add_perc": 30,
+    "limb_score_mods": [
+      { "limb_score": "reaction", "modifier": 0.7 },
+      { "limb_score": "block", "modifier": 0.5 },
+      { "limb_score": "balance", "modifier": 0.75 },
+      { "limb_score": "footing", "modifier": 0.75 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -2117,7 +2229,15 @@
     "remove_message": "You regain control of your muscles!",
     "desc": [ "Your muscles have seized up, and you can't control them!" ],
     "miss_messages": [ [ "Your muscles won't cooperate!", 20 ] ],
-    "base_mods": { "str_mod": [ -12 ], "dex_mod": [ -20 ] }
+    "base_mods": { "str_mod": [ -12 ], "dex_mod": [ -20 ] },
+    "limb_score_mods": [
+      { "limb_score": "reaction", "modifier": 0.2 },
+      { "limb_score": "block", "modifier": 0 },
+      { "limb_score": "balance", "modifier": 0.2 },
+      { "limb_score": "footing", "modifier": 0.2 },
+      { "limb_score": "crawl", "modifier": 0 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -2226,13 +2346,25 @@
     "rating": "bad",
     "miss_messages": [ [ "This goo makes you slip", 2 ] ],
     "base_mods": { "dex_mod": [ -2 ], "speed_mod": [ -25 ], "vomit_chance": [ 2100 ] },
-    "show_in_info": true
+    "show_in_info": true,
+    "limb_score_mods": [
+      { "limb_score": "lift", "modifier": 0.8, "scaling": -0.15 },
+      { "limb_score": "block", "modifier": 0.8, "scaling": -0.15 },
+      { "limb_score": "breathing", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "balance", "modifier": 8, "scaling": -0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
     "id": "hallu",
     "max_duration": "6 h",
-    "blood_analysis_description": "Hallucinations"
+    "blood_analysis_description": "Hallucinations",
+    "limb_score_mods": [
+      { "limb_score": "reaction", "modifier": 0.8, "scaling": -0.2 },
+      { "limb_score": "block", "modifier": 0.8, "scaling": -0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -2255,6 +2387,14 @@
       "stamina_chance": [ 2 ],
       "stamina_min": [ -2 ]
     },
+    "limb_score_mods": [
+      { "limb_score": "manip", "modifier": 0.8, "scaling": -0.2 },
+      { "limb_score": "grip", "modifier": 0.8, "scaling": -0.2 },
+      { "limb_score": "block", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "lift", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "move_speed", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "crawl", "modifier": 0.9, "scaling": -0.1 }
+    ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD_LOCAL" ]
   },
   {
@@ -2325,7 +2465,16 @@
     "speed_name": "Frostbite",
     "dur_add_perc": 0,
     "max_intensity": 2,
-    "scaling_mods": { "speed_mod": [ -5 ] }
+    "scaling_mods": { "speed_mod": [ -5 ] },
+    "limb_score_mods": [
+      { "limb_score": "manip", "modifier": 0 },
+      { "limb_score": "grip", "modifier": 0 },
+      { "limb_score": "block", "modifier": 0.5, "scaling": -0.25 },
+      { "limb_score": "lift", "modifier": 0.5, "scaling": -0.25 },
+      { "limb_score": "move_speed", "modifier": 0.75, "scaling": -0.25 },
+      { "limb_score": "crawl", "modifier": 0.75, "scaling": -0.25 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD_LOCAL" ]
   },
   {
     "type": "effect_type",
@@ -2379,7 +2528,14 @@
     "apply_message": "You're coated in sap!",
     "rating": "bad",
     "miss_messages": [ [ "The sap's too sticky for you to fight effectively.", 3 ] ],
-    "base_mods": { "speed_mod": [ -25 ], "dex_mod": [ -3 ] }
+    "base_mods": { "speed_mod": [ -25 ], "dex_mod": [ -3 ] },
+    "limb_score_mods": [
+      { "limb_score": "lift", "modifier": 0.8, "scaling": -0.15 },
+      { "limb_score": "block", "modifier": 0.8, "scaling": -0.15 },
+      { "limb_score": "breathing", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "balance", "modifier": 8, "scaling": -0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -2697,13 +2853,16 @@
       "pkill_tick": [ -10 ]
     },
     "limb_score_mods": [
-      {
-        "limb_score": "night_vis",
-        "modifier": 3.0,
-        "scaling": 1.0
-      }
+      { "limb_score": "manip", "modifier": 0.9, "scaling": -0.2 },
+      { "limb_score": "block", "modifier": 1.0, "scaling": -0.1 },
+      { "limb_score": "vision", "modifier": 1.0, "scaling": -0.05 },
+      { "limb_score": "reaction", "modifier": 0.9, "scaling": -0.2 },
+      { "limb_score": "move_speed", "modifier": 1.0, "scaling": -0.05 },
+      { "limb_score": "balance", "modifier": 0.9, "scaling": -0.2 },
+      { "limb_score": "footing", "modifier": 0.8, "scaling": -0.2 },
+      { "limb_score": "swim", "modifier": 1.0, "scaling": -0.2 }
     ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD"]
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -2732,7 +2891,20 @@
     "int_dur_factor": "200 s",
     "miss_messages": [ [ "You're winded.", 3 ] ],
     "base_mods": { "str_mod": [ -2 ], "dex_mod": [ -3 ], "speed_mod": [ -20 ] },
-    "scaling_mods": { "speed_mod": [ -40 ] }
+    "scaling_mods": { "speed_mod": [ -40 ] },
+    "limb_score_mods": [
+      { "limb_score": "manip", "modifier": 0.9, "scaling": -0.25 },
+      { "limb_score": "lift", "modifier": 0.9, "scaling": -0.2 },
+      { "limb_score": "grip", "modifier": 1.0, "scaling": -0.2 },
+      { "limb_score": "block", "modifier": 1.0, "scaling": -0.2 },
+      { "limb_score": "breathing", "modifier": 0.8, "scaling": -0.1 },
+      { "limb_score": "reaction", "modifier": 1.0, "scaling": -0.2 },
+      { "limb_score": "move_speed", "modifier": 1.0, "scaling": -0.1 },
+      { "limb_score": "balance", "modifier": 1.0, "scaling": -0.1 },
+      { "limb_score": "swim", "modifier": 0.75, "scaling": -0.25 },
+      { "limb_score": "crawl", "modifier": 0.9, "scaling": -0.1 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -2774,7 +2946,13 @@
     "apply_message": "You inhale sweetish gas.",
     "remove_message": "The slackness leaves your muscles.",
     "rating": "bad",
-    "base_mods": { "str_mod": [ -3 ], "dex_mod": [ -3 ], "int_mod": [ -2 ], "per_mod": [ -4 ] }
+    "base_mods": { "str_mod": [ -3 ], "dex_mod": [ -3 ], "int_mod": [ -2 ], "per_mod": [ -4 ] },
+    "limb_score_mods": [
+      { "limb_score": "reaction", "modifier": 0.5 },
+      { "limb_score": "move_speed", "modifier": 0.75 },
+      { "limb_score": "balance", "modifier": 0.75 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -2868,7 +3046,19 @@
     "max_intensity": 15,
     "base_mods": { "speed_mod": [ -15 ] },
     "scaling_mods": { "speed_mod": [ -5 ] },
-    "show_in_info": true
+    "show_in_info": true,
+    "show_intensity": true,
+    "//": "Monster attacks only grab the torso to keep the intensity check consistent, but assume limbs getting grabbed as well",
+    "limb_score_mods": [
+      { "limb_score": "manip", "modifier": 0.8, "scaling": -0.05 },
+      { "limb_score": "lift", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "block", "modifier": 0.7, "scaling": -0.1 },
+      { "limb_score": "breathing", "modifier": 0.8, "scaling": -0.1 },
+      { "limb_score": "reaction", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "balance", "modifier": 0.75, "scaling": -0.05 },
+      { "limb_score": "swim", "modifier": 0.8, "scaling": -0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",
@@ -2968,7 +3158,17 @@
     "max_duration": "2 s",
     "dur_add_perc": 20,
     "base_mods": { "speed_mod": [ -1000 ], "dex_mod": [ -100 ] },
-    "show_in_info": true
+    "show_in_info": true,
+    "limb_score_mods": [
+      { "limb_score": "manip", "modifier": 0.8, "scaling": -0.05 },
+      { "limb_score": "lift", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "block", "modifier": 0.7, "scaling": -0.1 },
+      { "limb_score": "breathing", "modifier": 0.8, "scaling": -0.1 },
+      { "limb_score": "reaction", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "balance", "modifier": 0.75, "scaling": -0.05 },
+      { "limb_score": "swim", "modifier": 0.8, "scaling": -0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",

--- a/data/json/limb_scores.json
+++ b/data/json/limb_scores.json
@@ -90,5 +90,29 @@
     "name": "Crawling",
     "affected_by_wounds": true,
     "affected_by_encumb": true
+  },
+  {
+    "type": "effect_type",
+    "id": "glare_test",
+    "name": [ "Glareeeeee" ],
+    "desc": [ "The sun is in your eyes." ],
+    "apply_message": "The sunlight's glare makes it hard to see.",
+    "rating": "bad",
+    "limb_score_mods": [
+      { "limb_score": "manip", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "lift", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "grip", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "block", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "breathing", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "vision", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "night_vis", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "reaction", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.025 },
+      { "limb_score": "move_speed", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "balance", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "footing", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "swim", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 },
+      { "limb_score": "crawl", "modifier": 1.0, "scaling": -0.01, "resist_scaling": -0.0025 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   }
 ]

--- a/data/json/monster_special_attacks/monster_attacks.json
+++ b/data/json/monster_special_attacks/monster_attacks.json
@@ -59,7 +59,7 @@
     "damage_max_instance": [ { "damage_type": "bash", "amount": 20, "armor_multiplier": 0.3 } ],
     "range": 2,
     "no_adjacent": true,
-    "effects": [ { "id": "stunned", "chance": 75, "duration": [ 2, 4 ] }, { "id": "downed", "chance": 50, "duration": [ 1, 3 ] } ],
+    "effects": [ { "id": "downed", "chance": 33, "duration": [ 1, 3 ] } ],
     "forbidden_effects_any": [ "maimed_tail" ],
     "dodgeable": false,
     "uncanny_dodgeable": true,
@@ -79,7 +79,6 @@
     "move_cost": 150,
     "damage_max_instance": [ { "damage_type": "stab", "amount": 15, "armor_penetration": 8, "armor_multiplier": 0.5 } ],
     "hitsize_min": 4,
-    "effects": [ { "id": "bleed", "duration": 100, "affect_hit_bp": true } ],
     "hit_dmg_u": "%1$s impales your %2$s!",
     "hit_dmg_npc": "%1$s impales <npcname>!",
     "miss_msg_u": "%1$s tries to impale your %2$s, but you dodge!",
@@ -222,14 +221,13 @@
     "move_cost": 100,
     "hitsize_min": 4,
     "hitsize_max": 4,
-    "damage_max_instance": [ { "damage_type": "cut", "amount": 11 } ],
+    "damage_max_instance": [ { "damage_type": "cut", "amount": 23 } ],
     "hit_dmg_u": "%1$s slashes at your neck, cutting your throat!",
     "hit_dmg_npc": "%1$s slashes at <npcname>!",
     "no_dmg_msg_u": "%1$s slashes at your neck, but glances off your armor!",
     "no_dmg_msg_npc": "%1$s slashes at <npcname>, but glances off armor!",
     "miss_msg_u": "%s slashes at your neck!  You duck!",
-    "miss_msg_npc": "%s slashes at <npcname>, but they duck!",
-    "effects": [ { "id": "bleed", "duration": 900, "bp": "head" } ]
+    "miss_msg_npc": "%s slashes at <npcname>, but they duck!"
   },
   {
     "type": "monster_attack",
@@ -398,7 +396,7 @@
     "attack_upper": false,
     "required_effects_any": [ "grabbing" ],
     "forbidden_effects_any": [ "maimed_mandible" ],
-    "damage_max_instance": [ { "damage_type": "bash", "amount": 10 } ],
+    "damage_max_instance": [ { "damage_type": "bash", "amount": 18 } ],
     "effects_require_dmg": false,
     "hit_dmg_u": "%1$s hits your legs, causing you to get knocked on your back!",
     "hit_dmg_npc": "%1$s knocks <npcname> prone!",
@@ -406,7 +404,7 @@
     "no_dmg_msg_npc": "%1$s tries to knock <npcname> down, but their armor protects them!",
     "miss_msg_u": "%s goes for your legs!  You duck!",
     "miss_msg_npc": "%s goes <npcname>'s legs, but they duck!",
-    "effects": [ { "id": "downed", "duration": 3 } ]
+    "effects": [ { "id": "downed", "chance": 33, "duration": 3 } ]
   },
   {
     "type": "monster_attack",
@@ -435,7 +433,6 @@
     "move_cost": 150,
     "damage_max_instance": [ { "damage_type": "stab", "amount": 36, "armor_penetration": 8, "armor_multiplier": 0.5 } ],
     "hitsize_min": 4,
-    "effects": [ { "id": "bleed", "duration": 5, "affect_hit_bp": true } ],
     "hit_dmg_u": "%1$s lunges and impales your %2$s!",
     "hit_dmg_npc": "%1$s lunges and impales <npcname>!",
     "miss_msg_u": "%1$s lunges and tries to impale your %2$s, but you dodge!",

--- a/data/mods/TEST_DATA/monsters.json
+++ b/data/mods/TEST_DATA/monsters.json
@@ -248,6 +248,14 @@
     ]
   },
   {
+    "id": "mon_debug_grab",
+    "type": "MONSTER",
+    "copy-from": "debug_mon",
+    "name": { "str": "debug grabber" },
+    "melee_skill": 200,
+    "special_attacks": [ [ "GRAB", 0 ] ]
+  },
+  {
     "id": "mon_debug_memory",
     "type": "MONSTER",
     "name": { "str": "memory", "str_pl": "memories" },

--- a/doc/EFFECTS_JSON.md
+++ b/doc/EFFECTS_JSON.md
@@ -348,6 +348,30 @@ As defined, this will cause non-resistant characters to gain between 1 and 2 of 
 
 For `chance_kill` and `chance_kill_resist`, it accepts an array of arrays in the format described. Each entry in the array will be applied for a successive intensity level of the field. If the intensity level of the field is greater than the number of entries in the array, the last entry will be used.
 
+### Limb score modifiers
+
+```JSON
+"limb_score_mods": [
+    {
+        "limb_score": "lift",
+        "modifier": 0.5,
+        "resist_modifier": 0.75,
+        "scaling": -0.1,
+        "resist_scaling": -0.05
+    }
+]
+```
+
+- "limb_score"        Mandatory, string id of the limb score in question
+- "modifier"          Optional float (default 1.0), the multiplier on the limb score at effect intensity 1
+- "resist_modifier"   Optional float (default 1.0), the multiplier on the limb score at effect intensity 1 when the character resists the effect
+- "scaling"           Optional float (default 0.0), amount added to the multiplier on every intensity level
+- "resist_scaling"    Optional float (default 0.0), amount added to the multiplier on every intensity level when the character resists the effect
+
+
+Limb score modifiers work as multipliers in the limb score calculations.  The example modifier will halve the non-resistant player's lift score at intensity 1 and decrease it by 10% of the start value for every successive intensity level (*0.4 at int 2, *0.3 at int 3 etc.), while decreasing a resistant character's lift score by 25% and intensifying in 5% steps (*0.70 at int 2, *0.65 at int 3).  Limb score modifiers are applied after health/encumbrance penalties multiplicatively (ex. 1.0 starting lift score reduced by two *0.5 modifiers equals 0.25, not 0), and separate instances of the same effect applied to separate bodyparts will be counted separately (ex. two instances of "staggered" on a character's arms will each apply their limb score modifiers).
+
+
 ### Effect effects
 ```C++
     "base_mods" : {

--- a/doc/EFFECTS_JSON.md
+++ b/doc/EFFECTS_JSON.md
@@ -205,6 +205,14 @@ Effects can only have one "resist_trait" and one "resist_effect" at a time.
 ```
 Having any of the defined character flags (See JSON_FLAGS.md#Character flags) will make you immune to the effect. Note that these are completely JSON-driven, so you can add a custom flag for your effect without C++ changes.
 
+### Bodypart Immunity Flags
+
+´´´JSON
+"immune_bp_flags": [ "LIMB_UPPER" ]
+````
+
+When applying the effect to a bodypart directly the part in question having this JSON character flag will prevent the effect from applying.
+
 ### Removes effects
 ```C++
     "removes_effects": ["bite", "flu"]
@@ -365,8 +373,8 @@ For `chance_kill` and `chance_kill_resist`, it accepts an array of arrays in the
 - "limb_score"        Mandatory, string id of the limb score in question
 - "modifier"          Optional float (default 1.0), the multiplier on the limb score at effect intensity 1
 - "resist_modifier"   Optional float (default 1.0), the multiplier on the limb score at effect intensity 1 when the character resists the effect
-- "scaling"           Optional float (default 0.0), amount added to the multiplier on every intensity level
-- "resist_scaling"    Optional float (default 0.0), amount added to the multiplier on every intensity level when the character resists the effect
+- "scaling"           Optional float (default 0.0), amount added to the multiplier on every intensity level above 1
+- "resist_scaling"    Optional float (default 0.0), amount added to the multiplier on every intensity level above 1 when the character resists the effect
 
 
 Limb score modifiers work as multipliers in the limb score calculations.  The example modifier will halve the non-resistant player's lift score at intensity 1 and decrease it by 10% of the start value for every successive intensity level (*0.4 at int 2, *0.3 at int 3 etc.), while decreasing a resistant character's lift score by 25% and intensifying in 5% steps (*0.70 at int 2, *0.65 at int 3).  Limb score modifiers are applied after health/encumbrance penalties multiplicatively (ex. 1.0 starting lift score reduced by two *0.5 modifiers equals 0.25, not 0), and separate instances of the same effect applied to separate bodyparts will be counted separately (ex. two instances of "staggered" on a character's arms will each apply their limb score modifiers).

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -599,6 +599,7 @@ Effect flags. These are checked by hardcode for monsters (introducing new flags 
 
 - ```DISABLE_FLIGHT``` Monsters affected by an effect with this flag will never count as flying (even if they have the `FLIES` flag).
 - ```EFFECT_IMPEDING``` Character affected by an effect with this flag can't move until they break free from the effect.  Breaking free requires a strength check: `x_in_y( STR * limb lifting score * limb grip score, 6 * get_effect_int( eff_id )`
+- ```EFFECT_LIMB_SCORE_MOD``` Effect with a limb score component to be used in Character::get_limb_score. See [EFFECTS_JSON.md](EFFECTS_JSON.md) for the exact function of limb score modifiers and [JSON_INFO.md](JSON_INFO.md#limb-scores) for the effects of the scores.
 
 ## Furniture and Terrain
 

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -822,6 +822,7 @@ reference at least one body part or sub body part.
 | `techniques`           | (_optional_) List of melee techniques granted by this limb as long as it's above its `health_limit` HP.  The chance for the technique to be included in each attack's tech list is dependent on limb encumbrance. ( `!x_in_y(current encumbrance / technique_encumbrance_limit`)
 | `technique_encumbrance_limit` | (_optional_) Level of encumbrance that disables the given techniques for this limb completely, lower encumbrance still reduces the chances of the technique being chosen (see above).
 | `limb_scores`          | (_optional_) List of arrays defining limb scores. Each array contains 2 mandatory values and 1 optional value. Value 1 is a reference to a `limb_score` id. Value 2 is a float defining the limb score's value. (optional) Value 3 is a float defining the limb score's maximum value (mostly just used for manipulator score).
+| `effects_on_hit`       | (_optional_) Array of effects that can apply whenever the limb is damaged.  For details see below.
 | `unarmed_damage`       | (_optional_) An array of objects, each detailing the amount of unarmed damage the bodypart contributes to unarmed attacks and their armor penetration. The unarmed damages of each limb are summed and added to the base unarmed damage. Should be used for limbs the character is expected to *always* attack with, for special attacks use a dedicated technique.
 | `armor`                | (_optional_) An object containing damage resistance values. Ex: `"armor": { "bash": 2, "cut": 1 }`. See [Part Resistance](#part-resistance) for details.
 
@@ -858,6 +859,53 @@ reference at least one body part or sub body part.
   "smash_message": "You elbow-smash the %s.",
   "bionic_slots": 20,
   "sub_parts": [ "arm_shoulder_l", "arm_upper_l", "arm_elbow_l", "arm_lower_l" ]
+}
+```
+
+# On-hit Effects
+
+An array of effects to add whenever the limb in question takes damage. Variables for each entry:
+
+| `Identifier`           | Description
+|---                     |---
+| `id`                   | (_mandatory_) ID of the effect to apply.
+| `dmg_type`             | (_optional_) String id of the damage type eligable to apply the effect. Defaults to all damage.
+| `dmg_threshold`        | (_optional_) Integer, amount of damage to trigger the effect. For main parts used as percent of limb max health, for minor parts as absolute damage amount. Default 1.
+| `dmg_scale_increment`  | (_optional_) Float, steps of scaling based on damage above `damage_threshold`. Default 1.
+| `chance`               | (_optional_) Integer, percent chance to trigger the effect. Default 100.
+| `chance_dmg_scaling`   | (_optional_) Float, chance is increased by this value for every `dmg_scale_increment` above `dmg_threshold`. Default 0.
+| `intensity`            | (_optional_) Integer, intensity of effect to apply. Default 1.
+| `intensity_dmg_scaling`| (_optional_) Float, intensity is increased by this value for every `dmg_scale_increment` above `dmg_threshold`. Default 0.
+| `max_intensity`        | (_optional_) Integer, max intensity the limb can gain as part of the onhit effect - other sources of effects like spells or explicit special attack effects can still apply higher intensities. Default INT_MAX.
+| `duration`             | (_optional_) Integer, duration of effect to apply in seconds. Default 1.
+| `duration_dmg_scaling` | (_optional_) Float, duration is increased by this value for every `dmg_scale_increment` above `dmg_threshold`. Default 0.
+| `max_duration`         | (_optional_) Integer, max seconds duration the limb can gain as part of the onhit effect - see `max_intensity`. Default INT_MAX.
+
+
+```json
+{
+"effects_on_hit": [
+    {
+      "id": "staggered",
+      "dmg_type": "bash",
+      "dmg_threshold": 5,
+      "dmg_scale_increment": 5,
+      "chance": 10,
+      "chance_dmg_scaling": 10,
+      "duration": 5,
+      "duration_dmg_scaling": 2,
+      "max_duration": 15
+    },
+    {
+      "id": "downed",
+      "dmg_threshold": 20,
+      "dmg_scale_increment": 10,
+      "chance": 5,
+      "chance_dmg_scaling": 20,
+      "duration": 2,
+      "duration_dmg_scaling": 0.5
+    }
+  ]
 }
 ```
 

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -869,6 +869,7 @@ An array of effects to add whenever the limb in question takes damage. Variables
 | `Identifier`           | Description
 |---                     |---
 | `id`                   | (_mandatory_) ID of the effect to apply.
+| `global`               | (_optional_) Bool, if true the effect won't apply to the bodypart but to the whole character. Default false.
 | `dmg_type`             | (_optional_) String id of the damage type eligible to apply the effect. Defaults to all damage.
 | `dmg_threshold`        | (_optional_) Integer, amount of damage to trigger the effect. For main parts used as percent of limb max health, for minor parts as absolute damage amount. Default 1.
 | `dmg_scale_increment`  | (_optional_) Float, steps of scaling based on damage above `damage_threshold`. Default 1.
@@ -898,6 +899,7 @@ An array of effects to add whenever the limb in question takes damage. Variables
     },
     {
       "id": "downed",
+      "global": true,
       "dmg_threshold": 20,
       "dmg_scale_increment": 10,
       "chance": 5,

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -869,7 +869,7 @@ An array of effects to add whenever the limb in question takes damage. Variables
 | `Identifier`           | Description
 |---                     |---
 | `id`                   | (_mandatory_) ID of the effect to apply.
-| `dmg_type`             | (_optional_) String id of the damage type eligable to apply the effect. Defaults to all damage.
+| `dmg_type`             | (_optional_) String id of the damage type eligible to apply the effect. Defaults to all damage.
 | `dmg_threshold`        | (_optional_) Integer, amount of damage to trigger the effect. For main parts used as percent of limb max health, for minor parts as absolute damage amount. Default 1.
 | `dmg_scale_increment`  | (_optional_) Float, steps of scaling based on damage above `damage_threshold`. Default 1.
 | `chance`               | (_optional_) Integer, percent chance to trigger the effect. Default 100.

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2889,7 +2889,7 @@ void activity_handlers::operation_do_turn( player_activity *act, Character *you 
             }
             if( !bps.empty() ) {
                 for( const bodypart_id &bp : bps ) {
-                    you->add_effect( effect_bleed,  1_minutes * difficulty, bp, false, true);
+                    you->add_effect( effect_bleed,  1_minutes * difficulty, bp, false, true );
                     you->apply_damage( nullptr, bp, 20 * difficulty );
 
                     if( u_see ) {
@@ -2902,7 +2902,7 @@ void activity_handlers::operation_do_turn( player_activity *act, Character *you 
                     }
                 }
             } else {
-                    you->add_effect( effect_bleed,  1_minutes * difficulty, bodypart_str_id::NULL_ID(), false, true);
+                you->add_effect( effect_bleed,  1_minutes * difficulty, bodypart_str_id::NULL_ID(), false, true );
                 you->apply_damage( nullptr, bodypart_id( "torso" ), 20 * difficulty );
             }
         }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -172,6 +172,7 @@ static const ammotype ammo_battery( "battery" );
 
 static const bionic_id bio_painkiller( "bio_painkiller" );
 
+static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_narcosis( "narcosis" );
@@ -2888,7 +2889,7 @@ void activity_handlers::operation_do_turn( player_activity *act, Character *you 
             }
             if( !bps.empty() ) {
                 for( const bodypart_id &bp : bps ) {
-                    you->make_bleed( effect_source::empty(), bp, 1_turns, difficulty, true );
+                    you->add_effect( effect_bleed,  1_minutes * difficulty, bp, false, true);
                     you->apply_damage( nullptr, bp, 20 * difficulty );
 
                     if( u_see ) {
@@ -2901,7 +2902,7 @@ void activity_handlers::operation_do_turn( player_activity *act, Character *you 
                     }
                 }
             } else {
-                you->make_bleed( effect_source::empty(), bodypart_id( "bp_null" ), 1_turns, difficulty, true );
+                    you->add_effect( effect_bleed,  1_minutes * difficulty, bodypart_str_id::NULL_ID(), false, true);
                 you->apply_damage( nullptr, bodypart_id( "torso" ), 20 * difficulty );
             }
         }

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -467,6 +467,7 @@ void body_part_type::load( const JsonObject &jo, const std::string & )
 void bp_onhit_effect::load( const JsonObject &jo )
 {
     mandatory( jo, false, "id", id );
+    optional( jo, false, "global", global );
     optional( jo, false, "dmg_type", dtype, damage_type::NONE );
     optional( jo, false, "dmg_threshold", dmg_threshold, 1 );
     optional( jo, false, "dmg_scale_increment", scale_increment, 1.0f );

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -420,6 +420,15 @@ void body_part_type::load( const JsonObject &jo, const std::string & )
         }
     }
 
+    if( jo.has_array( "effects_on_hit" ) ) {
+        effects_on_hit.clear();
+        for( const JsonObject effect_jo : jo.get_array( "effects_on_hit" ) ) {
+            bp_onhit_effect eff;
+            eff.load( effect_jo );
+            effects_on_hit.push_back( std::move( eff ) );
+        }
+    }
+
     if( jo.has_array( "temp_mod" ) ) {
         JsonArray temp_array = jo.get_array( "temp_mod" );
         temp_min = temp_array.get_int( 0 );
@@ -453,6 +462,22 @@ void body_part_type::load( const JsonObject &jo, const std::string & )
             encumbrance_per_weight.insert( std::pair<units::mass, int>( weight, encumbrance ) );
         }
     }
+}
+
+void bp_onhit_effect::load( const JsonObject &jo )
+{
+    mandatory( jo, false, "id", id );
+    optional( jo, false, "dmg_type", dtype, damage_type::NONE );
+    optional( jo, false, "dmg_threshold", dmg_threshold, 1 );
+    optional( jo, false, "dmg_scale_increment", scale_increment, 1.0f );
+    optional( jo, false, "chance", chance, 100 );
+    optional( jo, false, "chance_dmg_scaling", chance_dmg_scaling, 0.0f );
+    optional( jo, false, "intensity", intensity, 1 );
+    optional( jo, false, "intensity_dmg_scaling", intensity_dmg_scaling, 0.0f );
+    optional( jo, false, "max_intensity", max_intensity, INT_MAX );
+    optional( jo, false, "duration", duration, 1 );
+    optional( jo, false, "duration_dmg_scaling", duration_dmg_scaling, 0.0f );
+    optional( jo, false, "max_duration", max_duration, INT_MAX );
 }
 
 void body_part_type::reset()
@@ -900,6 +925,17 @@ std::set<matec_id> bodypart::get_limb_techs() const
     if( !x_in_y( get_encumbrance_data().encumbrance, id->technique_enc_limit  &&
                  hp_cur > id->health_limit ) ) {
         result.insert( id->techniques.begin(), id->techniques.end() );
+    }
+    return result;
+}
+
+std::vector<bp_onhit_effect> bodypart::get_onhit_effects( damage_type dtype ) const
+{
+    std::vector<bp_onhit_effect> result;
+    for( const bp_onhit_effect &effect : id->effects_on_hit ) {
+        if( effect.dtype == dtype || effect.dtype == damage_type::NONE ) {
+            result.push_back( effect );
+        }
     }
     return result;
 }

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -425,7 +425,7 @@ void body_part_type::load( const JsonObject &jo, const std::string & )
         for( const JsonObject effect_jo : jo.get_array( "effects_on_hit" ) ) {
             bp_onhit_effect eff;
             eff.load( effect_jo );
-            effects_on_hit.push_back( std::move( eff ) );
+            effects_on_hit.push_back( eff );
         }
     }
 

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -142,13 +142,16 @@ struct bp_limb_score {
 };
 
 struct bp_onhit_effect {
+    // ID of the effect to apply
+    efftype_id id;
+    // Apply the effect to the given bodypart, or to the whole character?
+    bool global = false;
     // Type of damage that causes the effect - NONE always applies
     damage_type dtype = damage_type::NONE;
     // Percent of the limb's max HP required for the effect to trigger (or absolute DMG for minor limbs)
     int dmg_threshold = 100;
     // Percent HP / absolute damage triggering a scale tick
     float scale_increment = 0.0f;
-    efftype_id id;
     // Percent chance (at damage threshold)
     int chance = 100;
     // Chance scaling for damage above the threshold

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -140,6 +140,34 @@ struct bp_limb_score {
     float max = 0.0f;
 };
 
+struct bp_onhit_effect {
+    // Type of damage that causes the effect - NONE always applies
+    damage_type dtype = damage_type::NONE;
+    // Percent of the limb's max HP required for the effect to trigger (or absolute DMG for minor limbs)
+    int dmg_threshold = 100;
+    // Percent HP / absolute damage triggering a scale tick
+    float scale_increment = 0.0f;
+    efftype_id id;
+    // Percent chance (at damage threshold)
+    int chance = 100;
+    // Chance scaling for damage above the threshold
+    float chance_dmg_scaling = 0.0f;
+    // Intensity applied at the damage threshold.
+    int intensity = 1;
+    // Intensity scaling for damage above the threshold.
+    float intensity_dmg_scaling = 0.0f;
+    // Duration in turns at the damage threshold.
+    int duration = 1;
+    // Duration scaling for damage above the threshold.
+    float duration_dmg_scaling = 0.0f;
+    // Max intensity applied via damage (direct effect addition is exempt)
+    int max_intensity = INT_MAX;
+    // Max duration applied via damage (direct effect addition is exempt)
+    int max_duration = INT_MAX;
+
+    void load( const JsonObject &jo );
+};
+
 struct body_part_type {
     public:
         /**
@@ -205,6 +233,9 @@ struct body_part_type {
 
         // Limb-specific attacks
         std::set<matec_id> techniques;
+
+        // Effects to trigger on getting hit
+        std::vector<bp_onhit_effect> effects_on_hit;
 
         // Those are stored untranslated
         translation name;
@@ -434,6 +465,9 @@ class bodypart
 
         // Get our limb attacks
         std::set<matec_id> get_limb_techs() const;
+
+        // Get onhit effects
+        std::vector<bp_onhit_effect> get_onhit_effects( damage_type dtype ) const;
 
         // Get modified limb score as defined in limb_scores.json.
         // override forces the limb score to be affected by encumbrance/wounds (-1 == no override).

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_BODYPART_H
 
 #include <array>
+#include <climits>
 #include <cstddef>
 #include <initializer_list>
 #include <iosfwd>

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4223,11 +4223,11 @@ void Character::on_damage_of_type( const effect_source &source, int adjusted_dam
 {
     // Handle bp onhit effects
     bodypart *body_part = get_part( bp );
-    bool is_minor = bp->main_part != bp->id;
+    const bool is_minor = bp->main_part != bp->id;
     add_msg_debug( debugmode::DF_CHARACTER, "Targeting limb %s with %d %s type damage", bp->name,
                    adjusted_damage, name_by_dt( type ) );
     // Damage as a percent of the limb's max hp or raw dmg for minor parts
-    float dmg_ratio = is_minor ? adjusted_damage : ( 100 * adjusted_damage ) / body_part->get_hp_max();
+    float dmg_ratio = is_minor ? adjusted_damage : 100 * adjusted_damage / body_part->get_hp_max();
     add_msg_debug( debugmode::DF_CHARACTER, "Main BP max hp %d, damage ratio %.1f",
                    body_part->get_hp_max(), dmg_ratio );
     for( const bp_onhit_effect &eff : body_part->get_onhit_effects( type ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3784,9 +3784,9 @@ int Character::get_arm_str() const
 
 int Character::get_eff_per() const
 {
-    return Character::get_per() * get_limb_score( limb_score_vision ) + int( Character::has_proficiency(
+    return ( Character::get_per() + int( Character::has_proficiency(
                 proficiency_prof_spotting ) ) *
-           Character::get_per_base();
+           Character::get_per_base() ) * get_limb_score( limb_score_vision ) ;
 }
 
 int Character::ranged_dex_mod() const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4217,7 +4217,7 @@ bool Character::is_mute() const
                    is_wearing( itype_foodperson_mask_on ) ) ) ||
            has_trait( trait_MUTE );
 }
-void Character::on_damage_of_type( effect_source &source, int adjusted_damage, damage_type type,
+void Character::on_damage_of_type( const effect_source &source, int adjusted_damage, damage_type type,
                                    const bodypart_id &bp )
 {
     // Handle bp onhit effects

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4217,7 +4217,8 @@ bool Character::is_mute() const
                    is_wearing( itype_foodperson_mask_on ) ) ) ||
            has_trait( trait_MUTE );
 }
-void Character::on_damage_of_type( const effect_source &source, int adjusted_damage, damage_type type,
+void Character::on_damage_of_type( const effect_source &source, int adjusted_damage,
+                                   damage_type type,
                                    const bodypart_id &bp )
 {
     // Handle bp onhit effects

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3785,8 +3785,8 @@ int Character::get_arm_str() const
 int Character::get_eff_per() const
 {
     return ( Character::get_per() + int( Character::has_proficiency(
-                proficiency_prof_spotting ) ) *
-           Character::get_per_base() ) * get_limb_score( limb_score_vision ) ;
+            proficiency_prof_spotting ) ) *
+             Character::get_per_base() ) * get_limb_score( limb_score_vision ) ;
 }
 
 int Character::ranged_dex_mod() const
@@ -5397,7 +5397,6 @@ bool Character::is_elec_immune() const
 
 bool Character::is_immune_effect( const efftype_id &eff ) const
 {
-    bool ret = false;
     if( eff == effect_downed ) {
         return is_throw_immune() || ( has_trait( trait_LEG_TENT_BRACE ) && is_barefoot() );
     } else if( eff == effect_onfire ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -38,7 +38,6 @@
 #include "coordinates.h"
 #include "creature_tracker.h"
 #include "cursesdef.h"
-#include "debug.h"
 #include "disease.h"
 #include "display.h"
 #include "effect.h"

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4270,7 +4270,9 @@ void Character::on_damage_of_type( const effect_source &source, int adjusted_dam
                                        "Limiting added duration to %d seconds", scaled_dur );
                     }
                 }
-                add_effect( source, eff.id, 1_turns * scaled_dur, bp, false, scaled_int );
+                // Add the effect globally if defined
+                add_effect( source, eff.id, 1_turns * scaled_dur, eff.global ? bodypart_str_id::NULL_ID() : bp,
+                            false, scaled_int );
             }
         }
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5397,6 +5397,7 @@ bool Character::is_elec_immune() const
 
 bool Character::is_immune_effect( const efftype_id &eff ) const
 {
+    bool ret = false;
     if( eff == effect_downed ) {
         return is_throw_immune() || ( has_trait( trait_LEG_TENT_BRACE ) && is_barefoot() );
     } else if( eff == effect_onfire ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4217,7 +4217,8 @@ bool Character::is_mute() const
                    is_wearing( itype_foodperson_mask_on ) ) ) ||
            has_trait( trait_MUTE );
 }
-void Character::on_damage_of_type( effect_source source, int adjusted_damage, damage_type type, const bodypart_id &bp )
+void Character::on_damage_of_type( effect_source &source, int adjusted_damage, damage_type type,
+                                   const bodypart_id &bp )
 {
     // Handle bp onhit effects
     bodypart *body_part = get_part( bp );
@@ -7622,7 +7623,7 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
     int recoil_mul = 100;
 
     if( bp == body_part_hand_l || bp == body_part_arm_l ||
-               bp == body_part_hand_r || bp == body_part_arm_r ) {
+        bp == body_part_hand_r || bp == body_part_arm_r ) {
         recoil_mul = 200;
     } else if( bp == bodypart_str_id::NULL_ID() ) {
         debugmsg( "Wacky body part hit!" );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3159,11 +3159,6 @@ bool Character::meets_requirements( const item &it, const item &context ) const
     return meets_stat_requirements( it ) && meets_skill_requirements( it.type->min_skills, ctx );
 }
 
-void Character::make_bleed( const effect_source &source, const bodypart_id &bp,
-                            time_duration duration, int intensity, bool permanent, bool force, bool defferred )
-{
-    add_effect( source, effect_bleed, duration, bp, permanent, intensity, force, defferred );
-}
 
 void Character::normalize()
 {
@@ -4222,8 +4217,61 @@ bool Character::is_mute() const
                    is_wearing( itype_foodperson_mask_on ) ) ) ||
            has_trait( trait_MUTE );
 }
-void Character::on_damage_of_type( int adjusted_damage, damage_type type, const bodypart_id &bp )
+void Character::on_damage_of_type( effect_source source, int adjusted_damage, damage_type type, const bodypart_id &bp )
 {
+    // Handle bp onhit effects
+    bodypart *body_part = get_part( bp );
+    bool is_minor = bp->main_part != bp->id;
+    add_msg_debug( debugmode::DF_CHARACTER, "Targeting limb %s with %d %s type damage", bp->name,
+                   adjusted_damage, name_by_dt( type ) );
+    // Damage as a percent of the limb's max hp or raw dmg for minor parts
+    float dmg_ratio = is_minor ? adjusted_damage : ( 100 * adjusted_damage ) / body_part->get_hp_max();
+    add_msg_debug( debugmode::DF_CHARACTER, "Main BP max hp %d, damage ratio %.1f",
+                   body_part->get_hp_max(), dmg_ratio );
+    for( const bp_onhit_effect &eff : body_part->get_onhit_effects( type ) ) {
+        if( dmg_ratio >= eff.dmg_threshold ) {
+            float scaling = ( dmg_ratio - eff.dmg_threshold ) / eff.scale_increment;
+            int scaled_chance = roll_remainder( std::max( static_cast<float>( eff.chance ),
+                                                eff.chance + eff.chance_dmg_scaling * scaling ) );
+            add_msg_debug( debugmode::DF_CHARACTER, "Scaling factor %.1f, base chance %d%%, scaled chance %d%%",
+                           scaling, eff.chance, scaled_chance );
+            if( x_in_y( scaled_chance, 100 ) ) {
+
+                // Scale based on damage done
+                int scaled_dur = roll_remainder( std::max( static_cast<float>( eff.duration ),
+                                                 eff.duration + eff.duration_dmg_scaling * scaling ) );
+                int scaled_int = roll_remainder( std::max( static_cast<float>( eff.intensity ),
+                                                 eff.intensity + eff.intensity_dmg_scaling * scaling ) );
+                add_msg_debug( debugmode::DF_CHARACTER,
+                               "Atempting to add effect %s, scaled duration %d turns, scaled intensity %d", eff.id.c_str(),
+                               scaled_dur,
+                               scaled_int );
+
+                // Handle intensity/duration clamping
+                if( eff.max_intensity != INT_MAX ) {
+                    int prev_int = get_effect( eff.id, bp ).get_intensity();
+                    add_msg_debug( debugmode::DF_CHARACTER,
+                                   "Max intensity %d, current intensity %d", eff.max_intensity, prev_int );
+                    if( ( prev_int + scaled_int ) > eff.max_intensity ) {
+                        scaled_int = eff.max_intensity - prev_int;
+                        add_msg_debug( debugmode::DF_CHARACTER,
+                                       "Limiting added intensity to %d", scaled_int );
+                    }
+                }
+                if( eff.max_duration != INT_MAX ) {
+                    int prev_dur = to_turns<int>( get_effect( eff.id, bp ).get_duration() );
+                    add_msg_debug( debugmode::DF_CHARACTER,
+                                   "Max duration %d, current duration %d", eff.max_duration, prev_dur );
+                    if( ( prev_dur + scaled_dur ) > eff.max_duration ) {
+                        scaled_dur = eff.max_duration - prev_dur;
+                        add_msg_debug( debugmode::DF_CHARACTER,
+                                       "Limiting added duration to %d seconds", scaled_dur );
+                    }
+                }
+                add_effect( source, eff.id, 1_turns * scaled_dur, bp, false, scaled_int );
+            }
+        }
+    }
     // Electrical damage has a chance to temporarily incapacitate bionics in the damaged body_part.
     if( type == damage_type::ELECTRIC ) {
         const time_duration min_disable_time = 10_turns * adjusted_damage;
@@ -7573,13 +7621,7 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
 
     int recoil_mul = 100;
 
-    if( bp == body_part_eyes ) {
-        if( dam > 5 || cut_dam > 0 ) {
-            const time_duration minblind = std::max( 1_turns, 1_turns * ( dam + cut_dam ) / 10 );
-            const time_duration maxblind = std::min( 5_turns, 1_turns * ( dam + cut_dam ) / 4 );
-            add_effect( effect_blind, rng( minblind, maxblind ) );
-        }
-    } else if( bp == body_part_hand_l || bp == body_part_arm_l ||
+    if( bp == body_part_hand_l || bp == body_part_arm_l ||
                bp == body_part_hand_r || bp == body_part_arm_r ) {
         recoil_mul = 200;
     } else if( bp == bodypart_str_id::NULL_ID() ) {

--- a/src/character.h
+++ b/src/character.h
@@ -2718,7 +2718,8 @@ class Character : public Creature, public visitable
                                             const cata::optional<tripoint> &blind_throw_from_pos = cata::nullopt );
 
     protected:
-        void on_damage_of_type( effect_source source, int adjusted_damage, damage_type type, const bodypart_id &bp ) override;
+        void on_damage_of_type( effect_source &source, int adjusted_damage, damage_type type,
+                                const bodypart_id &bp ) override;
     public:
         /** Called when an item is worn */
         void on_item_wear( const item &it );

--- a/src/character.h
+++ b/src/character.h
@@ -34,6 +34,7 @@
 #include "craft_command.h"
 #include "creature.h"
 #include "damage.h"
+#include "debug.h"
 #include "enums.h"
 #include "flat_set.h"
 #include "game_constants.h"
@@ -1236,6 +1237,8 @@ class Character : public Creature, public visitable
         float get_limb_score( const limb_score_id &score,
                               const body_part_type::type &bp = body_part_type::type::num_types,
                               int override_encumb = -1, int override_wounds = -1 ) const;
+        float manipulator_score(const std::map<bodypart_str_id, bodypart>& body,
+            body_part_type::type type, int override_encumb, int override_wounds) const;
 
         bool has_min_manipulators() const;
         // technically this is "has more than one arm"

--- a/src/character.h
+++ b/src/character.h
@@ -2211,9 +2211,6 @@ class Character : public Creature, public visitable
         std::vector<spell> spells_known_of_class( const trait_id &spell_class ) const;
         bool cast_spell( spell &sp, bool fake_spell, const cata::optional<tripoint> &target );
 
-        void make_bleed( const effect_source &source, const bodypart_id &bp, time_duration duration,
-                         int intensity = 1, bool permanent = false, bool force = false, bool defferred = false ) override;
-
         /** Called when a player triggers a trap, returns true if they don't set it off */
         bool avoid_trap( const tripoint &pos, const trap &tr ) const override;
 
@@ -2721,7 +2718,7 @@ class Character : public Creature, public visitable
                                             const cata::optional<tripoint> &blind_throw_from_pos = cata::nullopt );
 
     protected:
-        void on_damage_of_type( int adjusted_damage, damage_type type, const bodypart_id &bp ) override;
+        void on_damage_of_type( effect_source source, int adjusted_damage, damage_type type, const bodypart_id &bp ) override;
     public:
         /** Called when an item is worn */
         void on_item_wear( const item &it );

--- a/src/character.h
+++ b/src/character.h
@@ -2718,7 +2718,7 @@ class Character : public Creature, public visitable
                                             const cata::optional<tripoint> &blind_throw_from_pos = cata::nullopt );
 
     protected:
-        void on_damage_of_type( effect_source &source, int adjusted_damage, damage_type type,
+        void on_damage_of_type( const effect_source &source, int adjusted_damage, damage_type type,
                                 const bodypart_id &bp ) override;
     public:
         /** Called when an item is worn */

--- a/src/character.h
+++ b/src/character.h
@@ -1237,8 +1237,8 @@ class Character : public Creature, public visitable
         float get_limb_score( const limb_score_id &score,
                               const body_part_type::type &bp = body_part_type::type::num_types,
                               int override_encumb = -1, int override_wounds = -1 ) const;
-        float manipulator_score(const std::map<bodypart_str_id, bodypart>& body,
-            body_part_type::type type, int override_encumb, int override_wounds) const;
+        float manipulator_score( const std::map<bodypart_str_id, bodypart> &body,
+                                 body_part_type::type type, int override_encumb, int override_wounds ) const;
 
         bool has_min_manipulators() const;
         // technically this is "has more than one arm"

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -19,6 +19,9 @@
 
 static const bionic_id bio_sleep_shutdown( "bio_sleep_shutdown" );
 
+static const character_modifier_id
+character_modifier_stamina_recovery_breathing_mod( "stamina_recovery_breathing_mod" );
+
 static const efftype_id effect_bandaged( "bandaged" );
 static const efftype_id effect_bite( "bite" );
 static const efftype_id effect_bleed( "bleed" );
@@ -200,7 +203,8 @@ void Character::update_body( const time_point &from, const time_point &to )
         update_stamina( to_turns<int>( to - from ) );
     }
     if( can_recover_oxygen() && oxygen < get_oxygen_max() ) {
-        oxygen += std::max( ( to_turns<int>( to - from ) * get_stamina() * 5 ) / get_stamina_max(), 1 );
+        oxygen += std::max( roll_remainder( to_turns<int>( to - from ) * get_stamina() * 5 * get_modifier(
+                character_modifier_stamina_recovery_breathing_mod )  / get_stamina_max() ), 1 );
         oxygen = std::min( oxygen, get_oxygen_max() );
     }
     update_stomach( from, to );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -204,7 +204,7 @@ void Character::update_body( const time_point &from, const time_point &to )
     }
     if( can_recover_oxygen() && oxygen < get_oxygen_max() ) {
         oxygen += std::max( static_cast<int>( to_turns<int>( to - from ) * get_stamina() * 5 * get_modifier(
-                                                character_modifier_stamina_recovery_breathing_mod )  / get_stamina_max() ), 1 );
+                character_modifier_stamina_recovery_breathing_mod )  / get_stamina_max() ), 1 );
         oxygen = std::min( oxygen, get_oxygen_max() );
     }
     update_stomach( from, to );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -203,7 +203,7 @@ void Character::update_body( const time_point &from, const time_point &to )
         update_stamina( to_turns<int>( to - from ) );
     }
     if( can_recover_oxygen() && oxygen < get_oxygen_max() ) {
-        oxygen += std::max( roll_remainder( to_turns<int>( to - from ) * get_stamina() * 5 * get_modifier(
+        oxygen += std::max( static_cast<int>( to_turns<int>( to - from ) * get_stamina() * 5 * get_modifier(
                                                 character_modifier_stamina_recovery_breathing_mod )  / get_stamina_max() ), 1 );
         oxygen = std::min( oxygen, get_oxygen_max() );
     }

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -204,7 +204,7 @@ void Character::update_body( const time_point &from, const time_point &to )
     }
     if( can_recover_oxygen() && oxygen < get_oxygen_max() ) {
         oxygen += std::max( roll_remainder( to_turns<int>( to - from ) * get_stamina() * 5 * get_modifier(
-                character_modifier_stamina_recovery_breathing_mod )  / get_stamina_max() ), 1 );
+                                                character_modifier_stamina_recovery_breathing_mod )  / get_stamina_max() ), 1 );
         oxygen = std::min( oxygen, get_oxygen_max() );
     }
     update_stomach( from, to );

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -1,6 +1,9 @@
 #include "character.h"
 #include "character_modifier.h"
+#include "enum_conversions.h"
+#include "flag.h"
 #include "generic_factory.h"
+#include "messages.h"
 #include "move_mode.h"
 
 static const character_modifier_id
@@ -144,12 +147,13 @@ void character_modifier::load( const JsonObject &jo, const std::string & )
 // Scores
 
 // the total of the manipulator score in the best limb group
-static float manipulator_score( const std::map<bodypart_str_id, bodypart> &body,
-                                body_part_type::type type, int override_encumb, int override_wounds )
+float Character::manipulator_score( const std::map<bodypart_str_id, bodypart> &body,
+                                    body_part_type::type type, int override_encumb, int override_wounds ) const
 {
     std::map<body_part_type::type, std::vector<std::pair<bodypart, float>>> bodypart_groups;
     std::vector<float> score_groups;
     const bool required_type = type != body_part_type::type::num_types;
+    const bool local_effect = has_flag( flag_EFFECT_LIMB_SCORE_MOD_LOCAL );
     for( const std::pair<const bodypart_str_id, bodypart> &id : body ) {
         if( required_type ) {
             for( const auto &bp_type : id.first->limbtypes ) {
@@ -170,13 +174,32 @@ static float manipulator_score( const std::map<bodypart_str_id, bodypart> &body,
                    b.first.get_limb_score_max( limb_score_manip ) * b.second;
         } );
         for( const std::pair<bodypart, float> &id : part.second ) {
+            float local_mul = 1.0f;
+            // Calculate local effect modifiers
+            if( local_effect ) {
+                for( const effect &local : get_effects_from_bp( id.first.get_id() ) ) {
+                    if( local.has_flag( flag_EFFECT_LIMB_SCORE_MOD_LOCAL ) ) {
+                        float temp = local.get_limb_score_mod( limb_score_manip, resists_effect( local ) );
+                        local_mul *= temp;
+                        if( temp != 1.0f ) {
+                            add_msg_debug( debugmode::DF_CHARACTER,
+                                           "Local limb score modifier %s for manipulation score on BP %s found, effect multiplier %.1f",
+                                           local.disp_name(), id.first.get_id()->name, local_mul );
+                        }
+                    }
+                }
+            }
             total = std::min( total + id.first.get_limb_score( limb_score_manip, -1, override_encumb,
-                              override_wounds ) * id.second,
-                              id.first.get_limb_score_max( limb_score_manip ) * id.second );
+                              override_wounds ) * id.second * local_mul,
+                              id.first.get_limb_score_max( limb_score_manip ) * local_mul * id.second );
         }
+        add_msg_debug( debugmode::DF_CHARACTER,
+                       "Manipulation score of bodypart group %s %.1f",
+                       io::enum_to_string<body_part_type::type>( part.first ), total );
         score_groups.emplace_back( total );
     }
     const auto score_groups_max = std::max_element( score_groups.begin(), score_groups.end() );
+
     if( score_groups_max == score_groups.end() ) {
         return 0.0f;
     } else {
@@ -188,9 +211,14 @@ float Character::get_limb_score( const limb_score_id &score, const body_part_typ
                                  int override_encumb, int override_wounds ) const
 {
     int skill = -1;
+    float effect_mul = 1.0f;
+    // Check for any global limb score modifier
+    for( const effect &eff : get_effects_with_flag( flag_EFFECT_LIMB_SCORE_MOD ) ) {
+        effect_mul *= eff.get_limb_score_mod( score, resists_effect( eff ) );
+    }
     // manipulator/swim scores are treated a little special for now
     if( score == limb_score_manip ) {
-        return manipulator_score( body, bp, override_encumb, override_wounds );
+        return manipulator_score( body, bp, override_encumb, override_wounds ) * effect_mul;
     } else if( score == limb_score_swim ) {
         skill = get_skill_level( skill_swimming );
     }
@@ -203,9 +231,25 @@ float Character::get_limb_score( const limb_score_id &score, const body_part_typ
             mod = id.second.get_limb_score( score, skill, override_encumb,
                                             override_wounds ) * id.first->limbtypes.at( bp );
         }
+        if( has_flag( flag_EFFECT_LIMB_SCORE_MOD_LOCAL ) ) {
+            for( const effect &local : get_effects_from_bp( id.first ) ) {
+                float local_mul = 1.0f;
+                // Second filter to only apply the local effects at this step (non-local modifiers are already calulated)
+                if( local.has_flag( flag_EFFECT_LIMB_SCORE_MOD_LOCAL ) ) {
+                    local_mul = local.get_limb_score_mod( score, resists_effect( local ) );
+                    mod *= local_mul;
+                    if( local_mul != 1.0f ) {
+                        add_msg_debug( debugmode::DF_CHARACTER,
+                                       "Local limb score modifier %s for limb score %s on BP %s found, effect multiplier %.1f, score contribution after modifier %.1f",
+                                       local.disp_name(),
+                                       score.c_str(), id.first.c_str(), local_mul, mod );
+                    }
+                }
+            }
+        }
         total += mod;
     }
-    return std::max( 0.0f, total );
+    return std::max( 0.0f, total * effect_mul );
 }
 
 // Modifiers

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -849,9 +849,9 @@ void projectile::apply_effects_damage( Creature &target, Creature *source,
         }
     }
 
-    if( dealt_dam.bp_hit == bodypart_id( "head" ) && proj_effects.count( "BLINDS_EYES" ) ) {
+    if( dealt_dam.bp_hit->has_type(body_part_type::type::head) && proj_effects.count( "BLINDS_EYES" ) ) {
         // TODO: Change this to require bp_eyes
-        target.add_env_effect( effect_blind, bodypart_id( "eyes" ), 5, rng( 3_turns, 10_turns ) );
+        target.add_env_effect( effect_blind, target.get_random_body_part_of_type( body_part_type::type::sensor), 5, rng( 3_turns, 10_turns ) );
     }
 
     if( proj_effects.count( "APPLY_SAP" ) ) {
@@ -1243,14 +1243,11 @@ void Creature::deal_damage_handle_type( const effect_source &source, const damag
         case damage_type::CUT:
         case damage_type::STAB:
         case damage_type::BULLET:
-            // these are bleed inducing damage types
-            make_bleed( source, bp, 1_minutes * rng( 1, adjusted_damage ) );
-
         default:
             break;
     }
 
-    on_damage_of_type( adjusted_damage, du.type, bp );
+    on_damage_of_type( source, adjusted_damage, du.type, bp );
 
     damage += adjusted_damage;
     pain += roll_remainder( adjusted_damage / div );
@@ -2419,6 +2416,11 @@ std::vector<bodypart_id> Creature::get_all_body_parts_of_type(
     }
 
     return bodyparts;
+}
+
+bodypart_id Creature::get_random_body_part_of_type( body_part_type::type part_type ) const
+{
+    return random_entry( get_all_body_parts_of_type(part_type) );
 }
 
 std::vector<bodypart_id> Creature::get_all_body_parts_with_flag( const json_character_flag &flag )

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1629,6 +1629,19 @@ std::vector<effect> Creature::get_effects() const
     return effs;
 }
 
+std::vector<effect> Creature::get_effects_from_bp( const bodypart_id &bp ) const
+{
+    std::vector<effect> effs;
+    for( auto &elem : *effects ) {
+        for( const std::pair<const bodypart_id, effect> &_it : elem.second ) {
+            if( _it.first == bp){
+            effs.push_back( _it.second );
+            }
+        }
+    }
+    return effs;
+}
+
 effect &Creature::get_effect( const efftype_id &eff_id, const bodypart_id &bp )
 {
     return const_cast<effect &>( const_cast<const Creature *>( this )->get_effect( eff_id, bp ) );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1366,6 +1366,12 @@ void Creature::add_effect( const effect_source &source, const efftype_id &eff_id
         bp = bp->main_part;
     }
 
+    // Filter out bodypart immunity
+    for( json_character_flag flag : eff_id->immune_bp_flags )
+        if( bp->has_flag( flag ) ) {
+            return;
+        }
+
     bool found = false;
     // Check if we already have it
     auto matching_map = effects->find( eff_id );
@@ -1634,8 +1640,8 @@ std::vector<effect> Creature::get_effects_from_bp( const bodypart_id &bp ) const
     std::vector<effect> effs;
     for( auto &elem : *effects ) {
         for( const std::pair<const bodypart_id, effect> &_it : elem.second ) {
-            if( _it.first == bp){
-            effs.push_back( _it.second );
+            if( _it.first == bp ) {
+                effs.push_back( _it.second );
             }
         }
     }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -849,9 +849,11 @@ void projectile::apply_effects_damage( Creature &target, Creature *source,
         }
     }
 
-    if( dealt_dam.bp_hit->has_type(body_part_type::type::head) && proj_effects.count( "BLINDS_EYES" ) ) {
+    if( dealt_dam.bp_hit->has_type( body_part_type::type::head ) &&
+        proj_effects.count( "BLINDS_EYES" ) ) {
         // TODO: Change this to require bp_eyes
-        target.add_env_effect( effect_blind, target.get_random_body_part_of_type( body_part_type::type::sensor), 5, rng( 3_turns, 10_turns ) );
+        target.add_env_effect( effect_blind,
+                               target.get_random_body_part_of_type( body_part_type::type::sensor ), 5, rng( 3_turns, 10_turns ) );
     }
 
     if( proj_effects.count( "APPLY_SAP" ) ) {
@@ -2420,7 +2422,7 @@ std::vector<bodypart_id> Creature::get_all_body_parts_of_type(
 
 bodypart_id Creature::get_random_body_part_of_type( body_part_type::type part_type ) const
 {
-    return random_entry( get_all_body_parts_of_type(part_type) );
+    return random_entry( get_all_body_parts_of_type( part_type ) );
 }
 
 std::vector<bodypart_id> Creature::get_all_body_parts_with_flag( const json_character_flag &flag )

--- a/src/creature.h
+++ b/src/creature.h
@@ -473,10 +473,6 @@ class Creature : public viewer
         virtual void deal_damage_handle_type( const effect_source &source, const damage_unit &du,
                                               bodypart_id bp, int &damage, int &pain );
 
-        // Pass handling bleed to creature/character
-        virtual void make_bleed( const effect_source &source, const bodypart_id &bp, time_duration duration,
-                                 int intensity = 1, bool permanent = false, bool force = false, bool defferred = false ) = 0;
-
         // directly decrements the damage. ONLY handles damage, doesn't
         // increase pain, apply effects, etc
         virtual void apply_damage( Creature *source, bodypart_id bp, int amount,
@@ -747,6 +743,7 @@ class Creature : public viewer
         std::vector<bodypart_id> get_all_body_parts_of_type(
             body_part_type::type part_type,
             get_body_part_flags flags = get_body_part_flags::none ) const;
+        bodypart_id get_random_body_part_of_type(body_part_type::type part_type) const;
         bodypart_id get_root_body_part() const;
         /* Returns all body parts with the given flag */
         std::vector<bodypart_id> get_all_body_parts_with_flag( const json_character_flag &flag ) const;
@@ -1248,7 +1245,7 @@ class Creature : public viewer
 
         virtual void on_stat_change( const std::string &, int ) {}
         virtual void on_effect_int_change( const efftype_id &, int, const bodypart_id & ) {}
-        virtual void on_damage_of_type( int, damage_type, const bodypart_id & ) {}
+        virtual void on_damage_of_type( effect_source source, int, damage_type, const bodypart_id & ) {}
 
     public:
         // Keep a count of moves passed in which resets every 100 turns as a result of practicing archery proficiency

--- a/src/creature.h
+++ b/src/creature.h
@@ -1245,7 +1245,8 @@ class Creature : public viewer
 
         virtual void on_stat_change( const std::string &, int ) {}
         virtual void on_effect_int_change( const efftype_id &, int, const bodypart_id & ) {}
-        virtual void on_damage_of_type( const effect_source &source, int, damage_type, const bodypart_id & ) {}
+        virtual void on_damage_of_type( const effect_source &source, int, damage_type,
+                                        const bodypart_id & ) {}
 
     public:
         // Keep a count of moves passed in which resets every 100 turns as a result of practicing archery proficiency

--- a/src/creature.h
+++ b/src/creature.h
@@ -613,6 +613,7 @@ class Creature : public viewer
         bool has_effect_with_flag( const flag_id &flag, const bodypart_id &bp ) const;
         bool has_effect_with_flag( const flag_id &flag ) const;
         std::vector<effect> get_effects_with_flag( const flag_id &flag ) const;
+        std::vector<effect> get_effects_from_bp( const bodypart_id &bp ) const;
         std::vector<effect> get_effects() const;
 
         /** Return the effect that matches the given arguments exactly. */

--- a/src/creature.h
+++ b/src/creature.h
@@ -1245,7 +1245,7 @@ class Creature : public viewer
 
         virtual void on_stat_change( const std::string &, int ) {}
         virtual void on_effect_int_change( const efftype_id &, int, const bodypart_id & ) {}
-        virtual void on_damage_of_type( const effect_source &source, int, damage_type,
+        virtual void on_damage_of_type( const effect_source &, int, damage_type,
                                         const bodypart_id & ) {}
 
     public:

--- a/src/creature.h
+++ b/src/creature.h
@@ -1245,7 +1245,7 @@ class Creature : public viewer
 
         virtual void on_stat_change( const std::string &, int ) {}
         virtual void on_effect_int_change( const efftype_id &, int, const bodypart_id & ) {}
-        virtual void on_damage_of_type( effect_source &source, int, damage_type, const bodypart_id & ) {}
+        virtual void on_damage_of_type( const effect_source &source, int, damage_type, const bodypart_id & ) {}
 
     public:
         // Keep a count of moves passed in which resets every 100 turns as a result of practicing archery proficiency

--- a/src/creature.h
+++ b/src/creature.h
@@ -743,7 +743,7 @@ class Creature : public viewer
         std::vector<bodypart_id> get_all_body_parts_of_type(
             body_part_type::type part_type,
             get_body_part_flags flags = get_body_part_flags::none ) const;
-        bodypart_id get_random_body_part_of_type(body_part_type::type part_type) const;
+        bodypart_id get_random_body_part_of_type( body_part_type::type part_type ) const;
         bodypart_id get_root_body_part() const;
         /* Returns all body parts with the given flag */
         std::vector<bodypart_id> get_all_body_parts_with_flag( const json_character_flag &flag ) const;
@@ -1245,7 +1245,7 @@ class Creature : public viewer
 
         virtual void on_stat_change( const std::string &, int ) {}
         virtual void on_effect_int_change( const efftype_id &, int, const bodypart_id & ) {}
-        virtual void on_damage_of_type( effect_source source, int, damage_type, const bodypart_id & ) {}
+        virtual void on_damage_of_type( effect_source &source, int, damage_type, const bodypart_id & ) {}
 
     public:
         // Keep a count of moves passed in which resets every 100 turns as a result of practicing archery proficiency

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -123,6 +123,7 @@ static const achievement_id achievement_achievement_arcade_mode( "achievement_ar
 static const bodypart_str_id body_part_no_a_real_part( "no_a_real_part" );
 
 static const efftype_id effect_asthma( "asthma" );
+static const efftype_id effect_bleed( "bleed" );
 
 static const faction_id faction_no_faction( "no_faction" );
 
@@ -2999,7 +3000,7 @@ void debug()
                     break;
             }
             if( query_int( intensity, _( "Add bleeding duration in minutes, equal to intensity:" ) ) ) {
-                player_character.make_bleed( effect_source::empty(), part, 1_minutes * intensity );
+                player_character.add_effect( effect_bleed,  1_minutes * intensity, part );
             }
         }
         break;

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -777,7 +777,8 @@ std::string effect::disp_desc( bool reduced ) const
     if( has_flag( flag_EFFECT_LIMB_SCORE_MOD_LOCAL ) || has_flag( flag_EFFECT_LIMB_SCORE_MOD ) ) {
         std::string global = has_flag( flag_EFFECT_LIMB_SCORE_MOD ) ? "Global" : "Local";
         for( limb_score_effect &effect : get_limb_score_data() ) {
-            if( bp->has_limb_score( effect.score_id ) ) {
+            // Only print modifiers if they are global or if the limb has the score in the first place
+            if( bp->has_limb_score( effect.score_id ) || has_flag(flag_EFFECT_LIMB_SCORE_MOD)) {
                 ret += string_format( _( "%s %s modifier: x%.1f\n" ), global, effect.score_id->name().translated(),
                                       get_limb_score_mod( effect.score_id, reduced ) );
             }

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -1364,9 +1364,9 @@ float effect::get_limb_score_mod( const limb_score_id &score, bool reduced ) con
         float temp = 1.0f;
         if( score == effect.score_id ) {
             if( !reduced ) {
-                temp = effect.mod + effect.scaling * intensity;
+                temp = effect.mod + effect.scaling * ( intensity - 1 );
             } else {
-                temp = effect.red_mod + effect.red_scaling * intensity;
+                temp = effect.red_mod + effect.red_scaling * ( intensity - 1 );
             }
             ret *= std::max( 0.0f, temp );
         }
@@ -1467,6 +1467,7 @@ void load_effect_type( const JsonObject &jo )
         new_etype.resist_effects.emplace_back( f );
     }
     optional( jo, false, "immune_flags", new_etype.immune_flags );
+    optional( jo, false, "immune_bp_flags", new_etype.immune_bp_flags );
     for( auto &&f : jo.get_string_array( "removes_effects" ) ) { // *NOPAD*
         new_etype.removes_effects.emplace_back( f );
     }

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -12,6 +12,7 @@
 #include "effect_source.h"
 #include "enums.h"
 #include "event.h"
+#include "flag.h"
 #include "generic_factory.h"
 #include "json.h"
 #include "messages.h"
@@ -64,6 +65,22 @@ void vitamin_rate_effect::load( const JsonObject &jo )
 }
 
 void vitamin_rate_effect::deserialize( const JsonObject &jo )
+{
+    load( jo );
+}
+
+void limb_score_effect::load( const JsonObject &jo )
+{
+    mandatory( jo, false, "limb_score", score_id );
+
+    optional( jo, false, "modifier", mod, 1.0f );
+    optional( jo, false, "resist_modifier", red_mod, mod );
+    optional( jo, false, "scaling", scaling, 0.0f );
+    optional( jo, false, "resist_scaling", red_scaling, scaling );
+
+}
+
+void limb_score_effect::deserialize( const JsonObject &jo )
 {
     load( jo );
 }
@@ -756,6 +773,17 @@ std::string effect::disp_desc( bool reduced ) const
         ret += "\n";
     }
 
+    // Handle limb score modifiers if we have any
+    if( has_flag( flag_EFFECT_LIMB_SCORE_MOD_LOCAL ) || has_flag( flag_EFFECT_LIMB_SCORE_MOD ) ) {
+        std::string global = has_flag( flag_EFFECT_LIMB_SCORE_MOD ) ? "Global" : "Local";
+        for( limb_score_effect &effect : get_limb_score_data() ) {
+            if( bp->has_limb_score( effect.score_id ) ) {
+                ret += string_format( _( "%s %s modifier: x%.1f\n" ), global, effect.score_id->name().translated(),
+                                      get_limb_score_mod( effect.score_id, reduced ) );
+            }
+        }
+    }
+
     // Then print pain/damage/coughing/vomiting, we don't display pkill, health, or radiation
     std::vector<std::string> constant;
     std::vector<std::string> frequent;
@@ -1328,6 +1356,29 @@ bool effect::impairs_movement() const
     return eff_type->impairs_movement;
 }
 
+float effect::get_limb_score_mod( const limb_score_id &score, bool reduced ) const
+{
+    float ret = 1.0f;
+    for( const limb_score_effect &effect : eff_type->limb_score_data ) {
+        float temp = 1.0f;
+        if( score == effect.score_id ) {
+            if( !reduced ) {
+                temp = effect.mod + effect.scaling * intensity;
+            } else {
+                temp = effect.red_mod + effect.red_scaling * intensity;
+            }
+            ret *= std::max( 0.0f, temp );
+        }
+    }
+    if( ret != 1.0f ) {
+        add_msg_debug( debugmode::DF_CHARACTER,
+                       "Limb score modifier %s for limb score %s found\nIntensity %d\nResistance %s\nFinal effect multiplier %.1f",
+                       disp_name(),
+                       score.c_str(), intensity, reduced ? "true" : "false", ret );
+    }
+    return ret;
+}
+
 const effect_type *effect::get_effect_type() const
 {
     return eff_type;
@@ -1431,6 +1482,7 @@ void load_effect_type( const JsonObject &jo )
     }
 
     optional( jo, false, "vitamins", new_etype.vitamin_data );
+    optional( jo, false, "limb_score_mods", new_etype.limb_score_data );
     optional( jo, false, "chance_kill", new_etype.kill_chance );
     optional( jo, false, "chance_kill_resist", new_etype.red_kill_chance );
     optional( jo, false, "death_msg", new_etype.death_msg, to_translation( "You died." ) );
@@ -1476,6 +1528,12 @@ bool effect::has_flag( const flag_id &flag ) const
 {
     return eff_type->has_flag( flag );
 }
+
+std::vector<limb_score_effect> effect::get_limb_score_data() const
+{
+    return eff_type->limb_score_data;
+}
+
 
 bool effect::kill_roll( bool reduced ) const
 {

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -778,7 +778,7 @@ std::string effect::disp_desc( bool reduced ) const
         std::string global = has_flag( flag_EFFECT_LIMB_SCORE_MOD ) ? "Global" : "Local";
         for( limb_score_effect &effect : get_limb_score_data() ) {
             // Only print modifiers if they are global or if the limb has the score in the first place
-            if( bp->has_limb_score( effect.score_id ) || has_flag(flag_EFFECT_LIMB_SCORE_MOD)) {
+            if( bp->has_limb_score( effect.score_id ) || has_flag( flag_EFFECT_LIMB_SCORE_MOD ) ) {
                 ret += string_format( _( "%s %s modifier: x%.1f\n" ), global, effect.score_id->name().translated(),
                                       get_limb_score_mod( effect.score_id, reduced ) );
             }

--- a/src/effect.h
+++ b/src/effect.h
@@ -83,6 +83,20 @@ enum class mod_action : uint8_t {
     TICK,
 };
 
+// Limb score interactions
+struct limb_score_effect {
+    // Score id to affect
+    limb_score_id score_id;
+    // Multiplier to apply when not resisted
+    float mod;
+    float red_mod;
+    float scaling;
+    float red_scaling;
+
+    void load( const JsonObject &jo );
+    void deserialize( const JsonObject &jo );
+};
+
 class effect_type
 {
         friend void load_effect_type( const JsonObject &jo );
@@ -225,6 +239,7 @@ class effect_type
 
         std::unordered_map<std::string, std::unordered_map<uint32_t, modifier_value_arr>> mod_data;
         std::vector<vitamin_rate_effect> vitamin_data;
+        std::vector<limb_score_effect> limb_score_data;
         std::vector<std::pair<int, int>> kill_chance;
         std::vector<std::pair<int, int>> red_kill_chance;
 };
@@ -367,6 +382,9 @@ class effect
         /** Check if the effect has the specified flag */
         bool has_flag( const flag_id &flag ) const;
 
+        // Extract limb score modifiers for descriptions
+        std::vector<limb_score_effect> get_limb_score_data() const;
+
         bool kill_roll( bool reduced ) const;
         std::string get_death_message() const;
         event_type death_event() const;
@@ -396,6 +414,8 @@ class effect
 
         /** Returns if the effect is supposed to be handed in Creature::movement */
         bool impairs_movement() const;
+
+        float get_limb_score_mod( const limb_score_id &score, bool reduced = false ) const;
 
         /** Returns the effect's matching effect_type id. */
         const efftype_id &get_id() const {

--- a/src/effect.h
+++ b/src/effect.h
@@ -167,6 +167,7 @@ class effect_type
         }
         std::vector<enchantment_id> enchantments;
         cata::flat_set<json_character_flag> immune_flags;
+        cata::flat_set<json_character_flag> immune_bp_flags;
     protected:
         uint32_t get_effect_modifier_key( mod_action action, uint8_t reduction_level ) const {
             return static_cast<uint8_t>( action ) << 0 |

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -90,6 +90,8 @@ const flag_id flag_EATEN_COLD( "EATEN_COLD" );
 const flag_id flag_EATEN_HOT( "EATEN_HOT" );
 const flag_id flag_EDIBLE_FROZEN( "EDIBLE_FROZEN" );
 const flag_id flag_EFFECT_IMPEDING( "EFFECT_IMPEDING" );
+const flag_id flag_EFFECT_LIMB_SCORE_MOD( "EFFECT_LIMB_SCORE_MOD" );
+const flag_id flag_EFFECT_LIMB_SCORE_MOD_LOCAL( "EFFECT_LIMB_SCORE_MOD_LOCAL" );
 const flag_id flag_ELECTRIC_IMMUNE( "ELECTRIC_IMMUNE" );
 const flag_id flag_ELECTRONIC( "ELECTRONIC" );
 const flag_id flag_ETHEREAL_ITEM( "ETHEREAL_ITEM" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -100,6 +100,8 @@ extern const flag_id flag_EATEN_COLD;
 extern const flag_id flag_EATEN_HOT;
 extern const flag_id flag_EDIBLE_FROZEN;
 extern const flag_id flag_EFFECT_IMPEDING;
+extern const flag_id flag_EFFECT_LIMB_SCORE_MOD;
+extern const flag_id flag_EFFECT_LIMB_SCORE_MOD_LOCAL;
 extern const flag_id flag_ELECTRIC_IMMUNE;
 extern const flag_id flag_ELECTRONIC;
 extern const flag_id flag_ETHEREAL_ITEM;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -89,11 +89,9 @@ character_modifier_melee_thrown_move_lift_mod( "melee_thrown_move_lift_mod" );
 
 static const efftype_id effect_amigara( "amigara" );
 static const efftype_id effect_beartrap( "beartrap" );
-static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_contacts( "contacts" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_drunk( "drunk" );
-static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_grabbing( "grabbing" );
 static const efftype_id effect_heavysnare( "heavysnare" );
 static const efftype_id effect_hit_by_player( "hit_by_player" );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1133,21 +1133,6 @@ float Character::get_dodge() const
         ret /= 2;
     }
 
-    creature_tracker &creatures = get_creature_tracker();
-    if( has_effect( effect_grabbed ) ) {
-        int zed_number = 0;
-        for( const tripoint &dest : get_map().points_in_radius( pos(), 1, 0 ) ) {
-            const monster *const mon = creatures.creature_at<monster>( dest );
-            if( mon && mon->has_effect( effect_grabbing ) ) {
-                zed_number++;
-            }
-        }
-        if( zed_number > 0 ) {
-            ret /= zed_number + 1;
-            add_msg_debug( debugmode::DF_MELEE, "%d grabbing monsters found, modified dodge %.1f", ret );
-        }
-    }
-
     if( worn_with_flag( flag_ROLLER_INLINE ) ||
         worn_with_flag( flag_ROLLER_QUAD ) ||
         worn_with_flag( flag_ROLLER_ONE ) ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -376,11 +376,6 @@ float Character::hit_roll() const
         hit -= 2.0f;
     }
 
-    //Unstable ground chance of failure
-    if( has_effect( effect_bouldering ) ) {
-        hit *= 0.75f;
-    }
-
     hit *= get_modifier( character_modifier_melee_attack_roll_mod );
 
     return melee::melee_hit_range( hit );
@@ -1157,10 +1152,6 @@ float Character::get_dodge() const
         worn_with_flag( flag_ROLLER_QUAD ) ||
         worn_with_flag( flag_ROLLER_ONE ) ) {
         ret /= has_trait( trait_PROF_SKATER ) ? 2 : 5;
-    }
-
-    if( has_effect( effect_bouldering ) ) {
-        ret /= 4;
     }
 
     // Ensure no attempt to dodge without sources of extra dodges, eg martial arts

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -92,7 +92,7 @@ static const efftype_id effect_beartrap( "beartrap" );
 static const efftype_id effect_contacts( "contacts" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_drunk( "drunk" );
-static const efftype_id effect_grabbed("grabbed");
+static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_heavysnare( "heavysnare" );
 static const efftype_id effect_hit_by_player( "hit_by_player" );
 static const efftype_id effect_incorporeal( "incorporeal" );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -92,7 +92,7 @@ static const efftype_id effect_beartrap( "beartrap" );
 static const efftype_id effect_contacts( "contacts" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_drunk( "drunk" );
-static const efftype_id effect_grabbing( "grabbing" );
+static const efftype_id effect_grabbed("grabbed");
 static const efftype_id effect_heavysnare( "heavysnare" );
 static const efftype_id effect_hit_by_player( "hit_by_player" );
 static const efftype_id effect_incorporeal( "incorporeal" );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4784,7 +4784,8 @@ bool mattack::longswipe( monster *z )
                                        _( "The %1$s slashes at your neck, cutting your throat for %2$d damage!" ),
                                        _( "The %1$s slashes at <npcname>'s neck, cutting their throat for %2$d damage!" ),
                                        z->name(), dam );
-                target->add_effect(effect_source( z ), effect_bleed, 15_minutes, target->get_random_body_part_of_type( body_part_type::type::head));
+        target->add_effect( effect_source( z ), effect_bleed, 15_minutes,
+                            target->get_random_body_part_of_type( body_part_type::type::head ) );
     } else {
         target->add_msg_player_or_npc( _( "The %1$s slashes at your %2$s, but glances off your armor!" ),
                                        _( "The %1$s slashes at <npcname>'s %2$s, but glances off armor!" ),
@@ -5603,7 +5604,8 @@ bool mattack::bio_op_impale( monster *z )
         // Handle mons earlier - less to check for
         target->deal_damage( z, bodypart_id( "torso" ), damage_instance( damage_type::STAB, dam ) );
         if( do_bleed ) {
-                target->add_effect(effect_source( z ), effect_bleed, rng( 3_minutes, 10_minutes ), target->get_random_body_part_of_type( body_part_type::type::torso));
+            target->add_effect( effect_source( z ), effect_bleed, rng( 3_minutes, 10_minutes ),
+                                target->get_random_body_part_of_type( body_part_type::type::torso ) );
         }
         if( seen ) {
             add_msg( _( "The %1$s impales %2$s!" ), z->name(), target->disp_name() );
@@ -5624,7 +5626,7 @@ bool mattack::bio_op_impale( monster *z )
         target->add_msg_if_player( m_bad, _( "and deals %d damage!" ), t_dam );
 
         if( do_bleed ) {
-                target->add_effect(effect_source( z ), effect_bleed, rng( 75_turns, 125_turns ), hit);
+            target->add_effect( effect_source( z ), effect_bleed, rng( 75_turns, 125_turns ), hit );
         }
     } else {
         target->add_msg_player_or_npc( _( "but fails to penetrate your armor!" ),

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4784,7 +4784,7 @@ bool mattack::longswipe( monster *z )
                                        _( "The %1$s slashes at your neck, cutting your throat for %2$d damage!" ),
                                        _( "The %1$s slashes at <npcname>'s neck, cutting their throat for %2$d damage!" ),
                                        z->name(), dam );
-        target->make_bleed( effect_source( z ), bodypart_id( "head" ), 15_minutes );
+                target->add_effect(effect_source( z ), effect_bleed, 15_minutes, target->get_random_body_part_of_type( body_part_type::type::head));
     } else {
         target->add_msg_player_or_npc( _( "The %1$s slashes at your %2$s, but glances off your armor!" ),
                                        _( "The %1$s slashes at <npcname>'s %2$s, but glances off armor!" ),
@@ -5603,7 +5603,7 @@ bool mattack::bio_op_impale( monster *z )
         // Handle mons earlier - less to check for
         target->deal_damage( z, bodypart_id( "torso" ), damage_instance( damage_type::STAB, dam ) );
         if( do_bleed ) {
-            target->make_bleed( effect_source( z ), bodypart_id( "torso" ), rng( 3_minutes, 10_minutes ) );
+                target->add_effect(effect_source( z ), effect_bleed, rng( 3_minutes, 10_minutes ), target->get_random_body_part_of_type( body_part_type::type::torso));
         }
         if( seen ) {
             add_msg( _( "The %1$s impales %2$s!" ), z->name(), target->disp_name() );
@@ -5612,7 +5612,7 @@ bool mattack::bio_op_impale( monster *z )
         return true;
     }
 
-    const bodypart_id hit = target->get_random_body_part();
+    const bodypart_id hit = target->get_random_body_part( true );
 
     t_dam = foe->deal_damage( z, hit, damage_instance( damage_type::STAB, dam ) ).total_damage();
 
@@ -5624,7 +5624,7 @@ bool mattack::bio_op_impale( monster *z )
         target->add_msg_if_player( m_bad, _( "and deals %d damage!" ), t_dam );
 
         if( do_bleed ) {
-            target->make_bleed( effect_source( z ), hit, rng( 75_turns, 125_turns ) );
+                target->add_effect(effect_source( z ), effect_bleed, rng( 75_turns, 125_turns ), hit);
         }
     } else {
         target->add_msg_player_or_npc( _( "but fails to penetrate your armor!" ),

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2891,7 +2891,7 @@ bool mattack::ranged_pull( monster *z )
     const int prev_effect = target->get_effect_int( effect_grabbed, body_part_torso );
     //Duration needs to be at least 2, or grab will immediately be removed
     target->add_effect( effect_grabbed, 2_turns, body_part_torso, false, prev_effect + 4 );
-    z->add_effect( effect_grabbing, 2_turns );
+    z->add_effect( effect_grabbing, 2_turns, true );
     return true;
 }
 
@@ -2960,7 +2960,7 @@ bool mattack::grab( monster *z )
     }
 
     const int prev_effect = target->get_effect_int( effect_grabbed, body_part_torso );
-    z->add_effect( effect_grabbing, 2_turns );
+    z->add_effect( effect_grabbing, 2_turns, true );
     target->add_effect( effect_grabbed, 2_turns, body_part_torso, false,
                         prev_effect + z->get_grab_strength() );
 
@@ -3044,7 +3044,7 @@ bool mattack::grab_drag( monster *z )
     }
 
     const int prev_effect = target->get_effect_int( effect_grabbed, body_part_torso );
-    z->add_effect( effect_grabbing, 2_turns );
+    z->add_effect( effect_grabbing, 2_turns, true );
     target->add_effect( effect_grabbed, 2_turns, bodypart_id( "torso" ), false, prev_effect + 3 );
 
     // cooldown was not reset prior to refactor here

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1936,7 +1936,7 @@ void monster::deal_damage_handle_type( const effect_source &source, const damage
         case damage_type::CUT:
         case damage_type::STAB:
         case damage_type::BULLET:
-            make_bleed( source, 1_minutes * rng(1, adjusted_damage) );
+            make_bleed( source, 1_minutes * rng( 1, adjusted_damage ) );
         default:
             break;
     }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1627,8 +1627,8 @@ bool monster::is_immune_damage( const damage_type dt ) const
     }
 }
 
-void monster::make_bleed( const effect_source &source, const bodypart_id &bp,
-                          time_duration duration, int intensity, bool permanent, bool force, bool defferred )
+void monster::make_bleed( const effect_source &source, time_duration duration, int intensity,
+                          bool permanent, bool force, bool defferred )
 {
     if( type->bleed_rate == 0 ) {
         return;
@@ -1636,9 +1636,10 @@ void monster::make_bleed( const effect_source &source, const bodypart_id &bp,
 
     duration = ( duration * type->bleed_rate ) / 100;
     if( type->in_species( species_ROBOT ) ) {
-        add_effect( source, effect_dripping_mechanical_fluid, duration, bp );
+        add_effect( source, effect_dripping_mechanical_fluid, duration, bodypart_str_id::NULL_ID() );
     } else {
-        add_effect( source, effect_bleed, duration, bp, permanent, intensity, force, defferred );
+        add_effect( source, effect_bleed, duration, bodypart_str_id::NULL_ID(), permanent, intensity, force,
+                    defferred );
     }
 }
 
@@ -1899,6 +1900,7 @@ void monster::deal_projectile_attack( Creature *source, dealt_projectile_attack 
 void monster::deal_damage_handle_type( const effect_source &source, const damage_unit &du,
                                        bodypart_id bp, int &damage, int &pain )
 {
+    const int adjusted_damage = du.amount * du.damage_multiplier * du.unconditional_damage_mult;
     switch( du.type ) {
         case damage_type::ELECTRIC:
             if( has_flag( MF_ELECTRIC ) ) {
@@ -1929,10 +1931,12 @@ void monster::deal_damage_handle_type( const effect_source &source, const damage
         // typeless damage, should always go through
         case damage_type::BIOLOGICAL:
         // internal damage, like from smoke or poison
+        case damage_type::HEAT:
+            break;
         case damage_type::CUT:
         case damage_type::STAB:
         case damage_type::BULLET:
-        case damage_type::HEAT:
+            make_bleed( source, 1_minutes * rng(1, adjusted_damage) );
         default:
             break;
     }

--- a/src/monster.h
+++ b/src/monster.h
@@ -327,8 +327,8 @@ class monster : public Creature
         bool is_immune_effect( const efftype_id & ) const override;
         bool is_immune_damage( damage_type ) const override;
 
-        void make_bleed( const effect_source &source, const bodypart_id &bp, time_duration duration,
-                         int intensity = 1, bool permanent = false, bool force = false, bool defferred = false ) override;
+        void make_bleed( const effect_source &source, time_duration duration,
+                         int intensity = 1, bool permanent = false, bool force = false, bool defferred = false );
 
         const weakpoint *absorb_hit( const weakpoint_attack &attack, const bodypart_id &bp,
                                      damage_instance &dam ) override;

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -30,6 +30,8 @@
 
 class item;
 
+static const efftype_id effect_bleed( "bleed" );
+
 static const zone_type_id zone_type_ZONE_START_POINT( "ZONE_START_POINT" );
 
 namespace
@@ -488,7 +490,7 @@ void start_location::handle_heli_crash( avatar &you ) const
             // Damage + Bleed
             case 1:
             case 2:
-                you.make_bleed( effect_source::empty(), bp, 6_minutes );
+                you.add_effect( effect_bleed, 6_minutes, bp );
             /* fallthrough */
             case 3:
             case 4:

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1056,10 +1056,12 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
                 dam = std::max( 0, dam - armor );
                 critter->apply_damage( driver, bodypart_id( "torso" ), dam );
                 if( part_flag( ret.part, "SHARP" ) ) {
-                critter->add_effect(effect_source( driver ), effect_bleed, 1_minutes * rng( 1, dam ), critter->get_random_body_part_of_type( body_part_type::type::torso));
+                    critter->add_effect( effect_source( driver ), effect_bleed, 1_minutes * rng( 1, dam ),
+                                         critter->get_random_body_part_of_type( body_part_type::type::torso ) );
                 } else if( dam > 18 && rng( 1, 20 ) > 15 ) {
                     //low chance of lighter bleed even with non sharp objects.
-                critter->add_effect(effect_source( driver ), effect_bleed, 1_minutes, critter->get_random_body_part_of_type( body_part_type::type::torso));
+                    critter->add_effect( effect_source( driver ), effect_bleed, 1_minutes,
+                                         critter->get_random_body_part_of_type( body_part_type::type::torso ) );
                 }
                 add_msg_debug( debugmode::DF_VEHICLE_MOVE, "Critter collision damage: %d", dam );
             }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -42,6 +42,7 @@
 
 #define dbg(x) DebugLog((x),D_MAP) << __FILE__ << ":" << __LINE__ << ": "
 
+static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_harnessed( "harnessed" );
 static const efftype_id effect_pet( "pet" );
 static const efftype_id effect_stunned( "stunned" );
@@ -1055,10 +1056,10 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
                 dam = std::max( 0, dam - armor );
                 critter->apply_damage( driver, bodypart_id( "torso" ), dam );
                 if( part_flag( ret.part, "SHARP" ) ) {
-                    critter->make_bleed( effect_source( driver ), bodypart_id( "torso" ), 1_minutes * rng( 1, dam ) );
+                critter->add_effect(effect_source( driver ), effect_bleed, 1_minutes * rng( 1, dam ), critter->get_random_body_part_of_type( body_part_type::type::torso));
                 } else if( dam > 18 && rng( 1, 20 ) > 15 ) {
                     //low chance of lighter bleed even with non sharp objects.
-                    critter->make_bleed( effect_source( driver ), bodypart_id( "torso" ), 1_minutes );
+                critter->add_effect(effect_source( driver ), effect_bleed, 1_minutes, critter->get_random_body_part_of_type( body_part_type::type::torso));
                 }
                 add_msg_debug( debugmode::DF_VEHICLE_MOVE, "Critter collision damage: %d", dam );
             }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -113,10 +113,10 @@ void glare( const weather_type_id &w )
         incident_sun_irradiance( w, calendar::turn ) > irradiance::moderate ) {
         // Winter snow glare happens at lower irradiance
         effect = &effect_snow_glare;
-        dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
+        dur = player_character.has_effect( *effect ) ? 10_turns : 20_turns;
     } else if( incident_sun_irradiance( w, calendar::turn ) > irradiance::high ) {
         effect = &effect_glare;
-        dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
+        dur = player_character.has_effect( *effect ) ? 10_turns : 20_turns;
     }
 
     //apply final glare effect
@@ -125,7 +125,11 @@ void glare( const weather_type_id &w )
         if( player_character.has_trait( trait_CEPH_VISION ) ) {
             dur = dur * 2;
         }
-        player_character.add_env_effect( *effect, body_part_eyes, 2, dur );
+        // Glare in all your eyes
+        for( bodypart_id &bp : player_character.get_all_body_parts_of_type(
+                 body_part_type::type::sensor ) ) {
+            player_character.add_effect( *effect, dur, bp );
+        }
     }
 }
 

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -11,6 +11,7 @@
 #include "game.h"
 #include "item.h"
 #include "map_helpers.h"
+#include "monattack.h"
 #include "monster.h"
 #include "mtype.h"
 #include "player_helpers.h"
@@ -21,6 +22,7 @@ static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_grabbing( "grabbing" );
 
 static const mtype_id debug_mon( "debug_mon" );
+static const mtype_id debug_mon_grab( "mon_debug_grab" );
 static const mtype_id mon_zombie( "mon_zombie" );
 static const mtype_id mon_zombie_smoker( "mon_zombie_smoker" );
 
@@ -315,10 +317,10 @@ TEST_CASE( "player::get_dodge while grabbed", "[player][melee][dodge][grab]" )
     tripoint mon4_pos = dummy.pos() + tripoint_west;
 
     // Surrounded by zombies!
-    monster *zed1 = g->place_critter_at( debug_mon, mon1_pos );
-    monster *zed2 = g->place_critter_at( debug_mon, mon2_pos );
-    monster *zed3 = g->place_critter_at( debug_mon, mon3_pos );
-    monster *zed4 = g->place_critter_at( debug_mon, mon4_pos );
+    monster *zed1 = g->place_critter_at( debug_mon_grab, mon1_pos );
+    monster *zed2 = g->place_critter_at( debug_mon_grab, mon2_pos );
+    monster *zed3 = g->place_critter_at( debug_mon_grab, mon3_pos );
+    monster *zed4 = g->place_critter_at( debug_mon_grab, mon4_pos );
 
     // Make sure zombies are in their places
     REQUIRE( creatures.creature_at<monster>( mon1_pos ) );
@@ -326,50 +328,60 @@ TEST_CASE( "player::get_dodge while grabbed", "[player][melee][dodge][grab]" )
     REQUIRE( creatures.creature_at<monster>( mon3_pos ) );
     REQUIRE( creatures.creature_at<monster>( mon4_pos ) );
 
-    // Get grabbed
-    dummy.add_effect( effect_grabbed, 1_minutes );
-    REQUIRE( dummy.has_effect( effect_grabbed ) );
+    zed1->set_dest( dummy.get_location() );
+    zed2->set_dest( dummy.get_location() );
+    zed3->set_dest( dummy.get_location() );
+    zed4->set_dest( dummy.get_location() );
 
-    // When grabbed, dodge skill reduces for each additional grab
+    // Use actual grabbing attacks
 
-    SECTION( "1 grab: 1/2 dodge" ) {
-        zed1->add_effect( effect_grabbing, 1_minutes );
+    SECTION( "1 grab: approx. 1/2 dodge" ) {
+        mattack::grab( zed1 );
         REQUIRE( zed1->has_effect( effect_grabbing ) );
 
-        CHECK( dummy.get_dodge() == base_dodge / 2 );
+        REQUIRE( dummy.get_effect_int( effect_grabbed, body_part_torso ) == 1 );
+
+        CHECK( dummy.get_dodge() == Approx( base_dodge / 2 ).margin( 0.1f ) );
     }
 
-    SECTION( "2 grabs: 1/3 dodge" ) {
-        zed1->add_effect( effect_grabbing, 1_minutes );
-        zed2->add_effect( effect_grabbing, 1_minutes );
+    SECTION( "2 grabs:approx.  1/3 dodge" ) {
+        mattack::grab( zed1 );
+        mattack::grab( zed2 );
         REQUIRE( zed1->has_effect( effect_grabbing ) );
         REQUIRE( zed2->has_effect( effect_grabbing ) );
 
-        CHECK( dummy.get_dodge() == base_dodge / 3 );
+        REQUIRE( dummy.get_effect_int( effect_grabbed, body_part_torso ) == 2 );
+
+        CHECK( dummy.get_dodge() == Approx( base_dodge / 3 ).margin( 0.1f ) );
     }
 
-    SECTION( "3 grabs: 1/4 dodge" ) {
-        zed1->add_effect( effect_grabbing, 1_minutes );
-        zed2->add_effect( effect_grabbing, 1_minutes );
-        zed3->add_effect( effect_grabbing, 1_minutes );
+    SECTION( "3 grabs: approx. 1/4 dodge" ) {
+        mattack::grab( zed1 );
+        mattack::grab( zed2 );
+        mattack::grab( zed3 );
         REQUIRE( zed1->has_effect( effect_grabbing ) );
         REQUIRE( zed2->has_effect( effect_grabbing ) );
         REQUIRE( zed3->has_effect( effect_grabbing ) );
 
-        CHECK( dummy.get_dodge() == base_dodge / 4 );
+        REQUIRE( dummy.get_effect_int( effect_grabbed, body_part_torso ) == 3 );
+
+        CHECK( dummy.get_dodge() == Approx( base_dodge / 4 ).margin( 0.1f ) );
     }
 
-    SECTION( "4 grabs: 1/5 dodge" ) {
-        zed1->add_effect( effect_grabbing, 1_minutes );
-        zed2->add_effect( effect_grabbing, 1_minutes );
-        zed3->add_effect( effect_grabbing, 1_minutes );
-        zed4->add_effect( effect_grabbing, 1_minutes );
+    SECTION( "4 grabs: approx. 1/5 dodge" ) {
+        mattack::grab( zed1 );
+        mattack::grab( zed2 );
+        mattack::grab( zed3 );
+        mattack::grab( zed4 );
+
         REQUIRE( zed1->has_effect( effect_grabbing ) );
         REQUIRE( zed2->has_effect( effect_grabbing ) );
         REQUIRE( zed3->has_effect( effect_grabbing ) );
         REQUIRE( zed4->has_effect( effect_grabbing ) );
 
-        CHECK( dummy.get_dodge() == base_dodge / 5 );
+        REQUIRE( dummy.get_effect_int( effect_grabbed, body_part_torso ) == 4 );
+
+        CHECK( dummy.get_dodge() == Approx( base_dodge / 5 ).margin( 0.1f ) );
     }
 }
 

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -21,8 +21,7 @@
 static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_grabbing( "grabbing" );
 
-static const mtype_id debug_mon( "debug_mon" );
-static const mtype_id debug_mon_grab( "mon_debug_grab" );
+static const mtype_id mon_debug_grab( "mon_debug_grab" );
 static const mtype_id mon_zombie( "mon_zombie" );
 static const mtype_id mon_zombie_smoker( "mon_zombie_smoker" );
 
@@ -317,10 +316,10 @@ TEST_CASE( "player::get_dodge while grabbed", "[player][melee][dodge][grab]" )
     tripoint mon4_pos = dummy.pos() + tripoint_west;
 
     // Surrounded by zombies!
-    monster *zed1 = g->place_critter_at( debug_mon_grab, mon1_pos );
-    monster *zed2 = g->place_critter_at( debug_mon_grab, mon2_pos );
-    monster *zed3 = g->place_critter_at( debug_mon_grab, mon3_pos );
-    monster *zed4 = g->place_critter_at( debug_mon_grab, mon4_pos );
+    monster *zed1 = g->place_critter_at( mon_debug_grab, mon1_pos );
+    monster *zed2 = g->place_critter_at( mon_debug_grab, mon2_pos );
+    monster *zed3 = g->place_critter_at( mon_debug_grab, mon3_pos );
+    monster *zed4 = g->place_critter_at( mon_debug_grab, mon4_pos );
 
     // Make sure zombies are in their places
     REQUIRE( creatures.creature_at<monster>( mon1_pos ) );
@@ -335,7 +334,7 @@ TEST_CASE( "player::get_dodge while grabbed", "[player][melee][dodge][grab]" )
 
     // Use actual grabbing attacks
 
-    SECTION( "1 grab: approx. 1/2 dodge" ) {
+    SECTION( "1 grab: approx.  1/2 dodge" ) {
         mattack::grab( zed1 );
         REQUIRE( zed1->has_effect( effect_grabbing ) );
 
@@ -355,7 +354,7 @@ TEST_CASE( "player::get_dodge while grabbed", "[player][melee][dodge][grab]" )
         CHECK( dummy.get_dodge() == Approx( base_dodge / 3 ).margin( 0.1f ) );
     }
 
-    SECTION( "3 grabs: approx. 1/4 dodge" ) {
+    SECTION( "3 grabs: approx.  1/4 dodge" ) {
         mattack::grab( zed1 );
         mattack::grab( zed2 );
         mattack::grab( zed3 );
@@ -368,7 +367,7 @@ TEST_CASE( "player::get_dodge while grabbed", "[player][melee][dodge][grab]" )
         CHECK( dummy.get_dodge() == Approx( base_dodge / 4 ).margin( 0.1f ) );
     }
 
-    SECTION( "4 grabs: approx. 1/5 dodge" ) {
+    SECTION( "4 grabs: approx.  1/5 dodge" ) {
         mattack::grab( zed1 );
         mattack::grab( zed2 );
         mattack::grab( zed3 );

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -266,7 +266,7 @@ TEST_CASE( "player::get_dodge with effects", "[player][melee][dodge][effect]" )
     }
 
     SECTION( "unstable footing: 1/4 dodge" ) {
-        CHECK( dodge_with_effect( dummy, "bouldering" ) == base_dodge / 4 );
+        CHECK( dodge_with_effect( dummy, "bouldering" ) == Approx( base_dodge / 4 ).margin( 0.1f ) );
     }
 
     SECTION( "skating: amateur or pro?" ) {

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -212,6 +212,8 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
         epsilon_threshold threshold{ expected_damage, 2.5 };
         do {
             you.set_all_parts_hp_to_max();
+            // Remove stagger/winded effects
+            you.clear_effects();
             you.dodges_left = 1;
             int prev_hp = you.get_hp();
             // monster shoots the player


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add bodypart on-hit effects, allow effects to directly modify limb scores"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Unhardcode and limbify all the things - specifically different limbs should bleed differently, and different eyes should be able to be more/less resistant to blinding, and player status effects beyond those should move out of monster special attacks and instead be a function of the player's anatomy itself.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- Add on-hit limb effects, checked by `Character::deal_damage_handle_type` (which needed a bit of adjustment to track the damage source)
- Deprecate `Character::make_bleed`, the `Monster`-level function is useful enough until we get freely-defined monster effect resistances. Lead to having to mess with a lot of one-off hardcoded bleed sources
- Unhardcode the dodge effect of adjacent creatures and adjust the grab logic to prevent zombies sponatneously letting you go after two turns
- Slightly limb-proof blinding ranged attacks, but that whole function will need a slight overhaul for Limb Stuff in the future
- Slightly limb-proof the hardcoded monster attacks, though they should mostly be on the way out
- Limb-proofed adding glare
- Added the previously hardcoded effects to the limbs where they make sense (for a full list see Additional Context)
- Added ability to modify limb scores via effects - either as global modifiers per effect instance or locally on the affected limb itself

TODO:
- [x] Audit monster attacks for effects that fit more as on-hit ones
- [ ] More playtesting

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Overhaul bleeding in general - `int_dur_factor` means the scaling is pretty much linear, and the whole functionality could comfortably move over to EoCs / effect vitamin adjustments but that's pretty out of scope for this. I might look into that in a separate PR.

Don't bundle effect/limb score stuff into this, but that really opens the design space up for new onhit effects.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Loads, unit tests including the bleed inheritance one work. Debugmode messages tell you what is happening under the hood, intensity/duration limits are respected, scaling works as intended. Differential handling of minor and major parts works.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

The major change is you will usually get bled slightly more, but different bodyparts have different capacity to bleed and slightly different damage scaling based on damage type or limb - there's only so much bleeding a head can do, but a torso will rush up to major bleeding when shot pretty quickly. 

The other important points are the potential to get stunned (by major bash damage to your head), staggered (bash on torso), or downed (high amounts of any damage on your torso or bash damage on your legs), that should even the playing field slightly when it comes to incoming/outgoing status effects. Numbers are WIP, but there's no rush what with it being a definite Feature Freeze PR.
<details>
  <summary>Bodypart hit effects</summary>

 # Torso
 - Bleed on cut (max 1800s duration, 3% max HP threshold), stab, and bullet damage (unlimited duration, 1% damage threshold and faster scaling)
 - Winded on bash (10% base chance at 10% max HP threshold, max 15s duration)
 - Staggered (a new character version using limb score modifiers) scaling from 5% max HP for bash and 15% max HP for other damage types
 - Downed (15% max HP for bash and 25% max HP threshold for other damage types, 5% base chance)

# Head
- Bleed (lower max duration than torso)
- Stun (lower threshold on bash damage)

# Eyes
- Chance to blind on any damage above 3 HP, base 50% scaling with damage

# Arms
- Bleed with a relatively low max duration limit
- Staggered with the same setup as the torso

# Legs
- Bleed (higher max duration than arms, lower than torso)
- Bouldering 
- Downed
</details>
