### PR TITLE
Location-dependent hallucinations

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4809,8 +4809,18 @@ bool game::spawn_hallucination( const tripoint &p )
         }
     }
 
-    return spawn_hallucination( p, MonsterGenerator::generator().get_valid_hallucination(),
-                                cata::nullopt );
+    mtype_id hallu = MonsterGenerator::generator().get_valid_hallucination();
+
+    // If there's 'spawns' exist for player's current location, then
+    // spawn random hallucination monster from 'spawns'-dependent monster group
+    // instead of a completely random hallucination monster
+    const oter_id &terrain_type = overmap_buffer.ter( get_player_character().global_omt_location() );
+    const overmap_static_spawns &spawns = terrain_type->get_static_spawns();
+    if( !spawns.group.is_null() ) {
+        hallu = MonsterGroupManager::GetRandomMonsterFromGroup( spawns.group );
+    }
+
+    return spawn_hallucination( p, hallu, cata::nullopt );
 }
 /**
  * Attempts to spawn a hallucination at given location.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4812,11 +4812,11 @@ bool game::spawn_hallucination( const tripoint &p )
     mtype_id hallu = MonsterGenerator::generator().get_valid_hallucination();
 
     // If there's 'spawns' exist for player's current location, then
-    // spawn random hallucination monster from 'spawns'-dependent monster group
-    // instead of a completely random hallucination monster
+    // spawn random hallucination monster from 'spawns'-dependent monster group (90% chance)
+    // or a completely random hallucination monster (10% chance)
     const oter_id &terrain_type = overmap_buffer.ter( get_player_character().global_omt_location() );
     const overmap_static_spawns &spawns = terrain_type->get_static_spawns();
-    if( !spawns.group.is_null() ) {
+    if( !spawns.group.is_null() && !one_in( 9 ) ) {
         hallu = MonsterGroupManager::GetRandomMonsterFromGroup( spawns.group );
     }
 


### PR DESCRIPTION
#### Summary
Content "Location-dependent hallucinations"

#### Purpose of change
Inspired by #24688.

Hallucinations are too easy to differentiate from real creatures as very frequently they spawn clearly out of place, like a searchlight or a zombie shark inside a city house.

#### Describe the solution
If there's `spawns` exist for player's current location, then spawn random hallucination monster from `spawns`-dependent monster group (with 90% chance) or a completely random hallucination monster (10% chance). Thus, ordinary city houses will mostly spawn hallucination from `VANILLA` monster group, wasp towers will spawn hallucinations from `WASP_GUARD` monster group, and so on.

#### Describe alternatives you've considered
None.

#### Testing
Made my character hallucinating. Teleported to wasp tower, FEMA camp, butcher shop and checked which hallucinations are spawned. Also checked that completely random hallucinations are spawned on roads and other locations without defined `spawns`.

#### Additional context
This change severely lowers overall variety of spawning hallucination monsters, which may reduce fun for some players, so I'm putting [CR] tag.