### PR TITLE
silat unarmed + tkd tweaks

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -1105,17 +1105,20 @@
     "type": "martial_art",
     "id": "style_silat",
     "name": { "str": "Silat" },
-    "description": "Pencak Silat, of Indonesian origin, is a fighting style that covers the use of short blades and bludgeons.  Fighters stay low and mobile to avoid attacks, then unleash deadly critical hits.",
+    "description": "Pencak Silat is a style that covers a wide variety of weapons and unarmed fighting techniques.  Fighters stay low and mobile to avoid attacks, then unleash deadly critical hits.",
     "initiate": [ "You give a salute of respect as you prepare to combat.", "%s gives a combat salute." ],
     "learn_difficulty": 7,
     "primary_skill": "cutting",
-    "strictly_melee": true,
+    "arm_block": 3,
+    "leg_block": 5,
+    "strictly_melee": false,
     "static_buffs": [
       {
         "id": "buff_silat_static",
         "name": "Silat Stance",
         "description": "You try to stay loose as possible when fighting to have more chances to dodge.\n\n+1 dodge attempt.",
         "melee_allowed": true,
+        "unarmed_allowed": true,
         "bonus_dodges": 1
       }
     ],
@@ -1126,6 +1129,7 @@
         "description": "Each time you dodge an attack, you learn a bit more about your opponents' fighting style.  This allows you to make more precise attacks against them.\n\nAccuracy increased by 15% of Dexterity.\nLasts 2 turns.  Stacks 3 times.",
         "skill_requirements": [ { "name": "melee", "level": 1 } ],
         "melee_allowed": true,
+        "unarmed_allowed": true,
         "buff_duration": 2,
         "max_stacks": 3,
         "flat_bonuses": [ { "stat": "hit", "scaling-stat": "dex", "scale": 0.15 } ]
@@ -1138,12 +1142,13 @@
         "description": "You stay low as you move, making it harder for enemies to defend against you.\n\n+5% critical hit chance.\nLasts 1 turn.",
         "skill_requirements": [ { "name": "melee", "level": 1 } ],
         "melee_allowed": true,
+        "unarmed_allowed": true,
         "buff_duration": 1,
         "flat_bonuses": [ { "stat": "crit_chance", "scale": 5.0 } ]
       }
     ],
-    "techniques": [ "tec_silat_hamstring", "tec_silat_precise", "tec_silat_brutal", "tec_silat_dirty" ],
-    "weapon_category": [ "KNIVES", "BATONS", "QUARTERSTAVES", "BLADED_FARMING", "POLEARMS" ]
+    "techniques": [ "tec_silat_hamstring", "tec_silat_legsweep", "tec_silat_precise", "tec_silat_brutal", "tec_silat_dirty" ],
+    "weapon_category": [ "KNIVES", "BATONS", "SHORT SWORDS", "MEDIUM SWORDS", "QUARTERSTAVES", "BLADED_FARMING", "POLEARMS" ]
   },
   {
     "type": "martial_art",
@@ -1258,10 +1263,9 @@
     "id": "style_taekwondo",
     "name": { "str": "Taekwondo" },
     "description": "Taekwondo is the national sport of Korea, and was used by the South Korean army in the 20th century.  Focused on kicks and so it does not benefit from wielded weapons.  It also includes strength training; your blocks absorb extra damage and your attacks do more damage if you are not holding anything.",
-    "initiate": [ "You adopt a narrow fighting stance.", "%s adopts a narrow fighting stance." ],
+    "initiate": [ "You adopt a sideways fighting stance.", "%s adopts a sideways fighting stance." ],
     "learn_difficulty": 5,
     "arm_block": 1,
-    "leg_block": 3,
     "force_unarmed": true,
     "prevent_weapon_blocking": true,
     "allow_all_weapons": true,
@@ -1269,9 +1273,9 @@
       {
         "id": "buff_taekwondo_static",
         "name": "Taekwondo Stance",
-        "description": "Using your legs to attack allows your hands to be free for better defense.\n\nBlocked damage reduced by 50% of Strength.",
+        "description": "Using a mobile sideways stance makes it easier avoid attacks, while having both hands free allows for better blocks. \n\n+1.0 Dodging skill, blocked damage reduced by 50% of Strength.",
         "unarmed_allowed": true,
-        "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.5 } ]
+        "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.5 }, { "stat": "dodge", "scale": 1 } ]
       },
       {
         "id": "buff_taekwondo_static2",
@@ -1286,7 +1290,6 @@
       }
     ],
     "techniques": [
-      "tec_taekwondo_disarm",
       "tec_taekwondo_strong",
       "tec_taekwondo_roundhouse",
       "tec_taekwondo_feint",

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -1263,7 +1263,7 @@
     "id": "style_taekwondo",
     "name": { "str": "Taekwondo" },
     "description": "Taekwondo is the national sport of Korea, and was used by the South Korean army in the 20th century.  Focused on kicks and so it does not benefit from wielded weapons.  It also includes strength training; your blocks absorb extra damage and your attacks do more damage if you are not holding anything.",
-    "initiate": [ "You adopt a sideways fighting stance.", "%s adopts a sideways fighting stance." ],
+    "initiate": [ "You jump into a narrow side facing fighting stance.", "%s jumps into a narrow side facing fighting stance." ],
     "learn_difficulty": 5,
     "arm_block": 1,
     "force_unarmed": true,
@@ -1273,7 +1273,7 @@
       {
         "id": "buff_taekwondo_static",
         "name": "Taekwondo Stance",
-        "description": "Using a mobile sideways stance makes it easier avoid attacks, while having both hands free allows for better blocks. \n\n+1.0 Dodging skill, blocked damage reduced by 50% of Strength.",
+        "description": "Using a stance that presents less of a target makes it easier avoid attacks, while having both hands free allows for better blocks. \n\n+1.0 Dodging skill, blocked damage reduced by 50% of Strength.",
         "unarmed_allowed": true,
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.5 }, { "stat": "dodge", "scale": 1 } ]
       },

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -1273,7 +1273,7 @@
       {
         "id": "buff_taekwondo_static",
         "name": "Taekwondo Stance",
-        "description": "Using a stance that presents less of a target makes it easier avoid attacks, while having both hands free allows for better blocks. \n\n+1.0 Dodging skill, blocked damage reduced by 50% of Strength.",
+        "description": "Using a stance that presents less of a target makes it easier avoid attacks, while having both hands free allows for better blocks.\n\n+1.0 Dodging skill, blocked damage reduced by 50% of Strength.",
         "unarmed_allowed": true,
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.5 }, { "stat": "dodge", "scale": 1 } ]
       },

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -1108,7 +1108,6 @@
     "description": "Pencak Silat is a style that covers a wide variety of weapons and unarmed fighting techniques.  Fighters stay low and mobile to avoid attacks, then unleash deadly critical hits.",
     "initiate": [ "You give a salute of respect as you prepare to combat.", "%s gives a combat salute." ],
     "learn_difficulty": 7,
-    "primary_skill": "cutting",
     "arm_block": 3,
     "leg_block": 5,
     "strictly_melee": false,

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -1602,7 +1602,7 @@
     "messages": [ "You ground %s with a leg sweep", "<npcname> grounds %s with a leg sweep" ],
     "skill_requirements": [ { "name": "unarmed", "level": 2 } ],
     "melee_allowed": true,
-	"unarmed_allowed": true,
+    "unarmed_allowed": true,
     "crit_tec": true,
     "down_dur": 2,
     "attack_vectors": [ "FOOT", "LOWER_LEG", "THROW" ]
@@ -1623,7 +1623,7 @@
       { "stat": "damage", "type": "stab", "scale": 1.33 }
     ],
     "attack_vectors": [ "WEAPON" ],
-	"attack_vectors_random": [ "HAND", "FOOT", "ELBOW", "KNEE", "LOWER_LEG", "HEAD" ]
+    "attack_vectors_random": [ "HAND", "FOOT", "ELBOW", "KNEE", "LOWER_LEG", "HEAD" ]
   },
   {
     "type": "technique",
@@ -1635,7 +1635,7 @@
     "crit_tec": true,
     "stun_dur": 2,
     "attack_vectors": [ "WEAPON" ],
-	"attack_vectors_random": [ "HAND", "FOOT", "ELBOW", "KNEE", "LOWER_LEG", "HEAD" ]
+    "attack_vectors_random": [ "HAND", "FOOT", "ELBOW", "KNEE", "LOWER_LEG", "HEAD" ]
   },
   {
     "type": "technique",
@@ -1653,7 +1653,7 @@
       { "stat": "damage", "type": "stab", "scale": 1.33 }
     ],
     "attack_vectors": [ "WEAPON" ],
-	"attack_vectors_random": [ "HAND", "FOOT", "ELBOW", "KNEE", "LOWER_LEG", "HEAD" ]
+    "attack_vectors_random": [ "HAND", "FOOT", "ELBOW", "KNEE", "LOWER_LEG", "HEAD" ]
   },
   {
     "type": "technique",

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -1597,6 +1597,18 @@
   },
   {
     "type": "technique",
+    "id": "tec_silat_legsweep",
+    "name": "Leg Sweep",
+    "messages": [ "You ground %s with a leg sweep", "<npcname> grounds %s with a legsweep" ],
+    "skill_requirements": [ { "name": "unarmed", "level": 2 } ],
+    "melee_allowed": true,
+	"unarmed_allowed": true,
+    "crit_tec": true,
+    "down_dur": 2,
+    "attack_vectors": [ "FOOT", "LOWER_LEG", "THROW" ]
+  },
+  {
+    "type": "technique",
     "id": "tec_silat_precise",
     "name": "Vicious Precision",
     "messages": [ "You viciously wound %s", "<npcname> viciously wounds %s" ],
@@ -1610,7 +1622,8 @@
       { "stat": "damage", "type": "cut", "scale": 1.33 },
       { "stat": "damage", "type": "stab", "scale": 1.33 }
     ],
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "WEAPON" ],
+	"attack_vectors_random": [ "HAND", "FOOT", "ELBOW", "KNEE", "LOWER_LEG", "HEAD" ]
   },
   {
     "type": "technique",
@@ -1621,7 +1634,8 @@
     "melee_allowed": true,
     "crit_tec": true,
     "stun_dur": 2,
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "WEAPON" ],
+	"attack_vectors_random": [ "HAND", "FOOT", "ELBOW", "KNEE", "LOWER_LEG", "HEAD" ]
   },
   {
     "type": "technique",
@@ -1638,7 +1652,8 @@
       { "stat": "damage", "type": "cut", "scale": 1.33 },
       { "stat": "damage", "type": "stab", "scale": 1.33 }
     ],
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "WEAPON" ],
+	"attack_vectors_random": [ "HAND", "FOOT", "ELBOW", "KNEE", "LOWER_LEG", "HEAD" ]
   },
   {
     "type": "technique",
@@ -1735,18 +1750,6 @@
   },
   {
     "type": "technique",
-    "id": "tec_taekwondo_disarm",
-    "name": "Snatch Weapon",
-    "messages": [ "You snatch %s's weapon", "<npcname> snatches %s's weapon" ],
-    "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
-    "unarmed_allowed": true,
-    "weighting": 2,
-    "take_weapon": true,
-    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 0.5 } ],
-    "attack_vectors": [ "HAND" ]
-  },
-  {
-    "type": "technique",
     "id": "tec_taekwondo_strong",
     "name": "Spinning Back Kick",
     "messages": [
@@ -1771,7 +1774,7 @@
     "type": "technique",
     "id": "tec_taekwondo_push",
     "name": "Side Kick",
-    "messages": [ "You turn slightly and side-kick %s", "<npcname> turns slightly and side-kicks %s" ],
+    "messages": [ "You side-kick %s", "<npcname> side-kicks %s" ],
     "melee_allowed": true,
     "unarmed_allowed": true,
     "knockback_dist": 1,

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -1599,7 +1599,7 @@
     "type": "technique",
     "id": "tec_silat_legsweep",
     "name": "Leg Sweep",
-    "messages": [ "You ground %s with a leg sweep", "<npcname> grounds %s with a legsweep" ],
+    "messages": [ "You ground %s with a leg sweep", "<npcname> grounds %s with a leg sweep" ],
     "skill_requirements": [ { "name": "unarmed", "level": 2 } ],
     "melee_allowed": true,
 	"unarmed_allowed": true,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
silat is an extremely varied martial art irl. the game does a good job of representing the fighting stances and complicated movement patterns that are used in silat matches but it ignores the fact that a large subset of  silat practitioners only engage in unarmed sparring due to safety reasons.  we have chinese swords in game that have been used in indonesia for more than a 1000 years that should be usable with silat as well. 

tkd is the most popular martial art in the world and has a codified set of techniques. it has more than 20 named blocking techniques and none of these involve using your legs to block an incoming attack, instead relying on arm blocks, push kicks and quick distance shifts to avoid them.  the sideways fighting stance used in tkd sparring limits upper body movement and makes any circular motion very awkward but makes perfect sense in an art where both grappling and low kicks are outlawed because it enables rapid distance changes and offers less of a target to hit.  the game should represent the tradeoffs inherent in the tkd fighting stance more accurately.  

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
letting the player use silat unarmed, adding medium and short swords to silat. add a leg sweep takedown to silat (very common technique in modern competitive silat). removing leg blocks from tkd, +1 dodge skill on the static buff, removed the disarm

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
changin eskrima as well. splitting more silat techs into unarmed and weapon versions 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
a bit

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
removing leg blocks from tkd makes it more consistent with the shotokan karate we have in game which uses a more square stance and could a lot more easily adapt to leg blocks than tkd (look up kyokushin karate or muay thai and notice the more square stance that allows for easier lateral movement and good balance while grappling or blocking kicks with your shin  ).

any vaguely sword shaped object up to a meter in length has most likely seen extensive use in a silat martial arts context. if the weapon was used by a european or asian navy at some point it is even more likely. 

if you type stuff like kiam silat into a search engine you get wild indonesian wuxia novels from the 30s
![Giok+Siauw+Gin+Kiam+9-748673050](https://user-images.githubusercontent.com/75625092/200134099-7372e5d8-e12d-4b52-bbc7-f4d3c7f7ef79.jpg)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
