### PR TITLE
allow a couple items to act as fire for crafting

### DIFF
--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -762,6 +762,7 @@
     "max_charges": 20,
     "turns_per_charge": 60,
     "revert_to": "torch_done",
+    "sub": "fire",
     "use_action": [
       { "type": "firestarter", "moves": 30 },
       {

--- a/data/mods/Magiclysm/items/enchanted_misc.json
+++ b/data/mods/Magiclysm/items/enchanted_misc.json
@@ -104,6 +104,7 @@
       }
     ],
     "techniques": [ "WBLOCK_1" ],
+    "sub": "fire",
     "extend": { "flags": [ "FIRE", "LIGHT_240", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH" ] }
   },
   {

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -994,6 +994,7 @@
     "symbol": "*",
     "color": "yellow",
     "qualities": [ [ "BOIL", 2 ], [ "COOK", 3 ] ],
+    "sub": "fire",
     "use_action": [
       {
         "target": "pocket_sun_cover",
@@ -1003,7 +1004,7 @@
       },
       { "type": "firestarter", "moves": 10, "moves_slow": 100 }
     ],
-    "flags": [ "LIGHT_700", "TRADER_AVOID" ]
+    "flags": [ "FIRE", "LIGHT_700", "TRADER_AVOID" ]
   },
   {
     "id": "pocket_sun_cover",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
so there's this flag "FIRE" that says items with that flag will act as a nearby fire when crafting, that's a lie, rather it doesn't work

I somehow got the "FIRE" flag proposed behavior working after some tinkering inspired by a pr in the bn repo (their solution also didn't seem to work hence the tinkering), I referenced a pseudo item or something the crafting requirements list use "fire" the bn pr also used this json object `"sub"` that works in a similar? manner as copy-from; I copied something from "fire" and now I can use a lit torch as a fire in crafting

dirty hack; there's no code support for the "FIRE" flag, this is just an odd interaction

a couple items now serve as fire when crafting:
- the lit torch
- magiclysm's everburning torch and pocket sun

I realize now "sub" is thing we use quite a bit here, like for vehicles, or some tools, hey I didn't know


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![Screenshot from 2022-11-07 20-27-23](https://user-images.githubusercontent.com/58050969/200453878-59420ada-41d6-488d-9433-088075236981.png)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
