### PR TITLE
add a storage tank furniture and the associated recipe.

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2508,6 +2508,20 @@
     "pre_special": "check_empty",
     "post_terrain": "f_standing_tank"
   },
+  {  
+    "type": "construction",
+    "id": "constr_storage_tank",
+    "group": "build_storage_tank",
+    "//": "a huge metal tank, useful for holding very large volumes of liquids",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 6 ] ],
+    "time": "300 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_M", "level": 1 } ] ],
+    "using": [ [ "welding_standard", 16 ] ],
+    "components": [ [ [ "sheet_metal", 24 ], [ "sheet_metal_small", 576 ] ], [ [ "water_faucet", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_terrain": "f_storage_tank"
+  },
   {
     "type": "construction",
     "id": "constr_anvil",

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2508,7 +2508,7 @@
     "pre_special": "check_empty",
     "post_terrain": "f_standing_tank"
   },
-  {  
+  {
     "type": "construction",
     "id": "constr_storage_tank",
     "group": "build_storage_tank",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -776,6 +776,11 @@
   },
   {
     "type": "construction_group",
+    "id": "build_storage_tank",
+    "name": "Build Storage Tank"
+  },
+  {
+    "type": "construction_group",
     "id": "build_stone_fireplace",
     "name": "Build Stone Fireplace"
   },

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -1139,6 +1139,29 @@
   },
   {
     "type": "furniture",
+    "id": "f_storage_tank",
+    "name": "bulk storage tank",
+    "description": "A gigantic tank that can store all of the liquid. All of it.",
+    "symbol": "O",
+    "looks_like": "f_standing_tank",
+    "color": "light_gray",
+    "move_cost_mod": -1,
+    "coverage": 95,
+    "required_str": -1,
+    "flags": [ "CONTAINER", "LIQUIDCONT", "NOITEM", "SEALED" ],
+    "deconstruct": { "items": [ { "item": "sheet_metal", "count": 24 }, { "item": "water_faucet", "count": 1 } ] },
+    "examine_action": "keg",
+    "keg_capacity": 6000,
+    "bash": {
+      "str_min": 16,
+      "str_max": 32,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [ { "item": "scrap", "count": [ 40, 160 ] }, { "item": "water_faucet", "prob": 50 } ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_gas_tank",
     "name": "fuel tank",
     "description": "A tank filled with gasoline.",

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -1141,7 +1141,7 @@
     "type": "furniture",
     "id": "f_storage_tank",
     "name": "bulk storage tank",
-    "description": "A gigantic tank that can store all of the liquid. All of it.",
+    "description": "A gigantic tank that can store all of the liquid.  All of it.",
     "symbol": "O",
     "looks_like": "f_standing_tank",
     "color": "light_gray",

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -1141,7 +1141,7 @@
     "type": "furniture",
     "id": "f_storage_tank",
     "name": "bulk storage tank",
-    "description": "A gigantic tank that can store all of the liquid.  All of it.",
+    "description": "A 2 meters high tank that can store up to 1500 liters of liquid. That's a lot.",
     "symbol": "O",
     "looks_like": "f_standing_tank",
     "color": "light_gray",

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -1141,7 +1141,7 @@
     "type": "furniture",
     "id": "f_storage_tank",
     "name": "bulk storage tank",
-    "description": "A 2 meters high tank that can store up to 1500 liters of liquid. That's a lot.",
+    "description": "A 2 meters high tank that can store up to 1500 liters of liquid.  That's a lot.",
     "symbol": "O",
     "looks_like": "f_standing_tank",
     "color": "light_gray",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "add a new large opaque 1500L/400 gal standing tank."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The existing standing tank is described as huge despite the fact that it's only 300L in volume. That corresponds to a cylinder about 60 cm in diameter and 1 m in length/height. Each tile is 1 m^2 in area, and characters of any height, which can potentially reach 3 m, can move around indoors.
This implies the lower bound on the volume of each tile at 3 m^3. Then the standing tank only uses 1/10th of the volume. It is more space efficient to just pile up smaller tanks or drums than build or use a standing tank.

The recipe for the standing tank doesn't make too much sense either. We throw together 4 60L tanks to somehow get 5 60L tanks worth of volume in the final product.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added a new larger tank furniture. It has the volume of 1500L, which represents a cylinder 1 m in diameter and 2 m in height (1570L to be precise, but the tank should probably have some bulk to it). As the new tank is fairly big, it obscures vision. Added a construction recipe for the new tank, based on the recipe for a 200L steel drum, but with requirements scaled with the surface area of the new tank. The time increase in the construction recipe is arbitrary, just felt about right.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

1) Leave everything as is.

2) Substitute the existing standing tank with the new tank. Decided against it because it would probably break mapgen.

3) Change the standing tank volume and recipe. I'm not sure how that would play with fully or partially filled tanks. 

4) Add a smaller tank instead, maybe in the 600 - 1200L range.

5) Add some other type of furniture liquid storage, like 4, 8, or 12 200L steel drums banded together with wire and stacked on top of one another.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

1) Created a new world.

2) Debug spawned in the new tank furniture.

3) Filled it with fuel.

4) Used the new construction recipe to build another tank.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
