### PR TITLE
Change gunmods information display method

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3064,28 +3064,29 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
         std::map<gunmod_location, int> mod_locations = get_mod_locations();
 
         int iternum = 0;
+        mod_str += "\n";
         for( std::pair<const gunmod_location, int> &elem : mod_locations ) {
             if( iternum != 0 ) {
-                mod_str += "; ";
+                mod_str += "\n";
             }
             const int free_slots = elem.second - get_free_mod_locations( elem.first );
-            mod_str += string_format( "<bold>%d/%d</bold> %s", free_slots,  elem.second,
-                                      elem.first.name() );
-            bool first_mods = true;
+            mod_str += string_format( "<color_light_cyan>⋄ </color>%s:", elem.first.name() );
+
             for( const item *gmod : gunmods() ) {
                 if( gmod->type->gunmod->location == elem.first ) { // if mod for this location
-                    if( first_mods ) {
-                        mod_str += ": ";
-                        first_mods = false;
-                    } else {
-                        mod_str += ", ";
-                    }
-                    mod_str += string_format( "<stat>%s</stat>", gmod->tname() );
+                    mod_str +=
+                        string_format( "\n      <stat>[</stat><color_light_green>◉ </color><stat>%s]</stat>",
+                                       gmod->tname( 1, false ) );
                 }
+            }
+            for( int i = free_slots + 1 ; i <= elem.second ; i++ ) {
+                if( i == free_slots + 1 && i <= elem.second ) {
+                    mod_str += string_format( "\n      " );
+                }
+                mod_str += string_format( "<color_dark_gray>[-empty-]</color> " );
             }
             iternum++;
         }
-        mod_str += ".";
         info.emplace_back( "DESCRIPTION", mod_str );
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3083,8 +3083,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
                 if( i == free_slots + 1 && i <= elem.second ) {
                     mod_str += string_format( "\n    " );
                 }
-                mod_str +=
-                    string_format( "<color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> " );
+                mod_str += string_format( _( "<color_dark_gray>[-empty-]</color> " ) );
             }
             iternum++;
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3059,7 +3059,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     if( !gun.valid_mod_locations.empty() && parts->test( iteminfo_parts::DESCRIPTION_GUN_MODS ) ) {
         insert_separation_line( info );
 
-        std::string mod_str = _( "<bold>Mods</bold>: " );
+        std::string mod_str = _( "<bold>Mods</bold>:" );
 
         std::map<gunmod_location, int> mod_locations = get_mod_locations();
 
@@ -3081,9 +3081,9 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
             }
             for( int i = free_slots + 1 ; i <= elem.second ; i++ ) {
                 if( i == free_slots + 1 && i <= elem.second ) {
-                    mod_str += string_format( "\n    " );
+                    mod_str += string_format( "\n   " );
                 }
-                mod_str += string_format( _( "<color_dark_gray>[-empty-]</color> " ) );
+                mod_str += string_format( " <color_dark_gray>[-%s-]</color>", _( "empty" ) );
             }
             iternum++;
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3083,7 +3083,8 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
                 if( i == free_slots + 1 && i <= elem.second ) {
                     mod_str += string_format( "\n    " );
                 }
-                mod_str += string_format( "<color_dark_gray>[- empty -]</color> " );
+                mod_str +=
+                    string_format( "<color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> " );
             }
             iternum++;
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3070,20 +3070,20 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
                 mod_str += "\n";
             }
             const int free_slots = elem.second - get_free_mod_locations( elem.first );
-            mod_str += string_format( "<color_light_cyan>⋄ </color>%s:", elem.first.name() );
+            mod_str += string_format( "<color_cyan># </color>%s:", elem.first.name() );
 
             for( const item *gmod : gunmods() ) {
                 if( gmod->type->gunmod->location == elem.first ) { // if mod for this location
                     mod_str +=
-                        string_format( "\n      <stat>[</stat><color_light_green>◉ </color><stat>%s]</stat>",
+                        string_format( "\n    <stat>[</stat><color_light_green>● </color><stat>%s]</stat>",
                                        gmod->tname( 1, false ) );
                 }
             }
             for( int i = free_slots + 1 ; i <= elem.second ; i++ ) {
                 if( i == free_slots + 1 && i <= elem.second ) {
-                    mod_str += string_format( "\n      " );
+                    mod_str += string_format( "\n    " );
                 }
-                mod_str += string_format( "<color_dark_gray>[-empty-]</color> " );
+                mod_str += string_format( "<color_dark_gray>[- empty -]</color> " );
             }
             iternum++;
         }

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1648,17 +1648,17 @@ TEST_CASE( "gun or other ranged weapon attributes", "[iteminfo][weapon][gun]" )
     SECTION( "weapon mods" ) {
         CHECK( item_info_str( compbow, { iteminfo_parts::DESCRIPTION_GUN_MODS } ) ==
                "--\n"
-               "<color_c_white>Mods</color>:\n"
+               "<color_c_white>Mods</color>: \n"
                "<color_cyan># </color>accessories:\n"
-               "    <color_dark_gray>[-empty-]</color> <color_dark_gray>[-empty-]</color>\n"
+               "    <color_dark_gray>[-empty-]</color> <color_dark_gray>[-empty-]</color> \n"
                "<color_cyan># </color>dampening:\n"
-               "    <color_dark_gray>[-empty-]</color>\n"
+               "    <color_dark_gray>[-empty-]</color> \n"
                "<color_cyan># </color>sights:\n"
-               "    <color_dark_gray>[-empty-]</color>\n"
+               "    <color_dark_gray>[-empty-]</color> \n"
                "<color_cyan># </color>stabilizer:\n"
-               "    <color_dark_gray>[-empty-]</color>\n"
+               "    <color_dark_gray>[-empty-]</color> \n"
                "<color_cyan># </color>underbarrel:\n"
-               "    <color_dark_gray>[-empty-]</color>\n" );
+               "    <color_dark_gray>[-empty-]</color> \n" );
     }
 
     SECTION( "weapon dispersion" ) {

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1648,17 +1648,17 @@ TEST_CASE( "gun or other ranged weapon attributes", "[iteminfo][weapon][gun]" )
     SECTION( "weapon mods" ) {
         CHECK( item_info_str( compbow, { iteminfo_parts::DESCRIPTION_GUN_MODS } ) ==
                "--\n"
-               "<color_c_white>Mods</color>: "
-               "<color_cyan># </color>accessories:"
-               "    <color_dark_gray>[- empty -]</color> <color_dark_gray>[- empty -]</color> "
-               "<color_cyan># </color>dampening:"
-               "    <color_dark_gray>[- empty -]</color> "
-               "<color_cyan># </color>sights:"
-               "    <color_dark_gray>[- empty -]</color> "
-               "<color_cyan># </color>stabilizer:"
-               "    <color_dark_gray>[- empty -]</color> "
-               "<color_cyan># </color>underbarrel:"
-               "    <color_dark_gray>[- empty -]</color> " );
+               "<color_c_white>Mods</color>: \n"
+               "<color_cyan># </color>accessories:\n"
+               "    <color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> <color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> \n"
+               "<color_cyan># </color>dampening:\n"
+               "    <color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> \n"
+               "<color_cyan># </color>sights:\n"
+               "    <color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> \n"
+               "<color_cyan># </color>stabilizer:\n"
+               "    <color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> \n"
+               "<color_cyan># </color>underbarrel:\n"
+               "    <color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> \n" );
     }
 
     SECTION( "weapon dispersion" ) {

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1648,17 +1648,17 @@ TEST_CASE( "gun or other ranged weapon attributes", "[iteminfo][weapon][gun]" )
     SECTION( "weapon mods" ) {
         CHECK( item_info_str( compbow, { iteminfo_parts::DESCRIPTION_GUN_MODS } ) ==
                "--\n"
-               "<color_c_white>Mods</color>: \n"
+               "<color_c_white>Mods</color>:\n"
                "<color_cyan># </color>accessories:\n"
-               "    <color_dark_gray>[-empty-]</color> <color_dark_gray>[-empty-]</color> \n"
+               "    <color_dark_gray>[-empty-]</color> <color_dark_gray>[-empty-]</color>\n"
                "<color_cyan># </color>dampening:\n"
-               "    <color_dark_gray>[-empty-]</color> \n"
+               "    <color_dark_gray>[-empty-]</color>\n"
                "<color_cyan># </color>sights:\n"
-               "    <color_dark_gray>[-empty-]</color> \n"
+               "    <color_dark_gray>[-empty-]</color>\n"
                "<color_cyan># </color>stabilizer:\n"
-               "    <color_dark_gray>[-empty-]</color> \n"
+               "    <color_dark_gray>[-empty-]</color>\n"
                "<color_cyan># </color>underbarrel:\n"
-               "    <color_dark_gray>[-empty-]</color> \n" );
+               "    <color_dark_gray>[-empty-]</color>\n" );
     }
 
     SECTION( "weapon dispersion" ) {

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1648,17 +1648,17 @@ TEST_CASE( "gun or other ranged weapon attributes", "[iteminfo][weapon][gun]" )
     SECTION( "weapon mods" ) {
         CHECK( item_info_str( compbow, { iteminfo_parts::DESCRIPTION_GUN_MODS } ) ==
                "--\n"
-               "<color_c_white>Mods</color>: \n"
+               "<color_c_white>Mods</color>:\n"
                "<color_cyan># </color>accessories:\n"
-               "    <color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> <color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> \n"
+               "    <color_dark_gray>[-empty-]</color> <color_dark_gray>[-empty-]</color>\n"
                "<color_cyan># </color>dampening:\n"
-               "    <color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> \n"
+               "    <color_dark_gray>[-empty-]</color>\n"
                "<color_cyan># </color>sights:\n"
-               "    <color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> \n"
+               "    <color_dark_gray>[-empty-]</color>\n"
                "<color_cyan># </color>stabilizer:\n"
-               "    <color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> \n"
+               "    <color_dark_gray>[-empty-]</color>\n"
                "<color_cyan># </color>underbarrel:\n"
-               "    <color_dark_gray>[- </color><color_dark_gray>empty</color><color_dark_gray> -]</color> \n" );
+               "    <color_dark_gray>[-empty-]</color>\n" );
     }
 
     SECTION( "weapon dispersion" ) {

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1648,9 +1648,17 @@ TEST_CASE( "gun or other ranged weapon attributes", "[iteminfo][weapon][gun]" )
     SECTION( "weapon mods" ) {
         CHECK( item_info_str( compbow, { iteminfo_parts::DESCRIPTION_GUN_MODS } ) ==
                "--\n"
-               "<color_c_white>Mods</color>: <color_c_white>0/2</color> accessories;"
-               " <color_c_white>0/1</color> dampening; <color_c_white>0/1</color> sights;"
-               " <color_c_white>0/1</color> stabilizer; <color_c_white>0/1</color> underbarrel.\n" );
+               "<color_c_white>Mods</color>: "
+               "<color_cyan># </color>accessories:"
+               "    <color_dark_gray>[- empty -]</color> <color_dark_gray>[- empty -]</color> "
+               "<color_cyan># </color>dampening:"
+               "    <color_dark_gray>[- empty -]</color> "
+               "<color_cyan># </color>sights:"
+               "    <color_dark_gray>[- empty -]</color> "
+               "<color_cyan># </color>stabilizer:"
+               "    <color_dark_gray>[- empty -]</color> "
+               "<color_cyan># </color>underbarrel:"
+               "    <color_dark_gray>[- empty -]</color> " );
     }
 
     SECTION( "weapon dispersion" ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

Interface "Change gunmods information display method to make it clearer and more intuitive"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I and the CDDA players I know feel that the way the gun mod information is displayed is cluttered and difficult to read. To improve this, I have tried to change the method of displaying it.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I changed the display style by modified the gun_info() function.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I considered splitting the "mod position name display area" and the "mod name display area" into two, but did not have the capacity to do so:(
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

1. Modify code
2. Compiling CDDA with MSYS2
3. Launch the game
4. Open the information screen of a gun almost full of accessories and the information screen for loading and unloading accessories
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Screenshots after modification
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
![image](https://user-images.githubusercontent.com/40733256/200615097-2ce02980-5ca8-4ac9-9bf1-6c323064ad7e.png)
![image](https://user-images.githubusercontent.com/40733256/200615327-25faa00b-7d0b-4705-a1c1-7604fdda28f3.png)
