### PR TITLE
Update wooden beam recipes

### DIFF
--- a/data/json/recipes/other/parts_construction.json
+++ b/data/json/recipes/other/parts_construction.json
@@ -15,24 +15,23 @@
   },
   {
     "type": "recipe",
-    "activity_level": "fake",
+    "activity_level": "BRISK_EXERCISE",
     "result": "wood_beam",
     "id_suffix": "from logs",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
     "skill_used": "fabrication",
     "difficulty": 1,
-    "time": "1 h",
+    "time": "2 h",
     "autolearn": true,
     "byproducts": [ [ "splinter", 20 ] ],
     "qualities": [ { "id": "AXE", "level": 2 } ],
     "//": "Eventually, smoothing tools should also be required, or we should distinguish between rough-hewn and finished beams",
-    "components": [ [ [ "log", 6 ] ] ],
-    "//2": "This is a terrible stand-in for the fact that logs are only 10kg chunks and not big enough to hew into an 8' or longer wooden beam."
+    "components": [ [ [ "log", 2 ] ] ]
   },
   {
     "type": "recipe",
-    "activity_level": "fake",
+    "activity_level": "LIGHT_EXERCISE",
     "result": "wood_beam",
     "id_suffix": "with_planer",
     "category": "CC_OTHER",


### PR DESCRIPTION
#### Summary
Balance "Update wooden beam recipes"

#### Purpose of change
Wooden beams and their attendant recipes were added some years ago, in the best way they could be at the time. Since then, things have changed, logs quintupled(5x) in size (#45636), activity levels were added, and the recipes haven't really been updated (although a new recipe involving a planer was added 16 months ago).

I also increased the time to hew a log from 1hr to 2hr after checking around the internet. Sources in additional context.

#### Describe the solution
Update the recipes. Verify they make sense. Activity levels were set to replace the "fake" activity levels which defaulted to `MODERATE_EXERCISE`. Hewing by hand is a bit more tiring than that - with an electrically powered planing tool it's plenty less tiring than that, but still some work as you have to get the log onto the planer and manhandle it through.

Also delete a comment referencing the old values of logs which is no longer accurate.

#### Describe alternatives you've considered
Committing myself to learning hand hewing and coming back in a few months with personally-gathered data.

#### Testing
Loaded the game and made the recipes after spawning in their components. Compared the inputs and outputs. An image comparison is in the additional context section.

#### Additional context
New recipe inputs vs outputs:
![image](https://user-images.githubusercontent.com/84619419/202401257-ef657363-2e1f-44c6-82e7-4b7ef4f69313.png)
There's still a decent amount of missing volume and weight after processing, but I would personally chalk that up to the removed bark, sawdust, and other truly unusable refuse (unfit even for firewood).

Length of inputs: 140cm log + 140cm log = 244cm(8') beam. Seems to check out, more or less.

Trying to find data on how long it would take to hand hew a log took a bit, but we have a range.
https://www.youtube.com/watch?v=0sgLU5wM-zM (caption at 6:30 indicates "two sides in under 20 minutes", assuming '4' sides the scoring can be done in ~40 minutes. This does not include the juggling or final hewing. This channel is one I'm familiar with and they run a business selling hand tools and lessons about hand tools so I am inclined to rate them as trustworthy.)

https://www.youtube.com/watch?v=-UYMxPLky10 (completely random video I found trying to search for timelapses)
Given timelapse speed: 1 hour/minute
Video length: 2:29
Estimated time: 2.5 hours

https://www.bigsandwoodworking.com/hatsurou-kai/ (one of several search engine results, but the only one to give a time)
"Taking turns it took a 2.5-3 hours or so to fully rip the log". Please note this appears to have been written by an amateur, i.e. someone with no previous experience performing this activity. For the purposes of crafting we are (should be?) assuming the survivor has the required competence, as that's what fabrication *skill* represents. Maybe there should be a proficiency.

