### PR TITLE
additional footsteps for certain kinds of entities

### DIFF
--- a/data/json/species.json
+++ b/data/json/species.json
@@ -168,7 +168,7 @@
     "type": "SPECIES",
     "id": "ABERRATION",
     "description": "an aberration",
-    "footsteps": "footsteps from your nightmares."
+    "footsteps": "an arrhythmic susurrus hints at unknown things nearby."
   },
   {
     "type": "SPECIES",

--- a/data/json/species.json
+++ b/data/json/species.json
@@ -162,7 +162,7 @@
     "type": "SPECIES",
     "id": "HORROR",
     "description": "a horror",
-    "footsteps": "footsteps from your nightmares."
+    "footsteps": "clomping, stamping, horrible footsteps echo in your mind."
   },
   {
     "type": "SPECIES",

--- a/data/json/species.json
+++ b/data/json/species.json
@@ -185,6 +185,6 @@
     "type": "SPECIES",
     "id": "UNKNOWN",
     "description": "a bug",
-    "footsteps": "bugs"
+    "footsteps": "clisp, clisp, clisp, 'faster then slower'"
   }
 ]

--- a/data/json/species.json
+++ b/data/json/species.json
@@ -161,12 +161,14 @@
   {
     "type": "SPECIES",
     "id": "HORROR",
-    "description": "a horror"
+    "description": "a horror",
+    "footsteps": "footsteps from your nightmares."
   },
   {
     "type": "SPECIES",
     "id": "ABERRATION",
-    "description": "an aberration"
+    "description": "an aberration",
+    "footsteps": "footsteps from your nightmares."
   },
   {
     "type": "SPECIES",
@@ -182,6 +184,7 @@
   {
     "type": "SPECIES",
     "id": "UNKNOWN",
-    "description": "a bug"
+    "description": "a bug",
+    "footsteps": "bugs"
   }
 ]

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -366,6 +366,7 @@ cleansuit
 clearcrete
 clickity
 climbable
+clisp
 clockspring
 cloutie
 clutchmates


### PR DESCRIPTION
something from your nightmares is rapidly approaching

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Additional footstep types for certain types of entities"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I noticed some variety that was never needed in the first place lacking. So I added more footsteps to more entity types.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
It adds additional footsteps to the game.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
There arent any that I could think of, other than the player just pretending the footstep sounds are not what the game says they sound like.

#### Testing

Starting game after adding updated file. Custom Character -> Freeform
Adding good hearing and starting game.
Used debug menu to add Fey Hearing (best hearing i can get)
Standing behind wall of evac shelter
Spawned jabberwock on the other side.
<img width="639" alt="success" src="https://user-images.githubusercontent.com/46800751/203676254-3adab8a4-1097-4aec-b2e0-cd0b410a9ae4.png">
horror and abhorrent footsteps work.
complete - it works

Knowing I used the same technique for all footsteps, i am assuming that this PR is bugless.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Changed footsteps for:
- Horror
- Aberration
- Unknown (footsteps to differentiate between ~~lazy~~ forgetful / rushed contributors who forgot to put a category on their mobs and those who remembered to do so)

https://youtu.be/gHEYe-WwlSo

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
