### PR TITLE
Interface option to place asterisk before or after item's name

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6301,12 +6301,18 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     // item damage and/or fouling level
     std::string damtext;
 
+    if( get_option<std::string>( "ASTERISK_POSITION" ) == "prefix" ) {
+        if( is_favorite ) {
+            damtext = _( "* " ); // Display asterisk for favorite items, before item's name
+        }
+    }
+
     // for portions of string that have <color_ etc in them, this aims to truncate the whole string correctly
     unsigned int truncate_override = 0;
 
     if( ( damage() != 0 || ( degradation() > 0 && degradation() >= max_damage() / 5 ) ||
           ( get_option<bool>( "ITEM_HEALTH_BAR" ) && is_armor() ) ) && !is_null() && with_prefix ) {
-        damtext = durability_indicator();
+        damtext += durability_indicator();
         if( get_option<bool>( "ITEM_HEALTH_BAR" ) ) {
             // get the utf8 width of the tags
             truncate_override = utf8_width( damtext, false ) - utf8_width( damtext, true );
@@ -6554,8 +6560,10 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         tagtext += _( " (part sealed)" );
     }
 
-    if( is_favorite ) {
-        tagtext += _( " *" ); // Display asterisk for favorite items
+    if( get_option<std::string>( "ASTERISK_POSITION" ) == "suffix" ) {
+        if( is_favorite ) {
+            tagtext += _( " *" ); // Display asterisk for favorite items, after item's name
+        }
     }
 
     std::string modtext;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1957,6 +1957,12 @@ void options_manager::add_options_interface()
          true
        );
 
+    add( "ASTERISK_POSITION", "interface", to_translation( "Favorited item's mark position" ),
+         to_translation( "Where to place mark of the favorited item (asterisk): before item's name (prefix) or after item's name (suffix)." ),
+    { { "prefix", to_translation( "Prefix" ) }, { "suffix", to_translation( "Suffix" ) } },
+    "right"
+       );
+
     add_empty_line();
 
     add( "ENABLE_JOYSTICK", "interface", to_translation( "Enable joystick" ),


### PR DESCRIPTION
#### Summary
Interface "Interface option to place asterisk before or after item's name"

#### Purpose of change
* Closes #62282.

#### Describe the solution
Added game option in Interface section. Added a check for this option in `item::tname` function.

#### Describe alternatives you've considered
None.

#### Testing
Favorited item, changed option, checked how it's looked.

#### Additional context
![изображение](https://user-images.githubusercontent.com/11132525/204554347-42be5f0c-5a98-447b-8773-1a789599d7d5.png)

![изображение](https://user-images.githubusercontent.com/11132525/204554748-db699ed5-c983-48f4-a03e-131622b57788.png)