### PR TITLE
Grammar maintenance for some of the newer scenarios

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -827,7 +827,7 @@
   {
     "type": "scenario",
     "id": "nuclear_plant_start",
-    "name": "Scrammed",
+    "name": "Emergency Shutdown",
     "points": 1,
     "description": "When the Cataclysm happened, you were working in a nuclear power plant.  Now you're trapped inside, surrounded by the shambling bodies of what used to be your coworkers.  The reactor's shut down, but you don't know if there's been a radiation leak and you need to get away from here fast before you find out the hard way.",
     "start_name": "Nuclear Power Plant",

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -226,12 +226,13 @@
   },
   {
     "type": "scenario",
-    "name": "(un)living History",
-    "description": "After doing historical reenactment, you and your friend were taking a break inside the fort, and then you heard a scream and gunshot noises.",
+    "name": "Unliving History",
+    "description": "New England is dotted with old forts from the Revolutionary War, and many of them are still standing.  When things started getting really bad, it seemed like a natural place to hole up for a while, and it turns out that many, many other people had the same idea.  The peace didn't last long.  Now everyone else is undead, and you're trapped inside the walls with them.  The single entrance being a tight choke point is looking a lot less useful now…",
     "id": "BastionFortStart",
     "points": -2,
     "start_name": "Bastion Fort",
-    "allowed_locs": [ "sloc_fort" ]
+    "allowed_locs": [ "sloc_fort" ],
+    "flags": [ "CHALLENGE", "LONE_START" ]
   },
   {
     "type": "scenario",
@@ -752,7 +753,7 @@
     "id": "Mansion",
     "name": "Mansion Escape",
     "points": -1,
-    "description": "You were living the high life when the world ended, surrounded by riches and extravagant food every day, but now you find yourself awakening from an induced paralysis and carried to the basement of the mansion in which you used to live, heavy footsteps resound around you, are you ready to survive in this new world?",
+    "description": "You were living the high life when the world ended, surrounded by riches and extravagant food every day.  Now you've woken up alone in the basement of the mansion in which you used to live, your body heavy from paralyzing poison, with heavy footsteps all around.  Time to find out if you're ready to survive the real world again.",
     "allowed_locs": [ "sloc_mansion_basement" ],
     "start_name": "Mansion",
     "surround_groups": [ [ "GROUP_MANSION_START", 90.0 ], [ "GROUP_MANSION_ARMORED", 10.0 ] ],
@@ -792,7 +793,7 @@
     "id": "aircraft_carrier_start",
     "name": "CVN Sailor",
     "points": 4,
-    "description": "For some reason your mission off the coast of North Korea was ended in the middle of a lake, in an unknown location.  You have no idea what's happened, but now you have more important things to do.",
+    "description": "For some reason your mission off the coast of North Korea was ended in the middle of a lake, in an unknown location.  You have no idea what's happened, but now you have more important things to worry about.",
     "start_name": "Aircraft Carrier",
     "allowed_locs": [ "aircraft_carrier_berth", "aircraft_carrier_bridge" ],
     "professions": [
@@ -826,9 +827,9 @@
   {
     "type": "scenario",
     "id": "nuclear_plant_start",
-    "name": "Nuclear Power Plant",
+    "name": "Scrammed",
     "points": 1,
-    "description": "When the Cataclysm happened, you were working in a nuclear power plant.  Your power plant has been shut down.  And your colleagues have become zombies.  Looks like you're on your own…",
+    "description": "When the Cataclysm happened, you were working in a nuclear power plant.  Now you're trapped inside, surrounded by the shambling bodies of what used to be your coworkers.  The reactor's shut down, but you don't know if there's been a radiation leak and you need to get away from here fast before you find out the hard way.",
     "start_name": "Nuclear Power Plant",
     "allowed_locs": [ "nuclear_plant" ],
     "professions": [ "electrician", "labtech", "medic" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Grammar tweaks for various scenarios"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Writing consistency is always a thing that needs to happen; this PR's just one bit of progress. I'm attaching a bit of rationale for each of the individual changes in the next section:

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
* (un)living History - renamed to `Unliving History`, description completely rewritten, now `CHALLENGE` and `LONE_START`

The original description for this scenario was really simple and broke canon. The Cataclysm was obviously a lot more drawn out and high-visibility than `a scream and gunshot noises`, and I felt like bastion forts in particular offered a neat medium for telling a more nuanced story, even a minor one. In light of that, I made it a lone start scenario, and because of the comparative difficulty of starting inside the fort, I made sure that `Play Now!` wouldn't select it as a possible option.

* Mansion Escape - description updated

The existing desc. for Mansion Escape is one giant run-on sentence, and because of that it flows really weirdly. I split it up into several different sentences and adjusted the grammar to make those sentences flow together.

* CVN Sailor - `...more important things to do` changed to `...more important things to worry about`

It wasn't actually obvious what the "important things to do" in this case were other than "escape the carrier". This is a really minor tweak, but I feel like it helps establish the actual intent of the scenario.

* Nuclear Power Plant - renamed to `Emergency Shutdown`, description updated

This one was also kind of barebones, and it seems like a portion of it was copied from the Safe Place scenario. I made the description more urgent, with the intent of hinting at the radiation hazard and the threat inside and around the power plant. The name change is referencing the reactor itself, since the scenario stuck out in that it lacked a thematic name and instead just described the place you started at.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
N/A, really, although I'm open to tweaking any of these changes. Writing's always subjective. :P

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
I opened up the game and made sure that all of the descriptions and names were correct. I also started a new save in Unliving History to make sure that I no longer started with a static NPC.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
N/A