### PR TITLE
Removed restriction to auto pickup switching only from player UI

### DIFF
--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -442,14 +442,11 @@ void user_interface::show()
     ctxt.register_action( "MOVE_RULE_DOWN" );
     ctxt.register_action( "TEST_RULE" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
+    ctxt.register_action( "SWITCH_AUTO_PICKUP_OPTION" );
 
     const bool allow_swapping = tabs.size() == 2;
     if( allow_swapping ) {
         ctxt.register_action( "SWAP_RULE_GLOBAL_CHAR" );
-    }
-
-    if( is_autopickup ) {
-        ctxt.register_action( "SWITCH_AUTO_PICKUP_OPTION" );
     }
 
     while( true ) {
@@ -626,7 +623,6 @@ void user_interface::show()
         } else if( action == "TEST_RULE" && currentPageNonEmpty && !player_character.name.empty() ) {
             cur_rules[iLine].test_pattern();
         } else if( action == "SWITCH_AUTO_PICKUP_OPTION" ) {
-            // TODO: Now that NPCs use this function, it could be used for them too
             get_options().get_option( "AUTO_PICKUP" ).setNext();
             get_options().save();
         }
@@ -655,7 +651,6 @@ void player_settings::show()
     if( !player_character.name.empty() ) {
         ui.tabs.emplace_back( _( "[<Character>]" ), character_rules );
     }
-    ui.is_autopickup = true;
 
     ui.show();
 

--- a/src/auto_pickup.h
+++ b/src/auto_pickup.h
@@ -90,7 +90,6 @@ class user_interface
 
         std::string title;
         std::vector<tab> tabs;
-        bool is_autopickup = false;
 
         void show();
 


### PR DESCRIPTION
#### Summary
Interface "Removed restriction to auto pickup switching only from player UI"

#### Purpose of change
NPCs are using global `Auto pickup enabled` setting anyway, which can be changed from game options, so this is purely interface/QoL stuff.
* Closes #22321.

#### Describe the solution
Removed `is_autopickup` variable, which sole purpose, as far as I can tell, was to permit switching autopickup only from player UI and not from Pickup rules NPC dialog menu.

#### Describe alternatives you've considered
Implement separate `Auto pickup enabled` setting for NPCs, but I can't find any reason for them NOT to use auto pickup, globally, I mean. If player feels that NPC doesn't need to auto pickup something, he can simply remove all rules from the manager for that NPC.

Maybe we should remove `Auto pickup enabled` setting from game options altogether for this reason.

#### Testing
Opened NPC Pickup rules, tried to switch `Auto pickup enabled` setting from NPC dialog.

#### Additional context
None.