### PR TITLE
clean up bio_op_takedown

### DIFF
--- a/data/json/monster_special_attacks/monster_attacks.json
+++ b/data/json/monster_special_attacks/monster_attacks.json
@@ -418,14 +418,15 @@
     "hitsize_min": 4,
     "attack_upper": false,
     "damage_max_instance": [ { "damage_type": "bash", "amount": 10 } ],
-    "effects_require_dmg": false,
+    "effects_require_dmg": true,
     "hit_dmg_u": "%1$s kicks your %2$s and slams you to the ground!",
     "hit_dmg_npc": "%1$s kicks <npcname> and slams them to the ground!",
     "no_dmg_msg_u": "%1$s tries to kick %2$s and knock you down, but your armor protects you!",
     "no_dmg_msg_npc": "%1$s tries to kick and knock <npcname> down, but their armor protects them!",
     "miss_msg_u": "%s tries to kick your %2$s but you dodge!",
     "miss_msg_npc": "%s tries to kick and knock down <npcname>, but they dodge!",
-    "effects": [ { "id": "downed", "duration": 3 }, { "id": "stunned", "duration": 100 } ]
+    "effects": [ { "id": "downed", "duration": 3 }, { "id": "stunned", "duration": 1 } ],
+    "dodgeable": true
   },
   {
     "type": "monster_attack",

--- a/data/json/monster_special_attacks/monster_attacks.json
+++ b/data/json/monster_special_attacks/monster_attacks.json
@@ -418,7 +418,7 @@
     "hitsize_min": 4,
     "attack_upper": false,
     "damage_max_instance": [ { "damage_type": "bash", "amount": 10 } ],
-    "effects_require_dmg": true,
+    "effects_require_dmg": false,
     "hit_dmg_u": "%1$s kicks your %2$s and slams you to the ground!",
     "hit_dmg_npc": "%1$s kicks <npcname> and slams them to the ground!",
     "no_dmg_msg_u": "%1$s tries to kick %2$s and knock you down, but your armor protects you!",

--- a/data/json/monster_special_attacks/monster_attacks.json
+++ b/data/json/monster_special_attacks/monster_attacks.json
@@ -426,7 +426,8 @@
     "miss_msg_u": "%s tries to kick your %2$s but you dodge!",
     "miss_msg_npc": "%s tries to kick and knock down <npcname>, but they dodge!",
     "effects": [ { "id": "downed", "duration": 3 }, { "id": "stunned", "duration": [ 2, 3 ] } ],
-    "dodgeable": true
+    "dodgeable": true,
+    "blockable": false
   },
   {
     "type": "monster_attack",

--- a/data/json/monster_special_attacks/monster_attacks.json
+++ b/data/json/monster_special_attacks/monster_attacks.json
@@ -425,7 +425,7 @@
     "no_dmg_msg_npc": "%1$s tries to kick and knock <npcname> down, but their armor protects them!",
     "miss_msg_u": "%s tries to kick your %2$s but you dodge!",
     "miss_msg_npc": "%s tries to kick and knock down <npcname>, but they dodge!",
-    "effects": [ { "id": "downed", "duration": 3 }, { "id": "stunned", "duration": 1 } ],
+    "effects": [ { "id": "downed", "duration": 3 }, { "id": "stunned", "duration": [ 2, 3 ] } ],
     "dodgeable": true
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Make JSONified bio_op_takedown less insane"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The current bio_op_takedown was basically instant death unless you were in power armor. Regardless of whether or not it did damage to you, it inflicts the "downed" status effect for 3 turns and the "stunned" effect for 100 turns, which is itself a recent addition in the PR that made it JSONified. "Stunned" is a brutal status effect that works like "confusion" in roguelikes such as ADOM and DC:SS, in effect you can only do two things while stunned - move in a random direction or stand still and do nothing. Being totally helpless for an entire minute and forty seconds is very silly especially when the enemy (bio op or otherwise) can re apply the attack every 10 seconds. ~~It also was made completely undodgeable for some reason, even though it historically was dodgeable and even has dodge texts, it hits 100% of the time regardless of your dodge value.~~ This is wrong and I'm just dumb, didn't test it thoroughly enough.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Reduce stun duration to 1 second, down from 100 seconds. Also, make it dodgeable. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered making it only apply its effects apply if you took damage from the attack but decided against it.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
