### PR TITLE
stomach_size_multiplier for dragon size mutations

### DIFF
--- a/data/mods/Magiclysm/mutations/mutations.json
+++ b/data/mods/Magiclysm/mutations/mutations.json
@@ -227,6 +227,7 @@
     "category": [ "DRAGON_BLACK" ],
     "passive_mods": { "str_mod": 2 },
     "weight_capacity_modifier": 1.05,
+    "stomach_size_multiplier": 1.5,
     "anger_relations": [ [ "HUMAN", 10 ] ]
   },
   {
@@ -246,6 +247,7 @@
     "category": [ "DRAGON_BLACK" ],
     "passive_mods": { "str_mod": 2 },
     "weight_capacity_modifier": 1.05,
+    "stomach_size_multiplier": 1.5,
     "anger_relations": [ [ "HUMAN", 20 ] ]
   },
   {
@@ -270,6 +272,7 @@
     "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
     "destroys_gear": true,
     "weight_capacity_modifier": 1.1,
+    "stomach_size_multiplier": 2.0,
     "anger_relations": [ [ "HUMAN", 30 ] ]
   },
   {
@@ -344,6 +347,7 @@
     "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
     "destroys_gear": true,
     "weight_capacity_modifier": 1.1,
+    "stomach_size_multiplier": 2.0,
     "anger_relations": [ [ "HUMAN", 40 ] ]
   },
   {


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Added stomach_size_multiplier in line with mainline size mutations to black dragon size mutations."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Makes the black dragon mutation line viable considering the increased necessary nutrient intake.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added stomach_size_multiplier in line with mainline size mutations to black dragon size mutations.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Increasing metabolism_modifier and vitamins_absorb_multi, but that would both be illogical and go against the creators' intent with this mutation line.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Drank water till full, confirmed stomach contents, emptied stomach. Repeated with all 4 concerned mutations.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Exact values are copied from mainline, can be considered placeholder until whoever is working on this decides what they should be.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
