### PR TITLE
Addressing new flake warnings

### DIFF
--- a/tools/generate_changelog.py
+++ b/tools/generate_changelog.py
@@ -554,7 +554,7 @@ class CommitApi:
                 results_queue.append(commit)
 
             if request_generator.is_active and len(commit_list) == 0:
-                log.debug(f'Target page found, stop giving threads more '
+                log.debug('Target page found, stop giving threads more '
                           f'requests. Target URL: {api_request.full_url}')
                 request_generator.deactivate()
         return _process_commit_data_callback_closure
@@ -617,7 +617,7 @@ class PullRequestApi:
         requests per minute.
         """
         params = {
-            'q': f'is:pr is:merged repo:CleverRaven/Cataclysm-DDA '
+            'q': 'is:pr is:merged repo:CleverRaven/Cataclysm-DDA '
                  f'{commit_hash}'
         }
         request_builder = GitHubApiRequestBuilder(self.api_token)
@@ -701,7 +701,7 @@ class PullRequestApi:
             if len(pull_request_list) == 0 or target_page_found:
                 if request_generator.is_active:
                     log.debug(
-                        f'Target page found, stop giving threads more '
+                        'Target page found, stop giving threads more '
                         f'requests. Target URL: {api_request.full_url}')
                     request_generator.deactivate()
 
@@ -771,13 +771,13 @@ class MultiThreadedGitHubApi:
     def _process_api_requests_on_threads(request_generator, callback):
         """Process HTTP API requests and call the callback for each result
         JSON"""
-        log.debug(f'Thread Started!')
+        log.debug('Thread Started!')
         api_request = request_generator.generate()
         while api_request is not None:
             callback(do_github_request(api_request), request_generator,
                      api_request)
             api_request = request_generator.generate()
-        log.debug(f'No more requests left, killing Thread.')
+        log.debug('No more requests left, killing Thread.')
 
 
 class GitHubApiRequestBuilder(object):
@@ -970,7 +970,7 @@ def do_github_request(api_request, retry_on_limit=3):
                 log.exception(f'Unhandled Exception: {err} - '
                               f'HTTP Headers: {err.getheaders()}')
                 raise
-    raise Exception(f'Retry limit reached')
+    raise Exception('Retry limit reached')
 
 
 def read_personal_token(filename):

--- a/tools/generate_changelog.py
+++ b/tools/generate_changelog.py
@@ -1103,11 +1103,11 @@ def main_entry(argv):
     log.debug(f'Commandline Arguments (+defaults): {arguments}')
 
     if validate_file_for_writing(arguments.by_date):
-        raise ValueError(f"Specified directory in --by-date doesn't exist: "
+        raise ValueError("Specified directory in --by-date doesn't exist: "
                          f"{arguments.by_date.parent}")
 
     if validate_file_for_writing(arguments.by_build):
-        raise ValueError(f"Specified directory in --by-build doesn't exist: "
+        raise ValueError("Specified directory in --by-build doesn't exist: "
                          f"{arguments.by_build.parent}")
 
     personal_token = read_personal_token(arguments.token_file)
@@ -1239,7 +1239,7 @@ def build_output_by_date(pr_repo, commit_repo, target_dttm, end_dttm,
 
         if curr_date in commits_with_no_pr:
             if not flatten:
-                print(f"    MISC. COMMITS", file=output_file)
+                print("    MISC. COMMITS", file=output_file)
             for commit in commits_with_no_pr[curr_date]:
                 if not flatten:
                     print(f"        * {commit.message} (by {commit.author} in "
@@ -1253,7 +1253,7 @@ def build_output_by_date(pr_repo, commit_repo, target_dttm, end_dttm,
             include_summary_none and curr_date in pr_with_summary_none)
         if curr_date in pr_with_invalid_summary or is_included_summary_none:
             if not flatten:
-                print(f"    MISC. PULL REQUESTS", file=output_file)
+                print("    MISC. PULL REQUESTS", file=output_file)
             for pr in pr_with_invalid_summary[curr_date]:
                 if not flatten:
                     print(f"        * {pr.title} (by {pr.author} in "
@@ -1359,7 +1359,7 @@ def build_output_by_build(build_repo, pr_repo, commit_repo, output_file,
             print(file=output_file)
 
         if len(commits_with_no_pr) > 0:
-            print(f"    MISC. COMMITS", file=output_file)
+            print("    MISC. COMMITS", file=output_file)
             for commit in commits_with_no_pr:
                 print(f"        * {commit.message} (by {commit.author} in "
                       f"Commit {commit.hash[:7]})", file=output_file)
@@ -1368,7 +1368,7 @@ def build_output_by_build(build_repo, pr_repo, commit_repo, output_file,
         is_included_summary_none = (
             include_summary_none and len(pr_with_summary_none) > 0)
         if len(pr_with_invalid_summary) > 0 or is_included_summary_none:
-            print(f"    MISC. PULL REQUESTS", file=output_file)
+            print("    MISC. PULL REQUESTS", file=output_file)
             for pr in pr_with_invalid_summary:
                 print(f"        * {pr.title} (by {pr.author} in PR {pr.id})",
                       file=output_file)

--- a/tools/json_tools/cddatags.py
+++ b/tools/json_tools/cddatags.py
@@ -97,8 +97,8 @@ def main(args):
         pass
 
     existing_tags_lines = [
-        l.rstrip(b'\n') for l in existing_tags_lines if
-        not is_json_tag_line(l)]
+        line.rstrip(b'\n') for line in existing_tags_lines if
+        not is_json_tag_line(line)]
 
     all_tags_lines = sorted(json_tags_lines + existing_tags_lines)
 

--- a/utilities/building-utility/deconstruct.py
+++ b/utilities/building-utility/deconstruct.py
@@ -38,7 +38,7 @@ def internal_append(list_of_lists, appends):
     shortest list is exhausted.
     '''
 
-    return [l + [a] for l, a in zip(list_of_lists, appends)]
+    return [lst + [a] for lst, a in zip(list_of_lists, appends)]
 
 
 def get_map_cells(infile, cell_size):


### PR DESCRIPTION
#### Summary
None

Looks like our version of flake got bumped in the GHA runners, wich added new warnings that are failing.

```flake8
Error: ./utilities/building-utility/deconstruct.py:41:25: E741 ambiguous variable name 'l'
Error: ./tools/generate_changelog.py:774:19: F541 f-string is missing placeholders
Error: ./tools/generate_changelog.py:780:19: F541 f-string is missing placeholders
Error: ./tools/generate_changelog.py:973:21: F541 f-string is missing placeholders
Error: ./tools/generate_changelog.py:1242:23: F541 f-string is missing placeholders
Error: ./tools/generate_changelog.py:1256:23: F541 f-string is missing placeholders
Error: ./tools/generate_changelog.py:1362:19: F541 f-string is missing placeholders
Error: ./tools/generate_changelog.py:1371:19: F541 f-string is missing placeholders
Error: ./tools/json_tools/cddatags.py:100:29: E741 ambiguous variable name 'l'```