### PR TITLE
 Additional color variations (blue, pink, etc.) for vanilla hairstyles that didn't have them

### DIFF
--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -415,6 +415,45 @@
   },
 	{
     "type": "mutation",
+    "id": "crewcut",
+    "name": "Hair: crewcut",
+    "points": 0,
+    "description": "You have a black crewcut.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [	
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, crewcut" },
+        "description": "You have a blue crewcut.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, crewcut" },
+        "description": "You have a green crewcut.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, crewcut" },
+        "description": "You have a pink crewcut.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, crewcut" },
+        "description": "You have a purple crewcut.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+	{
+    "type": "mutation",
     "id": "medium-length",
     "name": "Hair: medium-length",
     "points": 0,

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -347,9 +347,9 @@
   {
     "type": "mutation",
     "id": "short_no_fringe",
-    "name": "Hair: short",
+    "name": "Hair: short without a fringe",
     "points": 0,
-    "description": "You have short black hair, without a fringe.",
+    "description": "You have short hair, without a fringe.",
     "starting_trait": true,
     "valid": false,
     "purifiable": false,
@@ -358,55 +358,55 @@
     "variants": [
       {
         "id": "blue",
-        "name": { "str": "Hair: blue, short" },
+        "name": { "str": "Hair: blue, short without a fringe" },
         "description": "You have short blue hair, without a fringe.",
         "weight": 1
       },
       {
         "id": "black",
-        "name": { "str": "Hair: black, short" },
+        "name": { "str": "Hair: black, short without a fringe" },
         "description": "You have short black hair, without a fringe.",
         "weight": 1
       },
       {
         "id": "blond",
-        "name": { "str": "Hair: blond, short" },
+        "name": { "str": "Hair: blond, short without a fringe" },
         "description": "You have short blond hair, without a fringe.",
         "weight": 1
       },
       {
         "id": "brown",
-        "name": { "str": "Hair: brown, short" },
+        "name": { "str": "Hair: brown, short without a fringe" },
         "description": "You have short brown hair, without a fringe.",
         "weight": 1
       },
       {
         "id": "red",
-        "name": { "str": "Hair: red, short" },
+        "name": { "str": "Hair: red, short without a fringe" },
         "description": "You have short red hair, without a fringe.",
         "weight": 1
       },
       {
         "id": "green",
-        "name": { "str": "Hair: green, short" },
+        "name": { "str": "Hair: green, short without a fringe" },
         "description": "You have short green hair, without a fringe.",
         "weight": 1
       },
       {
         "id": "pink",
-        "name": { "str": "Hair: pink, short" },
+        "name": { "str": "Hair: pink, short without a fringe" },
         "description": "You have short pink hair, without a fringe.",
         "weight": 1
       },
       {
         "id": "purple",
-        "name": { "str": "Hair: purple, short" },
+        "name": { "str": "Hair: purple, short without a fringe" },
         "description": "You have short purple hair, without a fringe.",
         "weight": 1
       },
       {
         "id": "white",
-        "name": { "str": "Hair: white, short" },
+        "name": { "str": "Hair: white, short without a fringe" },
         "description": "You have short white hair, without a fringe.",
         "weight": 1
       }
@@ -418,7 +418,7 @@
     "id": "crewcut",
     "name": "Hair: crewcut",
     "points": 0,
-    "description": "You have a black crewcut.",
+    "description": "You have a crewcut.",
     "starting_trait": true,
     "valid": false,
     "purifiable": false,
@@ -452,7 +452,7 @@
     "id": "mohawk",
     "name": "Hair: mohawk",
     "points": 0,
-    "description": "You have a black mohawk.",
+    "description": "You have a mohawk.",
     "starting_trait": true,
     "valid": false,
     "purifiable": false,
@@ -481,7 +481,7 @@
     "id": "fro",
     "name": "Hair: 'fro",
     "points": 0,
-    "description": "You have a black 'fro.",
+    "description": "You have a 'fro.",
     "starting_trait": true,
     "valid": false,
     "purifiable": false,
@@ -502,10 +502,44 @@
   },
   {
     "type": "mutation",
+    "id": "short",
+    "name": "Hair: short",
+    "points": 0,
+    "description": "You have short hair.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [
+      { "id": "blue", "name": { "str": "Hair: blue, short" }, "description": "You have short blue hair.", "weight": 1 },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, short" },
+        "description": "You have short green hair.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, short" },
+        "description": "You have short pink hair.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, short" },
+        "description": "You have short purple hair.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+  {
+    "type": "mutation",
     "id": "medium",
     "name": "Hair: medium-length",
     "points": 0,
-    "description": "You have a head of medium-length black hair.",
+    "description": "You have a head of medium-length hair.",
     "starting_trait": true,
     "valid": false,
     "purifiable": false,
@@ -544,7 +578,7 @@
     "id": "long",
     "name": "Hair: long",
     "points": 0,
-    "description": "You have long black hair.",
+    "description": "You have long hair.",
     "starting_trait": true,
     "valid": false,
     "purifiable": false,

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -554,7 +554,7 @@
     ],
     "types": [ "hair_style" ]
   },
-	{
+  {
     "type": "mutation",
     "id": "long",
     "name": "Hair: long",

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -415,6 +415,45 @@
   },
 	{
     "type": "mutation",
+    "id": "medium-length",
+    "name": "Hair: medium-length",
+    "points": 0,
+    "description": "You have a head of medium-length black hair.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [	
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, medium-length" },
+        "description": "You have a head of medium-length blue hair.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, medium-length" },
+        "description": "You have a head of medium-length green hair.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, medium-length" },
+        "description": "You have a head of medium-length pink hair.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, medium-length" },
+        "description": "You have a head of medium-length purple hair.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+	{
+    "type": "mutation",
     "id": "long",
     "name": "Hair: long",
     "points": 0,

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -458,13 +458,8 @@
     "purifiable": false,
     "player_display": true,
     "vanity": true,
-    "variants": [	
-      {
-        "id": "blue",
-        "name": { "str": "Hair: blue, mohawk" },
-        "description": "You have a blue mohawk.",
-        "weight": 1
-      },
+    "variants": [
+      { "id": "blue", "name": { "str": "Hair: blue, mohawk" }, "description": "You have a blue mohawk.", "weight": 1 },
       {
         "id": "green",
         "name": { "str": "Hair: green, mohawk" },

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -487,25 +487,10 @@
     "purifiable": false,
     "player_display": true,
     "vanity": true,
-    "variants": [	
-      {
-        "id": "blue",
-        "name": { "str": "Hair: blue, 'fro" },
-        "description": "You have a blue 'fro.",
-        "weight": 1
-      },
-      {
-        "id": "green",
-        "name": { "str": "Hair: green, 'fro" },
-        "description": "You have a green 'fro.",
-        "weight": 1
-      },
-      {
-        "id": "pink",
-        "name": { "str": "Hair: pink, 'fro" },
-        "description": "You have a pink 'fro.",
-        "weight": 1
-      },
+    "variants": [
+      { "id": "blue", "name": { "str": "Hair: blue, 'fro" }, "description": "You have a blue 'fro.", "weight": 1 },
+      { "id": "green", "name": { "str": "Hair: green, 'fro" }, "description": "You have a green 'fro.", "weight": 1 },
+      { "id": "pink", "name": { "str": "Hair: pink, 'fro" }, "description": "You have a pink 'fro.", "weight": 1 },
       {
         "id": "purple",
         "name": { "str": "Hair: purple, 'fro" },

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -578,12 +578,7 @@
         "description": "You have long green hair.",
         "weight": 1
       },
-      {
-        "id": "pink",
-        "name": { "str": "Hair: pink, long" },
-        "description": "You have long pink hair.",
-        "weight": 1
-      },
+      { "id": "pink", "name": { "str": "Hair: pink, long" }, "description": "You have long pink hair.", "weight": 1 },
       {
         "id": "purple",
         "name": { "str": "Hair: purple, long" },

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -476,7 +476,7 @@
     ],
     "types": [ "hair_style" ]
   },
-	{
+  {
     "type": "mutation",
     "id": "fro",
     "name": "Hair: 'fro",

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -526,7 +526,7 @@
     "purifiable": false,
     "player_display": true,
     "vanity": true,
-    "variants": [	
+    "variants": [
       {
         "id": "blue",
         "name": { "str": "Hair: blue, medium-length" },

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -515,7 +515,7 @@
     ],
     "types": [ "hair_style" ]
   },
-	{
+  {
     "type": "mutation",
     "id": "medium-length",
     "name": "Hair: medium-length",

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -466,12 +466,7 @@
         "description": "You have a green mohawk.",
         "weight": 1
       },
-      {
-        "id": "pink",
-        "name": { "str": "Hair: pink, mohawk" },
-        "description": "You have a pink mohawk.",
-        "weight": 1
-      },
+      { "id": "pink", "name": { "str": "Hair: pink, mohawk" }, "description": "You have a pink mohawk.", "weight": 1 },
       {
         "id": "purple",
         "name": { "str": "Hair: purple, mohawk" },

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -424,13 +424,8 @@
     "purifiable": false,
     "player_display": true,
     "vanity": true,
-    "variants": [	
-      {
-        "id": "blue",
-        "name": { "str": "Hair: blue, crewcut" },
-        "description": "You have a blue crewcut.",
-        "weight": 1
-      },
+    "variants": [
+      { "id": "blue", "name": { "str": "Hair: blue, crewcut" }, "description": "You have a blue crewcut.", "weight": 1 },
       {
         "id": "green",
         "name": { "str": "Hair: green, crewcut" },

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -413,7 +413,7 @@
     ],
     "types": [ "hair_style" ]
   },
-	{
+  {
     "type": "mutation",
     "id": "crewcut",
     "name": "Hair: crewcut",

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -416,32 +416,32 @@
   {
     "type": "mutation",
     "id": "crewcut",
-    "name": "Hair: crewcut",
+    "name": "Hair: crew cut",
     "points": 0,
-    "description": "You have a crewcut.",
+    "description": "You have a crew cut.",
     "starting_trait": true,
     "valid": false,
     "purifiable": false,
     "player_display": true,
     "vanity": true,
     "variants": [
-      { "id": "blue", "name": { "str": "Hair: blue, crewcut" }, "description": "You have a blue crewcut.", "weight": 1 },
+      { "id": "blue", "name": { "str": "Hair: blue, crew cut" }, "description": "You have a blue crew cut.", "weight": 1 },
       {
         "id": "green",
-        "name": { "str": "Hair: green, crewcut" },
-        "description": "You have a green crewcut.",
+        "name": { "str": "Hair: green, crew cut" },
+        "description": "You have a green crew cut.",
         "weight": 1
       },
       {
         "id": "pink",
-        "name": { "str": "Hair: pink, crewcut" },
-        "description": "You have a pink crewcut.",
+        "name": { "str": "Hair: pink, crew cut" },
+        "description": "You have a pink crew cut.",
         "weight": 1
       },
       {
         "id": "purple",
-        "name": { "str": "Hair: purple, crewcut" },
-        "description": "You have a purple crewcut.",
+        "name": { "str": "Hair: purple, crew cut" },
+        "description": "You have a purple crew cut.",
         "weight": 1
       }
     ],

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -565,13 +565,8 @@
     "purifiable": false,
     "player_display": true,
     "vanity": true,
-    "variants": [	
-      {
-        "id": "blue",
-        "name": { "str": "Hair: blue, long" },
-        "description": "You have long blue hair.",
-        "weight": 1
-      },
+    "variants": [
+      { "id": "blue", "name": { "str": "Hair: blue, long" }, "description": "You have long blue hair.", "weight": 1 },
       {
         "id": "green",
         "name": { "str": "Hair: green, long" },

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -412,5 +412,44 @@
       }
     ],
     "types": [ "hair_style" ]
+  },
+	{
+    "type": "mutation",
+    "id": "long",
+    "name": "Hair: long",
+    "points": 0,
+    "description": "You have long black hair.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [	
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, long" },
+        "description": "You have long blue hair.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, long" },
+        "description": "You have long green hair.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, long" },
+        "description": "You have long pink hair.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, long" },
+        "description": "You have long purple hair.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
   }
 ]

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -447,7 +447,7 @@
     ],
     "types": [ "hair_style" ]
   },
-	{
+  {
     "type": "mutation",
     "id": "mohawk",
     "name": "Hair: mohawk",

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -454,6 +454,84 @@
   },
 	{
     "type": "mutation",
+    "id": "mohawk",
+    "name": "Hair: mohawk",
+    "points": 0,
+    "description": "You have a black mohawk.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [	
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, mohawk" },
+        "description": "You have a blue mohawk.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, mohawk" },
+        "description": "You have a green mohawk.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, mohawk" },
+        "description": "You have a pink mohawk.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, mohawk" },
+        "description": "You have a purple mohawk.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+	{
+    "type": "mutation",
+    "id": "fro",
+    "name": "Hair: 'fro",
+    "points": 0,
+    "description": "You have a black 'fro.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [	
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, 'fro" },
+        "description": "You have a blue 'fro.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, 'fro" },
+        "description": "You have a green 'fro.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, 'fro" },
+        "description": "You have a pink 'fro.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, 'fro" },
+        "description": "You have a purple 'fro.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+	{
+    "type": "mutation",
     "id": "medium-length",
     "name": "Hair: medium-length",
     "points": 0,

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -502,7 +502,7 @@
   },
   {
     "type": "mutation",
-    "id": "medium-length",
+    "id": "medium",
     "name": "Hair: medium-length",
     "points": 0,
     "description": "You have a head of medium-length black hair.",

--- a/data/json/npcs/appearance_trait_groups.json
+++ b/data/json/npcs/appearance_trait_groups.json
@@ -320,7 +320,12 @@
       { "trait": "long_over_eye", "variant": "green", "prob": 10 },
       { "trait": "messy", "variant": "green", "prob": 13 },
       { "trait": "short_over_eye", "variant": "green", "prob": 10 },
-      { "trait": "short_no_fringe", "variant": "green", "prob": 15 }
+      { "trait": "short_no_fringe", "variant": "green", "prob": 15 },
+      { "trait": "crewcut", "variant": "green", "prob": 25 },
+      { "trait": "mohawk", "variant": "green", "prob": 1 },
+      { "trait": "fro", "variant": "green", "prob": 1 },
+      { "trait": "medium-length", "variant": "green", "prob": 25 },
+      { "trait": "long", "variant": "green", "prob": 13 }
     ]
   },
   {
@@ -333,7 +338,12 @@
       { "trait": "long_over_eye", "variant": "blue", "prob": 10 },
       { "trait": "messy", "variant": "blue", "prob": 13 },
       { "trait": "short_over_eye", "variant": "blue", "prob": 10 },
-      { "trait": "short_no_fringe", "variant": "blue", "prob": 15 }
+      { "trait": "short_no_fringe", "variant": "blue", "prob": 15 },
+      { "trait": "crewcut", "variant": "blue", "prob": 25 },
+      { "trait": "mohawk", "variant": "blue", "prob": 1 },
+      { "trait": "fro", "variant": "blue", "prob": 1 },
+      { "trait": "medium-length", "variant": "blue", "prob": 25 },
+      { "trait": "long", "variant": "blue", "prob": 13 }
     ]
   },
   {
@@ -346,7 +356,12 @@
       { "trait": "long_over_eye", "variant": "purple", "prob": 10 },
       { "trait": "messy", "variant": "purple", "prob": 13 },
       { "trait": "short_over_eye", "variant": "purple", "prob": 10 },
-      { "trait": "short_no_fringe", "variant": "purple", "prob": 15 }
+      { "trait": "short_no_fringe", "variant": "purple", "prob": 15 },
+      { "trait": "crewcut", "variant": "purple", "prob": 25 },
+      { "trait": "mohawk", "variant": "purple", "prob": 1 },
+      { "trait": "fro", "variant": "purple", "prob": 1 },
+      { "trait": "medium-length", "variant": "purple", "prob": 25 },
+      { "trait": "long", "variant": "purple", "prob": 13 }
     ]
   },
   {
@@ -359,7 +374,12 @@
       { "trait": "long_over_eye", "variant": "pink", "prob": 10 },
       { "trait": "messy", "variant": "pink", "prob": 13 },
       { "trait": "short_over_eye", "variant": "pink", "prob": 10 },
-      { "trait": "short_no_fringe", "variant": "pink", "prob": 15 }
+      { "trait": "short_no_fringe", "variant": "pink", "prob": 15 },
+      { "trait": "crewcut", "variant": "pink", "prob": 25 },
+      { "trait": "mohawk", "variant": "pink", "prob": 1 },
+      { "trait": "fro", "variant": "pink", "prob": 1 },
+      { "trait": "medium-length", "variant": "pink", "prob": 25 },
+      { "trait": "long", "variant": "pink", "prob": 13 }
     ]
   }
 ]

--- a/data/json/npcs/appearance_trait_groups.json
+++ b/data/json/npcs/appearance_trait_groups.json
@@ -324,8 +324,9 @@
       { "trait": "crewcut", "variant": "green", "prob": 25 },
       { "trait": "mohawk", "variant": "green", "prob": 1 },
       { "trait": "fro", "variant": "green", "prob": 1 },
-      { "trait": "medium-length", "variant": "green", "prob": 25 },
-      { "trait": "long", "variant": "green", "prob": 13 }
+      { "trait": "medium", "variant": "green", "prob": 25 },
+      { "trait": "long", "variant": "green", "prob": 13 },
+      { "trait": "short", "variant": "green", "prob": 35 }
     ]
   },
   {
@@ -342,8 +343,9 @@
       { "trait": "crewcut", "variant": "blue", "prob": 25 },
       { "trait": "mohawk", "variant": "blue", "prob": 1 },
       { "trait": "fro", "variant": "blue", "prob": 1 },
-      { "trait": "medium-length", "variant": "blue", "prob": 25 },
-      { "trait": "long", "variant": "blue", "prob": 13 }
+      { "trait": "medium", "variant": "blue", "prob": 25 },
+      { "trait": "long", "variant": "blue", "prob": 13 },
+      { "trait": "short", "variant": "blue", "prob": 35 }
     ]
   },
   {
@@ -360,8 +362,9 @@
       { "trait": "crewcut", "variant": "purple", "prob": 25 },
       { "trait": "mohawk", "variant": "purple", "prob": 1 },
       { "trait": "fro", "variant": "purple", "prob": 1 },
-      { "trait": "medium-length", "variant": "purple", "prob": 25 },
-      { "trait": "long", "variant": "purple", "prob": 13 }
+      { "trait": "medium", "variant": "purple", "prob": 25 },
+      { "trait": "long", "variant": "purple", "prob": 13 },
+      { "trait": "short", "variant": "purple", "prob": 35 }
     ]
   },
   {
@@ -378,8 +381,9 @@
       { "trait": "crewcut", "variant": "pink", "prob": 25 },
       { "trait": "mohawk", "variant": "pink", "prob": 1 },
       { "trait": "fro", "variant": "pink", "prob": 1 },
-      { "trait": "medium-length", "variant": "pink", "prob": 25 },
-      { "trait": "long", "variant": "pink", "prob": 13 }
+      { "trait": "medium", "variant": "pink", "prob": 25 },
+      { "trait": "long", "variant": "pink", "prob": 13 },
+      { "trait": "short", "variant": "pink", "prob": 35 }
     ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Additional color variations (blue, pink, etc.) for vanilla hairstyles that didn't have them"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Reopens #62657 


#### Describe the solution

- Reopen PR
- Add new trait to trait group

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Load without error

![image](https://user-images.githubusercontent.com/41293484/206856281-f2684e2a-7442-4a52-939a-c1cb61734511.png)

![image](https://user-images.githubusercontent.com/41293484/206856276-4ec6c709-b23e-480a-b2a7-b685bf61ec89.png)

Those colours are set to be pretty rare so I didn't manage to see tham appear in NPCs

#### Additional context

We should probably migrate the old trait to this new variant structure