### PR TITLE
Item names now include the number of additional pockets attached to them

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6350,7 +6350,8 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
 
     if( is_corpse() || typeId() == itype_blood || item_vars.find( "name" ) != item_vars.end() ) {
         maintext = type_name( quantity );
-    } else if( ( is_gun() || is_tool() || is_magazine() ) && !is_power_armor() ) {
+    } else if( ( ( is_gun() || is_tool() || is_magazine() ) && !is_power_armor() ) ||
+               contents.has_additional_pockets() ) {
         int amt = 0;
         maintext = label( quantity );
         for( const item *mod : is_gun() ? gunmods() : toolmods() ) {
@@ -6358,6 +6359,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
                 amt++;
             }
         }
+        amt += contents.get_added_pockets().size();
         if( amt ) {
             maintext += string_format( "+%d", amt );
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6351,7 +6351,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     if( is_corpse() || typeId() == itype_blood || item_vars.find( "name" ) != item_vars.end() ) {
         maintext = type_name( quantity );
     } else if( ( ( is_gun() || is_tool() || is_magazine() ) && !is_power_armor() ) ||
-               contents.has_additional_pockets() ) {
+               contents.has_additional_pockets() ) { 
         int amt = 0;
         maintext = label( quantity );
         for( const item *mod : is_gun() ? gunmods() : toolmods() ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6351,7 +6351,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     if( is_corpse() || typeId() == itype_blood || item_vars.find( "name" ) != item_vars.end() ) {
         maintext = type_name( quantity );
     } else if( ( ( is_gun() || is_tool() || is_magazine() ) && !is_power_armor() ) ||
-               contents.has_additional_pockets() ) { 
+               contents.has_additional_pockets() ) {
         int amt = 0;
         maintext = label( quantity );
         for( const item *mod : is_gun() ? gunmods() : toolmods() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Item names now include the number of pockets attached to them; for instance, a ballistic vest with three extra pouches might display as 'US ballistic vest+3'"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
MOLLE pockets are currently buried pretty deep in the interface; to see if an item has any attached pockets at all, you have to go into the item description and then scroll down to the storage section. There's no way to easily see at a glance how many pockets an item has attached.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
I appropriated the code used to display the number of mods on an item to also display the number of attached pockets. For instance, a US ballistic vest with four extra accessories would show up as `US ballistic vest+4`, in the same way that an M4 carbine with two mods would show up as `M4 carbine+2`. See below for screenies.

For items that can have both mods and attached pockets (I believe this is only applicable through modding right now), it will display the sum of mods and pockets. A modded gun with two mods and two pockets would show up as `modded gun+4`, and not `modded gun+2+2`.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I originally wanted this PR to be a general improvement to MOLLE pockets in that I tried to make them be filthy and damaged if the item they spawned attached to was also filthy and damaged. I couldn't actually figure out how to do that, though, so I scrapped it. Yay, rustiness!

I'd considered also making the number of attached pockets display as a unique thing on its own (such as `US ballistic vest+2 pockets` or `US ballistic vest (+2 pockets)` or something, but all the things I thought of seemed pretty jank to me. Including it with the number of existing mods seemed like the most natural display to me.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
I spawned in some zombie soldiers and killed 'em using debug, then searched the bodies. Items with attached pockets showed up using the new names, while items without any did not. Attaching a new pocket to an item caused its name to update to include that pocket as `+1`, and taking all pockets off removed the suffix from an item entirely.

I made sure that items with just mods (and no attached pockets) appeared correctly; an M4 carbine with just a shoulder strap appeared as `M4 carbine+1` correctly and lost the suffix when I took the strap off.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Some drops from a zombie soldier. Note the +4 on the load bearing vest.
![cataclysm-tiles_Y8qBILmW3J](https://user-images.githubusercontent.com/47678781/206853599-2827d2c7-e47d-407f-a6ee-9c46fb4356fc.png)

Looking further in the item card for the vest, we can see the pockets that were attached:
![cataclysm-tiles_zzr13daQra](https://user-images.githubusercontent.com/47678781/206853600-9fd67f53-8f9a-42ee-9326-dc804ecd17b3.png)

Bonus picture: my testing helper named Fred.
![image](https://user-images.githubusercontent.com/47678781/206853790-b5e5ac9e-4035-4747-be04-88e11b673003.png)
