### PR TITLE
Whitelists for Aftershock Exoplanet Map Specials

### DIFF
--- a/data/mods/Aftershock/maps/mutable_specials/formless_ruin.json
+++ b/data/mods/Aftershock/maps/mutable_specials/formless_ruin.json
@@ -14,6 +14,7 @@
       [ [ 0, -1, 0 ], [ "land" ] ],
       [ [ -1, 0, 0 ], [ "land" ] ]
     ],
+    "flags": [ "EXOPLANET" ],
     "joins": [ "ruin_to_ruin" ],
     "overmaps": {
       "ruin_core": {

--- a/data/mods/Aftershock/maps/mutable_specials/ravine_tunnels.json
+++ b/data/mods/Aftershock/maps/mutable_specials/ravine_tunnels.json
@@ -6,7 +6,7 @@
     "locations": [ "subterranean_empty", "ravine_edge", "land" ],
     "city_distance": [ 10, -1 ],
     "occurrences": [ 10, 10 ],
-    "flags": [ "WILDERNESS" ],
+    "flags": [ "WILDERNESS", "EXOPLANET" ],
     "check_for_locations": [
       [ [ 0, 0, 0 ], [ "ravine_edge" ] ],
       [ [ -1, 0, 0 ], [ "ravine_edge" ] ],

--- a/data/mods/Aftershock/maps/overmap_specials.json
+++ b/data/mods/Aftershock/maps/overmap_specials.json
@@ -16,7 +16,8 @@
     "locations": [ "land" ],
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 0, -1 ],
-    "occurrences": [ 0, 1 ]
+    "occurrences": [ 0, 1 ],
+    "flags": [ "EXOPLANET" ]
   },
   {
     "id": "municipal_reactor",
@@ -109,6 +110,6 @@
       { "point": [ 0, 0, 0 ], "overmap": "robot_dispatch_first_north" },
       { "point": [ 0, 0, 1 ], "overmap": "robot_dispatch_second_north" }
     ],
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "EXOPLANET" ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/region_settings.json
+++ b/data/mods/aftershock_exoplanet/region_settings.json
@@ -4,9 +4,9 @@
     "id": "default",
     "overmap_feature_flag_settings": {
       "clear_blacklist": false,
-      "blacklist": [ "BLOB", "BEE", "ANT", "FUNGAL", "SLIME", "TRIFFID", "MI-GO", "LAB", "CLASSIC" ],
+      "blacklist": [  ],
       "clear_whitelist": false,
-      "whitelist": [  ]
+      "whitelist": [ "EXOPLANET" ]
     },
     "default_oter": [
       "open_air",

--- a/data/mods/aftershock_exoplanet/region_settings.json
+++ b/data/mods/aftershock_exoplanet/region_settings.json
@@ -2,12 +2,7 @@
   {
     "type": "region_settings",
     "id": "default",
-    "overmap_feature_flag_settings": {
-      "clear_blacklist": false,
-      "blacklist": [  ],
-      "clear_whitelist": false,
-      "whitelist": [ "EXOPLANET" ]
-    },
+    "overmap_feature_flag_settings": { "clear_blacklist": false, "blacklist": [  ], "clear_whitelist": false, "whitelist": [ "EXOPLANET" ] },
     "default_oter": [
       "open_air",
       "open_air",


### PR DESCRIPTION
#### Summary
Mods "Aftershock Exoplanet: Spawn map specials using whitelists"

#### Purpose of change
Some vanilla structures where still spawning in the exoplanet. This is just a much easier way to control what spawns.

#### Describe the solution
Use an "EXOPLANET" map special flag. And added it to specials that are ready to spawn in there.

#### Testing
Load into the exoplanet. Verify the maps that are spawning.

