### PR TITLE
Changing mil composite armor removal requirements 

### DIFF
--- a/data/json/requirements/vehicle.json
+++ b/data/json/requirements/vehicle.json
@@ -41,5 +41,11 @@
     "type": "requirement",
     "//": "Counterpart to welding_* installation requirements",
     "qualities": [ { "id": "SAW_M", "level": 2 } ]
+  },
+    {
+    "id": "vehicle_weld_removal_cut_resistant",
+    "type": "requirement",
+    "//": "Used for parts that can't be cut with hand tools",
+    "qualities": [ { "id": "SAW_M", "level": 3 } ]
   }
 ]

--- a/data/json/requirements/vehicle.json
+++ b/data/json/requirements/vehicle.json
@@ -42,7 +42,7 @@
     "//": "Counterpart to welding_* installation requirements",
     "qualities": [ { "id": "SAW_M", "level": 2 } ]
   },
-    {
+  {
     "id": "vehicle_weld_removal_cut_resistant",
     "type": "requirement",
     "//": "Used for parts that can't be cut with hand tools",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2034,7 +2034,7 @@
     "location": "armor",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 6 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },
-      "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] }
+      "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal_cut_resistant", 1 ] ] }
     },
     "flags": [ "ARMOR", "NO_REPAIR" ],
     "breaks_into": [


### PR DESCRIPTION
#### Summary
Balance "Change military composite armor removal requirements to power tool level metal sawing"
#### Purpose of change
Military composite armor consists of much stronger materials than a handmade or regular store hacksaw can reliably saw, so changing the requirements to a power tool level sawing would make more sense. I think it also fits better with the fact that you can't craft military composite armor, so it should make sense it would be removable only with a tool you can't craft 

#### Describe the solution
Added a new requirement in requirement/vehicle.json called "vehicle_weld_removal_cut_resistant" which requires level 3 of metal sawing, and updating the military composite armor to require that. 

#### Describe alternatives you've considered
Hacksaw theoretically would be able to saw trough the armor, but it would require adding a charge mechanic to be able to replace the sawing blade. To actually saw the armor you would have to replace the blade multiple times over and over, which would also require a break in the part deconstruction, which isn't possible with current implementation. Also for this new hacksaw mechanic to work it would have to somehow know the material of the thing it's sawing to appropriately use more of it's charge (to emulate faster blade dulling).

Another solution would be to make the process of sawing take longer or faster depending on the level of the tool you are using, which would still make it fairly unrealistic to be able to cut trough heat treated composite steel armor using a regular hacksaw.

#### Testing
It's a simple json change which doesn't affect any other elements and just changes recipy requirements 

