### PR TITLE
Added a way to change color for 'Explored' tiles

### DIFF
--- a/data/core/overmap_terrain.json
+++ b/data/core/overmap_terrain.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "overmap_terrain",
+    "id": "",
+    "name": "nothing",
+    "sym": "%",
+    "color": "white",
+    "flags": [ "NO_ROTATE" ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "unexplored",
+    "name": "Unexplored",
+    "sym": "#",
+    "color": "dark_gray",
+    "flags": [ "NO_ROTATE", "SHOULD_NOT_SPAWN" ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "explored",
+    "name": "Explored",
+    "sym": "#",
+    "color": "dark_gray",
+    "flags": [ "NO_ROTATE", "SHOULD_NOT_SPAWN" ]
+  }
+]

--- a/data/json/mapgen/dummy/dummy.json
+++ b/data/json/mapgen/dummy/dummy.json
@@ -3,7 +3,7 @@
     "type": "mapgen",
     "method": "json",
     "//": "This mapgen exist only for suppressing 'No mapgen terrain exists for %s' type of errors on game start and shouldn't spawn ingame",
-    "om_terrain": [ "unexplored" ],
+    "om_terrain": [ "unexplored", "explored" ],
     "object": {
       "rows": [
         "                        ",

--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -17,6 +17,14 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "explored",
+    "name": "Explored",
+    "sym": "#",
+    "color": "dark_gray",
+    "flags": [ "NO_ROTATE", "SHOULD_NOT_SPAWN" ]
+  },
+  {
+    "type": "overmap_terrain",
     "abstract": "generic_city_building_no_sidewalk",
     "name": "city building",
     "sym": "^",

--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -1,30 +1,6 @@
 [
   {
     "type": "overmap_terrain",
-    "id": "",
-    "name": "nothing",
-    "sym": "%",
-    "color": "white",
-    "flags": [ "NO_ROTATE" ]
-  },
-  {
-    "type": "overmap_terrain",
-    "id": "unexplored",
-    "name": "Unexplored",
-    "sym": "#",
-    "color": "dark_gray",
-    "flags": [ "NO_ROTATE", "SHOULD_NOT_SPAWN" ]
-  },
-  {
-    "type": "overmap_terrain",
-    "id": "explored",
-    "name": "Explored",
-    "sym": "#",
-    "color": "dark_gray",
-    "flags": [ "NO_ROTATE", "SHOULD_NOT_SPAWN" ]
-  },
-  {
-    "type": "overmap_terrain",
     "abstract": "generic_city_building_no_sidewalk",
     "name": "city building",
     "sym": "^",

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -88,6 +88,7 @@ static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 static const mongroup_id GROUP_FOREST( "GROUP_FOREST" );
 static const mongroup_id GROUP_NEMESIS( "GROUP_NEMESIS" );
 
+static const oter_str_id oter_explored( "explored" );
 static const oter_str_id oter_forest( "forest" );
 static const oter_str_id oter_unexplored( "unexplored" );
 
@@ -601,7 +602,8 @@ static void draw_ascii(
         // Ok, we found something
         if( info ) {
             const bool explored = show_explored && overmap_buffer.is_explored( omp );
-            ter_color = explored ? c_dark_gray : info->get_color( uistate.overmap_show_land_use_codes );
+            ter_color = explored ? oter_explored.obj().get_color() :
+                        info->get_color( uistate.overmap_show_land_use_codes );
             ter_sym = info->get_symbol( uistate.overmap_show_land_use_codes );
         }
     };


### PR DESCRIPTION
#### Summary
Interface "Added a way to change color for 'Explored' tiles"

#### Purpose of change
I can't find it right now, but I'm pretty sure someone asked for a way to change default color for `Explored` overlay on overmap from dark gray to something else.

#### Describe the solution
- Added `explored` dummy overmap tile with a default dark gray color.
- Added a check for color of this OMT in `draw_ascii` function.

#### Describe alternatives you've considered
None.

#### Testing
Changed color of `Explored` overlay to yellow, opened overmap, marked some tiles as Explored, checked their color.

#### Additional context
![изображение](https://user-images.githubusercontent.com/11132525/208238798-9db2c87a-d876-43bd-a9ce-c729eaf5c0c0.png)