### PR TITLE
Aftershock: Space food

### DIFF
--- a/data/mods/Aftershock/itemgroups/astronaut_mre.json
+++ b/data/mods/Aftershock/itemgroups/astronaut_mre.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "item_group",
+    "id": "astronaut_mre_full_pack",
+    "subtype": "collection",
+    "entries": [ { "item": "afs_mre_package", "contents-group": "astronaut_mre_contents", "sealed": true } ]
+  },
+  {
+    "type": "item_group",
+    "id": "astronaut_mre_contents",
+    "subtype": "collection",
+    "entries": [
+      { "group": "mre_entrees", "count": 2 },
+      { "item": "heatpack", "count": 2 },
+      { "item": "crackers", "charges": [ 0, 2 ], "container-item": "mre_bag_small", "sealed": true }
+    ]
+  }
+]

--- a/data/mods/Aftershock/itemgroups/food_groups.json
+++ b/data/mods/Aftershock/itemgroups/food_groups.json
@@ -12,6 +12,80 @@
     ]
   },
   {
+    "id": "afs_spices",
+    "type": "item_group",
+    "//": "This group is for cupboard, drawer, or rack with spices.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "salt", "count": [ 2, 4 ], "prob": 15, "container-item": "afs_foil_bag" },
+      { "item": "cinnamon", "prob": 5, "container-item": "afs_foil_bag" },
+      { "item": "chilly-p", "prob": 15, "container-item": "afs_foil_bag" },
+      { "item": "sugar", "prob": 5, "container-item": "afs_foil_bag" },
+      { "item": "artificial_sweetener", "prob": 15, "container-item": "afs_foil_bag" },
+      { "item": "curry_powder", "prob": 25, "container-item": "afs_foil_bag" },
+      { "item": "garlic_powder", "prob": 25, "container-item": "afs_foil_bag" },
+      { "item": "seasoning_salt", "prob": 50, "container-item": "afs_foil_bag" },
+      { "group": "ketchup_sealed_rng", "prob": 35 },
+      { "group": "mustard_sealed_rng", "prob": 35 },
+      { "item": "soysauce", "prob": 25 },
+      { "item": "hot_sauce", "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "afs_dry_goods",
+    "ammo": 75,
+    "magazine": 100,
+    "subtype": "distribution",
+    "entries": [
+      { "item": "instant_coffee", "prob": 40, "container-item": "afs_foil_bag" },
+      { "item": "flour", "prob": 40, "container-item": "afs_foil_bag" },
+      { "item": "yeast", "prob": 50, "container-item": "afs_foil_bag" },
+      { "item": "fruit_leather", "prob": 15, "container-item": "afs_foil_bag" },
+      { "item": "dry_beans", "prob": 10, "container-item": "afs_foil_bag" },
+      { "item": "dry_lentils", "prob": 10, "container-item": "afs_foil_bag" },
+      { "item": "dry_rice", "prob": 10, "container-item": "afs_foil_bag" },
+      { "item": "gelatin_powder", "prob": 40, "container-item": "afs_foil_bag" },
+      { "item": "chem_agar", "prob": 15, "container-item": "afs_foil_bag" },
+      { "item": "gelatin_dessert_powder", "prob": 40, "container-item": "afs_foil_bag" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "afs_stored_meals",
+    "//": "Meals that require little to no preparation before eating.",
+    "entries": [
+      { "item": "afs_kibble", "prob": 10, "container-item": "afs_foil_bag" },
+      { "group": "astronaut_mre_full_pack", "prob": 10 },
+      { "group": "afs_cheap_food", "count": [ 2, 4 ], "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "afs_stored_meats",
+    "entries": [
+      { "item": "afs_synthetic_meat", "prob": 10, "container-item": "afs_foil_bag" },
+      { "item": "afs_jerky", "prob": 40, "container-item": "afs_foil_bag" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "afs_stored_veggies",
+    "entries": [ { "item": "afs_kelp", "prob": 40, "container-item": "afs_foil_bag" } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "afs_ruined_food",
+    "entries": [
+      { "item": "afs_ruined_food", "prob": 10, "charges": 2, "container-item": "can_food" },
+      { "item": "afs_ruined_food", "prob": 10, "container-item": "afs_foil_bag" }
+    ]
+  },
+  {
     "type": "item_group",
     "subtype": "collection",
     "id": "afs_mealgrub_procesing",

--- a/data/mods/Aftershock/itemgroups/kitchen_groups.json
+++ b/data/mods/Aftershock/itemgroups/kitchen_groups.json
@@ -14,5 +14,20 @@
       { "group": "SUS_kitchen_sink", "prob": 30 },
       { "group": "SUS_coffee_cupboard", "prob": 2 }
     ]
+  },
+  {
+    "id": "afs_old_food_storage",
+    "type": "item_group",
+    "//": "A cabinet, rack or equivalent storing food from before the discontinuity.  Should only contain nonperishable food and spawn in ruins.",
+    "subtype": "collection",
+    "items": [
+      { "group": "afs_cheap_food", "prob": 10, "count-min": 1, "count-max": 5 },
+      { "group": "afs_spices", "prob": 20, "count-min": 3, "count-max": 5 },
+      { "group": "afs_dry_goods", "prob": 10, "count-min": 1, "count-max": 2 },
+      { "group": "afs_stored_meals", "prob": 10, "count-min": 1, "count-max": 7 },
+      { "group": "afs_stored_meats", "prob": 5, "count-min": 1, "count-max": 2 },
+      { "group": "afs_stored_veggies", "prob": 10, "count-min": 1, "count-max": 2 },
+      { "group": "afs_ruined_food", "prob": 50, "count-min": 1, "count-max": 7 }
+    ]
   }
 ]

--- a/data/mods/Aftershock/items/comestibles/bug_brew.json
+++ b/data/mods/Aftershock/items/comestibles/bug_brew.json
@@ -96,6 +96,7 @@
     "cooks_like": "jerky",
     "color": "white",
     "spoils_in": "45 days",
+    "material": [ "flesh" ],
     "calories": 360,
     "healthy": 3,
     "charges": 5,

--- a/data/mods/Aftershock/items/comestibles/cheap_food.json
+++ b/data/mods/Aftershock/items/comestibles/cheap_food.json
@@ -194,5 +194,17 @@
     "fun": 6,
     "freezing_point": -9999,
     "vitamins": [ [ "bad_food", 1 ] ]
+  },
+  {
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "id": "afs_ruined_food",
+    "copy-from": "ruined_chunks",
+    "name": { "str_sp": "organic sludge" },
+    "charges": 5,
+    "volume": "500 ml",
+    "weight": "50 g",
+    "description": "Time and the elements have reverted this heavily processed meal to its original form.  Eating it isn't even worth thinking about.",
+    "material": [ "flesh", "veggy" ]
   }
 ]

--- a/data/mods/Aftershock/items/comestibles/flesh.json
+++ b/data/mods/Aftershock/items/comestibles/flesh.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "COMESTIBLE",
+    "id": "afs_synthetic_meat",
+    "copy-from": "meat",
+    "name": { "str_sp": "synthetic meat" },
+    "description": "A cut of vat grown lean meat, genetically similar to beef.  Conspicuously uniform in both looks and texture.",
+    "parasites": 0
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "afs_jerky",
+    "copy-from": "jerky",
+    "name": { "str_sp": "meat flakes" },
+    "description": "Transparent thin hexagonal cuts of dried meat.  Conspicuously uniform in both looks and texture."
+  }
+]

--- a/data/mods/Aftershock/items/comestibles/veggies.json
+++ b/data/mods/Aftershock/items/comestibles/veggies.json
@@ -1,0 +1,30 @@
+[
+  {
+    "type": "COMESTIBLE",
+    "id": "afs_kelp",
+    "copy-from": "spinach",
+    "name": { "str_sp": "kelp" },
+    "description": "Thin wafers of kelp, the essential greens of frontier cuisine.  These were probably grown in some farm ship or another.",
+    "volume": "1500 ml"
+  },
+  {
+    "id": "afs_kibble",
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "name": { "str_sp": "spiced chops" },
+    "description": "Kibble made for humans.  A heavy dressing of spices makes it impossible to discern the original flavours it might have had.",
+    "weight": "223 g",
+    "spoils_in": "1 day",
+    "volume": "250 ml",
+    "price": 500,
+    "to_hit": -5,
+    "material": [ "veggy" ],
+    "symbol": ";",
+    "charges": 2,
+    "quench": 2,
+    "calories": 800,
+    "vitamins": [ [ "vitC", 4 ], [ "iron", 17 ], [ "bad_food", 1 ] ],
+    "fun": 1,
+    "color": "brown"
+  }
+]

--- a/data/mods/Aftershock/items/containers.json
+++ b/data/mods/Aftershock/items/containers.json
@@ -31,5 +31,30 @@
     "copy-from": "pressure_tank",
     "name": { "str": "pressurized tank" },
     "flags": [ "NO_UNLOAD", "MAG_BULKY" ]
+  },
+  {
+    "id": "afs_mre_package",
+    "copy-from": "mre_package",
+    "type": "GENERIC",
+    "name": { "str": "Astronaut MRE" },
+    "description": "Marketing has adorned the package of this individual ration with white and red livery, a deliberate callback to the space corporations of old.  Despite best efforts, the food within is no more natural than usual, but is at least palatable."
+  },
+  {
+    "id": "afs_foil_bag",
+    "copy-from": "plastic_bag_vac",
+    "type": "GENERIC",
+    "name": { "str": "foil bag" },
+    "description": "A plastic and aluminum foil bag for long term food storage.",
+    "material": [ "plastic", "aluminum" ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "open_container": true,
+        "watertight": true,
+        "max_contains_volume": "1500 ml",
+        "max_contains_weight": "3 kg",
+        "sealed_data": { "spoil_multiplier": 0.0 }
+      }
+    ]
   }
 ]

--- a/data/mods/Aftershock/maps/mapgen/stratoscomm_relay.json
+++ b/data/mods/Aftershock/maps/mapgen/stratoscomm_relay.json
@@ -81,10 +81,7 @@
         "o": "f_habitat_kitchenette",
         "F": "f_fridge"
       },
-      "items": {
-        "o": { "item": "afs_kitchenette", "chance": 100 },
-        "F": { "item": "afs_cheap_food", "chance": 80, "repeat": [ 1, 10 ] }
-      },
+      "items": { "o": { "item": "afs_kitchenette", "chance": 100 }, "F": { "item": "afs_old_food_storage", "chance": 80 } },
       "monster": { "ö": { "monster": "mon_skitterbot" } }
     }
   },

--- a/data/mods/Aftershock/maps/mapgen_pallete/houses.json
+++ b/data/mods/Aftershock/maps/mapgen_pallete/houses.json
@@ -63,7 +63,7 @@
         { "item": "consumer_electronics", "chance": 10, "repeat": [ 1, 3 ] },
         { "item": "livingroom", "chance": 10, "repeat": [ 1, 3 ] }
       ],
-      "F": { "item": "SUS_fridge", "chance": 80 },
+      "F": { "item": "afs_ruined_food", "chance": 80, "repeat": [ 5, 13 ] },
       "P": { "item": "SUS_dishwasher", "chance": 70 },
       "f": [
         { "item": "elecsto_persele", "chance": 10, "repeat": [ 1, 3 ] },
@@ -83,8 +83,8 @@
       "V": [ { "item": "SUS_utensils", "chance": 50 }, { "item": "SUS_knife_drawer", "chance": 50 } ],
       "I": { "item": "SUS_junk_drawer", "chance": 100 },
       "^": { "item": "SUS_kitchen_sink", "chance": 100 },
-      "M": [ { "item": "SUS_pantry", "chance": 25 }, { "item": "cannedfood", "chance": 20, "repeat": [ 1, 2 ] } ],
-      "S": [ { "item": "SUS_breakfast_cupboard", "chance": 30 }, { "item": "SUS_coffee_cupboard", "chance": 50 } ],
+      "M": [ { "item": "afs_old_food_storage", "chance": 45 } ],
+      "S": [ { "item": "afs_old_food_storage", "chance": 30 }, { "item": "SUS_coffee_cupboard", "chance": 50 } ],
       "5": [ { "item": "SUS_bathroom_sink", "chance": 80 }, { "item": "SUS_bathroom_medicine", "chance": 60 } ],
       "9": { "item": "shower", "chance": 30, "repeat": [ 1, 2 ] },
       "@": { "item": "bed", "chance": 50 },

--- a/data/mods/Aftershock/requirements.json
+++ b/data/mods/Aftershock/requirements.json
@@ -46,7 +46,7 @@
     "id": "meat_raw_steak",
     "type": "requirement",
     "//": "An unbroken slab of raw meat.  For when scraps just aren't good enough.",
-    "extend": { "components": [ [ [ "frost_human_flesh", 1 ], [ "alien_flesh", 1 ] ] ] }
+    "extend": { "components": [ [ [ "frost_human_flesh", 1 ], [ "afs_synthetic_meat", 1 ], [ "alien_flesh", 1 ] ] ] }
   },
   {
     "id": "meat_red_raw",
@@ -76,28 +76,15 @@
     "id": "meat_nofish",
     "type": "requirement",
     "//": "Any type of raw meat except for fish.  About 300-400kcal of meat.",
-    "extend": {
-      "components": [
-        [
-          [ "alien_liver", 5 ],
-          [ "alien_kidney", 5 ],
-          [ "alien_sweetbread", 5 ],
-          [ "bacon", 4 ],
-          [ "bologna", 5 ],
-          [ "meat_pickled", 1 ],
-          [ "dry_meat", 1 ],
-          [ "jerky", 1 ],
-          [ "meat_smoked", 1 ],
-          [ "meat_salted", 1 ]
-        ]
-      ]
-    }
+    "extend": { "components": [ [ [ "afs_mealgrubs", 1 ], [ "alien_liver", 5 ], [ "alien_kidney", 5 ], [ "alien_sweetbread", 5 ] ] ] }
   },
   {
     "id": "meat_cooked",
     "type": "requirement",
     "//": "meat you'd put on a sandwich",
-    "extend": { "components": [ [ [ "alien_flesh_cooked", 1 ], [ "alien_meat_scrap_cooked", 10 ], [ "frost_human_cooked", 1 ] ] ] }
+    "extend": {
+      "components": [ [ [ "alien_flesh_cooked", 1 ], [ "alien_meat_scrap_cooked", 10 ], [ "frost_human_cooked", 1 ], [ "afs_jerky", 1 ] ] ]
+    }
   },
   {
     "id": "human_meat",
@@ -110,5 +97,17 @@
     "type": "requirement",
     "//": "Cooked meat that non-cannibals would be unhappy eating.",
     "extend": { "components": [ [ [ "frost_human_cooked", 1 ] ] ] }
+  },
+  {
+    "id": "veggy_any_fresh_uncooked",
+    "type": "requirement",
+    "//": "Any type of edible raw fat.",
+    "extend": { "components": [ [ [ "afs_kelp", 1 ] ] ] }
+  },
+  {
+    "id": "veggy_green",
+    "type": "requirement",
+    "//": "Any type of edible raw fat.",
+    "extend": { "components": [ [ [ "afs_kelp", 1 ] ] ] }
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: More space food."

#### Purpose of change
More items and item groups for later (and current) use in mod structures 

#### Describe the solution

Most items are just reskins on normal vanilla food with minimal changes. They exist mainly to affirm the setting.

#### Testing

Load game and tested item groups
