### PR TITLE
Seatbelt quality now matters

### DIFF
--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1453,7 +1453,7 @@
     "durability": 35,
     "description": "A belt, attached to a seat.",
     "folded_volume": "500 ml",
-    "bonus": 25,
+    "bonus": 10,
     "item": "rope_6",
     "location": "on_seat",
     "requirements": {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2129,6 +2129,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
         monster *pet = dynamic_cast<monster *>( rider );
 
         bool throw_from_seat = false;
+        int dmg = d_vel * rng_float( 1.0f, 2.0f );
         int move_resist = 1;
         if( psg ) {
             ///\EFFECT_STR reduces chance of being thrown from your seat when not wearing a seatbelt
@@ -2143,17 +2144,19 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
         if( veh.part_with_feature( ps, VPFLAG_SEATBELT, true ) == -1 ) {
             ///\EFFECT_STR reduces chance of being thrown from your seat when not wearing a seatbelt
             throw_from_seat = d_vel * rng( 80, 120 ) > move_resist;
+        } else {
+            // Reduce potential damage based on quality of seatbelt
+            dmg -= veh.part_info( veh.part_with_feature( ps, "SEATBELT", true ) ).bonus;
         }
 
         // Damage passengers if d_vel is too high
-        if( !throw_from_seat && ( 10 * d_vel ) > 6 * rng( 50, 100 ) ) {
-            const int dmg = d_vel * rng( 70, 100 ) / 400;
+        if( !throw_from_seat && ( 10 * d_vel ) > 6 * rng( 25, 50 ) ) {
             if( psg ) {
-                psg->hurtall( dmg, nullptr );
+                psg->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_type::BASH, dmg ) );
                 psg->add_msg_player_or_npc( m_bad,
                                             _( "You take %d damage by the power of the impact!" ),
                                             _( "<npcname> takes %d damage by the power of the "
-                                               "impact!" ),  dmg );
+                                               "impact!" ), dmg );
             } else {
                 pet->apply_damage( nullptr, bodypart_id( "torso" ), dmg );
             }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2146,7 +2146,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
             throw_from_seat = d_vel * rng( 80, 120 ) > move_resist;
         } else {
             // Reduce potential damage based on quality of seatbelt
-            dmg -= veh.part_info( veh.part_with_feature( ps, "SEATBELT", true ) ).bonus;
+            dmg -= veh.part_info( veh.part_with_feature( ps, VPFLAG_SEATBELT, true ) ).bonus;
         }
 
         // Damage passengers if d_vel is too high


### PR DESCRIPTION
#### Summary
Bugfixes "Damage done on collisions now scales based on seatbelt quality"

#### Purpose of change
Mechanics for collisions with characters wearing a seatbelt had several issues:
- Formula for determining if character wearing a seatbelt should take damage at all was way too harsh: 
`( 10 * d_vel ) > 6 * rng( 50, 100 )`
`d_vel` is a delta between vehicle velocity before and after collision. `Armored car` colliding with a concrete wall at 37 km/h has `d_vel` of ~28. 10 * `d_vel` is 280. It's never more than `6 * rng( 50, 100 )`, so it will never trigger the effect of damaging character wearing a seatbelt. Moving at faster velocity simply destroyed the seatbelt on collision, and thus will never trigger this effect too.
- Damage done on collisions was applied to all bodyparts at once, which made no sense since seatbelt is worn only over torso, and the damage should be done only to torso and not to head, arms, or legs.
- Seatbelt quality had no effect on distributing (=reducing) damage to torso on collisions, so both ordinary seatbelt and 5-point harness were essentially the same in terms of reducing damage.
- Closes #30239.

#### Describe the solution
- Changed formula to make more sense, so now damage on collisions to characters wearing seatbelts is now actually applied on sensible speeds..
- Damage done on collision for characters wearing seatbelts will now be applied only to torso.
- Seatbelt quality now reduces damage done on collision for characters wearing seatbelts.
- Lowered `bonus` parameter of ordinary seatbelt from 25 to 10. Now it's worse than 5-point harness with 25 `bonus`.

#### Describe alternatives you've considered
None.

#### Testing
Collided on `Armored car` (with a 5-point harness) with a concrete wall on 37 km/h. Randomized damage based on `d_vel` was 48, 5-point harness reduced damage by 25 points, so I got only 48-25=15 points of damage to torso only.
Collided on `Car` (with ordinary seatbelt) with a concrete wall on 50 km/h. Randomized damage was 40, seatbelt reduced damage by 10 points, so I got 40-10=30 points of damage to torso only.

#### Additional context
None.