### PR TITLE
Evac Shelter pencils now spawn with charges.

### DIFF
--- a/data/json/itemgroups/SUS/evac_shelter.json
+++ b/data/json/itemgroups/SUS/evac_shelter.json
@@ -259,7 +259,7 @@
       { "item": "evac_pamphlet", "prob": 15 },
       { "group": "games_basic", "prob": 15, "count": [ 1, 2 ] },
       { "item": "paper", "prob": 20, "count": [ 1, 3 ] },
-      { "item": "pencil", "prob": 20, "count": [ 1, 5 ], "charges": [ 0, 100 ] }
+      { "item": "pencil", "prob": 20, "count": [ 1, 5 ], "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -273,7 +273,7 @@
       { "item": "evac_pamphlet", "prob": 15 },
       { "group": "games_basic", "prob": 8 },
       { "item": "paper", "prob": 10, "count": [ 1, 2 ] },
-      { "item": "pencil", "prob": 10, "count": [ 1, 2 ], "charges": [ 0, 100 ] }
+      { "item": "pencil", "prob": 10, "count": [ 1, 2 ], "charges": [ 1, 100 ] }
     ]
   },
   {

--- a/data/json/itemgroups/SUS/evac_shelter.json
+++ b/data/json/itemgroups/SUS/evac_shelter.json
@@ -259,7 +259,7 @@
       { "item": "evac_pamphlet", "prob": 15 },
       { "group": "games_basic", "prob": 15, "count": [ 1, 2 ] },
       { "item": "paper", "prob": 20, "count": [ 1, 3 ] },
-      { "item": "pencil", "prob": 20, "count": [ 1, 5 ] }
+      { "item": "pencil", "prob": 20, "count": [ 1, 5 ], "charges": [ 0, 100 ] }
     ]
   },
   {
@@ -273,7 +273,7 @@
       { "item": "evac_pamphlet", "prob": 15 },
       { "group": "games_basic", "prob": 8 },
       { "item": "paper", "prob": 10, "count": [ 1, 2 ] },
-      { "item": "pencil", "prob": 10, "count": [ 1, 2 ] }
+      { "item": "pencil", "prob": 10, "count": [ 1, 2 ], "charges"" [ 0, 100 ] }
     ]
   },
   {

--- a/data/json/itemgroups/SUS/evac_shelter.json
+++ b/data/json/itemgroups/SUS/evac_shelter.json
@@ -273,7 +273,7 @@
       { "item": "evac_pamphlet", "prob": 15 },
       { "group": "games_basic", "prob": 8 },
       { "item": "paper", "prob": 10, "count": [ 1, 2 ] },
-      { "item": "pencil", "prob": 10, "count": [ 1, 2 ], "charges"" [ 0, 100 ] }
+      { "item": "pencil", "prob": 10, "count": [ 1, 2 ], "charges": [ 0, 100 ] }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "evac shelter pencils now spawn with graphite"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Previously, pencils in evac shelters always spawned with 0/100 charges. I doubt that they specifically went out of there way to stock these shelters with only pencil-less pencil eraser nubs.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Pencil spawns in evac shelters are now specified to have a random amount of charges from 0 to 100.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not that familiar with the code, so maybe there's some other way to make them spawn with charges than the "charges": thing I added, but this way seems to work as I wanted. The exact range of charges could be tweaked to something other than 0 to 100 if someone feels that some other range makes more sense.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went into some evac shelter basements and made sure pencils had a random amount of charges.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
![Screenshot 2022-12-24 100420](https://user-images.githubusercontent.com/38295275/209447255-5e1c5b3d-6e1a-41e3-998e-cf7a34a6f4b4.png)
![Screenshot 2022-12-24 100603](https://user-images.githubusercontent.com/38295275/209447257-65ee6f99-cbbb-47bb-84e3-f1ba9078506d.png)
![Screenshot 2022-12-24 100620](https://user-images.githubusercontent.com/38295275/209447258-072a4989-06f9-455d-b2d0-052ac41499a4.png)
#### Additional context
range has been updated to 1 to 100
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
