### PR TITLE
inv_ui: add key for overriding collapsed status

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2020,6 +2020,13 @@
   },
   {
     "type": "keybinding",
+    "id": "SHOW_HIDE_CONTENTS_ALL",
+    "category": "INVENTORY",
+    "name": "Show/hide all contents",
+    "bindings": [ { "input_method": "keyboard_char", "key": "E" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "TOGGLE_SKIP_UNSELECTABLE",
     "category": "INVENTORY",
     "name": "Toggle skipping unselectable items"

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -489,7 +489,7 @@ void uistatedata::deserialize( const JsonObject &jo )
 
 static const selection_column_preset selection_preset{};
 
-bool inventory_entry::is_hidden() const
+bool inventory_entry::is_hidden( cata::optional<bool> const &hide_entries_override ) const
 {
     if( !is_item() ) {
         return false;
@@ -504,6 +504,9 @@ bool inventory_entry::is_hidden() const
     }
 
     item_location item = locations.front();
+    if( hide_entries_override && topmost_parent && topmost_parent->is_container() ) {
+        return *hide_entries_override;
+    }
     while( item.has_parent() && item != topmost_parent ) {
         item_location parent = item.parent_item();
         if( parent.get_item()->contained_where( *item )->settings.is_collapsed() ) {
@@ -1239,7 +1242,7 @@ void inventory_column::on_change( const inventory_entry &/* entry */ )
 
 inventory_entry *inventory_column::add_entry( const inventory_entry &entry )
 {
-    entries_t &dest = entry.is_hidden() ? entries_hidden : entries;
+    entries_t &dest = entry.is_hidden( hide_entries_override ) ? entries_hidden : entries;
     if( std::find( dest.begin(), dest.end(), entry ) != dest.end() ) {
         debugmsg( "Tried to add a duplicate entry." );
         return nullptr;
@@ -1436,10 +1439,10 @@ void inventory_column::prepare_paging( const std::string &filter )
         return preset.get_filter( filter );
     } );
 
-    const auto is_visible = [&filter_fn, &filter]( inventory_entry const & it ) {
+    const auto is_visible = [&filter_fn, &filter, this]( inventory_entry const & it ) {
         return it.is_item() &&
                ( filter_fn( it ) &&
-                 ( ( !filter.empty() && !it.is_collation_entry() ) || !it.is_hidden() ) );
+                 ( ( !filter.empty() && !it.is_collation_entry() ) || !it.is_hidden( hide_entries_override ) ) );
     };
     const auto is_not_visible = [&is_visible]( inventory_entry const & it ) {
         return !is_visible( it );
@@ -1678,9 +1681,13 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
 
                 const std::string &hl_option = get_option<std::string>( "INVENTORY_HIGHLIGHT" );
                 if( cell_index == 0 && entry.chevron ) {
-                    nc_color const col = entry.is_collation_header() ? c_light_blue : c_dark_gray;
+                    bool const hide_override = hide_entries_override && entry.any_item()->is_container();
+                    nc_color const col = entry.is_collation_header() ? c_light_blue : hide_override ?
+                                         *hide_entries_override ? c_red : c_green : c_dark_gray;
+                    bool const stat = entry.is_collation_entry() ||
+                                      !hide_override ? entry.collapsed : *hide_entries_override;
                     trim_and_print( win, point( text_x - 1, yy ), 1, col,
-                                    entry.collapsed ? "▶" : "▼" );
+                                    stat ? "▶" : "▼" );
                 }
                 if( entry.is_item() && ( selected || !entry.is_selectable() ) ) {
                     trim_and_print( win, point( text_x, yy ), text_width, selected ? h_white : c_dark_gray,
@@ -2687,6 +2694,7 @@ inventory_selector::inventory_selector( Character &u, const inventory_selector_p
     ctxt.register_action( "RESET_FILTER" );
     ctxt.register_action( "EXAMINE" );
     ctxt.register_action( "SHOW_HIDE_CONTENTS", to_translation( "Show/hide contents" ) );
+    ctxt.register_action( "SHOW_HIDE_CONTENTS_ALL" );
     ctxt.register_action( "EXAMINE_CONTENTS" );
     ctxt.register_action( "TOGGLE_SKIP_UNSELECTABLE" );
     ctxt.register_action( "ORGANIZE_MENU" );
@@ -2756,6 +2764,19 @@ inventory_input inventory_selector::process_input( const std::string &action, in
     return res;
 }
 
+void inventory_column::cycle_hide_override()
+{
+    if( hide_entries_override ) {
+        if( *hide_entries_override ) {
+            hide_entries_override = cata::nullopt;
+        } else {
+            hide_entries_override = true;
+        }
+    } else {
+        hide_entries_override = false;
+    }
+}
+
 void inventory_selector::on_input( const inventory_input &input )
 {
     if( input.action == "CATEGORY_SELECTION" ) {
@@ -2807,7 +2828,12 @@ void inventory_selector::on_input( const inventory_input &input )
                 current_ui->mark_resize();
             }
         }
-        if( input.action == "SHOW_HIDE_CONTENTS" ) {
+        if( input.action == "SHOW_HIDE_CONTENTS_ALL" ) {
+            for( inventory_column *col : columns ) {
+                col->cycle_hide_override();
+            }
+        }
+        if( input.action == "SHOW_HIDE_CONTENTS" || input.action == "SHOW_HIDE_CONTENTS_ALL" ) {
             shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
             for( inventory_column * const &col : columns ) {
                 col->invalidate_paging();

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -131,7 +131,7 @@ class inventory_entry
         /**
         *  Whether it is hidden in inventory screen.
         * */
-        bool is_hidden() const;
+        bool is_hidden( cata::optional<bool> const &hide_entries_override ) const;
 
         /** Whether the entry can be selected */
         bool is_selectable() const {
@@ -486,6 +486,7 @@ class inventory_column
         void toggle_skip_unselectable( bool skip );
         void collate();
         void uncollate();
+        void cycle_hide_override();
 
     protected:
         struct entry_cell_cache_t {
@@ -564,6 +565,7 @@ class inventory_column
         mutable std::vector<entry_cell_cache_t> entries_cell_cache;
 
         cata::optional<bool> indent_entries_override = cata::nullopt;
+        cata::optional<bool> hide_entries_override = cata::nullopt;
         /** @return Number of visible cells */
         size_t visible_cells() const;
         void _get_entries( get_entries_t *res, entries_t const &ent,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add an action to inventory UIs for overriding the collapsed status of all containers
Fixes #62854
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add an action (unbound by default) that cycles collapsed status override between true/false/none. Since we're in string freeze, the override status is only indicated by colored chevrons.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Actually (un)collapsing: I playtested with that and I *hated* it. I don't want my carefully set-up inventory to get scrambled by a stray keypress. People who like floor/pocket pasta won't notice a difference anyway.

Only overriding (or uncollapsing) the visible containers or the top-level ones: seems like a half-way measure that won't satisfy anyone (except hardcore floor pasta enthusiasts).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Only the status of containers is overridden.

[output.webm](https://user-images.githubusercontent.com/68240139/209451563-906c265c-c866-40e1-abb8-f7112976e7e2.webm)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
