### PR TITLE
Non-lethal scratches

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10133,25 +10133,28 @@ point game::place_player( const tripoint &dest_loc, bool quick )
         !x_in_y( 1 + u.dex_cur / 2.0, 40 ) &&
         ( !u.in_vehicle && !m.veh_at( dest_loc ) ) && ( !u.has_proficiency( proficiency_prof_parkour ) ||
                 one_in( 4 ) ) && ( u.has_trait( trait_THICKSKIN ) ? !one_in( 8 ) : true ) ) {
+        const int sharp_damage = rng( 1, 10 );
         if( u.is_mounted() ) {
-            const int sharp_damage = rng( 1, 10 );
-            if( u.mounted_creature->get_armor_cut( bodypart_id( "torso" ) ) < sharp_damage ) {
+            if( u.mounted_creature->get_armor_cut( bodypart_id( "torso" ) ) < sharp_damage &&
+                u.mounted_creature->get_hp() > sharp_damage ) {
                 add_msg( _( "Your %s gets cut!" ), u.mounted_creature->get_name() );
                 u.mounted_creature->apply_damage( nullptr, bodypart_id( "torso" ), sharp_damage );
             }
         } else {
-            const bodypart_id bp = u.get_random_body_part();
-            if( u.deal_damage( nullptr, bp, damage_instance( damage_type::CUT, rng( 1,
-                               10 ) ) ).total_damage() > 0 ) {
-                //~ 1$s - bodypart name in accusative, 2$s is terrain name.
-                add_msg( m_bad, _( "You cut your %1$s on the %2$s!" ),
-                         body_part_name_accusative( bp ),
-                         m.has_flag_ter( ter_furn_flag::TFLAG_SHARP, dest_loc ) ? m.tername( dest_loc ) : m.furnname(
-                             dest_loc ) );
-                if( !u.has_flag( json_flag_INFECTION_IMMUNE ) ) {
-                    const int chance_in = u.has_trait( trait_INFRESIST ) ? 1024 : 256;
-                    if( one_in( chance_in ) ) {
-                        u.add_effect( effect_tetanus, 1_turns, true );
+            if( u.get_hp() > sharp_damage ) {
+                const bodypart_id bp = u.get_random_body_part();
+                if( u.deal_damage( nullptr, bp,
+                                   damage_instance( damage_type::CUT, sharp_damage ) ).total_damage() > 0 ) {
+                    //~ 1$s - bodypart name in accusative, 2$s is terrain name.
+                    add_msg( m_bad, _( "You cut your %1$s on the %2$s!" ),
+                             body_part_name_accusative( bp ),
+                             m.has_flag_ter( ter_furn_flag::TFLAG_SHARP, dest_loc ) ? m.tername( dest_loc ) : m.furnname(
+                                 dest_loc ) );
+                    if( !u.has_flag( json_flag_INFECTION_IMMUNE ) ) {
+                        const int chance_in = u.has_trait( trait_INFRESIST ) ? 1024 : 256;
+                        if( one_in( chance_in ) ) {
+                            u.add_effect( effect_tetanus, 1_turns, true );
+                        }
                     }
                 }
             }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1733,11 +1733,11 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
         const int sharp_damage = rng( 1, 10 );
         const int rough_damage = rng( 1, 2 );
         if( here.has_flag( ter_furn_flag::TFLAG_SHARP, pos() ) && !one_in( 4 ) &&
-            get_armor_cut( bodypart_id( "torso" ) ) < sharp_damage ) {
+            get_armor_cut( bodypart_id( "torso" ) ) < sharp_damage && get_hp() > sharp_damage ) {
             apply_damage( nullptr, bodypart_id( "torso" ), sharp_damage );
         }
         if( here.has_flag( ter_furn_flag::TFLAG_ROUGH, pos() ) && one_in( 6 ) &&
-            get_armor_cut( bodypart_id( "torso" ) ) < rough_damage ) {
+            get_armor_cut( bodypart_id( "torso" ) ) < rough_damage && get_hp() > rough_damage ) {
             apply_damage( nullptr, bodypart_id( "torso" ), rough_damage );
         }
     }


### PR DESCRIPTION
#### Summary
Balance "Non-lethal scratches"

#### Purpose of change
* Closes #36225.

#### Describe the solution
Don't apply scratch damage if this damage will kill monster, player, or his mount. This is applicable only on mundane move through sources of such damage (such as window frames or rose bushes).
Also don't kill monsters moving through rough terrain.

#### Describe alternatives you've considered
None.

#### Testing
Made myself a zombie with just 1 point of HP left. Made him step on rose bushes. Watched him not dying from scratches.

#### Additional context
This will make some tactics (such as waiting until all prisoners die on barbed wires in island prison before going out) no longer viable, but monsters and player dying from a last single scratch of a bush's thorn looks like a more serious problem.