### PR TITLE
Update stale exclusion labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,8 +25,8 @@ jobs:
           start-date: '2020-05-07'
           ascending: ${{ contains(fromJson('["01", "03", "05", "07", "09", "11"]'), env.time) }}
           operations-per-run: 250
-          exempt-issue-labels: '<Bug>,<Bugfix>,<Crash / Freeze>,Organization: Bounty,Good First Issue,(P1 - Critical),(P2 - High),(P3 - Medium),(P4 - Low),(P5 - Long-term),(S2 - Confirmed),0.E Feature Freeze,0.E Content Freeze,0.F Feature Freeze,0.F Content Freeze,0.F String Freeze,0.G Feature Freeze,0.G Content Freeze'
-          exempt-pr-labels: '<Bug>,<Bugfix>,<Crash / Freeze>,Organization: Bounty,Good First Issue,(P1 - Critical),(P2 - High),(P3 - Medium),(P4 - Low),(P5 - Long-term),(S2 - Confirmed),0.E Feature Freeze,0.E Content Freeze,0.F Feature Freeze,0.F Content Freeze,0.F String Freeze,0.G Feature Freeze,0.G Content Freeze'
+          exempt-issue-labels: '<Bug>,<Bugfix>,<Crash / Freeze>,Organization: Bounty,Good First Issue,(P1 - Critical),(P2 - High),(P3 - Medium),(P4 - Low),(P5 - Long-term),(S2 - Confirmed),0.G String Freeze,0.G Feature Freeze,0.G Content Freeze'
+          exempt-pr-labels: '<Bug>,<Bugfix>,<Crash / Freeze>,Organization: Bounty,Good First Issue,(P1 - Critical),(P2 - High),(P3 - Medium),(P4 - Low),(P5 - Long-term),(S2 - Confirmed),0.G String Freeze,0.G Feature Freeze,0.G Content Freeze'
           exempt-all-milestones: true
           exempt-all-assignees: true
       - name: Print outputs


### PR DESCRIPTION
#### Summary
None

The author of https://github.com/CleverRaven/Cataclysm-DDA/pull/62170 pointed out their PR shouldn't be staled, I checked and noticed ~~we're missing the 0.G String Freeze label~~.
While I was at it, I removed the old stale freeze labels.