### PR TITLE
build bed construction group

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2335,37 +2335,8 @@
   },
   {
     "type": "construction",
-    "id": "constr_bed",
-    "group": "build_bed_from_scratch",
-    "category": "FURN",
-    "required_skills": [ [ "fabrication", 4 ] ],
-    "time": "60 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 1 } ] ],
-    "components": [ [ [ "2x4", 12 ] ], [ [ "nail", 10 ] ], [ [ "mattress", 1 ], [ "down_mattress", 1 ] ] ],
-    "pre_special": "check_empty",
-    "post_terrain": "f_bed"
-  },
-  {
-    "type": "construction",
-    "id": "constr_bunkbed",
-    "group": "build_bunk_bed",
-    "category": "FURN",
-    "required_skills": [ [ "fabrication", 4 ] ],
-    "time": "130 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 1 } ] ],
-    "components": [
-      [ [ "2x4", 16 ], [ "wood_panel", 4 ] ],
-      [ [ "2x4", 14 ] ],
-      [ [ "nail", 30 ] ],
-      [ [ "mattress", 2 ], [ "down_mattress", 2 ] ]
-    ],
-    "pre_special": "check_empty",
-    "post_terrain": "f_bunkbed"
-  },
-  {
-    "type": "construction",
     "id": "constr_bed_frame",
-    "group": "build_bed_frame",
+    "group": "build_bed",
     "category": "FURN",
     "required_skills": [ [ "fabrication", 4 ] ],
     "time": "55 m",
@@ -2377,13 +2348,30 @@
   {
     "type": "construction",
     "id": "constr_finish_bed",
-    "group": "add_mattress_to_bed_frame",
+    "group": "build_bed",
     "category": "FURN",
     "required_skills": [ [ "fabrication", 0 ] ],
     "time": "5 m",
     "components": [ [ [ "mattress", 1 ], [ "down_mattress", 1 ] ] ],
     "pre_terrain": "f_bed_frame",
     "post_terrain": "f_bed"
+  },
+  {
+    "type": "construction",
+    "id": "constr_bunkbed",
+    "group": "build_bed",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 4 ] ],
+    "time": "70 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 1 } ] ],
+    "components": [
+      [ [ "2x4", 16 ], [ "wood_panel", 4 ] ],
+      [ [ "2x4", 2 ] ],
+      [ [ "nail", 20 ] ],
+      [ [ "mattress", 1 ], [ "down_mattress", 1 ] ]
+    ],
+    "pre_terrain": "f_bed",
+    "post_terrain": "f_bunkbed"
   },
   {
     "type": "construction",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1,11 +1,6 @@
 [
   {
     "type": "construction_group",
-    "id": "add_mattress_to_bed_frame",
-    "name": "Add Mattress to Bed Frame"
-  },
-  {
-    "type": "construction_group",
     "id": "armor_reinforced_window",
     "name": "Armor Reinforced Window"
   },
@@ -66,13 +61,8 @@
   },
   {
     "type": "construction_group",
-    "id": "build_bed_frame",
-    "name": "Build Bed Frame"
-  },
-  {
-    "type": "construction_group",
-    "id": "build_bed_from_scratch",
-    "name": "Build Bed from Scratch"
+    "id": "build_bed",
+    "name": "Build Bed/Bunk bed"
   },
   {
     "type": "construction_group",
@@ -93,11 +83,6 @@
     "type": "construction_group",
     "id": "build_bulletin_board",
     "name": "Build Bulletin Board"
-  },
-  {
-    "type": "construction_group",
-    "id": "build_bunk_bed",
-    "name": "Build Bunk Bed"
   },
   {
     "type": "construction_group",

--- a/data/json/furniture_and_terrain/furniture-sleep.json
+++ b/data/json/furniture_and_terrain/furniture-sleep.json
@@ -41,7 +41,8 @@
     "floor_bedding_warmth": 1000,
     "required_str": -1,
     "deconstruct": {
-      "items": [ { "item": "mattress", "count": 2 }, { "item": "2x4", "count": 28 }, { "item": "nail", "charges": [ 20, 30 ] } ]
+      "items": [ { "item": "mattress", "count": 1 }, { "item": "2x4", "count": 16 }, { "item": "nail", "charges": [ 10, 20 ] } ],
+      "furn_set": "f_bed"
     },
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "CAN_SIT" ],
     "bash": {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
closes #62871
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
removed `build bed from scratch` and moved `build bed frame` `add mattress to bed frame` `build bunk bed` into the same group
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
considering keeping bunk bed as is but it works fine in tests, if you can give me a reason to change it back let me know
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
built a bed > added the mattress > built the bunk bed > deconstructed the bunk bed > removed the mattress > deconstructed the bed frame
![image](https://user-images.githubusercontent.com/115079701/209596015-b5d80703-042f-4807-b314-c281e09938cd.png)
![image](https://user-images.githubusercontent.com/115079701/209596020-7e85a12d-9b49-48b0-b7c7-b00cc82662ef.png)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
