### PR TITLE
Reasons for slow or fast crafting are now described in details

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -47,9 +47,10 @@
 #include "ui_manager.h"
 #include "uistate.h"
 
+static const limb_score_id limb_score_manip( "manip" );
+
 static const std::string flag_BLIND_EASY( "BLIND_EASY" );
 static const std::string flag_BLIND_HARD( "BLIND_HARD" );
-
 
 class npc;
 
@@ -2050,7 +2051,7 @@ static void draw_can_craft_indicator( const catacurses::window &w, const recipe 
     } else if( player_character.crafting_speed_multiplier( rec ) < 1.0f ) {
         int morale_modifier = get_player_character().morale_crafting_speed_multiplier( rec ) * 100;
         int lighting_modifier = get_player_character().lighting_craft_speed_multiplier( rec ) * 100;
-        int limb_modifier = get_player_character().get_limb_score( limb_score_id( "manip" ) ) * 100;
+        int limb_modifier = get_player_character().get_limb_score( limb_score_manip ) * 100;
 
         std::stringstream modifiers_list;
         if( morale_modifier < 100 ) {
@@ -2060,7 +2061,7 @@ static void draw_can_craft_indicator( const catacurses::window &w, const recipe 
             if( !modifiers_list.str().empty() ) {
                 modifiers_list << ", ";
             }
-            modifiers_list << ( "lighting" ) << " " << lighting_modifier << "%";
+            modifiers_list << _( "lighting" ) << " " << lighting_modifier << "%";
         }
         if( limb_modifier < 100 ) {
             if( !modifiers_list.str().empty() ) {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -83,7 +83,6 @@ static std::vector<std::string> craft_cat_list;
 static std::map<std::string, std::vector<std::string> > craft_subcat_list;
 
 static bool query_is_yes( const std::string &query );
-static int craft_info_width( int window_width );
 static void draw_hidden_amount( const catacurses::window &w, int amount, int num_recipe );
 static void draw_can_craft_indicator( const catacurses::window &w, const recipe &rec );
 static std::map<size_t, inclusive_rectangle<point>> draw_recipe_tabs( const catacurses::window &w,
@@ -1042,7 +1041,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id goto_
 
         width = isWide ? ( freeWidth > FULL_SCREEN_WIDTH ? FULL_SCREEN_WIDTH * 2 : TERMX ) :
                 FULL_SCREEN_WIDTH;
-        const unsigned int header_info_width = craft_info_width( width );
+        const unsigned int header_info_width = width - FULL_SCREEN_WIDTH - 1;
         const int wStart = ( TERMX - width ) / 2;
 
         // Keybinding tips
@@ -2007,18 +2006,6 @@ static bool query_is_yes( const std::string &query )
     return subquery == "yes" || subquery == "y" || subquery == "1" ||
            subquery == "true" || subquery == "t" || subquery == "on" ||
            subquery == _( "yes" );
-}
-
-static int craft_info_width( const int window_width )
-{
-    int reason_width = 0;
-    //The crafting speed string is necessary.  Find the longest one
-    for( const auto &pair : craft_speed_reason_strings ) {
-        reason_width = std::max( utf8_width( pair.second.translated(), true ), reason_width );
-    }
-    reason_width += 2; //Allow for borders
-    //Use about a quarter of the screen if there's room to play, otherwise limit to the longest string
-    return std::max( window_width / 4, reason_width );
 }
 
 static void draw_hidden_amount( const catacurses::window &w, int amount, int num_recipe )


### PR DESCRIPTION
#### Summary
Interface "Reasons for slow or fast crafting is now described in details"

#### Purpose of change
* Closes #62868.

#### Describe the solution
- Display reasons for slow crafting: morale, lighting, and manipulator score modifiers. Modifiers are displayed only if they actually affect crafting.
- Display manipulator score modifier for fast crafting.
- Reworded message for slow/fast crafting. Previously the message was `crafting is slow 22%`. What does this mean? That crafting is slowed by 22% or to 22%? Unclear.

#### Describe alternatives you've considered
None.

#### Testing
Wore mittens to get hands encumbrance. Went into a dark tile. Opened crafting menu and checked message for slow crafting.

#### Additional context
Message for slow crafting due only to hands encumbrance
![изображение](https://user-images.githubusercontent.com/11132525/209672943-be639960-9e9d-4cfa-9479-3eb07f6e862f.png)

Message for slow crafting due to bad lighting and hands encumbrance
![изображение](https://user-images.githubusercontent.com/11132525/209672906-ffda6241-2440-44d4-bfdc-b13cbf83b8a4.png)

Can anyone please explain to me why it's cropping the message while there's obviously enough space for the whole message?