### PR TITLE
[Magiclysm] balance tweaks

### DIFF
--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -458,7 +458,7 @@
     "remove_message": "You no longer feel encumbered.",
     "rating": "good",
     "show_intensity": false,
-    "enchantments": [ { "values": [ { "value": "ATTACK_SPEED", "multiply": -0.25 }, { "value": "MELEE_DAMAGE", "multiply": 1.2 } ] } ]
+    "enchantments": [ { "values": [ { "value": "ATTACK_SPEED", "multiply": -0.25 }, { "value": "MELEE_DAMAGE", "multiply": 0.6 } ] } ]
   },
   {
     "id": "eshaper_crystal_wrap",

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -165,7 +165,7 @@
     "apply_message": "Your speed is boosted to superhuman levels!",
     "remove_message": "You return to your normal speed.",
     "rating": "good",
-    "base_mods": { "dex_mod": [ 4 ], "speed_mod": [ 250 ] }
+    "enchantments": [ { "values": [ { "value": "SPEED", "multiply": 2.5 }, { "value": "ATTACK_SPEED", "multiply": -0.7 } ] } ]
   },
   {
     "type": "effect_type",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I hear too much of "haste is op". Not anymore. Also just want to resolve the heft effect being same op
#### Describe the solution
Haste now provide only movement speed boost, and decrease the melee attack speed to the level same as it was before the speed buff
Also heft effect was halved - still nice buff, but not stupidly OP
#### Describe alternatives you've considered
uSe HaStE, iT iS rEaLLy gOoD
#### Testing
Works perfect
#### Additional context
![image](https://user-images.githubusercontent.com/67688115/209679526-eb750fb1-4ff1-4051-be13-e555c5351aa8.png)
![image](https://user-images.githubusercontent.com/67688115/209679558-67b4a214-c4d2-41e2-9440-1ff1a5b44551.png)
![image](https://user-images.githubusercontent.com/67688115/209679622-eaca2994-803e-4f20-becb-979b56f9555d.png)
![image](https://user-images.githubusercontent.com/67688115/209681317-97670f96-7600-4932-b223-1f5989303873.png)
![image](https://user-images.githubusercontent.com/67688115/209681366-f012a46e-327a-4390-808a-05a4b7c29ddf.png)
