### PR TITLE
Remove hardcoded material whitelist from salvage actor

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1325,11 +1325,6 @@ void salvage_actor::load( const JsonObject &obj )
 {
     assign( obj, "cost", cost );
     assign( obj, "moves_per_part", moves_per_part );
-
-    if( obj.has_array( "material_whitelist" ) ) {
-        material_whitelist.clear();
-        assign( obj, "material_whitelist", material_whitelist );
-    }
 }
 
 std::unique_ptr<iuse_actor> salvage_actor::clone() const
@@ -1382,14 +1377,27 @@ static void visit_salvage_products( const item &it,
     }
 }
 
-// Helper to find smallest sub-component of an item.
-static units::mass minimal_weight_to_cut( const item &it )
+static units::mass proportional_weight( const item &it, int material_portions )
 {
-    units::mass min_weight = units::mass_max;
-    visit_salvage_products( it, [&min_weight]( const item & exemplar ) {
-        min_weight = std::min( min_weight, exemplar.weight() );
-    } );
-    return min_weight;
+    int total_portions = std::max( 1, it.type->mat_portion_total );
+    return it.weight() * material_portions / total_portions;
+}
+
+// Helper to determine if there's enough of any material to even produce a result when cut up.
+static bool can_produce_results( const item &it )
+{
+    for( const std::pair<const material_id, int> &mat : it.made_of() ) {
+        if( const cata::optional<itype_id> mat_id = mat.first->salvaged_into() ) {
+            item material( *mat_id );
+            if( material.count_by_charges() ) {
+                material.charges = 1;
+            }
+            if( material.weight() <= proportional_weight( it, mat.second ) ) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 int salvage_actor::time_to_cut_up( const item &it ) const
@@ -1425,19 +1433,13 @@ bool salvage_actor::valid_to_cut_up( const Character *const p, const item &it ) 
         return false;
     }
 
-    if( !it.only_made_of( material_whitelist ) ) {
-        if( p ) {
-            add_msg( m_info, _( "The %s is made of material that cannot be cut up." ), it.tname() );
-        }
-        return false;
-    }
     if( !it.empty() ) {
         if( p ) {
             add_msg( m_info, _( "Please empty the %s before cutting it up." ), it.tname() );
         }
         return false;
     }
-    if( it.weight() < minimal_weight_to_cut( it ) ) {
+    if( !can_produce_results( it ) ) {
         if( p ) {
             add_msg( m_info, _( "The %s is too small to salvage material from." ), it.tname() );
         }
@@ -1510,11 +1512,9 @@ void salvage_actor::cut_up( Character &p, item_location &cut ) const
     efficiency *= std::min( std::pow( 0.8, cut.get_item()->damage_level() ), 1.0 );
 
     auto distribute_uniformly = [&mat_to_weight]( const item & x, float num_adjusted ) -> void {
-        const float mat_total = std::max( x.type->mat_portion_total, 1 );
         for( const auto &type : x.made_of() )
         {
-            mat_to_weight[type.first] += x.weight() * ( static_cast<float>( type.second ) / mat_total ) *
-            num_adjusted;
+            mat_to_weight[type.first] += proportional_weight( x, type.second ) * num_adjusted;
         }
     };
 
@@ -1575,13 +1575,11 @@ void salvage_actor::cut_up( Character &p, item_location &cut ) const
             // Find default components set from recipe
             for( const auto &altercomps : requirements.get_components() ) {
                 const item_comp &comp = altercomps.front();
-                if( comp.type->count_by_charges() ) {
-                    item next = item( comp.type, calendar::turn, comp.count );
-                    cut_up_component( next, num_adjusted );
-                } else {
-                    item next = item( comp.type, calendar::turn );
-                    cut_up_component( next, num_adjusted * comp.count );
+                item next = item( comp.type, calendar::turn );
+                if( next.count_by_charges() ) {
+                    next.charges = 1;
                 }
+                cut_up_component( next, num_adjusted * comp.count );
             }
         } else
         {

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -470,31 +470,6 @@ class salvage_actor : public iuse_actor
         /** Moves used per unit of volume of cut item */
         int moves_per_part = 25;
 
-        /** Materials it can cut */
-        std::set<material_id> material_whitelist = {
-            material_id( "acidchitin" ),
-            material_id( "alien_resin" ),
-            material_id( "bone" ),
-            material_id( "canvas" ),
-            material_id( "chitin" ),
-            material_id( "cotton" ),
-            material_id( "faux_fur" ),
-            material_id( "fur" ),
-            material_id( "kevlar" ),
-            material_id( "kevlar_layered" ),
-            material_id( "kevlar_rigid" ),
-            material_id( "leather" ),
-            material_id( "lycra" ),
-            material_id( "neoprene" ),
-            material_id( "nomex" ),
-            material_id( "nylon" ),
-            material_id( "plastic" ),
-            material_id( "rubber" ),
-            material_id( "thermo_resin" ),
-            material_id( "wood" ),
-            material_id( "wool" )
-        };
-
         cata::optional<int> try_to_cut_up( Character &p, item &cutter, item_location &cut ) const;
         int time_to_cut_up( const item &it ) const;
         bool valid_to_cut_up( const Character *p, const item &it ) const;


### PR DESCRIPTION
#### Summary
Infrastructure "Remove hardcoded material whitelist from salvage actor"

#### Purpose of change

Allow salvageable materials to be defined in json only.

#### Describe the solution

Just remove the hardcoded whitelist. This slightly changes behavior so you can cut up items made from _any_ salvageable material instead of only those made _completely_ from salvageable materials.
This causes a minor issue that some smaller items made from mixed materials that are too small to actually produce results show up in the menu. I tried to mitigate it a bit by improving the logic to determine if results can be produced, but the actual cutting is a little more complex, so there are some misses like wrist watches for example.

Also fixed a bug that meant resulting `count_by_charges` items would only spawn 1 charge at most.

#### Describe alternatives you've considered

Keeping the old behavior, but that would mean more work and doesn't necessarily make more sense.

#### Testing

Cut up some books and cardboard boxes since paper and cardboard are defined as salvageable in json but weren't present in the whitelist.

#### Additional context

