### PR TITLE
Consolidate fishing implements logic to use only tool quality, eliminate redundant item flags

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1322,14 +1322,6 @@
     "type": "json_flag"
   },
   {
-    "id": "FISH_GOOD",
-    "type": "json_flag"
-  },
-  {
-    "id": "FISH_POOR",
-    "type": "json_flag"
-  },
-  {
     "id": "FIT",
     "type": "json_flag"
   },

--- a/data/json/items/tool/fishing.json
+++ b/data/json/items/tool/fishing.json
@@ -77,7 +77,6 @@
     "material": [ "wood" ],
     "symbol": "/",
     "color": "brown",
-    "use_action": [ "FISH_ROD" ],
     "qualities": [ [ "FISHING_ROD", 1 ] ],
     "flags": [ "SHEATH_SPEAR" ]
   },
@@ -96,7 +95,6 @@
     "material": [ "plastic" ],
     "symbol": "/",
     "color": "brown",
-    "use_action": [ "FISH_ROD" ],
     "qualities": [ [ "FISHING_ROD", 2 ] ],
     "flags": [ "SHEATH_SPEAR" ]
   },
@@ -117,7 +115,6 @@
     "material": [ "plastic" ],
     "symbol": "/",
     "color": "black",
-    "use_action": [ "FISH_ROD" ],
     "qualities": [ [ "FISHING_ROD", 1 ] ]
   },
   {
@@ -136,7 +133,6 @@
     "material": [ "wood" ],
     "symbol": "/",
     "color": "brown",
-    "use_action": [ "FISH_ROD" ],
     "qualities": [ [ "FISHING_ROD", 1 ] ]
   }
 ]

--- a/data/json/items/tool/fishing.json
+++ b/data/json/items/tool/fishing.json
@@ -78,7 +78,7 @@
     "symbol": "/",
     "color": "brown",
     "use_action": [ "FISH_ROD" ],
-    "qualities": [ [ "FISHING", 1 ] ],
+    "qualities": [ [ "FISHING_ROD", 1 ] ],
     "flags": [ "SHEATH_SPEAR" ]
   },
   {
@@ -97,7 +97,7 @@
     "symbol": "/",
     "color": "brown",
     "use_action": [ "FISH_ROD" ],
-    "qualities": [ [ "FISHING", 2 ] ],
+    "qualities": [ [ "FISHING_ROD", 2 ] ],
     "flags": [ "SHEATH_SPEAR" ]
   },
   {
@@ -118,7 +118,7 @@
     "symbol": "/",
     "color": "black",
     "use_action": [ "FISH_ROD" ],
-    "qualities": [ [ "FISHING", 1 ] ]
+    "qualities": [ [ "FISHING_ROD", 1 ] ]
   },
   {
     "id": "hoboreel",
@@ -137,6 +137,6 @@
     "symbol": "/",
     "color": "brown",
     "use_action": [ "FISH_ROD" ],
-    "qualities": [ [ "FISHING", 1 ] ]
+    "qualities": [ [ "FISHING_ROD", 1 ] ]
   }
 ]

--- a/data/json/items/tool/fishing.json
+++ b/data/json/items/tool/fishing.json
@@ -79,7 +79,7 @@
     "color": "brown",
     "use_action": [ "FISH_ROD" ],
     "qualities": [ [ "FISHING", 1 ] ],
-    "flags": [ "FISH_POOR", "SHEATH_SPEAR" ]
+    "flags": [ "SHEATH_SPEAR" ]
   },
   {
     "id": "fishing_rod_professional",
@@ -98,7 +98,7 @@
     "color": "brown",
     "use_action": [ "FISH_ROD" ],
     "qualities": [ [ "FISHING", 2 ] ],
-    "flags": [ "FISH_GOOD", "SHEATH_SPEAR" ]
+    "flags": [ "SHEATH_SPEAR" ]
   },
   {
     "id": "plastichoboreel",
@@ -118,8 +118,7 @@
     "symbol": "/",
     "color": "black",
     "use_action": [ "FISH_ROD" ],
-    "qualities": [ [ "FISHING", 1 ] ],
-    "flags": [ "FISH_GOOD" ]
+    "qualities": [ [ "FISHING", 1 ] ]
   },
   {
     "id": "hoboreel",
@@ -138,7 +137,6 @@
     "symbol": "/",
     "color": "brown",
     "use_action": [ "FISH_ROD" ],
-    "qualities": [ [ "FISHING", 1 ] ],
-    "flags": [ "FISH_POOR" ]
+    "qualities": [ [ "FISHING", 1 ] ]
   }
 ]

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -49,7 +49,8 @@
   {
     "type": "tool_quality",
     "id": "FISHING_ROD",
-    "name": { "str": "fishing" }
+    "name": { "str": "fishing" },
+    "usages": [ [ 1, [ "FISH_ROD" ] ] ]
   },
   {
     "type": "tool_quality",

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -48,7 +48,7 @@
   },
   {
     "type": "tool_quality",
-    "id": "FISHING",
+    "id": "FISHING_ROD",
     "name": { "str": "fishing" }
   },
   {

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -1253,8 +1253,6 @@ Melee flags are fully compatible with tool flags, and vice versa.
 - ```DIG_TOOL``` If wielded, digs thorough terrain like rock and walls, as player walks into them. If item also has ```POWERED``` flag, then it digs faster, but uses up the item's ammo as if activating it.
 - ```FIRESTARTER``` Item will start fire with some difficulty.
 - ```FIRE``` Item will start a fire immediately.
-- ```FISH_GOOD``` When used for fishing, it's a good tool (requires that the matching use_action has been set).
-- ```FISH_POOR``` When used for fishing, it's a poor tool (requires that the matching use_action has been set).
 - ```HAS_RECIPE``` Used by the E-Ink tablet to indicate it's currently showing a recipe.
 - ```IS_UPS``` Item is Unified Power Supply. Used in active item processing.
 - ```LIGHT_[X]``` Illuminates the area with light intensity `[X]` where `[X]` is an intensity value. (e.x. `LIGHT_4` or `LIGHT_100`). Note: this flags sets `itype::light_emission` field and then is removed (can't be found using `has_flag`);

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -198,6 +198,7 @@ static const mongroup_id GROUP_FISH( "GROUP_FISH" );
 
 static const quality_id qual_BUTCHER( "BUTCHER" );
 static const quality_id qual_CUT_FINE( "CUT_FINE" );
+static const quality_id qual_FISHING( "FISHING" );
 
 static const skill_id skill_computer( "computer" );
 static const skill_id skill_firstaid( "firstaid" );
@@ -2670,12 +2671,18 @@ void activity_handlers::fish_do_turn( player_activity *act, Character *you )
     item &it = *act->targets.front();
     int fish_chance = 1;
     int survival_skill = you->get_skill_level( skill_survival );
-    if( it.has_flag( flag_FISH_POOR ) ) {
-        survival_skill += dice( 1, 6 );
-    } else if( it.has_flag( flag_FISH_GOOD ) ) {
-        // Much better chances with a good fishing implement.
-        survival_skill += dice( 4, 9 );
-        survival_skill *= 2;
+    switch( it.get_quality( qual_FISHING ) ) {
+        case 1:
+            survival_skill += dice( 1, 6 );
+            break;
+        case 2:
+            // Much better chances with a good fishing implement.
+            survival_skill += dice( 4, 9 );
+            survival_skill *= 2;
+            break;
+        default:
+            debugmsg( "ERROR: Invalid FISHING tool quality on %s", item::nname( it.typeId() ) );
+            break;
     }
     std::vector<monster *> fishables = g->get_fishable_monsters( act->coord_set );
     // Fish are always there, even if it doesn't seem like they are visible!

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -198,7 +198,7 @@ static const mongroup_id GROUP_FISH( "GROUP_FISH" );
 
 static const quality_id qual_BUTCHER( "BUTCHER" );
 static const quality_id qual_CUT_FINE( "CUT_FINE" );
-static const quality_id qual_FISHING( "FISHING" );
+static const quality_id qual_FISHING_ROD( "FISHING_ROD" );
 
 static const skill_id skill_computer( "computer" );
 static const skill_id skill_firstaid( "firstaid" );
@@ -2671,7 +2671,7 @@ void activity_handlers::fish_do_turn( player_activity *act, Character *you )
     item &it = *act->targets.front();
     int fish_chance = 1;
     int survival_skill = you->get_skill_level( skill_survival );
-    switch( it.get_quality( qual_FISHING ) ) {
+    switch( it.get_quality( qual_FISHING_ROD ) ) {
         case 1:
             survival_skill += dice( 1, 6 );
             break;
@@ -2681,7 +2681,7 @@ void activity_handlers::fish_do_turn( player_activity *act, Character *you )
             survival_skill *= 2;
             break;
         default:
-            debugmsg( "ERROR: Invalid FISHING tool quality on %s", item::nname( it.typeId() ) );
+            debugmsg( "ERROR: Invalid FISHING_ROD tool quality on %s", item::nname( it.typeId() ) );
             break;
     }
     std::vector<monster *> fishables = g->get_fishable_monsters( act->coord_set );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -110,7 +110,7 @@ static const itype_id itype_welder( "welder" );
 static const quality_id qual_AXE( "AXE" );
 static const quality_id qual_BUTCHER( "BUTCHER" );
 static const quality_id qual_DIG( "DIG" );
-static const quality_id qual_FISHING( "FISHING" );
+static const quality_id qual_FISHING_ROD( "FISHING_ROD" );
 static const quality_id qual_SAW_M( "SAW_M" );
 static const quality_id qual_SAW_W( "SAW_W" );
 static const quality_id qual_WELD( "WELD" );
@@ -1251,7 +1251,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
         std::vector<item *> rod_inv = you.items_with( []( const item & itm ) {
-            return itm.has_quality( qual_FISHING );
+            return itm.has_quality( qual_FISHING_ROD );
         } );
         if( rod_inv.empty() ) {
             return activity_reason_info::fail( do_activity_reason::NEEDS_FISHING );
@@ -2845,7 +2845,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
                 }
 
             } else if( reason == do_activity_reason::NEEDS_FISHING ) {
-                quality_comp_vector.push_back( std::vector<quality_requirement> {quality_requirement( qual_FISHING, 1, 1 )} );
+                quality_comp_vector.push_back( std::vector<quality_requirement> {quality_requirement( qual_FISHING_ROD, 1, 1 )} );
             } else if( reason == do_activity_reason::NEEDS_DISASSEMBLE ) {
                 quality_comp_vector = act_info.req.get_qualities();
                 tool_comp_vector = act_info.req.get_tools();
@@ -3006,11 +3006,11 @@ static bool generic_multi_activity_do(
             you.backlog.push_front( player_activity( act_id ) );
             return false;
         }
-    } else if( reason == do_activity_reason::NEEDS_FISHING && you.has_quality( qual_FISHING, 1 ) ) {
+    } else if( reason == do_activity_reason::NEEDS_FISHING && you.has_quality( qual_FISHING_ROD, 1 ) ) {
         you.backlog.push_front( player_activity( act_id ) );
         // we don't want to keep repeating the fishing activity, just piggybacking on this functions structure to find requirements.
         you.activity = player_activity();
-        item &best_rod = you.best_item_with_quality( qual_FISHING );
+        item &best_rod = you.best_item_with_quality( qual_FISHING_ROD );
         you.assign_activity( ACT_FISH, to_moves<int>( 5_hours ), 0,
                              0, best_rod.tname() );
         you.activity.targets.emplace_back( you, &best_rod );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1251,7 +1251,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
         std::vector<item *> rod_inv = you.items_with( []( const item & itm ) {
-            return itm.has_flag( flag_FISH_POOR ) || itm.has_flag( flag_FISH_GOOD );
+            return itm.has_quality( qual_FISHING );
         } );
         if( rod_inv.empty() ) {
             return activity_reason_info::fail( do_activity_reason::NEEDS_FISHING );

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -121,8 +121,6 @@ const flag_id flag_FIRE_100( "FIRE_100" );
 const flag_id flag_FIRE_20( "FIRE_20" );
 const flag_id flag_FIRE_50( "FIRE_50" );
 const flag_id flag_FIRE_TWOHAND( "FIRE_TWOHAND" );
-const flag_id flag_FISH_GOOD( "FISH_GOOD" );
-const flag_id flag_FISH_POOR( "FISH_POOR" );
 const flag_id flag_FIT( "FIT" );
 const flag_id flag_FIX_FARSIGHT( "FIX_FARSIGHT" );
 const flag_id flag_FIX_NEARSIGHT( "FIX_NEARSIGHT" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -131,8 +131,6 @@ extern const flag_id flag_FIRE_100;
 extern const flag_id flag_FIRE_20;
 extern const flag_id flag_FIRE_50;
 extern const flag_id flag_FIRE_TWOHAND;
-extern const flag_id flag_FISH_GOOD;
-extern const flag_id flag_FISH_POOR;
 extern const flag_id flag_FIT;
 extern const flag_id flag_FIX_FARSIGHT;
 extern const flag_id flag_FIX_NEARSIGHT;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Consolidate fishing implements logic to use only tool quality"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

a)
Fishing rods/reels have both `FISHING` tool quality as well as a flag, either `FISH_POOR` or `FISH_GOOD`:
https://github.com/CleverRaven/Cataclysm-DDA/blob/0eea824edfc3d54ee006544b40f47c38a488da45/data/json/items/tool/fishing.json#L100-L101

In the source code, some places checked the tool quality while other places used the flags. It was all rather redundant and inconsistent.

b)
`FISHING` tool quality applies only to fishing rods and are not related to fish traps, which are a different type of fishing implement.

c)
The `use_action` of `FISH_ROD` in each fishing rod's item definition is redundant with having the fishing rod tool quality

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

a)
Replace all source code that uses flags with corresponding code that checks the tool quality.
Eliminate the flags.

b)
Rename `FISHING` tool quality to `FISHING_ROD` to improve distinction vs `FISH_TRAP`.

c)
Declare `FISH_ROD` as a usage in the `FISHING_ROD` tool quality and remove it from `use_action` of individual items.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Switch everything to use flags only and eliminate the tool quality. That seems a poorer choice -- if one wanted to expand the possibilities with one more tier that will require another flag e.g. `FISH_EXCELLENT`. With the use of qualities it's just a number and will be much simpler to update to code to handle any future expansion.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Compile, run, set up a new character as fisher profession in wilderness desert island location, go fishing.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

nope

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
