### PR TITLE
[Xedra Evolved] Fix the mod has lack of own mana bar

### DIFF
--- a/data/mods/Xedra_Evolved/ui/sidebar.json
+++ b/data/mods/Xedra_Evolved/ui/sidebar.json
@@ -1,0 +1,184 @@
+[
+  {
+    "//": "Maximum mana points, in light blue color.",
+    "id": "xe_max_mana_num",
+    "type": "widget",
+    "label": "Max Mana",
+    "style": "number",
+    "var": "max_mana",
+    "colors": [ "c_pink" ]
+  },
+  {
+    "//": "Base widget for other mana widgets to copy-from.  Sets var and colors.",
+    "id": "xe_mana_base",
+    "type": "widget",
+    "var": "mana",
+    "colors": [ "c_red", "c_light_red", "c_yellow", "c_pink" ]
+  },
+  {
+    "//": "Current number of mana points, with color.",
+    "id": "xe_mana_num",
+    "type": "widget",
+    "copy-from": "xe_mana_base",
+    "label": "Mana",
+    "style": "number"
+  },
+  {
+    "//": "Wide bar-graph of current mana level, using the default 'bucket' fill.",
+    "id": "xe_mana_graph",
+    "type": "widget",
+    "copy-from": "xe_mana_base",
+    "label": "Mana",
+    "style": "graph",
+    "width": 25,
+    "symbols": ".-=#",
+    "fill": "bucket"
+  },
+  {
+    "//": "Like the mana graph, but using a 'pool' fill.",
+    "id": "xe_mana_pool",
+    "type": "widget",
+    "copy-from": "xe_mana_graph",
+    "fill": "pool"
+  },
+  {
+    "//": "Both current and maximum mana numbers, side by side",
+    "id": "xe_current_max_mana_nums_layout",
+    "type": "widget",
+    "label": "Xedra Current/Max Mana",
+    "style": "layout",
+    "arrange": "columns",
+    "widgets": [ "xe_mana_num", "xe_max_mana_num" ]
+  },
+  {
+    "//": "Bar graph of current mana, with 'bucket' fill.",
+    "id": "xe_mana_graph_layout",
+    "type": "widget",
+    "style": "layout",
+    "label": "Xedra Mana Graph",
+    "arrange": "columns",
+    "widgets": [ "xe_mana_graph" ]
+  },
+  {
+    "//": "Bar graph of current mana, with 'pool' fill.",
+    "id": "xe_mana_pool_layout",
+    "type": "widget",
+    "style": "layout",
+    "label": "Xedra Mana Pool",
+    "arrange": "columns",
+    "widgets": [ "xe_mana_pool" ]
+  },
+  {
+    "//": "Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "legacy_classic_sidebar",
+    "type": "widget",
+    "id": "legacy_classic_sidebar",
+    "extend": { "widgets": [ "xe_current_max_mana_nums_layout", "xe_mana_graph_layout", "xe_mana_pool_layout" ] }
+  },
+  {
+    "//": "Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "legacy_compact_sidebar",
+    "type": "widget",
+    "id": "legacy_compact_sidebar",
+    "extend": { "widgets": [ "xe_current_max_mana_nums_layout", "xe_mana_graph_layout", "xe_mana_pool_layout" ] }
+  },
+  {
+    "//": "Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "legacy_labels_narrow_sidebar",
+    "type": "widget",
+    "id": "legacy_labels_narrow_sidebar",
+    "extend": { "widgets": [ "xe_current_max_mana_nums_layout", "xe_mana_graph_layout", "xe_mana_pool_layout" ] }
+  },
+  {
+    "//": "Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "legacy_labels_sidebar",
+    "type": "widget",
+    "id": "legacy_labels_sidebar",
+    "extend": { "widgets": [ "xe_current_max_mana_nums_layout", "xe_mana_graph_layout", "xe_mana_pool_layout" ] }
+  },
+  {
+    "//": "Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "structured_sidebar",
+    "type": "widget",
+    "id": "structured_sidebar",
+    "extend": { "widgets": [ "xe_current_max_mana_nums_layout", "xe_mana_graph_layout", "xe_mana_pool_layout" ] }
+  },
+  {
+    "//": "spacebar Wide bar-graph of current mana level, using the default 'bucket' fill.",
+    "id": "xe_spacebar_mana_graph",
+    "type": "widget",
+    "copy-from": "xe_mana_base",
+    "label": "Mana",
+    "style": "graph",
+    "width": 36,
+    "symbols": ".oO",
+    "fill": "bucket"
+  },
+  {
+    "//": "spacebar Current number of mana points, with color.",
+    "id": "xe_spacebar_mana_num",
+    "type": "widget",
+    "copy-from": "xe_mana_base",
+    "label": "Mana",
+    "width": 28,
+    "style": "number",
+    "colors": [ "c_pink" ]
+  },
+  {
+    "//": "spacebar Maximum mana points, in light blue color.",
+    "id": "xe_spacebar_max_mana_num",
+    "type": "widget",
+    "label": "Max Mana",
+    "style": "number",
+    "var": "max_mana",
+    "width": 28,
+    "colors": [ "c_pink" ]
+  },
+  {
+    "//": "spacebar Both current and maximum mana numbers, side by side",
+    "id": "xe_spacebar_current_max_mana_nums_layout",
+    "type": "widget",
+    "label": "Xedra Current/Max Mana",
+    "style": "layout",
+    "arrange": "minimum_columns",
+    "width": 56,
+    "widgets": [ "xe_spacebar_mana_num", "xe_spacebar_max_mana_num" ]
+  },
+  {
+    "id": "xe_spacebar_mana_bar_block",
+    "type": "widget",
+    "style": "layout",
+    "label": "xe_mana_bar",
+    "arrange": "minimum_columns",
+    "widgets": [ "spacebar_separator_2", "xe_spacebar_mana_graph" ]
+  },
+  {
+    "id": "xe_spacebar_mana_numbers_block",
+    "type": "widget",
+    "style": "layout",
+    "label": "xe_mana_number",
+    "arrange": "minimum_columns",
+    "widgets": [ "spacebar_separator_2", "xe_spacebar_current_max_mana_nums_layout" ]
+  },
+  {
+    "//": "spacebar Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "spacebar",
+    "type": "widget",
+    "id": "spacebar",
+    "extend": { "widgets": [ "xe_spacebar_mana_numbers_block", "xe_spacebar_mana_bar_block" ] }
+  },
+  {
+    "//": "Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "my_labels_sidebar",
+    "type": "widget",
+    "id": "my_labels_sidebar",
+    "extend": { "widgets": [ "xe_current_max_mana_nums_layout", "xe_mana_graph_layout", "xe_mana_pool_layout" ] }
+  },
+  {
+    "//": "Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "legacy_classic_sidebar_one_padding",
+    "type": "widget",
+    "id": "legacy_classic_sidebar_one_padding",
+    "extend": { "widgets": [ "xe_current_max_mana_nums_layout", "xe_mana_graph_layout", "xe_mana_pool_layout" ] }
+  }
+]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Did you know xedra mod has no his own mana widget? everyone just uses the magiclysm one? an, what is fun, no one spot it for *checks the dates* 7 month?
#### Describe the solution
Add our own widget, which currently just copypasted mana widget from magiclysm, with changed color - currently its `c_pink`, but i need to discuss it with @maleclypse to pick the right color (the original idea was orange, but we have no orange color)
#### Testing
It works
#### Additional context
![image](https://user-images.githubusercontent.com/67688115/210158609-fef49c3a-50d7-4cc2-a0a7-fd4640d9d99b.png)
![image](https://user-images.githubusercontent.com/67688115/210158599-80e3c010-d562-4e56-9175-b9ae6aa1558f.png)