### PR TITLE
Disallow towing by racked parts

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8478,6 +8478,10 @@ cata::optional<int> iuse::tow_attach( Character *p, item *it, bool, const tripoi
                     p->add_msg_if_player( _( "You can't attach the tow-line to an internal part." ) );
                     return cata::nullopt;
                 }
+                if( !source_veh->part( vp->part_index() ).carried_stack.empty() ) {
+                    p->add_msg_if_player( _( "You can't attach the tow-line to a racked part." ) );
+                    return cata::nullopt;
+                }
             }
             const tripoint abspos = here.getabs( posp );
             it->set_var( "source_x", abspos.x );
@@ -8549,6 +8553,10 @@ cata::optional<int> iuse::tow_attach( Character *p, item *it, bool, const tripoi
             }
             if( !target_veh->is_external_part( vpos ) ) {
                 p->add_msg_if_player( _( "You can't attach the tow-line to an internal part." ) );
+                return cata::nullopt;
+            }
+            if( !target_veh->part( target_vp->part_index() ).carried_stack.empty() ) {
+                p->add_msg_if_player( _( "You can't attach the tow-line to a racked part." ) );
                 return cata::nullopt;
             }
             const vpart_id vpid( it->typeId().str() );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #62953

#### Describe the solution

Disallow attaching tow cable to carried parts.

This adds a string for the failure message, not sure how strict the string freeze is, I don't think silently failing is too elegant though

#### Describe alternatives you've considered

#### Testing

Use tow cable, select racked vehicle tile as first or second vehicle - should fail, non-racked tiles should work as usual

#### Additional context
