### PR TITLE
Fixes for map revert

### DIFF
--- a/data/json/portal_storm_effect_on_condition.json
+++ b/data/json/portal_storm_effect_on_condition.json
@@ -1182,7 +1182,7 @@
     "effect": [
       {
         "u_location_variable": { "global_val": "portal_dungeon" },
-        "target_params": { "om_terrain": "field", "search_range": 20, "min_distance": 3, "z": 0 }
+        "target_params": { "om_terrain": "field", "search_range": 200, "min_distance": 3, "z": 0 }
       },
       {
         "u_message": "You can feel the presence of something nearby, cracked in a way you can't put into words(check mission log for details)."

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1558,12 +1558,23 @@ void timed_event_manager::unserialize_all( const JsonArray &ja )
         jo.read( "key", key );
         point pt;
         for( JsonObject jp : jo.get_array( "revert" ) ) {
+            if( jp.has_member( "point" ) ) {
+                jp.get_member( "point" ).read( pt, false );
+            }
             revert.set_furn( pt, furn_id( jp.get_string( "furn" ) ) );
             revert.set_ter( pt, ter_id( jp.get_string( "ter" ) ) );
             revert.set_trap( pt, trap_id( jp.get_string( "trap" ) ) );
-            if( pt.x++ < SEEX ) {
-                pt.x = 0;
-                pt.y++;
+            if( jp.has_member( "items" ) ) {
+                cata::colony<item> itm;
+                jp.get_member( "items" ).read( itm, false );
+                revert.set_items( pt, itm );
+            }
+            // We didn't always save the point, this is the original logic, it doesn't work right but for older saves at least they won't crash
+            if( !jp.has_member( "point" ) ) {
+                if( pt.x++ < SEEX ) {
+                    pt.x = 0;
+                    pt.y++;
+                }
             }
         }
         get_timed_events().add( static_cast<timed_event_type>( type ), when, faction_id, map_square,
@@ -1635,9 +1646,11 @@ void timed_event_manager::serialize_all( JsonOut &jsout )
             for( int x = 0; x < SEEX; x++ ) {
                 jsout.start_object();
                 point pt( x, y );
+                jsout.member( "point", pt );
                 jsout.member( "furn", elem.revert.get_furn( pt ) );
                 jsout.member( "ter", elem.revert.get_ter( pt ) );
                 jsout.member( "trap", elem.revert.get_trap( pt ) );
+                jsout.member( "items", elem.revert.get_items( pt ) );
                 jsout.end_object();
             }
         }

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -354,6 +354,14 @@ void submap::revert_submap( submap_revert &sr )
             ter[x][y] = sr.get_ter( pt );
             trp[x][y] = sr.get_trap( pt );
             itm[x][y] = sr.get_items( pt );
+            for( item &itm : itm[x][y] ) {
+                if( itm.is_emissive() ) {
+                    this->update_lum_add( pt, itm );
+                }
+                if( itm.needs_processing() ) {
+                    active_items.add( itm, pt );
+                }
+            }
         }
     }
 }

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -353,6 +353,7 @@ void submap::revert_submap( submap_revert &sr )
             frn[x][y] = sr.get_furn( pt );
             ter[x][y] = sr.get_ter( pt );
             trp[x][y] = sr.get_trap( pt );
+            itm[x][y] = sr.get_items( pt );
         }
     }
 }
@@ -366,6 +367,7 @@ submap_revert submap::get_revert_submap() const
             ret.set_furn( pt, frn[x][y] );
             ret.set_ter( pt, ter[x][y] );
             ret.set_trap( pt, trp[x][y] );
+            ret.set_items( pt, itm[x][y] );
         }
     }
     return ret;

--- a/src/submap.h
+++ b/src/submap.h
@@ -104,8 +104,8 @@ class submap_revert : maptile_revert
             return itm[p.x][p.y];
         }
 
-        void set_items( const point &p, cata::colony<item> &revert_item ) {
-            itm[p.x][p.y] = revert_item;
+        void set_items( const point &p, cata::colony<item> revert_item ) {
+            itm[p.x][p.y] = std::move( revert_item );
         }
 };
 

--- a/src/submap.h
+++ b/src/submap.h
@@ -104,7 +104,7 @@ class submap_revert : maptile_revert
             return itm[p.x][p.y];
         }
 
-        void set_items( const point &p, cata::colony<item> revert_item ) {
+        void set_items( const point &p, cata::colony<item> &revert_item ) {
             itm[p.x][p.y] = revert_item;
         }
 };

--- a/src/submap.h
+++ b/src/submap.h
@@ -69,7 +69,9 @@ struct maptile_revert {
     cata::mdarray<ter_id, point_sm_ms>             ter; // Terrain on each square
     cata::mdarray<furn_id, point_sm_ms>            frn; // Furniture on each square
     cata::mdarray<trap_id, point_sm_ms>            trp; // Trap on each square
+    cata::mdarray<cata::colony<item>, point_sm_ms> itm; // Items on each square
 };
+
 class submap_revert : maptile_revert
 {
 
@@ -96,6 +98,14 @@ class submap_revert : maptile_revert
 
         void set_trap( const point &p, trap_id trap ) {
             trp[p.x][p.y] = trap;
+        }
+
+        cata::colony<item> get_items( const point &p ) const {
+            return itm[p.x][p.y];
+        }
+
+        void set_items( const point &p, cata::colony<item> revert_item ) {
+            itm[p.x][p.y] = revert_item;
         }
 };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #59450
Fixes issues I found in process
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Updated the search distance for portal storm dungeons so that it shouldn't fail to find one even in the water anymore.  
Added logic for map reverts to handle items so they won't vanish anymore.  
I discovered map reverts were totally screwing up the terrain if you saved the game while they were queued up so fixed the logic there to work.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
