### PR TITLE
Effect type modifiers rewrite

### DIFF
--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -42,6 +42,8 @@ static const itype_id itype_money_one( "money_one" );
 static const trait_id trait_LACTOSE( "LACTOSE" );
 static const trait_id trait_VEGETARIAN( "VEGETARIAN" );
 
+std::array<double, static_cast<size_t>( mod_type::MAX )> default_modifier_values = { 0, 0 };
+
 namespace
 {
 std::map<efftype_id, effect_type> effect_types;
@@ -238,200 +240,264 @@ void weed_msg( Character &p )
     }
 }
 
-static void extract_effect(
+std::array<const char *, static_cast<size_t>( mod_type::MAX )> MOD_TYPE_STRINGS {
+    "base_mods",
+    "scaling_mods",
+};
+
+void effect_type::extract_effect(
     const JsonObject &j,
-    std::unordered_map<std::tuple<std::string, bool, std::string, std::string>, double,
-    cata::tuple_hash> &data,
-    const std::string &mod_type, const std::string &data_key,
-    const std::string &type_key, const std::string &arg_key )
+    const std::string &effect_name,
+    const std::vector<std::pair<std::string, mod_action>> &action_keys )
 {
-    double val = 0;
-    double reduced_val = 0;
-    if( j.has_member( mod_type ) ) {
-        JsonArray jsarr = j.get_array( mod_type );
-        val = jsarr.get_float( 0 );
-        // If a second value exists use it, else reduced_val = val.
-        if( jsarr.size() >= 2 ) {
-            reduced_val = jsarr.get_float( 1 );
-        } else {
-            reduced_val = val;
+    std::unordered_map<uint32_t, modifier_value_arr> modifiers;
+
+    for( uint32_t cur_mod_type = 0; cur_mod_type < static_cast<size_t>( mod_type::MAX );
+         cur_mod_type++ ) {
+        if( !j.has_object( MOD_TYPE_STRINGS[cur_mod_type] ) ) {
+            continue;
+        }
+
+        const JsonObject base = j.get_object( MOD_TYPE_STRINGS[cur_mod_type] );
+
+        for( const auto &action_key : action_keys ) {
+            if( !base.has_array( action_key.first ) ) {
+                continue;
+            }
+
+            JsonArray jsarr = base.get_array( action_key.first );
+            if( jsarr.empty() ) {
+                continue;
+            }
+
+            mod_action action = action_key.second;
+            for( uint8_t i = 0; i < jsarr.size(); i++ ) {
+                uint32_t key = get_effect_modifier_key( action, i );
+
+                // Create default entry if doesn't exist
+                const auto &it = modifiers.try_emplace( key, default_modifier_values );
+
+                // Update entry with the fetched value
+                it.first->second[cur_mod_type] = jsarr.get_float( i );
+            }
         }
     }
-    // Store values if they aren't zero.
-    if( val != 0 ) {
-        data[std::make_tuple( data_key, false, type_key, arg_key )] = val;
+
+    if( modifiers.empty() ) {
+        return;
     }
-    if( reduced_val != 0 ) {
-        data[std::make_tuple( data_key, true, type_key, arg_key )] = reduced_val;
-    }
+
+    mod_data[effect_name] = std::move( modifiers );
 }
 
-bool effect_type::load_mod_data( const JsonObject &jo, const std::string &member )
+void effect_type::load_mod_data( const JsonObject &j )
 {
-    if( jo.has_object( member ) ) {
-        JsonObject j = jo.get_object( member );
+    // Stats first
+    extract_effect( j, "STR",   { {"str_mod",   mod_action::MIN} } );
+    extract_effect( j, "DEX",   { {"dex_mod",   mod_action::MIN} } );
+    extract_effect( j, "PER",   { {"per_mod",   mod_action::MIN} } );
+    extract_effect( j, "INT",   { {"int_mod",   mod_action::MIN} } );
+    extract_effect( j, "SPEED", { {"speed_mod", mod_action::MIN} } );
 
-        // Stats first
-        //                          json field                  type key    arg key
-        extract_effect( j, mod_data, "str_mod",          member, "STR",      "min" );
-        extract_effect( j, mod_data, "dex_mod",          member, "DEX",      "min" );
-        extract_effect( j, mod_data, "per_mod",          member, "PER",      "min" );
-        extract_effect( j, mod_data, "int_mod",          member, "INT",      "min" );
-        extract_effect( j, mod_data, "speed_mod",        member, "SPEED",    "min" );
+    // Then pain
+    extract_effect( j, "PAIN", {
+        { "pain_amount",     mod_action::AMOUNT},
+        { "pain_min",        mod_action::MIN},
+        { "pain_max",        mod_action::MAX},
+        { "pain_max_val",    mod_action::MAX_VAL},
+        { "pain_chance",     mod_action::CHANCE_TOP},
+        { "pain_chance_bot", mod_action::CHANCE_BOT},
+        { "pain_tick",       mod_action::TICK},
+    } );
 
-        // Then pain
-        extract_effect( j, mod_data, "pain_amount",      member, "PAIN",     "amount" );
-        extract_effect( j, mod_data, "pain_min",         member, "PAIN",     "min" );
-        extract_effect( j, mod_data, "pain_max",         member, "PAIN",     "max" );
-        extract_effect( j, mod_data, "pain_max_val",     member, "PAIN",     "max_val" );
-        extract_effect( j, mod_data, "pain_chance",      member, "PAIN",     "chance_top" );
-        extract_effect( j, mod_data, "pain_chance_bot",  member, "PAIN",     "chance_bot" );
-        extract_effect( j, mod_data, "pain_tick",        member, "PAIN",     "tick" );
+    // Then hurt
+    extract_effect( j, "HURT", {
+        {"hurt_amount",      mod_action::AMOUNT},
+        {"hurt_min",         mod_action::MIN},
+        {"hurt_max",         mod_action::MAX},
+        {"hurt_chance",      mod_action::CHANCE_TOP},
+        {"hurt_chance_bot",  mod_action::CHANCE_BOT},
+        {"hurt_tick",        mod_action::TICK},
+    } );
 
-        // Then hurt
-        extract_effect( j, mod_data, "hurt_amount",      member, "HURT",     "amount" );
-        extract_effect( j, mod_data, "hurt_min",         member, "HURT",     "min" );
-        extract_effect( j, mod_data, "hurt_max",         member, "HURT",     "max" );
-        extract_effect( j, mod_data, "hurt_chance",      member, "HURT",     "chance_top" );
-        extract_effect( j, mod_data, "hurt_chance_bot",  member, "HURT",     "chance_bot" );
-        extract_effect( j, mod_data, "hurt_tick",        member, "HURT",     "tick" );
+    // Then sleep
+    extract_effect( j, "SLEEP", {
+        {"sleep_amount",      mod_action::AMOUNT},
+        {"sleep_min",         mod_action::MIN},
+        {"sleep_max",         mod_action::MAX},
+        {"sleep_chance",      mod_action::CHANCE_TOP},
+        {"sleep_chance_bot",  mod_action::CHANCE_BOT},
+        {"sleep_tick",        mod_action::TICK},
+    } );
 
-        // Then sleep
-        extract_effect( j, mod_data, "sleep_amount",     member, "SLEEP",    "amount" );
-        extract_effect( j, mod_data, "sleep_min",        member, "SLEEP",    "min" );
-        extract_effect( j, mod_data, "sleep_max",        member, "SLEEP",    "max" );
-        extract_effect( j, mod_data, "sleep_chance",     member, "SLEEP",    "chance_top" );
-        extract_effect( j, mod_data, "sleep_chance_bot", member, "SLEEP",    "chance_bot" );
-        extract_effect( j, mod_data, "sleep_tick",       member, "SLEEP",    "tick" );
+    // Then pkill
+    extract_effect( j, "PKILL", {
+        {"pkill_amount",      mod_action::AMOUNT},
+        {"pkill_min",         mod_action::MIN},
+        {"pkill_max",         mod_action::MAX},
+        {"pkill_max_val",     mod_action::MAX_VAL},
+        {"pkill_chance",      mod_action::CHANCE_TOP},
+        {"pkill_chance_bot",  mod_action::CHANCE_BOT},
+        {"pkill_tick",        mod_action::TICK},
+    } );
 
-        // Then pkill
-        extract_effect( j, mod_data, "pkill_amount",     member, "PKILL",    "amount" );
-        extract_effect( j, mod_data, "pkill_min",        member, "PKILL",    "min" );
-        extract_effect( j, mod_data, "pkill_max",        member, "PKILL",    "max" );
-        extract_effect( j, mod_data, "pkill_max_val",    member, "PKILL",    "max_val" );
-        extract_effect( j, mod_data, "pkill_chance",     member, "PKILL",    "chance_top" );
-        extract_effect( j, mod_data, "pkill_chance_bot", member, "PKILL",    "chance_bot" );
-        extract_effect( j, mod_data, "pkill_tick",       member, "PKILL",    "tick" );
+    // Then stim
+    extract_effect( j, "STIM", {
+        {"stim_amount",      mod_action::AMOUNT},
+        {"stim_min",         mod_action::MIN},
+        {"stim_max",         mod_action::MAX},
+        {"stim_min_val",     mod_action::MIN_VAL},
+        {"stim_max_val",     mod_action::MAX_VAL},
+        {"stim_chance",      mod_action::CHANCE_TOP},
+        {"stim_chance_bot",  mod_action::CHANCE_BOT},
+        {"stim_tick",        mod_action::TICK},
+    } );
 
-        // Then stim
-        extract_effect( j, mod_data, "stim_amount",      member, "STIM",     "amount" );
-        extract_effect( j, mod_data, "stim_min",         member, "STIM",     "min" );
-        extract_effect( j, mod_data, "stim_max",         member, "STIM",     "max" );
-        extract_effect( j, mod_data, "stim_min_val",     member, "STIM",     "min_val" );
-        extract_effect( j, mod_data, "stim_max_val",     member, "STIM",     "max_val" );
-        extract_effect( j, mod_data, "stim_chance",      member, "STIM",     "chance_top" );
-        extract_effect( j, mod_data, "stim_chance_bot",  member, "STIM",     "chance_bot" );
-        extract_effect( j, mod_data, "stim_tick",        member, "STIM",     "tick" );
+    // Then health
+    extract_effect( j, "HEALTH", {
+        {"health_amount",      mod_action::AMOUNT},
+        {"health_min",         mod_action::MIN},
+        {"health_max",         mod_action::MAX},
+        {"health_min_val",     mod_action::MIN_VAL},
+        {"health_max_val",     mod_action::MAX_VAL},
+        {"health_chance",      mod_action::CHANCE_TOP},
+        {"health_chance_bot",  mod_action::CHANCE_BOT},
+        {"health_tick",        mod_action::TICK},
+    } );
 
-        // Then health
-        extract_effect( j, mod_data, "health_amount",    member, "HEALTH",   "amount" );
-        extract_effect( j, mod_data, "health_min",       member, "HEALTH",   "min" );
-        extract_effect( j, mod_data, "health_max",       member, "HEALTH",   "max" );
-        extract_effect( j, mod_data, "health_min_val",   member, "HEALTH",   "min_val" );
-        extract_effect( j, mod_data, "health_max_val",   member, "HEALTH",   "max_val" );
-        extract_effect( j, mod_data, "health_chance",    member, "HEALTH",   "chance_top" );
-        extract_effect( j, mod_data, "health_chance_bot", member, "HEALTH",   "chance_bot" );
-        extract_effect( j, mod_data, "health_tick",      member, "HEALTH",   "tick" );
+    // Then health mod
+    extract_effect( j, "H_MOD", {
+        {"h_mod_amount",      mod_action::AMOUNT},
+        {"h_mod_min",         mod_action::MIN},
+        {"h_mod_max",         mod_action::MAX},
+        {"h_mod_min_val",     mod_action::MIN_VAL},
+        {"h_mod_max_val",     mod_action::MAX_VAL},
+        {"h_mod_chance",      mod_action::CHANCE_TOP},
+        {"h_mod_chance_bot",  mod_action::CHANCE_BOT},
+        {"h_mod_tick",        mod_action::TICK},
+    } );
 
-        // Then health mod
-        extract_effect( j, mod_data, "h_mod_amount",     member, "H_MOD",    "amount" );
-        extract_effect( j, mod_data, "h_mod_min",        member, "H_MOD",    "min" );
-        extract_effect( j, mod_data, "h_mod_max",        member, "H_MOD",    "max" );
-        extract_effect( j, mod_data, "h_mod_min_val",    member, "H_MOD",    "min_val" );
-        extract_effect( j, mod_data, "h_mod_max_val",    member, "H_MOD",    "max_val" );
-        extract_effect( j, mod_data, "h_mod_chance",     member, "H_MOD",    "chance_top" );
-        extract_effect( j, mod_data, "h_mod_chance_bot", member, "H_MOD",    "chance_bot" );
-        extract_effect( j, mod_data, "h_mod_tick",       member, "H_MOD",    "tick" );
+    // Then radiation
+    extract_effect( j, "RAD", {
+        {"rad_amount",      mod_action::AMOUNT},
+        {"rad_min",         mod_action::MIN},
+        {"rad_max",         mod_action::MAX},
+        {"rad_max_val",     mod_action::MAX_VAL},
+        {"rad_chance",      mod_action::CHANCE_TOP},
+        {"rad_chance_bot",  mod_action::CHANCE_BOT},
+        {"rad_tick",        mod_action::TICK},
+    } );
 
-        // Then radiation
-        extract_effect( j, mod_data, "rad_amount",       member, "RAD",      "amount" );
-        extract_effect( j, mod_data, "rad_min",          member, "RAD",      "min" );
-        extract_effect( j, mod_data, "rad_max",          member, "RAD",      "max" );
-        extract_effect( j, mod_data, "rad_max_val",      member, "RAD",      "max_val" );
-        extract_effect( j, mod_data, "rad_chance",       member, "RAD",      "chance_top" );
-        extract_effect( j, mod_data, "rad_chance_bot",   member, "RAD",      "chance_bot" );
-        extract_effect( j, mod_data, "rad_tick",         member, "RAD",      "tick" );
+    // Then hunger
+    extract_effect( j, "HUNGER", {
+        {"hunger_amount",      mod_action::AMOUNT},
+        {"hunger_min",         mod_action::MIN},
+        {"hunger_max",         mod_action::MAX},
+        {"hunger_min_val",     mod_action::MIN_VAL},
+        {"hunger_max_val",     mod_action::MAX_VAL},
+        {"hunger_chance",      mod_action::CHANCE_TOP},
+        {"hunger_chance_bot",  mod_action::CHANCE_BOT},
+        {"hunger_tick",        mod_action::TICK},
+    } );
 
-        // Then hunger
-        extract_effect( j, mod_data, "hunger_amount",    member, "HUNGER",   "amount" );
-        extract_effect( j, mod_data, "hunger_min",       member, "HUNGER",   "min" );
-        extract_effect( j, mod_data, "hunger_max",       member, "HUNGER",   "max" );
-        extract_effect( j, mod_data, "hunger_min_val",   member, "HUNGER",   "min_val" );
-        extract_effect( j, mod_data, "hunger_max_val",   member, "HUNGER",   "max_val" );
-        extract_effect( j, mod_data, "hunger_chance",    member, "HUNGER",   "chance_top" );
-        extract_effect( j, mod_data, "hunger_chance_bot", member, "HUNGER",   "chance_bot" );
-        extract_effect( j, mod_data, "hunger_tick",      member, "HUNGER",   "tick" );
+    // Then thirst
+    extract_effect( j, "THIRST", {
+        {"thirst_amount",      mod_action::AMOUNT},
+        {"thirst_min",         mod_action::MIN},
+        {"thirst_max",         mod_action::MAX},
+        {"thirst_min_val",     mod_action::MIN_VAL},
+        {"thirst_max_val",     mod_action::MAX_VAL},
+        {"thirst_chance",      mod_action::CHANCE_TOP},
+        {"thirst_chance_bot",  mod_action::CHANCE_BOT},
+        {"thirst_tick",        mod_action::TICK},
+    } );
 
-        // Then thirst
-        extract_effect( j, mod_data, "thirst_amount",    member, "THIRST",   "amount" );
-        extract_effect( j, mod_data, "thirst_min",       member, "THIRST",   "min" );
-        extract_effect( j, mod_data, "thirst_max",       member, "THIRST",   "max" );
-        extract_effect( j, mod_data, "thirst_min_val",   member, "THIRST",   "min_val" );
-        extract_effect( j, mod_data, "thirst_max_val",   member, "THIRST",   "max_val" );
-        extract_effect( j, mod_data, "thirst_chance",    member, "THIRST",   "chance_top" );
-        extract_effect( j, mod_data, "thirst_chance_bot", member, "THIRST",   "chance_bot" );
-        extract_effect( j, mod_data, "thirst_tick",      member, "THIRST",   "tick" );
+    // Then thirst
+    extract_effect( j, "PERSPIRATION", {
+        {"perspiration_amount",      mod_action::AMOUNT},
+        {"perspiration_min",         mod_action::MIN},
+        {"perspiration_max",         mod_action::MAX},
+        {"perspiration_min_val",     mod_action::MIN_VAL},
+        {"perspiration_max_val",     mod_action::MAX_VAL},
+        {"perspiration_chance",      mod_action::CHANCE_TOP},
+        {"perspiration_chance_bot",  mod_action::CHANCE_BOT},
+        {"perspiration_tick",        mod_action::TICK},
+    } );
 
-        // Then thirst
-        extract_effect( j, mod_data, "perspiration_amount",    member, "PERSPIRATION",   "amount" );
-        extract_effect( j, mod_data, "perspiration_min",       member, "PERSPIRATION",   "min" );
-        extract_effect( j, mod_data, "perspiration_max",       member, "PERSPIRATION",   "max" );
-        extract_effect( j, mod_data, "perspiration_min_val",   member, "PERSPIRATION",   "min_val" );
-        extract_effect( j, mod_data, "perspiration_max_val",   member, "PERSPIRATION",   "max_val" );
-        extract_effect( j, mod_data, "perspiration_chance",    member, "PERSPIRATION",   "chance_top" );
-        extract_effect( j, mod_data, "perspiration_chance_bot", member, "PERSPIRATION",   "chance_bot" );
-        extract_effect( j, mod_data, "perspiration_tick",      member, "PERSPIRATION",   "tick" );
+    // Then fatigue
+    extract_effect( j, "FATIGUE", {
+        {"fatigue_amount",      mod_action::AMOUNT},
+        {"fatigue_min",         mod_action::MIN},
+        {"fatigue_max",         mod_action::MAX},
+        {"fatigue_min_val",     mod_action::MIN_VAL},
+        {"fatigue_max_val",     mod_action::MAX_VAL},
+        {"fatigue_chance",      mod_action::CHANCE_TOP},
+        {"fatigue_chance_bot",  mod_action::CHANCE_BOT},
+        {"fatigue_tick",        mod_action::TICK},
+    } );
 
-        // Then fatigue
-        extract_effect( j, mod_data, "fatigue_amount",    member, "FATIGUE",  "amount" );
-        extract_effect( j, mod_data, "fatigue_min",       member, "FATIGUE",  "min" );
-        extract_effect( j, mod_data, "fatigue_max",       member, "FATIGUE",  "max" );
-        extract_effect( j, mod_data, "fatigue_min_val",   member, "FATIGUE",  "min_val" );
-        extract_effect( j, mod_data, "fatigue_max_val",   member, "FATIGUE",  "max_val" );
-        extract_effect( j, mod_data, "fatigue_chance",    member, "FATIGUE",  "chance_top" );
-        extract_effect( j, mod_data, "fatigue_chance_bot", member, "FATIGUE",  "chance_bot" );
-        extract_effect( j, mod_data, "fatigue_tick",      member, "FATIGUE",  "tick" );
+    // Then stamina
+    extract_effect( j, "STAMINA", {
+        {"stamina_amount",      mod_action::AMOUNT},
+        {"stamina_min",         mod_action::MIN},
+        {"stamina_max",         mod_action::MAX},
+        {"stamina_max_val",     mod_action::MAX_VAL},
+        {"stamina_chance",      mod_action::CHANCE_TOP},
+        {"stamina_chance_bot",  mod_action::CHANCE_BOT},
+        {"stamina_tick",        mod_action::TICK},
+    } );
 
-        // Then stamina
-        extract_effect( j, mod_data, "stamina_amount",    member, "STAMINA",  "amount" );
-        extract_effect( j, mod_data, "stamina_min",       member, "STAMINA",  "min" );
-        extract_effect( j, mod_data, "stamina_max",       member, "STAMINA",  "max" );
-        extract_effect( j, mod_data, "stamina_max_val",   member, "STAMINA",  "max_val" );
-        extract_effect( j, mod_data, "stamina_chance",    member, "STAMINA",  "chance_top" );
-        extract_effect( j, mod_data, "stamina_chance_bot", member, "STAMINA",  "chance_bot" );
-        extract_effect( j, mod_data, "stamina_tick",      member, "STAMINA",  "tick" );
+    // Then coughing
+    extract_effect( j, "COUGH", {
+        {"cough_chance",      mod_action::CHANCE_TOP},
+        {"cough_chance_bot",  mod_action::CHANCE_BOT},
+        {"cough_tick",        mod_action::TICK},
+    } );
 
-        // Then coughing
-        extract_effect( j, mod_data, "cough_chance",     member, "COUGH",    "chance_top" );
-        extract_effect( j, mod_data, "cough_chance_bot", member, "COUGH",    "chance_bot" );
-        extract_effect( j, mod_data, "cough_tick",       member, "COUGH",    "tick" );
+    // Then vomiting
+    extract_effect( j, "VOMIT", {
+        {"vomit_chance",      mod_action::CHANCE_TOP},
+        {"vomit_chance_bot",  mod_action::CHANCE_BOT},
+        {"vomit_tick",        mod_action::TICK},
+    } );
 
-        // Then vomiting
-        extract_effect( j, mod_data, "vomit_chance",     member, "VOMIT",    "chance_top" );
-        extract_effect( j, mod_data, "vomit_chance_bot", member, "VOMIT",    "chance_bot" );
-        extract_effect( j, mod_data, "vomit_tick",       member, "VOMIT",    "tick" );
+    // Then healing effects
+    extract_effect( j, "HEAL_RATE",  { {"healing_rate",  mod_action::AMOUNT} } );
+    extract_effect( j, "HEAL_HEAD",  { {"healing_head",  mod_action::AMOUNT} } );
+    extract_effect( j, "HEAL_TORSO", { {"healing_torso", mod_action::AMOUNT} } );
 
-        // Then healing effects
-        extract_effect( j, mod_data, "healing_rate",    member, "HEAL_RATE",  "amount" );
-        extract_effect( j, mod_data, "healing_head",    member, "HEAL_HEAD",  "amount" );
-        extract_effect( j, mod_data, "healing_torso",   member, "HEAL_TORSO", "amount" );
+    // creature stats mod
+    extract_effect( j, "DODGE", { {"dodge_mod", mod_action::MIN} } );
+    extract_effect( j, "HIT",   { {"hit_mod",   mod_action::MIN} } );
+    extract_effect( j, "BASH",  { {"bash_mod",  mod_action::MIN} } );
+    extract_effect( j, "CUT",   { {"cut_mod",   mod_action::MIN} } );
+    extract_effect( j, "SIZE",  { {"size_mod",  mod_action::MIN} } );
+}
 
-        // creature stats mod
-        extract_effect( j, mod_data, "dodge_mod",    member, "DODGE",  "min" );
-        extract_effect( j, mod_data, "hit_mod",    member, "HIT",  "min" );
-        extract_effect( j, mod_data, "bash_mod",    member, "BASH",  "min" );
-        extract_effect( j, mod_data, "cut_mod",    member, "CUT",  "min" );
-        extract_effect( j, mod_data, "size_mod",    member, "SIZE",  "min" );
-
-        return true;
-    } else {
-        return false;
+double effect_type::get_mod_value( const std::string &type, mod_action action,
+                                   uint8_t reduction_level, int intensity ) const
+{
+    const auto &it = mod_data.find( type );
+    if( it == mod_data.cend() ) {
+        return 0;
     }
+
+    const auto &action_map = it->second;
+    const auto &modifier = action_map.find( get_effect_modifier_key( action, reduction_level ) );
+    if( modifier == action_map.end() ) {
+        return 0;
+    }
+
+    double ret = 0;
+    const auto &data_entry = modifier->second;
+    ret += data_entry[static_cast<size_t>( mod_type::BASE_MOD )];
+    ret += data_entry[static_cast<size_t>( mod_type::SCALING_MOD )] * ( intensity - 1 );
+    return ret;
 }
 
 void effect_type::check_consistency()
 {
-    for( const std::pair<efftype_id, effect_type> check : effect_types ) {
+    for( const std::pair<efftype_id, effect_type> &check : effect_types ) {
         check.second.verify();
     }
 }
@@ -1065,27 +1131,9 @@ std::vector<efftype_id> effect::get_blocks_effects() const
 
 int effect::get_mod( const std::string &arg, bool reduced ) const
 {
-    const auto &mod_data = eff_type->mod_data;
-    double min = 0;
-    double max = 0;
-    // Get the minimum total
-    auto found = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "min" ) );
-    if( found != mod_data.end() ) {
-        min += found->second;
-    }
-    found = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg, "min" ) );
-    if( found != mod_data.end() ) {
-        min += found->second * ( get_effective_intensity() - 1 );
-    }
-    // Get the maximum total
-    found = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "max" ) );
-    if( found != mod_data.end() ) {
-        max += found->second;
-    }
-    found = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg, "max" ) );
-    if( found != mod_data.end() ) {
-        max += found->second * ( get_effective_intensity() - 1 );
-    }
+    double min = eff_type->get_mod_value( arg, mod_action::MIN, reduced, get_effective_intensity() );
+    double max = eff_type->get_mod_value( arg, mod_action::MAX, reduced, get_effective_intensity() );
+
     if( static_cast<int>( max ) != 0 ) {
         // Return a random value between [min, max]
         return static_cast<int>( rng( min, max ) );
@@ -1097,27 +1145,9 @@ int effect::get_mod( const std::string &arg, bool reduced ) const
 
 int effect::get_avg_mod( const std::string &arg, bool reduced ) const
 {
-    const auto &mod_data = eff_type->mod_data;
-    double min = 0;
-    double max = 0;
-    // Get the minimum total
-    auto found = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "min" ) );
-    if( found != mod_data.end() ) {
-        min += found->second;
-    }
-    found = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg, "min" ) );
-    if( found != mod_data.end() ) {
-        min += found->second * ( get_effective_intensity() - 1 );
-    }
-    // Get the maximum total
-    found = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "max" ) );
-    if( found != mod_data.end() ) {
-        max += found->second;
-    }
-    found = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg, "max" ) );
-    if( found != mod_data.end() ) {
-        max += found->second * ( get_effective_intensity() - 1 );
-    }
+    double min = eff_type->get_mod_value( arg, mod_action::MIN, reduced, get_effective_intensity() );
+    double max = eff_type->get_mod_value( arg, mod_action::MAX, reduced, get_effective_intensity() );
+
     if( static_cast<int>( max ) != 0 ) {
         // Return an average of min and max
         return static_cast<int>( ( min + max ) / 2 );
@@ -1129,47 +1159,18 @@ int effect::get_avg_mod( const std::string &arg, bool reduced ) const
 
 int effect::get_amount( const std::string &arg, bool reduced ) const
 {
-    const auto &mod_data = eff_type->mod_data;
-    double ret = 0;
-    auto found = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "amount" ) );
-    if( found != mod_data.end() ) {
-        ret += found->second;
-    }
-    found = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg, "amount" ) );
-    if( found != mod_data.end() ) {
-        ret += found->second * ( get_effective_intensity() - 1 );
-    }
-    return static_cast<int>( ret );
+    return static_cast<int>( eff_type->get_mod_value( arg, mod_action::AMOUNT, reduced,
+                             get_effective_intensity() ) );
 }
 
 int effect::get_min_val( const std::string &arg, bool reduced ) const
 {
-    const auto &mod_data = eff_type->mod_data;
-    double ret = 0;
-    auto found = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "min_val" ) );
-    if( found != mod_data.end() ) {
-        ret += found->second;
-    }
-    found = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg, "min_val" ) );
-    if( found != mod_data.end() ) {
-        ret += found->second * ( intensity - 1 );
-    }
-    return static_cast<int>( ret );
+    return static_cast<int>( eff_type->get_mod_value( arg, mod_action::MIN_VAL, reduced, intensity ) );
 }
 
 int effect::get_max_val( const std::string &arg, bool reduced ) const
 {
-    const auto &mod_data = eff_type->mod_data;
-    double ret = 0;
-    auto found = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "max_val" ) );
-    if( found != mod_data.end() ) {
-        ret += found->second;
-    }
-    found = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg, "max_val" ) );
-    if( found != mod_data.end() ) {
-        ret += found->second * ( intensity - 1 );
-    }
-    return static_cast<int>( ret );
+    return static_cast<int>( eff_type->get_mod_value( arg, mod_action::MAX_VAL, reduced, intensity ) );
 }
 
 bool effect::get_sizing( const std::string &arg ) const
@@ -1184,77 +1185,36 @@ bool effect::get_sizing( const std::string &arg ) const
 
 double effect::get_percentage( const std::string &arg, int val, bool reduced ) const
 {
-    const auto &mod_data = eff_type->mod_data;
-    auto found_top_base = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "chance_top" ) );
-    auto found_top_scale = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg,
-                                          "chance_top" ) );
-    // Convert to int or 0
-    int top_base = 0;
-    int top_scale = 0;
-    if( found_top_base != mod_data.end() ) {
-        top_base = found_top_base->second;
-    }
-    if( found_top_scale != mod_data.end() ) {
-        top_scale = found_top_scale->second * ( intensity - 1 );
-    }
+    int top = eff_type->get_mod_value( arg, mod_action::CHANCE_TOP, reduced, intensity );
+
     // Check chances if value is 0 (so we can check valueless effects like vomiting)
     // Else a nonzero value overrides a 0 chance for default purposes
-    if( val == 0 ) {
-        // If both top values <= 0 then it should never trigger
-        if( top_base <= 0 && top_scale <= 0 ) {
-            return 0;
-        }
-        // It will also never trigger if top_base + top_scale <= 0
-        if( top_base + top_scale <= 0 ) {
-            return 0;
-        }
+    if( val == 0 && top <= 0 ) {
+        return 0;
     }
 
-    // We only need to calculate these if we haven't already returned
-    int bot_base = 0;
-    int bot_scale = 0;
-    int tick = 0;
-    auto found_bot_base = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "chance_bot" ) );
-    auto found_bot_scale = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg,
-                                          "chance_bot" ) );
-    auto found_tick_base = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "tick" ) );
-    auto found_tick_scale = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg, "tick" ) );
-    if( found_bot_base != mod_data.end() ) {
-        bot_base = found_bot_base->second;
-    }
-    if( found_bot_scale != mod_data.end() ) {
-        bot_scale = found_bot_scale->second * ( intensity - 1 );
-    }
-    if( found_tick_base != mod_data.end() ) {
-        tick += found_tick_base->second;
-    }
-    if( found_tick_scale != mod_data.end() ) {
-        tick += found_tick_scale->second * ( intensity - 1 );
-    }
+    int bot = eff_type->get_mod_value( arg, mod_action::CHANCE_BOT, reduced, intensity );
+    int tick = eff_type->get_mod_value( arg, mod_action::TICK, reduced, intensity );
+
     // Tick is the exception where tick = 0 means tick = 1
     if( tick == 0 ) {
         tick = 1;
     }
 
-    double ret = 0;
-    // If both bot values are zero the formula is one_in(top), else the formula is x_in_y(top, bot)
-    if( bot_base != 0 || bot_scale != 0 ) {
-        if( bot_base + bot_scale == 0 ) {
-            // Special crash avoidance case, in most effect fields 0 = "nothing happens"
-            // so assume false here for consistency
-            ret = 0;
-        } else {
-            // Cast to double here to allow for partial percentages
-            ret = 100 * static_cast<double>( top_base + top_scale ) / static_cast<double>
-                  ( bot_base + bot_scale );
-        }
+    // Start with 100%
+    double ret = 100;
+
+    // If bot is zero the formula is one_in(top), else the formula is x_in_y(top, bot)
+    if( bot ) {
+        // Cast to double here to allow for partial percentages
+        ret *= static_cast<double>( top ) / static_cast<double>( bot );
     } else {
         // Cast to double here to allow for partial percentages
-        ret = 100 / static_cast<double>( top_base + top_scale );
+        ret /= static_cast<double>( top );
     }
     // Divide by ticks between rolls
     if( tick > 1 ) {
-        ret = ret / tick;
+        ret /= tick;
     }
     return ret;
 }
@@ -1262,78 +1222,39 @@ double effect::get_percentage( const std::string &arg, int val, bool reduced ) c
 bool effect::activated( const time_point &when, const std::string &arg, int val, bool reduced,
                         double mod ) const
 {
-    const auto &mod_data = eff_type->mod_data;
-    auto found_top_base = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "chance_top" ) );
-    auto found_top_scale = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg,
-                                          "chance_top" ) );
-    // Convert to int or 0
-    int top_base = 0;
-    int top_scale = 0;
-    if( found_top_base != mod_data.end() ) {
-        top_base = found_top_base->second;
-    }
-    if( found_top_scale != mod_data.end() ) {
-        top_scale = found_top_scale->second * ( intensity - 1 );
-    }
+    int top = eff_type->get_mod_value( arg, mod_action::CHANCE_TOP, reduced, intensity );
+
     // Check chances if value is 0 (so we can check valueless effects like vomiting)
     // Else a nonzero value overrides a 0 chance for default purposes
-    if( val == 0 ) {
-        // If both top values <= 0 then it should never trigger
-        if( top_base <= 0 && top_scale <= 0 ) {
-            return false;
-        }
-        // It will also never trigger if top_base + top_scale <= 0
-        if( top_base + top_scale <= 0 ) {
-            return false;
-        }
+    if( val == 0 && top <= 0 ) {
+        return false;
     }
 
-    // We only need to calculate these if we haven't already returned
-    int bot_base = 0;
-    int bot_scale = 0;
-    int tick = 0;
-    auto found_bot_base = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "chance_bot" ) );
-    auto found_bot_scale = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg,
-                                          "chance_bot" ) );
-    auto found_tick_base = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "tick" ) );
-    auto found_tick_scale = mod_data.find( std::make_tuple( "scaling_mods", reduced, arg, "tick" ) );
-    if( found_bot_base != mod_data.end() ) {
-        bot_base = found_bot_base->second;
-    }
-    if( found_bot_scale != mod_data.end() ) {
-        bot_scale = found_bot_scale->second * ( intensity - 1 );
-    }
-    if( found_tick_base != mod_data.end() ) {
-        tick += found_tick_base->second;
-    }
-    if( found_tick_scale != mod_data.end() ) {
-        tick += found_tick_scale->second * ( intensity - 1 );
-    }
+    int tick = eff_type->get_mod_value( arg, mod_action::TICK, reduced, intensity );
+
     // Tick is the exception where tick = 0 means tick = 1
     if( tick == 0 ) {
         tick = 1;
+    } else if( tick < 0 ) {
+        return false;
     }
 
-    // Check if tick allows for triggering. If both bot values are zero the formula is
-    // x_in_y(1, top) i.e. one_in(top), else the formula is x_in_y(top, bot),
+
+    int bot = eff_type->get_mod_value( arg, mod_action::CHANCE_BOT, reduced, intensity );
+
+    // Check if tick allows for triggering.
+    if( ( when - calendar::turn_zero ) % time_duration::from_turns( tick ) != 0_turns ) {
+        return false;
+    }
+
+    // If bot value is zero the formula is x_in_y(1, top) i.e. one_in(top),
+    // else the formula is x_in_y(top, bot).
     // mod multiplies the overall percentage chances
-
-    // has to be an && here to avoid undefined behavior of turn % 0
-    if( tick > 0 &&
-        ( when - calendar::turn_zero ) % time_duration::from_turns( tick ) == 0_turns ) {
-        if( bot_base != 0 && bot_scale != 0 ) {
-            if( bot_base + bot_scale == 0 ) {
-                // Special crash avoidance case, in most effect fields 0 = "nothing happens"
-                // so assume false here for consistency
-                return false;
-            } else {
-                return x_in_y( ( top_base + top_scale ) * mod, bot_base + bot_scale );
-            }
-        } else {
-            return x_in_y( mod, top_base + top_scale );
-        }
+    if( !bot ) {
+        return x_in_y( mod, top );
+    } else {
+        return x_in_y( top * mod, bot );
     }
-    return false;
 }
 
 double effect::get_addict_mod( const std::string &arg, int addict_level ) const
@@ -1536,8 +1457,7 @@ void load_effect_type( const JsonObject &jo )
 
     new_etype.max_effective_intensity = jo.get_int( "max_effective_intensity", 0 );
 
-    new_etype.load_mod_data( jo, "base_mods" );
-    new_etype.load_mod_data( jo, "scaling_mods" );
+    new_etype.load_mod_data( jo );
 
     new_etype.impairs_movement = hardcoded_movement_impairing.count( new_etype.id ) > 0;
 

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -240,7 +240,7 @@ void weed_msg( Character &p )
     }
 }
 
-std::array<const char *, static_cast<size_t>( mod_type::MAX )> MOD_TYPE_STRINGS {
+static std::array<const char *, static_cast<size_t>( mod_type::MAX )> MOD_TYPE_STRINGS {
     "base_mods",
     "scaling_mods",
 };
@@ -271,11 +271,12 @@ void effect_type::extract_effect(
             }
 
             mod_action action = action_key.second;
-            for( uint8_t i = 0; i < jsarr.size(); i++ ) {
+            cata_assert( jsarr.size() < 0x100 );
+            for( size_t i = 0; i < jsarr.size(); i++ ) {
                 uint32_t key = get_effect_modifier_key( action, i );
 
                 // Create default entry if doesn't exist
-                const auto &it = modifiers.try_emplace( key, default_modifier_values );
+                const auto &it = modifiers.emplace( key, default_modifier_values );
 
                 // Update entry with the fetched value
                 it.first->second[cur_mod_type] = jsarr.get_float( i );
@@ -497,7 +498,7 @@ double effect_type::get_mod_value( const std::string &type, mod_action action,
 
 void effect_type::check_consistency()
 {
-    for( const std::pair<efftype_id, effect_type> &check : effect_types ) {
+    for( auto const &check : effect_types ) {
         check.second.verify();
     }
 }

--- a/src/effect.h
+++ b/src/effect.h
@@ -62,6 +62,27 @@ struct vitamin_applied_effect {
     vitamin_id vitamin;
 };
 
+enum class mod_type : uint8_t {
+    BASE_MOD = 0,
+    SCALING_MOD = 1,
+
+    MAX,
+};
+
+using modifier_value_arr = std::array<double, static_cast<size_t>( mod_type::MAX )>;
+extern modifier_value_arr default_modifier_values;
+
+enum class mod_action : uint8_t {
+    AMOUNT,
+    CHANCE_BOT,
+    CHANCE_TOP,
+    MAX,
+    MAX_VAL,
+    MIN,
+    MIN_VAL,
+    TICK,
+};
+
 class effect_type
 {
         friend void load_effect_type( const JsonObject &jo );
@@ -107,10 +128,13 @@ class effect_type
         /** Returns true if an effect will only target main body parts (i.e., those with HP). */
         bool get_main_parts() const;
 
+        double get_mod_value( const std::string &type, mod_action action, uint8_t reduction_level,
+                              int intensity ) const;
+
         bool is_show_in_info() const;
 
         /** Loading helper functions */
-        bool load_mod_data( const JsonObject &jo, const std::string &member );
+        void load_mod_data( const JsonObject &jo );
         bool load_miss_msgs( const JsonObject &jo, const std::string &member );
         bool load_decay_msgs( const JsonObject &jo, const std::string &member );
 
@@ -131,6 +155,16 @@ class effect_type
         std::vector<enchantment_id> enchantments;
         cata::flat_set<json_character_flag> immune_flags;
     protected:
+        uint32_t get_effect_modifier_key( mod_action action, uint8_t reduction_level ) const {
+            return static_cast<uint8_t>( action ) << 0 |
+                   reduction_level << 8;
+        }
+
+        void extract_effect(
+            const JsonObject &j,
+            const std::string &effect_name,
+            const std::vector<std::pair<std::string, mod_action>> &action_keys );
+
         int max_intensity = 0;
         int max_effective_intensity = 0;
         time_duration max_duration = 365_days;
@@ -190,9 +224,7 @@ class effect_type
         translation death_msg;
         cata::optional<event_type> death_event;
 
-        /** Key tuple order is:("base_mods"/"scaling_mods", reduced: bool, type of mod: "STR", desired argument: "tick") */
-        std::unordered_map <
-        std::tuple<std::string, bool, std::string, std::string>, double, cata::tuple_hash > mod_data;
+        std::unordered_map<std::string, std::unordered_map<uint32_t, modifier_value_arr>> mod_data;
         std::vector<vitamin_rate_effect> vitamin_data;
         std::vector<std::pair<int, int>> kill_chance;
         std::vector<std::pair<int, int>> red_kill_chance;


### PR DESCRIPTION
#### Summary
Performance "Effect modifier rewrite"

#### Purpose of change
The current effect.cpp `mod_data` code is rather slow: upon testing it took around 7-8% of runtime during sleep on a random save file.
Most of that time was spent hashing the large tuple of strings.

This change both attempts to speed this up (modifier calculation is now negligible), make the code MUCH more readable, and de-duplicate code.

#### Describe the solution
Instead of a tuple with strings, we use 2 levels of map indirection, and replace the strings with enums for fast hashing and lower memory usage.

#### Testing
Effects testing suite