### PR TITLE
Add debug menu item to spawn overmap NPC

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -152,6 +152,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::LONG_TELEPORT: return "LONG_TELEPORT";
         case debug_menu::debug_menu_index::REVEAL_MAP: return "REVEAL_MAP";
         case debug_menu::debug_menu_index::SPAWN_NPC: return "SPAWN_NPC";
+        case debug_menu::debug_menu_index::SPAWN_OM_NPC: return "SPAWN_OM_NPC";
         case debug_menu::debug_menu_index::SPAWN_MON: return "SPAWN_MON";
         case debug_menu::debug_menu_index::GAME_STATE: return "GAME_STATE";
         case debug_menu::debug_menu_index::KILL_AREA: return "KILL_AREA";
@@ -383,6 +384,7 @@ static int spawning_uilist()
     const std::vector<uilist_entry> uilist_initializer = {
         { uilist_entry( debug_menu_index::WISH, true, 'w', _( "Spawn an item" ) ) },
         { uilist_entry( debug_menu_index::SPAWN_NPC, true, 'n', _( "Spawn NPC" ) ) },
+        { uilist_entry( debug_menu_index::SPAWN_OM_NPC, true, 'N', _( "Spawn random NPC on overmap" ) ) },
         { uilist_entry( debug_menu_index::SPAWN_MON, true, 'm', _( "Spawn monster" ) ) },
         { uilist_entry( debug_menu_index::SPAWN_VEHICLE, true, 'v', _( "Spawn a vehicle" ) ) },
         { uilist_entry( debug_menu_index::SPAWN_ARTIFACT, true, 'a', _( "Spawn artifact" ) ) },
@@ -2556,6 +2558,16 @@ void debug()
                                     faction_id( new_fac_id ), faction_no_faction );
             temp->set_fac( new_solo_fac ? new_solo_fac->id : faction_no_faction );
             g->load_npcs();
+        }
+        break;
+
+        case debug_menu_index::SPAWN_OM_NPC: {
+            int num_of_npcs = 1;
+            if( query_int( num_of_npcs, _( "How many npcs to try spawning?" ), num_of_npcs ) ) {
+                for( int i = 0; i < num_of_npcs; i++ ) {
+                    g->perhaps_add_random_npc( true );
+                }
+            }
         }
         break;
 

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -27,6 +27,7 @@ enum class debug_menu_index : int {
     LONG_TELEPORT,
     REVEAL_MAP,
     SPAWN_NPC,
+    SPAWN_OM_NPC,
     SPAWN_MON,
     GAME_STATE,
     KILL_AREA,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Testing random npc spawns is currently awkward; spawning an npc from debug menu currently does not trigger `npc::long_term_goal_action` right away. Also spawning multiple NPCs instantly triggers a spam of forced NPC dialogue.

#### Describe the solution

PR adds debug menu item to trigger `game::perhaps_add_random_npc`, this allows easier testing for issues similar to #62985 and #62984 as it allows to spawn multiple npcs on overmap with random mission assignment.

Debug menu is translated, and this PR adds a string; so it has to wait until after 0.G

#### Describe alternatives you've considered

#### Testing

Use it from debug menu, a value of 10 will almost certainly trigger the spinner animation from #62985, or invalid achievement if used on commit before #62984 

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
