### PR TITLE
Remove the last mentions of rags in recipes

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -589,7 +589,7 @@
       { "item": "steel_lump", "count": [ 8, 13 ] },
       { "item": "steel_chunk", "count": [ 8, 13 ] },
       { "item": "scrap", "count": [ 8, 13 ] },
-      { "item": "rag", "count": [ 1, 2 ] },
+      { "item": "cotton_patchwork", "count": [ 1, 2 ] },
       { "item": "pipe", "count": [ 0, 1 ] },
       { "item": "hd_pipe", "count": [ 1, 2 ] },
       { "item": "sheet_metal_small", "count": [ 1, 2 ] },

--- a/data/json/items/migration.json
+++ b/data/json/items/migration.json
@@ -1455,7 +1455,7 @@
   {
     "id": "rag_bloody",
     "type": "MIGRATION",
-    "replace": "rag",
+    "replace": "cotton_patchwork",
     "flags": [ "FILTHY" ]
   },
   {

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -128,6 +128,29 @@
     "use_action": [ "MOP" ]
   },
   {
+    "id": "rag",
+    "type": "TOOL",
+    "category": "spare_parts",
+    "name": { "str": "rag" },
+    "description": "This is a largish piece of cloth, useful in crafting and possibly for staunching bleeding.",
+    "weight": "80 g",
+    "volume": "250 ml",
+    "//": "This is much, much bigger than it should be.",
+    "//2": "Based on the density used for cotton patchwork, which disassembles into rags, it should be 52ml.",
+    "//3": "But I don't want to touch the tests that are insistent it should take longer to manipulate, so here we are.",
+    "//4": "Rags will be going away soonish. I need to finish the other recipe changes first.",
+    "price": 0,
+    "price_postapoc": 0,
+    "material": [ "cotton" ],
+    "symbol": ",",
+    "color": "white",
+    "use_action": [
+      { "type": "heal", "move_cost": 200, "used_up_item": { "id": "rag", "quantity": 1, "flags": [ "FILTHY" ] } },
+      "WASH_HARD_ITEMS"
+    ],
+    "flags": [ "NO_SALVAGE" ]
+  },
+  {
     "id": "cotton_patchwork",
     "type": "TOOL",
     "category": "spare_parts",

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -128,29 +128,6 @@
     "use_action": [ "MOP" ]
   },
   {
-    "id": "rag",
-    "type": "TOOL",
-    "category": "spare_parts",
-    "name": { "str": "rag" },
-    "description": "This is a largish piece of cloth, useful in crafting and possibly for staunching bleeding.",
-    "weight": "80 g",
-    "volume": "250 ml",
-    "//": "This is much, much bigger than it should be.",
-    "//2": "Based on the density used for cotton patchwork, which disassembles into rags, it should be 52ml.",
-    "//3": "But I don't want to touch the tests that are insistent it should take longer to manipulate, so here we are.",
-    "//4": "Rags will be going away soonish. I need to finish the other recipe changes first.",
-    "price": 0,
-    "price_postapoc": 0,
-    "material": [ "cotton" ],
-    "symbol": ",",
-    "color": "white",
-    "use_action": [
-      { "type": "heal", "move_cost": 200, "used_up_item": { "id": "rag", "quantity": 1, "flags": [ "FILTHY" ] } },
-      "WASH_HARD_ITEMS"
-    ],
-    "flags": [ "NO_SALVAGE" ]
-  },
-  {
     "id": "cotton_patchwork",
     "type": "TOOL",
     "category": "spare_parts",

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_BARKEEP.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_BARKEEP.json
@@ -54,7 +54,7 @@
     "type": "item_group",
     "id": "NC_ANCILLA_BARKEEP_wield",
     "subtype": "collection",
-    "items": [ { "item": "rag" } ]
+    "items": [ { "item": "cotton_patchwork" } ]
   },
   {
     "type": "item_group",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -626,38 +626,6 @@
   },
   {
     "type": "recipe",
-    "activity_level": "NO_EXERCISE",
-    "result": "rag",
-    "id_suffix": "knitting",
-    "category": "CC_OTHER",
-    "//": "This should be obsoleted once we're sure nobody has any rags left and they're removed from any recipes i missed.",
-    "subcategory": "CSC_OTHER_MATERIALS",
-    "skill_used": "tailor",
-    "difficulty": 2,
-    "time": "6 m",
-    "autolearn": true,
-    "using": [ [ "filament", 80 ] ],
-    "qualities": [ { "id": "KNIT", "level": 1 } ],
-    "proficiencies": [ { "proficiency": "prof_knitting" }, { "proficiency": "prof_knitting_speed" } ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "result": "rag",
-    "id_suffix": "spinningwheel",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_MATERIALS",
-    "skill_used": "tailor",
-    "batch_time_factors": [ 70, 1 ],
-    "//": "This should be obsoleted once we're sure nobody has any rags left and they're removed from any recipes i missed.",
-    "time": "18 s",
-    "autolearn": true,
-    "tools": [ [ [ "spinwheelitem", -1 ] ] ],
-    "using": [ [ "filament", 80 ] ],
-    "proficiencies": [ { "proficiency": "prof_knitting" }, { "proficiency": "prof_knitting_speed" } ]
-  },
-  {
-    "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "sheet",
     "category": "CC_OTHER",
@@ -1298,19 +1266,6 @@
     "using": [ [ "forging_standard", 4 ], [ "steel_tiny", 4 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "budget_steel_chunk", 4 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "NO_EXERCISE",
-    "result": "cotton_patchwork",
-    "id_suffix": "from_rags",
-    "//": "This should be obsoleted once we're sure nobody has any rags left and they're removed from any recipes i missed.",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_MATERIALS",
-    "skill_used": "tailor",
-    "time": "0 s",
-    "autolearn": true,
-    "components": [ [ [ "rag", 1 ] ] ]
   },
   {
     "result": "plastic_sheet",

--- a/data/json/recipes/other/parts.json
+++ b/data/json/recipes/other/parts.json
@@ -880,18 +880,6 @@
   },
   {
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "result": "rag",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_MATERIALS",
-    "skill_used": "tailor",
-    "time": "1 s",
-    "autolearn": true,
-    "components": [ [ [ "cotton_patchwork", 1 ] ] ],
-    "//": "This is intended to be an interim measure until all recipes can be moved away from using or creating rags.  Once we're sure rags are gone, this can be obsolete."
-  },
-  {
-    "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
     "result": "sharp_rock",
     "category": "CC_OTHER",

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -313,7 +313,7 @@
     "time": "30 m",
     "book_learn": [ [ "textbook_chemistry", 4 ], [ "adv_chemistry", 4 ], [ "recipe_labchem", 4 ] ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "colander_steel", -1 ], [ "sieve_steel", -1 ], [ "sieve_primitive", -1 ], [ "rag", -1 ] ] ],
+    "tools": [ [ [ "colander_steel", -1 ], [ "sieve_steel", -1 ], [ "sieve_primitive", -1 ], [ "cotton_patchwork", -1 ] ] ],
     "components": [
       [
         [ "tobacco", 50 ],

--- a/data/json/recipes/recipe_obsolete.json
+++ b/data/json/recipes/recipe_obsolete.json
@@ -776,6 +776,24 @@
   },
   {
     "type": "recipe",
+    "result": "rag",
+    "id_suffix": "knitting",
+    "obsolete": true
+  },
+  {
+    "type": "recipe",
+    "result": "rag",
+    "id_suffix": "spinningwheel",
+    "obsolete": true
+  },
+  {
+    "type": "recipe",
+    "result": "cotton_patchwork",
+    "id_suffix": "from_rags",
+    "obsolete": true
+  },
+  {
+    "type": "recipe",
     "result": "chem_black_powder",
     "id_suffix": "generic",
     "obsolete": true

--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -800,7 +800,7 @@
       [ [ "pipe", 2 ] ],
       [ [ "hd_pipe", 2 ] ],
       [ [ "sheet_metal_small", 2 ] ],
-      [ [ "rag", 2 ] ],
+      [ [ "cotton_patchwork", 2 ] ],
       [ [ "metal_tank", 1 ] ],
       [ [ "nitrogen_membrane_filter", 1 ] ],
       [ [ "cable", 10 ] ],


### PR DESCRIPTION
#### Summary
Infrastructure "Removes the last mentions of rags in recipes"

#### Purpose of change

Fixes #62805

#### Describe the solution

migrate the existing recipes using `"rag"` to use `"cotton_patchwork"` instead;
remove the recipes for convertion from `rag`s to `cotton_patchwork`s and back

#### Describe alternatives you've considered

N/A

#### Testing
Create a game in 0.F, get skills to 10, learn all recipes, acquire a bunch of rags, save and quit.

Load the save in the PR
see the items that used to be rags are now cotton patches
see the cotton patch crafting recipes work
see the recipes formerly using rags use cotton patches now

#### Additional context

