### PR TITLE
fix prereq issues for INFIMMUNE and PARAIMMUNE

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3462,7 +3462,7 @@
     "name": { "str": "Infection Immune" },
     "points": 3,
     "description": "Your bloodstream has developed antibiotic properties.  Your wounds will never become infected.",
-    "prereqs": [ "DISRESISTANT" ],
+    "prereqs": [ "DISRESISTANT", "DISIMMUNE" ],
     "prereqs2": [ "INFRESIST" ],
     "category": [ "MEDICAL" ],
     "flags": [ "INFECTION_IMMUNE" ]
@@ -3484,7 +3484,7 @@
     "name": { "str": "Parasite Immune" },
     "points": 1,
     "description": "Your body is unusually inhospitable to parasitic lifeforms.  You will never become infested with internal parasites.",
-    "prereqs": [ "DISRESISTANT" ],
+    "prereqs": [ "DISRESISTANT", "DISIMMUNE" ],
     "prereqs2": [ "INFRESIST" ],
     "flags": [ "PARAIMMUNE" ],
     "category": [ "CHIMERA", "MEDICAL", "SLIME" ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3485,7 +3485,7 @@
     "points": 1,
     "description": "Your body is unusually inhospitable to parasitic lifeforms.  You will never become infested with internal parasites.",
     "prereqs": [ "DISRESISTANT", "DISIMMUNE" ],
-    "prereqs2": [ "INFRESIST" ],
+    "prereqs2": [ "INFRESIST", "INFIMMUNE" ],
     "flags": [ "PARAIMMUNE" ],
     "category": [ "CHIMERA", "MEDICAL", "SLIME" ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Infection/Parasite Immunity prereq fixes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Parasite immunity and infection immunity required disease resistant, but not disease immune, which meant that certain trees such as Medical would flip-flop between giving you disease immunity, rolling it back to disease resistant to give you parasite/infection immunity, then randomly deciding to give you disease immunity again. This was also true for parasite immunity, as it wanted infection resistant specifically and not infection immunity, so the mutations would repeatedly fight over their prerequisites until you mutated in the specific order of Parasite Immune -> Infection Immune -> Disease Immune at which point they would coexist peacefully. Since each random failure increments your instability this is especially annoying.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add the immunity as an alternative prerequisite to mutations that listed a resistance as a prerequisite.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
