### PR TITLE
Stop rigid boat hull breaking into pliable fabric sheets

### DIFF
--- a/data/json/items/vehicle/boat.json
+++ b/data/json/items/vehicle/boat.json
@@ -53,7 +53,7 @@
     "symbol": "o",
     "color": "brown",
     "name": { "str": "carbon fiber boat hull" },
-    "description": "A carbon fiber sheet that keeps the boat afloat.  Add boat hulls to a vehicle until it floats, then attach oars or a motor to get the boat to move.",
+    "description": "A rigid carbon fiber sheet that keeps the boat afloat.  Add boat hulls to a vehicle until it floats, then attach oars or a motor to get the boat to move.",
     "price": 40000,
     "price_postapoc": 500,
     "material": [ "kevlar_rigid" ],

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1129,7 +1129,7 @@
       "repair": { "skills": [ [ "mechanics", 7 ] ], "time": "60 m", "using": [ [ "adhesive", 3 ] ] }
     },
     "flags": [ "FLOATS", "BOARDABLE" ],
-    "breaks_into": [ { "item": "sheet_kevlar", "count": [ 1, 3 ] } ],
+    "breaks_into": [ { "item": "rigid_kevlar_plate", "count": [ 1, 3 ] } ],
     "damage_reduction": { "all": 14 }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Stop rigid boat hull breaking into pliable fabric sheets"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief desandcription of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The vehicle part `carbonfiber_boat_hull` built using item of same id is of material `kevlar_rigid` but breaks into whole sheets of pliable kevlar fabric `sheet_kevlar`.
https://github.com/CleverRaven/Cataclysm-DDA/blob/583923e3e26da60142a515ea749829e5938f4160/data/json/vehicleparts/vehicle_parts.json#L1132

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Such rigid kevlar material is made from multiple layers that have been bonded (with epoxy resin IRL; superglue in-game) and should not delaminate into intact sheets.

#### Describe the solution
Change outcome to rigid Kevlar plate `rigid_kevlar_plate` which corresponds to material `kevlar_rigid`.

Add word "rigid" to the item description (compare: `plastic_boat_hull` is "A rigid plastic sheet that keeps the boat afloat."); this is to emphasize that it is of rigid construction, not "skin-on-frame".

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- More damage, smaller pieces: requires creating a new item that smaller sized version of  `rigid_kevlar_plate`.
- Total obliteration: instead of rigid plates or intact sheets, only scraps of Kevlar fabric `scrap_kevlar` remain.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked valid json.
Unfortunately, smashing a racing kayak to bits with a sledgehammer in game tends to break the frame before the hull part.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This PR does not attempt to fix the mismatch in weight of maximum `breaks_into` output vs the part itself, which dates back a long way. `carbonfiber_boat_hull` has weighed 500g ever since it was added, but the `breaks_into` output has varied, and most probably has never come anywhere close to matching the item weight:

- up to 3 × `kevlar_plate` @ 360g each when added in #27251
- up to 3 × `kevlar_plate` @ 300g each just before #39964
- up to 3 × `sheet_kevlar` @ 5g each just after #39964
- up to 3 × `sheet_kevlar` @ 26g each as of this writing (583923e3e26da60142a515ea749829e5938f4160)
- up to 3 × `rigid_kevlar_plate` @ 429g each after this PR

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
