### PR TITLE
Aftershock: Furniture of Tomorrow

### DIFF
--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
@@ -115,17 +115,32 @@
     "crafting_pseudo_item": "mirror",
     "flags": [ "NOITEM", "BLOCKSDOOR" ],
     "examine_action": "change_appearance",
-    "bash": {
-      "str_min": 5,
-      "str_max": 16,
-      "sound": "glass breaking",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
+    "deconstruct": {
       "items": [
-        { "item": "glass_shard", "count": [ 25, 50 ] },
-        { "item": "scrap", "count": [ 2, 7 ] },
-        { "item": "afs_circuitry_1", "count": [ 2, 5 ] },
-        { "item": "cable", "charges": [ 4, 10 ] }
+        { "item": "large_lcd_screen", "count": 1 },
+        { "item": "small_lcd_screen", "count": 2 },
+        { "item": "sheet_metal_small", "count": [ 2, 3 ] },
+        { "item": "afs_circuitry_1", "count": [ 1, 2 ] },
+        { "item": "cable", "charges": [ 2, 4 ] },
+        { "item": "e_scrap", "count": [ 1, 3 ] },
+        { "item": "circuit", "count": [ 1, 2 ] }
+      ]
+    },
+    "bash": {
+      "str_min": 8,
+      "str_max": 150,
+      "sound": "crunch!",
+      "sound_fail": "whack!",
+      "items": [
+        { "item": "scrap", "count": [ 2, 4 ] },
+        { "item": "steel_chunk", "count": [ 2, 4 ] },
+        { "item": "plastic_chunk", "count": [ 2, 4 ] },
+        { "item": "small_lcd_screen", "count": 1, "prob": 50 },
+        { "item": "sheet_metal_small", "count": [ 2, 3 ] },
+        { "item": "afs_circuitry_1", "count": 1, "prob": 50 },
+        { "item": "cable", "charges": [ 0, 2 ] },
+        { "item": "e_scrap", "count": [ 0, 1 ] },
+        { "item": "circuit", "count": [ 0, 1 ] }
       ]
     }
   }

--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
@@ -107,7 +107,7 @@
     "id": "f_screenmirror",
     "name": "screen mirror",
     "symbol": "{",
-    "description": "A wall mounted digital display. It would once have served as an entertainment and advertising system.",
+    "description": "A wall mounted digital display.  It would once have served as an entertainment and advertising system.",
     "color": "dark_gray",
     "move_cost_mod": 2,
     "coverage": 80,

--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
@@ -33,5 +33,100 @@
     },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.1, "mass": 200000, "volume": "50L" }
+  },
+  {
+    "type": "furniture",
+    "id": "f_habitat_storage_board",
+    "name": "storage board",
+    "symbol": "#",
+    "looks_like": "f_cupboard",
+    "description": "The wall-mounted, steel and plastic storage solution of tomorrow.",
+    "color": "blue",
+    "move_cost_mod": 1,
+    "coverage": 55,
+    "required_str": -1,
+    "flags": [ "TRANSPARENT", "CONTAINER", "PLACE_ITEM", "MOUNTABLE", "FLAT_SURF" ],
+    "connect_groups": "COUNTER",
+    "connects_to": "COUNTER",
+    "rotates_to": "INDOORFLOOR",
+    "deconstruct": {
+      "items": [
+        { "item": "plastic_chunk", "count": 3 },
+        { "item": "scrap", "count": [ 2, 8 ] },
+        { "item": "rigid_plastic_sheet", "count": 1 },
+        { "item": "polycarbonate_sheet", "count": [ 2, 8 ] }
+      ]
+    },
+    "bash": {
+      "str_min": 8,
+      "str_max": 30,
+      "sound": "smash!",
+      "sound_fail": "whump.",
+      "items": [
+        { "item": "scrap", "count": [ 2, 8 ] },
+        { "item": "polycarbonate_sheet", "count": [ 1, 3 ] },
+        { "item": "rigid_plastic_sheet", "count": [ 0, 1 ] },
+        { "item": "plastic_chunk", "count": [ 2, 16 ] }
+      ]
+    },
+    "examine_action": "workbench",
+    "workbench": { "multiplier": 1.1, "mass": 200000, "volume": "75L" }
+  },
+  {
+    "type": "furniture",
+    "id": "f_habitat_bathroom",
+    "name": "integrated washroom",
+    "symbol": "#",
+    "looks_like": "f_shower",
+    "description": "Waste and water pipes, conjoined into the most compact bathroom that could possibly be built.",
+    "color": "white",
+    "move_cost_mod": 0,
+    "coverage": 35,
+    "required_str": -1,
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR" ],
+    "bash": {
+      "str_min": 6,
+      "str_max": 30,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "sound_vol": 16,
+      "sound_fail_vol": 12,
+      "items": [
+        { "item": "cable", "charges": [ 1, 2 ] },
+        { "item": "water_faucet", "count": 1 },
+        { "item": "hose", "count": [ 2, 3 ] },
+        { "item": "afs_circuitry_1", "count": [ 0, 1 ] },
+        { "item": "plastic_chunk", "count": [ 5, 10 ] },
+        { "item": "scrap", "count": [ 2, 7 ] },
+        { "item": "steel_chunk", "count": [ 0, 3 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_screenmirror",
+    "name": "screen mirror",
+    "symbol": "{",
+    "description": "A wall mounted digital display. It would once have served as an entertainment and advertising system.",
+    "color": "dark_gray",
+    "move_cost_mod": 2,
+    "coverage": 80,
+    "required_str": 5,
+    "crafting_pseudo_item": "mirror",
+    "flags": [ "NOITEM", "BLOCKSDOOR" ],
+    "examine_action": "change_appearance",
+    "bash": {
+      "str_min": 5,
+      "str_max": 16,
+      "sound": "glass breaking",
+      "sound_fail": "whack!",
+      "sound_vol": 16,
+      "items": [
+        { "item": "glass_shard", "count": [ 25, 50 ] },
+        { "item": "scrap", "count": [ 2, 7 ] },
+        { "item": "afs_circuitry_1", "count": [ 2, 5 ] },
+        { "item": "cable", "charges": [ 4, 10 ] }
+      ]
+    }
   }
 ]

--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat_machinery.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat_machinery.json
@@ -52,13 +52,15 @@
     "id": "f_cryofluid_pump",
     "name": "Cryo-fluid pump",
     "looks_like": "f_standing_tank",
-    "description": "An insulated metal tank prepared for the storage of exotic cryo-coolants.  Relatively advanced in construction, it can be disassembled for valuable scrap.",
+    "description": "An insulated metal tank prepared for the storage of exotic cryo-coolants.  Relatively advanced in construction, it can be salvaged for valuable scrap.",
     "symbol": "0",
     "bgcolor": "white",
     "move_cost_mod": -1,
     "coverage": 55,
     "required_str": -1,
     "flags": [ "CONTAINER", "PLACE_ITEM", "LIQUIDCONT", "NOITEM", "SEALED" ],
+    "examine_action": "keg",
+    "keg_capacity": 20,
     "bash": {
       "str_min": 18,
       "str_max": 50,
@@ -66,14 +68,48 @@
       "sound_fail": "clang!",
       "items": [
         { "item": "scrap", "count": [ 2, 7 ] },
-        { "item": "steel_chunk", "count": [ 0, 3 ] },
-        { "item": "sheet_metal", "count": [ 2, 6 ] },
-        { "item": "cable", "charges": [ 1, 15 ] },
+        { "item": "afs_material_2", "count": [ 0, 1 ] },
+        { "item": "afs_material_1", "count": [ 2, 12 ] },
+        { "item": "afs_circuitry_2", "count": [ 0, 2 ] },
+        { "item": "afs_energy_storage_1", "count": [ 1, 2 ] },
         { "item": "afs_heat_2_salvage", "count": [ 1, 4 ] },
-        { "item": "afs_circuitry_1", "count": [ 1, 4 ] },
-        { "item": "afs_material_1", "count": [ 2, 5 ] },
+        { "item": "frame", "count": 1 },
+        { "item": "cable", "charges": [ 1, 15 ] },
+        { "item": "hose", "count": [ 0, 2 ] },
         { "item": "cu_pipe", "count": [ 1, 4 ] },
-        { "item": "scrap_copper", "count": [ 0, 2 ] }
+        { "item": "polycarbonate_sheet", "count": [ 1, 2 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_atmospheric_control",
+    "name": "atmospherics controller",
+    "looks_like": "f_console",
+    "description": "An imposing brick of circuitry inlaid tubing adorned with a single console.  It might still half-work, even after all this time.",
+    "symbol": "0",
+    "bgcolor": "white",
+    "move_cost_mod": -1,
+    "coverage": 55,
+    "required_str": -1,
+    "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "ALLOW_FIELD_EFFECT", "FLAMMABLE", "PLACE_ITEM" ],
+    "bash": {
+      "str_min": 18,
+      "str_max": 50,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "scrap", "count": [ 2, 7 ] },
+        { "item": "afs_material_1", "count": [ 2, 12 ] },
+        { "item": "afs_circuitry_2", "count": [ 0, 2 ] },
+        { "item": "afs_energy_storage_1", "count": [ 1, 2 ] },
+        { "item": "afs_heat_2_salvage", "count": [ 1, 4 ] },
+        { "item": "frame", "count": 1 },
+        { "item": "oxygen_tank", "prob": 15, "charges-min": 4 },
+        { "item": "cable", "charges": [ 1, 15 ] },
+        { "item": "hose", "count": [ 3, 10 ] },
+        { "item": "cu_pipe", "count": [ 5, 15 ] },
+        { "item": "polycarbonate_sheet", "count": [ 1, 2 ] }
       ]
     }
   }

--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat_machinery.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat_machinery.json
@@ -1,0 +1,80 @@
+[
+  {
+    "type": "furniture",
+    "id": "f_ECU",
+    "name": "ECU",
+    "looks_like": "f_air_filter",
+    "description": "The central node of a life support system, tasked with regulating atmospherics and water flow to the rest of an habitat or ship.",
+    "symbol": "0",
+    "bgcolor": "white",
+    "move_cost_mod": -1,
+    "coverage": 60,
+    "required_str": -1,
+    "flags": [ "CONTAINER", "PLACE_ITEM", "LIQUIDCONT", "NOITEM", "SEALED" ],
+    "examine_action": "fireplace",
+    "deconstruct": {
+      "items": [
+        { "item": "pipe", "count": 1 },
+        { "item": "small_lcd_screen", "count": 1 },
+        { "item": "afs_circuitry_1", "count": [ 1, 4 ] },
+        { "item": "afs_circuitry_2", "count": 1 },
+        { "item": "afs_material_1", "count": [ 2, 5 ] },
+        { "item": "scrap", "count": [ 2, 6 ] },
+        { "item": "steel_chunk", "count": [ 1, 3 ] },
+        { "item": "sheet_metal", "count": [ 2, 6 ] },
+        { "item": "cable", "charges": [ 1, 15 ] },
+        { "item": "cu_pipe", "count": [ 2, 5 ] },
+        { "item": "thermostat", "count": 1 },
+        { "item": "pipe_fittings", "count": [ 2, 6 ] },
+        { "item": "afs_circuitry_1", "count": [ 1, 4 ] }
+      ]
+    },
+    "bash": {
+      "str_min": 18,
+      "str_max": 50,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "scrap", "count": [ 2, 7 ] },
+        { "item": "steel_chunk", "count": [ 0, 3 ] },
+        { "item": "sheet_metal", "count": [ 2, 6 ] },
+        { "item": "afs_material_1", "count": [ 2, 5 ] },
+        { "item": "cable", "charges": [ 1, 15 ] },
+        { "item": "afs_circuitry_1", "count": [ 1, 4 ] },
+        { "item": "cu_pipe", "count": [ 1, 4 ] },
+        { "item": "afs_circuitry_1", "count": [ 1, 4 ] },
+        { "item": "scrap_copper", "count": [ 0, 2 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_cryofluid_pump",
+    "name": "Cryo-fluid pump",
+    "looks_like": "f_standing_tank",
+    "description": "An insulated metal tank prepared for the storage of exotic cryo-coolants.  Relatively advanced in construction, it can be disassembled for valuable scrap.",
+    "symbol": "0",
+    "bgcolor": "white",
+    "move_cost_mod": -1,
+    "coverage": 55,
+    "required_str": -1,
+    "flags": [ "CONTAINER", "PLACE_ITEM", "LIQUIDCONT", "NOITEM", "SEALED" ],
+    "bash": {
+      "str_min": 18,
+      "str_max": 50,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "scrap", "count": [ 2, 7 ] },
+        { "item": "steel_chunk", "count": [ 0, 3 ] },
+        { "item": "sheet_metal", "count": [ 2, 6 ] },
+        { "item": "cable", "charges": [ 1, 15 ] },
+        { "item": "afs_heat_2_salvage", "count": [ 1, 4 ] },
+        { "item": "afs_circuitry_1", "count": [ 1, 4 ] },
+        { "item": "afs_material_1", "count": [ 2, 5 ] },
+        { "item": "cu_pipe", "count": [ 1, 4 ] },
+        { "item": "scrap_copper", "count": [ 0, 2 ] }
+      ]
+    }
+  }
+]

--- a/data/mods/Aftershock/maps/mapgen/stratoscomm_relay.json
+++ b/data/mods/Aftershock/maps/mapgen/stratoscomm_relay.json
@@ -74,6 +74,7 @@
       "terrain": { "5": "t_ramp_up_high", "6": "t_ramp_up_low", "#": "t_rock" },
       "furniture": {
         "@": "f_sleep_pod",
+        "~": "f_shower",
         "1": [ "f_mil_comms_power", "f_mil_comms_power_broken" ],
         "2": "f_mil_comms_terminal",
         "3": "f_mil_comms_heatsink",

--- a/data/mods/Aftershock/maps/mapgen_pallete/afs_habitat_structure.json
+++ b/data/mods/Aftershock/maps/mapgen_pallete/afs_habitat_structure.json
@@ -30,7 +30,7 @@
       ">": "t_stairs_down",
       "<": "t_stairs_up"
     },
-    "furniture": { "~": "f_habitat_bathroom", "^": "f_sink", "*": "f_sink", "%": "f_fireman_cabinet"}
+    "furniture": { "~": "f_habitat_bathroom", "^": "f_sink", "*": "f_sink", "%": "f_fireman_cabinet" }
   },
   {
     "type": "palette",

--- a/data/mods/Aftershock/maps/mapgen_pallete/afs_habitat_structure.json
+++ b/data/mods/Aftershock/maps/mapgen_pallete/afs_habitat_structure.json
@@ -30,7 +30,7 @@
       ">": "t_stairs_down",
       "<": "t_stairs_up"
     },
-    "furniture": { "~": "f_shower", "^": "f_sink", "*": "f_sink" }
+    "furniture": { "~": "f_habitat_bathroom", "^": "f_sink", "*": "f_sink", "%": "f_fireman_cabinet"}
   },
   {
     "type": "palette",
@@ -54,8 +54,8 @@
     "terrain": { "p": "t_sewage_pipe" },
     "furniture": {
       "@": "f_bed",
-      "f": "f_table",
-      "y": "f_table",
+      "f": "f_workbench",
+      "y": "f_workbench",
       "c": "f_console_broken",
       "h": "f_chair",
       "P": "f_water_purifier",
@@ -64,13 +64,10 @@
       "E": "f_machinery_electronic",
       "L": "f_machinery_light",
       "H": "f_machinery_heavy",
-      "O": "f_machinery_old",
+      "O": "f_ECU",
+      "T": "f_cryofluid_pump",
       "p": "f_solar_unit",
-      "t": "f_toposcan_process",
-      "T": "f_toposcan_terminal",
-      "S": "f_toposcan_scanner",
       "F": "f_fridge",
-      "^": "f_sink",
       "j": "f_counter",
       "q": "f_rack",
       "r": "f_bookcase",
@@ -86,6 +83,34 @@
         { "item": "afs_tools_structural_repair", "chance": 20, "repeat": [ 2, 5 ] }
       ],
       "k": { "item": "SUS_office_desk", "chance": 60 },
+      "l": { "item": "afs_frontier_cryo_g", "chance": 50 },
+      "@": { "item": "bed", "chance": 50 },
+      "v": { "item": "trash", "chance": 30, "repeat": [ 1, 4 ] }
+    }
+  },
+  {
+    "type": "palette",
+    "id": "afs_habitat_residential_furnishing",
+    "furniture": {
+      "@": "f_bed",
+      "f": "f_workbench",
+      "y": "f_table",
+      "c": "f_console_broken",
+      "h": "f_chair",
+      "j": "f_counter",
+      "o": "f_habitat_kitchenette",
+      "W": "f_habitat_storage_board",
+      "U": "f_habitat_storage_board",
+      "n": "f_screenmirror",
+      "q": "f_rack",
+      "v": "f_trashcan",
+      "l": "f_locker",
+      "k": "f_desk"
+    },
+    "items": {
+      "o": { "item": "afs_kitchenette", "chance": 60 },
+      "U": { "item": "afs_old_food_storage", "chance": 60 },
+      "W": { "item": "afs_colonist_outfit", "chance": 60 },
       "l": { "item": "afs_frontier_cryo_g", "chance": 50 },
       "@": { "item": "bed", "chance": 50 },
       "v": { "item": "trash", "chance": 30, "repeat": [ 1, 4 ] }


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Furniture for habitats"

#### Purpose of change
Mapgen pieces for the upcoming Aftershock habitats.

#### Describe the solution
New palettes and furniture.
Depends on #62818 

#### Testing
