### PR TITLE
Map optimizations

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8454,17 +8454,6 @@ bool map::inbounds( const tripoint_abs_ms &p ) const
     return inbounds( getlocal( p ) );
 }
 
-bool map::inbounds( const tripoint &p ) const
-{
-    static constexpr tripoint map_boundary_min( 0, 0, -OVERMAP_DEPTH );
-    static constexpr tripoint map_boundary_max( MAPSIZE_Y, MAPSIZE_X, OVERMAP_HEIGHT + 1 );
-
-    static constexpr half_open_cuboid<tripoint> map_boundaries(
-        map_boundary_min, map_boundary_max );
-
-    return map_boundaries.contains( p );
-}
-
 bool map::inbounds( const tripoint_bub_ms &p ) const
 {
     return inbounds( p.raw() );
@@ -8478,16 +8467,6 @@ bool map::inbounds( const tripoint_abs_omt &p ) const
            p.y() >= map_origin.y() &&
            p.x() <= map_origin.x() + my_HALF_MAPSIZE &&
            p.y() <= map_origin.y() + my_HALF_MAPSIZE;
-}
-
-bool tinymap::inbounds( const tripoint &p ) const
-{
-    constexpr tripoint map_boundary_min( 0, 0, -OVERMAP_DEPTH );
-    constexpr tripoint map_boundary_max( SEEY * 2, SEEX * 2, OVERMAP_HEIGHT + 1 );
-
-    constexpr half_open_cuboid<tripoint> map_boundaries( map_boundary_min, map_boundary_max );
-
-    return map_boundaries.contains( p );
 }
 
 // set up a map just long enough scribble on it
@@ -8641,6 +8620,7 @@ void map::build_outside_cache( const int zlev )
     if( zlev < 0 ) {
         std::uninitialized_fill_n(
             &outside_cache[0][0], MAPSIZE_X * MAPSIZE_Y, false );
+        ch.outside_cache_dirty = false;
         return;
     }
 

--- a/src/map.h
+++ b/src/map.h
@@ -1764,7 +1764,13 @@ class map
         tripoint_bub_ms bub_from_abs( const tripoint &p ) const;
         tripoint_bub_ms bub_from_abs( const tripoint_abs_ms &p ) const;
         // TODO: fix point types (remove the first overload)
-        virtual bool inbounds( const tripoint &p ) const;
+        bool inbounds(const tripoint& p) const {
+            half_open_cuboid<tripoint> map_boundaries(
+                tripoint(0, 0, -OVERMAP_DEPTH),
+                tripoint(SEEY * my_MAPSIZE, SEEX * my_MAPSIZE, OVERMAP_HEIGHT + 1)
+            );
+            return map_boundaries.contains(p);
+        }
         bool inbounds( const tripoint_bub_ms &p ) const;
         bool inbounds( const tripoint_abs_ms &p ) const;
         bool inbounds( const tripoint_abs_sm &p ) const {
@@ -2261,7 +2267,6 @@ class tinymap : public map
         friend class editmap;
     public:
         tinymap() : map( 2, false ) {}
-        bool inbounds( const tripoint &p ) const override;
 };
 
 class fake_map : public tinymap

--- a/src/map.h
+++ b/src/map.h
@@ -1764,12 +1764,12 @@ class map
         tripoint_bub_ms bub_from_abs( const tripoint &p ) const;
         tripoint_bub_ms bub_from_abs( const tripoint_abs_ms &p ) const;
         // TODO: fix point types (remove the first overload)
-        bool inbounds(const tripoint& p) const {
+        bool inbounds( const tripoint &p ) const {
             half_open_cuboid<tripoint> map_boundaries(
-                tripoint(0, 0, -OVERMAP_DEPTH),
-                tripoint(SEEY * my_MAPSIZE, SEEX * my_MAPSIZE, OVERMAP_HEIGHT + 1)
+                tripoint( 0, 0, -OVERMAP_DEPTH ),
+                tripoint( SEEY * my_MAPSIZE, SEEX * my_MAPSIZE, OVERMAP_HEIGHT + 1 )
             );
-            return map_boundaries.contains(p);
+            return map_boundaries.contains( p );
         }
         bool inbounds( const tripoint_bub_ms &p ) const;
         bool inbounds( const tripoint_abs_ms &p ) const;


### PR DESCRIPTION
#### Summary
Performance "Improve map code"

#### Purpose of change
Generally improve map's code

#### Describe the solution
1) Devirtualize `in_bounds`, as it is called _a lot_ and is duplicated in tiny_map. Also, move base functions to header file for inlining.
2) Mark outside_cache as non-dirty on negative z-levels as well to prevent memset loops.

#### Testing
Test suite