### PR TITLE
Add bodygraph with wetness data

### DIFF
--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -163,14 +163,14 @@ void Character::update_body_wetness( const w_point &weather )
         }
 
         // Add effects to track wetness
-        const int updatedWetness = get_part_wetness( bp );
-        const int wetnessCapacity = get_part_drench_capacity( bp );
-        if( updatedWetness < wetnessCapacity * .3 ) {
-            add_effect( effect_wet, 1_turns, bp, true, 1 );
-        } else if( updatedWetness < wetnessCapacity * .6 ) {
-            add_effect( effect_wet, 1_turns, bp, true, 2 );
-        } else if( updatedWetness < wetnessCapacity ) {
-            add_effect( effect_wet, 1_turns, bp, true, 3 );
+        if( get_part_wetness( bp ) > 0 ) {
+            const float wetness_pct = get_part_wetness_percentage( bp );
+            const int effect_level =
+                wetness_pct < BODYWET_PERCENT_WET ? 1 :
+                wetness_pct < BODYWET_PERCENT_SOAKED ? 2 :
+                3;
+
+            add_effect( effect_wet, 1_turns, bp, true, effect_level );
         }
     }
 }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -39,11 +39,12 @@ static const itype_id fuel_type_muscle( "muscle" );
 // Cache for the overmap widget string
 static disp_overmap_cache disp_om_cache;
 // Cache for the bodygraph widget string
-static std::array<disp_bodygraph_cache, 4> disp_bg_cache = { {
+static std::array<disp_bodygraph_cache, 5> disp_bg_cache = { {
         disp_bodygraph_cache( bodygraph_var::hp ),
         disp_bodygraph_cache( bodygraph_var::temp ),
         disp_bodygraph_cache( bodygraph_var::encumb ),
-        disp_bodygraph_cache( bodygraph_var::status )
+        disp_bodygraph_cache( bodygraph_var::status ),
+        disp_bodygraph_cache( bodygraph_var::wet )
     }
 };
 
@@ -1599,6 +1600,21 @@ nc_color display::get_bodygraph_bp_color( const Character &u, const bodypart_id 
         }
         case bodygraph_var::status: {
             return display::limb_color( u, bid, true, true, true );
+        }
+        case bodygraph_var::wet: {
+            const int cur_wet = u.get_part_wetness( bid );
+            if( cur_wet == 0 ) {
+                return c_light_gray; // dry
+            } else {
+                const float cur_wet = u.get_part_wetness_percentage( bid );
+                if( cur_wet < BODYWET_PERCENT_WET ) {
+                    return c_light_cyan;
+                } else if( cur_wet < BODYWET_PERCENT_SOAKED ) {
+                    return c_light_blue;
+                } else {
+                    return c_blue; // maximum wetness
+                }
+            }
         }
         // Fall-through - invalid
         case bodygraph_var::last:

--- a/src/display.h
+++ b/src/display.h
@@ -12,6 +12,7 @@ enum class bodygraph_var : int {
     temp,        // temperature
     encumb,      // encumbrance
     status,      // limb status (bite, bleeding, ...)
+    wet,         // wetness
     last // END OF ENUMS
 };
 

--- a/src/weather.h
+++ b/src/weather.h
@@ -45,6 +45,13 @@ static constexpr int BODYTEMP_SCORCHING = 9500;
 static constexpr int BODYTEMP_THRESHOLD = 500;
 ///@}
 
+// Wetness percentage 0.0f is DRY
+// Level 1 wetness (DAMP) is between 0.0f and Level 2
+// Level 2 wetness percentage
+static constexpr float BODYWET_PERCENT_WET = 0.3f;
+// Level 3 wetness percentage
+static constexpr float BODYWET_PERCENT_SOAKED = 0.6f;
+
 // Rough tresholds for sunlight intensity in W/m2.
 namespace irradiance
 {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -135,6 +135,8 @@ std::string enum_to_string<widget_var>( widget_var data )
             return "body_graph_encumb";
         case widget_var::body_graph_status:
             return "body_graph_status";
+        case widget_var::body_graph_wet:
+            return "body_graph_wet";
         case widget_var::bp_armor_outer_text:
             return "bp_armor_outer_text";
         case widget_var::carry_weight_text:
@@ -1000,6 +1002,7 @@ bool widget::uses_text_function() const
         case widget_var::body_graph_temp:
         case widget_var::body_graph_encumb:
         case widget_var::body_graph_status:
+        case widget_var::body_graph_wet:
         case widget_var::bp_armor_outer_text:
         case widget_var::carry_weight_text:
         case widget_var::compass_text:
@@ -1089,6 +1092,12 @@ std::string widget::color_text_function_string( const avatar &ava, unsigned int 
         case widget_var::body_graph_status:
             desc.first = display::colorized_bodygraph_text( ava, _body_graph,
                          bodygraph_var::status, _width == 0 ? max_width : _width, _height_max, _height );
+            update_height = true; // Dynamically adjusted height
+            apply_color = false; // Already colorized
+            break;
+        case widget_var::body_graph_wet:
+            desc.first = display::colorized_bodygraph_text( ava, _body_graph,
+                         bodygraph_var::wet, _width == 0 ? max_width : _width, _height_max, _height );
             update_height = true; // Dynamically adjusted height
             apply_color = false; // Already colorized
             break;

--- a/src/widget.h
+++ b/src/widget.h
@@ -50,6 +50,7 @@ enum class widget_var : int {
     body_graph_temp,     // Body graph showing color-coded body part temperature
     body_graph_encumb,     // Body graph showing color-coded body part encumbrance
     body_graph_status,     // Body graph showing color-coded body part status (bite, bleeding, ...)
+    body_graph_wet,        // Body graph showing color-coded body part wetness
     bp_armor_outer_text, // Outermost armor on body part, with color/damage bars
     carry_weight_text,   // Weight carried, relative to capacity, in %
     compass_text,   // Compass / visible threats by cardinal direction


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add bodygraph displaying wetness status"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I was making a custom sidebar and noticed that there are bodygraphs for hitpoints, encumbrance, body temperature and bodypart status, but wetness was missing. So I decided to add it to expand modding options.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This PR adds another bodygraph, which displays wetness of the corresponding body part. The bodygraph can be used same as the other 4 to build custom sidebar widgets (see the attached screenshot). 

![bodygraph_wet](https://user-images.githubusercontent.com/1553853/213035495-634a5611-4cf8-4dcd-aa35-946e5704dd67.png)

Sample widget json:

```
  {
    "id": "body_graph_wet",
    "type": "widget",
    "copy-from": "compact_body_graph_template",
    "var": "body_graph_wet"
  }
```

Wetness is color-coded as follows:
```
0%               - light gray (Dry)
0%  <  ... < 30% - light cyan (Damp)
30% <= ... < 60% - light blue (Wet)
60% <= ...       - blue (Soaked)
```
I took these breakpoints from the code that applies the wetness effect (src/character_body.cpp), and moved them to 2 new constants in weather.h

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Created a widget in a custom sidebar (sample code above), walked around, got wet, got dry (slowly), observed that the bodygraph colors match wetness effects in player info screen **'@'** and body part wetness percentage in Body Status screen **'{'**.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
