### PR TITLE
Make shells outer in addition to strapped

### DIFF
--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -704,7 +704,7 @@
     "color": "magenta",
     "warmth": 5,
     "environmental_protection": 10,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "BELTED", "WATERPROOF", "PADDED" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "BELTED", "WATERPROOF", "PADDED" ],
     "armor": [
       {
         "material": [ { "type": "chitin_light", "covered_by_mat": 100, "thickness": 10 } ],
@@ -738,7 +738,7 @@
     ],
     "warmth": 7,
     "environmental_protection": 13,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "BELTED", "WATERPROOF", "PADDED" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "BELTED", "WATERPROOF", "PADDED" ],
     "armor": [
       {
         "material": [ { "type": "chitin_light", "covered_by_mat": 100, "thickness": 15 } ],
@@ -772,7 +772,7 @@
     ],
     "warmth": 7,
     "environmental_protection": 13,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "BELTED", "WATERPROOF", "PADDED" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "BELTED", "WATERPROOF", "PADDED" ],
     "armor": [
       {
         "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 20 } ],

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -709,6 +709,7 @@
       {
         "material": [ { "type": "chitin_light", "covered_by_mat": 100, "thickness": 10 } ],
         "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper", "torso_lower", "torso_hanging_back" ],
         "coverage": 100,
         "encumbrance": 5
       }
@@ -743,6 +744,7 @@
       {
         "material": [ { "type": "chitin_light", "covered_by_mat": 100, "thickness": 15 } ],
         "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper", "torso_lower", "torso_hanging_back" ],
         "coverage": 100,
         "encumbrance": 10
       }
@@ -777,6 +779,7 @@
       {
         "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 20 } ],
         "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper", "torso_lower", "torso_hanging_back" ],
         "coverage": 100,
         "encumbrance": 10
       }


### PR DESCRIPTION
#### Summary
Balance "Make integrated shells outer in addition to strapped"

#### Purpose of change
Apparently, you could wear rigid armor over integrated shells, which doesn't make much sense at all. Oops!

#### Describe the solution
Give the OUTER tag to all 3 integrated shells (in addition to BELTED so backpacks etc still give you extra enc).

#### Describe alternatives you've considered
Leaving as is.

#### Testing
![image](https://user-images.githubusercontent.com/52408044/213160611-2e972ee5-7d78-4bd2-a940-fcaa4f9b28bd.png)

#### Additional context
N/A.
