### PR TITLE
Prevent loot-generation errors during ranged_balance_test

### DIFF
--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -142,9 +142,11 @@ void clear_map_and_put_player_underground()
     get_player_character().setpos( { 0, 0, -2 } );
 }
 
-monster &spawn_test_monster( const std::string &monster_type, const tripoint &start )
+monster &spawn_test_monster( const std::string &monster_type, const tripoint &start,
+                             const bool death_drops )
 {
     monster *const added = g->place_critter_at( mtype_id( monster_type ), start );
+    added->death_drops = death_drops;
     cata_assert( added );
     return *added;
 }

--- a/tests/map_helpers.h
+++ b/tests/map_helpers.h
@@ -21,7 +21,7 @@ void clear_map( int zmin = -2, int zmax = 0 );
 void clear_radiation();
 void clear_map_and_put_player_underground();
 monster &spawn_test_monster( const std::string &monster_type, const tripoint &start,
-                             const bool death_drops = true );
+                             bool death_drops = true );
 void clear_vehicles( map *target = nullptr );
 void build_test_map( const ter_id &terrain );
 void player_add_headlamp();

--- a/tests/map_helpers.h
+++ b/tests/map_helpers.h
@@ -20,7 +20,8 @@ void clear_zones();
 void clear_map( int zmin = -2, int zmax = 0 );
 void clear_radiation();
 void clear_map_and_put_player_underground();
-monster &spawn_test_monster( const std::string &monster_type, const tripoint &start );
+monster &spawn_test_monster( const std::string &monster_type, const tripoint &start,
+                             const bool death_drops = true );
 void clear_vehicles( map *target = nullptr );
 void build_test_map( const ter_id &terrain );
 void player_add_headlamp();

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -455,6 +455,9 @@ static void shoot_monster( const std::string &gun_type, const std::vector<std::s
         arm_shooter( *shooter, gun_type, mods, ammo_type );
         shooter->recoil = 0;
         monster &mon = spawn_test_monster( monster_type, monster_pos );
+        // This is weapon damage test, no need to spawn loot on death (and
+        // trigger obscure loot-generation errors in this test):
+        mon.death_drops = false;
         const int prev_HP = mon.get_hp();
         shooter->fire_gun( monster_pos, 1, *shooter->get_wielded_item() );
         damage.add( prev_HP - mon.get_hp() );

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -454,10 +454,7 @@ static void shoot_monster( const std::string &gun_type, const std::vector<std::s
         shooter->set_body();
         arm_shooter( *shooter, gun_type, mods, ammo_type );
         shooter->recoil = 0;
-        monster &mon = spawn_test_monster( monster_type, monster_pos );
-        // This is weapon damage test, no need to spawn loot on death (and
-        // trigger obscure loot-generation errors in this test):
-        mon.death_drops = false;
+        monster &mon = spawn_test_monster( monster_type, monster_pos, false );
         const int prev_HP = mon.get_hp();
         shooter->fire_gun( monster_pos, 1, *shooter->get_wielded_item() );
         damage.add( prev_HP - mon.get_hp() );

--- a/tests/throwing_test.cpp
+++ b/tests/throwing_test.cpp
@@ -98,7 +98,7 @@ static void test_throwing_player_versus(
         you.set_stamina( you.get_stamina_max() );
 
         you.wield( it );
-        monster &mon = spawn_test_monster( mon_id, monster_start );
+        monster &mon = spawn_test_monster( mon_id, monster_start, false );
         mon.set_moves( 0 );
 
         dealt_projectile_attack atk = you.throw_item( mon.pos(), it );
@@ -250,7 +250,7 @@ static void test_player_kills_monster(
 
         reset_player( you, pstats, player_start );
 
-        monster &mon = spawn_test_monster( mon_id, monster_start );
+        monster &mon = spawn_test_monster( mon_id, monster_start, false );
         mon.set_moves( 0 );
 
         while( !mon_is_dead ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent loot-generation during ranged weapons tests"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Ranged balance test was occasionally failing due to rare loot-generation issues (details below). 
This test is about 'shooting' creatures and testing damage output, dispersion etc. The items generated on creature's death are not used in any way. Therefore I suggest to turn off item drops for these 'test monsters' and avoid random build errors in PR workflows (see this PR for example: #63158 )

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes  
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

After the change (setting _monster.death_drops_ to false), this should not run, when the monster::die() is called (src/monster.cpp):
```
if( death_drops && !no_extra_death_drops ) {
     drop_items_on_death( corpse );
     spawn_dissectables_on_death( corpse );
 }

```

Otherwise the following can happen:
During loot generation, sometimes a container has too many items spawned for it (too much volume or weight). In game we get an error message saying something like:

ERROR : src/item.cpp:1495 [ret_val<void> item::put_in(const item &, item_pocket::pocket_type, const bool)] tried to put an item (creepy_doll) count (1) in a container (purse) that cannot contain it: pocket unacceptable because not enough space

This can happens even for regular zombies:
1. Zombie dies and its loot is generated
2. It can get  'small_bags' item_group, which has "contents-group": "default_zombie_items_bags_small"
3. 'small_bags' can become a 'purse' (5 L volume)
4. 'default_zombie_items_bags_small' in general has some small items + 50% chance for 'default_zombie_items_pockets'
5. 'default_zombie_items_pockets' also has small items and can get a 'softdrugs' category. Up to now the total volume of generated items very rarely reaches 3 L volume
6. But the 'softdrugs' item_group can potentially give us one of these:
  - 'alcohol_wipes' (which come in a small cardboard box (2.25 L)
  - 'used_1st_aid' item_group, which is a bunch of misc medical stuff with a 'container-item': '1st_aid_box' (2.9 L)  
7. When the code tries to put items into the purse, and there is not enough capacity, the game uses this debugmsg:

src/item.cpp:

```
ret_val<void> item::put_in( const item &payload, item_pocket::pocket_type pk_type, 
                            const bool unseal_pockets ) 
{      
    ret_val<item_pocket *> result = contents.insert_item( payload, pk_type ); 
    if( !result.success() ) { 
        debugmsg( "tried to put an item (%s) count (%d) in a container (%s) that cannot contain it: %s", 
                  payload.typeId().str(), payload.count(), typeId().str(), result.str() ); 
    } 
    ...

```

During the game it causes an error, but is a mild annoyance, the game can be continued fine (the excessive items are gone though).
But when this happens during tests, the PR workflow fails:

```
 ([slow] ~starting_items)=> (continued from above) ERROR : src/item.cpp:1495 [ret_val<void> item::put_in(const item &, item_pocket::pocket_type, const bool)] tried to put an item (creepy_doll) count (1) in a container (purse) that cannot contain it: pocket unacceptable because not enough space20.332 s: shot_features
([slow] ~starting_items)=> 18.893 s: shot_features_with_choke
([slow] ~starting_items)=> 154.325 s: starve_test
([slow] ~starting_items)=> 81.990 s: starve_test_hunger3
([slow] ~starting_items)=> 89.891 s: all_nutrition_starve_test
([slow] ~starting_items)=> ===============================================================================
([slow] ~starting_items)=> All tests passed (44056 assertions in 13 test cases)
([slow] ~starting_items)=> 
([slow] ~starting_items)=> 
([slow] ~starting_items)=> 01:26:41.610 INFO : Ended test at Wed Jan 18 01:26:41 2023
([slow] ~starting_items)=> 
([slow] ~starting_items)=> 01:26:41.611 INFO : The test took 1520.03 seconds
([slow] ~starting_items)=> 01:26:41.611 INFO : Randomness seeded to: 1674003632
([slow] ~starting_items)=> 01:26:41.611 INFO : Treating result as failure due to error logged during tests.
test exited with code 1
```



<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Remove the debugmsg in this case (maybe a warning could be logged somewhere?)
Instead of showing in-game error create a tiny static analysis tool to find 100% of such potentially problematic item_groups (when there is a non-zero probability of the container's capacity being overflown by the generated loot). This could be run anytime on the json data and report all such possible issues to the developer/modder instead of occasionally popping error messages to the players (and failing PR workflows). 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Assign custom drops with deliberately too much loot in some container for the test monster. Run the tests, observe no errors from ranged_balance_test

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
