### PR TITLE
Fix newcharacter screen hobby skills calculation

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3627,7 +3627,8 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                     profession::StartingSkillList::iterator i = hobby_skills.begin();
                     while( i != hobby_skills.end() ) {
                         if( i->first == elem->ident() ) {
-                            int skill_exp_bonus = calculate_cumulative_experience( i->second );
+                            int skill_exp_bonus = leftover_exp + calculate_cumulative_experience( i->second );
+                            leftover_exp = 0;
 
                             // Calculate Level up to find final level and remaining exp
                             while( skill_exp_bonus >= exp_to_level ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "newcharacter screen displays incorrect skill levels from profs/hobbies"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The last step during character generation displays character summary. Among other things it shows the skill levels that result from choices made during character generation.
But the code can miscalculate the actual skill experience that the character will have when the game starts. This happens when you choose several 'hobbies' that give bonus to the same skill. The code is discarding hobby skill experience which cannot bump the skill to the next level. And the more hobbies you choose - the larger error accumulates (eventually under-reporting full levels).

See this example (lots of bonuses to athletics, dodging, throwing):

![newchar1](https://user-images.githubusercontent.com/1553853/213706735-773863df-0ece-4c37-93a6-bc86583d0751.png)

The actual skill levels:

![realnewchar1](https://user-images.githubusercontent.com/1553853/213707173-d87ce3d5-8f20-4deb-bfe4-b146763ae9cd.png)

Athletics: 4.88 vs 4.04
Dodging: 3.75 vs 3.06
Throwing: 3.12 vs 2.11


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added the leftover_exp from the previous hobby to the calculated skill exp of the next one.
Now the numbers match the real skill levels after the game started:

![newchar2](https://user-images.githubusercontent.com/1553853/213711141-83ef0920-a166-4391-8047-b15ea48ac5fe.png)


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Create a character with multiple hobbies that give bonus to the same skill. Note the reported skills on the last page of character generation screen. Start the game and look at skills and compare to what was shown on character generation.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
