### PR TITLE
Change tree felling to produce furniture `f_trunk` instead of overwriting terrain to `t_trunk`

### DIFF
--- a/data/json/furniture_and_terrain/furniture-flora.json
+++ b/data/json/furniture_and_terrain/furniture-flora.json
@@ -1,6 +1,24 @@
 [
   {
     "type": "furniture",
+    "id": "f_trunk",
+    "name": "tree trunk",
+    "description": "A section of trunk from a tree that has been cut down.  Can be sawn into logs with the right tool.",
+    "symbol": "1",
+    "color": "brown",
+    "move_cost_mod": 4,
+    "coverage": 45,
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "REDUCE_SCENT", "MOUNTABLE", "SHORT" ],
+    "bash": {
+      "str_min": 80,
+      "str_max": 180,
+      "sound": "crunch!",
+      "sound_fail": "whack!",
+      "items": [ { "item": "splinter", "count": [ 5, 15 ] } ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_mutpoppy",
     "name": "mutated poppy flower",
     "description": "These strange flowers have appeared in the wake of the Cataclysm, and their buds can be used for medicinal purposes, like the seeds of the mundane poppy they're named after.  The dirt around them gently churns as their roots writhe beneath the soil, and it's surrounded by an overwhelming floral smell that makes you feel sleepy.",

--- a/data/json/furniture_and_terrain/furniture-flora.json
+++ b/data/json/furniture_and_terrain/furniture-flora.json
@@ -6,7 +6,9 @@
     "description": "A section of trunk from a tree that has been cut down.  Can be sawn into logs with the right tool.",
     "symbol": "1",
     "color": "brown",
-    "move_cost_mod": 4,
+    "looks_like": "t_trunk",
+    "move_cost_mod": 2,
+    "required_str": -1,
     "coverage": 45,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "REDUCE_SCENT", "MOUNTABLE", "SHORT" ],
     "bash": {

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -2265,6 +2265,7 @@
   {
     "type": "terrain",
     "id": "t_trunk",
+    "//": "slated for removal after all uses satisfactorily migrated to f_trunk",
     "name": "tree trunk",
     "description": "A section of trunk from a tree that has been cut down.  Can be sawn into logs with the right tool.",
     "symbol": "1",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5605,7 +5605,7 @@ void chop_tree_activity_actor::finish( player_activity &act, Character &who )
     std::vector<tripoint> tree = line_to( pos, to, rng( 1, 8 ) );
     for( const tripoint &elem : tree ) {
         here.batter( elem, 300, 5 );
-        here.ter_set( elem, t_trunk );
+        here.furn_set( elem, f_trunk );
     }
 
     here.ter_set( pos, t_stump );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -4254,7 +4254,7 @@ int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate
             std::vector<tripoint> tree = line_to( p, to, rng( 1, 8 ) );
             for( tripoint &elem : tree ) {
                 target_bay.destroy( elem );
-                target_bay.ter_set( elem, t_trunk );
+                target_bay.furn_set( elem, f_trunk );
             }
             target_bay.ter_set( p, t_dirt );
             harvested++;

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1194,7 +1194,7 @@ furn_id f_null, f_clear,
         f_large_canvas_door, f_large_canvas_door_o, f_center_groundsheet, f_skin_wall, f_skin_door,
         f_skin_door_o, f_skin_groundsheet,
         f_mutpoppy, f_flower_fungal, f_fungal_mass, f_fungal_clump,
-        f_cattails, f_lotus, f_lilypad,
+        f_trunk, f_cattails, f_lotus, f_lilypad,
         f_safe_c, f_safe_l, f_safe_o,
         f_plant_seed, f_plant_seedling, f_plant_mature, f_plant_harvest,
         f_fvat_empty, f_fvat_full,
@@ -1286,6 +1286,7 @@ void set_furn_ids()
     f_fungal_mass = furn_id( "f_fungal_mass" );
     f_fungal_clump = furn_id( "f_fungal_clump" );
     f_flower_fungal = furn_id( "f_flower_fungal" );
+    f_trunk = furn_id( "f_trunk" );
     f_cattails = furn_id( "f_cattails" );
     f_lilypad = furn_id( "f_lilypad" );
     f_lotus = furn_id( "f_lotus" );

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -809,7 +809,7 @@ about ter_id above.
 */
 // NOLINTNEXTLINE(cata-static-int_id-constants)
 extern furn_id f_null, f_clear,
-       f_hay, f_cattails, f_lotus, f_lilypad,
+       f_hay, f_trunk, f_cattails, f_lotus, f_lilypad,
        f_rubble, f_rubble_rock, f_wreckage, f_ash,
        f_barricade_road, f_sandbag_half, f_sandbag_wall,
        f_bulletin,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Change tree felling to produce furniture `f_trunk` instead of overwriting terrain to `t_trunk`"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Resolves #42428
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- [x] add furniture `f_trunk`, it will exist alongside `t_trunk` for now
  - fundamentally identical; move cost adjusted down as it is now calculated in addition to underlying terrain's move cost
- [x] change tree felling so that it produces furniture `f_trunk` instead of overwriting terrain to `t_trunk`
  - [ ] if original tile is open air, should impact next valid z-level below rather than hang in mid-air
- [ ] modify existing methods of chopping up trunks so that both `f_trunk` and `t_trunk` are acceptable inputs (for the time being)

#### Future work
Will not be addressed in this PR

- jsonize deconstruction for `f_trunk`
  - eliminate hardcoded means for chopping up trunks, or  
convert them to wrappers for the jsonized deconstruction
- eliminate `t_trunk` from mapgens etc
- :grey_question: somehow migrate any existing `t_trunk` in existing saves :grey_question:
- eventual complete elimination of `t_trunk`

#### Testing
Not yet
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Describe alternatives you've considered
Make the trunk an item rather than furniture, but I don't think it was intended to be something that could be moved around with ease.

#### Additional context
No new strings, as `f_trunk` is copied directly from `t_trunk`