### PR TITLE
Remove redundant `FARM_WOOD` constructions

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -73,18 +73,6 @@
   },
   {
     "type": "construction",
-    "id": "constr_chop_trunk",
-    "group": "chop_tree_trunk_into_planks",
-    "category": "FARM_WOOD",
-    "required_skills": [ [ "survival", 2 ] ],
-    "time": "60 m",
-    "qualities": [ [ { "id": "AXE", "level": 2 }, { "id": "SAW_W", "level": 2 } ] ],
-    "pre_terrain": "t_trunk",
-    "post_terrain": "t_dirt",
-    "post_special": "done_trunk_plank"
-  },
-  {
-    "type": "construction",
     "id": "constr_improvised_shelter",
     "group": "build_improvised_shelter",
     "category": "CONSTRUCT",

--- a/data/json/construction_category.json
+++ b/data/json/construction_category.json
@@ -42,11 +42,6 @@
   },
   {
     "type": "construction_category",
-    "id": "FARM_WOOD",
-    "name": "Farming and Woodcutting"
-  },
-  {
-    "type": "construction_category",
     "id": "TOOL",
     "name": "Tools"
   },

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -911,11 +911,6 @@
   },
   {
     "type": "construction_group",
-    "id": "chop_tree_trunk_into_planks",
-    "name": "Chop Tree Trunk Into Planks"
-  },
-  {
-    "type": "construction_group",
     "id": "clean_broken_window",
     "name": "Clean Broken Window"
   },

--- a/data/mods/CRT_EXPANSION/construction_group.json
+++ b/data/mods/CRT_EXPANSION/construction_group.json
@@ -1,11 +1,6 @@
 [
   {
     "type": "construction_group",
-    "id": "chop_tree_trunk_into_logs",
-    "name": "Chop Tree Trunk Into Logs"
-  },
-  {
-    "type": "construction_group",
     "id": "makeshift_wall",
     "name": "Makeshift Wall"
   }

--- a/data/mods/CRT_EXPANSION/constructions/crt_constructions.json
+++ b/data/mods/CRT_EXPANSION/constructions/crt_constructions.json
@@ -97,18 +97,6 @@
   },
   {
     "type": "construction",
-    "id": "constr_crt_chop_trunk",
-    "group": "chop_tree_trunk_into_logs",
-    "category": "FARM_WOOD",
-    "required_skills": [ [ "survival", 2 ] ],
-    "time": "45 m",
-    "qualities": [ [ { "id": "AXE", "level": 3 }, { "id": "SAW_W", "level": 1 } ] ],
-    "byproducts": [ { "item": "log", "count": [ 1, 3 ] } ],
-    "pre_terrain": "t_trunk",
-    "post_terrain": "t_dirt"
-  },
-  {
-    "type": "construction",
     "id": "constr_crt_wall_stick",
     "group": "makeshift_wall",
     "category": "OTHER",

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -156,7 +156,6 @@ static bool check_no_wiring( const tripoint_bub_ms & );
 
 // Special actions to be run post-terrain-mod
 static void done_nothing( const tripoint_bub_ms &, Character & ) {}
-static void done_trunk_plank( const tripoint_bub_ms &, Character & );
 static void done_grave( const tripoint_bub_ms &, Character & );
 static void done_vehicle( const tripoint_bub_ms &, Character & );
 static void done_appliance( const tripoint_bub_ms &, Character & );
@@ -1333,15 +1332,6 @@ bool construct::check_no_wiring( const tripoint_bub_ms &p )
     return !veh_target.has_tag( flag_WIRING );
 }
 
-void construct::done_trunk_plank( const tripoint_bub_ms &/*p*/, Character &/*who*/ )
-{
-    int num_logs = rng( 2, 3 );
-    Character &player_character = get_player_character();
-    for( int i = 0; i < num_logs; ++i ) {
-        iuse::cut_log_into_planks( player_character );
-    }
-}
-
 void construct::done_grave( const tripoint_bub_ms &p, Character &player_character )
 {
     map &here = get_map();
@@ -2016,7 +2006,6 @@ void load_construction( const JsonObject &jo )
     static const std::map<std::string, void( * )( const tripoint_bub_ms &, Character & )>
     post_special_map = {{
             { "", construct::done_nothing },
-            { "done_trunk_plank", construct::done_trunk_plank },
             { "done_grave", construct::done_grave },
             { "done_vehicle", construct::done_vehicle },
             { "done_appliance", construct::done_appliance },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Remove redundant `FARM_WOOD` constructions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

##### Remove construction id `constr_chop_trunk`
Contributes to #63203, part of a push to remove c++ hardcoded processes in favor of JSON crafting/construct/deconstruct recipes. Removing `constr_chop_trunk` allows us to eliminate `done_trunk_plank` as a construction `post_special` and corresponding c++ `construct::done_trunk_plank`. This sets up `iuse::cut_log_into_planks` as next on the chopping block.

Although this option has been removed from the construction menu, it does not cause any problems as the functionality is actually redundant -- it is also possible to accomplish the same task, by using an axe (by activating it). The aim is to eventually have axe use_action be superseded by a JSON deconstruct recipe rather than using hardcoded c++, and eliminate having the same processes being defined in multiple places that can have inconsistent/divergent requirements/outputs.

##### Remove construction id `constr_crt_chop_trunk`
Apart from the vanilla `constr_chop_trunk`, this mod construction is the only other member of `FARM_WOOD` construction category, which is woefully underused. This construction is similarly redundant to axe use_action; this again leads to potentially inconsistent requirements/outputs being defined in different places for the same thing and should thus be eliminated.

##### Remove construction category `FARM_WOOD`
This is an overspecific and underutilized category, by comparison to other categories. With the removal of both its constructions (that are supported in the official codebase) the category itself is obsolete and can also be deleted.

#### Describe the solution
- remove vanilla construction id `constr_chop_trunk` and construction group id `chop_tree_trunk_into_planks`
  - remove construction `post_special` `done_trunk_plank` and underlying C++ `construct::done_trunk_plank`
- remove CRIT mod construction id `constr_crt_chop_trunk` and construction group id `chop_tree_trunk_into_logs`
- remove construction category `FARM_WOOD`

#### Describe alternatives you've considered
Only delete `constr_chop_trunk` to facilitate removal of `done_trunk_plank`, which leaves the `FARM_WOOD` category empty unless playing with CRIT mod, in which case it only contains one construction.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
`FARM_WOOD` category no longer shows up in construction menu; axe actions to chop trunk to logs and planks function as per normal.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

