### PR TITLE
map/item: add only active contents to active cache

### DIFF
--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -19,17 +19,21 @@ void _remove_if( std::list<item_reference> &active_items, item const *it )
 
 } // namespace
 
+float item_reference::spoil_multiplier()
+{
+    return std::accumulate(
+               pocket_chain.begin(), pocket_chain.end(), 1.0F,
+    []( float a, item_pocket const * pk ) {
+        return a * pk->spoil_multiplier();
+    } );
+}
+
 void active_item_cache::remove( const item *it )
 {
-    int const ps = it->processing_speed();
-    if( ps == item::NO_PROCESSING ) {
-        // this item might have contained an active item so remove it from all queues
-        for( decltype( active_items )::value_type &al : active_items ) {
-            _remove_if( al.second, it );
-        }
-    } else {
-        _remove_if( active_items[ps], it );
+    for( item const *iter : it->all_items_ptr() ) {
+        _remove_if( active_items[iter->processing_speed()], iter );
     }
+    _remove_if( active_items[it->processing_speed()], it );
     if( it->can_revive() ) {
         special_items[ special_item_type::corpse ].remove_if( [it]( const item_reference & active_item ) {
             item *const target = active_item.item_ref.get();
@@ -45,8 +49,19 @@ void active_item_cache::remove( const item *it )
     }
 }
 
-void active_item_cache::add( item &it, point location )
+void active_item_cache::add( item &it, point location, item *parent,
+                             std::vector<item_pocket const *> const &pocket_chain )
 {
+    std::vector<item_pocket const *> pockets = pocket_chain;
+    for( item_pocket *pk : it.get_all_standard_pockets() ) {
+        pockets.emplace_back( pk );
+        for( item *pkit : pk->all_items_top() ) {
+            add( *pkit, location, &it, pockets );
+        }
+    }
+    if( it.processing_speed() == item::NO_PROCESSING ) {
+        return;
+    }
     // If the item is already in the cache for some reason, don't add a second reference
     std::list<item_reference> &target_list = active_items[it.processing_speed()];
     if( std::find_if( target_list.begin(),
@@ -55,13 +70,14 @@ void active_item_cache::add( item &it, point location )
     } ) != target_list.end() ) {
         return;
     }
+    item_reference ref{ location, it.get_safe_reference(), parent, pocket_chain };
     if( it.can_revive() ) {
-        special_items[ special_item_type::corpse ].push_back( item_reference{ location, it.get_safe_reference() } );
+        special_items[special_item_type::corpse].emplace_back( ref );
     }
     if( it.get_use( "explosion" ) ) {
-        special_items[ special_item_type::explosive ].push_back( item_reference{ location, it.get_safe_reference() } );
+        special_items[special_item_type::explosive].emplace_back( ref );
     }
-    target_list.push_back( item_reference{ location, it.get_safe_reference() } );
+    target_list.emplace_back( std::move( ref ) );
 }
 
 bool active_item_cache::empty() const
@@ -118,8 +134,14 @@ std::vector<item_reference> active_item_cache::get_for_processing()
 std::vector<item_reference> active_item_cache::get_special( special_item_type type )
 {
     std::vector<item_reference> matching_items;
-    for( const item_reference &it : special_items[type] ) {
-        matching_items.push_back( it );
+    std::list<item_reference> &items = special_items[type];
+    for( auto it = items.begin(); it != items.end(); ) {
+        if( it->item_ref ) {
+            matching_items.push_back( *it );
+            ++it;
+        } else {
+            it = items.erase( it );
+        }
     }
     return matching_items;
 }

--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -49,27 +49,21 @@ void active_item_cache::remove( const item *it )
     }
 }
 
-void active_item_cache::add( item &it, point location, item *parent,
+bool active_item_cache::add( item &it, point location, item *parent,
                              std::vector<item_pocket const *> const &pocket_chain )
 {
     std::vector<item_pocket const *> pockets = pocket_chain;
+    bool ret = false;
     for( item_pocket *pk : it.get_all_standard_pockets() ) {
         pockets.emplace_back( pk );
         for( item *pkit : pk->all_items_top() ) {
-            add( *pkit, location, &it, pockets );
+            ret |= add( *pkit, location, &it, pockets );
         }
     }
     if( it.processing_speed() == item::NO_PROCESSING ) {
-        return;
+        return ret;
     }
-    // If the item is already in the cache for some reason, don't add a second reference
     std::list<item_reference> &target_list = active_items[it.processing_speed()];
-    if( std::find_if( target_list.begin(),
-    target_list.end(), [&it]( const item_reference & active_item_ref ) {
-    return &it == active_item_ref.item_ref.get();
-    } ) != target_list.end() ) {
-        return;
-    }
     item_reference ref{ location, it.get_safe_reference(), parent, pocket_chain };
     if( it.can_revive() ) {
         special_items[special_item_type::corpse].emplace_back( ref );
@@ -78,6 +72,7 @@ void active_item_cache::add( item &it, point location, item *parent,
         special_items[special_item_type::explosive].emplace_back( ref );
     }
     target_list.emplace_back( std::move( ref ) );
+    return true;
 }
 
 bool active_item_cache::empty() const

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -58,7 +58,7 @@ class active_item_cache
          * Adds the reference to the cache. Does nothing if the reference is already in the cache.
          * Relies on the fact that item::processing_speed() is a constant.
          */
-        void add( item &it, point location, item *parent = nullptr,
+        bool add( item &it, point location, item *parent = nullptr,
                   std::vector<item_pocket const *> const &pocket_chain = {} );
 
         /**

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -11,11 +11,17 @@
 #include "safe_reference.h"
 
 class item;
+class item_pocket;
 
 // A struct used to uniquely identify an item within a submap or vehicle.
 struct item_reference {
     point location;
     safe_reference<item> item_ref;
+    // parent invalidating would also invalidate item_ref so it's safe to use a raw pointers here
+    item *parent = nullptr;
+    std::vector<item_pocket const *> pocket_chain;
+
+    float spoil_multiplier();
 };
 
 enum class special_item_type : int {
@@ -52,7 +58,8 @@ class active_item_cache
          * Adds the reference to the cache. Does nothing if the reference is already in the cache.
          * Relies on the fact that item::processing_speed() is a constant.
          */
-        void add( item &it, point location );
+        void add( item &it, point location, item *parent = nullptr,
+                  std::vector<item_pocket const *> const &pocket_chain = {} );
 
         /**
          * Returns true if the cache is empty

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11244,7 +11244,7 @@ void Character::leak_items()
 
 void Character::process_items()
 {
-    if( weapon.needs_processing() && weapon.process( get_map(), this, pos() ) ) {
+    if( weapon.process( get_map(), this, pos() ) ) {
         weapon.spill_contents( pos() );
         remove_weapon();
     }
@@ -11254,11 +11254,9 @@ void Character::process_items()
         if( !it ) {
             continue;
         }
-        if( it->needs_processing() ) {
-            if( it->process( get_map(), this, pos() ) ) {
-                it->spill_contents( pos() );
-                removed_items.push_back( it );
-            }
+        if( it->process( get_map(), this, pos() ) ) {
+            it->spill_contents( pos() );
+            removed_items.push_back( it );
         }
     }
     for( item_location removed : removed_items ) {

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -374,20 +374,18 @@ bool perform_liquid_transfer( item &liquid, const tripoint *const source_pos,
             if( target.item_loc && create_activity() ) {
                 serialize_liquid_target( player_character.activity, target.item_loc );
             } else if( player_character.pour_into( target.item_loc, liquid, true ) ) {
-                if( target.item_loc->needs_processing() ) {
-                    // Polymorphism fail, have to introspect into the type to set the target container as active.
-                    switch( target.item_loc.where() ) {
-                        case item_location::type::map:
-                            here.make_active( target.item_loc );
-                            break;
-                        case item_location::type::vehicle:
-                            here.veh_at( target.item_loc.position() )->vehicle().make_active( target.item_loc );
-                            break;
-                        case item_location::type::container:
-                        case item_location::type::character:
-                        case item_location::type::invalid:
-                            break;
-                    }
+                // Polymorphism fail, have to introspect into the type to set the target container as active.
+                switch( target.item_loc.where() ) {
+                    case item_location::type::map:
+                        here.make_active( target.item_loc );
+                        break;
+                    case item_location::type::vehicle:
+                        here.veh_at( target.item_loc.position() )->vehicle().make_active( target.item_loc );
+                        break;
+                    case item_location::type::container:
+                    case item_location::type::character:
+                    case item_location::type::invalid:
+                        break;
                 }
                 player_character.mod_moves( -100 );
             }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -939,19 +939,6 @@ units::volume inventory::volume_without( const std::map<const item *, int> &with
     return ret;
 }
 
-std::vector<item *> inventory::active_items()
-{
-    std::vector<item *> ret;
-    for( std::list<item> &elem : items ) {
-        for( item &elem_stack_iter : elem ) {
-            if( elem_stack_iter.needs_processing() ) {
-                ret.push_back( &elem_stack_iter );
-            }
-        }
-    }
-    return ret;
-}
-
 enchant_cache inventory::get_active_enchantment_cache( const Character &owner ) const
 {
     enchant_cache temp_cache;

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -210,10 +210,6 @@ class inventory : public visitable
         void dump( std::vector<item *> &dest );
         void dump( std::vector<const item *> &dest ) const;
 
-        // vector rather than list because it's NOT an item stack
-        // returns all items that need processing
-        std::vector<item *> active_items();
-
         void json_load_invcache( const JsonValue &jsin );
         void json_load_items( const JsonArray &ja );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -12517,16 +12517,7 @@ uint64_t item::make_component_hash() const
 
 bool item::needs_processing() const
 {
-    bool need_process = false;
-    visit_items( [&need_process]( const item * it, item * ) {
-        if( it->active || it->ethereal || it->wetness || it->has_flag( flag_RADIO_ACTIVATION ) ||
-            it->has_relic_recharge() ) {
-            need_process = true;
-            return VisitResponse::ABORT;
-        }
-        return VisitResponse::NEXT;
-    } );
-    return need_process;
+    return processing_speed() != NO_PROCESSING;
 }
 
 int item::processing_speed() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -12540,14 +12540,7 @@ int item::processing_speed() const
         return 1;
     }
 
-    // This item doesn't actually need processing.
-    // Either it contains items that need processing. Use processing speed from those.
-    // Or it is in same container with items that need processing.
-    int processing_speed = item::NO_PROCESSING;
-    for( const item *it : contents.all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
-        processing_speed = std::min( processing_speed, it->processing_speed() );
-    }
-    return processing_speed;
+    return item::NO_PROCESSING;
 }
 
 void item::apply_freezerburn()
@@ -13396,11 +13389,13 @@ bool item::process_blackpowder_fouling( Character *carrier )
 }
 
 bool item::process( map &here, Character *carrier, const tripoint &pos, float insulation,
-                    temperature_flag flag, float spoil_multiplier_parent )
+                    temperature_flag flag, float spoil_multiplier_parent, bool recursive )
 {
     process_relic( carrier, pos );
-    contents.process( here, carrier, pos, type->insulation_factor * insulation, flag,
-                      spoil_multiplier_parent );
+    if( recursive ) {
+        contents.process( here, carrier, pos, type->insulation_factor * insulation, flag,
+                          spoil_multiplier_parent );
+    }
     return process_internal( here, carrier, pos, insulation, flag, spoil_multiplier_parent );
 }
 

--- a/src/item.h
+++ b/src/item.h
@@ -1433,7 +1433,8 @@ class item : public visitable
          * Returns false if the item is not destroyed.
          */
         bool process( map &here, Character *carrier, const tripoint &pos, float insulation = 1,
-                      temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f );
+                      temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f,
+                      bool recursive = true );
 
         bool leak( map &here, Character *carrier, const tripoint &pos, item_pocket *pocke = nullptr );
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -631,13 +631,6 @@ class item_location::impl::item_in_container : public item_location::impl
         void remove_item() override {
             on_contents_changed();
             container->remove_item( *target() );
-            item_location ancestor = parent_item();
-            while( ancestor.has_parent() ) {
-                ancestor = ancestor.parent_item();
-            }
-            if( !ancestor->needs_processing() ) {
-                get_map().remove_active_item( ancestor.position(), ancestor.get_item() );
-            }
         }
 
         void on_contents_changed() override {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4973,11 +4973,10 @@ item &map::add_item( const tripoint &p, item new_item )
     current_submap->update_lum_add( l, new_item );
 
     const map_stack::iterator new_pos = current_submap->get_items( l ).insert( new_item );
-    if( new_item.needs_processing() ) {
+    if( current_submap->active_items.add( *new_pos, l ) ) {
         // TODO: fix point types
         submaps_with_active_items_dirty.insert( tripoint_abs_sm( abs_sub.x() + p.x / SEEX,
                                                 abs_sub.y() + p.y / SEEY, p.z ) );
-        current_submap->active_items.add( *new_pos, l );
     }
 
     return *new_pos;
@@ -5068,10 +5067,6 @@ void map::make_active( item_location &loc )
 {
     item *target = loc.get_item();
 
-    // Trust but verify, don't let stinking callers set items active when they shouldn't be.
-    if( !target->needs_processing() ) {
-        return;
-    }
     point l;
     submap *const current_submap = get_submap_at( loc.position(), l );
     if( current_submap == nullptr ) {
@@ -5081,10 +5076,11 @@ void map::make_active( item_location &loc )
     cata::colony<item> &item_stack = current_submap->get_items( l );
     cata::colony<item>::iterator iter = item_stack.get_iterator_from_pointer( target );
 
-    // TODO: fix point types
-    submaps_with_active_items_dirty.insert( tripoint_abs_sm( abs_sub.x() + loc.position().x / SEEX,
-                                            abs_sub.y() + loc.position().y / SEEY, loc.position().z ) );
-    current_submap->active_items.add( *iter, l );
+    if( current_submap->active_items.add( *iter, l ) ) {
+        // TODO: fix point types
+        submaps_with_active_items_dirty.insert( tripoint_abs_sm( abs_sub.x() + loc.position().x / SEEX,
+                                                abs_sub.y() + loc.position().y / SEEY, loc.position().z ) );
+    }
 }
 
 void map::update_lum( item_location &loc, bool add )

--- a/src/map.h
+++ b/src/map.h
@@ -1231,7 +1231,6 @@ class map
         map_stack::iterator i_rem( const point &location, const map_stack::const_iterator &it ) {
             return i_rem( tripoint( location, abs_sub.z() ), it );
         }
-        void remove_active_item( tripoint const &p, item *it );
         // TODO: fix point types (remove the first overload)
         void i_rem( const tripoint &p, item *it );
         void i_rem( const tripoint_bub_ms &p, item *it );
@@ -2156,6 +2155,7 @@ class map
          * Set of submaps that contain active items in absolute coordinates.
          */
         std::set<tripoint_abs_sm> submaps_with_active_items;
+        std::set<tripoint_abs_sm> submaps_with_active_items_dirty;
 
         /**
          * Cache of coordinate pairs recently checked for visibility.
@@ -2202,7 +2202,7 @@ class map
         void update_visibility_cache( int zlev );
         const visibility_variables &get_visibility_variables_cache() const;
 
-        void update_submap_active_item_status( const tripoint &p );
+        void update_submaps_with_active_items();
 
         // Just exposed for unit test introspection.
         const std::set<tripoint_abs_sm> &get_submaps_with_active_items() const {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -5020,9 +5020,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                 if( it.is_emissive() ) {
                     update_lum_add( p, it );
                 }
-                if( it.needs_processing() ) {
-                    active_items.add( it, p );
-                }
+                active_items.add( it, p );
                 if( savegame_loading_version < 33 ) {
                     // remove after 0.F
                     migrate_item_charges( it );

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -358,9 +358,7 @@ void submap::revert_submap( submap_revert &sr )
                 if( itm.is_emissive() ) {
                     this->update_lum_add( pt, itm );
                 }
-                if( itm.needs_processing() ) {
-                    active_items.add( itm, pt );
-                }
+                active_items.add( itm, pt );
             }
         }
     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5558,9 +5558,6 @@ vehicle_stack::iterator vehicle::remove_item( int part, const vehicle_stack::con
 {
     cata::colony<item> &veh_items = parts[part].items;
 
-    // remove from the active items cache (if it isn't there does nothing)
-    active_items.remove( &*it );
-
     invalidate_mass();
     return veh_items.erase( it );
 }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5452,9 +5452,6 @@ units::volume vehicle::free_volume( const int part ) const
 void vehicle::make_active( item_location &loc )
 {
     item &target = *loc;
-    if( !target.needs_processing() ) {
-        return;
-    }
     auto cargo_parts = get_parts_at( loc.position(), "CARGO", part_status_flag::any );
     if( cargo_parts.empty() ) {
         return;
@@ -5535,9 +5532,7 @@ cata::optional<vehicle_stack::iterator> vehicle::add_item( int part, const item 
     }
 
     const vehicle_stack::iterator new_pos = p.items.insert( itm_copy );
-    if( itm_copy.needs_processing() ) {
-        active_items.add( *new_pos, p.mount );
-    }
+    active_items.add( *new_pos, p.mount );
 
     invalidate_mass();
     return cata::optional<vehicle_stack::iterator>( new_pos );
@@ -5795,9 +5790,7 @@ void vehicle::refresh_active_item_cache()
         auto it = vp.part().items.begin();
         auto end = vp.part().items.end();
         for( ; it != end; ++it ) {
-            if( it->needs_processing() ) {
-                active_items.add( *it, vp.mount() );
-            }
+            active_items.add( *it, vp.mount() );
         }
     }
 }

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -437,22 +437,18 @@ void vehicle_part::process_contents( map &here, const tripoint &pos, const bool 
 {
     // for now we only care about processing food containers since things like
     // fuel don't care about temperature yet
-    if( base.has_item_with( []( const item & it ) {
-    return it.needs_processing();
-    } ) ) {
-        temperature_flag flag = temperature_flag::NORMAL;
-        if( e_heater ) {
-            flag = temperature_flag::HEATER;
-        }
-        if( enabled && info().has_flag( VPFLAG_FRIDGE ) ) {
-            flag = temperature_flag::FRIDGE;
-        } else if( enabled && info().has_flag( VPFLAG_FREEZER ) ) {
-            flag = temperature_flag::FREEZER;
-        } else if( enabled && info().has_flag( VPFLAG_HEATED_TANK ) ) {
-            flag = temperature_flag::HEATER;
-        }
-        base.process( here, nullptr, pos, 1, flag );
+    temperature_flag flag = temperature_flag::NORMAL;
+    if( e_heater ) {
+        flag = temperature_flag::HEATER;
     }
+    if( enabled && info().has_flag( VPFLAG_FRIDGE ) ) {
+        flag = temperature_flag::FRIDGE;
+    } else if( enabled && info().has_flag( VPFLAG_FREEZER ) ) {
+        flag = temperature_flag::FREEZER;
+    } else if( enabled && info().has_flag( VPFLAG_HEATED_TANK ) ) {
+        flag = temperature_flag::HEATER;
+    }
+    base.process( here, nullptr, pos, 1, flag );
 }
 
 bool vehicle_part::fill_with( item &liquid, int qty )

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -694,9 +694,6 @@ std::list<item> map_cursor::remove_items_with( const
 
     for( auto iter = stack.begin(); iter != stack.end(); ) {
         if( filter( *iter ) ) {
-            // remove from the active items cache (if it isn't there does nothing)
-            sub->active_items.remove( &*iter );
-
             // if necessary remove item from the luminosity map
             sub->update_lum_rem( offset, *iter );
 
@@ -715,7 +712,6 @@ std::list<item> map_cursor::remove_items_with( const
             ++iter;
         }
     }
-    here.update_submap_active_item_status( pos() );
     return res;
 }
 
@@ -753,9 +749,6 @@ std::list<item> vehicle_cursor::remove_items_with( const
     vehicle_part &p = veh.part( idx );
     for( auto iter = p.items.begin(); iter != p.items.end(); ) {
         if( filter( *iter ) ) {
-            // remove from the active items cache (if it isn't there does nothing)
-            veh.active_items.remove( &*iter );
-
             res.push_back( *iter );
             iter = p.items.erase( iter );
 

--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -36,12 +36,14 @@ TEST_CASE( "place_active_item_at_various_coordinates", "[item]" )
             REQUIRE( here.get_submaps_with_active_items().find( abs_loc ) ==
                      here.get_submaps_with_active_items().end() );
             item &item_ref = here.add_item( { x, y, z }, active );
+            here.update_submaps_with_active_items();
             REQUIRE( item_ref.active );
             REQUIRE_FALSE( here.get_submaps_with_active_items().empty() );
             REQUIRE( here.get_submaps_with_active_items().find( abs_loc ) !=
                      here.get_submaps_with_active_items().end() );
             REQUIRE_FALSE( here.i_at( tripoint{ x, y, z } ).empty() );
             here.i_clear( { x, y, z } );
+            here.process_items();
         }
     }
 }

--- a/tests/active_item_test.cpp
+++ b/tests/active_item_test.cpp
@@ -10,7 +10,7 @@
 #include "optional.h"
 #include "player_helpers.h"
 
-TEST_CASE( "active_items_processed_regularly", "[item]" )
+TEST_CASE( "active_items_processed_regularly", "[active_item]" )
 {
     clear_avatar();
     clear_map();

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -133,6 +133,7 @@ void clear_map( int zmin, int zmax )
     for( int z = zmin; z <= zmax; ++z ) {
         clear_items( z );
     }
+    here.process_items();
 }
 
 void clear_map_and_put_player_underground()

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -7,6 +7,7 @@
 #include "avatar.h"
 #include "coordinates.h"
 #include "enums.h"
+#include "itype.h"
 #include "game.h"
 #include "game_constants.h"
 #include "map_helpers.h"
@@ -139,6 +140,7 @@ TEST_CASE( "tinymap_bounds_checking" )
 
 void map::check_submap_active_item_consistency()
 {
+    process_items();
     for( int z = -OVERMAP_DEPTH; z < OVERMAP_HEIGHT; ++z ) {
         for( int x = 0; x < MAPSIZE; ++x ) {
             for( int y = 0; y < MAPSIZE; ++y ) {
@@ -169,7 +171,7 @@ TEST_CASE( "place_player_can_safely_move_multiple_submaps" )
     get_map().check_submap_active_item_consistency();
 }
 
-TEST_CASE( "inactive_container_with_active_contents" )
+TEST_CASE( "inactive_container_with_active_contents", "[active_item][map]" )
 {
     map &here = get_map();
     clear_map( -OVERMAP_DEPTH, OVERMAP_HEIGHT );
@@ -191,9 +193,10 @@ TEST_CASE( "inactive_container_with_active_contents" )
         bottle_plastic.put_in( disinfectant, item_pocket::pocket_type::CONTAINER );
     REQUIRE( ret.success() );
     REQUIRE( bottle_plastic.needs_processing() );
-    REQUIRE( bottle_plastic.processing_speed() == dis_speed );
+    REQUIRE( bottle_plastic.processing_speed() == bp_speed );
 
     item &bp = here.add_item( test_loc, bottle_plastic );
+    here.update_submaps_with_active_items();
     item_location bp_loc( map_cursor( test_loc ), &bp );
     item_location dis_loc( bp_loc, &bp.only_item() );
 
@@ -201,17 +204,71 @@ TEST_CASE( "inactive_container_with_active_contents" )
     here.check_submap_active_item_consistency();
 
     bool from_container = GENERATE( true, false );
+    CAPTURE( from_container );
 
     if( from_container ) {
         dis_loc.remove_item();
         CHECK( !bp.needs_processing() );
         CHECK( bp.processing_speed() == bp_speed );
     } else {
-        bp_loc->get_contents().clear_items();
-        CHECK( !bp.needs_processing() );
-        CHECK( bp.processing_speed() == bp_speed );
         bp_loc.remove_item();
     }
+    here.process_items();
     CHECK( here.get_submaps_with_active_items().count( test_loc_sm ) == 0 );
     here.check_submap_active_item_consistency();
+}
+
+TEST_CASE( "milk_rotting", "[active_item][map]" )
+{
+    map &here = get_map();
+    clear_map( -OVERMAP_DEPTH, OVERMAP_HEIGHT );
+    CAPTURE( here.get_abs_sub(), here.get_submaps_with_active_items() );
+    here.check_submap_active_item_consistency();
+    REQUIRE( here.get_submaps_with_active_items().empty() );
+    tripoint const test_loc;
+    tripoint_abs_sm const test_loc_sm = project_to<coords::sm>( here.getglobal( test_loc ) );
+
+    restore_on_out_of_scope<cata::optional<units::temperature>> restore_temp(
+                get_weather().forced_temperature );
+    get_weather().forced_temperature = units::from_celsius( 21 );
+    REQUIRE( units::to_celsius( get_weather().get_temperature( test_loc ) ) == 21 );
+
+    item almond_milk( "almond_milk" );
+    item *bp = nullptr;
+
+    bool const in_container = GENERATE( true, false );
+    CAPTURE( in_container );
+    bool sealed = false;
+
+    if( in_container ) {
+        sealed = GENERATE( true, false );
+        item bottle_plastic( "bottle_plastic" );
+        ret_val<void> const ret = bottle_plastic.put_in( almond_milk, item_pocket::pocket_type::CONTAINER );
+        REQUIRE( ret.success() );
+
+        bp = &here.add_item( test_loc, bottle_plastic );
+        REQUIRE( bp->num_item_stacks() == 1 );
+        if( sealed ) {
+            bp->get_contents().seal_all_pockets();
+        }
+        REQUIRE( bp->any_pockets_sealed() == sealed );
+    } else {
+        here.add_item( test_loc, almond_milk );
+    }
+    CAPTURE( sealed );
+    here.check_submap_active_item_consistency();
+    REQUIRE( here.get_submaps_with_active_items().count( test_loc_sm ) != 0 );
+
+    time_point const dest = calendar::turn + almond_milk.get_comestible()->spoils * 2;
+    while( calendar::turn < dest ) {
+        calendar::turn += time_duration::from_seconds( almond_milk.processing_speed() ) + 1_seconds;
+        here.process_items();
+    }
+    if( in_container ) {
+        CHECK( bp->num_item_stacks() == static_cast<size_t>( sealed ) );
+    } else {
+        CHECK( here.i_at( test_loc ).empty() == !sealed );
+    }
+    here.check_submap_active_item_consistency();
+    CHECK( here.get_submaps_with_active_items().count( test_loc_sm ) == static_cast<size_t>( sealed ) );
 }

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -185,15 +185,10 @@ TEST_CASE( "inactive_container_with_active_contents", "[active_item][map]" )
     REQUIRE( !bottle_plastic.needs_processing() );
     item disinfectant( "disinfectant" );
     REQUIRE( disinfectant.needs_processing() );
-    int const bp_speed = bottle_plastic.processing_speed();
-    int const dis_speed = disinfectant.processing_speed();
-    REQUIRE( bp_speed != dis_speed );
 
     ret_val<void> const ret =
         bottle_plastic.put_in( disinfectant, item_pocket::pocket_type::CONTAINER );
     REQUIRE( ret.success() );
-    REQUIRE( bottle_plastic.needs_processing() );
-    REQUIRE( bottle_plastic.processing_speed() == bp_speed );
 
     item &bp = here.add_item( test_loc, bottle_plastic );
     here.update_submaps_with_active_items();
@@ -208,8 +203,6 @@ TEST_CASE( "inactive_container_with_active_contents", "[active_item][map]" )
 
     if( from_container ) {
         dis_loc.remove_item();
-        CHECK( !bp.needs_processing() );
-        CHECK( bp.processing_speed() == bp_speed );
     } else {
         bp_loc.remove_item();
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
All contents of an item are processed as active items if any one of them is active

Follow up from #62916

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Partially revert #62916
When adding or removing items to/from the map (or vehicles), loop through contents and only cache the actually active items
Prune the active item and active submap caches while processing items instead of calling `active_item_cache::remove()` all over the place.

Items on characters still follow the old logic.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

<details>
<summary> TODO (finished) </summary>

- [x] figure out how to handle `item::unseal()`: added pocket chain to the cache and reverted to calculating spoil modifier on the spot

</details>

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The existing tests still pass, especially `inactive_container_with_active_contents` (from #62916) which targets this case.

New test unit for items rotting away in containers or (directly) on the map.

[Strathcona.zip](https://github.com/CleverRaven/Cataclysm-DDA/files/10473960/Strathcona.zip) In this save, there are 484 drums, each of which contains 599 rags and one active towel. Performance difference can be very clearly seen by waiting one hour. Verify that the towels are dry after one hour.

<details>
<summary>Profiling before</summary>

![before](https://user-images.githubusercontent.com/68240139/213906213-eff87428-a5b9-40b1-82b7-af2fde6ee361.png)

</details>


<details>
<summary>Profiling after</summary>

![after](https://user-images.githubusercontent.com/68240139/216781181-757bc725-0729-426c-ac55-a640e700e666.png)

</details>

[Storden-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/10713038/Storden-trimmed.tar.gz) This is a more realistic scenario created by starting the `Overrun` scenario and killing all monsters. Active items are on average only one container deep and don't share pockets with inactive items. We should still get a modest improvement due to the inactive containers not getting processed anymore.

<details>
<summary>debug timer & profiling before</summary>

![before](https://user-images.githubusercontent.com/68240139/218250529-dc53e51c-0dee-48ce-9520-0d3d23ef8cfa.png)

![profiling before](https://user-images.githubusercontent.com/68240139/218250757-e5a6dd34-c21e-4447-b2b2-1f0874971095.png)


</details>


<details>
<summary>debug timer & profiling after</summary>

![after](https://user-images.githubusercontent.com/68240139/218250542-a3a5d327-840c-4efb-84ed-ca8ac2d0a431.png)

![profiling after](https://user-images.githubusercontent.com/68240139/218250803-cae0a526-5c60-4f17-a6d7-9aadb3197542.png)

</details>

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Fris0uman you might be interested in this

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
