### PR TITLE
Equalize the smoked and wasteland sausages spoil time

### DIFF
--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -37,7 +37,7 @@
     ],
     "copy-from": "sausage_raw",
     "parasites": 0,
-    "spoils_in": "49 days",
+    "spoils_in": "14 days",
     "price_postapoc": 300,
     "description": "A hefty sausage that has been cured and smoked for long term storage.",
     "flags": [ "EATEN_HOT", "SMOKED" ],
@@ -206,6 +206,7 @@
     "type": "COMESTIBLE",
     "name": { "str": "wasteland sausage" },
     "description": "Lean sausage made from heavily salt-cured offal, with natural gut casing.  Waste not, want not.",
+    "spoils_in": "14 days",
     "quench": -7,
     "fun": -3,
     "flags": [ "SMOKED" ]

--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -206,7 +206,7 @@
     "type": "COMESTIBLE",
     "name": { "str": "wasteland sausage" },
     "description": "Lean sausage made from heavily salt-cured offal, with natural gut casing.  Waste not, want not.",
-    "spoils_in": 1176,
+    "spoils_in": "49 days",
     "quench": -7,
     "fun": -3,
     "flags": [ "SMOKED" ]

--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -206,7 +206,6 @@
     "type": "COMESTIBLE",
     "name": { "str": "wasteland sausage" },
     "description": "Lean sausage made from heavily salt-cured offal, with natural gut casing.  Waste not, want not.",
-    "spoils_in": "49 days",
     "quench": -7,
     "fun": -3,
     "flags": [ "SMOKED" ]

--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -37,7 +37,7 @@
     ],
     "copy-from": "sausage_raw",
     "parasites": 0,
-    "spoils_in": "24 days",
+    "spoils_in": "49 days",
     "price_postapoc": 300,
     "description": "A hefty sausage that has been cured and smoked for long term storage.",
     "flags": [ "EATEN_HOT", "SMOKED" ],

--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -206,7 +206,6 @@
     "type": "COMESTIBLE",
     "name": { "str": "wasteland sausage" },
     "description": "Lean sausage made from heavily salt-cured offal, with natural gut casing.  Waste not, want not.",
-    "spoils_in": "14 days",
     "quench": -7,
     "fun": -3,
     "flags": [ "SMOKED" ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #63249
#### Describe the solution
~~make both spoil in 49 days (which is wasteland sausage spoilage rate, 1176 hours) (wasteland sausage inherit the common sausage value, so i just removed it)~~
Upd: futher investigation needed, but it seems smoking do not prevent smoked meat to live as long as dried one. Made both spoil in two weeks as a temporary solution
#### Describe alternatives you've considered
Find better info about sausages spoilage and tweak it