### PR TITLE
Fix #63204: Make proficiency account for SKILL_TRAINING_SPEED

### DIFF
--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -180,7 +180,7 @@ float proficiency::default_weakpoint_penalty() const
 time_duration proficiency::time_to_learn() const
 {
     const double scaling = get_option<float>( "SKILL_TRAINING_SPEED" );
-    if ( scaling != 1.0 && scaling != 0.0 ) {
+    if( scaling != 1.0 && scaling != 0.0 ) {
         return _time_to_learn / scaling;
     } else {
         return _time_to_learn;

--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -129,7 +129,12 @@ const std::vector<proficiency_category> &proficiency_category::get_all()
 
 bool proficiency::can_learn() const
 {
-    return _can_learn;
+    if( _can_learn ) {
+        const double scaling = get_option<float>( "SKILL_TRAINING_SPEED" );
+        return scaling != 0.0;
+    } else {
+        return false;
+    }
 }
 
 bool proficiency::ignore_focus() const

--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -179,7 +179,12 @@ float proficiency::default_weakpoint_penalty() const
 
 time_duration proficiency::time_to_learn() const
 {
-    return _time_to_learn;
+    const double scaling = get_option<float>( "SKILL_TRAINING_SPEED" );
+    if ( scaling != 1.0 && scaling != 0.0 ) {
+        return _time_to_learn / scaling;
+    } else {
+        return _time_to_learn;
+    }
 }
 
 std::set<proficiency_id> proficiency::required_proficiencies() const

--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -11,6 +11,7 @@
 #include "json.h"
 #include "localized_comparator.h"
 #include "enums.h"
+#include "options.h"
 
 const float book_proficiency_bonus::default_time_factor = 0.5f;
 const float book_proficiency_bonus::default_fail_factor = 0.5f;

--- a/src/proficiency.h
+++ b/src/proficiency.h
@@ -12,7 +12,6 @@
 #include "color.h"
 #include "flat_set.h"
 #include "optional.h"
-#include "options.h"
 #include "translations.h"
 #include "type_id.h"
 

--- a/src/proficiency.h
+++ b/src/proficiency.h
@@ -12,6 +12,7 @@
 #include "color.h"
 #include "flat_set.h"
 #include "optional.h"
+#include "options.h"
 #include "translations.h"
 #include "type_id.h"
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Make proficiency account for SKILL_TRAINING_SPEED"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #63204 

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Proficiency has a field _time_to_learn. I checked the code and seems like this field is accessed only when creating proficiency from json, and then read only through corresponding getter time_to_learn(). I modified the getter, so that the value is adjusted accordingly to the SKILL_TRAINING_SPEED game option.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

New test char. Made 5 Z corpses, dissected them with scalpel, one time with default SKILL_TRAINING_SPEED (1.0), and then with modified (0.2). Numbers seem to respect the option now, see screenshots.

SKILL_TRAINING_SPEED 0.2:

![prof1a](https://user-images.githubusercontent.com/1553853/214033810-f2f93467-71aa-429d-b598-41e90b8f09ca.png)

![prof1b](https://user-images.githubusercontent.com/1553853/214033832-5aaff4a9-d361-48ad-999a-3342641ecb88.png)

SKILL_TRAINING_SPEED 1.0:

![prof2a](https://user-images.githubusercontent.com/1553853/214033937-7c1168ac-266f-4349-8831-c9e94c6f45ef.png)

![prof2b](https://user-images.githubusercontent.com/1553853/214033982-f4146f7c-f6e0-463a-83e1-2d60267fea29.png)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

UPD: fixed screenshots order
