### PR TITLE
inv_ui: item collation

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -163,7 +163,11 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
         // Set position after filter to keep cursor at the right position
         bool position_set = false;
         if( !u.activity.targets.empty() ) {
-            position_set = inv_s.highlight_one_of( u.activity.targets );
+            bool const hidden = u.activity.values.size() >= 3 && static_cast<bool>( u.activity.values[2] );
+            position_set = inv_s.highlight_one_of( u.activity.targets, hidden );
+            if( !position_set && hidden ) {
+                position_set = inv_s.highlight_one_of( u.activity.targets );
+            }
         }
         if( !position_set && u.activity.values.size() >= 2 ) {
             inv_s.highlight_position( std::make_pair( u.activity.values[0], u.activity.values[1] ) );
@@ -181,13 +185,18 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
     item_location location = inv_s.execute();
 
     if( u.has_activity( consuming ) ) {
+        inventory_entry const &e = inv_s.get_highlighted();
+        bool const collated = e.is_collation_entry();
         u.activity.values.clear();
         const auto init_pair = inv_s.get_highlighted_position();
         u.activity.values.push_back( init_pair.first );
         u.activity.values.push_back( init_pair.second );
+        u.activity.values.push_back( collated );
         u.activity.str_values.clear();
         u.activity.str_values.emplace_back( inv_s.get_filter() );
-        u.activity.targets = inv_s.get_highlighted().locations;
+        u.activity.targets = collated ? std::vector<item_location> { location, inv_s.get_collation_next() }
+                             :
+                             inv_s.get_highlighted().locations;
     }
 
     return location;
@@ -612,6 +621,7 @@ class comestible_inventory_preset : public inventory_selector_preset
         explicit comestible_inventory_preset( const Character &you ) : you( you ) {
 
             _indent_entries = false;
+            _collate_entries = true;
 
             append_cell( [&you]( const item_location & loc ) {
                 const nutrients nutr = you.compute_effective_nutrients( *loc );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1044,6 +1044,7 @@ class activatable_inventory_preset : public pickup_inventory_preset
     public:
         explicit activatable_inventory_preset( const Character &you ) : pickup_inventory_preset( you ),
             you( you ) {
+            _collate_entries = true;
             if( get_option<bool>( "INV_USE_ACTION_NAMES" ) ) {
                 append_cell( [ this ]( const item_location & loc ) {
                     return string_format( "<color_light_green>%s</color>", get_action_name( *loc ) );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1219,13 +1219,10 @@ inventory_entry *inventory_column::add_entry( const inventory_entry &entry )
                 return false;
             }
             item_location found_entry_item = e.locations.front();
-            // this would be much simpler if item::parent_item() didn't call debugmsg
             return e.get_category_ptr() == entry.get_category_ptr() &&
                    entry_item.where() == found_entry_item.where() &&
                    entry_item.position() == found_entry_item.position() &&
-                   ( ( !entry_item.has_parent() && !found_entry_item.has_parent() ) ||
-                     ( entry_item.has_parent() && found_entry_item.has_parent() &&
-                       entry_item.parent_item() == found_entry_item.parent_item() ) ) &&
+                   entry_item.parent_item() == found_entry_item.parent_item() &&
                    entry_item->is_collapsed() == found_entry_item->is_collapsed() &&
                    entry_item->display_stacked_with( *found_entry_item, preset.get_checking_components() );
         } );

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -384,7 +384,7 @@ class inventory_column
         void order_by_parent();
 
         inventory_entry *find_by_invlet( int invlet ) const;
-        inventory_entry *find_by_location( item_location &loc ) const;
+        inventory_entry *find_by_location( item_location const &loc, bool hidden = false ) const;
 
         void draw( const catacurses::window &win, const point &p,
                    std::vector< std::pair<inclusive_rectangle<point>, inventory_entry *>> &rect_entry_map );
@@ -397,7 +397,7 @@ class inventory_column
         void set_collapsed( inventory_entry &entry, bool collapse );
 
         /** Highlights the specified location. */
-        bool highlight( const item_location &loc );
+        bool highlight( const item_location &loc, bool front_only = false );
 
         /**
          * Change the highlight.
@@ -791,7 +791,7 @@ class inventory_selector
          * @param loc Location to highlight
          * @return true on success.
          */
-        bool highlight( const item_location &loc );
+        bool highlight( const item_location &loc, bool hidden = false, bool front_only = false );
 
         const inventory_entry &get_highlighted() const {
             return get_active_column().get_highlighted();
@@ -805,7 +805,7 @@ class inventory_selector
             get_active_column().highlight( position.second, scroll_direction::BACKWARD );
         }
 
-        bool highlight_one_of( const std::vector<item_location> &locations );
+        bool highlight_one_of( const std::vector<item_location> &locations, bool hidden = false );
 
         std::pair<size_t, size_t> get_highlighted_position() const {
             std::pair<size_t, size_t> position;

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -62,6 +62,12 @@ struct navigation_mode_data;
 using drop_location = std::pair<item_location, int>;
 using drop_locations = std::list<drop_location>;
 
+struct collation_meta_t {
+    item_location tip;
+    bool collapsed = true;
+    bool enabled = true;
+};
+
 class inventory_entry
 {
     public:
@@ -90,10 +96,10 @@ class inventory_entry
                                   bool enabled = true,
                                   const size_t chosen_count = 0,
                                   size_t generation_number = 0,
-                                  item *topmost_parent = nullptr, bool chevron = false ) :
+                                  item_location topmost_parent = {}, bool chevron = false ) :
             locations( locations ),
             chosen_count( chosen_count ),
-            topmost_parent( topmost_parent ),
+            topmost_parent( std::move( topmost_parent ) ),
             generation( generation_number ),
             chevron( chevron ),
             enabled( enabled ),
@@ -136,6 +142,18 @@ class inventory_entry
             return is_item() && ( enabled || !skip_unselectable );
         }
 
+        bool is_collated() const {
+            return static_cast<bool>( collation_meta );
+        }
+
+        bool is_collation_header() const {
+            return is_collated() && chevron;
+        }
+
+        bool is_collation_entry() const {
+            return is_collated() && !chevron;
+        }
+
         const item_location &any_item() const {
             if( locations.empty() ) {
                 debugmsg( "inventory_entry::any_item called on a non-item entry.  "
@@ -162,7 +180,8 @@ class inventory_entry
         bool highlight_as_child = false;
         bool collapsed = false;
         // topmost visible parent, used for visibility checks
-        item *topmost_parent = nullptr;
+        item_location topmost_parent;
+        std::shared_ptr<collation_meta_t> collation_meta;
         size_t generation = 0;
         bool chevron = false;
         int indent = 0;
@@ -171,6 +190,13 @@ class inventory_entry
 
         void set_custom_category( const item_category *category ) {
             custom_category = category;
+        }
+
+        void reset_collation() {
+            if( is_collation_header() ) {
+                chevron = false;
+            }
+            collation_meta.reset();
         }
 
     private:
@@ -231,6 +257,10 @@ class inventory_selector_preset
             return _indent_entries;
         }
 
+        bool collate_entries() const {
+            return _collate_entries;
+        }
+
         inventory_selector_save_state *save_state = nullptr;
 
     protected:
@@ -252,6 +282,7 @@ class inventory_selector_preset
 
         // whether to indent contained entries in the menu
         bool _indent_entries = true;
+        bool _collate_entries = false;
 
         item_pocket::pocket_type _pk_type = item_pocket::pocket_type::CONTAINER;
 
@@ -430,6 +461,10 @@ class inventory_column
             }
         }
 
+        bool collate_entries() const {
+            return preset.collate_entries();
+        }
+
         void set_indent_entries_override( bool entry_override ) {
             indent_entries_override = entry_override;
         }
@@ -444,6 +479,8 @@ class inventory_column
 
         /** Toggle being able to highlight unselectable entries*/
         void toggle_skip_unselectable( bool skip );
+        void collate();
+        void uncollate();
 
     protected:
         struct entry_cell_cache_t {
@@ -466,6 +503,7 @@ class inventory_column
 
         bool sort_compare( inventory_entry const &lhs, inventory_entry const &rhs );
         bool indented_sort_compare( inventory_entry const &lhs, inventory_entry const &rhs );
+        bool collated_sort_compare( inventory_entry const &lhs, inventory_entry const &rhs );
 
         /**
          * Indentation of the entry.
@@ -526,8 +564,10 @@ class inventory_column
         void _get_entries( get_entries_t *res, entries_t const &ent,
                            const ffilter_t &filter_func ) const;
         static void _move_entries_to( entries_t const &ent, inventory_column &dest );
+        static void _reset_collation( entries_t &ent );
 
         bool skip_unselectable = false;
+        bool _collated = false;
 };
 
 class selection_column : public inventory_column
@@ -569,7 +609,7 @@ class inventory_selector
         /** These functions add items from map / vehicles. */
         bool add_contained_items( item_location &container );
         bool add_contained_items( item_location &container, inventory_column &column,
-                                  const item_category *custom_category = nullptr, item *topmost_parent = nullptr,
+                                  const item_category *custom_category = nullptr, item_location const &topmost_parent = {},
                                   int indent = 0 );
         void add_contained_ebooks( item_location &container );
         void add_character_items( Character &character );
@@ -644,12 +684,12 @@ class inventory_selector
         inventory_entry *add_entry( inventory_column &target_column,
                                     std::vector<item_location> &&locations,
                                     const item_category *custom_category = nullptr,
-                                    size_t chosen_count = 0, item *topmost_parent = nullptr,
+                                    size_t chosen_count = 0, item_location const &topmost_parent = {},
                                     bool chevron = false );
         bool add_entry_rec( inventory_column &entry_column, inventory_column &children_column,
                             item_location &loc, item_category const *entry_category = nullptr,
                             item_category const *children_category = nullptr,
-                            item *topmost_parent = nullptr, int indent = 0 );
+                            item_location const &topmost_parent = {}, int indent = 0 );
 
         inventory_input get_input();
         inventory_input process_input( const std::string &action, int ch );
@@ -756,6 +796,8 @@ class inventory_selector
         const inventory_entry &get_highlighted() const {
             return get_active_column().get_highlighted();
         }
+
+        item_location get_collation_next() const;
 
         void highlight_position( std::pair<size_t, size_t> position ) {
             prepare_layout();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10215,6 +10215,11 @@ bool item::is_relic() const
     return !!relic_data;
 }
 
+bool item::is_same_relic( item const &rhs ) const
+{
+    return ( !is_relic() && !rhs.is_relic() ) || *relic_data == *rhs.relic_data;
+}
+
 bool item::has_relic_recharge() const
 {
     return is_relic() && relic_data->has_recharge();

--- a/src/item.h
+++ b/src/item.h
@@ -1495,6 +1495,7 @@ class item : public visitable
         bool is_tool() const;
         bool is_transformable() const;
         bool is_relic() const;
+        bool is_same_relic( item const &rhs ) const;
         bool is_bucket_nonempty() const;
 
         bool is_brewable() const;

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -830,7 +830,6 @@ item_location item_location::parent_item() const
     if( where() == type::container ) {
         return ptr->parent_item();
     }
-    debugmsg( "this item location type has no parent" );
     return item_location::nowhere;
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Sometimes when interacting with items in an inventory UI, we're not so interested in the distinction between different items of the same type, especially when the only distinction is in their invisible container, and it would be nice to compress them into one entry.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add some metadata and reuse the container collapsing functionality to optionally also collate items of the same type. Only items with no visible contents are collated.
Enable collation for the `E`at and `a`ctivate menus.

<details>
<summary>TODO (finished) </summary>

- [x] fix highlighting on return to the `E`at menu: it's ugly as sin but it probably can't be improved without a significant rework of `inventory_ui`

</details>
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Just stacking the item locations in the same entry? Less flexible and can show deceptive numbers
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Fresh batch of sauerkraut, among other food:
<details>
<summary>before</summary>

![before](https://user-images.githubusercontent.com/68240139/214373097-cf5ec07f-e63b-4584-b42b-75e23ee6ecf0.png)

Sauerkraut in different containers have different entries, but there is no real distinction between them.
</details>

<details>
<summary>after</summary>

![Screenshot from 2023-01-25 13-28-56](https://user-images.githubusercontent.com/68240139/214552494-9a87770a-0515-4d56-94cf-48ac77649a49.png)

Similar items are grouped and collapsed by default. The collation headers display total collated amounts.

![Screenshot from 2023-01-25 13-33-06](https://user-images.githubusercontent.com/68240139/214553100-6e38e622-50c7-4284-8946-51cb9bb263ae.png)


Collated items are still sorted properly: in this case, the top entry is the closest to spoilage. The header displays the info for the top entry.

![filter](https://user-images.githubusercontent.com/68240139/214373340-cc0aa5e3-795f-4ab2-8d99-855d53e89cb8.png)

Filter does not reveal hidden collated entries, unlike with regular hidden entries.

</details>

<details>
<summary>An extreme example, made by sitting on top of all the food supply from a Military Base warehouse.</summary>

![Screenshot from 2023-02-18 11-36-24](https://user-images.githubusercontent.com/68240139/219853243-ea3459e5-d535-47e6-81de-35b8f8633aee.png)


</details>

<details>
<summary>Verify that highlighting on return works as expected.</summary>

Quick test:

[output.webm](https://user-images.githubusercontent.com/68240139/214552690-6f24d85f-b869-418c-b3ce-f0bc32a4f3f2.webm)


</details>

<details>
<summary>Verify that nested collation works as expected.</summary>

Quick test:

[output.webm](https://user-images.githubusercontent.com/68240139/215315284-b8119887-c435-44fa-9ea4-8f2be3420735.webm)

Note that in categories mode all similar items are collated. In hierarchy mode, only items with the same parent are collated (ex: in different pockets, or with different spoilage).

</details>

</details>

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
GuardianDll you might be interested in this

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
