### PR TITLE
Unarmed hits correctly gain unarmed experience

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -438,7 +438,8 @@ void Character::roll_all_damage( bool crit, damage_instance &di, bool average,
     roll_other_damage( crit, di, average, weap, attack_vector, crit_mod );
 }
 
-static void melee_train( Character &you, int lo, int hi, const item &weap )
+static void melee_train( Character &you, int lo, int hi, const item &weap,
+                         const std::string &attack_vector )
 {
     you.practice( skill_melee, std::ceil( rng( lo, hi ) / 2.0 ), hi );
 
@@ -451,7 +452,7 @@ static void melee_train( Character &you, int lo, int hi, const item &weap )
     float total = std::max( cut + stab + bash, 1 );
 
     // Unarmed may deal cut, stab, and bash damage depending on the weapon
-    if( weap.is_null() ) {
+    if( attack_vector != "WEAPON" ) {
         you.practice( skill_unarmed, std::ceil( 1 * rng( lo, hi ) ), hi );
     } else {
         you.practice( skill_cutting,  std::ceil( cut  / total * rng( lo, hi ) ), hi );
@@ -680,7 +681,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
 
         // Practice melee and relevant weapon skill (if any) except when using CQB bionic
         if( !has_active_bionic( bio_cqb ) && !t.is_hallucination() ) {
-            melee_train( *this, 2, std::min( 5, skill_training_cap ), cur_weap );
+            std::string attack_vector = cur_weapon ? "WEAPON" : "HAND";
+            melee_train( *this, 2, std::min( 5, skill_training_cap ), cur_weap, attack_vector );
         }
 
         // Cap stumble penalty, heavy weapons are quite weak already
@@ -857,12 +859,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             melee::melee_stats.damage_amount += dam;
 
             // Practice melee and relevant weapon skill (if any) except when using CQB bionic
-            if( !has_active_bionic( bio_cqb ) && cur_weapon && !t.is_hallucination() ) {
-                if( technique.attack_override ) {
-                    melee_train( *this, 5, std::min( 10, skill_training_cap ), null_item_reference() );
-                } else {
-                    melee_train( *this, 5, std::min( 10, skill_training_cap ), cur_weap );
-                }
+            if( !has_active_bionic( bio_cqb ) && !t.is_hallucination() ) {
+                melee_train( *this, 5, std::min( 10, skill_training_cap ), cur_weap, attack_vector );
             }
 
             // Treat monster as seen if we see it before or after the attack


### PR DESCRIPTION
#### Summary

Bugfixes "Unarmed hits now correctly gain experience"

#### Purpose of change

Closes #63257 

Currently, landing an unarmed attack cannot gain you unarmed exp. Missing an unarmed attack can get you unarmed and melee exp up to level 6 as intended. Hitting with your bare fists gives you no exp, unarmed or melee. Hitting with a worn item (e.g. light gloves) will gain melee exp, and if the worn item has bash/cut/pierce values you will gain experience for that (even though those skills will not increase the damage dealt by those values), but you will not gain any unarmed exp.

#### Describe the solution

Currently there is a check that makes it so if you aren't hitting with a wielded weapon or a worn item you get no exp for either unarmed or melee; that is removed.

Secondly melee_train has had attack_vector input added and now checks if the attack vector is WEAPON. If it is not WEAPON, then it trains unarmed, otherwise it uses the values of the current weapon to train the relevant skills. Missing additionally has a fake attack vector set for WEAPON or HAND depending on if you are using a weapon to attack (this works properly with taekwondo).

#### Describe alternatives you've considered

Not using attack vector and putting the attack vector check before calling melee_train and having it set weapon to null item reference if attack vector isn't WEAPON. Putting attack vector in melee_train seems more robust and clarifies the intended behavior so hopefully this bug won't crop up yet again.

#### Testing

Compiled and attacked debug monster with several set ups and all had expected behavior.

No style and bare fists = Gain unarmed and melee for both hits and misses
No style and pipe mace wielded = Gain bashing and melee for both hits and misses
No style and light gloves worn = Gain unarmed and melee for both hits and misses
Taekwondo and pipe mace wielded = Gain unarmed and melee for both hits and misses (taekwondo forces you to use kicks)

#### Additional context

I have no idea what the intended functionality of attack_override is, but attack_overrides with no vector set have a vector of NONE so they will still correctly use and train unarmed skill even with their special use case removed.