### PR TITLE
Change three NPC MGOAL_GO_TO quest invocations to allow player to go alone

### DIFF
--- a/data/json/npcs/Backgrounds/hospital_2.json
+++ b/data/json/npcs/Backgrounds/hospital_2.json
@@ -159,14 +159,12 @@
     "type": "talk_topic",
     "dynamic_line": "Yeah, fat chance I'm giving up that kind of personal information to someone I barely know.  What are you trying to pull?",
     "responses": [ { "text": "…", "topic": "TALK_NONE" } ]
-  },  
+  },
   {
     "type": "effect_on_condition",
     "id": "EOC_HOSPITAL_2_MAKE_MISSION",
     "//": "Assigns the mission through an EOC to avoid having to bring the NPC along with the player.",
-    "effect": [
-      { "assign_mission": "directions_hospital_2_CABIN" }
-    ]
+    "effect": [ { "assign_mission": "directions_hospital_2_CABIN" } ]
   },
   {
     "id": "directions_hospital_2_CABIN",

--- a/data/json/npcs/Backgrounds/hospital_2.json
+++ b/data/json/npcs/Backgrounds/hospital_2.json
@@ -121,7 +121,7 @@
         "success": {
           "topic": "BGSS_HOSPITAL_2_CABINSUCCESS",
           "effect": [
-            { "add_mission": "directions_hospital_2_CABIN" },
+            { "run_eocs": [ "EOC_HOSPITAL_2_MAKE_MISSION" ] },
             { "u_message": "<npc_name> marks the location of the cabin on your map.", "type": "good", "popup": true }
           ]
         },
@@ -151,14 +151,22 @@
   {
     "id": "BGSS_HOSPITAL_2_CABINSUCCESS",
     "type": "talk_topic",
-    "dynamic_line": "I suppose it couldn't hurt now.  I doubt anyone's still there anyway.  Bring me with you when you go, though.  I want to be sure.",
-    "responses": [ { "text": "Thanks for the directions.  Let's check it out.", "topic": "TALK_NONE" } ]
+    "dynamic_line": "I suppose it couldn't hurt now.  I doubt anyone's still there anyway.",
+    "responses": [ { "text": "Thanks for the directions.  I'll check it out.", "topic": "TALK_NONE" } ]
   },
   {
     "id": "BGSS_HOSPITAL_2_CABINFAILURE",
     "type": "talk_topic",
     "dynamic_line": "Yeah, fat chance I'm giving up that kind of personal information to someone I barely know.  What are you trying to pull?",
     "responses": [ { "text": "…", "topic": "TALK_NONE" } ]
+  },  
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOSPITAL_2_MAKE_MISSION",
+    "//": "Assigns the mission through an EOC to avoid having to bring the NPC along with the player.",
+    "effect": [
+      { "assign_mission": "directions_hospital_2_CABIN" }
+    ]
   },
   {
     "id": "directions_hospital_2_CABIN",
@@ -172,7 +180,6 @@
       "assign_mission_target": { "om_special": "Cabin_2", "om_terrain": "cabin_2", "reveal_radius": 3, "search_range": 400 },
       "effect": { "u_add_var": "hospital_2_started_quest", "type": "mission", "context": "BGSS", "value": "yes" }
     },
-    "end": { "opinion": { "trust": 1, "value": 1 } },
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {
       "describe": "…",

--- a/data/json/npcs/Backgrounds/prepper_1.json
+++ b/data/json/npcs/Backgrounds/prepper_1.json
@@ -714,7 +714,7 @@
     "end": {
       "effect": [
         {
-          "u_message": "You approach the LMOE and do as you were told: prying back a thin piece of metal atop the doorframe, revealing an opening.  You reach inside and grab a handle attached to a wire, pull hard on it, and hear a heavy metal *clunk*.  The door is open.",
+          "u_message": "You approach the LMOE and do as you were told, prying back a thin piece of metal atop the doorframe, revealing an opening.  You reach inside and grab a handle attached to a wire, pull hard on it, and hear a heavy metal *clunk*.  The door is open.",
           "type": "good",
           "popup": true
         },

--- a/data/json/npcs/Backgrounds/prepper_1.json
+++ b/data/json/npcs/Backgrounds/prepper_1.json
@@ -288,7 +288,7 @@
     "id": "BGSS_PREPPER_1_SHELTERSUCCESS",
     "type": "talk_topic",
     "dynamic_line": "I marked the spot for you.  When you get there, pry off the metal above the door and you'll see the special latch I made to keep thieves out.  I trust you to make the right decisions.",
-    "responses": [ { "text": "Thanks for the directions.  Let's check it out.", "topic": "TALK_NONE" } ]
+    "responses": [ { "text": "Thanks for the directions.  I'll check it out.", "topic": "TALK_NONE" } ]
   },
   {
     "id": "BGSS_PREPPER_1_SHELTERFAILURE",

--- a/data/json/npcs/Backgrounds/prepper_1.json
+++ b/data/json/npcs/Backgrounds/prepper_1.json
@@ -63,17 +63,17 @@
       "type": "mission",
       "context": "BGSS",
       "value": "yes",
-      "no": "I still haven't made it there.  Every time I've tried I've been headed off by the <zombies>.  Who knows, maybe someday.",
+      "no": "I never made it there and can't imagine I ever will.  Every time I've tried I've been headed off by the <zombies>.",
       "yes": "The shelter's in your hands, at this point."
     },
     "responses": [
       { "text": "Could you tell me that story again?", "topic": "BGSS_PREPPER_1_STORY1" },
       {
-        "text": "We could go check out that shelter together if you like.  Might be better having another person to keep you safe?",
+        "text": "I could go check out that shelter for you if you like.  Bring back any supplies you left behind?",
         "//": "Checks to see if you have already finished this quest (by extension, it applies to any future NPC with this background), whether you have read their notes from TALK_PREPPER_1_COMPUTER, and whether you have already asked them about this quest. The conditional checks here look a little crazy but they simply gate you out of this conversation for various reasons.",
         "condition": {
           "and": [
-            { "not": "has_assigned_mission" },
+            { "not":  { "u_has_mission": "directions_prepper_1_SHELTER" } },
             {
               "not": { "u_has_var": "prepper_1_found_computer", "type": "mission", "context": "BGSS", "value": "yes" }
             },
@@ -100,7 +100,7 @@
         "success": {
           "topic": "BGSS_PREPPER_1_SHELTERSUCCESS",
           "effect": [
-            { "add_mission": "directions_prepper_1_SHELTER" },
+            { "run_eocs": [ "EOC_PREPPER_1_MAKE_MISSION" ] },
             {
               "u_message": "<npc_name> marks the location of the LMOE shelter on your map.",
               "type": "good",
@@ -287,7 +287,7 @@
   {
     "id": "BGSS_PREPPER_1_SHELTERSUCCESS",
     "type": "talk_topic",
-    "dynamic_line": "I marked the spot for you.  With everything I've seen out there, I suppose it's better to have someone on your side.  But I'll be watching to make sure you don't take anything…",
+    "dynamic_line": "I marked the spot for you.  When you get there, pry off the metal above the door and you'll see the special latch I made to keep thieves out.  I trust you to make the right decisions.",
     "responses": [ { "text": "Thanks for the directions.  Let's check it out.", "topic": "TALK_NONE" } ]
   },
   {
@@ -690,6 +690,15 @@
         "topic": "TALK_DONE"
       }
     ]
+  },  
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PREPPER_1_MAKE_MISSION",
+    "//": "Assigns the mission through an EOC to avoid having to bring the NPC along with the player.",
+    "effect": [
+      { "assign_mission": "directions_prepper_1_SHELTER" },
+      { "u_add_var": "prepper_1_started_quest", "type": "mission", "context": "BGSS", "value": "yes" }
+    ]
   },
   {
     "id": "directions_prepper_1_SHELTER",
@@ -700,14 +709,12 @@
     "difficulty": 2,
     "value": 0,
     "start": {
-      "assign_mission_target": { "om_special": "Locked LMOE Shelter", "om_terrain": "lmoe_prepperquest", "reveal_radius": 3, "search_range": 400 },
-      "effect": { "u_add_var": "prepper_1_started_quest", "type": "mission", "context": "BGSS", "value": "yes" }
+      "assign_mission_target": { "om_special": "Locked LMOE Shelter", "om_terrain": "lmoe_prepperquest", "reveal_radius": 3, "search_range": 400 }
     },
     "end": {
-      "opinion": { "trust": 1, "value": 1 },
       "effect": [
         {
-          "u_message": "<npc_name> walks up to the front door and pries back a thin piece of metal from the top of the doorframe, revealing an opening.  They reach inside, pull hard on something, and you hear a heavy metal *clunk*.",
+          "u_message": "You approach the LMOE and do as you were told: prying back a thin piece of metal atop the doorframe, revealing an opening.  You reach inside, pull hard on something, and hear a heavy metal *clunk*.  The door is open.",
           "type": "good",
           "popup": true
         },
@@ -722,7 +729,7 @@
       "accepted": "…",
       "rejected": "…",
       "advice": "…",
-      "inquire": "Any luck finding the LMOE shelter?  Don't forget to take me with you.  I changed the design and you sure as hell aren't getting in unless you know the trick.",
+      "inquire": "Any luck finding the LMOE shelter?",
       "success": "Damn, can't believe we finally made it.  I was smart enough not to store anything that might rot, so as long as nobody else already broke in, I bet there's at least two weeks of good food just sitting there.  Pristine workshop down there, too.  It cost me a pretty penny to get built.  I could tell you all about it sometime if you ever wanted.  Anyway, thanks for helping me get back here.  It sure ain't safe to travel on your own anymore.",
       "success_lie": "…",
       "failure": "Not that surprising."

--- a/data/json/npcs/Backgrounds/prepper_1.json
+++ b/data/json/npcs/Backgrounds/prepper_1.json
@@ -714,7 +714,7 @@
     "end": {
       "effect": [
         {
-          "u_message": "You approach the LMOE and do as you were told: prying back a thin piece of metal atop the doorframe, revealing an opening.  You reach inside, pull hard on something, and hear a heavy metal *clunk*.  The door is open.",
+          "u_message": "You approach the LMOE and do as you were told: prying back a thin piece of metal atop the doorframe, revealing an opening.  You reach inside and grab a handle attached to a wire, pull hard on it, and hear a heavy metal *clunk*.  The door is open.",
           "type": "good",
           "popup": true
         },

--- a/data/json/npcs/Backgrounds/prepper_1.json
+++ b/data/json/npcs/Backgrounds/prepper_1.json
@@ -73,7 +73,7 @@
         "//": "Checks to see if you have already finished this quest (by extension, it applies to any future NPC with this background), whether you have read their notes from TALK_PREPPER_1_COMPUTER, and whether you have already asked them about this quest. The conditional checks here look a little crazy but they simply gate you out of this conversation for various reasons.",
         "condition": {
           "and": [
-            { "not":  { "u_has_mission": "directions_prepper_1_SHELTER" } },
+            { "not": { "u_has_mission": "directions_prepper_1_SHELTER" } },
             {
               "not": { "u_has_var": "prepper_1_found_computer", "type": "mission", "context": "BGSS", "value": "yes" }
             },
@@ -690,7 +690,7 @@
         "topic": "TALK_DONE"
       }
     ]
-  },  
+  },
   {
     "type": "effect_on_condition",
     "id": "EOC_PREPPER_1_MAKE_MISSION",

--- a/data/json/npcs/Backgrounds/rural_1.json
+++ b/data/json/npcs/Backgrounds/rural_1.json
@@ -90,14 +90,12 @@
     "type": "talk_topic",
     "dynamic_line": "I don't know if I trust you quite like that, just giving away so many personal details all at once.  Maybe later…",
     "responses": [ { "text": "Sorry, didn't mean to intrude.", "topic": "TALK_NONE" } ]
-  },  
+  },
   {
     "type": "effect_on_condition",
     "id": "EOC_RURAL_1_MAKE_MISSION",
     "//": "Assigns the mission through an EOC to avoid having to bring the NPC along with the player.",
-    "effect": [
-      { "assign_mission": "directions_rural_1_FARM" }
-    ]
+    "effect": [ { "assign_mission": "directions_rural_1_FARM" } ]
   },
   {
     "id": "directions_rural_1_FARM",

--- a/data/json/npcs/Backgrounds/rural_1.json
+++ b/data/json/npcs/Backgrounds/rural_1.json
@@ -62,7 +62,7 @@
         "success": {
           "topic": "BGSS_RURAL_1_FARMSUCCESS",
           "effect": [
-            { "add_mission": "directions_rural_1_FARM" },
+            { "run_eocs": [ "EOC_RURAL_1_MAKE_MISSION" ] },
             { "u_message": "<npc_name> marks the location of the farm on your map.", "type": "good", "popup": true }
           ]
         },
@@ -82,14 +82,22 @@
   {
     "id": "BGSS_RURAL_1_FARMSUCCESS",
     "type": "talk_topic",
-    "dynamic_line": "I guess you look sturdy enough to take them on.  I marked the spot for you.  Take me with you so I can make sure you don't steal anything.  No offense… the farm is just all I've got.",
-    "responses": [ { "text": "Thanks for the directions.  Let's check it out.", "topic": "TALK_NONE" } ]
+    "dynamic_line": "I guess you look sturdy enough to take them on.  I marked the spot for you.",
+    "responses": [ { "text": "Thanks for the directions.  I'll check it out.", "topic": "TALK_NONE" } ]
   },
   {
     "id": "BGSS_RURAL_1_FARMFAILURE",
     "type": "talk_topic",
     "dynamic_line": "I don't know if I trust you quite like that, just giving away so many personal details all at once.  Maybe later…",
     "responses": [ { "text": "Sorry, didn't mean to intrude.", "topic": "TALK_NONE" } ]
+  },  
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_RURAL_1_MAKE_MISSION",
+    "//": "Assigns the mission through an EOC to avoid having to bring the NPC along with the player.",
+    "effect": [
+      { "assign_mission": "directions_rural_1_FARM" }
+    ]
   },
   {
     "id": "directions_rural_1_FARM",
@@ -103,7 +111,6 @@
       "assign_mission_target": { "om_special": "Farm", "om_terrain": "farm_3", "reveal_radius": 3, "search_range": 400 },
       "effect": { "u_add_var": "rural_1_started_quest", "type": "mission", "context": "BGSS", "value": "yes" }
     },
-    "end": { "opinion": { "trust": 2, "value": 2 } },
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {
       "describe": "…",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Change three NPC MGOAL_GO_TO quest invocations to allow player to go alone"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Changes three background NPC quest mechanics to a more logical goal type.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
A small follow-up to #59165. While developing that PR, I struggled to find a way to make the `MGOAL_GO_TO` quest type allow _just the player_ to fulfill the quest rather than requiring the NPC to follow the player to the goal. Turns out, all it takes is assigning the quest via an Effect on Condition rather than through the NPC's dialog!

I've fixed all three quests from the initial PR to work this way.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned in each NPC and walked through their dialog to make sure the change worked correctly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
