### PR TITLE
New missions for the heli crash scenario

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4766,7 +4766,8 @@
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boy_shorts" ]
     },
-    "flags": [ "SCEN_ONLY" ]
+    "flags": [ "SCEN_ONLY" ],
+    "missions": [ "MISSION_HELICOPTER_PILOT" ]
   },
   {
     "type": "profession",

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -633,7 +633,8 @@
       "combat-engineer"
     ],
     "map_extra": "mx_helicopter",
-    "flags": [ "HELI_CRASH", "LONE_START" ]
+    "flags": [ "HELI_CRASH", "LONE_START" ],
+    "missions": [ "MISSION_HELICOPTER_CRASH" ]
   },
   {
     "type": "scenario",

--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -640,7 +640,7 @@
       "assign_mission_target": {
         "om_terrain": "helipad_nw",
         "reveal_radius": 10,
-        "om_special": "helipad",
+        "om_special": "military helipad",
         "search_range": 70,
         "min_distance": 25,
         "z": 0

--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -628,20 +628,6 @@
     "origins": [ "ORIGIN_GAME_START" ]
   },
   {
-    "id": "MISSION_HELICOPTER_REFUEL",
-    "type": "mission_definition",
-    "name": { "str": "Refuel your helicopter." },
-    "description": "You were flying towards a nearby private airport before your forced landing.  You could still reach it by ground, and scavenge it for fuel.",
-    "goal": "MGOAL_GO_TO_TYPE",
-    "destination": "s_air_hangars",
-    "difficulty": 1,
-    "value": 0,
-    "start": {
-      "assign_mission_target": { "om_terrain": "s_air_hangars", "reveal_radius": 5, "om_special": "o_airport", "search_range": 120 }
-    },
-    "origins": [ "ORIGIN_GAME_START" ]
-  },
-  {
     "id": "MISSION_HELICOPTER_CRASH",
     "type": "mission_definition",
     "name": { "str": "Return to base" },

--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -628,6 +628,82 @@
     "origins": [ "ORIGIN_GAME_START" ]
   },
   {
+    "id": "MISSION_HELICOPTER_REFUEL",
+    "type": "mission_definition",
+    "name": { "str": "Refuel your helicopter." },
+    "description": "You were flying towards a nearby private airport before your forced landing.  You could still reach it by ground, and scavenge it for fuel.",
+    "goal": "MGOAL_GO_TO_TYPE",
+    "destination": "s_air_hangars",
+    "difficulty": 1,
+    "value": 0,
+    "start": {
+      "assign_mission_target": { "om_terrain": "s_air_hangars", "reveal_radius": 5, "om_special": "o_airport", "search_range": 120 }
+    },
+    "origins": [ "ORIGIN_GAME_START" ]
+  },
+  {
+    "id": "MISSION_HELICOPTER_CRASH",
+    "type": "mission_definition",
+    "name": { "str": "Return to base" },
+    "description": "Your helicopter was crashed to the ground, communications were lost with ground base, and the rest of your team died while landing, at least you still know the way back to the base.",
+    "goal": "MGOAL_GO_TO_TYPE",
+    "destination": "helipad_nw",
+    "difficulty": 4,
+    "value": 0,
+    "start": {
+      "assign_mission_target": {
+        "om_terrain": "helipad_nw",
+        "reveal_radius": 10,
+        "om_special": "helipad",
+        "search_range": 70,
+        "min_distance": 25,
+        "z": 0
+      }
+    },
+    "origins": [ "ORIGIN_GAME_START" ]
+  },
+  {
+    "id": "MISSION_HELICOPTER_PILOT",
+    "type": "mission_definition",
+    "name": { "str": "Go to the refueling stop" },
+    "description": "Your bird is now on the ground, never again able to fly, you could search for a new one in the closest refueling stop requisitioned by the military.",
+    "goal": "MGOAL_GO_TO_TYPE",
+    "difficulty": 3,
+    "start": {
+      "assign_mission_target": {
+        "om_terrain": "s_air_helicopter_pad",
+        "om_special": "o_airport",
+        "reveal_radius": 6,
+        "random": true,
+        "search_range": 65,
+        "min_distance": 15,
+        "z": 0
+      },
+      "update_mapgen": {
+        "place_monster": [
+          { "monster": "mon_zombie_military_pilot", "x": 1, "y": 1 },
+          { "monster": "mon_feral_soldier", "x": 3, "y": 3 },
+          { "monster": "mon_zombie_soldier", "x": 7, "y": 3 },
+          { "monster": "mon_zombie_soldier", "x": 8, "y": 2 },
+          { "monster": "mon_zombie_soldier", "x": 7, "y": 6 }
+        ]
+      }
+    },
+    "origins": [ "ORIGIN_GAME_START" ],
+    "value": 0,
+    "end": {
+      "effect": [
+        {
+          "u_add_morale": "morale_feeling_good",
+          "bonus": 10,
+          "max_bonus": 50,
+          "duration": "120 minutes",
+          "decay_start": "60 minutes"
+        }
+      ]
+    }
+  },
+  {
     "id": "MISSION_LAST_DELIVERY",
     "type": "mission_definition",
     "name": { "str": "Reach The Mansion And Finish This Delivery" },


### PR DESCRIPTION
#### Summary
Content "Adds 2 new simple missions to the helicopter crash scenario"

#### Purpose of change

A military squad crashing in the wilderness with only one survivor while in transport sounds like a very good scenario to have more content, or, in this case, more missions to explore these special circumstances a little.

#### Describe the solution
Adds 2 new missions, one for all the passengers of the helicopter to be able to return to their base of origin and another one for the pilot to search for a new ride in the supply point closest to the crash, just a pair of nice little flavor missions to spice the scenario.

#### Describe alternatives you've considered
To revamp a little the zombie spawns of the 2 locations while I was here, since they seem pretty... bland. Specially the military helipad where the game just spawns a bunch of zombie soldiers glued together in the same point, but that can always be done in a different PR if I find the time.

#### Testing
Tested the changes in my local copy of the game of my phone, the missions generate normally and everything works.

#### Additional context
I was able to make and test this in a cave! With a trash text editor! Meaning in my work, with my cellphone haha.