### PR TITLE
Added presets for pocket settings

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4076,6 +4076,27 @@
   },
   {
     "type": "keybinding",
+    "id": "FAV_SAVE_PRESET",
+    "category": "INVENTORY",
+    "name": "Save preset",
+    "bindings": [ { "input_method": "keyboard_any", "key": "S" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "FAV_APPLY_PRESET",
+    "category": "INVENTORY",
+    "name": "Apply preset",
+    "bindings": [ { "input_method": "keyboard_any", "key": "A" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "FAV_DEL_PRESET",
+    "category": "INVENTORY",
+    "name": "Delete preset",
+    "bindings": [ { "input_method": "keyboard_any", "key": "D" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "FAV_CLEAR",
     "category": "INVENTORY",
     "name": "Clear entries",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4079,21 +4079,27 @@
     "id": "FAV_SAVE_PRESET",
     "category": "INVENTORY",
     "name": "Save preset",
-    "bindings": [ { "input_method": "keyboard_any", "key": "S" } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "S" }, 
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_APPLY_PRESET",
     "category": "INVENTORY",
     "name": "Apply preset",
-    "bindings": [ { "input_method": "keyboard_any", "key": "A" } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "A" }, 
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_DEL_PRESET",
     "category": "INVENTORY",
     "name": "Delete preset",
-    "bindings": [ { "input_method": "keyboard_any", "key": "D" } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "D" }, 
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4079,27 +4079,21 @@
     "id": "FAV_SAVE_PRESET",
     "category": "INVENTORY",
     "name": "Save preset",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "S" }, 
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_APPLY_PRESET",
     "category": "INVENTORY",
     "name": "Apply preset",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "A" }, 
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_DEL_PRESET",
     "category": "INVENTORY",
     "name": "Delete preset",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "D" }, 
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2539,7 +2539,10 @@ void outfit::organize_items_menu()
         { "FAV_BLACKLIST", translation() },
         { "FAV_CLEAR", translation() },
         { "FAV_MOVE_ITEM", translation() },
-        { "FAV_CONTEXT_MENU", translation() }
+        { "FAV_CONTEXT_MENU", translation() },
+        { "FAV_SAVE_PRESET", translation()},
+        { "FAV_APPLY_PRESET", translation()},
+        { "FAV_DEL_PRESET", translation()}
     };
     // we override confirm
     pocket_selector.allow_confirm = false;

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2540,9 +2540,9 @@ void outfit::organize_items_menu()
         { "FAV_CLEAR", translation() },
         { "FAV_MOVE_ITEM", translation() },
         { "FAV_CONTEXT_MENU", translation() },
-        { "FAV_SAVE_PRESET", translation()},
-        { "FAV_APPLY_PRESET", translation()},
-        { "FAV_DEL_PRESET", translation()}
+        { "FAV_SAVE_PRESET", translation() },
+        { "FAV_APPLY_PRESET", translation() },
+        { "FAV_DEL_PRESET", translation() }
     };
     // we override confirm
     pocket_selector.allow_confirm = false;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -396,21 +396,21 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         if( !custom_preset_popup.canceled() ) {
             const std::string &rval = custom_preset_popup.text();
             // Check if already exists
-            selected_pocket->load_presets();
-            if( selected_pocket->has_preset( rval ) ) {
+            item_pocket::load_presets();
+            if( item_pocket::has_preset( rval ) ) {
                 if( query_yn( _( "Preset already exists, overwrite?" ) ) ) {
-                    selected_pocket->delete_preset( selected_pocket->find_preset( rval ) );
+                    item_pocket::delete_preset( item_pocket::find_preset( rval ) );
                     selected_pocket->settings.set_preset_name( rval );
-                    selected_pocket->add_preset( selected_pocket->settings );
+                    item_pocket::add_preset( selected_pocket->settings );
                 }
             } else {
                 selected_pocket->settings.set_preset_name( rval );
-                selected_pocket->add_preset( selected_pocket->settings );
+                item_pocket::add_preset( selected_pocket->settings );
             }
         }
         return true;
     } else if( action == "FAV_APPLY_PRESET" ) {
-        selected_pocket->load_presets();
+        item_pocket::load_presets();
         selector_menu.title = _( "Select a preset" );
         for( const item_pocket::favorite_settings &preset : item_pocket::pocket_presets ) {
             selector_menu.addentry( preset.get_preset_name().value() );
@@ -422,7 +422,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         }
         return true;
     } else if( action == "FAV_DEL_PRESET" ) {
-        selected_pocket->load_presets();
+        item_pocket::load_presets();
         for( const item_pocket::favorite_settings &preset : item_pocket::pocket_presets ) {
             selector_menu.addentry( preset.get_preset_name().value() );
         }
@@ -431,7 +431,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         if( selector_menu.ret >= 0 ) {
             if( query_yn( _( "Are you sure you wish to delete preset %s?" ),
                           item_pocket::pocket_presets[selector_menu.ret].get_preset_name().value() ) ) {
-                selected_pocket->delete_preset( item_pocket::pocket_presets.begin() + selector_menu.ret );
+                item_pocket::delete_preset( item_pocket::pocket_presets.begin() + selector_menu.ret );
             }
         }
         return true;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -388,8 +388,11 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         string_input_popup custom_preset_popup;
         custom_preset_popup
         .title( _( "Enter a preset name:" ) )
-        .width( 25 )
-        .query_string();
+        .width( 25 );
+        if( selected_pocket->settings.get_preset_name().has_value() ) {
+            custom_preset_popup.text( selected_pocket->settings.get_preset_name().value() );
+        }
+        custom_preset_popup.query_string();
         if( !custom_preset_popup.canceled() ) {
             const std::string &rval = custom_preset_popup.text();
             // Check if already exists

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -408,7 +408,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         return true;
     } else if( action == "FAV_APPLY_PRESET" ) {
         selected_pocket->load_presets();
-        selector_menu.title = _( "Select a Preset" );
+        selector_menu.title = _( "Select a preset" );
         for( const item_pocket::favorite_settings &preset : selected_pocket->pocket_presets ) {
             selector_menu.addentry( preset.get_preset_name() );
         }
@@ -426,7 +426,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         selector_menu.query();
 
         if( selector_menu.ret >= 0 ) {
-            if( query_yn( _( "Are you sure wish to delete preset: %s" ),
+            if( query_yn( _( "Are you sure you wish to delete preset %s?" ),
                           selected_pocket->pocket_presets[selector_menu.ret].get_preset_name() ) ) {
                 selected_pocket->delete_preset( selected_pocket->pocket_presets.begin() + selector_menu.ret );
             }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -410,7 +410,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         selected_pocket->load_presets();
         selector_menu.title = _( "Select a preset" );
         for( const item_pocket::favorite_settings &preset : selected_pocket->pocket_presets ) {
-            selector_menu.addentry( preset.get_preset_name() );
+            selector_menu.addentry( preset.get_preset_name().value() );
         }
         selector_menu.query();
 
@@ -421,13 +421,13 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
     } else if( action == "FAV_DEL_PRESET" ) {
         selected_pocket->load_presets();
         for( const item_pocket::favorite_settings &preset : selected_pocket->pocket_presets ) {
-            selector_menu.addentry( preset.get_preset_name() );
+            selector_menu.addentry( preset.get_preset_name().value() );
         }
         selector_menu.query();
 
         if( selector_menu.ret >= 0 ) {
             if( query_yn( _( "Are you sure you wish to delete preset %s?" ),
-                          selected_pocket->pocket_presets[selector_menu.ret].get_preset_name() ) ) {
+                          selected_pocket->pocket_presets[selector_menu.ret].get_preset_name().value() ) ) {
                 selected_pocket->delete_preset( selected_pocket->pocket_presets.begin() + selector_menu.ret );
             }
         }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -409,26 +409,26 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
     } else if( action == "FAV_APPLY_PRESET" ) {
         selected_pocket->load_presets();
         selector_menu.title = _( "Select a preset" );
-        for( const item_pocket::favorite_settings &preset : selected_pocket->pocket_presets ) {
+        for( const item_pocket::favorite_settings &preset : item_pocket::pocket_presets ) {
             selector_menu.addentry( preset.get_preset_name().value() );
         }
         selector_menu.query();
 
         if( selector_menu.ret >= 0 ) {
-            selected_pocket->settings = selected_pocket->pocket_presets[selector_menu.ret];
+            selected_pocket->settings = item_pocket::pocket_presets[selector_menu.ret];
         }
         return true;
     } else if( action == "FAV_DEL_PRESET" ) {
         selected_pocket->load_presets();
-        for( const item_pocket::favorite_settings &preset : selected_pocket->pocket_presets ) {
+        for( const item_pocket::favorite_settings &preset : item_pocket::pocket_presets ) {
             selector_menu.addentry( preset.get_preset_name().value() );
         }
         selector_menu.query();
 
         if( selector_menu.ret >= 0 ) {
             if( query_yn( _( "Are you sure you wish to delete preset %s?" ),
-                          selected_pocket->pocket_presets[selector_menu.ret].get_preset_name().value() ) ) {
-                selected_pocket->delete_preset( selected_pocket->pocket_presets.begin() + selector_menu.ret );
+                          item_pocket::pocket_presets[selector_menu.ret].get_preset_name().value() ) ) {
+                selected_pocket->delete_preset( item_pocket::pocket_presets.begin() + selector_menu.ret );
             }
         }
         return true;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -408,7 +408,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         return true;
     } else if( action == "FAV_APPLY_PRESET" ) {
         selected_pocket->load_presets();
-        selector_menu.title = "Select a Preset";
+        selector_menu.title = _( "Select a Preset" );
         for( auto preset : selected_pocket->pocket_presets ) {
             selector_menu.addentry( preset.get_preset_name() );
         }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -384,6 +384,53 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
             }
         }
         return true;
+    } else if( action == "FAV_SAVE_PRESET" ) {
+        string_input_popup custom_preset_popup;
+        custom_preset_popup
+        .title( _( "Enter a preset name:" ) )
+        .width( 25 )
+        .query_string();
+        if( !custom_preset_popup.canceled() ) {
+            std::string rval = custom_preset_popup.text();
+            // Check if already exists
+            selected_pocket->load_presets();
+            if( selected_pocket->has_preset( rval ) ) {
+                if( query_yn( _( "Preset already exists, overwrite?" ) ) ) {
+                    selected_pocket->delete_preset( selected_pocket->find_preset( rval ) );
+                    selected_pocket->settings.set_preset_name( rval );
+                    selected_pocket->add_preset( rval );
+                }
+            } else {
+                selected_pocket->settings.set_preset_name( rval );
+                selected_pocket->add_preset( rval );
+            }
+        }
+        return true;
+    } else if( action == "FAV_APPLY_PRESET" ) {
+        selected_pocket->load_presets();
+        for( auto preset : selected_pocket->pocket_presets ) {
+            selector_menu.addentry( preset.get_preset_name() );
+        }
+        selector_menu.query();
+
+        if( selector_menu.ret >= 0 ) {
+            selected_pocket->settings = selected_pocket->pocket_presets[selector_menu.ret];
+        }
+        return true;
+    } else if( action == "FAV_DEL_PRESET" ) {
+        selected_pocket->load_presets();
+        for( auto preset : selected_pocket->pocket_presets ) {
+            selector_menu.addentry( preset.get_preset_name() );
+        }
+        selector_menu.query();
+
+        if( selector_menu.ret >= 0 ) {
+            if( query_yn( _( "Are you sure wish to delete preset: %s" ),
+                          selected_pocket->pocket_presets[selector_menu.ret].get_preset_name() ) ) {
+                selected_pocket->delete_preset( selected_pocket->pocket_presets.begin() + selector_menu.ret );
+            }
+        }
+        return true;
     } else if( action == "FAV_CLEAR" ) {
         if( query_yn( _( "Are you sure you want to clear settings for pocket %d?" ), pocket_num ) ) {
             selected_pocket->settings.clear();
@@ -406,7 +453,13 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
                         ctxt.get_action_name( "FAV_AUTO_PICKUP" ) );
         cmenu.addentry( 7, true, inp_mngr.get_first_char_for_action( "FAV_AUTO_UNLOAD", "INVENTORY" ),
                         ctxt.get_action_name( "FAV_AUTO_UNLOAD" ) );
-        cmenu.addentry( 8, true, inp_mngr.get_first_char_for_action( "FAV_CLEAR", "INVENTORY" ),
+        cmenu.addentry( 8, true, inp_mngr.get_first_char_for_action( "FAV_SAVE_PRESET", "INVENTORY" ),
+                        ctxt.get_action_name( "FAV_SAVE_PRESET" ) );
+        cmenu.addentry( 9, true, inp_mngr.get_first_char_for_action( "FAV_APPLY_PRESET", "INVENTORY" ),
+                        ctxt.get_action_name( "FAV_APPLY_PRESET" ) );
+        cmenu.addentry( 10, true, inp_mngr.get_first_char_for_action( "FAV_DEL_PRESET", "INVENTORY" ),
+                        ctxt.get_action_name( "FAV_DEL_PRESET" ) );
+        cmenu.addentry( 11, true, inp_mngr.get_first_char_for_action( "FAV_CLEAR", "INVENTORY" ),
                         ctxt.get_action_name( "FAV_CLEAR" ) );
         cmenu.query();
 
@@ -437,6 +490,15 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
                 ev = "FAV_AUTO_UNLOAD";
                 break;
             case 8:
+                ev = "FAV_SAVE_PRESET";
+                break;
+            case 9:
+                ev = "FAV_APPLY_PRESET";
+                break;
+            case 10:
+                ev = "FAV_DEL_PRESET";
+                break;
+            case 11:
                 ev = "FAV_CLEAR";
                 break;
             default:
@@ -444,7 +506,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
 
         }
         const std::vector<input_event> evlist = inp_mngr.get_input_for_action( ev, "INVENTORY" );
-        if( cmenu.ret >= 0 && cmenu.ret <= 8 && !evlist.empty() ) {
+        if( cmenu.ret >= 0 && cmenu.ret <= 11 && !evlist.empty() ) {
             return key( ctxt, evlist.front(), -1, menu );
         }
         return true;
@@ -2365,7 +2427,10 @@ void item_contents::favorite_settings_menu( item *i )
         { "FAV_BLACKLIST", translation() },
         { "FAV_CLEAR", translation() },
         { "FAV_MOVE_ITEM", translation() },
-        { "FAV_CONTEXT_MENU", translation() }
+        { "FAV_CONTEXT_MENU", translation() },
+        { "FAV_SAVE_PRESET", translation() },
+        { "FAV_APPLY_PRESET", translation() },
+        { "FAV_DEL_PRESET", translation() }
     };
     // we override confirm
     pocket_selector.allow_confirm = false;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -398,16 +398,17 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
                 if( query_yn( _( "Preset already exists, overwrite?" ) ) ) {
                     selected_pocket->delete_preset( selected_pocket->find_preset( rval ) );
                     selected_pocket->settings.set_preset_name( rval );
-                    selected_pocket->add_preset( rval );
+                    selected_pocket->add_preset( selected_pocket->settings );
                 }
             } else {
                 selected_pocket->settings.set_preset_name( rval );
-                selected_pocket->add_preset( rval );
+                selected_pocket->add_preset( selected_pocket->settings );
             }
         }
         return true;
     } else if( action == "FAV_APPLY_PRESET" ) {
         selected_pocket->load_presets();
+        selector_menu.title = "Select a Preset";
         for( auto preset : selected_pocket->pocket_presets ) {
             selector_menu.addentry( preset.get_preset_name() );
         }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -391,7 +391,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         .width( 25 )
         .query_string();
         if( !custom_preset_popup.canceled() ) {
-            std::string rval = custom_preset_popup.text();
+            const std::string &rval = custom_preset_popup.text();
             // Check if already exists
             selected_pocket->load_presets();
             if( selected_pocket->has_preset( rval ) ) {
@@ -409,7 +409,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
     } else if( action == "FAV_APPLY_PRESET" ) {
         selected_pocket->load_presets();
         selector_menu.title = _( "Select a Preset" );
-        for( auto preset : selected_pocket->pocket_presets ) {
+        for( const item_pocket::favorite_settings &preset : selected_pocket->pocket_presets ) {
             selector_menu.addentry( preset.get_preset_name() );
         }
         selector_menu.query();
@@ -420,7 +420,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         return true;
     } else if( action == "FAV_DEL_PRESET" ) {
         selected_pocket->load_presets();
-        for( auto preset : selected_pocket->pocket_presets ) {
+        for( const item_pocket::favorite_settings &preset : selected_pocket->pocket_presets ) {
             selector_menu.addentry( preset.get_preset_name() );
         }
         selector_menu.query();

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2116,13 +2116,13 @@ void item_pocket::heat_up()
     }
 }
 
-void item_pocket::add_preset( const item_pocket::favorite_settings &preset ) const
+void item_pocket::add_preset( const item_pocket::favorite_settings &preset )
 {
     pocket_presets.emplace_back( preset );
     save_presets();
 }
 
-void item_pocket::save_presets() const
+void item_pocket::save_presets()
 {
     cata_path file = PATH_INFO::pocket_presets();
 
@@ -2149,7 +2149,6 @@ std::vector<item_pocket::favorite_settings>::iterator item_pocket::find_preset(
 }
 
 void item_pocket::delete_preset( const std::vector<item_pocket::favorite_settings>::iterator iter )
-const
 {
     pocket_presets.erase( iter );
     save_presets();
@@ -2175,7 +2174,7 @@ void item_pocket::load_presets()
     fin.close();
 }
 
-void item_pocket::serialize_presets( JsonOut &json ) const
+void item_pocket::serialize_presets( JsonOut &json )
 {
     json.start_array();
     for( const item_pocket::favorite_settings &preset : pocket_presets ) {

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2116,7 +2116,7 @@ void item_pocket::heat_up()
     }
 }
 
-void item_pocket::add_preset( const item_pocket::favorite_settings &preset )
+void item_pocket::add_preset( const item_pocket::favorite_settings &preset ) const
 {
     pocket_presets.emplace_back( preset );
     save_presets();
@@ -2149,6 +2149,7 @@ std::vector<item_pocket::favorite_settings>::iterator item_pocket::find_preset(
 }
 
 void item_pocket::delete_preset( const std::vector<item_pocket::favorite_settings>::iterator iter )
+const
 {
     pocket_presets.erase( iter );
     save_presets();

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2131,13 +2131,13 @@ void item_pocket::save_presets()
     }, _( "pocket preset configuration" ) );
 }
 
-bool item_pocket::has_preset( const std::string s )
+bool item_pocket::has_preset( const std::string &s )
 {
     return find_preset( s ) != pocket_presets.end();
 }
 
 std::vector<item_pocket::favorite_settings>::iterator item_pocket::find_preset(
-    const std::string s )
+    const std::string &s )
 {
     std::vector<item_pocket::favorite_settings>::iterator iter = std::find_if( pocket_presets.begin(),
             pocket_presets.end(),
@@ -2216,7 +2216,7 @@ units::volume pocket_data::max_contains_volume() const
 
 void item_pocket::favorite_settings::clear()
 {
-    preset_name = "";
+    preset_name = std::string();
     priority_rating = 0;
     item_whitelist.clear();
     item_blacklist.clear();
@@ -2420,12 +2420,12 @@ void item_pocket::favorite_settings::set_unloadable( bool flag )
     unload = flag;
 }
 
-void item_pocket::favorite_settings::set_preset_name( const std::string s )
+void item_pocket::favorite_settings::set_preset_name( const std::string &s )
 {
     preset_name = s;
 }
 
-std::string item_pocket::favorite_settings::get_preset_name() const
+const std::string &item_pocket::favorite_settings::get_preset_name() const
 {
     return preset_name;
 }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2114,13 +2114,13 @@ void item_pocket::heat_up()
     }
 }
 
-void item_pocket::add_preset( const item_pocket::favorite_settings preset )
+void item_pocket::add_preset( const item_pocket::favorite_settings &preset )
 {
     pocket_presets.emplace_back( preset );
     save_presets();
 }
 
-void item_pocket::save_presets()
+void item_pocket::save_presets() const
 {
     cata::ifstream fin;
     cata_path file = PATH_INFO::pocket_presets();
@@ -2176,7 +2176,7 @@ void item_pocket::load_presets()
 void item_pocket::serialize_presets( JsonOut &json ) const
 {
     json.start_array();
-    for( auto preset : pocket_presets ) {
+    for( const item_pocket::favorite_settings &preset : pocket_presets ) {
         preset.serialize( json );
     }
     json.end_array();

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2114,9 +2114,9 @@ void item_pocket::heat_up()
     }
 }
 
-void item_pocket::add_preset( std::string s )
+void item_pocket::add_preset( const item_pocket::favorite_settings preset )
 {
-    pocket_presets.emplace_back( settings );
+    pocket_presets.emplace_back( preset );
     save_presets();
 }
 
@@ -2216,6 +2216,7 @@ units::volume pocket_data::max_contains_volume() const
 
 void item_pocket::favorite_settings::clear()
 {
+    preset_name = "";
     priority_rating = 0;
     item_whitelist.clear();
     item_blacklist.clear();

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2217,7 +2217,7 @@ units::volume pocket_data::max_contains_volume() const
 
 void item_pocket::favorite_settings::clear()
 {
-    preset_name = std::string();
+    preset_name = cata::nullopt;
     priority_rating = 0;
     item_whitelist.clear();
     item_blacklist.clear();
@@ -2451,7 +2451,7 @@ void item_pocket::favorite_settings::info( std::vector<iteminfo> &info ) const
         info.emplace_back( "BASE", string_format(
                                _( "Items in this pocket <bad>won't be unloaded</bad> unless you manually drop them." ) ) );
     }
-    if( preset_name.value() != "" ) {
+    if( preset_name.has_value() ) {
         info.emplace_back( "BASE", string_format( _( "Preset Name: %s" ), preset_name.value() ) );
     }
 

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -59,6 +59,8 @@ std::string enum_to_string<item_pocket::pocket_type>( item_pocket::pocket_type d
 constexpr units::volume pocket_data::max_volume_for_container;
 constexpr units::mass pocket_data::max_weight_for_container;
 
+std::vector<item_pocket::favorite_settings> item_pocket::pocket_presets;
+
 std::string pocket_data::check_definition() const
 {
     if( type == item_pocket::pocket_type::MOD ||
@@ -2122,7 +2124,6 @@ void item_pocket::add_preset( const item_pocket::favorite_settings &preset )
 
 void item_pocket::save_presets() const
 {
-    cata::ifstream fin;
     cata_path file = PATH_INFO::pocket_presets();
 
     write_to_file( file, [&]( std::ostream & fout ) {
@@ -2142,7 +2143,7 @@ std::vector<item_pocket::favorite_settings>::iterator item_pocket::find_preset(
     std::vector<item_pocket::favorite_settings>::iterator iter = std::find_if( pocket_presets.begin(),
             pocket_presets.end(),
     [&s]( const item_pocket::favorite_settings & preset ) {
-        return preset.get_preset_name() == s;
+        return preset.get_preset_name().value() == s;
     } );
     return iter;
 }
@@ -2425,7 +2426,7 @@ void item_pocket::favorite_settings::set_preset_name( const std::string &s )
     preset_name = s;
 }
 
-const std::string &item_pocket::favorite_settings::get_preset_name() const
+const cata::optional<std::string> &item_pocket::favorite_settings::get_preset_name() const
 {
     return preset_name;
 }
@@ -2450,7 +2451,10 @@ void item_pocket::favorite_settings::info( std::vector<iteminfo> &info ) const
         info.emplace_back( "BASE", string_format(
                                _( "Items in this pocket <bad>won't be unloaded</bad> unless you manually drop them." ) ) );
     }
-    info.emplace_back( "BASE", string_format( _( "Preset Name: %s" ), preset_name ) );
+    if( preset_name.value() != "" ) {
+        info.emplace_back( "BASE", string_format( _( "Preset Name: %s" ), preset_name.value() ) );
+    }
+
     info.emplace_back( "BASE", string_format( "%s %d", _( "Priority:" ), priority_rating ) );
     info.emplace_back( "BASE", string_format( _( "Item Whitelist: %s" ),
                        item_whitelist.empty() ? _( "(empty)" ) :

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -113,7 +113,7 @@ class item_pocket
                 bool is_unloadable() const;
                 void set_unloadable( bool );
 
-                const std::string &get_preset_name() const;
+                const cata::optional<std::string> &get_preset_name() const;
                 void set_preset_name( const std::string & );
 
                 void info( std::vector<iteminfo> &info ) const;
@@ -121,7 +121,7 @@ class item_pocket
                 void serialize( JsonOut &json ) const;
                 void deserialize( const JsonObject &data );
             private:
-                std::string preset_name;
+                cata::optional<std::string> preset_name;
                 int priority_rating = 0;
                 cata::flat_set<itype_id> item_whitelist;
                 cata::flat_set<itype_id> item_blacklist;
@@ -394,7 +394,7 @@ class item_pocket
         std::vector<item_pocket::favorite_settings>::iterator find_preset( const std::string &s );
         bool has_preset( const std::string &s );
         void delete_preset( std::vector<item_pocket::favorite_settings>::iterator iter );
-        std::vector<item_pocket::favorite_settings> pocket_presets;
+        static std::vector<item_pocket::favorite_settings> pocket_presets;
 
         // should the name of this pocket be used as a description
         bool name_as_description = false; // NOLINT(cata-serialize)

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -114,7 +114,7 @@ class item_pocket
                 void set_unloadable( bool );
 
                 std::string get_preset_name() const;
-                void set_preset_name(const std::string);
+                void set_preset_name( const std::string );
 
                 void info( std::vector<iteminfo> &info ) const;
 
@@ -386,14 +386,14 @@ class item_pocket
         favorite_settings settings;
 
         // Pocket presets functions
-        void serialize_presets(JsonOut& json) const;
-        void deserialize_presets(const JsonArray& ja);
+        void serialize_presets( JsonOut &json ) const;
+        void deserialize_presets( const JsonArray &ja );
         void load_presets();
-        void add_preset(std::string s);
+        void add_preset( const item_pocket::favorite_settings preset );
         void save_presets();
-        std::vector<item_pocket::favorite_settings>::iterator find_preset(const std::string s);
-        bool has_preset(const std::string s);
-        void delete_preset(const std::vector<item_pocket::favorite_settings>::iterator iter);
+        std::vector<item_pocket::favorite_settings>::iterator find_preset( const std::string s );
+        bool has_preset( const std::string s );
+        void delete_preset( const std::vector<item_pocket::favorite_settings>::iterator iter );
         std::vector<item_pocket::favorite_settings> pocket_presets;
 
         // should the name of this pocket be used as a description

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -113,11 +113,15 @@ class item_pocket
                 bool is_unloadable() const;
                 void set_unloadable( bool );
 
+                std::string get_preset_name() const;
+                void set_preset_name(const std::string);
+
                 void info( std::vector<iteminfo> &info ) const;
 
                 void serialize( JsonOut &json ) const;
                 void deserialize( const JsonObject &data );
             private:
+                std::string preset_name = "";
                 int priority_rating = 0;
                 cata::flat_set<itype_id> item_whitelist;
                 cata::flat_set<itype_id> item_blacklist;
@@ -380,6 +384,17 @@ class item_pocket
         bool operator==( const item_pocket &rhs ) const;
 
         favorite_settings settings;
+
+        // Pocket presets functions
+        void serialize_presets(JsonOut& json) const;
+        void deserialize_presets(const JsonArray& ja);
+        void load_presets();
+        void add_preset(std::string s);
+        void save_presets();
+        std::vector<item_pocket::favorite_settings>::iterator find_preset(const std::string s);
+        bool has_preset(const std::string s);
+        void delete_preset(const std::vector<item_pocket::favorite_settings>::iterator iter);
+        std::vector<item_pocket::favorite_settings> pocket_presets;
 
         // should the name of this pocket be used as a description
         bool name_as_description = false; // NOLINT(cata-serialize)

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -113,15 +113,15 @@ class item_pocket
                 bool is_unloadable() const;
                 void set_unloadable( bool );
 
-                std::string get_preset_name() const;
-                void set_preset_name( const std::string );
+                const std::string &get_preset_name() const;
+                void set_preset_name( const std::string & );
 
                 void info( std::vector<iteminfo> &info ) const;
 
                 void serialize( JsonOut &json ) const;
                 void deserialize( const JsonObject &data );
             private:
-                std::string preset_name = "";
+                std::string preset_name;
                 int priority_rating = 0;
                 cata::flat_set<itype_id> item_whitelist;
                 cata::flat_set<itype_id> item_blacklist;
@@ -389,11 +389,11 @@ class item_pocket
         void serialize_presets( JsonOut &json ) const;
         void deserialize_presets( const JsonArray &ja );
         void load_presets();
-        void add_preset( const item_pocket::favorite_settings preset );
+        void add_preset( item_pocket::favorite_settings preset );
         void save_presets();
-        std::vector<item_pocket::favorite_settings>::iterator find_preset( const std::string s );
-        bool has_preset( const std::string s );
-        void delete_preset( const std::vector<item_pocket::favorite_settings>::iterator iter );
+        std::vector<item_pocket::favorite_settings>::iterator find_preset( const std::string &s );
+        bool has_preset( const std::string &s );
+        void delete_preset( std::vector<item_pocket::favorite_settings>::iterator iter );
         std::vector<item_pocket::favorite_settings> pocket_presets;
 
         // should the name of this pocket be used as a description

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -386,14 +386,14 @@ class item_pocket
         favorite_settings settings;
 
         // Pocket presets functions
-        void serialize_presets( JsonOut &json ) const;
-        void deserialize_presets( const JsonArray &ja );
-        void load_presets();
-        void add_preset( const item_pocket::favorite_settings &preset ) const;
-        void save_presets() const;
-        std::vector<item_pocket::favorite_settings>::iterator find_preset( const std::string &s );
-        bool has_preset( const std::string &s );
-        void delete_preset( std::vector<item_pocket::favorite_settings>::iterator iter ) const;
+        static void serialize_presets( JsonOut &json );
+        static void deserialize_presets( const JsonArray &ja );
+        static void load_presets();
+        static void add_preset( const item_pocket::favorite_settings &preset );
+        static void save_presets();
+        static std::vector<item_pocket::favorite_settings>::iterator find_preset( const std::string &s );
+        static bool has_preset( const std::string &s );
+        static void delete_preset( std::vector<item_pocket::favorite_settings>::iterator iter );
         static std::vector<item_pocket::favorite_settings> pocket_presets;
 
         // should the name of this pocket be used as a description

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -389,8 +389,8 @@ class item_pocket
         void serialize_presets( JsonOut &json ) const;
         void deserialize_presets( const JsonArray &ja );
         void load_presets();
-        void add_preset( item_pocket::favorite_settings preset );
-        void save_presets();
+        void add_preset( const item_pocket::favorite_settings &preset );
+        void save_presets() const;
         std::vector<item_pocket::favorite_settings>::iterator find_preset( const std::string &s );
         bool has_preset( const std::string &s );
         void delete_preset( std::vector<item_pocket::favorite_settings>::iterator iter );

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -389,11 +389,11 @@ class item_pocket
         void serialize_presets( JsonOut &json ) const;
         void deserialize_presets( const JsonArray &ja );
         void load_presets();
-        void add_preset( const item_pocket::favorite_settings &preset );
+        void add_preset( const item_pocket::favorite_settings &preset ) const;
         void save_presets() const;
         std::vector<item_pocket::favorite_settings>::iterator find_preset( const std::string &s );
         bool has_preset( const std::string &s );
-        void delete_preset( std::vector<item_pocket::favorite_settings>::iterator iter );
+        void delete_preset( std::vector<item_pocket::favorite_settings>::iterator iter ) const;
         static std::vector<item_pocket::favorite_settings> pocket_presets;
 
         // should the name of this pocket be used as a description

--- a/src/path_info.cpp
+++ b/src/path_info.cpp
@@ -343,6 +343,10 @@ cata_path PATH_INFO::panel_options()
 {
     return config_dir_path_value / "panel_options.json";
 }
+cata_path PATH_INFO::pocket_presets()
+{
+    return config_dir_path_value / "pocket_presets.json";
+}
 cata_path PATH_INFO::safemode()
 {
     return config_dir_path_value / "safemode.json";

--- a/src/path_info.h
+++ b/src/path_info.h
@@ -84,6 +84,7 @@ cata_path names();
 cata_path options();
 cata_path panel_options();
 cata_path player_base_save_path_path();
+cata_path pocket_presets();
 cata_path safemode();
 cata_path savedir_path();
 cata_path templatedir_path();

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -270,6 +270,7 @@ void item_pocket::deserialize( const JsonObject &data )
 void item_pocket::favorite_settings::serialize( JsonOut &json ) const
 {
     json.start_object();
+    json.member( "name", preset_name );
     json.member( "priority", priority_rating );
     json.member( "item_whitelist", item_whitelist );
     json.member( "item_blacklist", item_blacklist );
@@ -284,6 +285,9 @@ void item_pocket::favorite_settings::serialize( JsonOut &json ) const
 void item_pocket::favorite_settings::deserialize( const JsonObject &data )
 {
     data.allow_omitted_members();
+    if( data.has_member( "name" ) ) {
+        data.read( "name", preset_name );
+    }
     data.read( "priority", priority_rating );
     data.read( "item_whitelist", item_whitelist );
     data.read( "item_blacklist", item_blacklist );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Added Presets for pocket settings"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Added the ability to save and load presets onto pockets in the pocket management window i->i. This makes it much simpler and faster to use the pocket system once you've set up your presets..
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I added menu options in the i->i context menu for saving, applying, and deleting presets from a pocket_presets.json file. I used the existing item_pocket::favorite_settings struct while adding a preset_name field so I could use the same serializing functions.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I tried to put the code farther up in inventory to avoid having to load all the presets from the file whenever you used the action but it felt far more complicated that way. I'm open to suggestions on where to move this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I started a new character, set some whitelist, blacklist and priorities for pockets, Saved the preset, loaded it onto another pocket and then deleted the preset.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
![image](https://user-images.githubusercontent.com/9900620/216146064-e687b694-3191-48f5-9f21-2a1a326e60fd.png)
![image](https://user-images.githubusercontent.com/9900620/216130334-1637510d-f6b1-4e24-86de-e2c9078395b0.png)
![image](https://user-images.githubusercontent.com/9900620/216145994-146b6494-9d55-4253-92ef-c85774fe2a65.png)




<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
