### PR TITLE
Expand civilian / bugout bag ballistic vest loot

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/gear.json
+++ b/data/json/itemgroups/Clothing_Gear/gear.json
@@ -221,7 +221,28 @@
     "id": "civilian_body_armor",
     "subtype": "distribution",
     "//": "armor that a civilian might have.",
-    "entries": [ { "item": "kevlar", "prob": 20 } ]
+    "entries": [ 
+      { "item": "kevlar", "prob": 20 },
+      { "item": "soft_3a_vest", "prob": 15 },
+      { "item": "stab_vest", "prob": 15 },
+      { "item": "chestguard_hard", "prob": 5 },
+      { "item": "vest_leather", "prob": 10 },
+      { "collection": [ { "item": "ballistic_vest_light" }, { "group": "civilian_ballistic_inserts", "prob": 50 } ], "prob": 10 },
+      { "collection": [ { "item": "ballistic_vest_light_pouches" }, { "group": "civilian_ballistic_inserts", "prob": 50 } ], "prob": 10 },
+      { "collection": [ { "item": "ballistic_vest_light_operator" }, { "group": "civilian_ballistic_inserts", "prob": 50 } ], "prob": 10 },
+      { "collection": [ { "level_3_vest", "variant": "fema_armor_vest" }, { "group": "civilian_ballistic_inserts", "prob": 75 } ], "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "civilian_ballistic_inserts",
+    "subtype": "distribution",
+    "//": "armor that a civilian might have.",
+    "entries": [
+      { "group": "some_steel_front_plates", "prob": 30 },
+      { "group": "some_stab_front_plates", "prob": 45 },
+      { "group": "pristine_esapi_front_plates", "prob": 25 }
+    ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Clothing_Gear/gear.json
+++ b/data/json/itemgroups/Clothing_Gear/gear.json
@@ -227,10 +227,22 @@
       { "item": "stab_vest", "prob": 15 },
       { "item": "chestguard_hard", "prob": 5 },
       { "item": "vest_leather", "prob": 10 },
-      { "collection": [ { "item": "ballistic_vest_light" }, { "group": "civilian_ballistic_inserts", "prob": 50 } ], "prob": 10 },
-      { "collection": [ { "item": "ballistic_vest_light_pouches" }, { "group": "civilian_ballistic_inserts", "prob": 50 } ], "prob": 10 },
-      { "collection": [ { "item": "ballistic_vest_light_operator" }, { "group": "civilian_ballistic_inserts", "prob": 50 } ], "prob": 10 },
-      { "collection": [ { "item": "level_3_vest", "variant": "fema_armor_vest" }, { "group": "civilian_ballistic_inserts", "prob": 75 } ], "prob": 5 }
+      {
+        "collection": [ { "item": "ballistic_vest_light" }, { "group": "civilian_ballistic_inserts", "prob": 50 } ],
+        "prob": 10
+      },
+      {
+        "collection": [ { "item": "ballistic_vest_light_pouches" }, { "group": "civilian_ballistic_inserts", "prob": 50 } ],
+        "prob": 10
+      },
+      {
+        "collection": [ { "item": "ballistic_vest_light_operator" }, { "group": "civilian_ballistic_inserts", "prob": 50 } ],
+        "prob": 10
+      },
+      {
+        "collection": [ { "item": "level_3_vest", "variant": "fema_armor_vest" }, { "group": "civilian_ballistic_inserts", "prob": 75 } ],
+        "prob": 5
+      }
     ]
   },
   {

--- a/data/json/itemgroups/Clothing_Gear/gear.json
+++ b/data/json/itemgroups/Clothing_Gear/gear.json
@@ -221,7 +221,7 @@
     "id": "civilian_body_armor",
     "subtype": "distribution",
     "//": "armor that a civilian might have.",
-    "entries": [ 
+    "entries": [
       { "item": "kevlar", "prob": 20 },
       { "item": "soft_3a_vest", "prob": 15 },
       { "item": "stab_vest", "prob": 15 },

--- a/data/json/itemgroups/Clothing_Gear/gear.json
+++ b/data/json/itemgroups/Clothing_Gear/gear.json
@@ -230,7 +230,7 @@
       { "collection": [ { "item": "ballistic_vest_light" }, { "group": "civilian_ballistic_inserts", "prob": 50 } ], "prob": 10 },
       { "collection": [ { "item": "ballistic_vest_light_pouches" }, { "group": "civilian_ballistic_inserts", "prob": 50 } ], "prob": 10 },
       { "collection": [ { "item": "ballistic_vest_light_operator" }, { "group": "civilian_ballistic_inserts", "prob": 50 } ], "prob": 10 },
-      { "collection": [ { "level_3_vest", "variant": "fema_armor_vest" }, { "group": "civilian_ballistic_inserts", "prob": 75 } ], "prob": 5 }
+      { "collection": [ { "item": "level_3_vest", "variant": "fema_armor_vest" }, { "group": "civilian_ballistic_inserts", "prob": 75 } ], "prob": 5 }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "zombie backpacks have more than just basic kevlar vests"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently zombies' backpacks will only contain the standard "Kevlar Vest" (the one that fits under armor). I wanted to change that.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Now they will carry a lot more other types of vests. Most frequently they will have a cheap Light Ballistic Vest variant, but can also have soft armor vests, leather vests, hard chest guards, and rarely hard armor vests. If they spawn a compatible ballistic vest they will sometimes also spawn a matching pair of ballistic plates; most commonly soft stab panels, but also steel plates and rarely ESAPI plates.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Make the zombies wear the vests instead of carrying them in backpacks. It's a little funny that zombies just carry the vests in their backpacks, but there are at least some explanations for this. The people who didn't wear vests are the ones most likely to die so there is selection bias. Some of them may have gone feral (thus not dressing themselves) and then died. Some of them may have been caught unawares. Some of them may have tried to go without the vest for whatever reason (not everyone is wearing armor 24/7 even in the apocalypse). Etc. That's also a bit out of scope for a fairly simple change overall.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I ran around killing zombies for half an hour and observed the new spawns, they seem to be working correctly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
