### PR TITLE
Show radiation level using radiation badge instead of character's rads

### DIFF
--- a/data/json/ui/radiation.json
+++ b/data/json/ui/radiation.json
@@ -10,7 +10,7 @@
         "color": "white_green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "rad" }, "<=", { "const": 0 } ] },
+            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 0 } ] },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -21,8 +21,10 @@
         "color": "h_white",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "rad" }, "<=", { "const": 30 } ] },
-            { "compare_int": [ { "u_val": "rad" }, ">", { "const": 0 } ] },
+            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 30 } ] },
+            {
+              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 0 } ]
+            },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -33,8 +35,10 @@
         "color": "i_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "rad" }, "<=", { "const": 60 } ] },
-            { "compare_int": [ { "u_val": "rad" }, ">", { "const": 30 } ] },
+            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 60 } ] },
+            {
+              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 30 } ]
+            },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -45,8 +49,10 @@
         "color": "red_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "rad" }, "<=", { "const": 120 } ] },
-            { "compare_int": [ { "u_val": "rad" }, ">", { "const": 60 } ] },
+            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 120 } ] },
+            {
+              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 60 } ]
+            },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -57,8 +63,10 @@
         "color": "red_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "rad" }, "<=", { "const": 240 } ] },
-            { "compare_int": [ { "u_val": "rad" }, ">", { "const": 120 } ] },
+            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 240 } ] },
+            {
+              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 120 } ]
+            },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -69,7 +77,7 @@
         "color": "pink",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "rad" }, ">", { "const": 240 } ] },
+            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 240 } ] },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }

--- a/data/mods/TEST_DATA/widgets.json
+++ b/data/mods/TEST_DATA/widgets.json
@@ -167,7 +167,7 @@
         "color": "white_green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "rad" }, "<=", { "const": 0 } ] },
+            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 0 } ] },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -178,8 +178,10 @@
         "color": "h_white",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "rad" }, "<=", { "const": 30 } ] },
-            { "compare_int": [ { "u_val": "rad" }, ">", { "const": 0 } ] },
+            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 30 } ] },
+            {
+              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 0 } ]
+            },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -190,8 +192,10 @@
         "color": "i_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "rad" }, "<=", { "const": 60 } ] },
-            { "compare_int": [ { "u_val": "rad" }, ">", { "const": 30 } ] },
+            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 60 } ] },
+            {
+              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 30 } ]
+            },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -202,8 +206,10 @@
         "color": "red_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "rad" }, "<=", { "const": 120 } ] },
-            { "compare_int": [ { "u_val": "rad" }, ">", { "const": 60 } ] },
+            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 120 } ] },
+            {
+              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 60 } ]
+            },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -214,8 +220,10 @@
         "color": "red_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "rad" }, "<=", { "const": 240 } ] },
-            { "compare_int": [ { "u_val": "rad" }, ">", { "const": 120 } ] },
+            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 240 } ] },
+            {
+              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 120 } ]
+            },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -226,8 +234,7 @@
         "color": "pink",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "rad" }, "<=", { "const": 500 } ] },
-            { "compare_int": [ { "u_val": "rad" }, ">", { "const": 240 } ] },
+            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 240 } ] },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -793,3 +793,21 @@ int bucket_index_from_weight_list( const std::vector<int> &weights )
     }
     return index;
 }
+
+template<>
+std::string io::enum_to_string<aggregate_type>( aggregate_type agg )
+{
+    switch( agg ) {
+        // *INDENT-OFF*
+        case aggregate_type::FIRST:   return "first";
+        case aggregate_type::LAST:    return "last";
+        case aggregate_type::MIN:     return "min";
+        case aggregate_type::MAX:     return "max";
+        case aggregate_type::SUM:     return "sum";
+        case aggregate_type::AVERAGE: return "average";
+        // *INDENT-ON*
+        case aggregate_type::num_aggregate_types:
+            break;
+    }
+    cata_fatal( "Invalid aggregate type." );
+}

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -9,6 +9,7 @@
 #include <iosfwd>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <string> // IWYU pragma: keep
 #include <type_traits>
 #include <unordered_set>
@@ -628,5 +629,33 @@ int bucket_index_from_weight_list( const std::vector<int> &weights );
  * Implemented in `stdtiles.cpp`, `wincurse.cpp`, and `ncurses_def.cpp`.
  */
 void set_title( const std::string &title );
+
+/**
+ * Convenience function to get the aggregate value for a list of values.
+ */
+template<typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+T aggregate( const std::vector<T> &values, aggregate_type agg_func )
+{
+    if( values.empty() ) {
+        return T();
+    }
+    switch( agg_func ) {
+        case aggregate_type::FIRST:
+            return values.front();
+        case aggregate_type::LAST:
+            return *values.rbegin();
+        case aggregate_type::MIN:
+            return *std::min_element( values.begin(), values.end() );
+        case aggregate_type::MAX:
+            return *std::max_element( values.begin(), values.end() );
+        case aggregate_type::AVERAGE:
+        case aggregate_type::SUM: {
+            T agg_sum = std::accumulate( values.begin(), values.end(), 0 );
+            return agg_func == aggregate_type::SUM ? agg_sum : agg_sum / values.size();
+        }
+        default:
+            return T();
+    }
+}
 
 #endif // CATA_SRC_CATA_UTILITY_H

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1717,6 +1717,12 @@ std::function<int( const T & )> conditional_t<T>::get_get_int( const JsonObject 
             return [is_npc]( const T & d ) {
                 return d.actor( is_npc )->get_rad();
             };
+        } else if( checked_value == "item_rad" ) {
+            const std::string flag = jo.get_string( "flag" );
+            const aggregate_type agg = jo.get_enum_value<aggregate_type>( "aggregate", aggregate_type::FIRST );
+            return [is_npc, flag, agg]( const T & d ) {
+                return d.actor( is_npc )->item_rads( flag_id( flag ), agg );
+            };
         } else if( checked_value == "focus" ) {
             return [is_npc]( const T & d ) {
                 return d.actor( is_npc )->focus_cur();

--- a/src/enums.h
+++ b/src/enums.h
@@ -450,4 +450,19 @@ enum class character_type : int {
     FULL_RANDOM,
 };
 
+enum class aggregate_type : int {
+    FIRST,
+    LAST,
+    MIN,
+    MAX,
+    SUM,
+    AVERAGE,
+    num_aggregate_types
+};
+
+template<>
+struct enum_traits<aggregate_type> {
+    static constexpr aggregate_type last = aggregate_type::num_aggregate_types;
+};
+
 #endif // CATA_SRC_ENUMS_H

--- a/src/talker.h
+++ b/src/talker.h
@@ -486,6 +486,9 @@ class talker
         virtual bool has_item_with_flag( const flag_id & ) const {
             return false;
         }
+        virtual int item_rads( const flag_id &, aggregate_type ) const {
+            return 0;
+        }
         virtual units::energy power_cur() const {
             return 0_kJ;
         }

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -582,6 +582,17 @@ bool talker_character_const::has_item_with_flag( const flag_id &flag ) const
     return me_chr_const->has_item_with_flag( flag );
 }
 
+int talker_character_const::item_rads( const flag_id &flag, aggregate_type agg_func ) const
+{
+    std::vector<int> rad_vals;
+    for( const item *it : me_chr_const->all_items_with_flag( flag ) ) {
+        if( me_chr_const->is_worn( *it ) || me_chr_const->is_wielding( *it ) ) {
+            rad_vals.emplace_back( it->irradiation );
+        }
+    }
+    return aggregate( rad_vals, agg_func );
+}
+
 units::energy talker_character_const::power_cur() const
 {
     return me_chr_const->get_power_level();

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -118,6 +118,7 @@ class talker_character_const: public talker
         bool worn_with_flag( const flag_id &flag, const bodypart_id &bp ) const override;
         bool wielded_with_flag( const flag_id &flag ) const override;
         bool has_item_with_flag( const flag_id &flag ) const override;
+        int item_rads( const flag_id &flag, aggregate_type agg_func ) const override;
 
         bool can_see() const override;
         int morale_cur() const override;

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -1599,24 +1599,24 @@ TEST_CASE( "radiation badge widget", "[widget][radiation]" )
     CHECK( rads_w.layout( ava ) == "RADIATION: <color_c_light_gray>Unknown</color>" );
 
     // Acquire and wear a radiation badge
-    item_location rad_badge = ava.i_add( item( itype_rad_badge ) );
-    ava.worn.wear_item( ava, *rad_badge, false, false );
+    item rad_badge( itype_rad_badge );
+    item *rad_badge_worn = & **ava.worn.wear_item( ava, rad_badge, false, false );
 
     // Color indicator is shown when character has radiation badge
-    ava.set_rad( 0 );
+    rad_badge_worn->irradiation = 0;
     CHECK( rads_w.layout( ava ) == "RADIATION: <color_c_white_green> green </color>" );
     // Any positive value turns it blue
-    ava.set_rad( 1 );
+    rad_badge_worn->irradiation = 1;
     CHECK( rads_w.layout( ava ) == "RADIATION: <color_h_white> blue </color>" );
-    ava.set_rad( 29 );
+    rad_badge_worn->irradiation = 29;
     CHECK( rads_w.layout( ava ) == "RADIATION: <color_h_white> blue </color>" );
-    ava.set_rad( 31 );
+    rad_badge_worn->irradiation = 31;
     CHECK( rads_w.layout( ava ) == "RADIATION: <color_i_yellow> yellow </color>" );
-    ava.set_rad( 61 );
+    rad_badge_worn->irradiation = 61;
     CHECK( rads_w.layout( ava ) == "RADIATION: <color_c_red_yellow> orange </color>" );
-    ava.set_rad( 121 );
+    rad_badge_worn->irradiation = 121;
     CHECK( rads_w.layout( ava ) == "RADIATION: <color_c_red_red> red </color>" );
-    ava.set_rad( 241 );
+    rad_badge_worn->irradiation = 241;
     CHECK( rads_w.layout( ava ) == "RADIATION: <color_c_pink> black </color>" );
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
- Fixes #63283

#### Describe the solution
Determine the state of the sidebar radiation indicator using a worn or held radiation badge instead of using the character's current rad level.

#### Describe alternatives you've considered


#### Testing
Getting exposed to radiation while wearing the badge increases the radiation of the badge. Setting the player's rads to 50 (down from 180) doesn't affect the sidebar indicator, which shows as RED because the badge's irradiation is still 180:

![rad_badge](https://user-images.githubusercontent.com/12537966/216195026-753e7105-c58d-41f8-93df-024384f248ee.png)

![value in memory](https://user-images.githubusercontent.com/12537966/216194902-cd637b42-42d6-4faf-b4b0-8bc8ae194495.png)

#### Additional context
