### PR TITLE
Aero-Evaporator won't activate and will deactivate underwater

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -811,6 +811,13 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         get_wielded_item()->invlet = '#';
         weapon_bionic_uid = bio.get_uid();
     } else if( bio.id == bio_evap ) {
+        if( player_character.is_underwater() ) {
+            add_msg_if_player( m_info,
+                               _( "There's a lot of water around you already, no need to use your %s." ), bio.info().name );
+            bio.powered = false;
+            return false;
+        }
+
         add_msg_activate();
         const w_point weatherPoint = *get_weather().weather_precise;
         int humidity = get_local_humidity( weatherPoint.humidity, get_weather().weather_id,
@@ -1706,6 +1713,12 @@ void Character::process_bionic( bionic &bio )
             remove_effect( effect_asthma );
         }
     } else if( bio.id == bio_evap ) {
+        if( is_underwater() ) {
+            add_msg_if_player( m_info,
+                               _( "Your %s deactivates after it finds itself completely submerged in water." ), bio.info().name );
+            deactivate_bionic( bio );
+        }
+
         // Aero-Evaporator provides water at 60 watts with 2 L / kWh efficiency
         // which is 10 mL per 5 minutes.  Humidity can modify the amount gained.
         if( calendar::once_every( 5_minutes ) ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Make inventing memes harder.

#### Describe the solution
Don't let activate Aero-Evaporator and auto-deactivate it when character is underwater.

#### Describe alternatives you've considered
None.

#### Testing
Got myself underwater. Tried to activate Aero-Evaporator, failed at that.
Got to the dry land. Activated Aero-Evaporator. Dived into deep water. Aero-Evaporator auto-deactivated.

#### Additional context
[Original post on Reddit](https://www.reddit.com/r/cataclysmdda/comments/10qm1m1/i_hear_theres_pretty_good_fishing_on_the_gaslight/)
![изображение](https://user-images.githubusercontent.com/11132525/216420864-73882248-3765-43b7-93ce-7deb3320ad09.png)