### PR TITLE
Added Thought shield

### DIFF
--- a/data/mods/Magiclysm/Spells/classless.json
+++ b/data/mods/Magiclysm/Spells/classless.json
@@ -445,4 +445,3 @@
     "energy_source": "MANA"
   }
 ]
-

--- a/data/mods/Magiclysm/Spells/classless.json
+++ b/data/mods/Magiclysm/Spells/classless.json
@@ -1,3 +1,8 @@
+Cataclysm: Dark Days Ahead JSON Web Linting Tool
+This is a tool to help modders and editors of the open source game Cataclysm: Dark Days Ahead write JSON in the game's expected format.
+
+Paste some JSON into the field below and click "Lint" to run an autoformatter against it.
+
 [
   {
     "id": "crystallize_mana",
@@ -369,6 +374,53 @@
     "min_duration": 180000
   },
   {
+    "id": "thought_shield",
+    "type": "SPELL",
+    "name": "Thought Shield",
+    "description": "Two small shimmering spots appear on your temples, protecting your mind from outside influences.",
+    "valid_targets": [ "self" ],
+    "effect": "spawn_item",
+    "effect_str": "thought_shield_item",
+    "shape": "blast",
+    "energy_source": "MANA",
+    "flags": [ "CONCENTRATE", "NO_LEGS" ],
+    "difficulty": 6,
+    "min_damage": 1,
+    "max_damage": 1,
+    "max_level": 15,
+    "base_casting_time": 1500,
+    "base_energy_cost": 800,
+    "min_duration": 24000,
+    "max_duration": 360000,
+    "duration_increment": 24000,
+    "learn_spells": { "thought_shield_plus": 15 }
+  },
+  {
+    "id": "thought_shield_plus",
+    "type": "SPELL",
+    "name": "Thought Suit",
+    "description": "Why protect just your mind from outside influences? More shields all over your body should also prevent you from being teleported forcefully",
+    "valid_targets": [ "self" ],
+    "effect": "spawn_item",
+    "effect_str": "thought_shield_plus_item",
+    "shape": "blast",
+    "energy_source": "MANA",
+    "flags": [ "NO_LEGS" ],
+    "min_damage": 1,
+    "max_damage": 1,
+    "difficulty": 7,
+    "max_level": 25,
+    "base_casting_time": 1500,
+    "final_casting_time": 100,
+    "casting_time_increment": -56,
+    "base_energy_cost": 800,
+    "final_energy_cost": 200,
+    "energy_increment": -24,
+    "min_duration": 360000,
+    "max_duration": 2160000,
+    "duration_increment": 72000
+  },
+  {
     "id": "sound_bomb",
     "type": "SPELL",
     "name": "Sound Bomb",
@@ -398,3 +450,4 @@
     "energy_source": "MANA"
   }
 ]
+

--- a/data/mods/Magiclysm/Spells/classless.json
+++ b/data/mods/Magiclysm/Spells/classless.json
@@ -394,7 +394,7 @@
     "id": "thought_shield_plus",
     "type": "SPELL",
     "name": "Thought Suit",
-    "description": "Why protect just your mind from outside influences? More shields all over your body should also prevent you from being teleported forcefully",
+    "description": "Why protect just your mind from outside influences?  More shields all over your body should also prevent you from being teleported forcefully",
     "valid_targets": [ "self" ],
     "effect": "spawn_item",
     "effect_str": "thought_shield_plus_item",

--- a/data/mods/Magiclysm/Spells/classless.json
+++ b/data/mods/Magiclysm/Spells/classless.json
@@ -1,8 +1,3 @@
-Cataclysm: Dark Days Ahead JSON Web Linting Tool
-This is a tool to help modders and editors of the open source game Cataclysm: Dark Days Ahead write JSON in the game's expected format.
-
-Paste some JSON into the field below and click "Lint" to run an autoformatter against it.
-
 [
   {
     "id": "crystallize_mana",

--- a/data/mods/Magiclysm/itemgroups/spellbooks.json
+++ b/data/mods/Magiclysm/itemgroups/spellbooks.json
@@ -93,7 +93,8 @@
       [ "spell_scroll_boneclub", 20 ],
       [ "spell_scroll_flamesword", 35 ],
       [ "spell_scroll_force_jar", 30 ],
-      [ "spell_scroll_flamebreath", 30 ]
+      [ "spell_scroll_flamebreath", 30 ],
+      [ "spell_scroll_thought_shield", 35 ]
     ]
   },
   {

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -1164,5 +1164,64 @@
       "TRADER_AVOID",
       "REBREATHER"
     ]
+  },
+  {
+    "id": "thought_shield_item",
+    "name": { "str_sp": "thought shields" },
+    "description": "These two tiny shields on your temples should protect your mind from outside influences",
+    "type": "TOOL_ARMOR",
+    "category": "clothing",
+    "weight": "0 g",
+    "material": [ "concentrated_mana" ],
+    "environmental_protection": 1,
+    "volume": "1 ml",
+    "symbol": "0",
+    "color": "white",
+    "armor": [ { "encumbrance": 0, "coverage": 75, "covers": [ "head", "mouth", "eyes" ] } ],
+    "flags": [
+      "WATER_FRIENDLY",
+      "SEMITANGIBLE",
+      "ONLY_ONE",
+      "OVERSIZE",
+      "AURA",
+      "ZERO_WEIGHT",
+      "NO_TAKEOFF",
+      "NONCONDUCTIVE",
+      "TRADER_AVOID",
+      "PSYSHIELD_PARTIAL"
+    ]
+  },
+  {
+    "id": "thought_shield_plus_item",
+    "name": { "str_sp": "thought suit" },
+    "description": "The tiny shields all over your body should protect your mind from outside influences and your body from being moved by outside magic",
+    "type": "TOOL_ARMOR",
+    "category": "clothing",
+    "weight": "0 g",
+    "material": [ "concentrated_mana" ],
+    "environmental_protection": 1,
+    "volume": "1 ml",
+    "symbol": "0",
+    "color": "white",
+    "armor": [
+      {
+        "encumbrance": 0,
+        "coverage": 75,
+        "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+      }
+    ],
+    "flags": [
+      "WATER_FRIENDLY",
+      "SEMITANGIBLE",
+      "ONLY_ONE",
+      "OVERSIZE",
+      "AURA",
+      "ZERO_WEIGHT",
+      "NO_TAKEOFF",
+      "NONCONDUCTIVE",
+      "TRADER_AVOID",
+      "PSYSHIELD_PARTIAL",
+      "PORTAL_PROOF"
+    ]
   }
 ]

--- a/data/mods/Magiclysm/items/spell_scrolls.json
+++ b/data/mods/Magiclysm/items/spell_scrolls.json
@@ -62,7 +62,7 @@
     "id": "spell_scroll_thought_shield",
     "//": "Classless spell",
     "name": { "str": "Scroll of Thought Shield", "str_pl": "Scrolls of Thought Shield" },
-    "description": "Harried by evil spirits or creatures from beyond? This spell will keep your mind safe!",
+    "description": "Harried by evil spirits or creatures from beyond?  This spell will keep your mind safe!",
     "use_action": { "type": "learn_spell", "spells": [ "thought_shield" ] }
   },
   {

--- a/data/mods/Magiclysm/items/spell_scrolls.json
+++ b/data/mods/Magiclysm/items/spell_scrolls.json
@@ -59,6 +59,15 @@
   {
     "type": "BOOK",
     "copy-from": "spell_scroll",
+    "id": "spell_scroll_thought_shield",
+    "//": "Classless spell",
+    "name": { "str": "Scroll of Thought Shield", "str_pl": "Scrolls of Thought Shield" },
+    "description": "Harried by evil spirits or creatures from beyond? This spell will keep your mind safe!",
+    "use_action": { "type": "learn_spell", "spells": [ "thought_shield" ] }
+  },
+  {
+    "type": "BOOK",
+    "copy-from": "spell_scroll",
     "id": "spell_scroll_holographic_transposition",
     "//": "Technomancer spell",
     "name": { "str": "Scroll of Holographic Transposition", "str_pl": "Scrolls of Holographic Transposition" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Adds Thought Shield and Thought Suit spells"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Provide an alternative way to become more resistant to portal storms. 
Notably, these spells can be used by mutants that are restricted from wearing the phase immersion suit.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds the "Thought Shield" spell, which is a spell that summons a temporary aura item that grants the "PSYSHIELD_PARTIAL" effect from the phase immersion suit (on). The mana cost and cast time are on the higher end, so an out of mana caster might not be able to regenerate enough mana during a portal storm. This could be an issue, with the spell feeling weak, or a balancing point for having access to "PSYSHIELD_PARTIAL" from a fairly easy source. It's in the same itemgroup as spells such as Aura of Protection and Air Bubble, given that it has a similar function. The duration of the spell is the same as these two.

Just like those two spells, it also has an improved version. In this case, it gains the "PORTAL_PROOF" in addition to "PSYSHIELD_PARTIAL". Duration, max level etc is again equal to Aura of Protection, which the mana cost starting higher but scaling down to the same.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Making a permanent magical item with a similar effect
Having my phase immersion suit lie on the floor while my insect mutant falls asleep for five more days.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested whether the improved version was learned when the base version was leveled
Tested whether the items were instantly equipped when the spell was cast
Tested whether the items worked by pausing inside of a portal storm dungeon and comparing it to the phase immersion suit:
No gear: Exhausted in ~1.5 minutes
Thought Shield: Exhausted in ~5 minutes
Thought Suit: Exhausted in ~5 mintutes
Phase Immersion Suit: Exhausted in ~1.5 minutes
Phase Immersion Suit (on): Exhausted in ~5 minutes

Ran around in a portal storm
No gear: Got deja vu teleported after ~1 minute
Thought Shield: Got deja vu teleported pretty much immediately (effect was probably still active)
Thought Suit: Didn't get teleported after walking for 10 minutes
Phase Immersion Suit (on): Didn't get teleported after walking for 10 minutes
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
![Thought suit spell menu](https://user-images.githubusercontent.com/124247491/216455171-d159063b-68d3-4f76-863d-3f0d9fd24cd0.jpg)
![Thought shield Activate menu](https://user-images.githubusercontent.com/124247491/216455175-436ddab2-4d67-4b0c-8f0d-35c915ddc1eb.jpg)
![Thought shield learning menu](https://user-images.githubusercontent.com/124247491/216455177-2344f7f3-fb7a-4502-8ba8-22ba9a03fee3.jpg)
![Thought shield spell menu](https://user-images.githubusercontent.com/124247491/216455180-f71ee2f2-e6e9-45df-b893-5d72f6f96d5e.jpg)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

