### PR TITLE
Hallucinating taming attempts / success on hallucinated animals

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1608,7 +1608,9 @@ cata::optional<int> iuse::petfood( Character *p, item *it, bool, const tripoint 
             return cata::nullopt;
         }
 
-        if( mon->is_hallucination() ) {
+        bool halluc = mon->is_hallucination();
+
+        if( halluc && one_in( 4 ) ) {
             p->add_msg_if_player( _( "You try to feed the %1$s some %2$s, but it vanishes!" ),
                                   mon->type->nname(), it->tname() );
             mon->die( nullptr );
@@ -1625,7 +1627,12 @@ cata::optional<int> iuse::petfood( Character *p, item *it, bool, const tripoint 
 
         mon->friendly = -1;
         mon->add_effect( effect_pet, 1_turns, true );
-        p->consume_charges( *it, 1 );
+        if( halluc ) {
+            item drop_me = p->reduce_charges( it, 1 );
+            p->i_drop_at( drop_me );
+        } else {
+            p->consume_charges( *it, 1 );
+        }
         return cata::nullopt;
     }
     p->add_msg_if_player( _( "There is nothing to be fed here." ) );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1597,18 +1597,25 @@ cata::optional<int> iuse::petfood( Character *p, item *it, bool, const tripoint 
             return cata::nullopt;
         }
 
+        bool halluc = mon->is_hallucination();
+
         if( mon->type->id == mon_dog_thing ) {
-            p->deal_damage( mon, bodypart_id( "hand_r" ), damage_instance( damage_type::CUT, rng( 1, 10 ) ) );
+            if( !halluc ) {
+                p->deal_damage( mon, bodypart_id( "hand_r" ), damage_instance( damage_type::CUT, rng( 1, 10 ) ) );
+            }
             p->add_msg_if_player( m_bad, _( "You want to feed it the dog food, but it bites your fingers!" ) );
             if( one_in( 5 ) ) {
                 p->add_msg_if_player(
                     _( "Apparently, it's more interested in your flesh than the dog food in your hand!" ) );
-                p->consume_charges( *it, 1 );
+                if( halluc ) {
+                    item drop_me = p->reduce_charges( it, 1 );
+                    p->i_drop_at( drop_me );
+                } else {
+                    p->consume_charges( *it, 1 );
+                }
             }
             return cata::nullopt;
         }
-
-        bool halluc = mon->is_hallucination();
 
         if( halluc && one_in( 4 ) ) {
             p->add_msg_if_player( _( "You try to feed the %1$s some %2$s, but it vanishes!" ),


### PR DESCRIPTION
#### Summary
Content "Hallucinating taming attempts / success on hallucinated animals"

#### Purpose of change
Rather than simply have hallucinated animals always disappear upon taming attempts, have it possible to hallucinate the taming process and success.

#### Describe the solution
Only one in four chance that taming attempt will cause the animal to disappear, revealing that was hallucinated.
Rest of the time, all UI outputs to the player will be exactly what is expected from the taming process. However, the petfood is not consumed, only silently dropped to the ground without any feedback to the player. You might miss it if you aren't paying attention!

Also put in similar support for hallucinated interaction with hallucinated dogthing, that may or may not be a thing that could happen naturally in the game without debug intervention, but now we have the code to handle it.

#### Testing
Debug spawn hallucinated animal and corresponding petfood, try taming and not have it immediately disappear all the time.

