### PR TITLE
Ask before lighting fires adjacent to fireplaces

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1204,6 +1204,27 @@ bool firestarter_actor::prep_firestarter_use( const Character &p, tripoint_bub_m
             return false;
         }
     }
+    // Check for an adjacent fire container
+    for( const tripoint_bub_ms &query : here.points_in_radius( pos, 1 ) ) {
+        // Don't ask if we're setting a fire on top of a fireplace
+        // TODO: fix point types
+        if( here.has_flag_furn( "FIRE_CONTAINER", pos.raw() ) ) {
+            break;
+        }
+        // Skip the position we're trying to light on fire
+        if( query == pos ) {
+            continue;
+        }
+        // TODO: fix point types
+        if( here.has_flag_furn( "FIRE_CONTAINER", query.raw() ) ) {
+            if( !query_yn( _( "Are you sure you want to start fire here?  There's a fireplace adjacent." ) ) ) {
+                return false;
+            } else {
+                // Don't ask multiple times if they say no and there are multiple fireplaces
+                break;
+            }
+        }
+    }
     // Check for a brazier.
     bool has_unactivated_brazier = false;
     for( const item &i : here.i_at( pos ) ) {


### PR DESCRIPTION
#### Summary
Interface "Ask before lighting a fire adjacent to a fireplace"

#### Purpose of change
Resolves https://github.com/CleverRaven/Cataclysm-DDA/issues/57835
Nice quality-of-life feature.

#### Describe the solution
Check for a fireplace that is on any of the 8 adjacent squares if we're lighting a fire on a tile that is not a fireplace. If any we find a fireplace on any of those squares, ask once if they want to start a fire next to a fireplace.

#### Testing
![image](https://user-images.githubusercontent.com/44244083/216797044-47d84a6e-222e-4310-ab9c-5338073635ed.png)

1. Find or create two fireplaces next to each other.
2. Place flammable material (e.g. a plank) on a tile adjacent to both fireplaces.
3. Try to set the flammable material on fire.
4. Select no on the prompt, no fire is started.
5. Select yes on the prompt. You are only prompted once and a fire is created.