### PR TITLE
Unify airport symbols

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
@@ -322,45 +322,6 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [
-      "s_air_parking",
-      "s_air_term",
-      "s_air_atc",
-      "s_air_hangars",
-      "s_air_hangars_roof",
-      "s_air_term_roof",
-      "s_air_atc_2",
-      "s_air_atc_3"
-    ],
-    "name": "private airport",
-    "sym": "A",
-    "color": "i_cyan",
-    "see_cost": 5,
-    "extras": "build",
-    "mondensity": 2
-  },
-  {
-    "type": "overmap_terrain",
-    "id": [ "s_air_runway_l", "s_air_runway_B", "s_air_runway_term", "s_air_runway", "s_air_runway_hangars", "s_air_runway_r" ],
-    "name": "private airport runway",
-    "sym": "-",
-    "color": "blue",
-    "see_cost": 5,
-    "extras": "build",
-    "mondensity": 2
-  },
-  {
-    "type": "overmap_terrain",
-    "id": [ "s_air_helicopter_pad" ],
-    "name": "helicopter pad",
-    "sym": "H",
-    "color": "i_cyan",
-    "see_cost": 5,
-    "extras": "build",
-    "mondensity": 2
-  },
-  {
-    "type": "overmap_terrain",
     "id": [ "mine_entrance", "mine_entrance_loading_zone" ],
     "name": "mine entrance",
     "sym": "M",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -335,7 +335,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "control_tower_0", "control_tower_1", "control_tower_2" ],
+    "id": [ "control_tower_0", "control_tower_1", "control_tower_2", "s_air_atc", "s_air_atc_2", "s_air_atc_3" ],
     "name": "control tower",
     "sym": "X",
     "color": "i_light_gray",
@@ -349,16 +349,30 @@
     "sym": "X",
     "color": "i_light_gray",
     "see_cost": 5,
-    "extras": "road"
+    "extras": "build"
   },
   {
     "type": "overmap_terrain",
-    "id": [ "runway", "runway_carts", "runway_hangar", "runway_hangar2", "runway_wild", "runway_start", "runway_end" ],
+    "id": [
+      "runway",
+      "runway_carts",
+      "runway_hangar",
+      "runway_hangar2",
+      "runway_wild",
+      "runway_start",
+      "runway_end",
+      "s_air_runway_l",
+      "s_air_runway_B",
+      "s_air_runway_term",
+      "s_air_runway",
+      "s_air_runway_hangars",
+      "s_air_runway_r"
+    ],
     "name": "runway",
     "sym": "─",
     "color": "light_gray",
     "see_cost": 5,
-    "extras": "road"
+    "extras": "build"
   },
   {
     "type": "overmap_terrain",
@@ -391,7 +405,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "airport_lot_0", "airport_lot_1" ],
+    "id": [ "airport_lot_0", "airport_lot_1", "s_air_parking" ],
     "name": "parking lot",
     "sym": "O",
     "color": "dark_gray",
@@ -400,7 +414,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "hangar",
+    "id": [ "hangar", "s_air_hangars" ],
     "name": "small hangar",
     "sym": "O",
     "color": "white",
@@ -409,7 +423,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "hangar_roof",
+    "id": [ "hangar_roof", "s_air_hangars_roof" ],
     "name": "small hangar roof",
     "sym": "O",
     "color": "white",
@@ -418,21 +432,45 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "waiting_area",
-    "name": "waiting area",
-    "sym": "<",
-    "color": "i_light_cyan",
+    "id": "s_air_term",
+    "name": "private airport terminal",
+    "sym": "A",
+    "color": "light_gray",
     "see_cost": 5,
-    "extras": "build"
+    "extras": "build",
+    "mondensity": 2
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "s_air_term_roof",
+    "name": "private airport terminal roof",
+    "sym": "A",
+    "color": "light_gray",
+    "see_cost": 5,
+    "extras": "build",
+    "mondensity": 2
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "waiting_area",
+    "name": "regional airport terminal",
+    "copy-from": "s_air_term"
   },
   {
     "type": "overmap_terrain",
     "id": "waiting_area_roof",
-    "name": "waiting area roof",
-    "sym": "<",
-    "color": "i_light_cyan",
+    "name": "regional airport terminal roof",
+    "copy-from": "s_air_term_roof"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "s_air_helicopter_pad",
+    "name": "helicopter pad",
+    "sym": "H",
+    "color": "white",
     "see_cost": 5,
-    "extras": "build"
+    "extras": "build",
+    "mondensity": 2
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

No need to have two different symbols for one type of location.
Fixes map symbols for private runways, which weren't rotatable previously.
Partially addresses #62747

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Made private airports use the symbols used by regional airports.
Renamed "waiting area" to "regional/private airport terminal".

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Doing this the other way around. I found the symbols used by regional airports much more descriptive, however.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Debug-spawned in the world.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Regional & private airport
![kép](https://user-images.githubusercontent.com/44979050/216820305-64195c5f-4a07-478b-82f7-150ac339504d.png)

Private runway symbols now rotate
![kép](https://user-images.githubusercontent.com/44979050/216820330-54629987-249b-4a16-9eaa-a4dd2bda9e4e.png)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
