### PR TITLE
Monster update for the light industry location

### DIFF
--- a/data/json/mapgen/s_lightindustry.json
+++ b/data/json/mapgen/s_lightindustry.json
@@ -215,11 +215,13 @@
         { "group": "elecsto_diy", "chance": 60, "repeat": 4, "x": [ 34, 39 ], "y": [ 12, 14 ] },
         { "group": "elecsto_diy", "chance": 60, "repeat": 4, "x": [ 34, 37 ], "y": [ 4, 5 ] }
       ],
-      "place_monsters": [
-        { "monster": "GROUP_ZOMBIE", "x": [ 2, 22 ], "y": [ 7, 14 ], "density": 0.2 },
-        { "monster": "GROUP_ZOMBIE", "x": [ 25, 42 ], "y": [ 7, 14 ], "repeat": [ 1, 2 ], "density": 0.2 },
-        { "monster": "GROUP_ZOMBIE", "x": [ 2, 22 ], "y": [ 60, 71 ], "density": 0.2 },
-        { "monster": "GROUP_ZOMBIE", "x": [ 25, 42 ], "y": [ 60, 71 ], "repeat": [ 1, 2 ], "density": 0.2 }
+      "place_monster": [
+        { "group": "GROUP_VANILLA", "x": [ 2, 22 ], "y": [ 7, 14 ], "chance": 75, "repeat": [ 6, 12 ] },
+        { "group": "GROUP_VANILLA", "x": [ 25, 42 ], "y": [ 7, 14 ], "chance": 35, "repeat": [ 2, 6 ] },
+        { "group": "GROUP_VANILLA", "x": [ 2, 22 ], "y": [ 60, 71 ], "chance": 75, "repeat": [ 6, 12 ] },
+        { "group": "GROUP_VANILLA", "x": [ 25, 42 ], "y": [ 60, 71 ], "chance": 35, "repeat": [ 2, 6 ] },
+        { "group": "GROUP_SMALL_STATION", "x": [ 25, 42 ], "y": [ 7, 14 ], "chance": 75, "repeat": [ 3, 6 ] },
+        { "group": "GROUP_SMALL_STATION", "x": [ 25, 42 ], "y": [ 60, 71 ], "chance": 75, "repeat": [ 3, 6 ] }
       ],
       "place_vehicles": [ { "vehicle": "cube_van", "x": 31, "y": 50, "chance": 70, "rotation": 270 } ]
     }

--- a/data/mods/No_Hope/Mapgen/s_lightindustry.json
+++ b/data/mods/No_Hope/Mapgen/s_lightindustry.json
@@ -215,11 +215,13 @@
         { "group": "elecsto_diy", "chance": 20, "repeat": 4, "x": [ 34, 39 ], "y": [ 12, 14 ] },
         { "group": "elecsto_diy", "chance": 20, "repeat": 4, "x": [ 34, 37 ], "y": [ 4, 5 ] }
       ],
-      "place_monsters": [
-        { "monster": "GROUP_ZOMBIE", "x": [ 2, 22 ], "y": [ 7, 14 ], "density": 0.2 },
-        { "monster": "GROUP_ZOMBIE", "x": [ 25, 42 ], "y": [ 7, 14 ], "repeat": [ 1, 2 ], "density": 0.2 },
-        { "monster": "GROUP_ZOMBIE", "x": [ 2, 22 ], "y": [ 60, 71 ], "density": 0.2 },
-        { "monster": "GROUP_ZOMBIE", "x": [ 25, 42 ], "y": [ 60, 71 ], "repeat": [ 1, 2 ], "density": 0.2 }
+      "place_monster": [
+        { "group": "GROUP_VANILLA", "x": [ 2, 22 ], "y": [ 7, 14 ], "chance": 75, "repeat": [ 6, 12 ] },
+        { "group": "GROUP_VANILLA", "x": [ 25, 42 ], "y": [ 7, 14 ], "chance": 35, "repeat": [ 2, 6 ] },
+        { "group": "GROUP_VANILLA", "x": [ 2, 22 ], "y": [ 60, 71 ], "chance": 75, "repeat": [ 6, 12 ] },
+        { "group": "GROUP_VANILLA", "x": [ 25, 42 ], "y": [ 60, 71 ], "chance": 35, "repeat": [ 2, 6 ] },
+        { "group": "GROUP_SMALL_STATION", "x": [ 25, 42 ], "y": [ 7, 14 ], "chance": 75, "repeat": [ 3, 6 ] },
+        { "group": "GROUP_SMALL_STATION", "x": [ 25, 42 ], "y": [ 60, 71 ], "chance": 75, "repeat": [ 3, 6 ] }
       ],
       "place_vehicles": [ { "vehicle": "cube_van", "x": 31, "y": 50, "chance": 30, "rotation": 270, "status": -1 } ]
     }


### PR DESCRIPTION
#### Summary
Balance "Adds better monster spawning to the light industry location"

#### Purpose of change

I noticed the light industry location used "place_monsters" rather than "place_monster", and that they did not have spawns for mechanics/technicians, so I decided to change that.

#### Describe the solution
Changed all uses of "place_monsters" with "place_monster", changed normal zombie spawns to exclude zombie cops, firefigthers, etc. (Since it does not makes sense in the location), and added some spawns for mechanics in the location.

#### Describe alternatives you've considered
To only make the change of "place_monsters".

#### Testing
Spawned the location several times in the game, the spawns are working as they should.

#### Additional context
