### PR TITLE
Make Churls totally illiterate and socially inept

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
@@ -532,5 +532,11 @@
     "type": "talk_topic",
     "dynamic_line": "Pleasure doing business!",
     "responses": [ { "text": "You might be seeing more of me…", "topic": "TALK_DONE", "effect": "u_bulk_trade_accept" } ]
+  },
+  {
+    "id": "TALK_CHURL_FRIENDLY",
+    "type": "talk_topic",
+    "dynamic_line": "Excuse me?  Um… you mean you want to trade?",
+    "responses": [ { "text": "Ye!", "topic": "TALK_DONE", "effect": "start_trade" } ]
   }
 ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -706,7 +706,8 @@
       { "level": 1, "name": "fabrication" },
       { "level": 1, "name": "tailor" }
     ],
-    "traits": [ "PROF_CHURL", "ILLITERATE" ]
+    "traits": [ "PROF_CHURL", "ILLITERATE" ],
+    "flags": [ "SCEN_ONLY" ]
   },
   {
     "type": "profession",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -688,7 +688,7 @@
     "id": "churl",
     "name": "Churl",
     "description": "What the deuyl?  Ye ne wist noo thing of this straunge plaas nor what wycked enchauntment brought ye hidder.  Wyth this accoustrement ye must needs underfongen to find newe lyflode in the most hidous Cataclysm man hath witnessed sithen that deluge Noe rood out in his greet schippe.",
-    "points": 1,
+    "points": 0,
     "items": {
       "both": {
         "items": [ "footrags", "loincloth", "cloak_wool", "ragpouch", "small_relic", "gloves_wraps", "tunic_rag" ],
@@ -706,7 +706,7 @@
       { "level": 1, "name": "fabrication" },
       { "level": 1, "name": "tailor" }
     ],
-    "traits": [ "PROF_CHURL" ]
+    "traits": [ "PROF_CHURL", "ILLITERATE" ]
   },
   {
     "type": "profession",

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1393,9 +1393,12 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         add_response_done( _( "Bye." ) );
     }
 
-    if( player_character.has_trait( trait_PROF_CHURL ) && ( actor( true )->get_npc_trust() >= 0 ) && ( actor( true )->get_npc_anger() <= 0 ) && ( actor( true )->int_cur() >= 9 ) && !( the_topic.id == "TALK_CHURL_FRIENDLY" )){
-        add_response( _( "Ho there, otherwyrldly devyl!  Have yow ware for to chaffare?" ), "TALK_CHURL_FRIENDLY" );
-        add_response_done( _( "Bye." ) );
+    if( player_character.has_trait( trait_PROF_CHURL ) && ( actor( true )->get_npc_trust() >= 0 ) &&
+    ( actor( true )->get_npc_anger() <= 0 ) && ( actor( true )->int_cur() >= 9 ) &&
+    !( the_topic.id == "TALK_CHURL_FRIENDLY" ) ) {
+        add_response( _( "Ho there, otherwyrldly devyl!  Have yow ware for to chaffare?" ),
+            "TALK_CHURL_FRIENDLY" );
+        add_response_done( _( "Farewell!" ) );
     }
 
     if( responses.empty() ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1394,10 +1394,10 @@ void dialogue::gen_responses( const talk_topic &the_topic )
     }
 
     if( player_character.has_trait( trait_PROF_CHURL ) && ( actor( true )->get_npc_trust() >= 0 ) &&
-    ( actor( true )->get_npc_anger() <= 0 ) && ( actor( true )->int_cur() >= 9 ) &&
-    !( the_topic.id == "TALK_CHURL_FRIENDLY" ) ) {
+        ( actor( true )->get_npc_anger() <= 0 ) && ( actor( true )->int_cur() >= 9 ) &&
+        !( the_topic.id == "TALK_CHURL_FRIENDLY" ) ) {
         add_response( _( "Ho there, otherwyrldly devyl!  Have yow ware for to chaffare?" ),
-            "TALK_CHURL_FRIENDLY" );
+                "TALK_CHURL_FRIENDLY" );
         add_response_done( _( "Farewell!" ) );
     }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1038,11 +1038,11 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
                    _( "&You are mute and can't talk.  When you don't respond, %s becomes angry!" ),
                    actor( true )->disp_name() );
     } else if( topic == "TALK_CHURL" ) {
-        return _( "&You are just a simple churl and can't comprehend modern speech." );
+        return _( "&Thou art but a lowley churl and ye know not this newe tongue." );
 
     } else if( topic == "TALK_CHURL_ANGRY" ) {
         return string_format(
-                   _( "&You are just a simple churl and can't comprehend modern speech.  Unable to understand your dialect, %s becomes angry!" ),
+                   _( "&Thou art but a lowley churl and ye know not this newe tongue.  Unable to understand your dialect, %s becomes angry!" ),
                    actor( true )->disp_name() );
     }
     avatar &player_character = get_avatar();

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -105,6 +105,7 @@ static const skill_id skill_firstaid( "firstaid" );
 static const skill_id skill_speech( "speech" );
 
 static const trait_id trait_DEBUG_MIND_CONTROL( "DEBUG_MIND_CONTROL" );
+static const trait_id trait_PROF_CHURL( "PROF_CHURL" );
 static const trait_id trait_PROF_FOODP( "PROF_FOODP" );
 
 static const zone_type_id zone_type_NPC_INVESTIGATE_ONLY( "NPC_INVESTIGATE_ONLY" );
@@ -1038,11 +1039,17 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
                    _( "&You are mute and can't talk.  When you don't respond, %s becomes angry!" ),
                    actor( true )->disp_name() );
     } else if( topic == "TALK_CHURL" ) {
-        return _( "&Thou art but a lowley churl and ye know not this newe tongue." );
+        return string_format(
+                   _( "&Thou art but a lowley churl and ye know not this newe tongue.  %s seems unable to understand what you're saying." ),
+                   actor( true )->disp_name() );
 
     } else if( topic == "TALK_CHURL_ANGRY" ) {
         return string_format(
                    _( "&Thou art but a lowley churl and ye know not this newe tongue.  Unable to understand your dialect, %s becomes angry!" ),
+                   actor( true )->disp_name() );
+    } else if( topic == "TALK_CHURL_TRADE" ) {
+        return string_format(
+                   _( "&Thou art but a lowley churl wyth litel understonding of this newe langage, yet %s can understand you and seems willing to trade!" ),
                    actor( true )->disp_name() );
     }
     avatar &player_character = get_avatar();
@@ -1383,6 +1390,11 @@ void dialogue::gen_responses( const talk_topic &the_topic )
 
     if( actor( false )->has_trait( trait_DEBUG_MIND_CONTROL ) && !actor( true )->is_player_ally() ) {
         add_response( _( "OBEY ME!" ), "TALK_MIND_CONTROL" );
+        add_response_done( _( "Bye." ) );
+    }
+
+    if( player_character.has_trait( trait_PROF_CHURL ) && ( actor( true )->get_npc_trust() >= 0 ) && ( actor( true )->get_npc_anger() <= 0 ) && ( actor( true )->int_cur() >= 9 ) && !( the_topic.id == "TALK_CHURL_FRIENDLY" )){
+        add_response( _( "Ho there, otherwyrldly devyl!  Have yow ware for to chaffare?" ), "TALK_CHURL_FRIENDLY" );
         add_response_done( _( "Bye." ) );
     }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1397,7 +1397,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         ( actor( true )->get_npc_anger() <= 0 ) && ( actor( true )->int_cur() >= 9 ) &&
         !( the_topic.id == "TALK_CHURL_FRIENDLY" ) ) {
         add_response( _( "Ho there, otherwyrldly devyl!  Have yow ware for to chaffare?" ),
-                "TALK_CHURL_FRIENDLY" );
+                      "TALK_CHURL_FRIENDLY" );
         add_response_done( _( "Farewell!" ) );
     }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1037,6 +1037,13 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
         return string_format(
                    _( "&You are mute and can't talk.  When you don't respond, %s becomes angry!" ),
                    actor( true )->disp_name() );
+    } else if( topic == "TALK_CHURL" ) {
+        return _( "&You are just a simple churl and can't comprehend modern speech." );
+
+    } else if( topic == "TALK_CHURL_ANGRY" ) {
+        return string_format(
+                   _( "&You are just a simple churl and can't comprehend modern speech.  Unable to understand your dialect, %s becomes angry!" ),
+                   actor( true )->disp_name() );
     }
     avatar &player_character = get_avatar();
     if( topic == "TALK_SEDATED" ) {

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -194,7 +194,8 @@ std::vector<std::string> talker_npc::get_topics( bool radio_contact )
             add_topics.back() == me_npc->chatbin.talk_stranger_aggressive ) {
             me_npc->make_angry();
             add_topics.emplace_back( "TALK_CHURL_ANGRY" );
-        } else if(( me_npc->op_of_u.trust >= 0 ) && ( me_npc->op_of_u.anger <= 0 ) && ( me_npc->int_cur >= 9 )) {
+        } else if( ( me_npc->op_of_u.trust >= 0 ) && ( me_npc->op_of_u.anger <= 0 ) &&
+        ( me_npc->int_cur >= 9 ) ) {
             add_topics.emplace_back( "TALK_CHURL_TRADE" );
         } else {
             add_topics.emplace_back( "TALK_CHURL" );

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -54,6 +54,7 @@ static const itype_id itype_foodperson_mask_on( "foodperson_mask_on" );
 static const trait_id trait_DEBUG_MIND_CONTROL( "DEBUG_MIND_CONTROL" );
 static const trait_id trait_PROF_FOODP( "PROF_FOODP" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
+static const trait_id trait_PROF_CHURL( "PROF_CHURL" );
 
 talker_npc::talker_npc( npc *new_me )
 {
@@ -186,6 +187,15 @@ std::vector<std::string> talker_npc::get_topics( bool radio_contact )
             add_topics.emplace_back( "TALK_MUTE_ANGRY" );
         } else {
             add_topics.emplace_back( "TALK_MUTE" );
+        }
+    }
+    if( player_character.has_trait( trait_PROF_CHURL )) {
+        if( add_topics.back() == me_npc->chatbin.talk_mug ||
+            add_topics.back() == me_npc->chatbin.talk_stranger_aggressive ) {
+            me_npc->make_angry();
+            add_topics.emplace_back( "TALK_CHURL_ANGRY" );
+        } else {
+            add_topics.emplace_back( "TALK_CHURL" );
         }
     }
 

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -195,7 +195,7 @@ std::vector<std::string> talker_npc::get_topics( bool radio_contact )
             me_npc->make_angry();
             add_topics.emplace_back( "TALK_CHURL_ANGRY" );
         } else if( ( me_npc->op_of_u.trust >= 0 ) && ( me_npc->op_of_u.anger <= 0 ) &&
-        ( me_npc->int_cur >= 9 ) ) {
+            ( me_npc->int_cur >= 9 ) ) {
             add_topics.emplace_back( "TALK_CHURL_TRADE" );
         } else {
             add_topics.emplace_back( "TALK_CHURL" );

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -194,6 +194,8 @@ std::vector<std::string> talker_npc::get_topics( bool radio_contact )
             add_topics.back() == me_npc->chatbin.talk_stranger_aggressive ) {
             me_npc->make_angry();
             add_topics.emplace_back( "TALK_CHURL_ANGRY" );
+        } else if(( me_npc->op_of_u.trust >= 0 ) && ( me_npc->op_of_u.anger <= 0 ) && ( me_npc->int_cur >= 9 )) {
+            add_topics.emplace_back( "TALK_CHURL_TRADE" );
         } else {
             add_topics.emplace_back( "TALK_CHURL" );
         }

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -195,7 +195,7 @@ std::vector<std::string> talker_npc::get_topics( bool radio_contact )
             me_npc->make_angry();
             add_topics.emplace_back( "TALK_CHURL_ANGRY" );
         } else if( ( me_npc->op_of_u.trust >= 0 ) && ( me_npc->op_of_u.anger <= 0 ) &&
-            ( me_npc->int_cur >= 9 ) ) {
+                   ( me_npc->int_cur >= 9 ) ) {
             add_topics.emplace_back( "TALK_CHURL_TRADE" );
         } else {
             add_topics.emplace_back( "TALK_CHURL" );

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -52,9 +52,9 @@ static const itype_id itype_foodperson_mask( "foodperson_mask" );
 static const itype_id itype_foodperson_mask_on( "foodperson_mask_on" );
 
 static const trait_id trait_DEBUG_MIND_CONTROL( "DEBUG_MIND_CONTROL" );
+static const trait_id trait_PROF_CHURL( "PROF_CHURL" );
 static const trait_id trait_PROF_FOODP( "PROF_FOODP" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
-static const trait_id trait_PROF_CHURL( "PROF_CHURL" );
 
 talker_npc::talker_npc( npc *new_me )
 {

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -189,7 +189,7 @@ std::vector<std::string> talker_npc::get_topics( bool radio_contact )
             add_topics.emplace_back( "TALK_MUTE" );
         }
     }
-    if( player_character.has_trait( trait_PROF_CHURL )) {
+    if( player_character.has_trait( trait_PROF_CHURL ) ) {
         if( add_topics.back() == me_npc->chatbin.talk_mug ||
             add_topics.back() == me_npc->chatbin.talk_stranger_aggressive ) {
             me_npc->make_angry();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Make Churls totally illiterate and socially inept"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make Churls unable to talk to NPCs except for some trading, and make Churl scenario-only
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Churls are _literally_ ripped from another dimension, and would realistically lack even basic literacy skills because of their intended time period/profession. Right now, "Churl" exists as a normal profession but also through two challenge scenarios: "Portal Dependent" and "Medieval Peasant". This PR removes the normal profession due to the extradimensional nature of the churl and the new, somewhat hardcore additions that follow...

This PR also makes Churls (mostly) unable to speak to NPCs. The original author of the churl PR indicated their intent to try something like this. **You are still able to trade with friendly NPCs if they have 9 or more intelligence** who can understand your archaic drawl. Yep, it's a huge debuff, but I would argue Churls are a roleplay-heavy outlier anyway, so it's worth embracing! 👨‍🌾

![Capture2](https://user-images.githubusercontent.com/67405765/217384538-9859c9ae-8f9e-4909-9591-c8b280afdbcd.PNG)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The mere existence of churls is a little anatopistic, so this PR may literalize roleplay elements that don't really need it. Put another way, does it ruin immersion more to be a medieval peasant speaking in modern vernacular to all NPCs or to be prevented from talking to anyone at all? Perhaps churl roleplayers prefer to make these decisions on a case-by-case basis (whilst maintaining a thick, extradimensional Welsh accent at all times, surely).
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Aerin: `personally if i could be assed to learn a minimal amount of c++ I'd give the churl a unique trait that prevents them from talking to NPCs as well cuz you don't speak this universe's language. alas, i can not be assed.`

#12992 : `Future work: make chat with NPCs unintelligible.`

I have had suggestions to allow requests for NPCs to follow as well as replace more dialog with archaic nonsense (mixing up strings in dialog is, I think, close to what the original author was talking about). This is outside the scope of this PR, but interesting nonetheless!
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
