### PR TITLE
Add 14 scores, 24 achievements and 5 conducts related to vehicular travel

### DIFF
--- a/data/json/achievements.json
+++ b/data/json/achievements.json
@@ -165,6 +165,180 @@
     "requirements": [ { "event_statistic": "min_move_z", "is": "<=", "target": -10 } ]
   },
   {
+    "id": "achievement_vehicle_distance_gndv_berthabenz",
+    "type": "achievement",
+    "name": "Test Drive",
+    "//": "Approx distance covered by Bertha Benz in 1888 drive",
+    "requirements": [ { "event_statistic": "num_moves_gndv_ctrl_direct", "is": ">=", "target": 106000 } ]
+  },
+  {
+    "id": "achievement_vehicle_distance_gndv_daytona",
+    "type": "achievement",
+    "name": "Daytona",
+    "//": "Daytona 500 race distance",
+    "requirements": [ { "event_statistic": "num_moves_gndv_ctrl_direct", "is": ">=", "target": 804672 } ],
+    "hidden_by": [ "achievement_vehicle_distance_gndv_berthabenz" ]
+  },
+  {
+    "id": "achievement_vehicle_distance_gndv_arcticsounds",
+    "type": "achievement",
+    "name": "Too Far Inside a Car",
+    "//": "From the song by Modest Mouse; 1100 miles = 1770278 m",
+    "requirements": [ { "event_statistic": "num_moves_gndv_onboard", "is": ">=", "target": 1770278 } ],
+    "hidden_by": [ "achievement_vehicle_distance_gndv_daytona" ]
+  },
+  {
+    "id": "achievement_vehicle_distance_gndv_route66",
+    "type": "achievement",
+    "name": "Chicago to L.A.",
+    "//": "From the song by Bobby Troup; 1926 alignment; 2448 miles = 3939674 m",
+    "requirements": [ { "event_statistic": "num_moves_gndv_onboard", "is": ">=", "target": 3939674 } ],
+    "hidden_by": [ "achievement_vehicle_distance_gndv_arcticsounds" ]
+  },
+  {
+    "id": "achievement_vehicle_distance_boat_hocr",
+    "type": "achievement",
+    "name": "Head of the Charles",
+    "//": "Prestigious rowing race held in Boston",
+    "requirements": [ { "event_statistic": "num_moves_boat_ctrl_direct", "is": ">=", "target": 4800 } ]
+  },
+  {
+    "id": "achievement_vehicle_distance_boat_mayflower",
+    "type": "achievement",
+    "name": "Plymouth to Plymouth",
+    "//": "Approx distance sailed by the Pilgrims",
+    "requirements": [ { "event_statistic": "num_moves_boat_onboard", "is": ">=", "target": 5200000 } ],
+    "hidden_by": [ "achievement_vehicle_distance_boat_hocr" ]
+  },
+  {
+    "id": "achievement_vehicle_distance_boat_circumnavigate",
+    "type": "achievement",
+    "name": "Circumnavigator",
+    "//": "Approx distance covered by the Magellan–Elcano expedition",
+    "requirements": [ { "event_statistic": "num_moves_boat_onboard", "is": ">=", "target": 60440000 } ],
+    "hidden_by": [ "achievement_vehicle_distance_boat_mayflower" ]
+  },
+  {
+    "id": "achievement_vehicle_distance_acft_wright",
+    "type": "achievement",
+    "name": "Flying Wright",
+    "requirements": [ { "event_statistic": "num_moves_acft_ctrl_direct", "is": ">=", "target": 279 } ]
+  },
+  {
+    "id": "achievement_vehicle_distance_acft_bleriot",
+    "type": "achievement",
+    "name": "Better than Blériot",
+    "requirements": [ { "event_statistic": "num_moves_acft_ctrl_direct", "is": ">=", "target": 39650 } ],
+    "hidden_by": [ "achievement_vehicle_distance_acft_wright" ]
+  },
+  {
+    "id": "achievement_vehicle_distance_acft_lindbergh",
+    "type": "achievement",
+    "name": "Lindbergh's Loss",
+    "requirements": [ { "event_statistic": "num_moves_acft_ctrl_direct", "is": ">=", "target": 5809000 } ],
+    "hidden_by": [ "achievement_vehicle_distance_acft_bleriot" ]
+  },
+  {
+    "id": "achievement_vehicle_distance_acft_fosset",
+    "type": "achievement",
+    "name": "Further than Fosset",
+    "requirements": [ { "event_statistic": "num_moves_acft_ctrl_direct", "is": ">=", "target": 41467460 } ],
+    "hidden_by": [ "achievement_vehicle_distance_acft_lindbergh" ]
+  },
+  {
+    "id": "achievement_vehicle_distance_acft_flyergold",
+    "type": "achievement",
+    "name": "Frequent Flyer",
+    "//": "40,000 miles to qualify for Star Alliance Gold status",
+    "requirements": [ { "event_statistic": "num_moves_acft_onboard", "is": ">=", "target": 64373760 } ],
+    "hidden_by": [ "achievement_vehicle_distance_acft_fosset" ]
+  },
+  {
+    "id": "achievement_vehicle_onboard_rc",
+    "type": "achievement",
+    "name": "Driver's seat optional",
+    "requirements": [ { "event_statistic": "num_moves_veh_onboard_ctrl_remote", "is": ">=", "target": 100 } ]
+  },
+  {
+    "id": "achievement_vehicle_distance_passenger",
+    "type": "achievement",
+    "name": "Are we there yet?",
+    "requirements": [ { "event_statistic": "num_moves_veh_onboard_ctrl_none", "is": ">=", "target": 100000 } ]
+  },
+  {
+    "id": "achievement_vehicle_distance_skidding",
+    "type": "achievement",
+    "name": "I have full control of the car, I swear.",
+    "requirements": [ { "event_statistic": "num_moves_gndv_skidding", "is": ">=", "target": 100000 } ]
+  },
+  {
+    "id": "achievement_vehicle_velocity_gndv_42mph",
+    "type": "achievement",
+    "name": "Model T",
+    "requirements": [ { "event_statistic": "max_velocity_gndv", "is": ">=", "target": 4200 } ]
+  },
+  {
+    "id": "achievement_vehicle_velocity_gndv_135mph",
+    "type": "achievement",
+    "name": "Charger",
+    "//": "General Lee",
+    "requirements": [ { "event_statistic": "max_velocity_gndv", "is": ">=", "target": 13500 } ],
+    "hidden_by": [ "achievement_vehicle_velocity_gndv_42mph" ]
+  },
+  {
+    "id": "achievement_vehicle_velocity_rail_150mph",
+    "type": "achievement",
+    "name": "Acela",
+    "requirements": [ { "event_statistic": "max_velocity_rail", "is": ">=", "target": 15000 } ]
+  },
+  {
+    "id": "achievement_vehicle_velocity_boat_71mph",
+    "type": "achievement",
+    "name": "Miss America",
+    "requirements": [ { "event_statistic": "max_velocity_boat", "is": ">=", "target": 7143 } ]
+  },
+  {
+    "id": "achievement_vehicle_velocity_boat_125mph",
+    "type": "achievement",
+    "name": "Miss America X",
+    "requirements": [ { "event_statistic": "max_velocity_boat", "is": ">=", "target": 12486 } ],
+    "hidden_by": [ "achievement_vehicle_velocity_boat_71mph" ]
+  },
+  {
+    "id": "achievement_vehicle_velocity_acft_mach1",
+    "type": "achievement",
+    "name": "Going Mach",
+    "requirements": [ { "event_statistic": "max_velocity_acft", "is": ">=", "target": 76727 } ]
+  },
+  {
+    "id": "achievement_vehicle_acft_max_z_level",
+    "type": "achievement",
+    "name": "Up Like Icarus",
+    "requirements": [ { "event_statistic": "max_move_acft_ctrl_direct_z", "is": ">=", "target": 9 } ]
+  },
+  {
+    "id": "achievement_vehicle_velocity_drift_50mph",
+    "type": "achievement",
+    "name": "KANSEI DORIFTO?!",
+    "requirements": [ { "event_statistic": "max_velocity_skidding", "is": ">=", "target": 5000, "visible": "when_achievement_completed" } ]
+  },
+  {
+    "id": "achievement_vehicle_velocity_rail_human50mph",
+    "type": "achievement",
+    "name": "The human body was not designed for this",
+    "requirements": [
+      { "event_statistic": "max_velocity_rail", "is": ">=", "target": 5000, "visible": "when_achievement_completed" },
+      { "event_statistic": "num_installs_cbm", "is": "<=", "target": 0, "visible": "when_achievement_completed" },
+      {
+        "event_statistic": "num_installs_faulty_cbm",
+        "is": "<=",
+        "target": 0,
+        "visible": "when_achievement_completed"
+      },
+      { "event_statistic": "num_gains_mutation", "is": "<=", "target": 0, "visible": "when_achievement_completed" }
+    ]
+  },
+  {
     "id": "achievement_wield_crowbar",
     "type": "achievement",
     "name": "Freeman's favorite",

--- a/data/json/conducts.json
+++ b/data/json/conducts.json
@@ -159,5 +159,64 @@
     "type": "conduct",
     "name": "Nudist",
     "requirements": [ { "event_statistic": "num_avatar_wears_item", "is": "<=", "target": 0, "description": "Wear no clothing" } ]
+  },
+  {
+    "id": "conduct_speed_limit_35",
+    "type": "conduct",
+    "name": "Residential speed limit",
+    "requirements": [
+      {
+        "event_statistic": "max_velocity_gndv",
+        "is": "<=",
+        "target": 3500,
+        "description": "Do not exceed 35mph when driving land vehicles"
+      }
+    ]
+  },
+  {
+    "id": "conduct_speed_limit_50",
+    "type": "conduct",
+    "name": "Rural road speed limit",
+    "requirements": [
+      {
+        "event_statistic": "max_velocity_gndv",
+        "is": "<=",
+        "target": 5000,
+        "description": "Do not exceed 50mph when driving land vehicles"
+      }
+    ],
+    "hidden_by": [ "conduct_speed_limit_35" ]
+  },
+  {
+    "id": "conduct_speed_limit_65",
+    "type": "conduct",
+    "name": "Freeway speed limit",
+    "requirements": [
+      {
+        "event_statistic": "max_velocity_gndv",
+        "is": "<=",
+        "target": 6500,
+        "description": "Do not exceed 65mph when driving land vehicles"
+      }
+    ],
+    "hidden_by": [ "conduct_speed_limit_50" ]
+  },
+  {
+    "id": "conduct_no_transport",
+    "type": "conduct",
+    "name": "On My Own Two Feet",
+    "requirements": [
+      { "event_statistic": "num_moves_mounted", "is": "<=", "target": 0, "description": "Ride no mounts" },
+      { "event_statistic": "num_moves_veh_onboard", "is": "<=", "target": 0, "description": "Ride no vehicles" }
+    ]
+  },
+  {
+    "id": "conduct_landlubber",
+    "type": "conduct",
+    "name": "Landlubber",
+    "requirements": [
+      { "event_statistic": "num_moves_swam", "is": "<=", "target": 0, "description": "No swimming" },
+      { "event_statistic": "num_moves_boat_onboard", "is": "<=", "target": 0, "description": "Ride no watercraft" }
+    ]
   }
 ]

--- a/data/json/scores.json
+++ b/data/json/scores.json
@@ -50,6 +50,76 @@
     "statistic": "max_move_z"
   },
   {
+    "id": "score_distance_veh_onboard",
+    "type": "score",
+    "statistic": "num_moves_veh_onboard"
+  },
+  {
+    "id": "score_distance_gndv_onboard",
+    "type": "score",
+    "statistic": "num_moves_gndv_onboard"
+  },
+  {
+    "id": "score_distance_rail_onboard",
+    "type": "score",
+    "statistic": "num_moves_rail_onboard"
+  },
+  {
+    "id": "score_distance_boat_onboard",
+    "type": "score",
+    "statistic": "num_moves_boat_onboard"
+  },
+  {
+    "id": "score_distance_acft_onboard",
+    "type": "score",
+    "statistic": "num_moves_acft_onboard"
+  },
+  {
+    "id": "score_distance_veh_ctrl_remote",
+    "type": "score",
+    "statistic": "num_moves_veh_ctrl_remote"
+  },
+  {
+    "id": "score_max_velocity_gndv",
+    "type": "score",
+    "statistic": "max_velocity_gndv"
+  },
+  {
+    "id": "score_max_velocity_rail",
+    "type": "score",
+    "statistic": "max_velocity_rail"
+  },
+  {
+    "id": "score_max_velocity_boat",
+    "type": "score",
+    "statistic": "max_velocity_boat"
+  },
+  {
+    "id": "score_max_velocity_acft",
+    "type": "score",
+    "statistic": "max_velocity_acft"
+  },
+  {
+    "id": "score_min_veh_z",
+    "type": "score",
+    "statistic": "min_move_veh_onboard_z"
+  },
+  {
+    "id": "score_max_veh_z",
+    "type": "score",
+    "statistic": "max_move_veh_onboard_z"
+  },
+  {
+    "id": "score_max_gndv_z",
+    "type": "score",
+    "statistic": "max_move_gndv_ctrl_direct_z"
+  },
+  {
+    "id": "score_max_acft_z",
+    "type": "score",
+    "statistic": "max_move_acft_ctrl_direct_z"
+  },
+  {
     "id": "score_damage_taken",
     "type": "score",
     "statistic": "avatar_damage_taken"

--- a/data/json/scores.json
+++ b/data/json/scores.json
@@ -40,6 +40,16 @@
     "statistic": "num_moves_swam_underwater"
   },
   {
+    "id": "score_min_move_z",
+    "type": "score",
+    "statistic": "min_move_z"
+  },
+  {
+    "id": "score_max_move_z",
+    "type": "score",
+    "statistic": "max_move_z"
+  },
+  {
     "id": "score_damage_taken",
     "type": "score",
     "statistic": "avatar_damage_taken"
@@ -53,16 +63,6 @@
     "id": "score_headshots",
     "type": "score",
     "statistic": "avatar_num_headshots"
-  },
-  {
-    "id": "score_min_move_z",
-    "type": "score",
-    "statistic": "min_move_z"
-  },
-  {
-    "id": "score_max_move_z",
-    "type": "score",
-    "statistic": "max_move_z"
   },
   {
     "id": "score_cut_trees",

--- a/data/json/statistics.json
+++ b/data/json/statistics.json
@@ -391,6 +391,285 @@
     "description": { "str_sp": "minimum z level reached underwater" }
   },
   {
+    "id": "moves_veh_onboard",
+    "type": "event_transformation",
+    "event_type": "vehicle_moves",
+    "value_constraints": { "avatar_on_board": { "equals": true } },
+    "drop_fields": [ "avatar_on_board" ]
+  },
+  {
+    "id": "num_moves_veh_onboard",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_veh_onboard",
+    "description": { "str": "square travelled on board vehicles", "str_pl": "squares travelled on board vehicles" }
+  },
+  {
+    "id": "min_move_veh_onboard_z",
+    "type": "event_statistic",
+    "stat_type": "minimum",
+    "field": "z",
+    "event_transformation": "moves_veh_onboard",
+    "description": { "str_sp": "minimum z level reached in a vehicle" }
+  },
+  {
+    "id": "max_move_veh_onboard_z",
+    "type": "event_statistic",
+    "stat_type": "maximum",
+    "field": "z",
+    "event_transformation": "moves_veh_onboard",
+    "description": { "str_sp": "maximum z level reached in a vehicle" }
+  },
+  {
+    "id": "moves_veh_ctrl_direct",
+    "type": "event_transformation",
+    "event_type": "vehicle_moves",
+    "value_constraints": { "avatar_is_driving": { "equals": true } },
+    "drop_fields": [ "avatar_is_driving" ]
+  },
+  {
+    "id": "num_moves_veh_ctrl_direct",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_veh_ctrl_direct",
+    "description": { "str": "square travelled while controlling vehicle", "str_pl": "squares travelled while controlling vehicle" }
+  },
+  {
+    "id": "moves_veh_ctrl_remote",
+    "type": "event_transformation",
+    "event_type": "vehicle_moves",
+    "value_constraints": { "avatar_remote_control": { "equals": true } },
+    "drop_fields": [ "avatar_remote_control" ]
+  },
+  {
+    "id": "num_moves_veh_ctrl_remote",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_veh_ctrl_remote",
+    "description": { "str": "square traversed by remote controlled vehicles", "str_pl": "squares traversed by remote controlled vehicles" }
+  },
+  {
+    "id": "moves_veh_onboard_ctrl_remote",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_onboard",
+    "value_constraints": { "avatar_remote_control": { "equals": true } },
+    "drop_fields": [ "avatar_remote_control" ]
+  },
+  {
+    "id": "num_moves_veh_onboard_ctrl_remote",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_veh_onboard_ctrl_remote",
+    "description": {
+      "str": "square travelled on board remote controlled vehicle",
+      "str_pl": "squares travelled on board remote controlled vehicle"
+    }
+  },
+  {
+    "id": "moves_veh_onboard_ctrl_none",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_onboard",
+    "value_constraints": { "avatar_is_driving": { "equals": false }, "avatar_remote_control": { "equals": false } },
+    "drop_fields": [ "avatar_is_driving", "avatar_remote_control" ]
+  },
+  {
+    "id": "num_moves_veh_onboard_ctrl_none",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_veh_onboard_ctrl_none",
+    "description": { "str": "square travelled as vehicle passenger", "str_pl": "squares travelled as vehicle passenger" }
+  },
+  {
+    "id": "moves_acft_onboard",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_onboard",
+    "value_constraints": { "is_flying_aircraft": { "equals": true } },
+    "drop_fields": [ "is_flying_aircraft" ]
+  },
+  {
+    "id": "num_moves_acft_onboard",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_acft_onboard",
+    "description": { "str": "square travelled on board aircraft", "str_pl": "squares travelled on board aircraft" }
+  },
+  {
+    "id": "moves_acft_ctrl_direct",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_ctrl_direct",
+    "value_constraints": { "is_flying_aircraft": { "equals": true } },
+    "drop_fields": [ "is_flying_aircraft" ]
+  },
+  {
+    "id": "num_moves_acft_ctrl_direct",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_acft_ctrl_direct",
+    "description": { "str": "square travelled while piloting aircraft", "str_pl": "squares travelled while piloting aircraft" }
+  },
+  {
+    "id": "max_velocity_acft",
+    "type": "event_statistic",
+    "stat_type": "maximum",
+    "field": "velocity",
+    "event_transformation": "moves_acft_ctrl_direct",
+    "description": { "str_sp": "maximum velocity attained while piloting an aircraft" }
+  },
+  {
+    "id": "max_move_acft_ctrl_direct_z",
+    "type": "event_statistic",
+    "stat_type": "maximum",
+    "field": "z",
+    "event_transformation": "moves_acft_ctrl_direct",
+    "description": { "str_sp": "maximum z level reached while piloting an aircraft" }
+  },
+  {
+    "id": "moves_boat_onboard",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_onboard",
+    "value_constraints": { "is_floating_watercraft": { "equals": true } },
+    "drop_fields": [ "is_floating_watercraft" ]
+  },
+  {
+    "id": "num_moves_boat_onboard",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_boat_onboard",
+    "description": { "str": "square travelled on board watercraft", "str_pl": "squares travelled on board watercraft" }
+  },
+  {
+    "id": "moves_boat_ctrl_direct",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_ctrl_direct",
+    "value_constraints": { "is_floating_watercraft": { "equals": true } },
+    "drop_fields": [ "is_floating_watercraft" ]
+  },
+  {
+    "id": "num_moves_boat_ctrl_direct",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_boat_ctrl_direct",
+    "description": { "str": "square travelled while sailing watercraft", "str_pl": "squares travelled while sailing watercraft" }
+  },
+  {
+    "id": "max_velocity_boat",
+    "type": "event_statistic",
+    "stat_type": "maximum",
+    "field": "velocity",
+    "event_transformation": "moves_boat_ctrl_direct",
+    "description": { "str_sp": "maximum velocity attained while sailing a watercraft" }
+  },
+  {
+    "id": "moves_rail_onboard",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_onboard",
+    "value_constraints": { "is_on_rails": { "equals": true } },
+    "drop_fields": [ "is_on_rails" ]
+  },
+  {
+    "id": "num_moves_rail_onboard",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_rail_onboard",
+    "description": { "str": "square travelled on board rail vehicles", "str_pl": "squares travelled on board rail vehicles" }
+  },
+  {
+    "id": "moves_rail_ctrl_direct",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_ctrl_direct",
+    "value_constraints": { "is_on_rails": { "equals": true } },
+    "drop_fields": [ "is_on_rails" ]
+  },
+  {
+    "id": "num_moves_rail_ctrl_direct",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_rail_ctrl_direct",
+    "description": { "str": "square travelled while driving rail vehicles", "str_pl": "squares travelled while driving rail vehicles" }
+  },
+  {
+    "id": "max_velocity_rail",
+    "type": "event_statistic",
+    "stat_type": "maximum",
+    "field": "velocity",
+    "event_transformation": "moves_rail_ctrl_direct",
+    "description": { "str_sp": "maximum velocity attained while driving a rail vehicle" }
+  },
+  {
+    "id": "moves_gndv_onboard",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_onboard",
+    "value_constraints": {
+      "is_flying_aircraft": { "equals": false },
+      "is_floating_watercraft": { "equals": false },
+      "is_on_rails": { "equals": false }
+    },
+    "drop_fields": [ "is_flying_aircraft", "is_floating_watercraft", "is_on_rails" ]
+  },
+  {
+    "id": "num_moves_gndv_onboard",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_gndv_onboard",
+    "description": { "str": "square travelled on board land vehicles", "str_pl": "squares travelled on board land vehicles" }
+  },
+  {
+    "id": "moves_gndv_ctrl_direct",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_ctrl_direct",
+    "value_constraints": {
+      "is_flying_aircraft": { "equals": false },
+      "is_floating_watercraft": { "equals": false },
+      "is_on_rails": { "equals": false }
+    },
+    "drop_fields": [ "is_flying_aircraft", "is_floating_watercraft", "is_on_rails" ]
+  },
+  {
+    "id": "num_moves_gndv_ctrl_direct",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_gndv_ctrl_direct",
+    "description": { "str": "square travelled while driving land vehicles", "str_pl": "squares travelled while driving land vehicles" }
+  },
+  {
+    "id": "max_velocity_gndv",
+    "type": "event_statistic",
+    "stat_type": "maximum",
+    "field": "velocity",
+    "event_transformation": "moves_gndv_ctrl_direct",
+    "description": { "str_sp": "maximum velocity attained while driving a land vehicle" }
+  },
+  {
+    "id": "max_move_gndv_ctrl_direct_z",
+    "type": "event_statistic",
+    "stat_type": "maximum",
+    "field": "z",
+    "event_transformation": "moves_gndv_ctrl_direct",
+    "description": { "str_sp": "maximum z level reached while driving a land vehicle" }
+  },
+  {
+    "id": "moves_gndv_skidding",
+    "type": "event_transformation",
+    "event_transformation": "moves_gndv_ctrl_direct",
+    "value_constraints": { "is_skidding": { "equals": true } },
+    "drop_fields": [ "is_skidding" ]
+  },
+  {
+    "id": "num_moves_gndv_skidding",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "moves_gndv_skidding",
+    "description": { "str": "square skidded while driving land vehicles", "str_pl": "squares skidded while driving land vehicles" }
+  },
+  {
+    "id": "max_velocity_skidding",
+    "type": "event_statistic",
+    "stat_type": "maximum",
+    "field": "velocity",
+    "event_transformation": "moves_gndv_skidding",
+    "description": { "str_sp": "maximum velocity that a driven vehicle skidded at" }
+  },
+  {
     "id": "avatar_wields_item",
     "type": "event_transformation",
     "event_type": "character_wields_item",

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -100,6 +100,7 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::triggers_alarm: return "triggers_alarm";
         case event_type::uses_debug_menu: return "uses_debug_menu";
         case event_type::u_var_changed: return "u_var_changed";
+        case event_type::vehicle_moves: return "vehicle_moves";
         // *INDENT-ON*
         case event_type::num_event_types:
             break;
@@ -123,7 +124,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 86,
+static_assert( static_cast<int>( event_type::num_event_types ) == 87,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );
@@ -181,6 +182,7 @@ DEFINE_EVENT_FIELDS( telefrags_creature )
 DEFINE_EVENT_FIELDS( teleports_into_wall )
 DEFINE_EVENT_FIELDS( uses_debug_menu )
 DEFINE_EVENT_FIELDS( u_var_changed )
+DEFINE_EVENT_FIELDS( vehicle_moves )
 
 } // namespace event_detail
 

--- a/src/event.h
+++ b/src/event.h
@@ -111,6 +111,7 @@ enum class event_type : int {
     triggers_alarm,
     uses_debug_menu,
     u_var_changed,
+    vehicle_moves,
     num_event_types // last
 };
 
@@ -171,7 +172,7 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 86,
+static_assert( static_cast<int>( event_type::num_event_types ) == 87,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -735,6 +736,24 @@ struct event_spec<event_type::u_var_changed> {
     static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = { {
             { "var", cata_variant_type::string },
             { "value", cata_variant_type::string },
+        }
+    };
+};
+
+template<>
+struct event_spec<event_type::vehicle_moves> {
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 11> fields = {{
+            { "avatar_on_board", cata_variant_type::bool_ },
+            { "avatar_is_driving", cata_variant_type::bool_ }, // non-remote-control
+            { "avatar_remote_control", cata_variant_type::bool_ },
+            { "is_flying_aircraft", cata_variant_type::bool_ }, // actual viable aircraft
+            { "is_floating_watercraft", cata_variant_type::bool_ }, // actual viable boat
+            { "is_on_rails", cata_variant_type::bool_ }, // railway vehicle on rails
+            { "is_falling", cata_variant_type::bool_ }, // not an aircraft, just getting air time
+            { "is_sinking", cata_variant_type::bool_ }, // sinking in water
+            { "is_skidding", cata_variant_type::bool_ },
+            { "velocity", cata_variant_type::int_ }, // vehicle current velocity, mph * 100
+            { "z", cata_variant_type::int_ },
         }
     };
 };

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -1099,6 +1099,7 @@ void memorial_logger::notify( const cata::event &e )
         case event_type::game_load:
         case event_type::game_save:
         case event_type::u_var_changed:
+        case event_type::vehicle_moves:
             break;
         case event_type::num_event_types: {
             debugmsg( "Invalid event type" );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3090,19 +3090,7 @@ int vehicle::part_displayed_at( const point &dp, bool include_fake, bool below_r
     bool in_vehicle = !roof;
 
     if( roof ) {
-        Character &player_character = get_player_character();
-        in_vehicle = player_character.in_vehicle;
-        if( in_vehicle ) {
-            // They're in a vehicle, but are they in /this/ vehicle?
-            std::vector<int> psg_parts = boarded_parts();
-            in_vehicle = false;
-            for( const int &psg_part : psg_parts ) {
-                if( get_passenger( psg_part ) == &player_character ) {
-                    in_vehicle = true;
-                    break;
-                }
-            }
-        }
+        in_vehicle = is_passenger( get_player_character() );
     }
 
     int hide_z_at_or_above = in_vehicle ? ON_ROOF_Z : INT_MAX;
@@ -3225,6 +3213,20 @@ std::vector<rider_data> vehicle::get_riders() const
         }
     }
     return res;
+}
+
+bool vehicle::is_passenger( Character &c ) const
+{
+    if( !c.in_vehicle ) {
+        return false;
+    }
+    std::vector<int> psg_parts = boarded_parts();
+    for( const int &psg_part : psg_parts ) {
+        if( get_passenger( psg_part ) == &c ) {
+            return true;
+        }
+    }
+    return false;
 }
 
 Character *vehicle::get_passenger( int you ) const

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5398,6 +5398,14 @@ void vehicle::on_move()
     if( has_part( "REAPER", true ) ) {
         operate_reaper();
     }
+
+    Character &pc = get_player_character();
+    get_event_bus().send<event_type::vehicle_moves>(
+        is_passenger( pc ), player_in_control( pc ), remote_controlled( pc ),
+        is_flying_in_air(), is_watercraft() && can_float(), can_use_rails(),
+        is_falling, is_in_water( true ) && !can_float(),
+        skidding, velocity, sm_pos.z
+    );
 }
 
 void vehicle::slow_leak()

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1234,6 +1234,8 @@ class vehicle
         // get a list of part indices and Creature pointers with a rider
         std::vector<rider_data> get_riders() const;
 
+        // is given character a passenger of this vehicle
+        bool is_passenger( Character &c ) const;
         // get passenger at part p
         Character *get_passenger( int you ) const;
         // get monster on a boardable part at p


### PR DESCRIPTION
#### Summary
Content "Add 14 scores, 24 achievements and 5 conducts related to vehicular travel"

#### Purpose of change
More stats and challenges for players

#### Describe the solution
Add an event for vehicle movement, with a whopping 11 fields, supporting 20+ new event statistics that feed into scores, achievements and conducts.

#### Describe alternatives you've considered
So much more would be possible if `value_constraints` could do more than just equality tests. lteq/gteq compares would be really handy. But I can't be assed to implement that right now.

#### Testing
`cata_test` has stopped yelling at me for silly careless mistakes, which is probably good.

Get some of the scores to increment in game by doing the things.
Lose conducts by violating the requirements.
Some achievements can be tested without too much trouble; others are harder unfortunately.

![fly](https://user-images.githubusercontent.com/28502722/217870378-4ccddcc7-0c2d-4609-90a6-b5a9d370b1ab.png)
