### PR TITLE
Automatic weekly changelogs

### DIFF
--- a/.github/workflows/weekly-changelog.yml
+++ b/.github/workflows/weekly-changelog.yml
@@ -1,0 +1,50 @@
+name: "Weekly changelog update"
+
+on:
+  schedule:
+    - cron: "45 0 * * 1"
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/weekly-changelog.yml'
+
+jobs:
+  weekly-changelog:
+    if: github.repository == 'CleverRaven/Cataclysm-DDA'
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Get current date"
+        uses: 1466587594/get-current-time@v2
+        id: current-date
+        with:
+          format: 'YYYYMMDD'
+      - name: "Get changes since last week"
+        id: getting-changes
+        env:
+          CURR_DATE: ${{ steps.current-date.outputs.formattedTime }}
+        run: |
+          LAST_WEEK="$(date -d "@$(( $(date +%s -d $CURR_DATE) - (60*60*24*7) ))" +"%Y-%m-%d")"
+          tools/generate_changelog.py -f --by-date /tmp/changelog.txt -T "${{ secrets.TX_TOKEN }}" "$LAST_WEEK"
+          tac /tmp/changelog.txt > /tmp/changelog_rev.txt
+          tools/merge_summaries.sh /tmp/changelog_rev.txt data/changelog.txt
+          echo "date=$( date +"%Y-%m-%d" -d $CURR_DATE )" >> $GITHUB_OUTPUT
+          echo "old_date=$LAST_WEEK" >> $GITHUB_OUTPUT
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3.10.0
+        with:
+          commit-message: Weekly Changelog ${{ steps.getting-changes.outputs.old_date }} to ${{ steps.getting-changes.outputs.date }}
+          committer: David Seguin <davidseguin@live.ca>
+          author: David Seguin <davidseguin@live.ca>
+          token: ${{ secrets.TX_PR_CREATOR }}
+          branch: changelog-weekly
+          delete-branch: true
+          base: master
+          title: Weekly Changelog ${{ steps.getting-changes.outputs.old_date }} to ${{ steps.getting-changes.outputs.date }}
+          body: "#### Summary\nNone\n\n#### Additional context\n`Automatically generated as a draft. Please copy-edit before merging.`"
+          labels: Organization,<Documentation>
+          # create as a draft to allow maintainers to cull the changes before merging
+          draft: true
+

--- a/data/changelog.txt
+++ b/data/changelog.txt
@@ -1,3 +1,35 @@
+# 0.H
+
+## Features:
+
+
+## Content:
+
+
+## Interface:
+
+
+## Mods:
+
+
+## Balance:
+
+
+## Bugfixes:
+
+
+## Performance:
+
+
+## Infrastructure:
+
+
+## Build:
+
+
+## I18N and A11Y:
+
+
 # 0.G (Gaiman)
 
 ## Highlights

--- a/tools/generate_changelog.py
+++ b/tools/generate_changelog.py
@@ -1072,6 +1072,12 @@ def main_entry(argv):
     )
 
     parser.add_argument(
+        '-T', '--token-string',
+        help='Specify the Personal Token as an inline argument.',
+        default=None
+    )
+
+    parser.add_argument(
         '-N', '--include-summary-none',
         action='store_true',
         help='Indicates if Pull Requests with Summary "None" should be '
@@ -1112,8 +1118,10 @@ def main_entry(argv):
 
     personal_token = read_personal_token(arguments.token_file)
     if personal_token is None:
-        log.warning("GitHub Token was not provided, API calls will have "
-                    "severely limited rates.")
+        personal_token = arguments.token_string
+        if personal_token is None:
+            log.warning("GitHub Token was not provided, API calls will have "
+                        "severely limited rates.")
 
     if arguments.by_date is None and arguments.by_build is None:
         raise ValueError("Script should be called with either --by-date or "


### PR DESCRIPTION
#### Summary
None

To be merge after 0.G is tagged

#### Purpose of change
Instead of sifting through tens of thousands of changelog entries at the end of a release cycle, update the changelog weekly with an automatic workflow.

#### Describe the solution
The workflow relies on the existing (admittedly, pretty janky) method of pulling changelog entries using `generate_changelog.py`.

The empty categories for "0.H" are necessary to slot in the new changes using the (janky) python scripts. Once the automated changelog update PR is submitted, it'll need to be copy edited to remove entries that wouldn't end up on the final changelog for 0.H.

#### Describe alternatives you've considered
Doing it the old way of "not bothering until the very end".

#### Testing
The workflow produces a PR like this one: https://github.com/dseguin/Cataclysm-DDA/pull/4

#### Additional context
