### PR TITLE
Update events to account for ability to swap avatars (debug or upon death)

### DIFF
--- a/data/json/statistics.json
+++ b/data/json/statistics.json
@@ -2,8 +2,8 @@
   {
     "id": "avatar_id",
     "type": "event_statistic",
-    "stat_type": "unique_value",
-    "event_type": "game_start",
+    "stat_type": "last_value",
+    "event_type": "game_avatar_new",
     "field": "avatar_id"
   },
   {

--- a/data/json/statistics.json
+++ b/data/json/statistics.json
@@ -7,6 +7,13 @@
     "field": "avatar_id"
   },
   {
+    "id": "last_words",
+    "type": "event_statistic",
+    "stat_type": "last_value",
+    "event_type": "game_avatar_death",
+    "field": "last_words"
+  },
+  {
     "id": "avatar_wakes_up",
     "type": "event_transformation",
     "event_type": "character_wakes_up",

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -166,7 +166,7 @@ static void swap_npc( npc &one, npc &two, npc &tmp )
     two = std::move( tmp );
 }
 
-void avatar::control_npc( npc &np )
+void avatar::control_npc( npc &np, const bool debug )
 {
     if( !np.is_player_ally() ) {
         debugmsg( "control_npc() called on non-allied npc %s", np.name );
@@ -204,11 +204,11 @@ void avatar::control_npc( npc &np )
     character_mood_face( true );
 
     profession_id prof_id = prof ? prof->ident() : profession::generic()->ident();
-    get_event_bus().send<event_type::game_avatar_new>( false, getID(), name, male,
-            prof_id, custom_profession );
+    get_event_bus().send<event_type::game_avatar_new>( /*is_new_game=*/false, debug,
+            getID(), name, male, prof_id, custom_profession );
 }
 
-void avatar::control_npc_menu()
+void avatar::control_npc_menu( const bool debug )
 {
     std::vector<shared_ptr_fast<npc>> followers;
     uilist charmenu;
@@ -229,7 +229,7 @@ void avatar::control_npc_menu()
     if( charmenu.ret < 0 || static_cast<size_t>( charmenu.ret ) >= followers.size() ) {
         return;
     }
-    get_avatar().control_npc( *followers[charmenu.ret] );
+    get_avatar().control_npc( *followers[charmenu.ret], debug );
 }
 
 void avatar::longpull( const std::string &name )

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -203,8 +203,9 @@ void avatar::control_npc( npc &np )
     g->update_map( *this, z_level_changed );
     character_mood_face( true );
 
+    profession_id prof_id = prof ? prof->ident() : profession::generic()->ident();
     get_event_bus().send<event_type::game_avatar_new>( false, getID(), name, male,
-            prof->ident(), custom_profession );
+            prof_id, custom_profession );
 }
 
 void avatar::control_npc_menu()

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -202,6 +202,9 @@ void avatar::control_npc( npc &np )
     const bool z_level_changed = g->vertical_shift( posz() );
     g->update_map( *this, z_level_changed );
     character_mood_face( true );
+
+    get_event_bus().send<event_type::game_avatar_new>( false, getID(), name, male,
+            prof->ident(), custom_profession );
 }
 
 void avatar::control_npc_menu()

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -126,11 +126,11 @@ class avatar : public Character
          * Makes the avatar "take over" the given NPC, while the current avatar character
          * becomes an NPC.
          */
-        void control_npc( npc & );
+        void control_npc( npc &, bool debug = false );
         /**
          * Open a menu to choose the NPC to take over.
          */
-        void control_npc_menu();
+        void control_npc_menu( bool debug = false );
         using Character::query_yn;
         bool query_yn( const std::string &mes ) const override;
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1376,7 +1376,7 @@ static void spawn_nested_mapgen()
 
 static void control_npc_menu()
 {
-    get_avatar().control_npc_menu();
+    get_avatar().control_npc_menu( true );
 }
 
 static void character_edit_stats_menu( Character &you )

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -43,12 +43,12 @@ static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 
 static const bionic_id bio_alarm( "bio_alarm" );
 
-static const event_statistic_id event_statistic_last_words( "last_words" );
-
 static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_npc_suspend( "npc_suspend" );
 static const efftype_id effect_ridden( "ridden" );
 static const efftype_id effect_sleep( "sleep" );
+
+static const event_statistic_id event_statistic_last_words( "last_words" );
 
 static const trait_id trait_HAS_NEMESIS( "HAS_NEMESIS" );
 

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -29,6 +29,7 @@
 #include "scent_map.h"
 #include "sdlsound.h"
 #include "string_input_popup.h"
+#include "stats_tracker.h"
 #include "timed_event.h"
 #include "ui_manager.h"
 #include "vehicle.h"
@@ -42,18 +43,14 @@ static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 
 static const bionic_id bio_alarm( "bio_alarm" );
 
+static const event_statistic_id event_statistic_last_words( "last_words" );
+
 static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_npc_suspend( "npc_suspend" );
 static const efftype_id effect_ridden( "ridden" );
 static const efftype_id effect_sleep( "sleep" );
 
-static const itype_id itype_holybook_bible1( "holybook_bible1" );
-static const itype_id itype_holybook_bible2( "holybook_bible2" );
-static const itype_id itype_holybook_bible3( "holybook_bible3" );
-
-static const trait_id trait_CANNIBAL( "CANNIBAL" );
 static const trait_id trait_HAS_NEMESIS( "HAS_NEMESIS" );
-static const trait_id trait_PSYCHOPATH( "PSYCHOPATH" );
 
 #if defined(__ANDROID__)
 extern std::map<std::string, std::list<input_event>> quick_shortcuts_map;
@@ -88,196 +85,16 @@ bool cleanup_at_end()
     }
 
     if( g->uquit == QUIT_DIED || g->uquit == QUIT_SUICIDE ) {
-        std::vector<std::string> vRip;
-
-        int iMaxWidth = 0;
-        int iNameLine = 0;
-        int iInfoLine = 0;
-
-        if( u.has_amount( itype_holybook_bible1, 1 ) || u.has_amount( itype_holybook_bible2, 1 ) ||
-            u.has_amount( itype_holybook_bible3, 1 ) ) {
-            if( !( u.has_trait( trait_CANNIBAL ) || u.has_trait( trait_PSYCHOPATH ) ) ) {
-                vRip.emplace_back( "               _______  ___" );
-                vRip.emplace_back( "              <       `/   |" );
-                vRip.emplace_back( "               >  _     _ (" );
-                vRip.emplace_back( "              |  |_) | |_) |" );
-                vRip.emplace_back( "              |  | \\ | |   |" );
-                vRip.emplace_back( "   ______.__%_|            |_________  __" );
-                vRip.emplace_back( " _/                                  \\|  |" );
-                iNameLine = vRip.size();
-                vRip.emplace_back( "|                                        <" );
-                vRip.emplace_back( "|                                        |" );
-                iMaxWidth = utf8_width( vRip.back() );
-                vRip.emplace_back( "|                                        |" );
-                vRip.emplace_back( "|_____.-._____              __/|_________|" );
-                vRip.emplace_back( "              |            |" );
-                iInfoLine = vRip.size();
-                vRip.emplace_back( "              |            |" );
-                vRip.emplace_back( "              |           <" );
-                vRip.emplace_back( "              |            |" );
-                vRip.emplace_back( "              |   _        |" );
-                vRip.emplace_back( "              |__/         |" );
-                vRip.emplace_back( "             % / `--.      |%" );
-                vRip.emplace_back( "         * .%%|          -< @%%%" ); // NOLINT(cata-text-style)
-                vRip.emplace_back( "         `\\%`@|            |@@%@%%" );
-                vRip.emplace_back( "       .%%%@@@|%     `   % @@@%%@%%%%" );
-                vRip.emplace_back( "  _.%%%%%%@@@@@@%%%__/\\%@@%%@@@@@@@%%%%%%" );
-
-            } else {
-                vRip.emplace_back( "               _______  ___" );
-                vRip.emplace_back( "              |       \\/   |" );
-                vRip.emplace_back( "              |            |" );
-                vRip.emplace_back( "              |            |" );
-                iInfoLine = vRip.size();
-                vRip.emplace_back( "              |            |" );
-                vRip.emplace_back( "              |            |" );
-                vRip.emplace_back( "              |            |" );
-                vRip.emplace_back( "              |            |" );
-                vRip.emplace_back( "              |           <" );
-                vRip.emplace_back( "              |   _        |" );
-                vRip.emplace_back( "              |__/         |" );
-                vRip.emplace_back( "   ______.__%_|            |__________  _" );
-                vRip.emplace_back( " _/                                   \\| \\" );
-                iNameLine = vRip.size();
-                vRip.emplace_back( "|                                         <" );
-                vRip.emplace_back( "|                                         |" );
-                iMaxWidth = utf8_width( vRip.back() );
-                vRip.emplace_back( "|                                         |" );
-                vRip.emplace_back( "|_____.-._______            __/|__________|" );
-                vRip.emplace_back( "             % / `_-.   _  |%" );
-                vRip.emplace_back( "         * .%%|  |_) | |_)< @%%%" ); // NOLINT(cata-text-style)
-                vRip.emplace_back( "         `\\%`@|  | \\ | |   |@@%@%%" );
-                vRip.emplace_back( "       .%%%@@@|%     `   % @@@%%@%%%%" );
-                vRip.emplace_back( "  _.%%%%%%@@@@@@%%%__/\\%@@%%@@@@@@@%%%%%%" );
-            }
-        } else {
-            vRip.emplace_back( R"(           _________  ____           )" );
-            vRip.emplace_back( R"(         _/         `/    \_         )" );
-            vRip.emplace_back( R"(       _/      _     _      \_.      )" );
-            vRip.emplace_back( R"(     _%\      |_) | |_)       \_     )" );
-            vRip.emplace_back( R"(   _/ \/      | \ | |           \_   )" );
-            vRip.emplace_back( R"( _/                               \_ )" );
-            vRip.emplace_back( R"(|                                   |)" );
-            iNameLine = vRip.size();
-            vRip.emplace_back( R"( )                                 < )" );
-            vRip.emplace_back( R"(|                                   |)" );
-            vRip.emplace_back( R"(|                                   |)" );
-            vRip.emplace_back( R"(|   _                               |)" );
-            vRip.emplace_back( R"(|__/                                |)" );
-            iMaxWidth = utf8_width( vRip.back() );
-            vRip.emplace_back( R"( / `--.                             |)" );
-            vRip.emplace_back( R"(|                                  ( )" );
-            iInfoLine = vRip.size();
-            vRip.emplace_back( R"(|                                   |)" );
-            vRip.emplace_back( R"(|                                   |)" );
-            vRip.emplace_back( R"(|     %                         .   |)" );
-            vRip.emplace_back( R"(|  @`                            %% |)" );
-            vRip.emplace_back( R"(| %@%@%\                *      %`%@%|)" );
-            vRip.emplace_back( R"(%%@@@.%@%\%%            `\  %%.%%@@%@)" );
-            vRip.emplace_back( R"(@%@@%%%%%@@@@@@%%%%%%%%@@%%@@@%%%@%%@)" );
-        }
-
-        const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
-
-        catacurses::window w_rip = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                   iOffset );
-        draw_border( w_rip );
-
-        sfx::do_player_death_hurt( get_player_character(), true );
-        sfx::fade_audio_group( sfx::group::weather, 2000 );
-        sfx::fade_audio_group( sfx::group::time_of_day, 2000 );
-        sfx::fade_audio_group( sfx::group::context_themes, 2000 );
-        sfx::fade_audio_group( sfx::group::fatigue, 2000 );
-
-        for( size_t iY = 0; iY < vRip.size(); ++iY ) {
-            size_t iX = 0;
-            const char *str = vRip[iY].data();
-            for( int slen = vRip[iY].size(); slen > 0; ) {
-                const uint32_t cTemp = UTF8_getch( &str, &slen );
-                if( cTemp != U' ' ) {
-                    nc_color ncColor = c_light_gray;
-
-                    if( cTemp == U'%' ) {
-                        ncColor = c_green;
-
-                    } else if( cTemp == U'_' || cTemp == U'|' ) {
-                        ncColor = c_white;
-
-                    } else if( cTemp == U'@' ) {
-                        ncColor = c_brown;
-
-                    } else if( cTemp == U'*' ) {
-                        ncColor = c_red;
-                    }
-
-                    mvwputch( w_rip, point( iX + FULL_SCREEN_WIDTH / 2 - ( iMaxWidth / 2 ), iY + 1 ), ncColor,
-                              cTemp );
-                }
-                iX += mk_wcwidth( cTemp );
-            }
-        }
-
-        std::string sTemp;
-
-        center_print( w_rip, iInfoLine++, c_white, _( "Survived:" ) );
-
-        const time_duration survived = calendar::turn - calendar::start_of_game;
-        const int minutes = to_minutes<int>( survived ) % 60;
-        const int hours = to_hours<int>( survived ) % 24;
-        const int days = to_days<int>( survived );
-
-        if( days > 0 ) {
-            // NOLINTNEXTLINE(cata-translate-string-literal)
-            sTemp = string_format( "%dd %dh %dm", days, hours, minutes );
-        } else if( hours > 0 ) {
-            // NOLINTNEXTLINE(cata-translate-string-literal)
-            sTemp = string_format( "%dh %dm", hours, minutes );
-        } else {
-            // NOLINTNEXTLINE(cata-translate-string-literal)
-            sTemp = string_format( "%dm", minutes );
-        }
-
-        center_print( w_rip, iInfoLine++, c_white, sTemp );
-
-        const int iTotalKills = g->get_kill_tracker().monster_kill_count();
-
-        sTemp = _( "Kills:" );
-        mvwprintz( w_rip, point( FULL_SCREEN_WIDTH / 2 - 5, 1 + iInfoLine++ ), c_light_gray,
-                   ( sTemp + " " ) );
-        wprintz( w_rip, c_magenta, "%d", iTotalKills );
-
-        sTemp = _( "In memory of:" );
-        mvwprintz( w_rip, point( FULL_SCREEN_WIDTH / 2 - utf8_width( sTemp ) / 2, iNameLine++ ),
-                   c_light_gray,
-                   sTemp );
-
-        sTemp = u.get_name();
-        mvwprintz( w_rip, point( FULL_SCREEN_WIDTH / 2 - utf8_width( sTemp ) / 2, iNameLine++ ), c_white,
-                   sTemp );
-
-        sTemp = _( "Last Words:" );
-        mvwprintz( w_rip, point( FULL_SCREEN_WIDTH / 2 - utf8_width( sTemp ) / 2, iNameLine++ ),
-                   c_light_gray,
-                   sTemp );
-
-        int iStartX = FULL_SCREEN_WIDTH / 2 - ( ( iMaxWidth - 4 ) / 2 );
-        std::string sLastWords = string_input_popup()
-                                 .window( w_rip, point( iStartX, iNameLine ), iStartX + iMaxWidth - 4 - 1 )
-                                 .max_length( iMaxWidth - 4 - 1 )
-                                 .query_string();
         g->death_screen();
-        const bool is_suicide = g->uquit == QUIT_SUICIDE;
         std::chrono::seconds time_since_load =
             std::chrono::duration_cast<std::chrono::seconds>(
                 std::chrono::steady_clock::now() - g->time_of_last_load );
         std::chrono::seconds total_time_played = g->time_played_at_last_load + time_since_load;
-        get_event_bus().send<event_type::game_avatar_death>( u.getID(), u.name, u.male, is_suicide,
-                sLastWords );
         get_event_bus().send<event_type::game_over>( total_time_played );
         // Struck the save_player_data here to forestall Weirdness
         g->move_save_to_graveyard();
-        g->write_memorial_file( sLastWords );
+        g->write_memorial_file( g->stats().value_of( event_statistic_last_words )
+                                .get<cata_variant_type::string>() );
         get_memorial().clear();
         std::vector<std::string> characters = g->list_active_saves();
         // remove current player from the active characters list, as they are dead

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -82,9 +82,7 @@ bool cleanup_at_end()
 
         // and the overmap, and the local map.
         g->save_maps(); //Omap also contains the npcs who need to be saved.
-    }
 
-    if( g->uquit == QUIT_DIED || g->uquit == QUIT_SUICIDE ) {
         g->death_screen();
         std::chrono::seconds time_since_load =
             std::chrono::duration_cast<std::chrono::seconds>(

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -272,7 +272,9 @@ bool cleanup_at_end()
             std::chrono::duration_cast<std::chrono::seconds>(
                 std::chrono::steady_clock::now() - g->time_of_last_load );
         std::chrono::seconds total_time_played = g->time_played_at_last_load + time_since_load;
-        get_event_bus().send<event_type::game_over>( is_suicide, sLastWords, total_time_played );
+        get_event_bus().send<event_type::game_avatar_death>( u.getID(), u.name, u.male, is_suicide,
+                sLastWords );
+        get_event_bus().send<event_type::game_over>( total_time_played );
         // Struck the save_player_data here to forestall Weirdness
         g->move_save_to_graveyard();
         g->write_memorial_file( sLastWords );

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -74,6 +74,8 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::gains_addiction: return "gains_addiction";
         case event_type::gains_mutation: return "gains_mutation";
         case event_type::gains_skill_level: return "gains_skill_level";
+        case event_type::game_avatar_death: return "game_avatar_death";
+        case event_type::game_avatar_new: return "game_avatar_new";
         case event_type::game_load: return "game_load";
         case event_type::game_over: return "game_over";
         case event_type::game_save: return "game_save";
@@ -124,7 +126,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 87,
+static_assert( static_cast<int>( event_type::num_event_types ) == 89,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );
@@ -165,6 +167,8 @@ DEFINE_EVENT_FIELDS( fuel_tank_explodes )
 DEFINE_EVENT_FIELDS( gains_addiction )
 DEFINE_EVENT_FIELDS( gains_mutation )
 DEFINE_EVENT_FIELDS( gains_skill_level )
+DEFINE_EVENT_FIELDS( game_avatar_death )
+DEFINE_EVENT_FIELDS( game_avatar_new )
 DEFINE_EVENT_FIELDS( game_load )
 DEFINE_EVENT_FIELDS( game_over )
 DEFINE_EVENT_FIELDS( game_save )

--- a/src/event.h
+++ b/src/event.h
@@ -572,8 +572,9 @@ struct event_spec<event_type::game_avatar_death> {
 
 template<>
 struct event_spec<event_type::game_avatar_new> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 6> fields = {{
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 7> fields = {{
             { "is_new_game", cata_variant_type::bool_ },
+            { "is_debug", cata_variant_type::bool_ },
             { "avatar_id", cata_variant_type::character_id },
             { "avatar_name", cata_variant_type::string },
             { "avatar_is_male", cata_variant_type::bool_ },

--- a/src/event.h
+++ b/src/event.h
@@ -85,6 +85,8 @@ enum class event_type : int {
     gains_addiction,
     gains_mutation,
     gains_skill_level,
+    game_avatar_death,
+    game_avatar_new,
     game_load,
     game_over,
     game_save,
@@ -172,7 +174,7 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 87,
+static_assert( static_cast<int>( event_type::num_event_types ) == 89,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -557,6 +559,31 @@ struct event_spec<event_type::gains_skill_level> {
 };
 
 template<>
+struct event_spec<event_type::game_avatar_death> {
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 5> fields = {{
+            { "avatar_id", cata_variant_type::character_id },
+            { "avatar_name", cata_variant_type::string },
+            { "avatar_is_male", cata_variant_type::bool_ },
+            { "is_suicide", cata_variant_type::bool_ },
+            { "last_words", cata_variant_type::string },
+        }
+    };
+};
+
+template<>
+struct event_spec<event_type::game_avatar_new> {
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 6> fields = {{
+            { "is_new_game", cata_variant_type::bool_ },
+            { "avatar_id", cata_variant_type::character_id },
+            { "avatar_name", cata_variant_type::string },
+            { "avatar_is_male", cata_variant_type::bool_ },
+            { "avatar_profession", cata_variant_type::profession_id },
+            { "avatar_custom_profession", cata_variant_type::string },
+        }
+    };
+};
+
+template<>
 struct event_spec<event_type::game_load> {
     static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
             { "cdda_version", cata_variant_type::string },
@@ -566,9 +593,7 @@ struct event_spec<event_type::game_load> {
 
 template<>
 struct event_spec<event_type::game_over> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = {{
-            { "is_suicide", cata_variant_type::bool_ },
-            { "last_words", cata_variant_type::string },
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
             { "total_time_played", cata_variant_type::chrono_seconds },
         }
     };
@@ -585,12 +610,7 @@ struct event_spec<event_type::game_save> {
 
 template<>
 struct event_spec<event_type::game_start> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 6> fields = {{
-            { "avatar_id", cata_variant_type::character_id },
-            { "avatar_name", cata_variant_type::string },
-            { "avatar_is_male", cata_variant_type::bool_ },
-            { "avatar_profession", cata_variant_type::profession_id },
-            { "avatar_custom_profession", cata_variant_type::string },
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
             { "game_version", cata_variant_type::string },
         }
     };

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -684,7 +684,7 @@ struct event_statistic_count : event_statistic::impl {
     }
 
     monotonically monotonicity() const override {
-        return source->monotonicity();
+        return monotonically::increasing;
     }
 
     std::unique_ptr<impl> clone() const override {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1003,8 +1003,9 @@ bool game::start_game()
         }
     }
 
-    get_event_bus().send<event_type::game_start>( u.getID(), u.name, u.male, u.prof->ident(),
-            u.custom_profession, getVersionString() );
+    get_event_bus().send<event_type::game_start>( getVersionString() );
+    get_event_bus().send<event_type::game_avatar_new>( true, u.getID(), u.name, u.male,
+            u.prof->ident(), u.custom_profession );
     time_played_at_last_load = std::chrono::seconds( 0 );
     time_of_last_load = std::chrono::steady_clock::now();
     tripoint_abs_omt abs_omt = u.global_omt_location();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2652,7 +2652,7 @@ bool game::is_game_over()
     return false;
 }
 
-void game::bury_screen()
+void game::bury_screen() const
 {
     avatar &u = get_avatar();
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1009,8 +1009,8 @@ bool game::start_game()
     }
 
     get_event_bus().send<event_type::game_start>( getVersionString() );
-    get_event_bus().send<event_type::game_avatar_new>( true, u.getID(), u.name, u.male,
-            u.prof->ident(), u.custom_profession );
+    get_event_bus().send<event_type::game_avatar_new>( /*is_new_game=*/true, /*is_debug=*/false,
+            u.getID(), u.name, u.male, u.prof->ident(), u.custom_profession );
     time_played_at_last_load = std::chrono::seconds( 0 );
     time_of_last_load = std::chrono::steady_clock::now();
     tripoint_abs_omt abs_omt = u.global_omt_location();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -250,6 +250,9 @@ static const itype_id fuel_type_animal( "animal" );
 static const itype_id itype_battery( "battery" );
 static const itype_id itype_disassembly( "disassembly" );
 static const itype_id itype_grapnel( "grapnel" );
+static const itype_id itype_holybook_bible1( "holybook_bible1" );
+static const itype_id itype_holybook_bible2( "holybook_bible2" );
+static const itype_id itype_holybook_bible3( "holybook_bible3" );
 static const itype_id itype_manhole_cover( "manhole_cover" );
 static const itype_id itype_remotevehcontrol( "remotevehcontrol" );
 static const itype_id itype_rope_30( "rope_30" );
@@ -291,6 +294,7 @@ static const species_id species_PLANT( "PLANT" );
 static const string_id<npc_template> npc_template_cyborg_rescued( "cyborg_rescued" );
 
 static const trait_id trait_BADKNEES( "BADKNEES" );
+static const trait_id trait_CANNIBAL( "CANNIBAL" );
 static const trait_id trait_CENOBITE( "CENOBITE" );
 static const trait_id trait_ILLITERATE( "ILLITERATE" );
 static const trait_id trait_INATTENTIVE( "INATTENTIVE" );
@@ -303,6 +307,7 @@ static const trait_id trait_M_IMMUNE( "M_IMMUNE" );
 static const trait_id trait_NPC_STARTING_NPC( "NPC_STARTING_NPC" );
 static const trait_id trait_NPC_STATIC_NPC( "NPC_STATIC_NPC" );
 static const trait_id trait_PROF_CHURL( "PROF_CHURL" );
+static const trait_id trait_PSYCHOPATH( "PSYCHOPATH" );
 static const trait_id trait_THICKSKIN( "THICKSKIN" );
 static const trait_id trait_VINES2( "VINES2" );
 static const trait_id trait_VINES3( "VINES3" );
@@ -2609,6 +2614,7 @@ bool game::is_game_over()
         return true;
     }
     if( uquit == QUIT_SUICIDE ) {
+        bury_screen();
         if( u.in_vehicle ) {
             m.unboard_vehicle( u.pos() );
         }
@@ -2623,6 +2629,7 @@ bool game::is_game_over()
         if( !u.is_dead_state() ) {
             return false;
         }
+        bury_screen();
         effect_on_conditions::avatar_death();
         if( !u.is_dead_state() ) {
             return false;
@@ -2643,6 +2650,194 @@ bool game::is_game_over()
         return is_game_over();
     }
     return false;
+}
+
+void game::bury_screen()
+{
+    avatar &u = get_avatar();
+
+    std::vector<std::string> vRip;
+
+    int iMaxWidth = 0;
+    int iNameLine = 0;
+    int iInfoLine = 0;
+
+    if( u.has_amount( itype_holybook_bible1, 1 ) || u.has_amount( itype_holybook_bible2, 1 ) ||
+        u.has_amount( itype_holybook_bible3, 1 ) ) {
+        if( !( u.has_trait( trait_CANNIBAL ) || u.has_trait( trait_PSYCHOPATH ) ) ) {
+            vRip.emplace_back( "               _______  ___" );
+            vRip.emplace_back( "              <       `/   |" );
+            vRip.emplace_back( "               >  _     _ (" );
+            vRip.emplace_back( "              |  |_) | |_) |" );
+            vRip.emplace_back( "              |  | \\ | |   |" );
+            vRip.emplace_back( "   ______.__%_|            |_________  __" );
+            vRip.emplace_back( " _/                                  \\|  |" );
+            iNameLine = vRip.size();
+            vRip.emplace_back( "|                                        <" );
+            vRip.emplace_back( "|                                        |" );
+            iMaxWidth = utf8_width( vRip.back() );
+            vRip.emplace_back( "|                                        |" );
+            vRip.emplace_back( "|_____.-._____              __/|_________|" );
+            vRip.emplace_back( "              |            |" );
+            iInfoLine = vRip.size();
+            vRip.emplace_back( "              |            |" );
+            vRip.emplace_back( "              |           <" );
+            vRip.emplace_back( "              |            |" );
+            vRip.emplace_back( "              |   _        |" );
+            vRip.emplace_back( "              |__/         |" );
+            vRip.emplace_back( "             % / `--.      |%" );
+            vRip.emplace_back( "         * .%%|          -< @%%%" ); // NOLINT(cata-text-style)
+            vRip.emplace_back( "         `\\%`@|            |@@%@%%" );
+            vRip.emplace_back( "       .%%%@@@|%     `   % @@@%%@%%%%" );
+            vRip.emplace_back( "  _.%%%%%%@@@@@@%%%__/\\%@@%%@@@@@@@%%%%%%" );
+
+        } else {
+            vRip.emplace_back( "               _______  ___" );
+            vRip.emplace_back( "              |       \\/   |" );
+            vRip.emplace_back( "              |            |" );
+            vRip.emplace_back( "              |            |" );
+            iInfoLine = vRip.size();
+            vRip.emplace_back( "              |            |" );
+            vRip.emplace_back( "              |            |" );
+            vRip.emplace_back( "              |            |" );
+            vRip.emplace_back( "              |            |" );
+            vRip.emplace_back( "              |           <" );
+            vRip.emplace_back( "              |   _        |" );
+            vRip.emplace_back( "              |__/         |" );
+            vRip.emplace_back( "   ______.__%_|            |__________  _" );
+            vRip.emplace_back( " _/                                   \\| \\" );
+            iNameLine = vRip.size();
+            vRip.emplace_back( "|                                         <" );
+            vRip.emplace_back( "|                                         |" );
+            iMaxWidth = utf8_width( vRip.back() );
+            vRip.emplace_back( "|                                         |" );
+            vRip.emplace_back( "|_____.-._______            __/|__________|" );
+            vRip.emplace_back( "             % / `_-.   _  |%" );
+            vRip.emplace_back( "         * .%%|  |_) | |_)< @%%%" ); // NOLINT(cata-text-style)
+            vRip.emplace_back( "         `\\%`@|  | \\ | |   |@@%@%%" );
+            vRip.emplace_back( "       .%%%@@@|%     `   % @@@%%@%%%%" );
+            vRip.emplace_back( "  _.%%%%%%@@@@@@%%%__/\\%@@%%@@@@@@@%%%%%%" );
+        }
+    } else {
+        vRip.emplace_back( R"(           _________  ____           )" );
+        vRip.emplace_back( R"(         _/         `/    \_         )" );
+        vRip.emplace_back( R"(       _/      _     _      \_.      )" );
+        vRip.emplace_back( R"(     _%\      |_) | |_)       \_     )" );
+        vRip.emplace_back( R"(   _/ \/      | \ | |           \_   )" );
+        vRip.emplace_back( R"( _/                               \_ )" );
+        vRip.emplace_back( R"(|                                   |)" );
+        iNameLine = vRip.size();
+        vRip.emplace_back( R"( )                                 < )" );
+        vRip.emplace_back( R"(|                                   |)" );
+        vRip.emplace_back( R"(|                                   |)" );
+        vRip.emplace_back( R"(|   _                               |)" );
+        vRip.emplace_back( R"(|__/                                |)" );
+        iMaxWidth = utf8_width( vRip.back() );
+        vRip.emplace_back( R"( / `--.                             |)" );
+        vRip.emplace_back( R"(|                                  ( )" );
+        iInfoLine = vRip.size();
+        vRip.emplace_back( R"(|                                   |)" );
+        vRip.emplace_back( R"(|                                   |)" );
+        vRip.emplace_back( R"(|     %                         .   |)" );
+        vRip.emplace_back( R"(|  @`                            %% |)" );
+        vRip.emplace_back( R"(| %@%@%\                *      %`%@%|)" );
+        vRip.emplace_back( R"(%%@@@.%@%\%%            `\  %%.%%@@%@)" );
+        vRip.emplace_back( R"(@%@@%%%%%@@@@@@%%%%%%%%@@%%@@@%%%@%%@)" );
+    }
+
+    const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                         TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
+
+    catacurses::window w_rip = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
+                               iOffset );
+    draw_border( w_rip );
+
+    sfx::do_player_death_hurt( get_player_character(), true );
+    sfx::fade_audio_group( sfx::group::weather, 2000 );
+    sfx::fade_audio_group( sfx::group::time_of_day, 2000 );
+    sfx::fade_audio_group( sfx::group::context_themes, 2000 );
+    sfx::fade_audio_group( sfx::group::fatigue, 2000 );
+
+    for( size_t iY = 0; iY < vRip.size(); ++iY ) {
+        size_t iX = 0;
+        const char *str = vRip[iY].data();
+        for( int slen = vRip[iY].size(); slen > 0; ) {
+            const uint32_t cTemp = UTF8_getch( &str, &slen );
+            if( cTemp != U' ' ) {
+                nc_color ncColor = c_light_gray;
+
+                if( cTemp == U'%' ) {
+                    ncColor = c_green;
+
+                } else if( cTemp == U'_' || cTemp == U'|' ) {
+                    ncColor = c_white;
+
+                } else if( cTemp == U'@' ) {
+                    ncColor = c_brown;
+
+                } else if( cTemp == U'*' ) {
+                    ncColor = c_red;
+                }
+
+                mvwputch( w_rip, point( iX + FULL_SCREEN_WIDTH / 2 - ( iMaxWidth / 2 ), iY + 1 ), ncColor,
+                          cTemp );
+            }
+            iX += mk_wcwidth( cTemp );
+        }
+    }
+
+    std::string sTemp;
+
+    center_print( w_rip, iInfoLine++, c_white, _( "Survived:" ) );
+
+    const time_duration survived = calendar::turn - calendar::start_of_game;
+    const int minutes = to_minutes<int>( survived ) % 60;
+    const int hours = to_hours<int>( survived ) % 24;
+    const int days = to_days<int>( survived );
+
+    if( days > 0 ) {
+        // NOLINTNEXTLINE(cata-translate-string-literal)
+        sTemp = string_format( "%dd %dh %dm", days, hours, minutes );
+    } else if( hours > 0 ) {
+        // NOLINTNEXTLINE(cata-translate-string-literal)
+        sTemp = string_format( "%dh %dm", hours, minutes );
+    } else {
+        // NOLINTNEXTLINE(cata-translate-string-literal)
+        sTemp = string_format( "%dm", minutes );
+    }
+
+    center_print( w_rip, iInfoLine++, c_white, sTemp );
+
+    const int iTotalKills = g->get_kill_tracker().monster_kill_count();
+
+    sTemp = _( "Kills:" );
+    mvwprintz( w_rip, point( FULL_SCREEN_WIDTH / 2 - 5, 1 + iInfoLine++ ), c_light_gray,
+               ( sTemp + " " ) );
+    wprintz( w_rip, c_magenta, "%d", iTotalKills );
+
+    sTemp = _( "In memory of:" );
+    mvwprintz( w_rip, point( FULL_SCREEN_WIDTH / 2 - utf8_width( sTemp ) / 2, iNameLine++ ),
+               c_light_gray,
+               sTemp );
+
+    sTemp = u.get_name();
+    mvwprintz( w_rip, point( FULL_SCREEN_WIDTH / 2 - utf8_width( sTemp ) / 2, iNameLine++ ), c_white,
+               sTemp );
+
+    sTemp = _( "Last Words:" );
+    mvwprintz( w_rip, point( FULL_SCREEN_WIDTH / 2 - utf8_width( sTemp ) / 2, iNameLine++ ),
+               c_light_gray,
+               sTemp );
+
+    int iStartX = FULL_SCREEN_WIDTH / 2 - ( ( iMaxWidth - 4 ) / 2 );
+    std::string sLastWords = string_input_popup()
+                             .window( w_rip, point( iStartX, iNameLine ), iStartX + iMaxWidth - 4 - 1 )
+                             .max_length( iMaxWidth - 4 - 1 )
+                             .query_string();
+
+    const bool is_suicide = uquit == QUIT_SUICIDE;
+    get_event_bus().send<event_type::game_avatar_death>( u.getID(), u.name, u.male, is_suicide,
+            sLastWords );
 }
 
 void game::death_screen()

--- a/src/game.h
+++ b/src/game.h
@@ -947,7 +947,7 @@ class game
         void item_action_menu( item_location loc = item_location() ); // Displays item action menu
 
         bool is_game_over();     // Returns true if the player quit or died
-        void bury_screen();      // Bury a dead character (record their last words)
+        void bury_screen() const;// Bury a dead character (record their last words)
         void death_screen();     // Display our stats, "GAME OVER BOO HOO"
         void draw_minimap();     // Draw the 5x5 minimap
     public:

--- a/src/game.h
+++ b/src/game.h
@@ -947,6 +947,7 @@ class game
         void item_action_menu( item_location loc = item_location() ); // Displays item action menu
 
         bool is_game_over();     // Returns true if the player quit or died
+        void bury_screen();      // Bury a dead character (record their last words)
         void death_screen();     // Display our stats, "GAME OVER BOO HOO"
         void draw_minimap();     // Draw the 5x5 minimap
     public:

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -877,7 +877,7 @@ void memorial_logger::notify( const cata::event &e )
             }
             break;
         }
-        case event_type::game_over: {
+        case event_type::game_avatar_death: {
             bool suicide = e.get<bool>( "is_suicide" );
             std::string last_words = e.get<cata_variant_type::string>( "last_words" );
             if( suicide ) {
@@ -896,11 +896,19 @@ void memorial_logger::notify( const cata::event &e )
             }
             break;
         }
-        case event_type::game_start: {
-            add( //~ %s is player name
-                pgettext( "memorial_male", "%s began their journey into the Cataclysm." ),
-                pgettext( "memorial_female", "%s began their journey into the Cataclysm." ),
-                avatar_name );
+        case event_type::game_avatar_new: {
+            bool new_game = e.get<bool>( "is_new_game" );
+            if( new_game ) {
+                add( //~ %s is player name
+                    pgettext( "memorial_male", "%s began their journey into the Cataclysm." ),
+                    pgettext( "memorial_female", "%s began their journey into the Cataclysm." ),
+                    avatar_name );
+            } else {
+                add( //~ %s is player name
+                    pgettext( "memorial_male", "%s took over the journey through the Cataclysm." ),
+                    pgettext( "memorial_female", "%s took over the journey through the Cataclysm." ),
+                    avatar_name );
+            }
             break;
         }
         case event_type::installs_cbm: {
@@ -1097,7 +1105,9 @@ void memorial_logger::notify( const cata::event &e )
         case event_type::cuts_tree:
         case event_type::reads_book:
         case event_type::game_load:
+        case event_type::game_over:
         case event_type::game_save:
+        case event_type::game_start:
         case event_type::u_var_changed:
         case event_type::vehicle_moves:
             break;

--- a/src/past_games_info.cpp
+++ b/src/past_games_info.cpp
@@ -63,7 +63,7 @@ past_game_info::past_game_info( const JsonObject &jo )
     auto avatar_name_it = start_event_data.find( "avatar_name" );
     if( avatar_name_it != start_event_data.end() ) {
         avatar_name_ = avatar_name_it->second.get_string() +
-                       ( new_avatar_counts.size() > 0 ? " et. al." : "" );
+                       ( !new_avatar_counts.empty() ? " et. al." : "" );
     } else {
         const cata::event::data_type &new_avatar_event_data = new_avatar_counts.begin()->first;
         avatar_name_it = new_avatar_event_data.find( "avatar_name" );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4707,6 +4707,7 @@ void stats_tracker::deserialize( const JsonObject &jo )
             // retroactively insert starting avatar
             cata::event::data_type gan_data( gs_data );
             gan_data["is_new_game"] = cata_variant::make<cata_variant_type::bool_>( true );
+            gan_data["is_debug"] = cata_variant::make<cata_variant_type::bool_>( false );
             gan_data.erase( "game_version" );
             get_event_bus().send( cata::event( event_type::game_avatar_new, calendar::start_of_game,
                                                std::move( gan_data ) ) );
@@ -4716,17 +4717,17 @@ void stats_tracker::deserialize( const JsonObject &jo )
             avatar &u = get_avatar();
             if( u.getID() != gs_data["avatar_id"].get<cata_variant_type::character_id>() ) {
                 profession_id prof_id = u.prof ? u.prof->ident() : profession::generic()->ident();
-                get_event_bus().send( cata::event::make<event_type::game_avatar_new>(
-                                          false, u.getID(), u.name, u.male, prof_id, u.custom_profession ) );
+                get_event_bus().send( cata::event::make<event_type::game_avatar_new>( false, false,
+                                      u.getID(), u.name, u.male, prof_id, u.custom_profession ) );
             }
         } else {
             // last ditch effort for really old saves that don't even have event_type::game_start
-            // treat current avatar as the starting avatar
+            // treat current avatar as the starting avatar; abuse is_new_game=false to flag such cases
             avatar &u = get_avatar();
             profession_id prof_id = u.prof ? u.prof->ident() : profession::generic()->ident();
             std::swap( calendar::turn, calendar::start_of_game );
-            get_event_bus().send( cata::event::make<event_type::game_avatar_new>(
-                                      false, u.getID(), u.name, u.male, prof_id, u.custom_profession ) );
+            get_event_bus().send( cata::event::make<event_type::game_avatar_new>( false, false,
+                                  u.getID(), u.name, u.male, prof_id, u.custom_profession ) );
             std::swap( calendar::turn, calendar::start_of_game );
         }
     }

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -219,13 +219,13 @@ TEST_CASE( "memorials", "[memorial]" )
     check_memorial<event_type::gains_skill_level>(
         m, b, "Reached skill level 8 in vehicles.", ch, skill_driving, 8 );
 
-    check_memorial<event_type::game_over>(
-        m, b, u_name + " was killed.\nLast words: last_words", false, "last_words",
-        std::chrono::seconds( 100 ) );
+    check_memorial<event_type::game_avatar_death>(
+        m, b, u_name + " was killed.\nLast words: last_words", ch, u_name, player_character.male, false,
+        "last_words" );
 
-    check_memorial<event_type::game_start>(
-        m, b, u_name + " began their journey into the Cataclysm.", ch, u_name, player_character.male,
-        player_character.prof->ident(), player_character.custom_profession, "VERSION_STRING" );
+    check_memorial<event_type::game_avatar_new>(
+        m, b, u_name + " began their journey into the Cataclysm.", true, ch, u_name, player_character.male,
+        player_character.prof->ident(), player_character.custom_profession );
 
     check_memorial<event_type::installs_cbm>(
         m, b, "Installed bionic: Alarm System.", ch, cbm );

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -224,8 +224,8 @@ TEST_CASE( "memorials", "[memorial]" )
         "last_words" );
 
     check_memorial<event_type::game_avatar_new>(
-        m, b, u_name + " began their journey into the Cataclysm.", true, ch, u_name, player_character.male,
-        player_character.prof->ident(), player_character.custom_profession );
+        m, b, u_name + " began their journey into the Cataclysm.", true, false, ch, u_name,
+        player_character.male, player_character.prof->ident(), player_character.custom_profession );
 
     check_memorial<event_type::installs_cbm>(
         m, b, "Installed bionic: Alarm System.", ch, cbm );

--- a/tests/stats_tracker_test.cpp
+++ b/tests/stats_tracker_test.cpp
@@ -206,8 +206,8 @@ TEST_CASE( "stats_tracker_event_time_bounds", "[stats]" )
 static void send_game_start( event_bus &b, const character_id &u_id )
 {
     b.send<event_type::game_start>( "VERION_STRING" );
-    b.send<event_type::game_avatar_new>( /*is_new_game=*/true, u_id, "Avatar name",
-            /*is_male=*/false, profession_id::NULL_ID(), "CUSTOM_PROFESSION" );
+    b.send<event_type::game_avatar_new>( /*is_new_game=*/true, /*is_debug=*/false, u_id,
+            "Avatar name", /*is_male=*/false, profession_id::NULL_ID(), "CUSTOM_PROFESSION" );
 }
 
 TEST_CASE( "stats_tracker_with_event_statistics", "[stats]" )

--- a/tests/stats_tracker_test.cpp
+++ b/tests/stats_tracker_test.cpp
@@ -695,7 +695,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
         } else {
             CHECK( a.ui_text_for( &*a_kill_in_first_minute ) ==
                    "<color_c_red>Rude awakening</color>\n"
-                   "  <color_c_red>Failed Year 1, Spring, day 1 0001.00</color>\n"
+                   "  <color_c_red>Failed Year 1, Spring, day 1 0010.00</color>\n"
                    "  <color_c_yellow>0/1 monster killed</color>\n" );
         }
 
@@ -709,7 +709,11 @@ TEST_CASE( "achievements_tracker", "[stats]" )
                "  <color_c_green>Kill no characters</color>\n" );
 
         CHECK( achievements_completed.empty() );
-        CHECK( achievements_failed.empty() );
+        if( time_since_game_start < 1_minutes ) {
+            CHECK( achievements_failed.empty() );
+        } else {
+            CHECK( achievements_failed.count( a_kill_in_first_minute ) );
+        }
         b.send( avatar_zombie_kill );
 
         if( time_since_game_start < 1_minutes ) {

--- a/tests/stats_tracker_test.cpp
+++ b/tests/stats_tracker_test.cpp
@@ -205,9 +205,9 @@ TEST_CASE( "stats_tracker_event_time_bounds", "[stats]" )
 
 static void send_game_start( event_bus &b, const character_id &u_id )
 {
-    b.send<event_type::game_start>(
-        u_id, "Avatar name", /*is_male=*/false, profession_id::NULL_ID(), "CUSTOM_PROFESSION",
-        "VERION_STRING" );
+    b.send<event_type::game_start>( "VERION_STRING" );
+    b.send<event_type::game_avatar_new>( /*is_new_game=*/true, u_id, "Avatar name",
+            /*is_male=*/false, profession_id::NULL_ID(), "CUSTOM_PROFESSION" );
 }
 
 TEST_CASE( "stats_tracker_with_event_statistics", "[stats]" )


### PR DESCRIPTION
#### Summary
Bugfixes "Update events to account for ability to swap avatars (debug or upon death)"

#### Purpose of change

Resolves #63455 

#51450 and #53606 gave the ability to switch to another character.
Preexisting game events (that feed into memorial, stats, achievements, conducts, scores) are not equipped to handle this, as they only recorded the starting character in `event_type::game_start` and then death and last words in `event_type::game_over`. This oversight causes some things to break.

#### Describe the solution
- [x] split `game_avatar_new` off from `game_start` and `game_avatar_death` from `game_over`
- [x] add migration for existing saves that retroactively populates `game_avatar_new` from available information
  - where `game_start` is available, get starting character information from it
    - if current character is different from starting character, add it as well, treating current turn as the time they took over
  - if `game_start` is also not available (pretty old save!) treat current character as starting character.
- [x] adjust existing event emissions (split into two events accordingly)
- [x] emit `game_avatar_new` at the end of `avatar::control_npc()` when new avatar takes over
- [x] show the "tombstone" screen and prompt for last words on death of all player characters (not just the final one when you run out of "continues" or choose not to do so)
- [x] emit `game_avatar_death` to record last words of all dead PCs
- [x] change `avatar_id` event statistic to pull its value from the most recent `game_avatar_new` event
- [x] memorial logger logs `game_avatar_death` instead of `game_over`
- [x] memorial logger logs `game_avatar_new` instead of `game_start`, and will have different text for a character swap rather than a brand new game
- [x] past games info will try to account for multiple characters over the course of a save, insofar as the information is available. It will pull the starting character name from the first `game_avatar_new` entry. Depending on how many `game_avatar_new` entries there are, it will append "et. al." to indicate that there was/were subsequent character(s) that took over from the starting character due to death or debug. If there are no `game_avatar_new` entries, it will fall back on the legacy approach and pull the starting character name from `game_start`.

#### Behavior of stats after this PR
- any statistic that doesn't rely on comparison against the `avatar_id` statistic continue working as they did
- any statistic that depends on `avatar_id` will switch to the "lifetime" stats of the new avatar when switching to them
  - this includes things they did as an NPC, e.g. any kills, skill gain etc that was captured by the events system

This is imperfect, but now we are at least capturing an event whenever player control switches from one character to another. This ensures that save games will contain the information needed when a fuller solution is developed.

Subsequent work can look into a different way for event transformation to filter events (e.g. kills) to match them against the player character `avatar_id` ***at the time the event occurred*** rather than the current avatar, so that the affected scores, achievements and conducts are on the basis of *player action*.

#### Additional context
I can't do anything about information that was lost between #51450 / #53606 and now, because it wasn't able to be captured.

~This will probably break some achievements in existing saves, because they'd look for `avatar_id` but be unable to resolve a value for it when there are no `game_avatar_new` events yet. There's no way in the event statistics system to "union" two event streams (`game_start` with `game_avatar_new`) and implementing such a feature looks like it will get really complex, so I don't think it's worth it just for the sake of this one unusual case. Perhaps some other migration strategy could be devised? In any case, the affected achievements are already broken anyway ( #63455 ) so I'd be satisfied with fixing things so that they work correctly for new saves henceforth.~

#### Describe alternatives you've considered
Hijack the existing `game_start` and `game_over` so that they are also emitted whenever there is a character swap, but that seems weird esp. with respect to the game version and total play time fields.

#### Testing

Simple test case: [TestLand.zip](https://github.com/CleverRaven/Cataclysm-DDA/files/10696161/TestLand.zip)

1. Build this PR, load the save in and verify that the score screen shows 5 monsters killed as the first stat on top. Spawn a slow, harmless monster e.g. water strider and kill it; check that the count has increased to 6.

1. Using the debug menu, `p`, `x` to switch to the follower NPC. Check the score screen, which should now shows 0 kills (Antonia Boswell's lifetime stats). Spawn water strider; kill; check that the count has increased to 1.

1. Switch back to the original character. Check score screen, which should list 6 kills.

1. Fire up a recent experimental build and load up the original save file again. Verify that the score screen shows 5 monsters killed.

1. Switch to the follower NPC. Check that score screen; it shows 5 kills. Spawn water strider; kill; check the count, which did not increase.

1. Save the game and transfer it to the PR build. The score screen should reflect Antonia's 1 kill.

1. Spawn water strider; kill; check count increased to 2.

1. Switch back to the original character. The score screen should reflect their 5 kills.