### PR TITLE
Determine how much you can squish a soft container by its contents

### DIFF
--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1234,6 +1234,26 @@ void item_pocket::favorite_info( std::vector<iteminfo> &info ) const
     settings.info( info );
 }
 
+// for soft containers check all content items to see if they all would fit
+static int charges_per_volume_recursive( const units::volume &max_item_volume,
+        const item &it )
+{
+    int min_charges = item::INFINITE_CHARGES;
+
+    if( !it.is_soft() ) {
+        return it.charges_per_volume( max_item_volume );
+    }
+
+    for( const item *content : it.all_items_top() ) {
+        min_charges = std::min( min_charges, charges_per_volume_recursive( max_item_volume, *content ) );
+        if( min_charges == 0 ) {
+            return 0;
+        }
+    }
+
+    return min_charges;
+}
+
 ret_val<item_pocket::contain_code> item_pocket::is_compatible( const item &it ) const
 {
     if( it.has_flag( flag_NO_UNWIELD ) ) {
@@ -1309,9 +1329,8 @@ ret_val<item_pocket::contain_code> item_pocket::is_compatible( const item &it ) 
     // soft items also avoid the size limit
     // count_by_charges items check volume of single charge
     if( !it.made_of( phase_id::LIQUID ) && !it.made_of( phase_id::GAS ) &&
-        !it.is_frozen_liquid() &&
-        !it.is_soft() && data->max_item_volume &&
-        !it.charges_per_volume( *data->max_item_volume ) ) {
+        !it.is_frozen_liquid() && data->max_item_volume &&
+        !charges_per_volume_recursive( *data->max_item_volume, it ) ) {
         return ret_val<item_pocket::contain_code>::make_failure(
                    contain_code::ERR_TOO_BIG, _( "item too big" ) );
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Determine how much you can squish a soft container by its contents"

#### Purpose of change

Fixes #63451

#### Describe the solution

Instead of treating soft containers as infinitely squishable no matter their contents, check if all their contents would also fit the given maximum volume when trying to insert them into pockets with a maximum item volume.
Determining if you can shove something through a bottleneck should depend on a lot more things, but this is better than before (anything goes if you put it in a soft container first).

#### Describe alternatives you've considered



#### Testing

Tried to put a rock in a paper wrapper into a glass bottle, but it can't fit anymore. 10 pieces of chewing gum in a paper wrapper still fit in the bottle.

#### Additional context

