### PR TITLE
wilderness spawn rework

### DIFF
--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -4,7 +4,6 @@
     "name": "GROUP_CAVE",
     "is_animal": true,
     "monsters": [
-      { "monster": "mon_null", "weight": 15 },
       { "monster": "mon_bat", "weight": 600, "cost_multiplier": 5, "pack_size": [ 6, 32 ] },
       { "monster": "mon_bear", "weight": 100, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
       { "monster": "mon_cougar", "weight": 100, "cost_multiplier": 20, "pack_size": [ 1, 2 ] },
@@ -21,7 +20,31 @@
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
-      { "group": "GROUP_WILDERNESS_FOREST_MAMMAL", "weight": 300 },
+      { "group": "GROUP_WILDERNESS_FOREST_MAMMAL", "weight": 75, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_MAMMAL",
+        "weight": 75,
+        "ends": "3 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_MAMMAL",
+        "weight": 75,
+        "ends": "7 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_MAMMAL",
+        "weight": 75,
+        "ends": "28 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_MAMMAL",
+        "weight": 75,
+        "ends": "90 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
       { "group": "GROUP_WILDERNESS_FOREST_BIRD", "weight": 300 },
       {
         "group": "GROUP_WILDERNESS_FOREST_INSECT_HARMLESS",
@@ -92,124 +115,32 @@
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
-      {
-        "monster": "mon_bat",
-        "weight": 10,
-        "cost_multiplier": 2,
-        "pack_size": [ 3, 12 ],
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      { "monster": "mon_bear", "weight": 1, "cost_multiplier": 10, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
-      {
-        "monster": "mon_bear",
-        "weight": 1,
-        "cost_multiplier": 10,
-        "ends": "3 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bear",
-        "weight": 1,
-        "cost_multiplier": 10,
-        "ends": "7 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bear",
-        "weight": 1,
-        "cost_multiplier": 10,
-        "ends": "28 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bear",
-        "weight": 1,
-        "cost_multiplier": 10,
-        "ends": "90 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
+      { "monster": "mon_bat", "weight": 10, "cost_multiplier": 2, "pack_size": [ 3, 12 ] },
+      { "monster": "mon_bear", "weight": 1, "cost_multiplier": 10 },
       { "monster": "mon_bobcat", "weight": 7, "cost_multiplier": 2 },
       { "monster": "mon_boar_wild", "weight": 2, "cost_multiplier": 2, "pack_size": [ 1, 4 ] },
       { "group": "GROUP_STRAY_CATS", "weight": 10 },
       { "group": "GROUP_STRAY_CATS", "weight": 1, "pack_size": [ 2, 8 ] },
-      {
-        "monster": "mon_chipmunk",
-        "weight": 30,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 2 ],
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
+      { "monster": "mon_chipmunk", "weight": 30, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
       { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3 },
-      { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "3 days" },
-      { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "7 days" },
-      { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "28 days" },
-      { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "90 days" },
       { "monster": "mon_deer", "weight": 4, "cost_multiplier": 2, "pack_size": [ 1, 5 ] },
-      {
-        "monster": "mon_reindeer",
-        "weight": 3,
-        "cost_multiplier": 3,
-        "pack_size": [ 2, 6 ],
-        "conditions": [ "AUTUMN", "WINTER" ]
-      },
+      { "monster": "mon_reindeer", "weight": 3, "cost_multiplier": 3, "pack_size": [ 2, 6 ] },
       { "group": "GROUP_STRAY_DOGS", "weight": 6, "cost_multiplier": 25, "pack_size": [ 1, 6 ] },
       { "monster": "mon_fox_gray", "weight": 1, "cost_multiplier": 0 },
-      { "monster": "mon_fox_gray", "weight": 1, "cost_multiplier": 0, "ends": "3 days" },
-      { "monster": "mon_fox_gray", "weight": 1, "cost_multiplier": 0, "ends": "7 days" },
-      { "monster": "mon_fox_gray", "weight": 1, "cost_multiplier": 0, "ends": "28 days" },
-      { "monster": "mon_fox_gray", "weight": 1, "cost_multiplier": 0, "ends": "90 days" },
       { "monster": "mon_fox_red", "weight": 1, "cost_multiplier": 0 },
-      { "monster": "mon_fox_red", "weight": 1, "cost_multiplier": 0, "ends": "3 days" },
-      { "monster": "mon_fox_red", "weight": 1, "cost_multiplier": 0, "ends": "7 days" },
-      { "monster": "mon_fox_red", "weight": 1, "cost_multiplier": 0, "ends": "28 days" },
-      { "monster": "mon_fox_red", "weight": 1, "cost_multiplier": 0, "ends": "90 days" },
       { "monster": "mon_wolf", "weight": 1, "cost_multiplier": 2, "pack_size": [ 2, 5 ] },
-      { "monster": "mon_wolf", "weight": 1, "cost_multiplier": 2, "ends": "3 days", "pack_size": [ 2, 5 ] },
-      { "monster": "mon_wolf", "weight": 1, "cost_multiplier": 2, "ends": "7 days", "pack_size": [ 2, 5 ] },
-      { "monster": "mon_wolf", "weight": 1, "cost_multiplier": 2, "ends": "28 days", "pack_size": [ 2, 5 ] },
-      { "monster": "mon_wolf", "weight": 1, "cost_multiplier": 2, "ends": "90 days", "pack_size": [ 2, 5 ] },
       { "monster": "mon_coyote", "weight": 1, "cost_multiplier": 2, "pack_size": [ 1, 6 ] },
-      { "monster": "mon_coyote", "weight": 1, "cost_multiplier": 2, "ends": "3 days", "pack_size": [ 1, 6 ] },
-      { "monster": "mon_coyote", "weight": 1, "cost_multiplier": 2, "ends": "7 days", "pack_size": [ 1, 6 ] },
-      { "monster": "mon_coyote", "weight": 1, "cost_multiplier": 2, "ends": "28 days", "pack_size": [ 1, 6 ] },
-      { "monster": "mon_coyote", "weight": 1, "cost_multiplier": 2, "ends": "90 days", "pack_size": [ 1, 6 ] },
       { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "pack_size": [ 1, 8 ] },
-      { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "ends": "3 days", "pack_size": [ 1, 8 ] },
-      { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "ends": "7 days", "pack_size": [ 1, 8 ] },
-      { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "ends": "28 days", "pack_size": [ 1, 8 ] },
-      { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "ends": "90 days", "pack_size": [ 1, 8 ] },
-      { "monster": "mon_horse", "weight": 2, "cost_multiplier": 15, "pack_size": [ 1, 4 ], "ends": "3 days" },
+      { "monster": "mon_horse", "weight": 1, "cost_multiplier": 15, "pack_size": [ 1, 4 ] },
       { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3 },
-      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "3 days" },
-      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "7 days" },
-      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "28 days" },
-      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "90 days" },
-      {
-        "monster": "mon_groundhog",
-        "weight": 30,
-        "cost_multiplier": 5,
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
+      { "monster": "mon_groundhog", "weight": 30, "cost_multiplier": 5, "pack_size": [ 1, 6 ] },
       { "monster": "mon_hare", "weight": 12, "cost_multiplier": 2, "pack_size": [ 1, 6 ] },
       { "monster": "mon_rabbit", "weight": 10, "cost_multiplier": 0, "pack_size": [ 1, 5 ] },
       { "monster": "mon_squirrel", "weight": 50, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
       { "monster": "mon_squirrel_red", "weight": 50, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
       { "monster": "mon_weasel", "weight": 5, "cost_multiplier": 5 },
-      {
-        "monster": "mon_raccoon",
-        "weight": 8,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_opossum",
-        "weight": 8,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
+      { "monster": "mon_raccoon", "weight": 8, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_opossum", "weight": 8, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
       { "monster": "mon_black_rat", "weight": 10, "cost_multiplier": 0, "pack_size": [ 1, 5 ] }
     ]
   },

--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -344,7 +344,6 @@
       { "monster": "mon_frog", "weight": 5, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
       { "monster": "mon_zhark", "weight": 1, "cost_multiplier": 25, "starts": "3 days", "pack_size": [ 1, 3 ] },
       { "monster": "mon_zhark", "weight": 2, "cost_multiplier": 25, "starts": "28 days", "pack_size": [ 1, 3 ] },
-      { "monster": "mon_feral_diver_knife", "weight": 1, "cost_multiplier": 10, "starts": "1 days" },
       { "monster": "mon_fish_eel", "weight": 6, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
       { "monster": "mon_fish_bowfin", "weight": 6, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
       { "monster": "mon_fish_bullhead", "weight": 6, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },

--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -11,7 +11,7 @@
       { "monster": "mon_nakedmolerat_giant", "weight": 100, "cost_multiplier": 3 },
       { "monster": "mon_mole_cricket", "weight": 60, "cost_multiplier": 3 },
       { "monster": "mon_woodlouse", "weight": 60, "cost_multiplier": 3, "pack_size": [ 2, 4 ] },
-      { "monster": "mon_stag_beetle_larva", "freq": 40, "cost_multiplier": 5 }
+      { "monster": "mon_stag_beetle_larva", "weight": 40, "cost_multiplier": 5 }
     ]
   },
   {
@@ -385,7 +385,7 @@
         "cost_multiplier": 2,
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
-      { "monster": "mon_frog", "freq": 30, "cost_multiplier": 2, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
+      { "monster": "mon_frog", "weight": 30, "cost_multiplier": 2, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
       { "monster": "mon_toad", "weight": 50, "cost_multiplier": 2, "pack_size": [ 1, 3 ] }
     ]
   },

--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -309,41 +309,11 @@
     "monsters": [
       { "monster": "mon_beaver", "weight": 8, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
       {
-        "monster": "mon_beaver",
-        "weight": 15,
-        "cost_multiplier": 10,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "NIGHT" ]
-      },
-      { "monster": "mon_beaver_mutant_huge", "weight": 3, "cost_multiplier": 5, "pack_size": [ 1, 2 ] },
-      {
-        "monster": "mon_beaver_mutant_huge",
-        "weight": 3,
-        "cost_multiplier": 5,
-        "pack_size": [ 1, 2 ],
-        "conditions": [ "NIGHT" ]
-      },
-      { "monster": "mon_beaver_mutant_avian", "weight": 3, "cost_multiplier": 3, "pack_size": [ 1, 2 ] },
-      {
-        "monster": "mon_beaver_mutant_avian",
-        "weight": 3,
-        "cost_multiplier": 3,
-        "pack_size": [ 1, 2 ],
-        "conditions": [ "NIGHT" ]
-      },
-      {
         "monster": "mon_mink",
         "weight": 3,
         "cost_multiplier": 20,
         "pack_size": [ 1, 2 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_mink",
-        "weight": 5,
-        "cost_multiplier": 20,
-        "pack_size": [ 1, 2 ],
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
         "monster": "mon_muskrat",
@@ -353,13 +323,6 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_muskrat",
-        "weight": 15,
-        "cost_multiplier": 5,
-        "pack_size": [ 1, 5 ],
-        "conditions": [ "NIGHT", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
         "monster": "mon_otter",
         "weight": 5,
         "cost_multiplier": 5,
@@ -367,39 +330,18 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_otter",
-        "weight": 5,
-        "cost_multiplier": 5,
-        "pack_size": [ 1, 8 ],
-        "conditions": [ "NIGHT", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
         "monster": "mon_duck",
-        "weight": 8,
-        "cost_multiplier": 5,
-        "pack_size": [ 1, 4 ],
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_duck",
-        "weight": 15,
-        "cost_multiplier": 5,
-        "pack_size": [ 1, 4 ],
-        "conditions": [ "DAWN", "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_goose_canadian",
-        "weight": 8,
+        "weight": 20,
         "cost_multiplier": 5,
         "pack_size": [ 1, 4 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
         "monster": "mon_goose_canadian",
-        "weight": 15,
+        "weight": 20,
         "cost_multiplier": 5,
         "pack_size": [ 1, 4 ],
-        "conditions": [ "DAWN", "DAY", "SPRING", "SUMMER", "AUTUMN" ]
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       { "monster": "mon_frog", "weight": 5, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
       { "monster": "mon_zhark", "weight": 1, "cost_multiplier": 25, "starts": "1 days", "pack_size": [ 1, 3 ] },
@@ -408,253 +350,36 @@
       { "monster": "mon_mutant_carp", "weight": 3, "cost_multiplier": 15, "starts": "7 days" },
       { "monster": "mon_mutant_salmon", "weight": 2, "cost_multiplier": 15, "starts": "7 days" },
       { "monster": "mon_fish_eel", "weight": 6, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_eel",
-        "weight": 12,
-        "cost_multiplier": 3,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_bowfin", "weight": 6, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_bowfin",
-        "weight": 12,
-        "cost_multiplier": 3,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_bullhead", "weight": 6, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_bullhead",
-        "weight": 12,
-        "cost_multiplier": 3,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_brown_trout", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_brown_trout",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_brook_trout", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_brook_trout",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_lake_trout", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_lake_trout",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_rainbow_trout", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_rainbow_trout",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_kokanee_salmon", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_kokanee_salmon",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_walleye", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_walleye",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_pumpkinseed", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_pumpkinseed",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_redbreast", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_redbreast",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_green_sunfish", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_green_sunfish",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_rock_bass", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_rock_bass",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_calico_bass", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_calico_bass",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_warmouth", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_warmouth",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_channel_catfish", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_channel_catfish",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_white_catfish", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_white_catfish",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_muskellunge", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_muskellunge",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_white_sucker", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_white_sucker",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_grass_carp", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_grass_carp",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_fallfish", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_fallfish",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_carp", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_carp",
-        "weight": 8,
-        "cost_multiplier": 10,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_pike", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_pike",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_sbass", "weight": 10, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_sbass",
-        "weight": 20,
-        "cost_multiplier": 3,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_perch", "weight": 10, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_perch",
-        "weight": 20,
-        "cost_multiplier": 3,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_salmon", "weight": 6, "cost_multiplier": 8, "pack_size": [ 4, 6 ] },
-      {
-        "monster": "mon_fish_salmon",
-        "weight": 10,
-        "cost_multiplier": 8,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 4, 6 ]
-      },
       { "monster": "mon_fish_lbass", "weight": 10, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_lbass",
-        "weight": 20,
-        "cost_multiplier": 3,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_pbass", "weight": 10, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_pbass",
-        "weight": 20,
-        "cost_multiplier": 3,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_bluegill", "weight": 10, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_bluegill",
-        "weight": 20,
-        "cost_multiplier": 3,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_whitefish", "weight": 10, "cost_multiplier": 2, "pack_size": [ 4, 6 ] },
-      {
-        "monster": "mon_fish_whitefish",
-        "weight": 20,
-        "cost_multiplier": 2,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 4, 6 ]
-      },
       { "monster": "mon_fish_pickerel", "weight": 6, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_fish_pickerel",
-        "weight": 10,
-        "cost_multiplier": 10,
-        "conditions": [ "DAWN", "DUSK" ],
-        "pack_size": [ 1, 3 ]
-      },
       { "monster": "mon_fish_blinky", "weight": 5, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
       { "monster": "mon_dragonfly_naiad", "weight": 10, "cost_multiplier": 2, "ends": "7 days" },
       {
@@ -728,29 +453,6 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_mosquito_giant",
-        "weight": 70,
-        "pack_size": [ 2, 5 ],
-        "starts": "180 hours",
-        "ends": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_mosquito_giant",
-        "weight": 80,
-        "pack_size": [ 2, 6 ],
-        "starts": "15 days",
-        "ends": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_mosquito_giant",
-        "weight": 80,
-        "pack_size": [ 3, 7 ],
-        "starts": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
         "monster": "mon_dragonfly_giant",
         "weight": 35,
         "cost_multiplier": 2,
@@ -801,13 +503,6 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_dragonfly_mega",
-        "weight": 10,
-        "starts": "180 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "cost_multiplier": 2
-      },
-      {
         "monster": "mon_fly_small",
         "weight": 100,
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
@@ -847,48 +542,6 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_centipede_giant",
-        "weight": 45,
-        "pack_size": [ 2, 3 ],
-        "cost_multiplier": 2,
-        "starts": "15 days",
-        "ends": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_centipede_mom",
-        "weight": 15,
-        "pack_size": [ 1, 2 ],
-        "cost_multiplier": 2,
-        "starts": "15 days",
-        "ends": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_centipede_giant",
-        "weight": 60,
-        "cost_multiplier": 2,
-        "pack_size": [ 2, 3 ],
-        "starts": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_centipede_mom",
-        "weight": 20,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 3 ],
-        "starts": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_centipede_mega",
-        "weight": 20,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 3 ],
-        "starts": "30 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
         "monster": "mon_spider_jumping_small",
         "weight": 20,
         "cost_multiplier": 2,
@@ -923,23 +576,6 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_spider_jumping_giant",
-        "weight": 35,
-        "cost_multiplier": 2,
-        "pack_size": [ 2, 3 ],
-        "starts": "15 days",
-        "ends": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_giant",
-        "weight": 40,
-        "cost_multiplier": 2,
-        "pack_size": [ 2, 3 ],
-        "starts": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
         "monster": "mon_spider_wolf_small",
         "weight": 20,
         "cost_multiplier": 2,
@@ -971,23 +607,6 @@
         "pack_size": [ 2, 3 ],
         "starts": "180 hours",
         "ends": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_giant",
-        "weight": 35,
-        "cost_multiplier": 2,
-        "pack_size": [ 2, 3 ],
-        "starts": "15 days",
-        "ends": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_giant",
-        "weight": 40,
-        "cost_multiplier": 2,
-        "pack_size": [ 2, 3 ],
-        "starts": "540 hours",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       { "monster": "mon_zpider_mass", "weight": 5, "cost_multiplier": 2, "starts": "42 hours", "ends": "84 hours" },
@@ -1026,37 +645,6 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_dermatik_larva",
-        "weight": 15,
-        "cost_multiplier": 2,
-        "ends": "42 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_dermatik_larva",
-        "weight": 20,
-        "cost_multiplier": 2,
-        "starts": "42 hours",
-        "ends": "84 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_dermatik_larva",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "starts": "84 hours",
-        "ends": "180 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_dermatik_larva",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "starts": "180 hours",
-        "ends": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
         "monster": "mon_dermatik",
         "weight": 40,
         "cost_multiplier": 2,
@@ -1087,37 +675,6 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_slug_small",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "starts": "84 hours",
-        "ends": "180 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_slug_small",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "starts": "180 hours",
-        "ends": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_slug_giant",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "starts": "15 days",
-        "ends": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_slug_giant",
-        "weight": 35,
-        "cost_multiplier": 2,
-        "starts": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
         "monster": "mon_snail_forest",
         "weight": 15,
         "cost_multiplier": 2,
@@ -1130,37 +687,6 @@
         "cost_multiplier": 2,
         "starts": "42 hours",
         "ends": "84 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_snail_small",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "starts": "84 hours",
-        "ends": "180 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_snail_small",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "starts": "180 hours",
-        "ends": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_snail_giant",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "starts": "15 days",
-        "ends": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_snail_giant",
-        "weight": 35,
-        "cost_multiplier": 2,
-        "starts": "540 hours",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
@@ -1184,44 +710,6 @@
         "cost_multiplier": 2,
         "starts": 95,
         "ends": 180,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_frog_small",
-        "weight": 20,
-        "cost_multiplier": 2,
-        "ends": "84 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_frog_small",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "starts": "84 hours",
-        "ends": "180 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_frog_small",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "starts": "180 hours",
-        "ends": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_frog_giant",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "starts": "15 days",
-        "ends": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_frog_giant",
-        "weight": 40,
-        "cost_multiplier": 2,
-        "starts": "540 hours",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
@@ -1251,77 +739,10 @@
         "ends": "15 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
-      {
-        "monster": "mon_giant_crayfish",
-        "weight": 30,
-        "starts": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      { "monster": "mon_mutant_experimental", "weight": 2, "cost_multiplier": 6 },
+      { "monster": "mon_mutant_experimental", "weight": 1, "cost_multiplier": 6 },
       { "monster": "mon_mantis_small", "weight": 2, "cost_multiplier": 8 },
       { "monster": "mon_antlion_giant", "weight": 4, "cost_multiplier": 10 },
-      {
-        "monster": "mon_toad",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "ends": 24,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_toad",
-        "weight": 35,
-        "cost_multiplier": 2,
-        "starts": 24,
-        "ends": 95,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_toad",
-        "weight": 40,
-        "cost_multiplier": 2,
-        "starts": 95,
-        "ends": 180,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_toad_small",
-        "weight": 20,
-        "cost_multiplier": 2,
-        "ends": "84 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_toad_small",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "starts": "84 hours",
-        "ends": "180 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_toad_small",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "starts": "180 hours",
-        "ends": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_toad_giant",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "starts": "15 days",
-        "ends": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_toad_giant",
-        "weight": 40,
-        "cost_multiplier": 2,
-        "starts": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      { "monster": "mon_toad", "weight": 20, "cost_multiplier": 2, "pack_size": [ 1, 3 ] }
+      { "monster": "mon_toad", "weight": 50, "cost_multiplier": 2, "pack_size": [ 1, 3 ] }
     ]
   },
   {
@@ -1329,24 +750,16 @@
     "name": "GROUP_PARK_ANIMAL",
     "is_animal": true,
     "monsters": [
-      { "monster": "mon_null", "weight": 330, "cost_multiplier": 0 },
       { "monster": "mon_crow", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_raven", "weight": 45, "cost_multiplier": 0 },
-      { "monster": "mon_crow_mutant_small", "weight": 25, "cost_multiplier": 2 },
       {
         "monster": "mon_pigeon",
         "weight": 50,
         "cost_multiplier": 0,
         "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK", "DAY", "SPRING", "SUMMER", "AUTUMN" ]
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
-      {
-        "monster": "mon_pigeon",
-        "weight": 15,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK", "DAY", "WINTER" ]
-      },
+      { "monster": "mon_pigeon", "weight": 15, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
       { "monster": "mon_bluejay", "weight": 25, "cost_multiplier": 0 },
       { "monster": "mon_cardinal", "weight": 25, "cost_multiplier": 0 },
       { "monster": "mon_robin", "weight": 35, "cost_multiplier": 0 },
@@ -1359,10 +772,8 @@
       { "monster": "mon_squirrel_red", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_mantis_small", "weight": 5, "cost_multiplier": 10 },
       { "monster": "mon_lady_bug", "weight": 8, "cost_multiplier": 10 },
-      { "monster": "mon_lady_bug_giant", "weight": 8, "cost_multiplier": 10, "starts": "15 days" },
       { "monster": "mon_aphid", "weight": 20, "cost_multiplier": 0 },
       { "monster": "mon_grasshopper_small", "weight": 30, "cost_multiplier": 0 },
-      { "monster": "mon_antlion_larva", "weight": 7, "cost_multiplier": 10 },
       { "monster": "mon_antlion_giant", "weight": 5, "cost_multiplier": 10 },
       { "monster": "mon_hummingbird", "weight": 25, "cost_multiplier": 0 },
       { "monster": "mon_woodpecker", "weight": 25, "cost_multiplier": 0 }
@@ -1373,25 +784,23 @@
     "name": "GROUP_ROOF_ANIMAL",
     "is_animal": true,
     "monsters": [
-      { "monster": "mon_null", "weight": 490, "cost_multiplier": 0 },
       { "monster": "mon_crow", "weight": 45, "cost_multiplier": 0 },
       { "monster": "mon_raven", "weight": 45, "cost_multiplier": 0 },
       { "monster": "mon_robin", "weight": 25, "cost_multiplier": 0 },
       { "monster": "mon_sparrow", "weight": 25, "cost_multiplier": 0 },
-      { "monster": "mon_crow_mutant_small", "weight": 25, "cost_multiplier": 0 },
       {
         "monster": "mon_pigeon",
         "weight": 40,
         "cost_multiplier": 0,
         "pack_size": [ 1, 7 ],
-        "conditions": [ "DAWN", "DUSK", "DAY", "SPRING", "SUMMER", "AUTUMN" ]
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
         "monster": "mon_pigeon",
         "weight": 15,
         "cost_multiplier": 0,
         "pack_size": [ 1, 7 ],
-        "conditions": [ "DAWN", "DUSK", "DAY", "WINTER" ]
+        "conditions": [ "WINTER" ]
       },
       { "group": "GROUP_STRAY_CATS", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_chipmunk", "weight": 50, "cost_multiplier": 0 },
@@ -1404,21 +813,21 @@
         "weight": 25,
         "cost_multiplier": 0,
         "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK", "NIGHT", "SPRING", "SUMMER", "AUTUMN" ]
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
         "monster": "mon_opossum",
         "weight": 25,
         "cost_multiplier": 0,
         "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK", "NIGHT", "SPRING", "SUMMER", "AUTUMN" ]
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
         "monster": "mon_bat",
         "weight": 20,
         "cost_multiplier": 0,
         "pack_size": [ 6, 12 ],
-        "conditions": [ "DAWN", "DUSK", "NIGHT", "SPRING", "SUMMER", "AUTUMN" ]
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       { "monster": "mon_woodpecker", "weight": 25, "cost_multiplier": 0 }
     ]
@@ -1428,7 +837,6 @@
     "name": "GROUP_POND_ANIMAL",
     "is_animal": true,
     "monsters": [
-      { "monster": "mon_null", "weight": 850, "cost_multiplier": 0 },
       { "monster": "mon_rabbit", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_squirrel_red", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_squirrel", "weight": 50, "cost_multiplier": 0 },
@@ -1441,7 +849,6 @@
     "name": "GROUP_POND_BIRD",
     "is_animal": true,
     "monsters": [
-      { "monster": "mon_null", "weight": 900, "cost_multiplier": 0 },
       { "monster": "mon_duck", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_goose_canadian", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_goose", "weight": 50, "cost_multiplier": 0 },
@@ -1457,7 +864,6 @@
     "name": "GROUP_POND_FISH",
     "is_animal": true,
     "monsters": [
-      { "monster": "mon_null", "weight": 820, "cost_multiplier": 0 },
       { "monster": "mon_fish_bluegill", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_fish_carp", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_fish_sbass", "weight": 50, "cost_multiplier": 0 },
@@ -1470,7 +876,6 @@
     "name": "GROUP_BIRDFEEDER",
     "is_animal": true,
     "monsters": [
-      { "monster": "mon_null", "weight": 775, "cost_multiplier": 0 },
       { "monster": "mon_bluejay", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_cardinal", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_robin", "weight": 50, "cost_multiplier": 0 },

--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -23,7 +23,35 @@
     "monsters": [
       { "group": "GROUP_WILDERNESS_FOREST_MAMMAL", "weight": 300 },
       { "group": "GROUP_WILDERNESS_FOREST_BIRD", "weight": 300 },
-      { "group": "GROUP_WILDERNESS_FOREST_INSECT", "weight": 300 },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_INSECT_HARMLESS",
+        "weight": 75,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_INSECT",
+        "weight": 75,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "3 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_INSECT",
+        "weight": 75,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "7 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_INSECT",
+        "weight": 75,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "28 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_INSECT",
+        "weight": 75,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "90 days"
+      },
       { "monster": "mon_frog", "weight": 3, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
       { "monster": "mon_toad", "weight": 3, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
       {
@@ -36,6 +64,7 @@
         "monster": "mon_worm_small",
         "weight": 1,
         "cost_multiplier": 0,
+        "starts": "3 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
@@ -49,23 +78,20 @@
         "monster": "mon_worm_small",
         "weight": 1,
         "cost_multiplier": 0,
-        "starts": "14 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_worm_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "21 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_worm_small",
-        "weight": 1,
-        "cost_multiplier": 0,
         "starts": "28 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      }
+      },
+      {
+        "monster": "mon_worm_small",
+        "weight": 1,
+        "cost_multiplier": 0,
+        "starts": "90 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10, "starts": "3 days" },
+      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10, "starts": "7 days" },
+      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10, "starts": "28 days" },
+      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10, "starts": "90 days" }
     ]
   },
   {
@@ -76,31 +102,18 @@
     "monsters": [
       {
         "monster": "mon_bat",
-        "weight": 50,
+        "weight": 10,
         "cost_multiplier": 2,
         "pack_size": [ 3, 12 ],
-        "conditions": [ "DAWN", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       { "monster": "mon_bear", "weight": 1, "cost_multiplier": 10, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
       {
         "monster": "mon_bear",
-        "weight": 3,
-        "cost_multiplier": 10,
-        "conditions": [ "NIGHT", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bear",
         "weight": 1,
         "cost_multiplier": 10,
         "ends": "3 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bear",
-        "weight": 3,
-        "cost_multiplier": 10,
-        "ends": "3 days",
-        "conditions": [ "NIGHT", "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
         "monster": "mon_bear",
@@ -111,24 +124,10 @@
       },
       {
         "monster": "mon_bear",
-        "weight": 3,
-        "cost_multiplier": 10,
-        "ends": "7 days",
-        "conditions": [ "NIGHT", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bear",
         "weight": 1,
         "cost_multiplier": 10,
         "ends": "28 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bear",
-        "weight": 3,
-        "cost_multiplier": 10,
-        "ends": "28 days",
-        "conditions": [ "NIGHT", "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
         "monster": "mon_bear",
@@ -137,87 +136,35 @@
         "ends": "90 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
-      {
-        "monster": "mon_bear",
-        "weight": 3,
-        "cost_multiplier": 10,
-        "ends": "90 days",
-        "conditions": [ "NIGHT", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      { "monster": "mon_bear_mutant_3headed", "weight": 1, "cost_multiplier": 10 },
-      { "monster": "mon_bear_mutant_3headed", "weight": 2, "cost_multiplier": 10, "starts": "28 days" },
       { "monster": "mon_zombear", "weight": 1, "cost_multiplier": 10, "starts": "3 days" },
       { "monster": "mon_zombear", "weight": 2, "cost_multiplier": 10, "starts": "7 days" },
       { "monster": "mon_zombear", "weight": 3, "cost_multiplier": 10, "starts": "28 days" },
       { "monster": "mon_zombear", "weight": 4, "cost_multiplier": 10, "starts": "90 days" },
       { "monster": "mon_bobcat", "weight": 7, "cost_multiplier": 2 },
-      { "monster": "mon_bobcat", "weight": 12, "cost_multiplier": 2, "conditions": [ "DAWN", "DUSK" ] },
       { "monster": "mon_boar_wild", "weight": 2, "cost_multiplier": 2, "pack_size": [ 1, 4 ] },
-      {
-        "monster": "mon_boar_wild",
-        "weight": 4,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 4 ],
-        "conditions": [ "DAY" ]
-      },
       { "group": "GROUP_STRAY_CATS", "weight": 10 },
-      { "group": "GROUP_STRAY_CATS", "weight": 14, "conditions": [ "DAWN", "DUSK" ] },
       { "group": "GROUP_STRAY_CATS", "weight": 1, "pack_size": [ 2, 8 ] },
-      { "group": "GROUP_STRAY_CATS", "weight": 4, "pack_size": [ 2, 8 ], "conditions": [ "DAWN", "DUSK" ] },
-      { "monster": "mon_cat_mutant_prism", "weight": 1, "pack_size": [ 1, 2 ] },
-      { "monster": "mon_cat_mutant_prism", "weight": 2, "pack_size": [ 1, 2 ], "conditions": [ "DAWN", "DUSK" ] },
-      {
-        "monster": "mon_cat_mutant_prism",
-        "weight": 3,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "SUMMER", "AUTUMN", "WINTER" ]
-      },
       {
         "monster": "mon_chipmunk",
         "weight": 30,
         "cost_multiplier": 0,
         "pack_size": [ 1, 2 ],
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3 },
-      { "monster": "mon_cougar", "weight": 2, "cost_multiplier": 3, "conditions": [ "DAWN", "DUSK" ] },
+      { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "3 days" },
       { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "7 days" },
-      {
-        "monster": "mon_cougar",
-        "weight": 2,
-        "cost_multiplier": 3,
-        "ends": "7 days",
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "21 days" },
-      {
-        "monster": "mon_cougar",
-        "weight": 2,
-        "cost_multiplier": 3,
-        "ends": "21 days",
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "42 days" },
-      {
-        "monster": "mon_cougar",
-        "weight": 2,
-        "cost_multiplier": 3,
-        "ends": "42 days",
-        "conditions": [ "DAWN", "DUSK" ]
-      },
+      { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "28 days" },
       { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "90 days" },
-      {
-        "monster": "mon_cougar",
-        "weight": 2,
-        "cost_multiplier": 3,
-        "ends": "90 days",
-        "conditions": [ "DAWN", "DUSK" ]
-      },
+      { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "3 days" },
       { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "7 days" },
-      { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "21 days" },
-      { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "42 days" },
+      { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "28 days" },
       { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "90 days" },
       { "monster": "mon_deer", "weight": 4, "cost_multiplier": 2, "pack_size": [ 1, 5 ] },
+      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ], "starts": "3 days" },
+      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ], "starts": "7 days" },
+      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ], "starts": "28 days" },
+      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ], "starts": "90 days" },
       {
         "monster": "mon_reindeer",
         "weight": 3,
@@ -225,794 +172,71 @@
         "pack_size": [ 2, 6 ],
         "conditions": [ "AUTUMN", "WINTER" ]
       },
-      { "monster": "mon_zeindeer", "weight": 1, "cost_multiplier": 15, "pack_size": [ 2, 5 ], "starts": "180 hours" },
       {
         "monster": "mon_zeindeer",
-        "weight": 4,
-        "cost_multiplier": 10,
-        "pack_size": [ 3, 5 ],
-        "starts": "180 hours",
+        "weight": 1,
+        "cost_multiplier": 15,
+        "pack_size": [ 2, 5 ],
+        "starts": "3 days",
         "conditions": [ "AUTUMN", "WINTER" ]
       },
-      { "monster": "mon_deer", "weight": 15, "cost_multiplier": 2, "pack_size": [ 1, 5 ], "conditions": [ "DAY" ] },
-      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ], "starts": "3 days" },
-      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ], "starts": "7 days" },
-      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ], "starts": "28 days" },
-      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ], "starts": "90 days" },
-      { "group": "GROUP_STRAY_DOGS", "weight": 3, "cost_multiplier": 25, "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_deer_mutant_spider",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 3 ],
-        "starts": "7 days"
-      },
-      {
-        "monster": "mon_deer_mutant_spider",
-        "weight": 3,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 3 ],
-        "starts": "7 days",
-        "conditions": [ "DUSK", "NIGHT" ]
-      },
-      {
-        "monster": "mon_dog",
-        "weight": 2,
-        "cost_multiplier": 25,
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_bull", "weight": 1, "cost_multiplier": 25, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_bull",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_auscattle", "weight": 1, "cost_multiplier": 25, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_auscattle",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_pitbullmix", "weight": 3, "cost_multiplier": 25, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_pitbullmix",
-        "weight": 2,
-        "cost_multiplier": 25,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_beagle", "weight": 1, "cost_multiplier": 25, "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_dog_beagle",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_bcollie", "weight": 1, "cost_multiplier": 25, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_bcollie",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_boxer", "weight": 1, "cost_multiplier": 25, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_boxer",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_chihuahua", "weight": 1, "cost_multiplier": 25, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_chihuahua",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_dachshund", "weight": 1, "cost_multiplier": 25, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_dachshund",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_gshepherd", "weight": 1, "cost_multiplier": 25, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_gshepherd",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog", "weight": 3, "cost_multiplier": 25, "ends": "3 days", "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_dog",
-        "weight": 2,
-        "cost_multiplier": 25,
-        "ends": "3 days",
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_bull", "weight": 1, "cost_multiplier": 25, "ends": "3 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_bull",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "3 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_auscattle", "weight": 1, "cost_multiplier": 25, "ends": "3 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_auscattle",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "3 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_pitbullmix", "weight": 3, "cost_multiplier": 25, "ends": "3 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_pitbullmix",
-        "weight": 2,
-        "cost_multiplier": 25,
-        "ends": "3 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_beagle", "weight": 1, "cost_multiplier": 25, "ends": "3 days", "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_dog_beagle",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "3 days",
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_bcollie", "weight": 1, "cost_multiplier": 25, "ends": "3 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_bcollie",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "3 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_boxer", "weight": 1, "cost_multiplier": 25, "ends": "3 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_boxer",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "3 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_chihuahua", "weight": 1, "cost_multiplier": 25, "ends": "3 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_chihuahua",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "3 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_dachshund", "weight": 1, "cost_multiplier": 25, "ends": "3 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_dachshund",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "3 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_gshepherd", "weight": 1, "cost_multiplier": 25, "ends": "3 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_gshepherd",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "3 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog", "weight": 3, "cost_multiplier": 25, "ends": "7 days", "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_dog",
-        "weight": 2,
-        "cost_multiplier": 25,
-        "ends": "7 days",
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_bull", "weight": 1, "cost_multiplier": 25, "ends": "7 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_bull",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "7 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_auscattle", "weight": 1, "cost_multiplier": 25, "ends": "7 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_auscattle",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "7 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_pitbullmix", "weight": 3, "cost_multiplier": 25, "ends": "7 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_pitbullmix",
-        "weight": 2,
-        "cost_multiplier": 25,
-        "ends": "7 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_beagle", "weight": 1, "cost_multiplier": 25, "ends": "7 days", "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_dog_beagle",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "7 days",
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_bcollie", "weight": 1, "cost_multiplier": 25, "ends": "7 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_bcollie",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "7 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_boxer", "weight": 1, "cost_multiplier": 25, "ends": "7 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_boxer",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "7 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_chihuahua", "weight": 1, "cost_multiplier": 25, "ends": "7 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_chihuahua",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "7 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_dachshund", "weight": 1, "cost_multiplier": 25, "ends": "7 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_dachshund",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "7 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_gshepherd", "weight": 1, "cost_multiplier": 25, "ends": "7 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_gshepherd",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "7 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog", "weight": 3, "cost_multiplier": 25, "ends": "28 days", "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_dog",
-        "weight": 2,
-        "cost_multiplier": 25,
-        "ends": "28 days",
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_bull", "weight": 1, "cost_multiplier": 25, "ends": "28 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_bull",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "28 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_auscattle", "weight": 1, "cost_multiplier": 25, "ends": "28 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_auscattle",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "28 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      {
-        "monster": "mon_dog_pitbullmix",
-        "weight": 3,
-        "cost_multiplier": 25,
-        "ends": "28 days",
-        "pack_size": [ 1, 3 ]
-      },
-      {
-        "monster": "mon_dog_pitbullmix",
-        "weight": 2,
-        "cost_multiplier": 25,
-        "ends": "28 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_beagle", "weight": 1, "cost_multiplier": 25, "ends": "28 days", "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_dog_beagle",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "28 days",
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_bcollie", "weight": 1, "cost_multiplier": 25, "ends": "28 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_bcollie",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "28 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_boxer", "weight": 1, "cost_multiplier": 25, "ends": "28 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_boxer",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "28 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_chihuahua", "weight": 1, "cost_multiplier": 25, "ends": "28 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_chihuahua",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "28 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_dachshund", "weight": 1, "cost_multiplier": 25, "ends": "28 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_dachshund",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "28 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_gshepherd", "weight": 1, "cost_multiplier": 25, "ends": "28 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_gshepherd",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "28 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog", "weight": 3, "cost_multiplier": 25, "ends": "90 days", "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_dog",
-        "weight": 2,
-        "cost_multiplier": 25,
-        "ends": "90 days",
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_bull", "weight": 1, "cost_multiplier": 25, "ends": "90 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_bull",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "90 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_auscattle", "weight": 1, "cost_multiplier": 25, "ends": "90 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_auscattle",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "90 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      {
-        "monster": "mon_dog_pitbullmix",
-        "weight": 3,
-        "cost_multiplier": 25,
-        "ends": "90 days",
-        "pack_size": [ 1, 3 ]
-      },
-      {
-        "monster": "mon_dog_pitbullmix",
-        "weight": 2,
-        "cost_multiplier": 25,
-        "ends": "90 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_beagle", "weight": 1, "cost_multiplier": 25, "ends": "90 days", "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_dog_beagle",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "90 days",
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_bcollie", "weight": 1, "cost_multiplier": 25, "ends": "90 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_bcollie",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "90 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_boxer", "weight": 1, "cost_multiplier": 25, "ends": "90 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_boxer",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "90 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_chihuahua", "weight": 1, "cost_multiplier": 25, "ends": "90 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_chihuahua",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "90 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_dachshund", "weight": 1, "cost_multiplier": 25, "ends": "90 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_dachshund",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "90 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_gshepherd", "weight": 1, "cost_multiplier": 25, "ends": "90 days", "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_dog_gshepherd",
-        "weight": 1,
-        "cost_multiplier": 25,
-        "ends": "90 days",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      { "monster": "mon_dog_mutant_mongrel", "weight": 1, "cost_multiplier": 0 },
-      { "monster": "mon_dog_mutant_mongrel", "weight": 1, "cost_multiplier": 0, "conditions": [ "DAWN", "DUSK" ] },
-      {
-        "monster": "mon_dog_mutant_mongrel",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "conditions": [ "DAWN", "DUSK", "SUMMER", "AUTUMN", "WINTER" ]
-      },
+      { "group": "GROUP_STRAY_DOGS", "weight": 6, "cost_multiplier": 25, "pack_size": [ 1, 6 ] },
       { "monster": "mon_fox_gray", "weight": 1, "cost_multiplier": 0 },
-      { "monster": "mon_fox_gray", "weight": 2, "cost_multiplier": 0, "conditions": [ "DAWN", "DUSK" ] },
       { "monster": "mon_fox_gray", "weight": 1, "cost_multiplier": 0, "ends": "3 days" },
-      {
-        "monster": "mon_fox_gray",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "ends": "3 days",
-        "conditions": [ "DAWN", "DUSK" ]
-      },
       { "monster": "mon_fox_gray", "weight": 1, "cost_multiplier": 0, "ends": "7 days" },
-      {
-        "monster": "mon_fox_gray",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "ends": "7 days",
-        "conditions": [ "DAWN", "DUSK" ]
-      },
       { "monster": "mon_fox_gray", "weight": 1, "cost_multiplier": 0, "ends": "28 days" },
-      {
-        "monster": "mon_fox_gray",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "ends": "28 days",
-        "conditions": [ "DAWN", "DUSK" ]
-      },
       { "monster": "mon_fox_gray", "weight": 1, "cost_multiplier": 0, "ends": "90 days" },
-      {
-        "monster": "mon_fox_gray",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "ends": "90 days",
-        "conditions": [ "DAWN", "DUSK" ]
-      },
       { "monster": "mon_fox_red", "weight": 1, "cost_multiplier": 0 },
-      { "monster": "mon_fox_red", "weight": 2, "cost_multiplier": 0, "conditions": [ "DAWN", "DUSK" ] },
       { "monster": "mon_fox_red", "weight": 1, "cost_multiplier": 0, "ends": "3 days" },
-      {
-        "monster": "mon_fox_red",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "ends": "3 days",
-        "conditions": [ "DAWN", "DUSK" ]
-      },
       { "monster": "mon_fox_red", "weight": 1, "cost_multiplier": 0, "ends": "7 days" },
-      {
-        "monster": "mon_fox_red",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "ends": "7 days",
-        "conditions": [ "DAWN", "DUSK" ]
-      },
       { "monster": "mon_fox_red", "weight": 1, "cost_multiplier": 0, "ends": "28 days" },
-      {
-        "monster": "mon_fox_red",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "ends": "28 days",
-        "conditions": [ "DAWN", "DUSK" ]
-      },
       { "monster": "mon_fox_red", "weight": 1, "cost_multiplier": 0, "ends": "90 days" },
-      {
-        "monster": "mon_fox_red",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "ends": "90 days",
-        "conditions": [ "DAWN", "DUSK" ]
-      },
       { "monster": "mon_wolf", "weight": 1, "cost_multiplier": 2, "pack_size": [ 2, 5 ] },
-      { "monster": "mon_wolf", "weight": 2, "cost_multiplier": 2, "pack_size": [ 2, 5 ], "conditions": [ "NIGHT" ] },
       { "monster": "mon_wolf", "weight": 1, "cost_multiplier": 2, "ends": "3 days", "pack_size": [ 2, 5 ] },
-      {
-        "monster": "mon_wolf",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "ends": "3 days",
-        "pack_size": [ 2, 5 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_wolf", "weight": 1, "cost_multiplier": 2, "ends": "7 days", "pack_size": [ 2, 5 ] },
-      {
-        "monster": "mon_wolf",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "ends": "7 days",
-        "pack_size": [ 2, 5 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_wolf", "weight": 1, "cost_multiplier": 2, "ends": "28 days", "pack_size": [ 2, 5 ] },
-      {
-        "monster": "mon_wolf",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "ends": "28 days",
-        "pack_size": [ 2, 5 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_wolf", "weight": 1, "cost_multiplier": 2, "ends": "90 days", "pack_size": [ 2, 5 ] },
-      {
-        "monster": "mon_wolf",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "ends": "90 days",
-        "pack_size": [ 2, 5 ],
-        "conditions": [ "NIGHT" ]
-      },
-      { "monster": "mon_wolf_mutant_huge", "weight": 1, "cost_multiplier": 0, "starts": "21 days" },
-      {
-        "monster": "mon_wolf_mutant_huge",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "21 days",
-        "pack_size": [ 1, 2 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_coyote", "weight": 1, "cost_multiplier": 2, "pack_size": [ 1, 6 ] },
-      { "monster": "mon_coyote", "weight": 2, "cost_multiplier": 2, "pack_size": [ 1, 6 ], "conditions": [ "NIGHT" ] },
       { "monster": "mon_coyote", "weight": 1, "cost_multiplier": 2, "ends": "3 days", "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_coyote",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "ends": "3 days",
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_coyote", "weight": 1, "cost_multiplier": 2, "ends": "7 days", "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_coyote",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "ends": "7 days",
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_coyote", "weight": 1, "cost_multiplier": 2, "ends": "28 days", "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_coyote",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "ends": "28 days",
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_coyote", "weight": 1, "cost_multiplier": 2, "ends": "90 days", "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_coyote",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "ends": "90 days",
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "NIGHT" ]
-      },
-      { "monster": "mon_coyote_mutant_shark", "weight": 1, "cost_multiplier": 2, "pack_size": [ 1, 6 ] },
-      {
-        "monster": "mon_coyote_mutant_shark",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 6 ],
-        "conditions": [ "NIGHT" ]
-      },
-      { "monster": "mon_coyote_mutant_venom", "weight": 2, "cost_multiplier": 2, "pack_size": [ 1, 8 ] },
-      {
-        "monster": "mon_coyote_mutant_venom",
-        "weight": 3,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 8 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "pack_size": [ 1, 8 ] },
-      {
-        "monster": "mon_coyote_wolf",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 8 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "ends": "3 days", "pack_size": [ 1, 8 ] },
-      {
-        "monster": "mon_coyote_wolf",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "ends": "3 days",
-        "pack_size": [ 1, 8 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "ends": "7 days", "pack_size": [ 1, 8 ] },
-      {
-        "monster": "mon_coyote_wolf",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "ends": "7 days",
-        "pack_size": [ 1, 8 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "ends": "28 days", "pack_size": [ 1, 8 ] },
-      {
-        "monster": "mon_coyote_wolf",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "ends": "28 days",
-        "pack_size": [ 1, 8 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "ends": "90 days", "pack_size": [ 1, 8 ] },
-      {
-        "monster": "mon_coyote_wolf",
-        "weight": 2,
-        "cost_multiplier": 2,
-        "ends": "90 days",
-        "pack_size": [ 1, 8 ],
-        "conditions": [ "NIGHT" ]
-      },
       { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "3 days" },
       { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "7 days" },
-      { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "14 days" },
-      { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "21 days" },
       { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "28 days" },
-      { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "890 hours" },
-      { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "42 days" },
-      { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "56 days" },
-      { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "70 days" },
       { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "90 days" },
       { "monster": "mon_zolf", "weight": 2, "cost_multiplier": 2, "starts": "3 days", "pack_size": [ 1, 4 ] },
       { "monster": "mon_zolf", "weight": 2, "cost_multiplier": 2, "starts": "7 days", "pack_size": [ 1, 4 ] },
       { "monster": "mon_zolf", "weight": 2, "cost_multiplier": 2, "starts": "28 days", "pack_size": [ 1, 4 ] },
       { "monster": "mon_zolf", "weight": 2, "cost_multiplier": 2, "starts": "90 days", "pack_size": [ 1, 4 ] },
-      {
-        "monster": "mon_zombie_horse",
-        "weight": 2,
-        "cost_multiplier": 15,
-        "ends": "2000 hours",
-        "conditions": [ "DAWN", "SPRING", "SUMMER", "AUTUMN" ],
-        "pack_size": [ 1, 4 ]
-      },
+      { "monster": "mon_horse", "weight": 2, "cost_multiplier": 15, "pack_size": [ 1, 4 ], "ends": "3 days" },
+      { "monster": "mon_zombie_horse", "weight": 2, "cost_multiplier": 15, "pack_size": [ 1, 4 ], "starts": "3 days" },
+      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3 },
+      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "3 days" },
+      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "7 days" },
+      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "28 days" },
+      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "90 days" },
+      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10, "starts": "3 days" },
+      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10, "starts": "7 days" },
+      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10, "starts": "28 days" },
+      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10, "starts": "90 days" },
       {
         "monster": "mon_groundhog",
         "weight": 30,
         "cost_multiplier": 5,
         "pack_size": [ 1, 6 ],
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       { "monster": "mon_hare", "weight": 12, "cost_multiplier": 2, "pack_size": [ 1, 6 ] },
-      { "monster": "mon_hare", "weight": 18, "cost_multiplier": 2, "pack_size": [ 1, 6 ], "conditions": [ "NIGHT" ] },
-      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3 },
-      { "monster": "mon_moose", "weight": 2, "cost_multiplier": 3, "conditions": [ "DAY" ] },
-      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "3 days" },
-      { "monster": "mon_moose", "weight": 2, "cost_multiplier": 3, "ends": "3 days", "conditions": [ "DAY" ] },
-      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "7 days" },
-      { "monster": "mon_moose", "weight": 2, "cost_multiplier": 3, "ends": "7 days", "conditions": [ "DAY" ] },
-      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "28 days" },
-      { "monster": "mon_moose", "weight": 2, "cost_multiplier": 3, "ends": "28 days", "conditions": [ "DAY" ] },
-      { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "90 days" },
-      { "monster": "mon_moose", "weight": 2, "cost_multiplier": 3, "ends": "90 days", "conditions": [ "DAY" ] },
-      { "monster": "mon_tusked_moose", "weight": 1, "cost_multiplier": 10, "starts": "35 days" },
-      { "monster": "mon_tusked_moose", "weight": 2, "cost_multiplier": 10, "starts": "53 days" },
-      { "monster": "mon_tusked_moose", "weight": 3, "cost_multiplier": 10, "starts": "90 days" },
-      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10, "starts": "3 days" },
-      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10, "starts": "7 days" },
-      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10, "starts": "28 days" },
-      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10, "starts": "90 days" },
       { "monster": "mon_rabbit", "weight": 10, "cost_multiplier": 0, "pack_size": [ 1, 5 ] },
-      {
-        "monster": "mon_rabbit",
-        "weight": 15,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 5 ],
-        "conditions": [ "DUSK", "NIGHT", "DAWN" ]
-      },
-      {
-        "monster": "mon_squirrel",
-        "weight": 50,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 2 ],
-        "conditions": [ "DAY" ]
-      },
-      {
-        "monster": "mon_squirrel",
-        "weight": 25,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 2 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
-      {
-        "monster": "mon_squirrel_red",
-        "weight": 50,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 2 ],
-        "conditions": [ "DAY" ]
-      },
-      {
-        "monster": "mon_squirrel_red",
-        "weight": 25,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 2 ],
-        "conditions": [ "DAWN", "DUSK" ]
-      },
+      { "monster": "mon_squirrel", "weight": 50, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_squirrel_red", "weight": 50, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
       { "monster": "mon_weasel", "weight": 5, "cost_multiplier": 5 },
-      { "monster": "mon_weasel", "weight": 15, "cost_multiplier": 5, "conditions": [ "NIGHT" ] },
       {
         "monster": "mon_raccoon",
         "weight": 8,
@@ -1021,41 +245,13 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_raccoon",
-        "weight": 12,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
         "monster": "mon_opossum",
         "weight": 8,
         "cost_multiplier": 0,
         "pack_size": [ 1, 3 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
-      {
-        "monster": "mon_opossum",
-        "weight": 12,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_black_rat",
-        "weight": 10,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 5 ],
-        "conditions": [ "DAY" ]
-      },
-      {
-        "monster": "mon_black_rat",
-        "weight": 15,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 5 ],
-        "conditions": [ "NIGHT" ]
-      },
-      { "monster": "mon_nakedmolerat_giant", "weight": 1, "cost_multiplier": 3, "conditions": [ "DUSK", "NIGHT" ] }
+      { "monster": "mon_black_rat", "weight": 10, "cost_multiplier": 0, "pack_size": [ 1, 5 ] }
     ]
   },
   {
@@ -1066,19 +262,11 @@
     "monsters": [
       { "monster": "mon_bluejay", "weight": 2, "cost_multiplier": 0, "pack_size": [ 1, 10 ] },
       { "monster": "mon_crow", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 14 ] },
-      { "monster": "mon_crow", "weight": 15, "cost_multiplier": 0, "pack_size": [ 1, 14 ], "conditions": [ "DAY" ] },
       { "monster": "mon_raven", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 14 ] },
       { "monster": "mon_robin", "weight": 4, "cost_multiplier": 0, "pack_size": [ 1, 14 ] },
       { "monster": "mon_sparrow", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 15 ] },
-      {
-        "monster": "mon_pigeon",
-        "weight": 5,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK", "DAY" ]
-      },
+      { "monster": "mon_pigeon", "weight": 1, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
       { "monster": "mon_turkey", "weight": 6, "cost_multiplier": 2, "pack_size": [ 1, 18 ] },
-      { "monster": "mon_turkey", "weight": 9, "cost_multiplier": 2, "pack_size": [ 1, 18 ], "conditions": [ "DAY" ] },
       {
         "monster": "mon_duck",
         "weight": 4,
@@ -1087,40 +275,24 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_duck",
-        "weight": 6,
-        "cost_multiplier": 5,
-        "pack_size": [ 1, 4 ],
-        "conditions": [ "DAWN", "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
         "monster": "mon_goose_canadian",
         "weight": 4,
         "cost_multiplier": 5,
         "pack_size": [ 1, 4 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
-      {
-        "monster": "mon_goose_canadian",
-        "weight": 6,
-        "cost_multiplier": 5,
-        "pack_size": [ 1, 4 ],
-        "conditions": [ "DAWN", "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_hummingbird",
-        "weight": 5,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK", "DAY" ]
-      },
-      {
-        "monster": "mon_woodpecker",
-        "weight": 5,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK", "DAY" ]
-      }
+      { "monster": "mon_hummingbird", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_woodpecker", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 3 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FOREST_INSECT_HARMLESS",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_fly_small", "weight": 2, "cost_multiplier": 0 },
+      { "monster": "mon_aphid", "weight": 3, "pack_size": [ 1, 5 ], "cost_multiplier": 0 }
     ]
   },
   {
@@ -1129,709 +301,21 @@
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
-      { "monster": "mon_bee_small", "weight": 3, "cost_multiplier": 0, "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ] },
-      {
-        "monster": "mon_bee_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "1 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "3 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "5 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "7 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "9 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "12 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "14 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "16 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "19 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "21 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "23 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "26 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "28 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "30 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "33 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "1 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "1 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "3 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "3 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "5 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "5 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "7 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "7 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "9 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "9 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "12 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "12 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "14 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "14 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "16 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "16 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "19 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "19 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "21 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "21 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "23 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "23 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "26 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "26 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "28 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "28 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "30 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "30 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "793 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 3,
-        "cost_multiplier": 0,
-        "starts": "33 days",
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "1 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "1 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "3 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "5 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "5 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "7 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "9 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "9 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "12 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "14 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "14 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "16 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "19 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "19 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "21 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "23 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "23 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "26 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "28 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "28 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "30 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "33 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "33 days",
-        "conditions": [ "DAWN", "DAY", "DUSK", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "1 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "1 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "3 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "5 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "5 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "7 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "9 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "9 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "12 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "14 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "14 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "16 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "19 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "19 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "21 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "23 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "23 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "26 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "28 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "28 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "30 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "33 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 2,
-        "cost_multiplier": 0,
-        "starts": "33 days",
-        "conditions": [ "DUSK", "NIGHT", "DAWN", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10, "starts": "3 days" },
-      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10, "starts": "7 days" },
-      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10, "starts": "28 days" },
-      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10, "starts": "90 days" },
-      {
-        "monster": "mon_wasp_small",
-        "weight": 20,
-        "cost_multiplier": 2,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "7 days"
-      },
-      {
-        "monster": "mon_wasp_small",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "starts": "7 days",
-        "ends": "14 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_wasp_small",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 2 ],
-        "starts": "14 days",
-        "ends": "30 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      { "monster": "mon_mantis_small", "weight": 8, "cost_multiplier": 10 },
+      { "monster": "mon_bee_small", "weight": 3, "cost_multiplier": 0 },
+      { "monster": "mon_fly_small", "weight": 2, "cost_multiplier": 0 },
+      { "monster": "mon_spider_jumping_small", "weight": 1, "cost_multiplier": 0 },
+      { "monster": "mon_spider_wolf_small", "weight": 1, "cost_multiplier": 0 },
+      { "monster": "mon_wasp_small", "weight": 20, "cost_multiplier": 2 },
+      { "monster": "mon_mantis_small", "weight": 2, "cost_multiplier": 10 },
       { "monster": "mon_lady_bug", "weight": 5, "cost_multiplier": 10 },
-      { "monster": "mon_aphid", "weight": 15, "pack_size": [ 1, 5 ], "cost_multiplier": 0 },
-      { "monster": "mon_grasshopper_small", "weight": 15, "pack_size": [ 1, 3 ], "cost_multiplier": 0 },
-      { "monster": "mon_antlion_larva", "weight": 7, "cost_multiplier": 10 },
-      { "monster": "mon_stag_beetle_small", "freq": 2, "cost_multiplier": 0, "starts": 168, "ends": 720 },
-      { "monster": "mon_stag_beetle_small", "freq": 2, "cost_multiplier": 0, "starts": 168 },
-      { "monster": "mon_caterpillar_butterfly", "weight": 3, "cost_multiplier": 0 },
-      { "monster": "mon_caterpillar_moth", "weight": 3, "cost_multiplier": 0 },
-      { "monster": "mon_woodlouse", "weight": 3, "cost_multiplier": 0 },
-      { "monster": "mon_butterfly", "weight": 2, "cost_multiplier": 0 },
-      { "monster": "mon_moth", "weight": 2, "cost_multiplier": 0, "conditions": [ "DAWN", "DUSK" ] },
-      { "monster": "mon_cicada", "weight": 1, "cost_multiplier": 3, "starts": "240 hours" }
+      { "monster": "mon_aphid", "weight": 3, "pack_size": [ 1, 5 ], "cost_multiplier": 0 },
+      { "monster": "mon_grasshopper_small", "weight": 3, "pack_size": [ 1, 3 ], "cost_multiplier": 0 },
+      { "monster": "mon_antlion_giant", "weight": 1, "cost_multiplier": 10 },
+      { "monster": "mon_stag_beetle_small", "weight": 2, "cost_multiplier": 10 },
+      { "monster": "mon_woodlouse", "weight": 3, "cost_multiplier": 3 },
+      { "monster": "mon_butterfly", "weight": 2, "cost_multiplier": 3 },
+      { "monster": "mon_moth", "weight": 2, "cost_multiplier": 3 },
+      { "monster": "mon_cicada", "weight": 1, "cost_multiplier": 3 }
     ]
   },
   {
@@ -2556,32 +1040,6 @@
         "pack_size": [ 1, 2 ],
         "starts": "14 days",
         "ends": "30 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_wasp",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 2 ],
-        "starts": "30 days",
-        "ends": "60 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_wasp",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 3 ],
-        "starts": "60 days",
-        "ends": "90 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_wasp",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "pack_size": [ 2, 5 ],
-        "starts": "90 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {

--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -19,7 +19,59 @@
     "type": "monstergroup",
     "name": "GROUP_FOREST",
     "default": "mon_null",
-    "//": "Current SPRING first DAY count is 513.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
+    "is_animal": true,
+    "monsters": [
+      { "group": "GROUP_WILDERNESS_FOREST_MAMMAL", "weight": 300 },
+      { "group": "GROUP_WILDERNESS_FOREST_BIRD", "weight": 300 },
+      { "group": "GROUP_WILDERNESS_FOREST_INSECT", "weight": 300 },
+      { "monster": "mon_frog", "weight": 3, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_toad", "weight": 3, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
+      {
+        "monster": "mon_rattlesnake",
+        "weight": 3,
+        "cost_multiplier": 5,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_worm_small",
+        "weight": 1,
+        "cost_multiplier": 0,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_worm_small",
+        "weight": 1,
+        "cost_multiplier": 0,
+        "starts": "7 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_worm_small",
+        "weight": 1,
+        "cost_multiplier": 0,
+        "starts": "14 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_worm_small",
+        "weight": 1,
+        "cost_multiplier": 0,
+        "starts": "21 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_worm_small",
+        "weight": 1,
+        "cost_multiplier": 0,
+        "starts": "28 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FOREST_MAMMAL",
+    "default": "mon_null",
     "is_animal": true,
     "monsters": [
       {
@@ -165,21 +217,6 @@
       { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "21 days" },
       { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "42 days" },
       { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "90 days" },
-      { "monster": "mon_crow", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 14 ] },
-      { "monster": "mon_crow", "weight": 15, "cost_multiplier": 0, "pack_size": [ 1, 14 ], "conditions": [ "DAY" ] },
-      { "monster": "mon_raven", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 14 ] },
-      { "monster": "mon_robin", "weight": 4, "cost_multiplier": 0, "pack_size": [ 1, 14 ] },
-      { "monster": "mon_sparrow", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 15 ] },
-      { "monster": "mon_bluejay", "weight": 2, "cost_multiplier": 0, "pack_size": [ 1, 10 ] },
-      { "monster": "mon_crow", "weight": 2, "cost_multiplier": 0, "pack_size": [ 1, 10 ] },
-      { "monster": "mon_crow_mutant_small", "weight": 3, "cost_multiplier": 0, "pack_size": [ 1, 8 ] },
-      {
-        "monster": "mon_pigeon",
-        "weight": 5,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK", "DAY" ]
-      },
       { "monster": "mon_deer", "weight": 4, "cost_multiplier": 2, "pack_size": [ 1, 5 ] },
       {
         "monster": "mon_reindeer",
@@ -976,37 +1013,6 @@
       },
       { "monster": "mon_weasel", "weight": 5, "cost_multiplier": 5 },
       { "monster": "mon_weasel", "weight": 15, "cost_multiplier": 5, "conditions": [ "NIGHT" ] },
-      { "monster": "mon_turkey", "weight": 6, "cost_multiplier": 2, "pack_size": [ 1, 18 ] },
-      { "monster": "mon_turkey", "weight": 9, "cost_multiplier": 2, "pack_size": [ 1, 18 ], "conditions": [ "DAY" ] },
-      { "monster": "mon_frog", "weight": 5, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_duck",
-        "weight": 4,
-        "cost_multiplier": 5,
-        "pack_size": [ 1, 4 ],
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_duck",
-        "weight": 6,
-        "cost_multiplier": 5,
-        "pack_size": [ 1, 4 ],
-        "conditions": [ "DAWN", "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_goose_canadian",
-        "weight": 4,
-        "cost_multiplier": 5,
-        "pack_size": [ 1, 4 ],
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_goose_canadian",
-        "weight": 6,
-        "cost_multiplier": 5,
-        "pack_size": [ 1, 4 ],
-        "conditions": [ "DAWN", "DAY", "SPRING", "SUMMER", "AUTUMN" ]
-      },
       {
         "monster": "mon_raccoon",
         "weight": 8,
@@ -1049,24 +1055,81 @@
         "pack_size": [ 1, 5 ],
         "conditions": [ "NIGHT" ]
       },
+      { "monster": "mon_nakedmolerat_giant", "weight": 1, "cost_multiplier": 3, "conditions": [ "DUSK", "NIGHT" ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FOREST_BIRD",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_bluejay", "weight": 2, "cost_multiplier": 0, "pack_size": [ 1, 10 ] },
+      { "monster": "mon_crow", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 14 ] },
+      { "monster": "mon_crow", "weight": 15, "cost_multiplier": 0, "pack_size": [ 1, 14 ], "conditions": [ "DAY" ] },
+      { "monster": "mon_raven", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 14 ] },
+      { "monster": "mon_robin", "weight": 4, "cost_multiplier": 0, "pack_size": [ 1, 14 ] },
+      { "monster": "mon_sparrow", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 15 ] },
       {
-        "monster": "mon_rattlesnake",
-        "weight": 15,
-        "cost_multiplier": 5,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_rattlesnake_giant",
-        "weight": 10,
-        "cost_multiplier": 5,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_bee_small",
-        "weight": 3,
+        "monster": "mon_pigeon",
+        "weight": 5,
         "cost_multiplier": 0,
-        "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ]
+        "pack_size": [ 1, 3 ],
+        "conditions": [ "DAWN", "DUSK", "DAY" ]
       },
+      { "monster": "mon_turkey", "weight": 6, "cost_multiplier": 2, "pack_size": [ 1, 18 ] },
+      { "monster": "mon_turkey", "weight": 9, "cost_multiplier": 2, "pack_size": [ 1, 18 ], "conditions": [ "DAY" ] },
+      {
+        "monster": "mon_duck",
+        "weight": 4,
+        "cost_multiplier": 5,
+        "pack_size": [ 1, 4 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_duck",
+        "weight": 6,
+        "cost_multiplier": 5,
+        "pack_size": [ 1, 4 ],
+        "conditions": [ "DAWN", "DAY", "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_goose_canadian",
+        "weight": 4,
+        "cost_multiplier": 5,
+        "pack_size": [ 1, 4 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_goose_canadian",
+        "weight": 6,
+        "cost_multiplier": 5,
+        "pack_size": [ 1, 4 ],
+        "conditions": [ "DAWN", "DAY", "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_hummingbird",
+        "weight": 5,
+        "cost_multiplier": 0,
+        "pack_size": [ 1, 3 ],
+        "conditions": [ "DAWN", "DUSK", "DAY" ]
+      },
+      {
+        "monster": "mon_woodpecker",
+        "weight": 5,
+        "cost_multiplier": 0,
+        "pack_size": [ 1, 3 ],
+        "conditions": [ "DAWN", "DUSK", "DAY" ]
+      }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FOREST_INSECT",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_bee_small", "weight": 3, "cost_multiplier": 0, "conditions": [ "DAY", "SPRING", "SUMMER", "AUTUMN" ] },
       {
         "monster": "mon_bee_small",
         "weight": 2,
@@ -1756,123 +1819,26 @@
         "ends": "30 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
-      {
-        "monster": "mon_wasp",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "starts": "30 days",
-        "ends": "60 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_wasp",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 2 ],
-        "starts": "60 days",
-        "ends": "90 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_wasp",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 3 ],
-        "starts": "90 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_worm_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_worm_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "7 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_worm_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "14 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_worm_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "21 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_worm_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "28 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      { "monster": "mon_nakedmolerat_giant", "weight": 1, "cost_multiplier": 3, "conditions": [ "DUSK", "NIGHT" ] },
-      { "monster": "mon_mutant_experimental", "weight": 3, "cost_multiplier": 0, "conditions": [ "DUSK", "NIGHT" ] },
       { "monster": "mon_mantis_small", "weight": 8, "cost_multiplier": 10 },
       { "monster": "mon_lady_bug", "weight": 5, "cost_multiplier": 10 },
-      { "monster": "mon_lady_bug_giant", "weight": 5, "cost_multiplier": 10, "starts": "15 days" },
       { "monster": "mon_aphid", "weight": 15, "pack_size": [ 1, 5 ], "cost_multiplier": 0 },
       { "monster": "mon_grasshopper_small", "weight": 15, "pack_size": [ 1, 3 ], "cost_multiplier": 0 },
       { "monster": "mon_antlion_larva", "weight": 7, "cost_multiplier": 10 },
-      { "monster": "mon_antlion_giant", "weight": 2, "cost_multiplier": 10 },
       { "monster": "mon_stag_beetle_small", "freq": 2, "cost_multiplier": 0, "starts": 168, "ends": 720 },
       { "monster": "mon_stag_beetle_small", "freq": 2, "cost_multiplier": 0, "starts": 168 },
-      { "monster": "mon_stag_beetle_giant", "freq": 1, "cost_multiplier": 0, "starts": 720 },
       { "monster": "mon_caterpillar_butterfly", "weight": 3, "cost_multiplier": 0 },
       { "monster": "mon_caterpillar_moth", "weight": 3, "cost_multiplier": 0 },
       { "monster": "mon_woodlouse", "weight": 3, "cost_multiplier": 0 },
       { "monster": "mon_butterfly", "weight": 2, "cost_multiplier": 0 },
       { "monster": "mon_moth", "weight": 2, "cost_multiplier": 0, "conditions": [ "DAWN", "DUSK" ] },
-      { "monster": "mon_butterfly_giant", "weight": 1, "cost_multiplier": 3, "starts": "240 hours" },
-      { "monster": "mon_butterfly_titan", "weight": 1, "cost_multiplier": 3, "starts": "480 hours" },
-      {
-        "monster": "mon_moth_giant",
-        "weight": 1,
-        "cost_multiplier": 3,
-        "conditions": [ "DAWN", "DUSK" ],
-        "starts": "240 hours"
-      },
-      {
-        "monster": "mon_moth_titan",
-        "weight": 1,
-        "cost_multiplier": 3,
-        "conditions": [ "DAWN", "DUSK" ],
-        "starts": "480 hours"
-      },
-      { "monster": "mon_cicada", "weight": 1, "cost_multiplier": 3, "starts": "240 hours" },
-      { "monster": "mon_toad", "weight": 5, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
-      {
-        "monster": "mon_hummingbird",
-        "weight": 5,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK", "DAY" ]
-      },
-      {
-        "monster": "mon_woodpecker",
-        "weight": 5,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "DAWN", "DUSK", "DAY" ]
-      }
+      { "monster": "mon_cicada", "weight": 1, "cost_multiplier": 3, "starts": "240 hours" }
     ]
   },
   {
     "type": "monstergroup",
     "name": "GROUP_RIVER",
     "default": "mon_null",
-    "//": "Current SPRING first DAY count is 944.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
-    "//2": "DDA weight in this group is somewhere around 803.  Leaving roughly 190 frequency points left for mods.",
     "monsters": [
       { "monster": "mon_beaver", "weight": 8, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
       {
@@ -2256,7 +2222,6 @@
     "type": "monstergroup",
     "name": "GROUP_SWAMP",
     "default": "mon_null",
-    "//": "Current SPRING first DAY count is 417.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
     "monsters": [
       {
@@ -2921,7 +2886,6 @@
   {
     "type": "monstergroup",
     "name": "GROUP_PARK_ANIMAL",
-    "//": "Current SPRING first DAY count is 425.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_null", "weight": 330, "cost_multiplier": 0 },
@@ -2966,7 +2930,6 @@
   {
     "type": "monstergroup",
     "name": "GROUP_ROOF_ANIMAL",
-    "//": "Current SPRING first DAY count is 350.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_null", "weight": 490, "cost_multiplier": 0 },
@@ -3022,7 +2985,6 @@
   {
     "type": "monstergroup",
     "name": "GROUP_POND_ANIMAL",
-    "//": "Current count is 150.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_null", "weight": 850, "cost_multiplier": 0 },
@@ -3036,7 +2998,6 @@
   {
     "type": "monstergroup",
     "name": "GROUP_POND_BIRD",
-    "//": "Current count is 100.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_null", "weight": 900, "cost_multiplier": 0 },
@@ -3053,7 +3014,6 @@
   {
     "type": "monstergroup",
     "name": "GROUP_POND_FISH",
-    "//": "Current count is 150.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_null", "weight": 820, "cost_multiplier": 0 },
@@ -3067,7 +3027,6 @@
   {
     "type": "monstergroup",
     "name": "GROUP_BIRDFEEDER",
-    "//": "Current count is 225.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "is_animal": true,
     "monsters": [
       { "monster": "mon_null", "weight": 775, "cost_multiplier": 0 },

--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -344,7 +344,7 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       { "monster": "mon_frog", "weight": 5, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
-      { "monster": "mon_zhark", "weight": 1, "cost_multiplier": 25, "starts": "1 days", "pack_size": [ 1, 3 ] },
+      { "monster": "mon_zhark", "weight": 1, "cost_multiplier": 25, "starts": "3 days", "pack_size": [ 1, 3 ] },
       { "monster": "mon_zhark", "weight": 2, "cost_multiplier": 25, "starts": "28 days", "pack_size": [ 1, 3 ] },
       { "monster": "mon_feral_diver_knife", "weight": 1, "cost_multiplier": 10, "starts": "1 days" },
       { "monster": "mon_mutant_carp", "weight": 3, "cost_multiplier": 15, "starts": "7 days" },
@@ -396,8 +396,8 @@
       { "monster": "mon_cormorant", "weight": 15, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
       { "monster": "mon_grebe", "weight": 15, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
       { "monster": "mon_toad", "weight": 5, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
-      { "monster": "mon_diving_larva", "weight": 10, "cost_multiplier": 2, "ends": "7 days" },
-      { "monster": "mon_diving_larva", "weight": 30, "cost_multiplier": 3, "starts": "7 days", "pack_size": [ 1, 3 ] },
+      { "monster": "mon_diving_larva", "weight": 10, "cost_multiplier": 2, "starts": "3 days" },
+      { "monster": "mon_diving_larva", "weight": 20, "cost_multiplier": 3, "starts": "7 days", "pack_size": [ 1, 3 ] },
       { "monster": "mon_water_scorpion_larva", "weight": 10, "cost_multiplier": 2, "ends": "7 days" },
       {
         "monster": "mon_water_scorpion_larva",
@@ -417,202 +417,64 @@
     "is_animal": true,
     "monsters": [
       {
+        "group": "GROUP_WILDERNESS_SWAMP_INSECT",
+        "weight": 100,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "3 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_SWAMP_INSECT",
+        "weight": 100,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "7 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_SWAMP_INSECT",
+        "weight": 100,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "28 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_SWAMP_INSECT",
+        "weight": 100,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "90 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_INSECT",
+        "weight": 50,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "3 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_INSECT",
+        "weight": 50,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "7 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_INSECT",
+        "weight": 50,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "28 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_INSECT",
+        "weight": 50,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "90 days"
+      },
+      {
         "monster": "mon_lemming",
         "weight": 50,
         "pack_size": [ 2, 7 ],
-        "ends": "15 days",
+        "ends": "90 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
-      {
-        "monster": "mon_firefly",
-        "weight": 30,
-        "pack_size": [ 1, 4 ],
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_mosquito_small",
-        "weight": 50,
-        "pack_size": [ 1, 3 ],
-        "ends": "42 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_mosquito_small",
-        "weight": 60,
-        "pack_size": [ 1, 5 ],
-        "starts": "42 hours",
-        "ends": "84 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_mosquito_small",
-        "weight": 70,
-        "pack_size": [ 2, 6 ],
-        "starts": "84 hours",
-        "ends": "180 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_dragonfly_giant",
-        "weight": 35,
-        "cost_multiplier": 2,
-        "ends": "42 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_dragonfly_giant",
-        "weight": 45,
-        "cost_multiplier": 2,
-        "starts": "42 hours",
-        "ends": "84 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_dragonfly_giant",
-        "weight": 45,
-        "cost_multiplier": 2,
-        "starts": "84 hours",
-        "ends": "180 hours",
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_dragonfly_giant",
-        "weight": 55,
-        "pack_size": [ 2, 5 ],
-        "cost_multiplier": 2,
-        "starts": "180 hours",
-        "ends": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_dragonfly_giant",
-        "weight": 55,
-        "pack_size": [ 4, 7 ],
-        "cost_multiplier": 2,
-        "starts": "15 days",
-        "ends": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_dragonfly_giant",
-        "weight": 65,
-        "pack_size": [ 4, 7 ],
-        "cost_multiplier": 2,
-        "starts": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_fly_small",
-        "weight": 100,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "//": "No scaling, since they don't (yet) add challenge"
-      },
-      {
-        "monster": "mon_centipede_small",
-        "weight": 40,
-        "cost_multiplier": 2,
-        "ends": "42 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_centipede_small",
-        "weight": 50,
-        "cost_multiplier": 2,
-        "starts": "42 hours",
-        "ends": "84 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_centipede_small",
-        "weight": 50,
-        "pack_size": [ 1, 3 ],
-        "cost_multiplier": 2,
-        "starts": "84 hours",
-        "ends": "180 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_centipede_small",
-        "weight": 60,
-        "cost_multiplier": 2,
-        "pack_size": [ 2, 3 ],
-        "starts": "180 hours",
-        "ends": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 20,
-        "cost_multiplier": 2,
-        "ends": "42 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 3 ],
-        "starts": "42 hours",
-        "ends": "84 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 3 ],
-        "starts": "84 hours",
-        "ends": "180 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_jumping_small",
-        "weight": 35,
-        "cost_multiplier": 2,
-        "pack_size": [ 2, 3 ],
-        "starts": "180 hours",
-        "ends": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 20,
-        "cost_multiplier": 2,
-        "ends": "42 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 3 ],
-        "starts": "42 hours",
-        "ends": "84 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 30,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 3 ],
-        "starts": "84 hours",
-        "ends": "180 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_spider_wolf_small",
-        "weight": 35,
-        "cost_multiplier": 2,
-        "pack_size": [ 2, 3 ],
-        "starts": "180 hours",
-        "ends": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      { "monster": "mon_zpider_mass", "weight": 5, "cost_multiplier": 2, "starts": "42 hours", "ends": "84 hours" },
-      { "monster": "mon_zpider_mass", "weight": 10, "cost_multiplier": 2, "starts": "84 hours", "ends": "180 hours" },
-      { "monster": "mon_zpider_mass", "weight": 20, "cost_multiplier": 2, "starts": "180 hours", "ends": "15 days" },
-      { "monster": "mon_zpider_mass", "weight": 25, "cost_multiplier": 2, "starts": "15 days", "ends": "540 hours" },
+      { "monster": "mon_zpider_mass", "weight": 5, "cost_multiplier": 2, "starts": "3 days" },
+      { "monster": "mon_zpider_mass", "weight": 10, "cost_multiplier": 2, "starts": "7 days" },
+      { "monster": "mon_zpider_mass", "weight": 20, "cost_multiplier": 2, "starts": "28 days" },
+      { "monster": "mon_zpider_mass", "weight": 25, "cost_multiplier": 2, "starts": "90 days" },
       {
         "monster": "mon_zpider_mass",
         "weight": 25,
@@ -621,128 +483,33 @@
         "starts": "540 hours"
       },
       {
-        "monster": "mon_wasp_small",
-        "weight": 20,
-        "cost_multiplier": 2,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "42 hours"
-      },
-      {
-        "monster": "mon_wasp_small",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "starts": "42 hours",
-        "ends": "84 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_wasp_small",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 2 ],
-        "starts": "14 days",
-        "ends": "30 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_dermatik",
-        "weight": 40,
-        "cost_multiplier": 2,
-        "starts": "15 days",
-        "ends": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_dermatik",
-        "weight": 50,
-        "cost_multiplier": 2,
-        "starts": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
         "monster": "mon_slug_forest",
         "weight": 15,
         "cost_multiplier": 2,
-        "ends": "42 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_slug_forest",
-        "weight": 20,
-        "cost_multiplier": 2,
-        "starts": "42 hours",
-        "ends": "84 hours",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
         "monster": "mon_snail_forest",
         "weight": 15,
         "cost_multiplier": 2,
-        "ends": "42 hours",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
-      {
-        "monster": "mon_snail_forest",
-        "weight": 20,
-        "cost_multiplier": 2,
-        "starts": "42 hours",
-        "ends": "84 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_frog",
-        "freq": 30,
-        "cost_multiplier": 2,
-        "ends": 24,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_frog",
-        "freq": 35,
-        "cost_multiplier": 2,
-        "starts": 24,
-        "ends": 95,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_frog",
-        "freq": 40,
-        "cost_multiplier": 2,
-        "starts": 95,
-        "ends": 180,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_crayfish_small",
-        "weight": 10,
-        "ends": "42 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_crayfish_small",
-        "weight": 15,
-        "starts": "42 hours",
-        "ends": "84 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_crayfish_small",
-        "weight": 20,
-        "starts": "84 hours",
-        "ends": "180 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_crayfish_small",
-        "weight": 30,
-        "starts": "180 hours",
-        "ends": "15 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      { "monster": "mon_mutant_experimental", "weight": 1, "cost_multiplier": 6 },
-      { "monster": "mon_mantis_small", "weight": 2, "cost_multiplier": 8 },
-      { "monster": "mon_antlion_giant", "weight": 4, "cost_multiplier": 10 },
+      { "monster": "mon_frog", "freq": 30, "cost_multiplier": 2, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
       { "monster": "mon_toad", "weight": 50, "cost_multiplier": 2, "pack_size": [ 1, 3 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_SWAMP_INSECT",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_firefly", "weight": 30, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_mosquito_small", "weight": 50, "pack_size": [ 1, 6 ] },
+      { "monster": "mon_dragonfly_giant", "weight": 35, "cost_multiplier": 2, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_centipede_small", "weight": 40, "cost_multiplier": 2 },
+      { "monster": "mon_dermatik", "weight": 40, "cost_multiplier": 2 },
+      { "monster": "mon_crayfish_small", "weight": 10 }
     ]
   },
   {

--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -52,6 +52,30 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
         "starts": "90 days"
       },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_ZOMBIE",
+        "weight": 50,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "3 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_ZOMBIE",
+        "weight": 50,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "7 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_ZOMBIE",
+        "weight": 50,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "28 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_ZOMBIE",
+        "weight": 50,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "90 days"
+      },
       { "monster": "mon_frog", "weight": 3, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
       { "monster": "mon_toad", "weight": 3, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
       {
@@ -59,39 +83,7 @@
         "weight": 3,
         "cost_multiplier": 5,
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_worm_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "3 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_worm_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "7 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_worm_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "28 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_worm_small",
-        "weight": 1,
-        "cost_multiplier": 0,
-        "starts": "90 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10, "starts": "3 days" },
-      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10, "starts": "7 days" },
-      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10, "starts": "28 days" },
-      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10, "starts": "90 days" }
+      }
     ]
   },
   {
@@ -136,10 +128,6 @@
         "ends": "90 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
-      { "monster": "mon_zombear", "weight": 1, "cost_multiplier": 10, "starts": "3 days" },
-      { "monster": "mon_zombear", "weight": 2, "cost_multiplier": 10, "starts": "7 days" },
-      { "monster": "mon_zombear", "weight": 3, "cost_multiplier": 10, "starts": "28 days" },
-      { "monster": "mon_zombear", "weight": 4, "cost_multiplier": 10, "starts": "90 days" },
       { "monster": "mon_bobcat", "weight": 7, "cost_multiplier": 2 },
       { "monster": "mon_boar_wild", "weight": 2, "cost_multiplier": 2, "pack_size": [ 1, 4 ] },
       { "group": "GROUP_STRAY_CATS", "weight": 10 },
@@ -156,28 +144,12 @@
       { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "7 days" },
       { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "28 days" },
       { "monster": "mon_cougar", "weight": 1, "cost_multiplier": 3, "ends": "90 days" },
-      { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "3 days" },
-      { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "7 days" },
-      { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "28 days" },
-      { "monster": "mon_zougar", "weight": 3, "cost_multiplier": 10, "starts": "90 days" },
       { "monster": "mon_deer", "weight": 4, "cost_multiplier": 2, "pack_size": [ 1, 5 ] },
-      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ], "starts": "3 days" },
-      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ], "starts": "7 days" },
-      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ], "starts": "28 days" },
-      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ], "starts": "90 days" },
       {
         "monster": "mon_reindeer",
         "weight": 3,
         "cost_multiplier": 3,
         "pack_size": [ 2, 6 ],
-        "conditions": [ "AUTUMN", "WINTER" ]
-      },
-      {
-        "monster": "mon_zeindeer",
-        "weight": 1,
-        "cost_multiplier": 15,
-        "pack_size": [ 2, 5 ],
-        "starts": "3 days",
         "conditions": [ "AUTUMN", "WINTER" ]
       },
       { "group": "GROUP_STRAY_DOGS", "weight": 6, "cost_multiplier": 25, "pack_size": [ 1, 6 ] },
@@ -206,25 +178,12 @@
       { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "ends": "7 days", "pack_size": [ 1, 8 ] },
       { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "ends": "28 days", "pack_size": [ 1, 8 ] },
       { "monster": "mon_coyote_wolf", "weight": 1, "cost_multiplier": 2, "ends": "90 days", "pack_size": [ 1, 8 ] },
-      { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "3 days" },
-      { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "7 days" },
-      { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "28 days" },
-      { "monster": "mon_zombie_dog", "weight": 4, "cost_multiplier": 2, "starts": "90 days" },
-      { "monster": "mon_zolf", "weight": 2, "cost_multiplier": 2, "starts": "3 days", "pack_size": [ 1, 4 ] },
-      { "monster": "mon_zolf", "weight": 2, "cost_multiplier": 2, "starts": "7 days", "pack_size": [ 1, 4 ] },
-      { "monster": "mon_zolf", "weight": 2, "cost_multiplier": 2, "starts": "28 days", "pack_size": [ 1, 4 ] },
-      { "monster": "mon_zolf", "weight": 2, "cost_multiplier": 2, "starts": "90 days", "pack_size": [ 1, 4 ] },
       { "monster": "mon_horse", "weight": 2, "cost_multiplier": 15, "pack_size": [ 1, 4 ], "ends": "3 days" },
-      { "monster": "mon_zombie_horse", "weight": 2, "cost_multiplier": 15, "pack_size": [ 1, 4 ], "starts": "3 days" },
       { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3 },
       { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "3 days" },
       { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "7 days" },
       { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "28 days" },
       { "monster": "mon_moose", "weight": 1, "cost_multiplier": 3, "ends": "90 days" },
-      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10, "starts": "3 days" },
-      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10, "starts": "7 days" },
-      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10, "starts": "28 days" },
-      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10, "starts": "90 days" },
       {
         "monster": "mon_groundhog",
         "weight": 30,
@@ -315,7 +274,31 @@
       { "monster": "mon_woodlouse", "weight": 3, "cost_multiplier": 3 },
       { "monster": "mon_butterfly", "weight": 2, "cost_multiplier": 3 },
       { "monster": "mon_moth", "weight": 2, "cost_multiplier": 3 },
-      { "monster": "mon_cicada", "weight": 1, "cost_multiplier": 3 }
+      { "monster": "mon_cicada", "weight": 1, "cost_multiplier": 3 },
+      { "monster": "mon_worm_small", "weight": 1, "cost_multiplier": 0 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FOREST_ZOMBIE",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 10, "pack_size": [ 1, 5 ] },
+      { "monster": "mon_zougar", "weight": 2, "cost_multiplier": 10 },
+      { "monster": "mon_zolf", "weight": 2, "cost_multiplier": 2, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_zombear", "weight": 1, "cost_multiplier": 10 },
+      {
+        "monster": "mon_zeindeer",
+        "weight": 1,
+        "cost_multiplier": 15,
+        "pack_size": [ 2, 5 ],
+        "conditions": [ "AUTUMN", "WINTER" ]
+      },
+      { "monster": "mon_zombie_dog", "weight": 1, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_horse", "weight": 1, "cost_multiplier": 15, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10 },
+      { "monster": "mon_zpider_mass", "weight": 1, "cost_multiplier": 10 }
     ]
   },
   {

--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -260,11 +260,9 @@
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
-      { "monster": "mon_bee_small", "weight": 3, "cost_multiplier": 0 },
       { "monster": "mon_fly_small", "weight": 2, "cost_multiplier": 0 },
       { "monster": "mon_spider_jumping_small", "weight": 1, "cost_multiplier": 0 },
       { "monster": "mon_spider_wolf_small", "weight": 1, "cost_multiplier": 0 },
-      { "monster": "mon_wasp_small", "weight": 20, "cost_multiplier": 2 },
       { "monster": "mon_mantis_small", "weight": 2, "cost_multiplier": 10 },
       { "monster": "mon_lady_bug", "weight": 5, "cost_multiplier": 10 },
       { "monster": "mon_aphid", "weight": 3, "pack_size": [ 1, 5 ], "cost_multiplier": 0 },
@@ -347,8 +345,6 @@
       { "monster": "mon_zhark", "weight": 1, "cost_multiplier": 25, "starts": "3 days", "pack_size": [ 1, 3 ] },
       { "monster": "mon_zhark", "weight": 2, "cost_multiplier": 25, "starts": "28 days", "pack_size": [ 1, 3 ] },
       { "monster": "mon_feral_diver_knife", "weight": 1, "cost_multiplier": 10, "starts": "1 days" },
-      { "monster": "mon_mutant_carp", "weight": 3, "cost_multiplier": 15, "starts": "7 days" },
-      { "monster": "mon_mutant_salmon", "weight": 2, "cost_multiplier": 15, "starts": "7 days" },
       { "monster": "mon_fish_eel", "weight": 6, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
       { "monster": "mon_fish_bowfin", "weight": 6, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
       { "monster": "mon_fish_bullhead", "weight": 6, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
@@ -441,46 +437,11 @@
         "starts": "90 days"
       },
       {
-        "group": "GROUP_WILDERNESS_FOREST_INSECT",
-        "weight": 50,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "starts": "3 days"
-      },
-      {
-        "group": "GROUP_WILDERNESS_FOREST_INSECT",
-        "weight": 50,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "starts": "7 days"
-      },
-      {
-        "group": "GROUP_WILDERNESS_FOREST_INSECT",
-        "weight": 50,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "starts": "28 days"
-      },
-      {
-        "group": "GROUP_WILDERNESS_FOREST_INSECT",
-        "weight": 50,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "starts": "90 days"
-      },
-      {
         "monster": "mon_lemming",
         "weight": 50,
         "pack_size": [ 2, 7 ],
         "ends": "90 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      { "monster": "mon_zpider_mass", "weight": 5, "cost_multiplier": 2, "starts": "3 days" },
-      { "monster": "mon_zpider_mass", "weight": 10, "cost_multiplier": 2, "starts": "7 days" },
-      { "monster": "mon_zpider_mass", "weight": 20, "cost_multiplier": 2, "starts": "28 days" },
-      { "monster": "mon_zpider_mass", "weight": 25, "cost_multiplier": 2, "starts": "90 days" },
-      {
-        "monster": "mon_zpider_mass",
-        "weight": 25,
-        "cost_multiplier": 2,
-        "pack_size": [ 1, 3 ],
-        "starts": "540 hours"
       },
       {
         "monster": "mon_slug_forest",
@@ -519,13 +480,7 @@
     "monsters": [
       { "monster": "mon_crow", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_raven", "weight": 45, "cost_multiplier": 0 },
-      {
-        "monster": "mon_pigeon",
-        "weight": 50,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 3 ],
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
+      { "monster": "mon_pigeon", "weight": 50, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
       { "monster": "mon_pigeon", "weight": 15, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
       { "monster": "mon_bluejay", "weight": 25, "cost_multiplier": 0 },
       { "monster": "mon_cardinal", "weight": 25, "cost_multiplier": 0 },
@@ -555,20 +510,7 @@
       { "monster": "mon_raven", "weight": 45, "cost_multiplier": 0 },
       { "monster": "mon_robin", "weight": 25, "cost_multiplier": 0 },
       { "monster": "mon_sparrow", "weight": 25, "cost_multiplier": 0 },
-      {
-        "monster": "mon_pigeon",
-        "weight": 40,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 7 ],
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_pigeon",
-        "weight": 15,
-        "cost_multiplier": 0,
-        "pack_size": [ 1, 7 ],
-        "conditions": [ "WINTER" ]
-      },
+      { "monster": "mon_pigeon", "weight": 40, "cost_multiplier": 0, "pack_size": [ 1, 7 ] },
       { "group": "GROUP_STRAY_CATS", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_chipmunk", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_squirrel", "weight": 50, "cost_multiplier": 0 },

--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -411,7 +411,6 @@
       { "monster": "mon_crow", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_raven", "weight": 45, "cost_multiplier": 0 },
       { "monster": "mon_pigeon", "weight": 50, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
-      { "monster": "mon_pigeon", "weight": 15, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
       { "monster": "mon_bluejay", "weight": 25, "cost_multiplier": 0 },
       { "monster": "mon_cardinal", "weight": 25, "cost_multiplier": 0 },
       { "monster": "mon_robin", "weight": 35, "cost_multiplier": 0 },


### PR DESCRIPTION
#### Summary
Balance "wilderness spawn rework"

#### Purpose of change

Make it simpler to balance and manage wilderness spawns

#### Describe the solution

Creates new spawn groups for the enormous FOREST monster spawn group and manages them so that insect and zombie spawns increase over time. 
Same for smaller SWAMP group
Removes a bunch of comment lines I added to document the old confusing spawn system that doesn't exist anymore
Removes "mon_null" spawns
Changes all "freq" to "weight"
Manages insect and zombie evolution and insect seasons and mammal decline with the groups
Removes lines dedicated to micromanaging spawns based on time of day, which is either entirely or mostly broken.
Uses existing cat and dog groups to manage cat and dog spawns instead of duplicating them here. 
Standardizes times to 3 days, 7 days, 28 days, and 90 days to make management possible.
Standardizes insect spawns to be consistent.
Assigns insects to either be on forest or swamp, not both
Real world colony insects like wasps, bees, and ants don't spawn randomly alone
Removes duplicate lines of monsters at different stages of mutation since that is now duplicative with the newish mutation system.
Day 1 forest spawns are now only living unmutated animals and harmless mutant insects. That becomes much less true over time.

#### Describe alternatives you've considered

Doing less

#### Testing

Game loads no errors, monsters spawn as intended

#### Additional context

Overdue review after the spawn group rework