### PR TITLE
Convert EOC to use doubles instead of ints

### DIFF
--- a/data/json/addictions_eocs.json
+++ b/data/json/addictions_eocs.json
@@ -3,7 +3,7 @@
     "type": "effect_on_condition",
     "id": "EOC_CAFFEINE_ADDICTION",
     "condition": {
-      "compare_int": [
+      "compare_num": [
         { "rand": 2000 },
         "<=",
         { "u_val": "addiction_intensity", "addiction": "caffeine", "mod": { "val": 2000, "step": 20 } }
@@ -18,9 +18,9 @@
             "id": "EOC_CAFFEINE_ADDICTION_MODSTIM",
             "condition": {
               "and": [
-                { "compare_int": [ { "u_val": "stim" }, ">", { "u_val": "addiction_intensity", "addiction": "caffeine", "mod": -10 } ] },
+                { "compare_num": [ { "u_val": "stim" }, ">", { "u_val": "addiction_intensity", "addiction": "caffeine", "mod": -10 } ] },
                 {
-                  "compare_int": [ { "rand": 10 }, "<", { "u_val": "addiction_intensity", "addiction": "caffeine" } ]
+                  "compare_num": [ { "rand": 10 }, "<", { "u_val": "addiction_intensity", "addiction": "caffeine" } ]
                 }
               ]
             },
@@ -30,9 +30,9 @@
             "id": "EOC_CAFFEINE_ADDICTION_SHAKES",
             "condition": {
               "and": [
-                { "compare_int": [ { "u_val": "addiction_intensity", "addiction": "caffeine" }, ">=", { "const": 8 } ] },
+                { "compare_num": [ { "u_val": "addiction_intensity", "addiction": "caffeine" }, ">=", { "const": 8 } ] },
                 {
-                  "compare_int": [ { "rand": 392 }, "<", { "u_val": "addiction_intensity", "addiction": "caffeine" } ]
+                  "compare_num": [ { "rand": 392 }, "<", { "u_val": "addiction_intensity", "addiction": "caffeine" } ]
                 }
               ]
             },
@@ -51,8 +51,8 @@
     "//": "Actual effects processed in player::can_sleep().  Here, only prolong this addiction longer than usual.",
     "condition": {
       "and": [
-        { "compare_int": [ { "rand": 2 }, "==", { "const": 1 } ] },
-        { "compare_int": [ { "u_val": "addiction_turns", "addiction": "sleeping pill" }, "<", { "const": 0 } ] }
+        { "compare_num": [ { "rand": 2 }, "==", { "const": 1 } ] },
+        { "compare_num": [ { "u_val": "addiction_turns", "addiction": "sleeping pill" }, "<", { "const": 0 } ] }
       ]
     },
     "effect": { "arithmetic": [ { "u_val": "addiction_turns", "addiction": "sleeping pill" }, "+=", { "const": 1 } ] }
@@ -61,7 +61,7 @@
     "type": "effect_on_condition",
     "id": "EOC_MARLOSS_R_ADDICTION",
     "condition": {
-      "compare_int": [
+      "compare_num": [
         { "rand": 800 },
         "<=",
         { "u_val": "addiction_intensity", "addiction": "marloss_r", "mod": { "val": 800, "step": 20 } }
@@ -74,7 +74,7 @@
         "run_eocs": [
           {
             "id": "EOC_MARLOSS_R_ADDICTION_MODFOCUS",
-            "condition": { "compare_int": [ { "u_val": "focus" }, ">", { "const": 40 } ] },
+            "condition": { "compare_num": [ { "u_val": "focus" }, ">", { "const": 40 } ] },
             "effect": { "arithmetic": [ { "u_val": "focus" }, "-=", { "const": 1 } ] }
           }
         ]
@@ -85,7 +85,7 @@
     "type": "effect_on_condition",
     "id": "EOC_MARLOSS_B_ADDICTION",
     "condition": {
-      "compare_int": [
+      "compare_num": [
         { "rand": 800 },
         "<=",
         { "u_val": "addiction_intensity", "addiction": "marloss_b", "mod": { "val": 800, "step": 20 } }
@@ -98,7 +98,7 @@
         "run_eocs": [
           {
             "id": "EOC_MARLOSS_B_ADDICTION_MODFOCUS",
-            "condition": { "compare_int": [ { "u_val": "focus" }, ">", { "const": 40 } ] },
+            "condition": { "compare_num": [ { "u_val": "focus" }, ">", { "const": 40 } ] },
             "effect": { "arithmetic": [ { "u_val": "focus" }, "-=", { "const": 1 } ] }
           }
         ]
@@ -109,7 +109,7 @@
     "type": "effect_on_condition",
     "id": "EOC_MARLOSS_Y_ADDICTION",
     "condition": {
-      "compare_int": [
+      "compare_num": [
         { "rand": 800 },
         "<=",
         { "u_val": "addiction_intensity", "addiction": "marloss_y", "mod": { "val": 800, "step": 20 } }
@@ -122,7 +122,7 @@
         "run_eocs": [
           {
             "id": "EOC_MARLOSS_Y_ADDICTION_MODFOCUS",
-            "condition": { "compare_int": [ { "u_val": "focus" }, ">", { "const": 40 } ] },
+            "condition": { "compare_num": [ { "u_val": "focus" }, ">", { "const": 40 } ] },
             "effect": { "arithmetic": [ { "u_val": "focus" }, "-=", { "const": 1 } ] }
           }
         ]
@@ -139,14 +139,14 @@
           {
             "id": "EOC_MUTAGEN_ADDICTION_JUNKIE_MORALE",
             "condition": {
-              "compare_int": [ { "rand": 600 }, "<=", { "u_val": "addiction_intensity", "addiction": "mutagen", "mod": { "val": 600, "step": 50 } } ]
+              "compare_num": [ { "rand": 600 }, "<=", { "u_val": "addiction_intensity", "addiction": "mutagen", "mod": { "val": 600, "step": 50 } } ]
             },
             "effect": [
               {
                 "run_eocs": [
                   {
                     "id": "EOC_MUTAGEN_ADDICTION_JUNKIE_MORALE_MSG",
-                    "condition": { "compare_int": [ { "rand": 6 }, "<", { "u_val": "addiction_intensity", "addiction": "mutagen" } ] },
+                    "condition": { "compare_num": [ { "rand": 6 }, "<", { "u_val": "addiction_intensity", "addiction": "mutagen" } ] },
                     "effect": { "u_message": "You so miss the exquisite rainbow of post-humanity.", "type": "warning" },
                     "false_effect": { "u_message": "Your body is SOO booorrrring.  Just a little sip to liven things up?", "type": "warning" }
                   }
@@ -159,9 +159,9 @@
             "id": "EOC_MUTAGEN_ADDICTION_JUNKIE_FOCUS",
             "condition": {
               "and": [
-                { "compare_int": [ { "u_val": "focus" }, ">", { "const": 40 } ] },
+                { "compare_num": [ { "u_val": "focus" }, ">", { "const": 40 } ] },
                 {
-                  "compare_int": [ { "rand": 800 }, "<=", { "u_val": "addiction_intensity", "addiction": "mutagen", "mod": { "val": 800, "step": 20 } } ]
+                  "compare_num": [ { "rand": 800 }, "<=", { "u_val": "addiction_intensity", "addiction": "mutagen", "mod": { "val": 800, "step": 20 } } ]
                 }
               ]
             },
@@ -181,14 +181,14 @@
         {
           "id": "EOC_MUTAGEN_ADDICTION_NOJUNKIE",
           "condition": {
-            "compare_int": [ { "rand": 500 }, "<=", { "u_val": "addiction_intensity", "addiction": "mutagen", "mod": { "val": 500, "step": 15 } } ]
+            "compare_num": [ { "rand": 500 }, "<=", { "u_val": "addiction_intensity", "addiction": "mutagen", "mod": { "val": 500, "step": 15 } } ]
           },
           "effect": [
             {
               "run_eocs": [
                 {
                   "id": "EOC_MUTAGEN_ADDICTION_NOJUNKIE_MSG",
-                  "condition": { "compare_int": [ { "rand": 6 }, "<", { "u_val": "addiction_intensity", "addiction": "mutagen" } ] },
+                  "condition": { "compare_num": [ { "rand": 6 }, "<", { "u_val": "addiction_intensity", "addiction": "mutagen" } ] },
                   "effect": { "u_message": "You haven't had any mutagen lately.", "type": "warning" },
                   "false_effect": { "u_message": "You could use some new parts…", "type": "warning" }
                 }

--- a/data/json/effect_on_condition.json
+++ b/data/json/effect_on_condition.json
@@ -98,7 +98,7 @@
       "and": [
         { "or": [ { "is_weather": "thunder" }, { "is_weather": "lightning" } ] },
         { "one_in_chance": 50 },
-        { "compare_int": [ { "u_val": "pos_z" }, ">=", { "const": 0 } ] }
+        { "compare_num": [ { "u_val": "pos_z" }, ">=", { "const": 0 } ] }
       ]
     },
     "deactivate_condition": { "not": { "or": [ { "is_weather": "thunder" }, { "is_weather": "lightning" } ] } },
@@ -116,7 +116,7 @@
       "and": [
         { "is_weather": "lightning" },
         { "one_in_chance": 600 },
-        { "compare_int": [ { "u_val": "pos_z" }, ">=", { "const": 0 } ] }
+        { "compare_num": [ { "u_val": "pos_z" }, ">=", { "const": 0 } ] }
       ]
     },
     "deactivate_condition": { "not": { "is_weather": "lightning" } },
@@ -134,7 +134,7 @@
     "global": true,
     "run_for_npcs": true,
     "condition": {
-      "and": [ { "is_weather": "acid_drizzle" }, "u_is_outside", { "compare_int": [ { "u_val": "pain" }, "<", { "const": 30 } ] } ]
+      "and": [ { "is_weather": "acid_drizzle" }, "u_is_outside", { "compare_num": [ { "u_val": "pain" }, "<", { "const": 30 } ] } ]
     },
     "deactivate_condition": { "not": { "is_weather": "acid_drizzle" } },
     "effect": [
@@ -152,7 +152,7 @@
       "and": [
         { "is_weather": "acid_rain" },
         "u_is_outside",
-        { "compare_int": [ { "u_val": "pain" }, "<", { "const": 100 } ] },
+        { "compare_num": [ { "u_val": "pain" }, "<", { "const": 100 } ] },
         {
           "not": { "or": [ { "u_has_wielded_with_flag": "RAIN_PROTECT" }, { "u_has_worn_with_flag": "RAINPROOF" } ] }
         }
@@ -185,7 +185,7 @@
     "type": "effect_on_condition",
     "id": "bio_drain",
     "recurrence": [ "30 minutes", "1 hours 30 minutes" ],
-    "condition": { "and": [ { "u_has_bionics": "bio_drain" }, { "compare_int": [ { "u_val": "power" }, ">=", { "power": "25 kJ" } ] } ] },
+    "condition": { "and": [ { "u_has_bionics": "bio_drain" }, { "compare_num": [ { "u_val": "power" }, ">=", { "power": "25 kJ" } ] } ] },
     "deactivate_condition": { "not": { "u_has_bionics": "bio_drain" } },
     "effect": [
       { "u_message": "Your batteries discharge slightly.", "type": "bad" },
@@ -287,7 +287,7 @@
     "id": "bio_shakes",
     "recurrence": [ "1 hours", "3 hours" ],
     "condition": {
-      "and": [ { "u_has_bionics": "bio_shakes" }, { "compare_int": [ { "u_val": "power" }, ">=", { "power": "25 kJ" } ] } ]
+      "and": [ { "u_has_bionics": "bio_shakes" }, { "compare_num": [ { "u_val": "power" }, ">=", { "power": "25 kJ" } ] } ]
     },
     "deactivate_condition": { "not": { "u_has_bionics": "bio_shakes" } },
     "effect": [
@@ -305,7 +305,7 @@
       "and": [
         { "u_has_bionics": "bio_glowy" },
         { "not": { "u_has_effect": "glowy_led" } },
-        { "compare_int": [ { "u_val": "power" }, ">=", { "power": "1 kJ" } ] }
+        { "compare_num": [ { "u_val": "power" }, ">=", { "power": "1 kJ" } ] }
       ]
     },
     "deactivate_condition": { "not": { "u_has_bionics": "bio_glowy" } },
@@ -383,7 +383,7 @@
     "id": "EOC_DEATH_PORTAL_DUNGEON",
     "type": "effect_on_condition",
     "eoc_type": "AVATAR_DEATH",
-    "condition": { "compare_int": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "!=", { "const": 0 } ] },
+    "condition": { "compare_num": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "!=", { "const": 0 } ] },
     "effect": [
       {
         "u_message": "Your ultimate fate is hard to sum up in words but suffice to say, the thing that used to be you wishes it had hidden from the storm.",
@@ -485,7 +485,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_last_amigara_death",
-    "condition": { "compare_int": [ { "global_val": "monsters_nearby", "id": "mon_amigara_horror" }, "<", { "const": 1 } ] },
+    "condition": { "compare_num": [ { "global_val": "monsters_nearby", "id": "mon_amigara_horror" }, "<", { "const": 1 } ] },
     "effect": [
       { "mapgen_update": "amigara_death" },
       { "u_lose_effect": "effect_amigara" },
@@ -504,7 +504,7 @@
       {
         "run_eocs": {
           "id": "EOC_HALLUCINATION_ATTACKS",
-          "condition": { "compare_int": [ { "global_val": "monsters_nearby" }, ">", { "const": 1 } ] },
+          "condition": { "compare_num": [ { "global_val": "monsters_nearby" }, ">", { "const": 1 } ] },
           "effect": [
             {
               "u_spawn_monster": "GROUP_YOUR_FEARS",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3683,7 +3683,7 @@
     "remove_message": "Reality reasserts itself and your perspective returns to normal.",
     "rating": "bad",
     "show_intensity": false,
-    "base_mods": { "per_mod": [ 6, 0 ] }
+    "base_mods": { "per_mod": [ -6, 0 ] }
   },
   {
     "id": "weakened_gravity",
@@ -3707,7 +3707,7 @@
     "show_intensity": false,
     "enchantments": [
       {
-        "values": [ { "value": "CARRY_WEIGHT", "multiply": { "global_val": "var", "var_name": "portal_dungeon_carry_strength" } } ]
+        "values": [ { "value": "CARRY_WEIGHT", "add": { "global_val": "var", "var_name": "portal_dungeon_carry_strength" } } ]
       }
     ]
   },
@@ -3721,7 +3721,7 @@
     "rating": "bad",
     "show_intensity": false,
     "enchantments": [
-      { "values": [ { "value": "SPEED", "multiply": { "global_val": "var", "var_name": "portal_dungeon_slow_strength" } } ] }
+      { "values": [ { "value": "SPEED", "add": { "global_val": "var", "var_name": "portal_dungeon_slow_strength" } } ] }
     ]
   }
 ]

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3720,8 +3720,6 @@
     "remove_message": "Reality reasserts itself and your time returns to normal.",
     "rating": "bad",
     "show_intensity": false,
-    "enchantments": [
-      { "values": [ { "value": "SPEED", "add": { "global_val": "var", "var_name": "portal_dungeon_slow_strength" } } ] }
-    ]
+    "enchantments": [ { "values": [ { "value": "SPEED", "add": { "global_val": "var", "var_name": "portal_dungeon_slow_strength" } } ] } ]
   }
 ]

--- a/data/json/encounters/randec_valhallist_cult.json
+++ b/data/json/encounters/randec_valhallist_cult.json
@@ -39,7 +39,7 @@
             "is_night"
           ]
         },
-        { "compare_int": [ { "global_val": "var", "var_name": "VC_Shoppers_visiting" }, "==", { "const": 1 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "VC_Shoppers_visiting" }, "==", { "const": 1 } ] },
         { "not": { "u_near_om_location": "pagan_cult_left_corner_up", "range": 2 } }
       ]
     },

--- a/data/json/encounters/randenc_caravans.json
+++ b/data/json/encounters/randenc_caravans.json
@@ -36,7 +36,7 @@
       "and": [
         { "u_compare_time_since_var": "RandEnc", "type": "timer", "context": "caravan", "op": ">", "time": "1 h" },
         { "not": { "u_near_om_location": "roadstop_a", "range": 2 } },
-        { "compare_int": [ { "global_val": "var", "var_name": "RandEnc_Caravan" }, "==", { "const": 1 } ] }
+        { "compare_num": [ { "global_val": "var", "var_name": "RandEnc_Caravan" }, "==", { "const": 1 } ] }
       ]
     },
     "effect": [

--- a/data/json/encounters/randenc_refugee_center.json
+++ b/data/json/encounters/randenc_refugee_center.json
@@ -40,7 +40,7 @@
             "is_night"
           ]
         },
-        { "compare_int": [ { "global_val": "var", "var_name": "RC_Shoppers_visiting" }, "==", { "const": 1 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "RC_Shoppers_visiting" }, "==", { "const": 1 } ] },
         { "not": { "u_near_om_location": "evac_center_13", "range": 2 } }
       ]
     },
@@ -94,7 +94,7 @@
             "is_night"
           ]
         },
-        { "compare_int": [ { "global_val": "var", "var_name": "RC_JohnBailey_visiting" }, "==", { "const": 1 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "RC_JohnBailey_visiting" }, "==", { "const": 1 } ] },
         { "not": { "u_near_om_location": "evac_center_13", "range": 2 } }
       ]
     },

--- a/data/json/mapgen/godco/godco_eocs.json
+++ b/data/json/mapgen/godco/godco_eocs.json
@@ -6,7 +6,7 @@
     "global": false,
     "condition": {
       "and": [
-        { "compare_int": [ { "global_val": "var", "var_name": "darryl_building_coop" }, "==", { "const": 1 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "darryl_building_coop" }, "==", { "const": 1 } ] },
         {
           "npc_compare_time_since_var": "coop_in_progress",
           "type": "timer",
@@ -17,7 +17,7 @@
         { "npc_near_om_location": "godco_7", "range": 12 }
       ]
     },
-    "deactivate_condition": { "compare_int": [ { "global_val": "var", "var_name": "darryl_building_coop" }, "==", { "const": 2 } ] },
+    "deactivate_condition": { "compare_num": [ { "global_val": "var", "var_name": "darryl_building_coop" }, "==", { "const": 2 } ] },
     "effect": [
       { "mapgen_update": "darryl_place_coop", "om_terrain": "godco_7" },
       { "arithmetic": [ { "global_val": "var", "var_name": "darryl_building_coop" }, "=", { "const": 2 } ] },
@@ -31,7 +31,7 @@
     "global": false,
     "condition": {
       "and": [
-        { "compare_int": [ { "global_val": "var", "var_name": "kostas_building_garden" }, "==", { "const": 1 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "kostas_building_garden" }, "==", { "const": 1 } ] },
         {
           "npc_compare_time_since_var": "herb_garden_in_progress",
           "type": "timer",
@@ -42,7 +42,7 @@
         { "npc_near_om_location": "godco_1_2", "range": 12 }
       ]
     },
-    "deactivate_condition": { "compare_int": [ { "global_val": "var", "var_name": "kostas_building_garden" }, "==", { "const": 2 } ] },
+    "deactivate_condition": { "compare_num": [ { "global_val": "var", "var_name": "kostas_building_garden" }, "==", { "const": 2 } ] },
     "effect": [
       { "mapgen_update": "place_herb_garden", "om_terrain": "godco_1_2" },
       { "arithmetic": [ { "global_val": "var", "var_name": "kostas_building_garden" }, "=", { "const": 2 } ] },
@@ -57,7 +57,7 @@
     "//": "4 hours 20 minutes per wall (from regular ground to full palisade) * 373 walls = ~1,567 hours.  Divided into 8-hour work shifts, thats ~196 days, or six and a half months for one person.  Presuming we have ~11 people working in a single shift, each building 1 wall, that should be ~18 days to build.  Please correct me if I messed up the math.",
     "condition": {
       "and": [
-        { "compare_int": [ { "global_val": "var", "var_name": "wall_in_progress" }, "==", { "const": 1 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "wall_in_progress" }, "==", { "const": 1 } ] },
         {
           "npc_compare_time_since_var": "wall_started_building",
           "type": "timer",
@@ -68,7 +68,7 @@
         { "npc_near_om_location": "godco_5", "range": 12 }
       ]
     },
-    "deactivate_condition": { "compare_int": [ { "global_val": "var", "var_name": "wall_in_progress" }, "==", { "const": 2 } ] },
+    "deactivate_condition": { "compare_num": [ { "global_val": "var", "var_name": "wall_in_progress" }, "==", { "const": 2 } ] },
     "effect": [
       { "mapgen_update": "place_right_corner_wall", "om_terrain": "godco_1" },
       { "mapgen_update": "place_gate_wall", "om_terrain": "godco_2" },

--- a/data/json/mapgen/robofaq_locs/EOC_robofac_hq_updater.json
+++ b/data/json/mapgen/robofaq_locs/EOC_robofac_hq_updater.json
@@ -15,7 +15,7 @@
       "and": [
         { "u_near_om_location": "robofachq_surface_road1", "range": 30 },
         { "not": { "u_near_om_location": "robofachq_surface_road1", "range": 4 } },
-        { "compare_int": [ { "global_val": "var", "var_name": "robofac_destroyed" }, "!=", { "const": 1 } ] }
+        { "compare_num": [ { "global_val": "var", "var_name": "robofac_destroyed" }, "!=", { "const": 1 } ] }
       ]
     },
     "effect": {
@@ -33,7 +33,7 @@
           "id": "EOC_ROBOFAC_HQ_PLACE_ANCILLA_FORTRESS",
           "condition": {
             "and": [
-              { "compare_int": [ { "global_val": "var", "var_name": "ancilla_fortress_placed" }, "!=", { "const": 1 } ] },
+              { "compare_num": [ { "global_val": "var", "var_name": "ancilla_fortress_placed" }, "!=", { "const": 1 } ] },
               { "days_since_cataclysm": 45 }
             ]
           },
@@ -46,7 +46,7 @@
           "id": "EOC_ROBOFAC_HQ_PLACE_ANCILLA_BAR",
           "condition": {
             "and": [
-              { "compare_int": [ { "global_val": "var", "var_name": "ancilla_bar_placed" }, "!=", { "const": 1 } ] },
+              { "compare_num": [ { "global_val": "var", "var_name": "ancilla_bar_placed" }, "!=", { "const": 1 } ] },
               { "days_since_cataclysm": 60 }
             ]
           },

--- a/data/json/mapgen/robofaq_locs/ancillia_bar_updater.json
+++ b/data/json/mapgen/robofaq_locs/ancillia_bar_updater.json
@@ -7,7 +7,7 @@
     "condition": {
       "and": [
         { "not": { "u_near_om_location": "robofachq_subcc_a2", "range": 1 } },
-        { "compare_int": [ { "global_val": "var", "var_name": "ancilla_bar_exists" }, "==", { "const": 1 } ] }
+        { "compare_num": [ { "global_val": "var", "var_name": "ancilla_bar_exists" }, "==", { "const": 1 } ] }
       ]
     },
     "effect": [

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -556,7 +556,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_absence_capture_attack",
-    "condition": { "compare_int": [ { "distance": [ "u", "npc" ] }, ">", { "const": 3 } ] },
+    "condition": { "compare_num": [ { "distance": [ "u", "npc" ] }, ">", { "const": 3 } ] },
     "effect": [
       { "u_location_variable": { "global_val": "portal_cage" } },
       {
@@ -688,7 +688,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_mon_swarm_structure_attack",
-    "condition": { "compare_int": [ { "distance": [ "u", "npc" ] }, ">", { "const": 4 } ] },
+    "condition": { "compare_num": [ { "distance": [ "u", "npc" ] }, ">", { "const": 4 } ] },
     "effect": [
       { "u_location_variable": { "npc_val": "swarm_target" }, "min_radius": 1, "max_radius": 2 },
       { "npc_teleport": { "npc_val": "swarm_target" } }
@@ -768,9 +768,9 @@
                       "id": "portal_storm_reflection_summon_guilt",
                       "condition": {
                         "and": [
-                          { "compare_int": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, ">", { "const": 0 } ] },
+                          { "compare_num": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, ">", { "const": 0 } ] },
                           {
-                            "compare_int": [
+                            "compare_num": [
                               { "global_val": "monsters_nearby", "target_var": { "global_val": "dungeon_loc" }, "id": "mon_guilt" },
                               "<",
                               { "const": 1 }
@@ -795,9 +795,9 @@
                       "id": "portal_storm_reflection_summon_sloth",
                       "condition": {
                         "and": [
-                          { "compare_int": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, ">", { "const": 0 } ] },
+                          { "compare_num": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, ">", { "const": 0 } ] },
                           {
-                            "compare_int": [
+                            "compare_num": [
                               { "global_val": "monsters_nearby", "target_var": { "global_val": "dungeon_loc" }, "id": "mon_sloth" },
                               "<",
                               { "const": 1 }

--- a/data/json/mutations/changing_eocs.json
+++ b/data/json/mutations/changing_eocs.json
@@ -6,7 +6,7 @@
     "recurrence": [ "30 m", "45 m" ],
     "condition": {
       "and": [
-        { "compare_int": [ { "u_val": "vitamin", "name": "mutagen" }, ">=", { "const": 450 } ] },
+        { "compare_num": [ { "u_val": "vitamin", "name": "mutagen" }, ">=", { "const": 450 } ] },
         { "not": { "u_has_flag": "CHANGING" } }
       ]
     },
@@ -51,7 +51,7 @@
           {
             "id": "changing_mutate2",
             "//": "Mutate!",
-            "condition": { "compare_int": [ { "u_val": "vitamin", "name": "mutagen" }, ">=", { "const": 300 } ] },
+            "condition": { "compare_num": [ { "u_val": "vitamin", "name": "mutagen" }, ">=", { "const": 300 } ] },
             "effect": [
               { "u_message": "You feel a deep, churning sensation fill your body.", "type": "mixed" },
               { "u_mutate": 0 },

--- a/data/json/mutations/mutation_eocs.json
+++ b/data/json/mutations/mutation_eocs.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_BIOLUM3_activated",
-    "condition": { "compare_int": [ { "u_val": "stamina" }, ">=", { "const": 3000 } ] },
+    "condition": { "compare_num": [ { "u_val": "stamina" }, ">=", { "const": 3000 } ] },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "3 seconds" },
       { "arithmetic": [ { "u_val": "stamina" }, "-=", { "const": 700 } ] },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -366,13 +366,13 @@
     "triggers": [
       [
         {
-          "condition": { "compare_int": [ { "u_val": "morale" }, "<", { "const": -50 } ] },
+          "condition": { "compare_num": [ { "u_val": "morale" }, "<", { "const": -50 } ] },
           "msg_on": { "text": "Everything is terrible and this makes you so ANGRY!", "rating": "mixed" }
         }
       ],
       [
         {
-          "condition": { "or": [ { "compare_int": [ "hour", "<", { "const": 6 } ] }, { "compare_int": [ "hour", ">", { "const": 21 } ] } ] },
+          "condition": { "or": [ { "compare_num": [ "hour", "<", { "const": 6 } ] }, { "compare_num": [ "hour", ">", { "const": 21 } ] } ] },
           "msg_on": { "text": "Everything is terrible and this makes you so ANGRY!", "rating": "mixed" }
         }
       ]
@@ -391,7 +391,7 @@
     "triggers": [
       [
         {
-          "condition": { "and": [ { "compare_int": [ "hour", ">", { "const": 6 } ] }, { "compare_int": [ "hour", "<", { "const": 21 } ] } ] },
+          "condition": { "and": [ { "compare_num": [ "hour", ">", { "const": 6 } ] }, { "compare_num": [ "hour", "<", { "const": 21 } ] } ] },
           "msg_on": { "text": "As the morning comes, you return back to normal.", "rating": "good" }
         }
       ]
@@ -500,7 +500,7 @@
     "category": [ "INSECT", "TROGLOBITE", "RAT" ],
     "enchantments": [
       {
-        "condition": { "compare_int": [ { "u_val": "pos_z" }, "<", { "const": 0 } ] },
+        "condition": { "compare_num": [ { "u_val": "pos_z" }, "<", { "const": 0 } ] },
         "values": [ { "value": "BONUS_BLOCK", "add": 1 }, { "value": "BONUS_DODGE", "add": 1 } ]
       }
     ]
@@ -612,7 +612,7 @@
     "threshreq": [ "THRESH_BATRACHIAN" ],
     "enchantments": [
       {
-        "condition": { "compare_int": [ { "u_val": "pos_z" }, "<", { "const": 0 } ] },
+        "condition": { "compare_num": [ { "u_val": "pos_z" }, "<", { "const": 0 } ] },
         "values": [ { "value": "SLEEPY", "add": 20 } ]
       }
     ]

--- a/data/json/npcs/Backgrounds/OtherSurvivorStories/Brigitte_LaCroix_Background.json
+++ b/data/json/npcs/Backgrounds/OtherSurvivorStories/Brigitte_LaCroix_Background.json
@@ -10,7 +10,7 @@
         "condition": {
           "and": [
             {
-              "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
             },
             { "npc_has_trait": "BOSS_Brigitte_LaCroix_01" },
             {

--- a/data/json/npcs/Backgrounds/OtherSurvivorStories/Lapin_01.json
+++ b/data/json/npcs/Backgrounds/OtherSurvivorStories/Lapin_01.json
@@ -10,7 +10,7 @@
         "condition": {
           "and": [
             {
-              "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
             },
             { "npc_has_trait": "BOSS_Lapin_01" },
             { "not": { "u_has_var": "directions", "type": "BOSS", "context": "mission", "value": "lapin" } }

--- a/data/json/npcs/Backgrounds/OtherSurvivorStories/NC_Farmer_background.json
+++ b/data/json/npcs/Backgrounds/OtherSurvivorStories/NC_Farmer_background.json
@@ -10,7 +10,7 @@
         "condition": {
           "and": [
             {
-              "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
             },
             { "npc_has_trait": "BOSS_NC_FARMER_01" },
             { "not": { "u_has_var": "directions", "type": "BOSS", "context": "mission", "value": "farmer" } }

--- a/data/json/npcs/Backgrounds/OtherSurvivorStories/NC_SURVIVOR_CHEF_background.json
+++ b/data/json/npcs/Backgrounds/OtherSurvivorStories/NC_SURVIVOR_CHEF_background.json
@@ -10,7 +10,7 @@
         "condition": {
           "and": [
             {
-              "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
             },
             { "npc_has_trait": "BOSS_NC_SURVIVOR_CHEF_01" },
             { "not": { "u_has_var": "directions", "type": "BOSS", "context": "mission", "value": "chef" } }

--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -881,106 +881,106 @@
     "id": "TALK_TEST_COMPARE_INT_OP",
     "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
     "responses": [
-      { "text": "Two = five.", "topic": "TALK_DONE", "condition": { "compare_int": [ { "const": 2 }, "=", { "const": 5 } ] } },
+      { "text": "Two = five.", "topic": "TALK_DONE", "condition": { "compare_num": [ { "const": 2 }, "=", { "const": 5 } ] } },
       {
         "text": "Two == five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 2 }, "==", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 2 }, "==", { "const": 5 } ] }
       },
       {
         "text": "Two != five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 2 }, "!=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 2 }, "!=", { "const": 5 } ] }
       },
       {
         "text": "Two <= five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 2 }, "<=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 2 }, "<=", { "const": 5 } ] }
       },
       {
         "text": "Two >= five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 2 }, ">=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 2 }, ">=", { "const": 5 } ] }
       },
       {
         "text": "Two < five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 2 }, "<", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 2 }, "<", { "const": 5 } ] }
       },
       {
         "text": "Two > five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 2 }, ">", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 2 }, ">", { "const": 5 } ] }
       },
       {
         "text": "Five = five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, "=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, "=", { "const": 5 } ] }
       },
       {
         "text": "Five == five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, "==", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, "==", { "const": 5 } ] }
       },
       {
         "text": "Five != five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, "!=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, "!=", { "const": 5 } ] }
       },
       {
         "text": "Five <= five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, "<=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, "<=", { "const": 5 } ] }
       },
       {
         "text": "Five >= five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, ">=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, ">=", { "const": 5 } ] }
       },
       {
         "text": "Five < five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, "<", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, "<", { "const": 5 } ] }
       },
       {
         "text": "Five > five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, ">", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, ">", { "const": 5 } ] }
       },
       {
         "text": "Five = two.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, "=", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, "=", { "const": 2 } ] }
       },
       {
         "text": "Five == two.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, "==", { "const": 2 } ] }
       },
       {
         "text": "Five != two.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, "!=", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, "!=", { "const": 2 } ] }
       },
       {
         "text": "Five <= two.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, "<=", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, "<=", { "const": 2 } ] }
       },
       {
         "text": "Five >= two.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, ">=", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, ">=", { "const": 2 } ] }
       },
       {
         "text": "Five < two.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, "<", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, "<", { "const": 2 } ] }
       },
       {
         "text": "Five > two.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "const": 5 }, ">", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "const": 5 }, ">", { "const": 2 } ] }
       }
     ]
   },
@@ -1018,79 +1018,79 @@
       {
         "text": "PC strength is five.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "strength" }, "=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "u_val": "strength" }, "=", { "const": 5 } ] }
       },
       {
         "text": "PC dexterity is six.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "dexterity" }, "=", { "const": 6 } ] }
+        "condition": { "compare_num": [ { "u_val": "dexterity" }, "=", { "const": 6 } ] }
       },
       {
         "text": "PC intelligence is seven.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "intelligence" }, "=", { "const": 7 } ] }
+        "condition": { "compare_num": [ { "u_val": "intelligence" }, "=", { "const": 7 } ] }
       },
       {
         "text": "PC perception is eight.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "perception" }, "=", { "const": 8 } ] }
+        "condition": { "compare_num": [ { "u_val": "perception" }, "=", { "const": 8 } ] }
       },
       {
         "text": "NPC strength is nine.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "npc_val": "strength" }, "=", { "const": 9 } ] }
+        "condition": { "compare_num": [ { "npc_val": "strength" }, "=", { "const": 9 } ] }
       },
       {
         "text": "NPC dexterity is ten.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "npc_val": "dexterity" }, "=", { "const": 10 } ] }
+        "condition": { "compare_num": [ { "npc_val": "dexterity" }, "=", { "const": 10 } ] }
       },
       {
         "text": "NPC intelligence is eleven.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "npc_val": "intelligence" }, "=", { "const": 11 } ] }
+        "condition": { "compare_num": [ { "npc_val": "intelligence" }, "=", { "const": 11 } ] }
       },
       {
         "text": "NPC perception is twelve.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "npc_val": "perception" }, "=", { "const": 12 } ] }
+        "condition": { "compare_num": [ { "npc_val": "perception" }, "=", { "const": 12 } ] }
       },
       {
         "text": "PC Custom var is one.",
         "topic": "TALK_DONE",
         "condition": {
-          "compare_int": [ { "u_val": "var", "var_name": "test", "type": "test", "context": "var_compare_test" }, "=", { "const": 1 } ]
+          "compare_num": [ { "u_val": "var", "var_name": "test", "type": "test", "context": "var_compare_test" }, "=", { "const": 1 } ]
         }
       },
       {
         "text": "NPC Custom var is two.",
         "topic": "TALK_DONE",
         "condition": {
-          "compare_int": [ { "npc_val": "var", "var_name": "test", "type": "test", "context": "var_compare_test" }, "=", { "const": 2 } ]
+          "compare_num": [ { "npc_val": "var", "var_name": "test", "type": "test", "context": "var_compare_test" }, "=", { "const": 2 } ]
         }
       },
       {
         "text": "This is a u_var time test response for > 3_days.",
         "topic": "TALK_DONE",
         "condition": {
-          "compare_int": [ { "u_val": "var", "var_name": "test", "type": "test", "context": "var_time_test" }, ">", { "time": "3 days" } ]
+          "compare_num": [ { "u_val": "var", "var_name": "test", "type": "test", "context": "var_time_test" }, ">", { "time": "3 days" } ]
         }
       },
       {
         "text": "time_since_cataclysm > 3_days.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "time_since_cataclysm": "turns" }, ">", { "time": "3 days" } ] }
+        "condition": { "compare_num": [ { "time_since_cataclysm": "turns" }, ">", { "time": "3 days" } ] }
       },
       {
         "text": "time_since_cataclysm in days > 3",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "time_since_cataclysm": "days" }, ">", { "const": 3 } ] }
+        "condition": { "compare_num": [ { "time_since_cataclysm": "days" }, ">", { "const": 3 } ] }
       },
       {
         "text": "This is a time since u_var test response for > 3_days.",
         "topic": "TALK_DONE",
         "condition": {
-          "compare_int": [
+          "compare_num": [
             { "u_val": "time_since_var", "var_name": "test", "type": "test", "context": "var_time_test" },
             ">",
             { "time": "3 days" }
@@ -1100,202 +1100,202 @@
       {
         "text": "Allies equals 1",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "allies" }, "=", { "const": 1 } ] }
+        "condition": { "compare_num": [ { "u_val": "allies" }, "=", { "const": 1 } ] }
       },
       {
         "text": "Cash equals 13",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "cash" }, "=", { "const": 13 } ] }
+        "condition": { "compare_num": [ { "u_val": "cash" }, "=", { "const": 13 } ] }
       },
       {
         "text": "Owed amount equals 14",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "owed" }, "=", { "const": 14 } ] }
+        "condition": { "compare_num": [ { "u_val": "owed" }, "=", { "const": 14 } ] }
       },
       {
         "text": "Driving skill more than or equal to 5",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "skill_level", "skill": "driving" }, ">=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "u_val": "skill_level", "skill": "driving" }, ">=", { "const": 5 } ] }
       },
       {
         "text": "A random number between 0 and 10 equals 11.",
         "topic": "TALK_DONE",
         "//": "Should never be true, kept here to show how the syntax is used.",
-        "condition": { "compare_int": [ { "rand": 10 }, "=", { "const": 11 } ] }
+        "condition": { "compare_num": [ { "rand": 10 }, "=", { "const": 11 } ] }
       },
       {
         "text": "Temperature is 21.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "weather": "temperature" }, "=", { "const": 21 } ] }
+        "condition": { "compare_num": [ { "weather": "temperature" }, "=", { "const": 21 } ] }
       },
       {
         "text": "Windpower is 15.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "weather": "windpower" }, "=", { "const": 15 } ] }
+        "condition": { "compare_num": [ { "weather": "windpower" }, "=", { "const": 15 } ] }
       },
       {
         "text": "Humidity is 16.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "weather": "humidity" }, "=", { "const": 16 } ] }
+        "condition": { "compare_num": [ { "weather": "humidity" }, "=", { "const": 16 } ] }
       },
       {
         "text": "Pressure is 17.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "weather": "pressure" }, "=", { "const": 17 } ] }
+        "condition": { "compare_num": [ { "weather": "pressure" }, "=", { "const": 17 } ] }
       },
       {
         "text": "Pos_x is 18.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "pos_x" }, "=", { "const": 18 } ] }
+        "condition": { "compare_num": [ { "u_val": "pos_x" }, "=", { "const": 18 } ] }
       },
       {
         "text": "Pos_y is 19.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "pos_y" }, "=", { "const": 19 } ] }
+        "condition": { "compare_num": [ { "u_val": "pos_y" }, "=", { "const": 19 } ] }
       },
       {
         "text": "Pos_z is 20. This should be cause for alarm.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "pos_z" }, "=", { "const": 20 } ] }
+        "condition": { "compare_num": [ { "u_val": "pos_z" }, "=", { "const": 20 } ] }
       },
       {
         "text": "Pain level is 21.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "pain" }, "=", { "const": 21 } ] }
+        "condition": { "compare_num": [ { "u_val": "pain" }, "=", { "const": 21 } ] }
       },
       {
         "text": "Bionic power is 22.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "power" }, "=", { "const": 22 } ] }
+        "condition": { "compare_num": [ { "u_val": "power" }, "=", { "const": 22 } ] }
       },
       {
         "text": "Bionic power max is 44.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "power_max" }, "=", { "const": 44 } ] }
+        "condition": { "compare_num": [ { "u_val": "power_max" }, "=", { "const": 44 } ] }
       },
       {
         "text": "Bionic power is at 50%.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "power_percentage" }, "=", { "const": 50 } ] }
+        "condition": { "compare_num": [ { "u_val": "power_percentage" }, "=", { "const": 50 } ] }
       },
       {
         "text": "Morale is 23.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "morale" }, "=", { "const": 23 } ] }
+        "condition": { "compare_num": [ { "u_val": "morale" }, "=", { "const": 23 } ] }
       },
       {
         "text": "Focus is 24.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "focus" }, "=", { "const": 24 } ] }
+        "condition": { "compare_num": [ { "u_val": "focus" }, "=", { "const": 24 } ] }
       },
       {
         "text": "Mana is 25.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "mana" }, "=", { "const": 25 } ] }
+        "condition": { "compare_num": [ { "u_val": "mana" }, "=", { "const": 25 } ] }
       },
       {
         "text": "Mana max is 900.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "mana_max" }, "=", { "const": 900 } ] }
+        "condition": { "compare_num": [ { "u_val": "mana_max" }, "=", { "const": 900 } ] }
       },
       {
         "text": "Mana is at 2%.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "mana_percentage" }, "=", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "u_val": "mana_percentage" }, "=", { "const": 2 } ] }
       },
       {
         "text": "Hunger is 26.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "hunger" }, "=", { "const": 26 } ] }
+        "condition": { "compare_num": [ { "u_val": "hunger" }, "=", { "const": 26 } ] }
       },
       {
         "text": "Thirst is 27.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "thirst" }, "=", { "const": 27 } ] }
+        "condition": { "compare_num": [ { "u_val": "thirst" }, "=", { "const": 27 } ] }
       },
       {
         "text": "Stored kcal is 55'000.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "stored_kcal" }, "=", { "const": 55000 } ] }
+        "condition": { "compare_num": [ { "u_val": "stored_kcal" }, "=", { "const": 55000 } ] }
       },
       {
         "text": "Stored kcal is at 100% of healthy.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "stored_kcal_percentage" }, "=", { "const": 100 } ] }
+        "condition": { "compare_num": [ { "u_val": "stored_kcal_percentage" }, "=", { "const": 100 } ] }
       },
       {
         "text": "Has 3 glass bottles.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "item_count", "item": "bottle_glass" }, "=", { "const": 3 } ] }
+        "condition": { "compare_num": [ { "u_val": "item_count", "item": "bottle_glass" }, "=", { "const": 3 } ] }
       },
       {
         "text": "Has more or equal to 35 experience.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "exp" }, ">=", { "const": 35 } ] }
+        "condition": { "compare_num": [ { "u_val": "exp" }, ">=", { "const": 35 } ] }
       },
       {
         "text": "Highest spell level in school test_trait is 1.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "spell_level", "school": "test_trait" }, "==", { "const": 1 } ] }
+        "condition": { "compare_num": [ { "u_val": "spell_level", "school": "test_trait" }, "==", { "const": 1 } ] }
       },
       {
         "text": "Spell level of Pew, Pew is 4.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "spell_level", "spell": "test_spell_pew" }, "==", { "const": 4 } ] }
+        "condition": { "compare_num": [ { "u_val": "spell_level", "spell": "test_spell_pew" }, "==", { "const": 4 } ] }
       },
       {
         "text": "Spell level of highest spell is 12.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "spell_level" }, "==", { "const": 12 } ] }
+        "condition": { "compare_num": [ { "u_val": "spell_level" }, "==", { "const": 12 } ] }
       },
       {
         "text": "Exp of Pew, Pew is -1.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "spell_exp", "spell": "test_spell_pew" }, "==", { "const": -1 } ] }
+        "condition": { "compare_num": [ { "u_val": "spell_exp", "spell": "test_spell_pew" }, "==", { "const": -1 } ] }
       },
       {
         "text": "Exp of Pew, Pew is 11006.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "spell_exp", "spell": "test_spell_pew" }, "==", { "const": 11006 } ] }
+        "condition": { "compare_num": [ { "u_val": "spell_exp", "spell": "test_spell_pew" }, "==", { "const": 11006 } ] }
       },
       {
         "text": "Test Proficiency learning is 5 out of 10.",
         "topic": "TALK_DONE",
-        "condition": { "compare_int": [ { "u_val": "proficiency", "proficiency_id": "prof_test", "format": 10 }, "==", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "u_val": "proficiency", "proficiency_id": "prof_test", "format": 10 }, "==", { "const": 5 } ] }
       },
       {
         "text": "Test Proficiency learning done is 12 hours total.",
         "topic": "TALK_DONE",
         "condition": {
-          "compare_int": [ { "u_val": "proficiency", "proficiency_id": "prof_test", "format": "time_spent" }, "==", { "time": "12h" } ]
+          "compare_num": [ { "u_val": "proficiency", "proficiency_id": "prof_test", "format": "time_spent" }, "==", { "time": "12h" } ]
         }
       },
       {
         "text": "Test Proficiency learning is 50% learnt.",
         "topic": "TALK_DONE",
         "condition": {
-          "compare_int": [ { "u_val": "proficiency", "proficiency_id": "prof_test", "format": "percent" }, "==", { "const": 50 } ]
+          "compare_num": [ { "u_val": "proficiency", "proficiency_id": "prof_test", "format": "percent" }, "==", { "const": 50 } ]
         }
       },
       {
         "text": "Test Proficiency learning is 500 permille learnt.",
         "topic": "TALK_DONE",
         "condition": {
-          "compare_int": [ { "u_val": "proficiency", "proficiency_id": "prof_test", "format": "permille" }, "==", { "const": 500 } ]
+          "compare_num": [ { "u_val": "proficiency", "proficiency_id": "prof_test", "format": "permille" }, "==", { "const": 500 } ]
         }
       },
       {
         "text": "Test Proficiency total learning time is 24 hours.",
         "topic": "TALK_DONE",
         "condition": {
-          "compare_int": [ { "u_val": "proficiency", "proficiency_id": "prof_test", "format": "total_time_required" }, "==", { "time": "24h" } ]
+          "compare_num": [ { "u_val": "proficiency", "proficiency_id": "prof_test", "format": "total_time_required" }, "==", { "time": "24h" } ]
         }
       },
       {
         "text": "Test Proficiency time lest to learn is 12h.",
         "topic": "TALK_DONE",
         "condition": {
-          "compare_int": [ { "u_val": "proficiency", "proficiency_id": "prof_test", "format": "time_left" }, "==", { "time": "12h" } ]
+          "compare_num": [ { "u_val": "proficiency", "proficiency_id": "prof_test", "format": "time_left" }, "==", { "time": "12h" } ]
         }
       }
     ]

--- a/data/json/npcs/computers/TALK_COMPUTER.json
+++ b/data/json/npcs/computers/TALK_COMPUTER.json
@@ -43,7 +43,7 @@
     "dynamic_line": "REFUGEE CENTER FOUND!  IF YOU HAVE ANY FEEDBACK CONCERNING YOUR VISIT PLEASE CONTACT\n THE DEPARTMENT OF EMERGENCY MANAGEMENT PUBLIC AFFAIRS OFFICE.\n THE LOCAL OFFICE CAN BE REACHED BETWEEN THE HOURS OF 9AM AND\n 4PM AT 555-0164.\n\nIF YOU WOULD LIKE TO SPEAK WITH SOMEONE IN PERSON OR WOULD LIKE\nTO WRITE US A LETTER PLEASE SEND IT TO…",
     "responses": [
       {
-        "condition": { "not": { "compare_int": [ { "global_val": "var", "var_name": "find_refugee_center" }, "=", { "const": 1 } ] } },
+        "condition": { "not": { "compare_num": [ { "global_val": "var", "var_name": "find_refugee_center" }, "=", { "const": 1 } ] } },
         "text": "Make a note of the location.",
         "topic": "COMP_REFUGEE_CENTER_MAIN",
         "effect": [
@@ -52,7 +52,7 @@
         ]
       },
       {
-        "condition": { "compare_int": [ { "global_val": "var", "var_name": "find_refugee_center" }, "=", { "const": 1 } ] },
+        "condition": { "compare_num": [ { "global_val": "var", "var_name": "find_refugee_center" }, "=", { "const": 1 } ] },
         "text": "Press any key.",
         "topic": "COMP_REFUGEE_CENTER_MAIN"
       }

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -142,7 +142,7 @@
       {
         "//": "Check to see if you've sold enough for Rubik's trust in you to increase a bit",
         "condition": {
-          "and": [ { "compare_int": [ { "u_val": "sold" }, ">=", { "const": 20 } ] }, { "not": { "u_has_faction_trust": 20 } } ]
+          "and": [ { "compare_num": [ { "u_val": "sold" }, ">=", { "const": 20 } ] }, { "not": { "u_has_faction_trust": 20 } } ]
         },
         "effect": [ { "arithmetic": [ { "u_val": "sold" }, "-=", { "const": 20 } ] }, { "u_add_faction_trust": 1 } ]
       },
@@ -239,7 +239,7 @@
     "//~": "For a card an' a wink, eh? --> That was a good exchange",
     "speaker_effect": {
       "condition": {
-        "and": [ { "compare_int": [ { "u_val": "sold" }, ">=", { "const": 20 } ] }, { "not": { "u_has_faction_trust": 21 } } ]
+        "and": [ { "compare_num": [ { "u_val": "sold" }, ">=", { "const": 20 } ] }, { "not": { "u_has_faction_trust": 21 } } ]
       },
       "effect": [ { "arithmetic": [ { "u_val": "sold" }, "-=", { "const": 20 } ] }, { "u_add_faction_trust": 1 } ]
     },

--- a/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
@@ -24,7 +24,7 @@
     "id": "TALK_EXODII_MERCHANT_Exodize",
     "type": "talk_topic",
     "dynamic_line": {
-      "compare_int": [ { "u_val": "sold" }, ">=", { "const": 100 } ],
+      "compare_num": [ { "u_val": "sold" }, ">=", { "const": 100 } ],
       "yes": "Oh HO!  Well, well.  Now you're yarkin' the King's Anglic.  Aye, us'n can fix ye good, if'n ye're tassed to repay it in kind.  Us'll speak it as clear-like as this Rubik can.  If ye'n use it to put the dead back in the ground, us'n can fix ye with some goods like this, aye.  Stuck in the flesh and to the bone, wired into the brain.  Ye kennit?  If no, us'll speak to the Great Grey for a pint o' the ol' clarity-draught.",
       "no": {
         "u_has_faction_trust": 5,
@@ -37,31 +37,31 @@
       {
         "text": "If I just keep on killing zombies, you'll help turn me into a cyborg?  Why are we still yarkin', then?  Sign me the heck up.",
         "topic": "TALK_EXODII_MERCHANT_ExodizeMe1",
-        "condition": { "or": [ { "compare_int": [ { "u_val": "sold" }, ">=", { "const": 100 } ] }, { "u_has_faction_trust": 5 } ] }
+        "condition": { "or": [ { "compare_num": [ { "u_val": "sold" }, ">=", { "const": 100 } ] }, { "u_has_faction_trust": 5 } ] }
       },
       {
         "text": "On second thought, I'm not sure I want to let a bunch of unfamiliar alien robots do brain surgery on me.",
         "topic": "TALK_EXODII_MERCHANT_ExodizeNope",
-        "condition": { "or": [ { "compare_int": [ { "u_val": "sold" }, ">=", { "const": 100 } ] }, { "u_has_faction_trust": 5 } ] }
+        "condition": { "or": [ { "compare_num": [ { "u_val": "sold" }, ">=", { "const": 100 } ] }, { "u_has_faction_trust": 5 } ] }
       },
       {
         "text": "Maybe try that clarity-draught?",
         "topic": "TALK_EXODII_MERCHANT_ExodizeTranslate",
-        "condition": { "or": [ { "compare_int": [ { "u_val": "sold" }, ">=", { "const": 100 } ] }, { "u_has_faction_trust": 5 } ] }
+        "condition": { "or": [ { "compare_num": [ { "u_val": "sold" }, ">=", { "const": 100 } ] }, { "u_has_faction_trust": 5 } ] }
       },
       {
         "text": "OK, well, I've got some stuff I could trade right now.",
         "effect": "start_trade",
         "topic": "TALK_EXODII_MERCHANT_DoneTrade",
         "condition": {
-          "and": [ { "compare_int": [ { "u_val": "sold" }, "<", { "const": 100 } ] }, { "not": { "u_has_faction_trust": 5 } } ]
+          "and": [ { "compare_num": [ { "u_val": "sold" }, "<", { "const": 100 } ] }, { "not": { "u_has_faction_trust": 5 } } ]
         }
       },
       {
         "text": "OK, maybe I'll come back when I've traded a bit more.",
         "topic": "TALK_DONE",
         "condition": {
-          "and": [ { "compare_int": [ { "u_val": "sold" }, "<", { "const": 100 } ] }, { "not": { "u_has_faction_trust": 5 } } ]
+          "and": [ { "compare_num": [ { "u_val": "sold" }, "<", { "const": 100 } ] }, { "not": { "u_has_faction_trust": 5 } } ]
         }
       }
     ]

--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -164,7 +164,7 @@
       {
         "item": "RobofacCoin",
         "fixed_adj": 0.15,
-        "condition": { "compare_int": [ { "global_val": "var", "var_name": "free_merchants_hub_trade_route" }, "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "global_val": "var", "var_name": "free_merchants_hub_trade_route" }, "==", { "const": 2 } ] }
       },
       { "group": "NC_ROBOFAC_gear", "markup": 2.5 }
     ],

--- a/data/json/npcs/godco/NPC_Darryl_Johnstone.json
+++ b/data/json/npcs/godco/NPC_Darryl_Johnstone.json
@@ -65,7 +65,7 @@
         "text": "How are the chickens?",
         "condition": {
           "and": [
-            { "compare_int": [ { "global_val": "var", "var_name": "darryl_building_coop" }, "==", { "const": 2 } ] },
+            { "compare_num": [ { "global_val": "var", "var_name": "darryl_building_coop" }, "==", { "const": 2 } ] },
             { "npc_has_var": "u_met_godco_darryl", "type": "general", "context": "meeting", "value": "yes" }
           ]
         },

--- a/data/json/npcs/godco/classes.json
+++ b/data/json/npcs/godco/classes.json
@@ -256,7 +256,7 @@
       {
         "group": "GODCO_russell_carried",
         "rigid": true,
-        "condition": { "compare_int": [ { "npc_val": "var", "var_name": "NEVER" }, "==", { "const": 1 } ] },
+        "condition": { "compare_num": [ { "npc_val": "var", "var_name": "NEVER" }, "==", { "const": 1 } ] },
         "refusal": "<npcname> will never sell this"
       }
     ],

--- a/data/json/npcs/lumbermill_employees/lumbermill_employees.json
+++ b/data/json/npcs/lumbermill_employees/lumbermill_employees.json
@@ -64,7 +64,7 @@
       {
         "group": "NC_LUMBERJACK_tools",
         "rigid": true,
-        "condition": { "compare_int": [ { "npc_val": "var", "var_name": "NEVER" }, "==", { "const": 1 } ] },
+        "condition": { "compare_num": [ { "npc_val": "var", "var_name": "NEVER" }, "==", { "const": 1 } ] },
         "refusal": "<npcname> will never sell this"
       }
     ],

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
@@ -133,19 +133,19 @@
     "type": "talk_topic",
     "id": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS",
     "dynamic_line": {
-      "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 0 } ],
+      "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 0 } ],
       "yes": "No, sorry.  Nothin' much worth notin' out there these days, just the odd scattered survivor and they usually don't want random visitors.",
       "no": {
-        "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ],
+        "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ],
         "yes": "Matter of fact, yeah.  Ran into a bunch of farmers.  They don't want much to do with our caravans, but someone like you they might be OK with.",
         "no": {
-          "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 2 } ],
+          "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 2 } ],
           "yes": "There's been rumors.  Folks talkin' about some kind of secret lab, out in the wilds, with survivors in it.  I haven't seen it myself, mind you.",
           "no": {
-            "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 3 } ],
+            "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 3 } ],
             "yes": "Well, a few of my caravans have come back now talkin' about this giant metal castle on top of a rock, in the middle of nowhere.  They ain't been crazy enough to check it out, but you could if you want.",
             "no": {
-              "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 4 } ],
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 4 } ],
               "yes": "A few of my people have come back now talkin' about some yuppie trying to start a bank that uses bullets for money.  Silly idea but the lad lives on a homestead with a woman who wouldn't let my guys leave without a full belly.",
               "no": "ERROR: out of bounds on randomize_directions."
             }
@@ -160,7 +160,7 @@
         "condition": {
           "and": [
             {
-              "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
             },
             { "not": { "u_has_var": "directions", "type": "teamster", "context": "mission", "value": "isherwood" } }
           ]
@@ -174,7 +174,7 @@
         "condition": {
           "and": [
             {
-              "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 2 } ]
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 2 } ]
             },
             { "not": { "u_has_var": "directions", "type": "teamster", "context": "mission", "value": "hub01" } }
           ]
@@ -188,7 +188,7 @@
         "condition": {
           "and": [
             {
-              "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 3 } ]
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 3 } ]
             },
             { "not": { "u_has_var": "directions", "type": "teamster", "context": "mission", "value": "exodii" } }
           ]
@@ -202,7 +202,7 @@
         "condition": {
           "and": [
             {
-              "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 4 } ]
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 4 } ]
             },
             { "not": { "u_has_var": "directions", "type": "teamster", "context": "mission", "value": "artisans" } }
           ]

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_visiting_scavenger.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_visiting_scavenger.json
@@ -54,16 +54,16 @@
     "type": "talk_topic",
     "id": "TALK_RC_SURVIVOR_Tips",
     "dynamic_line": {
-      "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 0 } ],
+      "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 0 } ],
       "yes": "Sure.  Seen more'n I'd like to think about honestly.  Like, I think these zombies are evolving?  I've seen new things come out that I swear aren't natural.  One of them looked like it was sparking with electricity.",
       "no": {
-        "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ],
+        "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ],
         "yes": "Come to think of it, yeah.  The other day, I met this weird old man in the woods.  Obsessed with rabbits.  He seemed like a nice fellow, open to visitors, if you'd like I can send you his way to trade.",
         "no": {
-          "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 2 } ],
+          "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 2 } ],
           "yes": "I could point you to some acquaintances of mine that have a farm, they're decent folk, if you have goods to trade.  Be careful around them, I get a vibe like they don't like visitors too much, and honestly it makes me nervous that they made it through this so together.  Kinda of ominous, you know?",
           "no": {
-            "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 3 } ],
+            "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 3 } ],
             "yes": "There's so much weird stuff out there in the wilderness now.  A while back, I found this weird cartoon sign with a map on it, pointing to some kind of trade center.  Haven't been there yet but I can show you my copy of the map if you want.",
             "no": "ERROR: out of bounds on randomize_directions."
           }
@@ -77,7 +77,7 @@
         "condition": {
           "and": [
             {
-              "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
             },
             { "not": { "u_has_var": "directions", "type": "teamster", "context": "mission", "value": "lapin" } }
           ]
@@ -91,7 +91,7 @@
         "condition": {
           "and": [
             {
-              "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 2 } ]
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 2 } ]
             },
             { "not": { "u_has_var": "directions", "type": "teamster", "context": "mission", "value": "isherwood" } }
           ]
@@ -105,7 +105,7 @@
         "condition": {
           "and": [
             {
-              "compare_int": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 3 } ]
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 3 } ]
             },
             { "not": { "u_has_var": "directions", "type": "teamster", "context": "mission", "value": "exodii" } }
           ]

--- a/data/json/npcs/robofac/NPC_Cranberry_Foster.json
+++ b/data/json/npcs/robofac/NPC_Cranberry_Foster.json
@@ -332,7 +332,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_var": "asked_gender", "type": "dialogue", "context": "robofac_merc_1", "value": "yes" } },
-            { "compare_int": [ { "npc_val": "npc_trust" }, ">=", { "const": 3 } ] }
+            { "compare_num": [ { "npc_val": "npc_trust" }, ">=", { "const": 3 } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_MERC_1_GENDER"

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -34,8 +34,8 @@
         "rigid": true,
         "condition": {
           "or": [
-            { "compare_int": [ { "u_val": "var", "var_name": "hub01_good_candidate" }, "==", { "const": 1 } ] },
-            { "compare_int": [ { "u_val": "var", "var_name": "hub01_completed_missions" }, ">=", { "const": 2 } ] }
+            { "compare_num": [ { "u_val": "var", "var_name": "hub01_good_candidate" }, "==", { "const": 1 } ] },
+            { "compare_num": [ { "u_val": "var", "var_name": "hub01_completed_missions" }, ">=", { "const": 2 } ] }
           ]
         },
         "refusal": "You're not yet qualified to buy this"
@@ -46,7 +46,7 @@
         "strict": true,
         "condition": {
           "and": [
-            { "compare_int": [ { "global_val": "var", "var_name": "hub01_uhmwpe_researched" }, "==", { "const": 1 } ] },
+            { "compare_num": [ { "global_val": "var", "var_name": "hub01_uhmwpe_researched" }, "==", { "const": 1 } ] },
             { "not": { "u_has_var": "u_can_buy_armor", "type": "dialogue", "context": "hub_rnd", "value": "yes" } }
           ]
         }
@@ -71,7 +71,7 @@
           "and": [
             { "u_has_var": "u_has_researched_gun", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
             {
-              "compare_int": [ { "global_val": "var", "var_name": "hub01_hwp_exotic_researched" }, "==", { "const": 1 } ]
+              "compare_num": [ { "global_val": "var", "var_name": "hub01_hwp_exotic_researched" }, "==", { "const": 1 } ]
             }
           ]
         }
@@ -170,7 +170,7 @@
           "run_eocs": [
             {
               "id": "EOC_INTERCOM_MAYBE_ADD_FREE_MERCHANT_CAMP",
-              "condition": { "compare_int": [ { "global_val": "var", "var_name": "free_merchants_hub_trade_route" }, "==", { "const": 1 } ] },
+              "condition": { "compare_num": [ { "global_val": "var", "var_name": "free_merchants_hub_trade_route" }, "==", { "const": 1 } ] },
               "effect": [
                 { "mapgen_update": "nest_robofac_add_free_merchant_camp", "om_terrain": "robofachq_surface_parking" },
                 {

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
@@ -11,7 +11,7 @@
           "and": [
             { "u_compare_time_since_var": "u_waiting_on_armor", "type": "timer", "context": "hub_rnd", "op": "<", "time": "1 d" },
             {
-              "compare_int": [ { "global_val": "var", "var_name": "hub01_uhmwpe_researched" }, "!=", { "const": 1 } ]
+              "compare_num": [ { "global_val": "var", "var_name": "hub01_uhmwpe_researched" }, "!=", { "const": 1 } ]
             },
             { "u_has_var": "u_gave_armor_disk", "type": "dialogue", "context": "hub_rnd", "value": "yes" }
           ]
@@ -24,7 +24,7 @@
           "and": [
             { "u_compare_time_since_var": "u_waiting_on_armor", "type": "timer", "context": "hub_rnd", "op": ">", "time": "1 d" },
             {
-              "compare_int": [ { "global_val": "var", "var_name": "hub01_uhmwpe_researched" }, "!=", { "const": 1 } ]
+              "compare_num": [ { "global_val": "var", "var_name": "hub01_uhmwpe_researched" }, "!=", { "const": 1 } ]
             },
             { "u_has_var": "u_gave_armor_disk", "type": "dialogue", "context": "hub_rnd", "value": "yes" }
           ]
@@ -223,7 +223,7 @@
         "text": "I've found a rifle chambered for a caliber I don't recognize.  Do you think you could make an HWP adapter for it?",
         "condition": {
           "and": [
-            { "compare_int": [ { "global_val": "var", "var_name": "hub01_hwp_exotic_researched" }, "!=", { "const": 1 } ] },
+            { "compare_num": [ { "global_val": "var", "var_name": "hub01_hwp_exotic_researched" }, "!=", { "const": 1 } ] },
             { "not": { "u_has_var": "u_project_ongoing", "type": "dialogue", "context": "hub_rnd", "value": "yes" } },
             { "u_has_var": "u_has_researched_gun", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
             {

--- a/data/json/npcs/scrap_trader/scrap_trader.json
+++ b/data/json/npcs/scrap_trader/scrap_trader.json
@@ -64,7 +64,7 @@
       {
         "group": "no_sell",
         "rigid": true,
-        "condition": { "compare_int": [ { "npc_val": "var", "var_name": "NEVER" }, "==", { "const": 1 } ] },
+        "condition": { "compare_num": [ { "npc_val": "var", "var_name": "NEVER" }, "==", { "const": 1 } ] },
         "refusal": "<npcname> will never sell this"
       }
     ],

--- a/data/json/obsoletion/mutations.json
+++ b/data/json/obsoletion/mutations.json
@@ -10,11 +10,11 @@
     "triggers": [
       [
         {
-          "condition": { "compare_int": [ { "u_val": "morale" }, ">", { "const": 20 } ] },
+          "condition": { "compare_num": [ { "u_val": "morale" }, ">", { "const": 20 } ] },
           "msg_off": { "text": "Your glow fades.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_int": [ { "u_val": "hunger" }, ">", { "const": 110 } ] },
+          "condition": { "compare_num": [ { "u_val": "hunger" }, ">", { "const": 110 } ] },
           "msg_off": { "text": "Your glow fades.", "rating": "mixed" }
         }
       ]

--- a/data/json/portal_dependent_effect_on_condition.json
+++ b/data/json/portal_dependent_effect_on_condition.json
@@ -15,7 +15,7 @@
     "effect": {
       "run_eocs": {
         "id": "EOC_PDEPENDENT_STRONG_WEAK_EFFECTS_ACCEPTANCE",
-        "condition": { "compare_int": [ { "global_val": "var", "var_name": "ps_str" }, ">", { "const": 4 } ] },
+        "condition": { "compare_num": [ { "global_val": "var", "var_name": "ps_str" }, ">", { "const": 4 } ] },
         "effect": {
           "weighted_list_eocs": [
             [ "EOC_PORTAL_DEPENDENT_MESSAGES_GOOD", { "const": 10 } ],

--- a/data/json/portal_storm_effect_on_condition.json
+++ b/data/json/portal_storm_effect_on_condition.json
@@ -130,8 +130,8 @@
         "or": [
           { "is_weather": "portal_storm" },
           { "is_weather": "early_portal_storm" },
-          { "compare_int": [ { "global_val": "var", "var_name": "cause_portal_storm" }, "=", { "const": 1 } ] },
-          { "compare_int": [ { "global_val": "var", "var_name": "cause_early_portal_storm" }, "=", { "const": 1 } ] }
+          { "compare_num": [ { "global_val": "var", "var_name": "cause_portal_storm" }, "=", { "const": 1 } ] },
+          { "compare_num": [ { "global_val": "var", "var_name": "cause_early_portal_storm" }, "=", { "const": 1 } ] }
         ]
       }
     },
@@ -155,7 +155,7 @@
       "not": {
         "or": [
           { "is_weather": "portal_storm" },
-          { "compare_int": [ { "global_val": "var", "var_name": "cause_portal_storm" }, "=", { "const": 1 } ] }
+          { "compare_num": [ { "global_val": "var", "var_name": "cause_portal_storm" }, "=", { "const": 1 } ] }
         ]
       }
     },
@@ -203,8 +203,8 @@
       "or": [
         { "is_weather": "portal_storm" },
         { "is_weather": "early_portal_storm" },
-        { "compare_int": [ { "global_val": "var", "var_name": "cause_portal_storm" }, "=", { "const": 1 } ] },
-        { "compare_int": [ { "global_val": "var", "var_name": "cause_early_portal_storm" }, "=", { "const": 1 } ] }
+        { "compare_num": [ { "global_val": "var", "var_name": "cause_portal_storm" }, "=", { "const": 1 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "cause_early_portal_storm" }, "=", { "const": 1 } ] }
       ]
     },
     "effect": [
@@ -260,8 +260,8 @@
     "condition": {
       "and": [
         { "is_weather": "portal_storm" },
-        { "compare_int": [ { "global_val": "var", "var_name": "ps_str" }, "<=", { "const": 2 } ] },
-        { "compare_int": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "=", { "const": 0 } ] }
+        { "compare_num": [ { "global_val": "var", "var_name": "ps_str" }, "<=", { "const": 2 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "=", { "const": 0 } ] }
       ]
     },
     "deactivate_condition": { "not": { "is_weather": "portal_storm" } },
@@ -288,9 +288,9 @@
     "condition": {
       "and": [
         { "is_weather": "portal_storm" },
-        { "compare_int": [ { "global_val": "var", "var_name": "ps_str" }, ">", { "const": 2 } ] },
-        { "compare_int": [ { "global_val": "var", "var_name": "ps_str" }, "<=", { "const": 4 } ] },
-        { "compare_int": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "=", { "const": 0 } ] }
+        { "compare_num": [ { "global_val": "var", "var_name": "ps_str" }, ">", { "const": 2 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "ps_str" }, "<=", { "const": 4 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "=", { "const": 0 } ] }
       ]
     },
     "deactivate_condition": { "not": { "is_weather": "portal_storm" } },
@@ -321,8 +321,8 @@
     "condition": {
       "and": [
         { "is_weather": "portal_storm" },
-        { "compare_int": [ { "global_val": "var", "var_name": "ps_str" }, ">", { "const": 4 } ] },
-        { "compare_int": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "=", { "const": 0 } ] }
+        { "compare_num": [ { "global_val": "var", "var_name": "ps_str" }, ">", { "const": 4 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "=", { "const": 0 } ] }
       ]
     },
     "deactivate_condition": { "not": { "is_weather": "portal_storm" } },
@@ -591,7 +591,7 @@
       "and": [
         { "not": "u_driving" },
         { "not": { "u_has_worn_with_flag": "PORTAL_PROOF" } },
-        { "compare_int": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "==", { "const": 0 } ] }
+        { "compare_num": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "==", { "const": 0 } ] }
       ]
     },
     "effect": [
@@ -780,7 +780,7 @@
     "id": "EOC_PORTAL_STORM_CELL",
     "condition": {
       "and": [
-        { "compare_int": [ { "u_val": "var", "var_name": "in_portal_cell" }, "=", { "const": 0 } ] },
+        { "compare_num": [ { "u_val": "var", "var_name": "in_portal_cell" }, "=", { "const": 0 } ] },
         { "not": { "u_has_worn_with_flag": "PORTAL_PROOF" } },
         { "not": "u_driving" }
       ]
@@ -899,7 +899,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_STORM_DUNGEON_SHIFT",
-    "condition": { "compare_int": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, ">", { "const": 0 } ] },
+    "condition": { "compare_num": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, ">", { "const": 0 } ] },
     "effect": [
       { "mapgen_update": "portal_dungeon", "target_var": { "global_val": "dungeon_loc" } },
       { "queue_eocs": "EOC_PORTAL_STORM_DUNGEON_SHIFT", "time_in_future": [ "5 seconds", "15 seconds" ] }
@@ -911,30 +911,30 @@
     "global": true,
     "condition": {
       "and": [
-        { "compare_int": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, ">", { "const": 0 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, ">", { "const": 0 } ] },
         {
-          "compare_int": [
+          "compare_num": [
             { "global_val": "monsters_nearby", "target_var": { "global_val": "dungeon_loc" }, "id": "mon_pale_reflection" },
             "<",
             { "const": 1 }
           ]
         },
         {
-          "compare_int": [
+          "compare_num": [
             { "global_val": "monsters_nearby", "target_var": { "global_val": "dungeon_loc" }, "id": "mon_twisted_reflection" },
             "<",
             { "const": 1 }
           ]
         },
         {
-          "compare_int": [
+          "compare_num": [
             { "global_val": "monsters_nearby", "target_var": { "global_val": "dungeon_loc" }, "id": "mon_dark_reflection" },
             "<",
             { "const": 1 }
           ]
         },
         {
-          "compare_int": [
+          "compare_num": [
             { "global_val": "monsters_nearby", "target_var": { "global_val": "dungeon_loc" }, "id": "mon_better_half" },
             "<",
             { "const": 1 }
@@ -991,7 +991,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_STORM_DUNGEON_EXIT",
-    "condition": { "compare_int": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "!=", { "const": 0 } ] },
+    "condition": { "compare_num": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "!=", { "const": 0 } ] },
     "effect": [
       { "mapgen_update": "portal_dungeon_cleanup", "target_var": { "global_val": "dungeon_loc" } },
       {
@@ -1012,7 +1012,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "TAINTED_SHADOW" },
-        { "compare_int": [ { "u_val": "monsters_nearby", "id": "mon_tainted_shadow" }, "<", { "const": 1 } ] }
+        { "compare_num": [ { "u_val": "monsters_nearby", "id": "mon_tainted_shadow" }, "<", { "const": 1 } ] }
       ]
     },
     "effect": [

--- a/data/json/ui/activity.json
+++ b/data/json/ui/activity.json
@@ -9,37 +9,37 @@
         "id": "none",
         "text": "None",
         "color": "light_gray",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 0 } ] }
       },
       {
         "id": "light",
         "text": "Light",
         "color": "yellow",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 1 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 1 } ] }
       },
       {
         "id": "moderate",
         "text": "Moderate",
         "color": "yellow",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 2 } ] }
       },
       {
         "id": "brisk",
         "text": "Brisk",
         "color": "light_red",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 3 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 3 } ] }
       },
       {
         "id": "active",
         "text": "Active",
         "color": "light_red",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 4 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 4 } ] }
       },
       {
         "id": "extreme",
         "text": "Extreme",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, ">=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, ">=", { "const": 5 } ] }
       }
     ]
   },

--- a/data/json/ui/body_temp.json
+++ b/data/json/ui/body_temp.json
@@ -8,7 +8,7 @@
         "id": "scorching",
         "text": "Scorching!",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "body_temp" }, ">", { "const": 9500 } ] }
+        "condition": { "compare_num": [ { "u_val": "body_temp" }, ">", { "const": 9500 } ] }
       },
       {
         "id": "very_hot",
@@ -16,8 +16,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp" }, "<=", { "const": 9500 } ] },
-            { "compare_int": [ { "u_val": "body_temp" }, ">", { "const": 8000 } ] }
+            { "compare_num": [ { "u_val": "body_temp" }, "<=", { "const": 9500 } ] },
+            { "compare_num": [ { "u_val": "body_temp" }, ">", { "const": 8000 } ] }
           ]
         }
       },
@@ -27,8 +27,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp" }, "<=", { "const": 8000 } ] },
-            { "compare_int": [ { "u_val": "body_temp" }, ">", { "const": 6500 } ] }
+            { "compare_num": [ { "u_val": "body_temp" }, "<=", { "const": 8000 } ] },
+            { "compare_num": [ { "u_val": "body_temp" }, ">", { "const": 6500 } ] }
           ]
         }
       },
@@ -38,8 +38,8 @@
         "color": "green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp" }, "<=", { "const": 6500 } ] },
-            { "compare_int": [ { "u_val": "body_temp" }, ">", { "const": 3500 } ] }
+            { "compare_num": [ { "u_val": "body_temp" }, "<=", { "const": 6500 } ] },
+            { "compare_num": [ { "u_val": "body_temp" }, ">", { "const": 3500 } ] }
           ]
         }
       },
@@ -49,8 +49,8 @@
         "color": "light_blue",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp" }, "<=", { "const": 3500 } ] },
-            { "compare_int": [ { "u_val": "body_temp" }, ">", { "const": 2000 } ] }
+            { "compare_num": [ { "u_val": "body_temp" }, "<=", { "const": 3500 } ] },
+            { "compare_num": [ { "u_val": "body_temp" }, ">", { "const": 2000 } ] }
           ]
         }
       },
@@ -60,8 +60,8 @@
         "color": "cyan",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp" }, "<=", { "const": 2000 } ] },
-            { "compare_int": [ { "u_val": "body_temp" }, ">", { "const": 500 } ] }
+            { "compare_num": [ { "u_val": "body_temp" }, "<=", { "const": 2000 } ] },
+            { "compare_num": [ { "u_val": "body_temp" }, ">", { "const": 500 } ] }
           ]
         }
       },
@@ -69,7 +69,7 @@
         "id": "freezing",
         "text": "Freezing!",
         "color": "blue",
-        "condition": { "compare_int": [ { "u_val": "body_temp" }, "<=", { "const": 500 } ] }
+        "condition": { "compare_num": [ { "u_val": "body_temp" }, "<=", { "const": 500 } ] }
       }
     ]
   },
@@ -84,7 +84,7 @@
         "text": "(Rising!!)",
         "sym": "↑↑↑",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "body_temp_delta" }, ">", { "const": 4500 } ] }
+        "condition": { "compare_num": [ { "u_val": "body_temp_delta" }, ">", { "const": 4500 } ] }
       },
       {
         "id": "rising2",
@@ -93,8 +93,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp_delta" }, "<=", { "const": 4500 } ] },
-            { "compare_int": [ { "u_val": "body_temp_delta" }, ">", { "const": 3000 } ] }
+            { "compare_num": [ { "u_val": "body_temp_delta" }, "<=", { "const": 4500 } ] },
+            { "compare_num": [ { "u_val": "body_temp_delta" }, ">", { "const": 3000 } ] }
           ]
         }
       },
@@ -105,8 +105,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp_delta" }, "<=", { "const": 3000 } ] },
-            { "compare_int": [ { "u_val": "body_temp_delta" }, ">", { "const": 1500 } ] }
+            { "compare_num": [ { "u_val": "body_temp_delta" }, "<=", { "const": 3000 } ] },
+            { "compare_num": [ { "u_val": "body_temp_delta" }, ">", { "const": 1500 } ] }
           ]
         }
       },
@@ -117,8 +117,8 @@
         "color": "light_blue",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp_delta" }, "<", { "const": -1500 } ] },
-            { "compare_int": [ { "u_val": "body_temp_delta" }, ">=", { "const": -3000 } ] }
+            { "compare_num": [ { "u_val": "body_temp_delta" }, "<", { "const": -1500 } ] },
+            { "compare_num": [ { "u_val": "body_temp_delta" }, ">=", { "const": -3000 } ] }
           ]
         }
       },
@@ -129,8 +129,8 @@
         "color": "cyan",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp_delta" }, "<", { "const": -3000 } ] },
-            { "compare_int": [ { "u_val": "body_temp_delta" }, ">=", { "const": -4500 } ] }
+            { "compare_num": [ { "u_val": "body_temp_delta" }, "<", { "const": -3000 } ] },
+            { "compare_num": [ { "u_val": "body_temp_delta" }, ">=", { "const": -4500 } ] }
           ]
         }
       },
@@ -139,7 +139,7 @@
         "text": "(Falling!!)",
         "sym": "↓↓↓",
         "color": "blue",
-        "condition": { "compare_int": [ { "u_val": "body_temp_delta" }, "<", { "const": -4500 } ] }
+        "condition": { "compare_num": [ { "u_val": "body_temp_delta" }, "<", { "const": -4500 } ] }
       }
     ]
   },

--- a/data/json/ui/bodypart_color_text.json
+++ b/data/json/ui/bodypart_color_text.json
@@ -21,7 +21,7 @@
           "and": [
             { "u_has_effect": "bite" },
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -38,7 +38,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 11 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -49,7 +49,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
           ]
         }
       },
@@ -79,7 +79,7 @@
           "and": [
             { "u_has_effect": "bite" },
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -96,7 +96,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 11 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -107,7 +107,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
           ]
         }
       },
@@ -137,7 +137,7 @@
           "and": [
             { "u_has_effect": "bite" },
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -154,7 +154,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 11 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -165,7 +165,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
           ]
         }
       },
@@ -195,7 +195,7 @@
           "and": [
             { "u_has_effect": "bite" },
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -212,7 +212,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 11 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -223,7 +223,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
           ]
         }
       },
@@ -253,7 +253,7 @@
           "and": [
             { "u_has_effect": "bite" },
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -270,7 +270,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 11 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -281,7 +281,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
           ]
         }
       },
@@ -311,7 +311,7 @@
           "and": [
             { "u_has_effect": "bite" },
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -328,7 +328,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 11 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -339,7 +339,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
           ]
         }
       },

--- a/data/json/ui/bodypart_status.json
+++ b/data/json/ui/bodypart_status.json
@@ -17,7 +17,7 @@
         "text": "broken",
         "sym": "%",
         "color": "magenta",
-        "condition": { "compare_int": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
       },
       {
         "id": "splinted",
@@ -48,7 +48,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
           ]
         }
       },
@@ -60,7 +60,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 11 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },

--- a/data/json/ui/fatigue.json
+++ b/data/json/ui/fatigue.json
@@ -10,8 +10,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "fatigue" }, ">=", { "const": 191 } ] },
-            { "compare_int": [ { "u_val": "fatigue" }, "<", { "const": 383 } ] }
+            { "compare_num": [ { "u_val": "fatigue" }, ">=", { "const": 191 } ] },
+            { "compare_num": [ { "u_val": "fatigue" }, "<", { "const": 383 } ] }
           ]
         }
       },
@@ -21,8 +21,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "fatigue" }, ">=", { "const": 383 } ] },
-            { "compare_int": [ { "u_val": "fatigue" }, "<", { "const": 575 } ] }
+            { "compare_num": [ { "u_val": "fatigue" }, ">=", { "const": 383 } ] },
+            { "compare_num": [ { "u_val": "fatigue" }, "<", { "const": 575 } ] }
           ]
         }
       },
@@ -30,7 +30,7 @@
         "id": "exhausted",
         "text": "Exhausted",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "fatigue" }, ">=", { "const": 575 } ] }
+        "condition": { "compare_num": [ { "u_val": "fatigue" }, ">=", { "const": 575 } ] }
       }
     ]
   },

--- a/data/json/ui/health.json
+++ b/data/json/ui/health.json
@@ -8,7 +8,7 @@
         "id": "horrible",
         "text": "Horrible",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "health" }, "<", { "const": -100 } ] }
+        "condition": { "compare_num": [ { "u_val": "health" }, "<", { "const": -100 } ] }
       },
       {
         "id": "very_bad",
@@ -16,8 +16,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "health" }, ">=", { "const": -100 } ] },
-            { "compare_int": [ { "u_val": "health" }, "<", { "const": -50 } ] }
+            { "compare_num": [ { "u_val": "health" }, ">=", { "const": -100 } ] },
+            { "compare_num": [ { "u_val": "health" }, "<", { "const": -50 } ] }
           ]
         }
       },
@@ -27,8 +27,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "health" }, ">=", { "const": -50 } ] },
-            { "compare_int": [ { "u_val": "health" }, "<", { "const": -10 } ] }
+            { "compare_num": [ { "u_val": "health" }, ">=", { "const": -50 } ] },
+            { "compare_num": [ { "u_val": "health" }, "<", { "const": -10 } ] }
           ]
         }
       },
@@ -38,8 +38,8 @@
         "color": "light_gray",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "health" }, ">=", { "const": -10 } ] },
-            { "compare_int": [ { "u_val": "health" }, "<", { "const": 10 } ] }
+            { "compare_num": [ { "u_val": "health" }, ">=", { "const": -10 } ] },
+            { "compare_num": [ { "u_val": "health" }, "<", { "const": 10 } ] }
           ]
         }
       },
@@ -49,8 +49,8 @@
         "color": "white",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "health" }, ">=", { "const": 10 } ] },
-            { "compare_int": [ { "u_val": "health" }, "<", { "const": 50 } ] }
+            { "compare_num": [ { "u_val": "health" }, ">=", { "const": 10 } ] },
+            { "compare_num": [ { "u_val": "health" }, "<", { "const": 50 } ] }
           ]
         }
       },
@@ -60,8 +60,8 @@
         "color": "green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "health" }, ">=", { "const": 50 } ] },
-            { "compare_int": [ { "u_val": "health" }, "<", { "const": 100 } ] }
+            { "compare_num": [ { "u_val": "health" }, ">=", { "const": 50 } ] },
+            { "compare_num": [ { "u_val": "health" }, "<", { "const": 100 } ] }
           ]
         }
       },
@@ -69,7 +69,7 @@
         "id": "excellent",
         "text": "Excellent",
         "color": "light_green",
-        "condition": { "compare_int": [ { "u_val": "health" }, ">=", { "const": 100 } ] }
+        "condition": { "compare_num": [ { "u_val": "health" }, ">=", { "const": 100 } ] }
       }
     ]
   },

--- a/data/json/ui/lighting.json
+++ b/data/json/ui/lighting.json
@@ -9,31 +9,31 @@
         "id": "bright",
         "text": "bright",
         "color": "yellow",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, "<=", { "const": 1 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, "<=", { "const": 1 } ] }
       },
       {
         "id": "cloudy",
         "text": "cloudy",
         "color": "white",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 2 } ] }
       },
       {
         "id": "shady",
         "text": "shady",
         "color": "light_gray",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 3 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 3 } ] }
       },
       {
         "id": "dark",
         "text": "dark",
         "color": "dark_gray",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 4 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 4 } ] }
       },
       {
         "id": "very dark",
         "text": "very dark",
         "color": "black_white",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, ">=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, ">=", { "const": 5 } ] }
       }
     ]
   },

--- a/data/json/ui/moon.json
+++ b/data/json/ui/moon.json
@@ -9,55 +9,55 @@
         "id": "new_moon",
         "text": "New moon",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 0 } ] }
       },
       {
         "id": "waxing_crescent",
         "text": "Waxing crescent",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 1 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 1 } ] }
       },
       {
         "id": "half_moon",
         "text": "Half moon",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 2 } ] }
       },
       {
         "id": "waxing_gibbous",
         "text": "Waxing gibbous",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 3 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 3 } ] }
       },
       {
         "id": "full_moon",
         "text": "Full moon",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 4 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 4 } ] }
       },
       {
         "id": "waning_gibbous",
         "text": "Waning gibbous",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 5 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 5 } ] }
       },
       {
         "id": "half_moon",
         "text": "Half moon",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 6 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 6 } ] }
       },
       {
         "id": "waning_crescent",
         "text": "Waning crescent",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 7 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 7 } ] }
       },
       {
         "id": "dark_moon",
         "text": "Dark moon",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 8 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 8 } ] }
       }
     ]
   },
@@ -67,54 +67,54 @@
     "label": "Moon",
     "style": "text",
     "clauses": [
-      { "id": "new_moon", "text": " -- ", "color": "white", "condition": { "compare_int": [ "moon", "==", { "const": 0 } ] } },
+      { "id": "new_moon", "text": " -- ", "color": "white", "condition": { "compare_num": [ "moon", "==", { "const": 0 } ] } },
       {
         "id": "waxing_crescent",
         "text": "   ) ↑",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 1 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 1 } ] }
       },
       {
         "id": "half_moon",
         "text": "  |) ↑",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 2 } ] }
       },
       {
         "id": "waxing_gibbous",
         "text": " ||) ↑",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 3 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 3 } ] }
       },
       {
         "id": "full_moon",
         "text": "(||)",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 4 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 4 } ] }
       },
       {
         "id": "waning_gibbous",
         "text": "(||  ↓",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 5 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 5 } ] }
       },
       {
         "id": "half_moon",
         "text": "(|   ↓",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 6 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 6 } ] }
       },
       {
         "id": "waning_crescent",
         "text": "(    ↓",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 7 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 7 } ] }
       },
       {
         "id": "dark_moon",
         "text": " -- ",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 8 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 8 } ] }
       }
     ]
   }

--- a/data/json/ui/radiation.json
+++ b/data/json/ui/radiation.json
@@ -10,7 +10,7 @@
         "color": "white_green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 0 } ] },
+            { "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 0 } ] },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -21,9 +21,9 @@
         "color": "h_white",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 30 } ] },
+            { "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 30 } ] },
             {
-              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 0 } ]
+              "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 0 } ]
             },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
@@ -35,9 +35,9 @@
         "color": "i_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 60 } ] },
+            { "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 60 } ] },
             {
-              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 30 } ]
+              "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 30 } ]
             },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
@@ -49,9 +49,9 @@
         "color": "red_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 120 } ] },
+            { "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 120 } ] },
             {
-              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 60 } ]
+              "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 60 } ]
             },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
@@ -63,9 +63,9 @@
         "color": "red_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 240 } ] },
+            { "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 240 } ] },
             {
-              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 120 } ]
+              "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 120 } ]
             },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
@@ -77,7 +77,7 @@
         "color": "pink",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 240 } ] },
+            { "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 240 } ] },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }

--- a/data/json/ui/sidebar-mobile.json
+++ b/data/json/ui/sidebar-mobile.json
@@ -542,7 +542,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
           ]
         }
       },
@@ -553,7 +553,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 11 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -633,12 +633,12 @@
       {
         "id": "broken",
         "widgets": [ "l_nw", "l_bp_LA", "l_nc_cl", "i_bp_LA_broken_sym", "l_ne" ],
-        "condition": { "compare_int": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
       },
       {
         "id": "intact",
         "widgets": [ "l_nw", "l_bp_LA", "l_nc_cl", "i_bp_LA_hp_graph", "l_ne" ],
-        "condition": { "compare_int": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
       }
     ],
     "type": "widget"
@@ -654,12 +654,12 @@
       {
         "id": "broken",
         "widgets": [ "l_nw", "l_bp_HD", "l_nc_cl", "i_bp_HD_broken_sym", "l_ne" ],
-        "condition": { "compare_int": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
       },
       {
         "id": "intact",
         "widgets": [ "l_nw", "l_bp_HD", "l_nc_cl", "i_bp_HD_hp_graph", "l_ne" ],
-        "condition": { "compare_int": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
       }
     ],
     "type": "widget"
@@ -675,12 +675,12 @@
       {
         "id": "broken",
         "widgets": [ "l_nw", "l_bp_RA", "l_nc_cl", "i_bp_RA_broken_sym", "l_ne" ],
-        "condition": { "compare_int": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
       },
       {
         "id": "intact",
         "widgets": [ "l_nw", "l_bp_RA", "l_nc_cl", "i_bp_RA_hp_graph", "l_ne" ],
-        "condition": { "compare_int": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
       }
     ],
     "type": "widget"
@@ -696,12 +696,12 @@
       {
         "id": "broken",
         "widgets": [ "l_nw", "l_bp_LL", "l_nc_cl", "i_bp_LL_broken_sym", "l_ne" ],
-        "condition": { "compare_int": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
       },
       {
         "id": "intact",
         "widgets": [ "l_nw", "l_bp_LL", "l_nc_cl", "i_bp_LL_hp_graph", "l_ne" ],
-        "condition": { "compare_int": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
       }
     ],
     "type": "widget"
@@ -717,12 +717,12 @@
       {
         "id": "broken",
         "widgets": [ "l_nw", "l_bp_CT", "l_nc_cl", "i_bp_CT_broken_sym", "l_ne" ],
-        "condition": { "compare_int": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
       },
       {
         "id": "intact",
         "widgets": [ "l_nw", "l_bp_CT", "l_nc_cl", "i_bp_CT_hp_graph", "l_ne" ],
-        "condition": { "compare_int": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
       }
     ],
     "type": "widget"
@@ -738,12 +738,12 @@
       {
         "id": "broken",
         "widgets": [ "l_nw", "l_bp_RL", "l_nc_cl", "i_bp_RL_broken_sym", "l_ne" ],
-        "condition": { "compare_int": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
       },
       {
         "id": "intact",
         "widgets": [ "l_nw", "l_bp_RL", "l_nc_cl", "i_bp_RL_hp_graph", "l_ne" ],
-        "condition": { "compare_int": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
       }
     ],
     "type": "widget"
@@ -945,91 +945,91 @@
         "id": "new_moon",
         "sym": "⎛   ⎞",
         "color": "c_light_gray",
-        "condition": { "compare_int": [ "moon", "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 0 } ] }
       },
       {
         "id": "waxing_crescent1",
         "sym": "⎛  ",
         "color": "c_light_gray",
-        "condition": { "compare_int": [ "moon", "==", { "const": 1 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 1 } ] }
       },
       {
         "id": "waxing_crescent2",
         "sym": "▊⎞",
         "color": "c_black_white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 1 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 1 } ] }
       },
       {
         "id": "half_moon1",
         "sym": "⎛ ▐",
         "color": "c_light_gray",
-        "condition": { "compare_int": [ "moon", "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 2 } ] }
       },
       {
         "id": "half_moon2",
         "sym": "⡡⎞",
         "color": "c_black_white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 2 } ] }
       },
       {
         "id": "waxing_gibbous1",
         "sym": "⎛",
         "color": "c_light_gray",
-        "condition": { "compare_int": [ "moon", "==", { "const": 3 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 3 } ] }
       },
       {
         "id": "waxing_gibbous2",
         "sym": "▎⢁⡡⎞",
         "color": "c_black_white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 3 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 3 } ] }
       },
       {
         "id": "full_moon",
         "sym": "⎛⡐⢁⡡⎞",
         "color": "c_black_white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 4 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 4 } ] }
       },
       {
         "id": "waning_gibbous1",
         "sym": "⎛⡐⢁",
         "color": "c_black_white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 5 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 5 } ] }
       },
       {
         "id": "waning_gibbous2",
         "sym": "▎⎞",
         "color": "c_light_gray",
-        "condition": { "compare_int": [ "moon", "==", { "const": 5 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 5 } ] }
       },
       {
         "id": "half_moon1",
         "sym": "⎛⡐",
         "color": "c_black_white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 6 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 6 } ] }
       },
       {
         "id": "half_moon2",
         "sym": "▌ ⎞",
         "color": "c_light_gray",
-        "condition": { "compare_int": [ "moon", "==", { "const": 6 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 6 } ] }
       },
       {
         "id": "waning_crescent1",
         "sym": "⎛",
         "color": "c_black_white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 7 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 7 } ] }
       },
       {
         "id": "waning_crescent2",
         "sym": "▎  ⎞",
         "color": "c_light_gray",
-        "condition": { "compare_int": [ "moon", "==", { "const": 7 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 7 } ] }
       },
       {
         "id": "dark_moon",
         "sym": "⎛   ⎞",
         "color": "c_light_gray",
-        "condition": { "compare_int": [ "moon", "==", { "const": 8 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 8 } ] }
       }
     ],
     "type": "widget"
@@ -1122,31 +1122,31 @@
         "id": "bright",
         "text": "☼☼☼☼☼",
         "color": "c_white",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, "<=", { "const": 1 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, "<=", { "const": 1 } ] }
       },
       {
         "id": "cloudy",
         "text": "☼☼☼☼",
         "color": "c_yellow",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 2 } ] }
       },
       {
         "id": "shady",
         "text": "☼☼☼",
         "color": "c_light_gray",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 3 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 3 } ] }
       },
       {
         "id": "dark",
         "text": "☼☼",
         "color": "c_dark_gray",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 4 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 4 } ] }
       },
       {
         "id": "very dark",
         "text": "☼",
         "color": "c_dark_gray",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, ">=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, ">=", { "const": 5 } ] }
       }
     ],
     "type": "widget"
@@ -1311,31 +1311,31 @@
         "id": "20%",
         "color": "h_yellow",
         "sym": "1",
-        "condition": { "compare_int": [ { "u_val": "power_percentage" }, ">", { "const": 19 } ] }
+        "condition": { "compare_num": [ { "u_val": "power_percentage" }, ">", { "const": 19 } ] }
       },
       {
         "id": "40%",
         "color": "h_yellow",
         "sym": "2",
-        "condition": { "compare_int": [ { "u_val": "power_percentage" }, ">", { "const": 39 } ] }
+        "condition": { "compare_num": [ { "u_val": "power_percentage" }, ">", { "const": 39 } ] }
       },
       {
         "id": "60%",
         "color": "h_yellow",
         "sym": "3",
-        "condition": { "compare_int": [ { "u_val": "power_percentage" }, ">", { "const": 59 } ] }
+        "condition": { "compare_num": [ { "u_val": "power_percentage" }, ">", { "const": 59 } ] }
       },
       {
         "id": "80%",
         "color": "h_yellow",
         "sym": "4",
-        "condition": { "compare_int": [ { "u_val": "power_percentage" }, ">", { "const": 79 } ] }
+        "condition": { "compare_num": [ { "u_val": "power_percentage" }, ">", { "const": 79 } ] }
       },
       {
         "id": "99%",
         "color": "h_yellow",
         "sym": "5",
-        "condition": { "compare_int": [ { "u_val": "power_percentage" }, ">", { "const": 99 } ] }
+        "condition": { "compare_num": [ { "u_val": "power_percentage" }, ">", { "const": 99 } ] }
       }
     ],
     "default_clause": { "text": "     " },
@@ -1476,7 +1476,7 @@
         "id": "turgid",
         "text": "o⁰ₒ○",
         "color": "c_light_green_green",
-        "condition": { "compare_int": [ { "u_val": "instant_thirst" }, "<", { "const": -60 } ] }
+        "condition": { "compare_num": [ { "u_val": "instant_thirst" }, "<", { "const": -60 } ] }
       },
       {
         "id": "hydrated",
@@ -1484,8 +1484,8 @@
         "color": "h_green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">=", { "const": -60 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<", { "const": -20 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">=", { "const": -60 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<", { "const": -20 } ] }
           ]
         }
       },
@@ -1495,8 +1495,8 @@
         "color": "h_green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">=", { "const": -20 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<", { "const": 0 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">=", { "const": -20 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<", { "const": 0 } ] }
           ]
         }
       },
@@ -1506,8 +1506,8 @@
         "color": "h_green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">=", { "const": 0 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<=", { "const": 40 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">=", { "const": 0 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<=", { "const": 40 } ] }
           ]
         }
       },
@@ -1517,8 +1517,8 @@
         "color": "h_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">", { "const": 40 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<=", { "const": 80 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">", { "const": 40 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<=", { "const": 80 } ] }
           ]
         }
       },
@@ -1528,8 +1528,8 @@
         "color": "h_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">", { "const": 80 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<=", { "const": 240 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">", { "const": 80 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<=", { "const": 240 } ] }
           ]
         }
       },
@@ -1539,8 +1539,8 @@
         "color": "h_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">", { "const": 240 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<=", { "const": 450 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">", { "const": 240 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<=", { "const": 450 } ] }
           ]
         }
       },
@@ -1550,8 +1550,8 @@
         "color": "h_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">", { "const": 450 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<=", { "const": 520 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">", { "const": 450 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<=", { "const": 520 } ] }
           ]
         }
       },
@@ -1559,7 +1559,7 @@
         "id": "parched",
         "text": "XXXX",
         "color": "i_red",
-        "condition": { "compare_int": [ { "u_val": "instant_thirst" }, ">", { "const": 520 } ] }
+        "condition": { "compare_num": [ { "u_val": "instant_thirst" }, ">", { "const": 520 } ] }
       }
     ],
     "type": "widget"
@@ -1581,7 +1581,7 @@
         "id": "sk",
         "sym": "ₒ",
         "color": "c_red",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
       },
       {
         "id": "e",
@@ -1589,8 +1589,8 @@
         "color": "c_light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
           ]
         }
       },
@@ -1600,8 +1600,8 @@
         "color": "c_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
           ]
         }
       },
@@ -1611,8 +1611,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
           ]
         }
       },
@@ -1622,8 +1622,8 @@
         "color": "c_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
           ]
         }
       },
@@ -1633,8 +1633,8 @@
         "color": "c_light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
           ]
         }
       },
@@ -1644,8 +1644,8 @@
         "color": "c_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
           ]
         }
       },
@@ -1653,7 +1653,7 @@
         "id": "m_o",
         "sym": "ₒ",
         "color": "c_white",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] }
       }
     ],
     "type": "widget"
@@ -1667,19 +1667,19 @@
         "id": "sk",
         "sym": "⎻⎺",
         "color": "c_brown",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
       },
       {
         "id": "sk",
         "sym": "ₗ",
         "color": "c_yellow",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
       },
       {
         "id": "sk",
         "sym": "  ",
         "color": "c_brown",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
       },
       {
         "id": "e",
@@ -1687,8 +1687,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
           ]
         }
       },
@@ -1698,8 +1698,8 @@
         "color": "c_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
           ]
         }
       },
@@ -1709,8 +1709,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
           ]
         }
       },
@@ -1720,8 +1720,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
           ]
         }
       },
@@ -1731,8 +1731,8 @@
         "color": "c_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
           ]
         }
       },
@@ -1742,8 +1742,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
           ]
         }
       },
@@ -1753,8 +1753,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
           ]
         }
       },
@@ -1764,8 +1764,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
           ]
         }
       },
@@ -1775,8 +1775,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
           ]
         }
       },
@@ -1786,8 +1786,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
           ]
         }
       },
@@ -1797,8 +1797,8 @@
         "color": "c_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
           ]
         }
       },
@@ -1808,8 +1808,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
           ]
         }
       },
@@ -1819,8 +1819,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
           ]
         }
       },
@@ -1830,8 +1830,8 @@
         "color": "c_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
           ]
         }
       },
@@ -1841,8 +1841,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
           ]
         }
       },
@@ -1852,8 +1852,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
           ]
         }
       },
@@ -1863,8 +1863,8 @@
         "color": "c_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
           ]
         }
       },
@@ -1874,8 +1874,8 @@
         "color": "c_brown",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
           ]
         }
       },
@@ -1883,19 +1883,19 @@
         "id": "m_o",
         "sym": "  ",
         "color": "c_brown",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] }
       },
       {
         "id": "m_o",
         "sym": "ₕ",
         "color": "c_red",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] }
       },
       {
         "id": "m_o",
         "sym": " ⎺",
         "color": "c_brown",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] }
       }
     ],
     "type": "widget"
@@ -2093,37 +2093,37 @@
         "id": "none",
         "text": "None       ",
         "color": "light_gray",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 0 } ] }
       },
       {
         "id": "light",
         "text": "Light      ",
         "color": "yellow",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 1 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 1 } ] }
       },
       {
         "id": "moderate",
         "text": "Moderate   ",
         "color": "yellow",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 2 } ] }
       },
       {
         "id": "brisk",
         "text": "Brisk      ",
         "color": "light_red",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 3 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 3 } ] }
       },
       {
         "id": "active",
         "text": "Active     ",
         "color": "light_red",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 4 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 4 } ] }
       },
       {
         "id": "extreme",
         "text": "Extreme    ",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, ">=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, ">=", { "const": 5 } ] }
       }
     ],
     "type": "widget"

--- a/data/json/ui/spacebar/spacebar_separators.json
+++ b/data/json/ui/spacebar/spacebar_separators.json
@@ -11,8 +11,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "pain" }, ">=", { "const": 3 } ] },
-            { "compare_int": [ { "u_val": "pain" }, "<", { "const": 40 } ] }
+            { "compare_num": [ { "u_val": "pain" }, ">=", { "const": 3 } ] },
+            { "compare_num": [ { "u_val": "pain" }, "<", { "const": 40 } ] }
           ]
         }
       },
@@ -22,8 +22,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "pain" }, ">=", { "const": 40 } ] },
-            { "compare_int": [ { "u_val": "pain" }, "<", { "const": 60 } ] }
+            { "compare_num": [ { "u_val": "pain" }, ">=", { "const": 40 } ] },
+            { "compare_num": [ { "u_val": "pain" }, "<", { "const": 60 } ] }
           ]
         }
       },
@@ -31,7 +31,7 @@
         "id": "haevy",
         "text": "]>=---=---=<>=---=<<>>=---=<<>>=---=<<>>=---=<>=---=---=<[",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "pain" }, ">=", { "const": 60 } ] }
+        "condition": { "compare_num": [ { "u_val": "pain" }, ">=", { "const": 60 } ] }
       }
     ],
     "default_clause": { "text": "]>=---=---=---=---=---=---=----=---=---=---=---=---=---=<[", "color": "dark_gray" },
@@ -48,8 +48,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "pain" }, ">=", { "const": 3 } ] },
-            { "compare_int": [ { "u_val": "pain" }, "<", { "const": 40 } ] }
+            { "compare_num": [ { "u_val": "pain" }, ">=", { "const": 3 } ] },
+            { "compare_num": [ { "u_val": "pain" }, "<", { "const": 40 } ] }
           ]
         }
       },
@@ -59,8 +59,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "pain" }, ">=", { "const": 40 } ] },
-            { "compare_int": [ { "u_val": "pain" }, "<", { "const": 60 } ] }
+            { "compare_num": [ { "u_val": "pain" }, ">=", { "const": 40 } ] },
+            { "compare_num": [ { "u_val": "pain" }, "<", { "const": 60 } ] }
           ]
         }
       },
@@ -68,7 +68,7 @@
         "id": "haevy",
         "text": "]>=--=---=<<>>=---=<<>>=---=<<>>=---=--=<[",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "pain" }, ">=", { "const": 60 } ] }
+        "condition": { "compare_num": [ { "u_val": "pain" }, ">=", { "const": 60 } ] }
       }
     ],
     "default_clause": { "text": "]>=---=---=---=---=----=---=---=---=---=<[", "color": "dark_gray" }

--- a/data/json/ui/thirst.json
+++ b/data/json/ui/thirst.json
@@ -10,7 +10,7 @@
         "id": "parched",
         "text": "Parched",
         "color": "light_red",
-        "condition": { "compare_int": [ { "u_val": "instant_thirst" }, ">", { "const": 520 } ] }
+        "condition": { "compare_num": [ { "u_val": "instant_thirst" }, ">", { "const": 520 } ] }
       },
       {
         "id": "dehydrated",
@@ -18,8 +18,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">", { "const": 240 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<=", { "const": 520 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">", { "const": 240 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<=", { "const": 520 } ] }
           ]
         }
       },
@@ -29,8 +29,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">", { "const": 80 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<=", { "const": 240 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">", { "const": 80 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<=", { "const": 240 } ] }
           ]
         }
       },
@@ -40,8 +40,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">", { "const": 40 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<=", { "const": 80 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">", { "const": 40 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<=", { "const": 80 } ] }
           ]
         }
       },
@@ -51,8 +51,8 @@
         "color": "white",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">=", { "const": 0 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<=", { "const": 40 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">=", { "const": 0 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<=", { "const": 40 } ] }
           ]
         }
       },
@@ -62,8 +62,8 @@
         "color": "green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">=", { "const": -20 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<", { "const": 0 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">=", { "const": -20 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<", { "const": 0 } ] }
           ]
         }
       },
@@ -73,8 +73,8 @@
         "color": "green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "instant_thirst" }, ">=", { "const": -60 } ] },
-            { "compare_int": [ { "u_val": "instant_thirst" }, "<", { "const": -20 } ] }
+            { "compare_num": [ { "u_val": "instant_thirst" }, ">=", { "const": -60 } ] },
+            { "compare_num": [ { "u_val": "instant_thirst" }, "<", { "const": -20 } ] }
           ]
         }
       },
@@ -82,7 +82,7 @@
         "id": "turgid",
         "text": "Turgid",
         "color": "green",
-        "condition": { "compare_int": [ { "u_val": "instant_thirst" }, "<", { "const": -60 } ] }
+        "condition": { "compare_num": [ { "u_val": "instant_thirst" }, "<", { "const": -60 } ] }
       }
     ]
   },

--- a/data/json/ui/weight.json
+++ b/data/json/ui/weight.json
@@ -9,7 +9,7 @@
         "id": "skeletal",
         "text": "Skeletal",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
       },
       {
         "id": "emaciated",
@@ -17,8 +17,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
           ]
         }
       },
@@ -28,8 +28,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
           ]
         }
       },
@@ -40,8 +40,8 @@
         "//": "Actually 18.5 - 25",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
           ]
         }
       },
@@ -51,8 +51,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
           ]
         }
       },
@@ -62,8 +62,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
           ]
         }
       },
@@ -73,8 +73,8 @@
         "color": "red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
           ]
         }
       },
@@ -82,7 +82,7 @@
         "id": "morbidly_obese",
         "text": "Morbidly Obese",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] }
       }
     ]
   },

--- a/data/json/weather_type.json
+++ b/data/json/weather_type.json
@@ -18,8 +18,8 @@
     "condition": {
       "and": [
         "is_day",
-        { "compare_int": [ { "weather": "pressure" }, ">=", { "const": 1020 } ] },
-        { "compare_int": [ { "weather": "humidity" }, "<", { "const": 70 } ] }
+        { "compare_num": [ { "weather": "pressure" }, ">=", { "const": 1020 } ] },
+        { "compare_num": [ { "weather": "humidity" }, "<", { "const": 70 } ] }
       ]
     }
   },
@@ -42,8 +42,8 @@
     "sound_category": "cloudy",
     "condition": {
       "and": [
-        { "compare_int": [ { "weather": "humidity" }, ">=", { "const": 40 } ] },
-        { "compare_int": [ { "weather": "pressure" }, "<", { "const": 1010 } ] }
+        { "compare_num": [ { "weather": "humidity" }, ">=", { "const": 40 } ] },
+        { "compare_num": [ { "weather": "pressure" }, "<", { "const": 1010 } ] }
       ]
     }
   },
@@ -69,8 +69,8 @@
     "required_weathers": [ "cloudy" ],
     "condition": {
       "or": [
-        { "compare_int": [ { "weather": "humidity" }, ">=", { "const": 96 } ] },
-        { "compare_int": [ { "weather": "pressure" }, "<", { "const": 1003 } ] }
+        { "compare_num": [ { "weather": "humidity" }, ">=", { "const": 96 } ] },
+        { "compare_num": [ { "weather": "pressure" }, "<", { "const": 1003 } ] }
       ]
     }
   },
@@ -96,8 +96,8 @@
     "required_weathers": [ "light_drizzle" ],
     "condition": {
       "or": [
-        { "compare_int": [ { "weather": "humidity" }, ">=", { "const": 97 } ] },
-        { "compare_int": [ { "weather": "pressure" }, "<", { "const": 1000 } ] }
+        { "compare_num": [ { "weather": "humidity" }, ">=", { "const": 97 } ] },
+        { "compare_num": [ { "weather": "pressure" }, "<", { "const": 1000 } ] }
       ]
     }
   },
@@ -123,8 +123,8 @@
     "required_weathers": [ "light_drizzle", "drizzle" ],
     "condition": {
       "or": [
-        { "compare_int": [ { "weather": "humidity" }, ">=", { "const": 98 } ] },
-        { "compare_int": [ { "weather": "pressure" }, "<", { "const": 993 } ] }
+        { "compare_num": [ { "weather": "humidity" }, ">=", { "const": 98 } ] },
+        { "compare_num": [ { "weather": "pressure" }, "<", { "const": 993 } ] }
       ]
     }
   },
@@ -150,8 +150,8 @@
     "required_weathers": [ "rain" ],
     "condition": {
       "and": [
-        { "compare_int": [ { "weather": "temperature" }, ">=", { "const": 33 } ] },
-        { "compare_int": [ { "weather": "windpower" }, ">=", { "const": 15 } ] }
+        { "compare_num": [ { "weather": "temperature" }, ">=", { "const": 33 } ] },
+        { "compare_num": [ { "weather": "windpower" }, ">=", { "const": 15 } ] }
       ]
     }
   },
@@ -175,7 +175,7 @@
     "weather_animation": { "factor": 0.02, "color": "light_blue", "sym": "." },
     "sound_category": "thunder",
     "required_weathers": [ "rain" ],
-    "condition": { "compare_int": [ { "weather": "pressure" }, "<", { "const": 996 } ] }
+    "condition": { "compare_num": [ { "weather": "pressure" }, "<", { "const": 996 } ] }
   },
   {
     "id": "lightning",
@@ -197,7 +197,7 @@
     "weather_animation": { "factor": 0.04, "color": "light_blue", "sym": "," },
     "sound_category": "thunder",
     "required_weathers": [ "thunder" ],
-    "condition": { "compare_int": [ { "weather": "pressure" }, "<", { "const": 990 } ] }
+    "condition": { "compare_num": [ { "weather": "pressure" }, "<", { "const": 990 } ] }
   },
   {
     "id": "acid_drizzle",
@@ -261,7 +261,7 @@
     "weather_animation": { "factor": 0.01, "color": "white", "sym": "." },
     "sound_category": "flurries",
     "required_weathers": [ "flurries" ],
-    "condition": { "compare_int": [ { "weather": "temperature" }, "<", { "const": 33 } ] }
+    "condition": { "compare_num": [ { "weather": "temperature" }, "<", { "const": 33 } ] }
   },
   {
     "id": "snowing",
@@ -283,7 +283,7 @@
     "weather_animation": { "factor": 0.02, "color": "white", "sym": "," },
     "sound_category": "snow",
     "required_weathers": [ "rain", "thunder", "lightning" ],
-    "condition": { "compare_int": [ { "weather": "temperature" }, "<", { "const": 33 } ] }
+    "condition": { "compare_num": [ { "weather": "temperature" }, "<", { "const": 33 } ] }
   },
   {
     "id": "snowstorm",
@@ -307,8 +307,8 @@
     "required_weathers": [ "thunder", "lightning" ],
     "condition": {
       "and": [
-        { "compare_int": [ { "weather": "temperature" }, "<", { "const": 33 } ] },
-        { "compare_int": [ { "weather": "windpower" }, ">=", { "const": 15 } ] }
+        { "compare_num": [ { "weather": "temperature" }, "<", { "const": 33 } ] },
+        { "compare_num": [ { "weather": "windpower" }, ">=", { "const": 15 } ] }
       ]
     }
   },
@@ -333,7 +333,7 @@
     "tiles_animation": "weather_portal_storm",
     "weather_animation": { "factor": 0.01, "color": "red", "sym": "*" },
     "sound_category": "portal_storm",
-    "condition": { "compare_int": [ { "global_val": "var", "var_name": "cause_early_portal_storm" }, "=", { "const": 1 } ] }
+    "condition": { "compare_num": [ { "global_val": "var", "var_name": "cause_early_portal_storm" }, "=", { "const": 1 } ] }
   },
   {
     "id": "portal_storm",
@@ -356,6 +356,6 @@
     "tiles_animation": "weather_portal_storm",
     "weather_animation": { "factor": 0.01, "color": "red", "sym": "*" },
     "sound_category": "portal_storm",
-    "condition": { "compare_int": [ { "global_val": "var", "var_name": "cause_portal_storm" }, "=", { "const": 1 } ] }
+    "condition": { "compare_num": [ { "global_val": "var", "var_name": "cause_portal_storm" }, "=", { "const": 1 } ] }
   }
 ]

--- a/data/mods/CrazyCataclysm/crazy_widgets.json
+++ b/data/mods/CrazyCataclysm/crazy_widgets.json
@@ -10,7 +10,7 @@
         "id": "skeletal",
         "text": "Spooky Scary Skeleton",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
       },
       {
         "id": "emaciated",
@@ -18,8 +18,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
           ]
         }
       },
@@ -29,8 +29,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
           ]
         }
       },
@@ -41,8 +41,8 @@
         "//": "Actually 18.5 - 25",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
           ]
         }
       },
@@ -52,8 +52,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
           ]
         }
       },
@@ -63,8 +63,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
           ]
         }
       },
@@ -74,8 +74,8 @@
         "color": "red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
           ]
         }
       },
@@ -85,8 +85,8 @@
         "color": "red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 45000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 45000 } ] }
           ]
         }
       },
@@ -96,8 +96,8 @@
         "color": "red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 45000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 50000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 45000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 50000 } ] }
           ]
         }
       },
@@ -105,7 +105,7 @@
         "id": "morbidly_obese_plus_10",
         "text": "AW HELL NAH",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 50000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 50000 } ] }
       }
     ]
   },

--- a/data/mods/TEST_DATA/addictions.json
+++ b/data/mods/TEST_DATA/addictions.json
@@ -3,7 +3,7 @@
     "type": "effect_on_condition",
     "id": "test_EOC_CAFFEINE_ADDICTION",
     "condition": {
-      "compare_int": [
+      "compare_num": [
         { "rand": 2000 },
         "<=",
         { "u_val": "addiction_intensity", "addiction": "test_caffeine", "mod": { "val": 2000, "step": 20 } }
@@ -18,10 +18,10 @@
             "condition": {
               "and": [
                 {
-                  "compare_int": [ { "u_val": "stim" }, ">", { "u_val": "addiction_intensity", "addiction": "test_caffeine", "mod": -10 } ]
+                  "compare_num": [ { "u_val": "stim" }, ">", { "u_val": "addiction_intensity", "addiction": "test_caffeine", "mod": -10 } ]
                 },
                 {
-                  "compare_int": [ { "rand": 10 }, "<", { "u_val": "addiction_intensity", "addiction": "test_caffeine" } ]
+                  "compare_num": [ { "rand": 10 }, "<", { "u_val": "addiction_intensity", "addiction": "test_caffeine" } ]
                 }
               ]
             },
@@ -31,9 +31,9 @@
             "id": "test_EOC_CAFFEINE_ADDICTION_SHAKES",
             "condition": {
               "and": [
-                { "compare_int": [ { "u_val": "addiction_intensity", "addiction": "test_caffeine" }, ">=", { "const": 8 } ] },
+                { "compare_num": [ { "u_val": "addiction_intensity", "addiction": "test_caffeine" }, ">=", { "const": 8 } ] },
                 {
-                  "compare_int": [ { "rand": 392 }, "<", { "u_val": "addiction_intensity", "addiction": "test_caffeine" } ]
+                  "compare_num": [ { "rand": 392 }, "<", { "u_val": "addiction_intensity", "addiction": "test_caffeine" } ]
                 }
               ]
             },

--- a/data/mods/TEST_DATA/mutations.json
+++ b/data/mods/TEST_DATA/mutations.json
@@ -44,31 +44,31 @@
     "triggers": [
       [
         {
-          "condition": { "compare_int": [ { "u_val": "morale" }, ">", { "const": 20 } ] },
+          "condition": { "compare_num": [ { "u_val": "morale" }, ">", { "const": 20 } ] },
           "msg_on": { "text": "Your mood is above 20 and triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "and": [ { "compare_int": [ "moon", ">", { "const": 3 } ] }, { "compare_int": [ "moon", "<", { "const": 5 } ] } ] },
+          "condition": { "and": [ { "compare_num": [ "moon", ">", { "const": 3 } ] }, { "compare_num": [ "moon", "<", { "const": 5 } ] } ] },
           "msg_on": { "text": "This is the full moon and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_int": [ { "u_val": "hunger" }, ">", { "const": 110 } ] },
+          "condition": { "compare_num": [ { "u_val": "hunger" }, ">", { "const": 110 } ] },
           "msg_on": { "text": "You're very hungry and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_int": [ { "u_val": "pain" }, ">", { "const": 110 } ] },
+          "condition": { "compare_num": [ { "u_val": "pain" }, ">", { "const": 110 } ] },
           "msg_on": { "text": "You're in pain and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_int": [ { "u_val": "thirst" }, ">", { "const": 110 } ] },
+          "condition": { "compare_num": [ { "u_val": "thirst" }, ">", { "const": 110 } ] },
           "msg_on": { "text": "You're thirsty and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_int": [ { "u_val": "stamina" }, "<", { "const": 1 } ] },
+          "condition": { "compare_num": [ { "u_val": "stamina" }, "<", { "const": 1 } ] },
           "msg_on": { "text": "You're low on stamina and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "and": [ { "compare_int": [ "hour", ">", { "const": 1 } ] }, { "compare_int": [ "hour", "<", { "const": 3 } ] } ] },
+          "condition": { "and": [ { "compare_num": [ "hour", ">", { "const": 1 } ] }, { "compare_num": [ "hour", "<", { "const": 3 } ] } ] },
           "msg_on": { "text": "It's 2 am and it triggers the trigger.", "rating": "mixed" }
         }
       ]
@@ -85,31 +85,31 @@
     "triggers": [
       [
         {
-          "condition": { "compare_int": [ { "u_val": "morale" }, "<", { "const": 20 } ] },
+          "condition": { "compare_num": [ { "u_val": "morale" }, "<", { "const": 20 } ] },
           "msg_off": { "text": "Your mood is below 20 and triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "or": [ { "compare_int": [ "moon", "<", { "const": 3 } ] }, { "compare_int": [ "moon", ">", { "const": 5 } ] } ] },
+          "condition": { "or": [ { "compare_num": [ "moon", "<", { "const": 3 } ] }, { "compare_num": [ "moon", ">", { "const": 5 } ] } ] },
           "msg_on": { "text": "This is not the full moon anymore and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_int": [ { "u_val": "hunger" }, "<", { "const": 110 } ] },
+          "condition": { "compare_num": [ { "u_val": "hunger" }, "<", { "const": 110 } ] },
           "msg_on": { "text": "You're no longer very hungry and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_int": [ { "u_val": "pain" }, "<", { "const": 110 } ] },
+          "condition": { "compare_num": [ { "u_val": "pain" }, "<", { "const": 110 } ] },
           "msg_on": { "text": "You're no longer in pain and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_int": [ { "u_val": "thirst" }, "<", { "const": 110 } ] },
+          "condition": { "compare_num": [ { "u_val": "thirst" }, "<", { "const": 110 } ] },
           "msg_on": { "text": "You're no longer thirsty and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_int": [ { "u_val": "stamina" }, ">", { "const": 1 } ] },
+          "condition": { "compare_num": [ { "u_val": "stamina" }, ">", { "const": 1 } ] },
           "msg_on": { "text": "You're no longer low on stamina and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "or": [ { "compare_int": [ "hour", "<", { "const": 1 } ] }, { "compare_int": [ "hour", ">", { "const": 2 } ] } ] },
+          "condition": { "or": [ { "compare_num": [ "hour", "<", { "const": 1 } ] }, { "compare_num": [ "hour", ">", { "const": 2 } ] } ] },
           "msg_on": { "text": "It's no longer 2 am and it triggers the trigger.", "rating": "mixed" }
         }
       ]
@@ -125,10 +125,10 @@
     "triggers": [
       [
         {
-          "condition": { "and": [ { "compare_int": [ "moon", ">", { "const": 3 } ] }, { "compare_int": [ "moon", "<", { "const": 5 } ] } ] }
+          "condition": { "and": [ { "compare_num": [ "moon", ">", { "const": 3 } ] }, { "compare_num": [ "moon", "<", { "const": 5 } ] } ] }
         }
       ],
-      [ { "condition": { "compare_int": [ { "u_val": "pain" }, ">", { "const": 110 } ] } } ]
+      [ { "condition": { "compare_num": [ { "u_val": "pain" }, ">", { "const": 110 } ] } } ]
     ],
     "transform": { "target": "TEST_TRIGGER_2_active", "msg_transform": "The trigger is triggered.", "active": true, "moves": 10 }
   },
@@ -142,11 +142,11 @@
     "triggers": [
       [
         {
-          "condition": { "or": [ { "compare_int": [ "moon", "<", { "const": 3 } ] }, { "compare_int": [ "moon", ">", { "const": 5 } ] } ] },
+          "condition": { "or": [ { "compare_num": [ "moon", "<", { "const": 3 } ] }, { "compare_num": [ "moon", ">", { "const": 5 } ] } ] },
           "msg_on": { "text": "This is not the full moon anymore and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_int": [ { "u_val": "pain" }, "<", { "const": 110 } ] },
+          "condition": { "compare_num": [ { "u_val": "pain" }, "<", { "const": 110 } ] },
           "msg_on": { "text": "You're no longer in pain and it triggers the trigger.", "rating": "mixed" }
         }
       ]

--- a/data/mods/TEST_DATA/widgets.json
+++ b/data/mods/TEST_DATA/widgets.json
@@ -10,37 +10,37 @@
         "id": "none",
         "text": "None",
         "color": "light_gray",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 0 } ] }
       },
       {
         "id": "light",
         "text": "Light",
         "color": "yellow",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 1 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 1 } ] }
       },
       {
         "id": "moderate",
         "text": "Moderate",
         "color": "yellow",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 2 } ] }
       },
       {
         "id": "brisk",
         "text": "Brisk",
         "color": "light_red",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 3 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 3 } ] }
       },
       {
         "id": "active",
         "text": "Active",
         "color": "light_red",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, "==", { "const": 4 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 4 } ] }
       },
       {
         "id": "extreme",
         "text": "Extreme",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "activity_level" }, ">=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "u_val": "activity_level" }, ">=", { "const": 5 } ] }
       }
     ]
   },
@@ -56,8 +56,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "fatigue" }, ">", { "const": 191 } ] },
-            { "compare_int": [ { "u_val": "fatigue" }, "<=", { "const": 383 } ] }
+            { "compare_num": [ { "u_val": "fatigue" }, ">", { "const": 191 } ] },
+            { "compare_num": [ { "u_val": "fatigue" }, "<=", { "const": 383 } ] }
           ]
         }
       },
@@ -67,8 +67,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "fatigue" }, ">", { "const": 383 } ] },
-            { "compare_int": [ { "u_val": "fatigue" }, "<=", { "const": 575 } ] }
+            { "compare_num": [ { "u_val": "fatigue" }, ">", { "const": 383 } ] },
+            { "compare_num": [ { "u_val": "fatigue" }, "<=", { "const": 575 } ] }
           ]
         }
       },
@@ -76,7 +76,7 @@
         "id": "exhausted",
         "text": "Exhausted",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "fatigue" }, ">", { "const": 575 } ] }
+        "condition": { "compare_num": [ { "u_val": "fatigue" }, ">", { "const": 575 } ] }
       }
     ]
   },
@@ -99,7 +99,7 @@
         "text": "broken",
         "sym": "%",
         "color": "magenta",
-        "condition": { "compare_int": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
       },
       {
         "id": "splinted",
@@ -130,7 +130,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
           ]
         }
       },
@@ -142,7 +142,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 11 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -167,7 +167,7 @@
         "color": "white_green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 0 } ] },
+            { "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 0 } ] },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -178,9 +178,9 @@
         "color": "h_white",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 30 } ] },
+            { "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 30 } ] },
             {
-              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 0 } ]
+              "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 0 } ]
             },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
@@ -192,9 +192,9 @@
         "color": "i_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 60 } ] },
+            { "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 60 } ] },
             {
-              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 30 } ]
+              "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 30 } ]
             },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
@@ -206,9 +206,9 @@
         "color": "red_yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 120 } ] },
+            { "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 120 } ] },
             {
-              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 60 } ]
+              "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 60 } ]
             },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
@@ -220,9 +220,9 @@
         "color": "red_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 240 } ] },
+            { "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, "<=", { "const": 240 } ] },
             {
-              "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 120 } ]
+              "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 120 } ]
             },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
@@ -234,7 +234,7 @@
         "color": "pink",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 240 } ] },
+            { "compare_num": [ { "u_val": "item_rad", "flag": "RAD_DETECT", "aggregate": "min" }, ">", { "const": 240 } ] },
             { "or": [ { "u_has_worn_with_flag": "RAD_DETECT" }, { "u_has_wielded_with_flag": "RAD_DETECT" } ] }
           ]
         }
@@ -251,7 +251,7 @@
         "id": "parched",
         "text": "Parched",
         "color": "light_red",
-        "condition": { "compare_int": [ { "u_val": "thirst" }, ">", { "const": 520 } ] }
+        "condition": { "compare_num": [ { "u_val": "thirst" }, ">", { "const": 520 } ] }
       },
       {
         "id": "dehydrated",
@@ -259,8 +259,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "thirst" }, ">", { "const": 240 } ] },
-            { "compare_int": [ { "u_val": "thirst" }, "<=", { "const": 520 } ] }
+            { "compare_num": [ { "u_val": "thirst" }, ">", { "const": 240 } ] },
+            { "compare_num": [ { "u_val": "thirst" }, "<=", { "const": 520 } ] }
           ]
         }
       },
@@ -270,8 +270,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "thirst" }, ">", { "const": 80 } ] },
-            { "compare_int": [ { "u_val": "thirst" }, "<=", { "const": 240 } ] }
+            { "compare_num": [ { "u_val": "thirst" }, ">", { "const": 80 } ] },
+            { "compare_num": [ { "u_val": "thirst" }, "<=", { "const": 240 } ] }
           ]
         }
       },
@@ -281,8 +281,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "thirst" }, ">", { "const": 40 } ] },
-            { "compare_int": [ { "u_val": "thirst" }, "<=", { "const": 80 } ] }
+            { "compare_num": [ { "u_val": "thirst" }, ">", { "const": 40 } ] },
+            { "compare_num": [ { "u_val": "thirst" }, "<=", { "const": 80 } ] }
           ]
         }
       },
@@ -292,8 +292,8 @@
         "color": "white",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "thirst" }, ">=", { "const": 0 } ] },
-            { "compare_int": [ { "u_val": "thirst" }, "<=", { "const": 40 } ] }
+            { "compare_num": [ { "u_val": "thirst" }, ">=", { "const": 0 } ] },
+            { "compare_num": [ { "u_val": "thirst" }, "<=", { "const": 40 } ] }
           ]
         }
       },
@@ -303,8 +303,8 @@
         "color": "green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "thirst" }, ">=", { "const": -20 } ] },
-            { "compare_int": [ { "u_val": "thirst" }, "<", { "const": 0 } ] }
+            { "compare_num": [ { "u_val": "thirst" }, ">=", { "const": -20 } ] },
+            { "compare_num": [ { "u_val": "thirst" }, "<", { "const": 0 } ] }
           ]
         }
       },
@@ -314,8 +314,8 @@
         "color": "green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "thirst" }, ">=", { "const": -60 } ] },
-            { "compare_int": [ { "u_val": "thirst" }, "<", { "const": -20 } ] }
+            { "compare_num": [ { "u_val": "thirst" }, ">=", { "const": -60 } ] },
+            { "compare_num": [ { "u_val": "thirst" }, "<", { "const": -20 } ] }
           ]
         }
       },
@@ -323,7 +323,7 @@
         "id": "turgid",
         "text": "Turgid",
         "color": "green",
-        "condition": { "compare_int": [ { "u_val": "thirst" }, "<", { "const": -60 } ] }
+        "condition": { "compare_num": [ { "u_val": "thirst" }, "<", { "const": -60 } ] }
       }
     ]
   },
@@ -393,31 +393,31 @@
         "id": "bright",
         "text": "bright",
         "color": "yellow",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, "<=", { "const": 1 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, "<=", { "const": 1 } ] }
       },
       {
         "id": "cloudy",
         "text": "cloudy",
         "color": "white",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 2 } ] }
       },
       {
         "id": "shady",
         "text": "shady",
         "color": "light_gray",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 3 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 3 } ] }
       },
       {
         "id": "dark",
         "text": "dark",
         "color": "dark_gray",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 4 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, "==", { "const": 4 } ] }
       },
       {
         "id": "very dark",
         "text": "very dark",
         "color": "black_white",
-        "condition": { "compare_int": [ { "u_val": "fine_detail_vision_mod" }, ">=", { "const": 5 } ] }
+        "condition": { "compare_num": [ { "u_val": "fine_detail_vision_mod" }, ">=", { "const": 5 } ] }
       }
     ]
   },
@@ -431,55 +431,55 @@
         "id": "new_moon",
         "text": "New moon",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 0 } ] }
       },
       {
         "id": "waxing_crescent",
         "text": "Waxing crescent",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 1 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 1 } ] }
       },
       {
         "id": "half_moon",
         "text": "Half moon",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 2 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 2 } ] }
       },
       {
         "id": "waxing_gibbous",
         "text": "Waxing gibbous",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 3 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 3 } ] }
       },
       {
         "id": "full_moon",
         "text": "Full moon",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 4 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 4 } ] }
       },
       {
         "id": "waning_gibbous",
         "text": "Waning gibbous",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 5 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 5 } ] }
       },
       {
         "id": "half_moon",
         "text": "Half moon",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 6 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 6 } ] }
       },
       {
         "id": "waning_crescent",
         "text": "Waning crescent",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 7 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 7 } ] }
       },
       {
         "id": "dark_moon",
         "text": "Dark moon",
         "color": "white",
-        "condition": { "compare_int": [ "moon", "==", { "const": 8 } ] }
+        "condition": { "compare_num": [ "moon", "==", { "const": 8 } ] }
       }
     ]
   },
@@ -493,7 +493,7 @@
         "id": "horrible",
         "text": "Horrible",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "health" }, "<", { "const": -100 } ] }
+        "condition": { "compare_num": [ { "u_val": "health" }, "<", { "const": -100 } ] }
       },
       {
         "id": "very_bad",
@@ -501,8 +501,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "health" }, ">=", { "const": -100 } ] },
-            { "compare_int": [ { "u_val": "health" }, "<", { "const": -50 } ] }
+            { "compare_num": [ { "u_val": "health" }, ">=", { "const": -100 } ] },
+            { "compare_num": [ { "u_val": "health" }, "<", { "const": -50 } ] }
           ]
         }
       },
@@ -512,8 +512,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "health" }, ">=", { "const": -50 } ] },
-            { "compare_int": [ { "u_val": "health" }, "<", { "const": -10 } ] }
+            { "compare_num": [ { "u_val": "health" }, ">=", { "const": -50 } ] },
+            { "compare_num": [ { "u_val": "health" }, "<", { "const": -10 } ] }
           ]
         }
       },
@@ -523,8 +523,8 @@
         "color": "light_gray",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "health" }, ">=", { "const": -10 } ] },
-            { "compare_int": [ { "u_val": "health" }, "<", { "const": 10 } ] }
+            { "compare_num": [ { "u_val": "health" }, ">=", { "const": -10 } ] },
+            { "compare_num": [ { "u_val": "health" }, "<", { "const": 10 } ] }
           ]
         }
       },
@@ -534,8 +534,8 @@
         "color": "white",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "health" }, ">=", { "const": 10 } ] },
-            { "compare_int": [ { "u_val": "health" }, "<", { "const": 50 } ] }
+            { "compare_num": [ { "u_val": "health" }, ">=", { "const": 10 } ] },
+            { "compare_num": [ { "u_val": "health" }, "<", { "const": 50 } ] }
           ]
         }
       },
@@ -545,8 +545,8 @@
         "color": "green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "health" }, ">=", { "const": 50 } ] },
-            { "compare_int": [ { "u_val": "health" }, "<", { "const": 100 } ] }
+            { "compare_num": [ { "u_val": "health" }, ">=", { "const": 50 } ] },
+            { "compare_num": [ { "u_val": "health" }, "<", { "const": 100 } ] }
           ]
         }
       },
@@ -554,7 +554,7 @@
         "id": "excellent",
         "text": "Excellent",
         "color": "light_green",
-        "condition": { "compare_int": [ { "u_val": "health" }, ">=", { "const": 100 } ] }
+        "condition": { "compare_num": [ { "u_val": "health" }, ">=", { "const": 100 } ] }
       }
     ]
   },
@@ -568,7 +568,7 @@
         "id": "scorching",
         "text": "Scorching!",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "body_temp" }, ">", { "const": 9500 } ] }
+        "condition": { "compare_num": [ { "u_val": "body_temp" }, ">", { "const": 9500 } ] }
       },
       {
         "id": "very_hot",
@@ -576,8 +576,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp" }, "<=", { "const": 9500 } ] },
-            { "compare_int": [ { "u_val": "body_temp" }, ">", { "const": 8000 } ] }
+            { "compare_num": [ { "u_val": "body_temp" }, "<=", { "const": 9500 } ] },
+            { "compare_num": [ { "u_val": "body_temp" }, ">", { "const": 8000 } ] }
           ]
         }
       },
@@ -587,8 +587,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp" }, "<=", { "const": 8000 } ] },
-            { "compare_int": [ { "u_val": "body_temp" }, ">", { "const": 6500 } ] }
+            { "compare_num": [ { "u_val": "body_temp" }, "<=", { "const": 8000 } ] },
+            { "compare_num": [ { "u_val": "body_temp" }, ">", { "const": 6500 } ] }
           ]
         }
       },
@@ -598,8 +598,8 @@
         "color": "green",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp" }, "<=", { "const": 6500 } ] },
-            { "compare_int": [ { "u_val": "body_temp" }, ">", { "const": 3500 } ] }
+            { "compare_num": [ { "u_val": "body_temp" }, "<=", { "const": 6500 } ] },
+            { "compare_num": [ { "u_val": "body_temp" }, ">", { "const": 3500 } ] }
           ]
         }
       },
@@ -609,8 +609,8 @@
         "color": "light_blue",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp" }, "<=", { "const": 3500 } ] },
-            { "compare_int": [ { "u_val": "body_temp" }, ">", { "const": 2000 } ] }
+            { "compare_num": [ { "u_val": "body_temp" }, "<=", { "const": 3500 } ] },
+            { "compare_num": [ { "u_val": "body_temp" }, ">", { "const": 2000 } ] }
           ]
         }
       },
@@ -620,8 +620,8 @@
         "color": "cyan",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp" }, "<=", { "const": 2000 } ] },
-            { "compare_int": [ { "u_val": "body_temp" }, ">", { "const": 500 } ] }
+            { "compare_num": [ { "u_val": "body_temp" }, "<=", { "const": 2000 } ] },
+            { "compare_num": [ { "u_val": "body_temp" }, ">", { "const": 500 } ] }
           ]
         }
       },
@@ -629,7 +629,7 @@
         "id": "freezing",
         "text": "Freezing!",
         "color": "blue",
-        "condition": { "compare_int": [ { "u_val": "body_temp" }, "<=", { "const": 500 } ] }
+        "condition": { "compare_num": [ { "u_val": "body_temp" }, "<=", { "const": 500 } ] }
       }
     ]
   },
@@ -645,7 +645,7 @@
         "text": "(Rising!!)",
         "sym": "↑↑↑",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "body_temp_delta" }, ">", { "const": 4500 } ] }
+        "condition": { "compare_num": [ { "u_val": "body_temp_delta" }, ">", { "const": 4500 } ] }
       },
       {
         "id": "rising2",
@@ -654,8 +654,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp_delta" }, "<=", { "const": 4500 } ] },
-            { "compare_int": [ { "u_val": "body_temp_delta" }, ">", { "const": 3000 } ] }
+            { "compare_num": [ { "u_val": "body_temp_delta" }, "<=", { "const": 4500 } ] },
+            { "compare_num": [ { "u_val": "body_temp_delta" }, ">", { "const": 3000 } ] }
           ]
         }
       },
@@ -666,8 +666,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp_delta" }, "<=", { "const": 3000 } ] },
-            { "compare_int": [ { "u_val": "body_temp_delta" }, ">", { "const": 1500 } ] }
+            { "compare_num": [ { "u_val": "body_temp_delta" }, "<=", { "const": 3000 } ] },
+            { "compare_num": [ { "u_val": "body_temp_delta" }, ">", { "const": 1500 } ] }
           ]
         }
       },
@@ -678,8 +678,8 @@
         "color": "light_blue",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp_delta" }, "<", { "const": -1500 } ] },
-            { "compare_int": [ { "u_val": "body_temp_delta" }, ">=", { "const": -3000 } ] }
+            { "compare_num": [ { "u_val": "body_temp_delta" }, "<", { "const": -1500 } ] },
+            { "compare_num": [ { "u_val": "body_temp_delta" }, ">=", { "const": -3000 } ] }
           ]
         }
       },
@@ -690,8 +690,8 @@
         "color": "cyan",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "body_temp_delta" }, "<", { "const": -3000 } ] },
-            { "compare_int": [ { "u_val": "body_temp_delta" }, ">=", { "const": -4500 } ] }
+            { "compare_num": [ { "u_val": "body_temp_delta" }, "<", { "const": -3000 } ] },
+            { "compare_num": [ { "u_val": "body_temp_delta" }, ">=", { "const": -4500 } ] }
           ]
         }
       },
@@ -700,7 +700,7 @@
         "text": "(Falling!!)",
         "sym": "↓↓↓",
         "color": "blue",
-        "condition": { "compare_int": [ { "u_val": "body_temp_delta" }, "<", { "const": -4500 } ] }
+        "condition": { "compare_num": [ { "u_val": "body_temp_delta" }, "<", { "const": -4500 } ] }
       }
     ]
   },
@@ -1314,7 +1314,7 @@
         "id": "skeletal",
         "text": "Skeletal",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 14000 } ] }
       },
       {
         "id": "emaciated",
@@ -1322,8 +1322,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 14000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 16000 } ] }
           ]
         }
       },
@@ -1333,8 +1333,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 16000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 18500 } ] }
           ]
         }
       },
@@ -1345,8 +1345,8 @@
         "//": "Actually 18.5 - 25",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 18500 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 25000 } ] }
           ]
         }
       },
@@ -1356,8 +1356,8 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 25000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
           ]
         }
       },
@@ -1367,8 +1367,8 @@
         "color": "light_red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 35000 } ] }
           ]
         }
       },
@@ -1378,8 +1378,8 @@
         "color": "red",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 35000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 40000 } ] }
           ]
         }
       },
@@ -1387,7 +1387,7 @@
         "id": "morbidly_obese",
         "text": "Morbidly Obese",
         "color": "red",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 40000 } ] }
       }
     ]
   },
@@ -1401,22 +1401,22 @@
       {
         "text": "Skin and Bones",
         "color": "yellow",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 18000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 18000 } ] }
       },
       {
         "text": "Boring",
         "color": "white",
         "condition": {
           "and": [
-            { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 18000 } ] },
-            { "compare_int": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
+            { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 18000 } ] },
+            { "compare_num": [ { "u_val": "bmi_permil" }, "<=", { "const": 30000 } ] }
           ]
         }
       },
       {
         "text": "C H O N K",
         "color": "pink",
-        "condition": { "compare_int": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] }
+        "condition": { "compare_num": [ { "u_val": "bmi_permil" }, ">", { "const": 30000 } ] }
       }
     ]
   },
@@ -1522,7 +1522,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 1 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 11 } ] }
           ]
         }
       },
@@ -1534,7 +1534,7 @@
         "condition": {
           "and": [
             { "u_has_effect": "bleed", "intensity": 11 },
-            { "compare_int": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
+            { "compare_num": [ { "u_val": "effect_intensity", "effect": "bleed" }, "<", { "const": 21 } ] }
           ]
         }
       },
@@ -1559,14 +1559,14 @@
         "text": "broken",
         "sym": "ℵ",
         "color": "c_red_white",
-        "condition": { "compare_int": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, "==", { "const": 0 } ] }
       },
       {
         "id": "intact",
         "text": "intact",
         "sym": "‖",
         "color": "c_dark_gray_white",
-        "condition": { "compare_int": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
+        "condition": { "compare_num": [ { "u_val": "hp" }, ">", { "const": 0 } ] }
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/addiction_eocs.json
+++ b/data/mods/Xedra_Evolved/addiction_eocs.json
@@ -3,7 +3,7 @@
     "type": "effect_on_condition",
     "id": "EOC_BLOOD_ADDICTION",
     "condition": {
-      "compare_int": [ { "rand": 2000 }, "<=", { "u_val": "addiction_intensity", "addiction": "blood", "mod": { "val": 2000, "step": 20 } } ]
+      "compare_num": [ { "rand": 2000 }, "<=", { "u_val": "addiction_intensity", "addiction": "blood", "mod": { "val": 2000, "step": 20 } } ]
     },
     "effect": [
       { "u_message": "You want some blood.", "type": "warning" },
@@ -15,13 +15,13 @@
             "condition": {
               "and": [
                 {
-                  "compare_int": [
+                  "compare_num": [
                     { "u_val": "vitamin", "name": "human_blood_vitamin" },
                     ">",
                     { "u_val": "addiction_intensity", "addiction": "blood", "mod": -10 }
                   ]
                 },
-                { "compare_int": [ { "rand": 10 }, "<", { "u_val": "addiction_intensity", "addiction": "blood" } ] }
+                { "compare_num": [ { "rand": 10 }, "<", { "u_val": "addiction_intensity", "addiction": "blood" } ] }
               ]
             },
             "effect": {
@@ -32,8 +32,8 @@
             "id": "EOC_BLOOD_ADDICTION_BLIND",
             "condition": {
               "and": [
-                { "compare_int": [ { "u_val": "addiction_intensity", "addiction": "blood" }, ">=", { "const": 8 } ] },
-                { "compare_int": [ { "rand": 392 }, "<", { "u_val": "addiction_intensity", "addiction": "blood" } ] }
+                { "compare_num": [ { "u_val": "addiction_intensity", "addiction": "blood" }, ">=", { "const": 8 } ] },
+                { "compare_num": [ { "rand": 392 }, "<", { "u_val": "addiction_intensity", "addiction": "blood" } ] }
               ]
             },
             "effect": [
@@ -45,8 +45,8 @@
             "id": "EOC_BLOOD_ADDICTION_SHAKES",
             "condition": {
               "and": [
-                { "compare_int": [ { "u_val": "addiction_intensity", "addiction": "blood" }, ">=", { "const": 8 } ] },
-                { "compare_int": [ { "rand": 392 }, "<", { "u_val": "addiction_intensity", "addiction": "blood" } ] }
+                { "compare_num": [ { "u_val": "addiction_intensity", "addiction": "blood" }, ">=", { "const": 8 } ] },
+                { "compare_num": [ { "rand": 392 }, "<", { "u_val": "addiction_intensity", "addiction": "blood" } ] }
               ]
             },
             "effect": [

--- a/data/mods/Xedra_Evolved/effects/vampvirus.json
+++ b/data/mods/Xedra_Evolved/effects/vampvirus.json
@@ -15,7 +15,7 @@
         "run_eocs": [
           {
             "id": "EOC_REDUCE_VAMPVIRUS",
-            "condition": { "compare_int": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, "=", { "const": 1 } ] },
+            "condition": { "compare_num": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, "=", { "const": 1 } ] },
             "effect": [
               { "u_lose_effect": "vampire_virus" },
               { "u_lose_trait": "VAMPIRE" },
@@ -26,7 +26,7 @@
           },
           {
             "id": "EOC_REDUCE_VAMPVIRUS1",
-            "condition": { "compare_int": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, "=", { "const": 2 } ] },
+            "condition": { "compare_num": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, "=", { "const": 2 } ] },
             "effect": [
               { "u_add_effect": "vampire_virus", "intensity": 1, "duration": "PERMANENT" },
               { "u_lose_trait": "VAMPIRE2" },
@@ -40,7 +40,7 @@
           },
           {
             "id": "EOC_REDUCE_VAMPVIRUS2",
-            "condition": { "compare_int": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, "=", { "const": 3 } ] },
+            "condition": { "compare_num": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, "=", { "const": 3 } ] },
             "effect": [
               { "u_add_effect": "vampire_virus", "intensity": 2, "duration": "PERMANENT" },
               { "u_lose_trait": "VAMPIRE3" },
@@ -58,7 +58,7 @@
               "and": [
                 { "u_has_effect": "vampire_virus_ascendant", "intensity": 1 },
                 {
-                  "compare_int": [ { "u_val": "effect_intensity", "effect": "vampire_virus_ascendant" }, "=", { "const": 1 } ]
+                  "compare_num": [ { "u_val": "effect_intensity", "effect": "vampire_virus_ascendant" }, "=", { "const": 1 } ]
                 }
               ]
             },
@@ -76,7 +76,7 @@
               "and": [
                 { "u_has_effect": "vampire_virus_post_mortal", "intensity": 1 },
                 {
-                  "compare_int": [ { "u_val": "effect_intensity", "effect": "vampire_virus_post_mortal" }, "=", { "const": 1 } ]
+                  "compare_num": [ { "u_val": "effect_intensity", "effect": "vampire_virus_post_mortal" }, "=", { "const": 1 } ]
                 }
               ]
             },
@@ -113,7 +113,7 @@
           "condition": {
             "and": [
               { "u_has_effect": "vampire_virus", "intensity": 1 },
-              { "compare_int": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, "=", { "const": 1 } ] }
+              { "compare_num": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, "=", { "const": 1 } ] }
             ]
           },
           "effect": {
@@ -138,7 +138,7 @@
           "condition": {
             "and": [
               { "u_has_effect": "vampire_virus", "intensity": 2 },
-              { "compare_int": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, "=", { "const": 2 } ] }
+              { "compare_num": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, "=", { "const": 2 } ] }
             ]
           },
           "effect": {
@@ -163,7 +163,7 @@
           "condition": {
             "and": [
               { "u_has_effect": "vampire_virus", "intensity": 3 },
-              { "compare_int": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, "=", { "const": 3 } ] }
+              { "compare_num": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, "=", { "const": 3 } ] }
             ]
           },
           "effect": {
@@ -195,7 +195,7 @@
     "recurrence": [ "8 hours", "14 hours 15 minutes" ],
     "condition": {
       "and": [
-        { "compare_int": [ { "u_val": "vitamin", "name": "blood" }, "<=", { "const": 450 } ] },
+        { "compare_num": [ { "u_val": "vitamin", "name": "blood" }, "<=", { "const": 450 } ] },
         { "u_has_effect": "vampire_virus" }
       ]
     },
@@ -207,7 +207,7 @@
           "condition": {
             "and": [
               { "u_has_effect": "vampire_virus", "intensity": 1 },
-              { "compare_int": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, ">=", { "const": 1 } ] }
+              { "compare_num": [ { "u_val": "effect_intensity", "effect": "vampire_virus" }, ">=", { "const": 1 } ] }
             ]
           },
           "effect": {

--- a/data/mods/Xedra_Evolved/mutations/mutation_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/mutation_eocs.json
@@ -6,7 +6,7 @@
     "recurrence": [ "5 h", "120 h" ],
     "condition": {
       "and": [
-        { "compare_int": [ "moon", "==", { "const": 3 } ] },
+        { "compare_num": [ "moon", "==", { "const": 3 } ] },
         { "or": [ { "u_has_trait": "EGGSAC_SURVIVABLE" }, { "u_has_trait": "EGGSAC_FATAL" } ] }
       ]
     },

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_EYEGLEAM_activated",
-    "condition": { "compare_int": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, ">=", { "const": -500 } ] },
+    "condition": { "compare_num": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, ">=", { "const": -500 } ] },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
       { "arithmetic": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, "-=", { "const": 100 } ] },
@@ -26,7 +26,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_STAMINAFORBLOOD_activated",
-    "condition": { "compare_int": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, ">=", { "const": -500 } ] },
+    "condition": { "compare_num": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, ">=", { "const": -500 } ] },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
       { "arithmetic": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, "-=", { "const": 100 } ] },
@@ -50,7 +50,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_COAGULANTWEAVE_activated",
-    "condition": { "compare_int": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, ">=", { "const": 500 } ] },
+    "condition": { "compare_num": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, ">=", { "const": 500 } ] },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
       { "arithmetic": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, "-=", { "const": 500 } ] },
@@ -74,7 +74,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_BLOODHEAL_activated",
-    "condition": { "compare_int": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, ">=", { "const": -9500 } ] },
+    "condition": { "compare_num": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, ">=", { "const": -9500 } ] },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
       { "arithmetic": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, "-=", { "const": 750 } ] },
@@ -95,7 +95,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_HYPNOTIC_GAZE_activated",
-    "condition": { "compare_int": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, ">=", { "const": -500 } ] },
+    "condition": { "compare_num": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, ">=", { "const": -500 } ] },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
       { "arithmetic": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, "-=", { "const": 150 } ] },
@@ -116,7 +116,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_BLOODHASTE_activated",
-    "condition": { "compare_int": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, ">=", { "const": -1500 } ] },
+    "condition": { "compare_num": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, ">=", { "const": -1500 } ] },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
       { "arithmetic": [ { "u_val": "vitamin", "name": "human_blood_vitamin" }, "-=", { "const": 750 } ] },

--- a/data/mods/Xedra_Evolved/spells/spell_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/spell_eocs.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "eoc_artifact_spawn",
-    "condition": { "compare_int": [ { "u_val": "vitamin", "name": "creative_spark" }, ">=", { "const": 1 } ] },
+    "condition": { "compare_num": [ { "u_val": "vitamin", "name": "creative_spark" }, ">=", { "const": 1 } ] },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
       { "arithmetic": [ { "u_val": "vitamin", "name": "creative_spark" }, "-=", { "const": 1 } ] },

--- a/data/mods/aftershock_exoplanet/weather_type.json
+++ b/data/mods/aftershock_exoplanet/weather_type.json
@@ -21,8 +21,8 @@
     "required_weathers": [ "cloudy" ],
     "condition": {
       "or": [
-        { "compare_int": [ { "weather": "humidity" }, ">=", { "const": 97 } ] },
-        { "compare_int": [ { "weather": "pressure" }, "<", { "const": 1000 } ] }
+        { "compare_num": [ { "weather": "humidity" }, ">=", { "const": 97 } ] },
+        { "compare_num": [ { "weather": "pressure" }, "<", { "const": 1000 } ] }
       ]
     }
   },
@@ -46,7 +46,7 @@
     "sound_category": "snowstorm",
     "sun_multiplier": 0.15,
     "required_weathers": [ "cloudy", "afs_flurries" ],
-    "condition": { "and": [ "is_day", { "compare_int": [ { "weather": "windpower" }, ">=", { "const": 20 } ] } ] }
+    "condition": { "and": [ "is_day", { "compare_num": [ { "weather": "windpower" }, ">=", { "const": 20 } ] } ] }
   },
   {
     "id": "afs_snowing",
@@ -70,8 +70,8 @@
     "required_weathers": [ "afs_flurries", "afs_whiteout" ],
     "condition": {
       "or": [
-        { "compare_int": [ { "weather": "humidity" }, ">=", { "const": 98 } ] },
-        { "compare_int": [ { "weather": "pressure" }, "<", { "const": 993 } ] }
+        { "compare_num": [ { "weather": "humidity" }, ">=", { "const": 98 } ] },
+        { "compare_num": [ { "weather": "pressure" }, "<", { "const": 993 } ] }
       ]
     }
   },
@@ -95,7 +95,7 @@
     "sound_category": "snowstorm",
     "sun_multiplier": 0.01,
     "required_weathers": [ "afs_snowing" ],
-    "condition": { "compare_int": [ { "weather": "pressure" }, "<", { "const": 990 } ] }
+    "condition": { "compare_num": [ { "weather": "pressure" }, "<", { "const": 990 } ] }
   },
   {
     "id": "afs_lightning",
@@ -117,6 +117,6 @@
     "sound_category": "snowstorm",
     "sun_multiplier": 0.01,
     "required_weathers": [ "afs_thunder" ],
-    "condition": { "compare_int": [ { "weather": "pressure" }, "<", { "const": 980 } ] }
+    "condition": { "compare_num": [ { "weather": "pressure" }, "<", { "const": 980 } ] }
   }
 ]

--- a/data/mods/deadly_bites/effect_on_conditions.json
+++ b/data/mods/deadly_bites/effect_on_conditions.json
@@ -33,7 +33,7 @@
             "condition": {
               "and": [
                 { "u_has_effect": "zombie_virus", "intensity": 2 },
-                { "compare_int": [ { "u_val": "effect_intensity", "effect": "zombie_virus" }, "=", { "const": 2 } ] }
+                { "compare_num": [ { "u_val": "effect_intensity", "effect": "zombie_virus" }, "=", { "const": 2 } ] }
               ]
             },
             "effect": [
@@ -49,7 +49,7 @@
             "condition": {
               "and": [
                 { "u_has_effect": "zombie_virus", "intensity": 3 },
-                { "compare_int": [ { "u_val": "effect_intensity", "effect": "zombie_virus" }, "=", { "const": 3 } ] }
+                { "compare_num": [ { "u_val": "effect_intensity", "effect": "zombie_virus" }, "=", { "const": 3 } ] }
               ]
             },
             "effect": [
@@ -65,7 +65,7 @@
             "condition": {
               "and": [
                 { "u_has_effect": "zombie_virus", "intensity": 4 },
-                { "compare_int": [ { "u_val": "effect_intensity", "effect": "zombie_virus" }, "=", { "const": 4 } ] }
+                { "compare_num": [ { "u_val": "effect_intensity", "effect": "zombie_virus" }, "=", { "const": 4 } ] }
               ]
             },
             "effect": [

--- a/data/mods/desert_region/weather/desert_weather_type.json
+++ b/data/mods/desert_region/weather/desert_weather_type.json
@@ -16,7 +16,7 @@
     "acidic": false,
     "sound_category": "flurries",
     "sun_multiplier": 0.2,
-    "condition": { "compare_int": [ { "global_val": "var", "var_name": "cause_early_dust_storm" }, "=", { "const": 1 } ] }
+    "condition": { "compare_num": [ { "global_val": "var", "var_name": "cause_early_dust_storm" }, "=", { "const": 1 } ] }
   },
   {
     "id": "dust_storm",
@@ -36,6 +36,6 @@
     "weather_animation": { "factor": 0.04, "color": "yellow", "sym": "-" },
     "sound_category": "snow",
     "sun_multiplier": 0.01,
-    "condition": { "compare_int": [ { "global_val": "var", "var_name": "cause_dust_storm" }, "=", { "const": 1 } ] }
+    "condition": { "compare_num": [ { "global_val": "var", "var_name": "cause_dust_storm" }, "=", { "const": 1 } ] }
   }
 ]

--- a/data/mods/desert_region/weather/weather_eoc.json
+++ b/data/mods/desert_region/weather/weather_eoc.json
@@ -55,12 +55,12 @@
         "or": [
           { "is_weather": "dust_storm" },
           { "is_weather": "early_dust_storm" },
-          { "compare_int": [ { "global_val": "var", "var_name": "cause_dust_storm" }, "=", { "const": 1 } ] },
-          { "compare_int": [ { "global_val": "var", "var_name": "cause_early_dust_storm" }, "=", { "const": 1 } ] },
+          { "compare_num": [ { "global_val": "var", "var_name": "cause_dust_storm" }, "=", { "const": 1 } ] },
+          { "compare_num": [ { "global_val": "var", "var_name": "cause_early_dust_storm" }, "=", { "const": 1 } ] },
           { "is_weather": "portal_storm" },
           { "is_weather": "early_portal_storm" },
-          { "compare_int": [ { "global_val": "var", "var_name": "cause_portal_storm" }, "=", { "const": 1 } ] },
-          { "compare_int": [ { "global_val": "var", "var_name": "cause_early_portal_storm" }, "=", { "const": 1 } ] }
+          { "compare_num": [ { "global_val": "var", "var_name": "cause_portal_storm" }, "=", { "const": 1 } ] },
+          { "compare_num": [ { "global_val": "var", "var_name": "cause_early_portal_storm" }, "=", { "const": 1 } ] }
         ]
       }
     },
@@ -103,7 +103,7 @@
       "not": {
         "or": [
           { "is_weather": "dust_storm" },
-          { "compare_int": [ { "global_val": "var", "var_name": "cause_dust_storm" }, "=", { "const": 1 } ] }
+          { "compare_num": [ { "global_val": "var", "var_name": "cause_dust_storm" }, "=", { "const": 1 } ] }
         ]
       }
     },
@@ -135,8 +135,8 @@
       "or": [
         { "is_weather": "dust_storm" },
         { "is_weather": "early_dust_storm" },
-        { "compare_int": [ { "global_val": "var", "var_name": "cause_dust_storm" }, "=", { "const": 1 } ] },
-        { "compare_int": [ { "global_val": "var", "var_name": "cause_early_dust_storm" }, "=", { "const": 1 } ] }
+        { "compare_num": [ { "global_val": "var", "var_name": "cause_dust_storm" }, "=", { "const": 1 } ] },
+        { "compare_num": [ { "global_val": "var", "var_name": "cause_early_dust_storm" }, "=", { "const": 1 } ] }
       ]
     },
     "effect": [
@@ -160,7 +160,7 @@
     "recurrence": [ "10 seconds", "30 seconds" ],
     "global": true,
     "condition": {
-      "and": [ { "compare_int": [ { "weather": "windpower" }, "<=", { "const": 60 } ] }, { "is_weather": "early_dust_storm" } ]
+      "and": [ { "compare_num": [ { "weather": "windpower" }, "<=", { "const": 60 } ] }, { "is_weather": "early_dust_storm" } ]
     },
     "deactivate_condition": { "not": { "is_weather": "early_dust_storm" } },
     "effect": [ { "arithmetic": [ { "weather": "windpower" }, "+=", { "const": 3 } ] }, { "u_message": "WIND", "type": "bad" } ]
@@ -179,7 +179,7 @@
     "id": "EOC_DUST_WIND_STRONG",
     "recurrence": [ "10 seconds", "30 seconds" ],
     "global": true,
-    "condition": { "and": [ { "compare_int": [ { "weather": "windpower" }, "<=", { "const": 120 } ] }, { "is_weather": "dust_storm" } ] },
+    "condition": { "and": [ { "compare_num": [ { "weather": "windpower" }, "<=", { "const": 120 } ] }, { "is_weather": "dust_storm" } ] },
     "deactivate_condition": { "not": { "is_weather": "dust_storm" } },
     "effect": [ { "arithmetic": [ { "weather": "windpower" }, "+=", { "const": 4 } ] }, { "u_message": "WIND", "type": "bad" } ]
   }

--- a/data/mods/innawood/portal_storm_effect_on_condition.json
+++ b/data/mods/innawood/portal_storm_effect_on_condition.json
@@ -6,13 +6,13 @@
     "condition": {
       "and": [
         { "not": { "u_has_trait": "PORTAL_DEPENDENT" } },
-        { "compare_int": [ { "global_val": "var", "var_name": "ps_min_woc" }, "<", { "time": "45 days" } ] }
+        { "compare_num": [ { "global_val": "var", "var_name": "ps_min_woc" }, "<", { "time": "45 days" } ] }
       ]
     },
     "deactivate_condition": {
       "or": [
         { "u_has_trait": "PORTAL_DEPENDENT" },
-        { "compare_int": [ { "global_val": "var", "var_name": "ps_min_woc" }, ">=", { "time": "45 days" } ] }
+        { "compare_num": [ { "global_val": "var", "var_name": "ps_min_woc" }, ">=", { "time": "45 days" } ] }
       ]
     },
     "effect": [
@@ -37,13 +37,13 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_WEAKEN",
-    "condition": { "compare_int": [ { "global_val": "var", "var_name": "ps_base_str" }, ">=", { "const": 1 } ] },
+    "condition": { "compare_num": [ { "global_val": "var", "var_name": "ps_base_str" }, ">=", { "const": 1 } ] },
     "effect": { "arithmetic": [ { "global_val": "var", "var_name": "ps_base_str" }, "--" ], "max": 8 }
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_SHORTEN",
-    "condition": { "compare_int": [ { "global_val": "var", "var_name": "ps_min_length" }, ">=", { "time": "15 minutes" } ] },
+    "condition": { "compare_num": [ { "global_val": "var", "var_name": "ps_min_length" }, ">=", { "time": "15 minutes" } ] },
     "effect": [
       { "arithmetic": [ { "global_val": "var", "var_name": "ps_min_length" }, "-=", { "time": "15 minutes" } ] },
       { "arithmetic": [ { "global_val": "var", "var_name": "ps_max_length" }, "-=", { "time": "15 minutes" } ] }

--- a/data/mods/translate-dialogue/rubik.json
+++ b/data/mods/translate-dialogue/rubik.json
@@ -254,7 +254,7 @@
     "id": "TALK_EXODII_MERCHANT_Exodize",
     "type": "talk_topic",
     "dynamic_line": {
-      "compare_int": [ { "u_val": "sold" }, ">=", { "const": 100 } ],
+      "compare_num": [ { "u_val": "sold" }, ">=", { "const": 100 } ],
       "yes": "Oh HO!  Well, well.  Now you're yarkin' the King's Anglic.  Aye, us'n can fix ye good, if'n ye're tassed to repay it in kind.  Us'll speak it as clear-like as this Rubik can.  If ye'n use it to put the dead back in the ground, us'n can fix ye with some goods like this, aye.  Stuck in the flesh and to the bone, wired into the brain.  Ye kennit?  If no, us'll speak to the Great Grey for a pint o' the ol' clarity-draught.\"\n\n[TRANSLATE:] \"Oh HO!  Well, now you're speaking my language.  We can fix you up good, if you're willing to pay us back.  I'll say it as clearly as I can.  If you help us kill the undead, we can help you get fixed up like us, yeah.  Stuck right into your flesh and bone and wired into your brain.  You understand?  If not, we'll ask the Great Grey to help clear it up.",
       "no": {
         "u_has_faction_trust": 5,

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -672,7 +672,7 @@ Each turn, the player's addictions are processed using either the given `effect_
 {
   "type": "effect_on_condition",
   "id": "EOC_MARLOSS_R_ADDICTION",
-  "condition": { "compare_int": [ { "rand": 800 }, "<", { "u_val": "addiction_intensity", "addiction": "marloss_r", "mod": 20 } ] },
+  "condition": { "compare_num": [ { "rand": 800 }, "<", { "u_val": "addiction_intensity", "addiction": "marloss_r", "mod": 20 } ] },
   "effect": [
     { "u_add_morale": "morale_craving_marloss", "bonus": -5, "max_bonus": -30 },
     { "u_message": "You daydream about luscious pink berries as big as your fist.", "type": "info" },
@@ -680,7 +680,7 @@ Each turn, the player's addictions are processed using either the given `effect_
       "run_eocs": [
         {
           "id": "EOC_MARLOSS_R_ADDICTION_MODFOCUS",
-          "condition": { "compare_int": [ { "u_val": "focus" }, ">", { "const": 40 } ] },
+          "condition": { "compare_num": [ { "u_val": "focus" }, ">", { "const": 40 } ] },
           "effect": { "arithmetic": [ { "u_val": "focus" }, "-=", { "const": 1 } ] }
         }
       ]

--- a/doc/MUTATIONS.md
+++ b/doc/MUTATIONS.md
@@ -216,7 +216,7 @@ Note that **all new traits that can be obtained through mutation must be purifia
   "triggers": [                               // List of sublist of triggers, all sublists must be True for the mutation to activate.
     [                                         // Sublist of trigger: at least one trigger must be true for the sublist to be true.
         {
-          "condition": { "compare_int": [ { "u_val": "morale" }, "<", { "const": -50 } ] },               // Dialog condition (see NPCs.md).
+          "condition": { "compare_num": [ { "u_val": "morale" }, "<", { "const": -50 } ] },               // Dialog condition (see NPCs.md).
           "msg_on": { "text": "Everything is terrible and this makes you so ANGRY!", "rating": "mixed" }  // Message displayed when the trigger activates.
         }
     ],
@@ -224,8 +224,8 @@ Note that **all new traits that can be obtained through mutation must be purifia
       {
         "condition": {                        // Dialog condition (see NPCs.md).
           "or": [
-            { "compare_int": [ { "hour", "<", { "const": 2 } } ] },
-            { "compare_int": [ { "hour", ">", { "const": 20 } } ] }
+            { "compare_num": [ { "hour", "<", { "const": 2 } } ] },
+            { "compare_num": [ { "hour", ">", { "const": 20 } } ] }
           ]
         },
         "msg_on": { "text": "Everything is terrible and this makes you so ANGRY!", "rating": "mixed" } // Message displayed when the trigger activates.

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -674,7 +674,7 @@ One of `"for_item"` or `"for_category"`, and each can either be a single string 
 ---
 
 #### Variable Object
-`variable_object`: This is either an object, an `arithmetic` [expression](#compare-integers-and-arithmetics) or array describing a variable name. It can either describe an int, a time duration or a string. If it is an array it must have 2 values the first of which will be a minimum and the second will be a maximum, the value will be randomly between the two. If it is an int `default` is an int which will be the value returned if the variable is not defined. If is it a duration then `default` can be either an int or a string describing a time span. `u_val`, `npc_val`, or `global_val` can be the used for the variable name element.  If `u_val` is used it describes a variable on player u, if `npc_val` is used it describes a variable on player npc, if `global_val` is used it describes a global variable.  If this is a duration `infinite` will be accepted to be a virtually infinite value(it is actually more than a year, if longer is needed a code change to make this a flag or something will be needed).
+`variable_object`: This is either an object, an `arithmetic` [expression](#compare-numbers-and-arithmetics) or array describing a variable name. It can either describe a double, a time duration or a string. If it is an array it must have 2 values the first of which will be a minimum and the second will be a maximum, the value will be randomly between the two. If it is a double `default` is a double which will be the value returned if the variable is not defined. If is it a duration then `default` can be either an int or a string describing a time span. `u_val`, `npc_val`, or `global_val` can be the used for the variable name element.  If `u_val` is used it describes a variable on player u, if `npc_val` is used it describes a variable on player npc, if `global_val` is used it describes a global variable.  If this is a duration `infinite` will be accepted to be a virtually infinite value(it is actually more than a year, if longer is needed a code change to make this a flag or something will be needed).
 
 example json:
 ```
@@ -1006,18 +1006,18 @@ Condition | Type | Description
 `"mod_is_loaded"` | string or [variable object](#variable-object) | `true` if the mod with the given ID is loaded.
 
 
-#### Compare Integers and Arithmetics
-`"compare_int"` can be used to compare two values to each other, while `"arithmetic"` can be used to take up to two values, perform arithmetic on them, and then save them in a third value. The syntax is as follows.
+#### Compare Numbers and Arithmetics
+`"compare_num"` can be used to compare two values to each other, while `"arithmetic"` can be used to take up to two values, perform arithmetic on them, and then save them in a third value. The syntax is as follows.
 ```
 {
   "text": "If player strength is more than or equal to 5, sets time since cataclysm to the player's focus times the player's maximum mana with at maximum a value of 15.",
   "topic": "TALK_DONE",
-  "condition": { "compare_int": [ { "u_val": "strength" }, ">=", { "const": 5 } ] }
+  "condition": { "compare_num": [ { "u_val": "strength" }, ">=", { "const": 5 } ] }
   "effect": { "arithmetic": [ { "time_since_cataclysm": "turns" }, "=", { "u_val": "focus" }, "*", { "u_val": "mana_max" } ], "max":15 }
 },
 ```
-`min` and `max` are optional int or variable_object values.  If supplied they will limit the result, it will be no lower than `min` and no higher than `max`. `min_time` and `max_time` work the same way but will parse times written as a string i.e. "10 hours".
-`"compare_int"` supports the following operators: `"=="`, `"="` (Both are treated the same, as a compare), `"!="`, `"<="`, `">="`, `"<"`, and `">"`.
+`min` and `max` are optional double or variable_object values.  If supplied they will limit the result, it will be no lower than `min` and no higher than `max`. `min_time` and `max_time` work the same way but will parse times written as a string i.e. "10 hours".
+`"compare_num"` supports the following operators: `"=="`, `"="` (Both are treated the same, as a compare), `"!="`, `"<="`, `">="`, `"<"`, and `">"`.
 
 `"arithmetic"` supports the following operators: `"*"`, `"/"`, `"+"`, `"-"`, `"%"`, `"&"`, `"|"`, `"<<"`, `">>"`, `"~"`, `"^"` and the following results `"="`, `"*="`, `"/="`, `"+="`, `"-="`, `"%="`, `"++"`, and `"--"`
 
@@ -1082,7 +1082,7 @@ Example | Description
 `"moon"` | Phase of the moon. MOON_NEW =0, WAXING_CRESCENT =1, HALF_MOON_WAXING =2, WAXING_GIBBOUS =3, FULL =4, WANING_GIBBOUS =5, HALF_MOON_WANING =6, WANING_CRESCENT =7
 `"arithmetic"` | An arithmetic expression with no result.   
 ```
-"condition": { "compare_int": [ { "distance": [ "u",{ "u_val": "stuck", "type": "ps", "context": "teleport" }  ] }, ">", { "const": 5 } ] }
+"condition": { "compare_num": [ { "distance": [ "u",{ "u_val": "stuck", "type": "ps", "context": "teleport" }  ] }, ">", { "const": 5 } ] }
 "real_count": { "arithmetic": [ { "arithmetic": [ { "const":1 }, "+", { "const": 1 } ] }, "+", { "const": 1 } ] },
 ```
 

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -995,7 +995,7 @@ Condition | Type | Description
 `"is_day"` | simple string | `true` if it is currently daytime.
 `"u_is_outside"`</br>`"npc_is_outside"`  | simple string | `true` if you or the NPC is on a tile without a roof.
 `"u_is_underwater"`</br>`"npc_is_underwater"`  | simple string | `true` if you or the NPC is underwater.
-`"one_in_chance"` | intor [variable object](#variable-object) | `true` if a one in `one_in_chance` random chance occurs.
+`"one_in_chance"` | int or [variable object](#variable-object) | `true` if a one in `one_in_chance` random chance occurs.
 `"x_in_y_chance"` | object | `true` if a `x` in `y` random chance occurs. `x` and `y` are either ints  or [variable object](#variable-object).
 `"is_weather"` | string or [variable object](#variable-object)  | `true` if current weather is `"is_weather"`.
 

--- a/doc/OVERMAP.md
+++ b/doc/OVERMAP.md
@@ -272,7 +272,7 @@ an exhaustive example...
     "mapgen_four_way": [ { "method": "builtin", "name": "road_four_way" } ],
     "eoc": {
       "id": "EOC_REFUGEE_CENTER_GENERATE",
-      "condition": { "compare_int": [ { "global_val": "var", "var_name": "refugee_centers", "default": 0 }, "<", { "const": 1 } ] },
+      "condition": { "compare_num": [ { "global_val": "var", "var_name": "refugee_centers", "default": 0 }, "<", { "const": 1 } ] },
       "effect": [ { "arithmetic": [ { "global_val": "var", "var_name": "refugee_centers" }, "++" ] } ]
     }
 }

--- a/doc/WIDGETS.md
+++ b/doc/WIDGETS.md
@@ -476,7 +476,7 @@ The below widget is a prime example of a text widget, and is used to display a p
       "id": "parched",
       "text": "Parched",
       "color": "light_red",
-      "condition": { "compare_int": [ { "u_val": "thirst" }, ">", { "const": 520 } ] }
+      "condition": { "compare_num": [ { "u_val": "thirst" }, ">", { "const": 520 } ] }
     },
     {
       "id": "dehydrated",
@@ -484,8 +484,8 @@ The below widget is a prime example of a text widget, and is used to display a p
       "color": "light_red",
       "condition": {
         "and": [
-          { "compare_int": [ { "u_val": "thirst" }, ">", { "const": 240 } ] },
-          { "compare_int": [ { "u_val": "thirst" }, "<=", { "const": 520 } ] }
+          { "compare_num": [ { "u_val": "thirst" }, ">", { "const": 240 } ] },
+          { "compare_num": [ { "u_val": "thirst" }, "<=", { "const": 520 } ] }
         ]
       }
     },
@@ -495,8 +495,8 @@ The below widget is a prime example of a text widget, and is used to display a p
       "color": "yellow",
       "condition": {
         "and": [
-          { "compare_int": [ { "u_val": "thirst" }, ">", { "const": 80 } ] },
-          { "compare_int": [ { "u_val": "thirst" }, "<=", { "const": 240 } ] }
+          { "compare_num": [ { "u_val": "thirst" }, ">", { "const": 80 } ] },
+          { "compare_num": [ { "u_val": "thirst" }, "<=", { "const": 240 } ] }
         ]
       }
     },
@@ -506,8 +506,8 @@ The below widget is a prime example of a text widget, and is used to display a p
       "color": "yellow",
       "condition": {
         "and": [
-          { "compare_int": [ { "u_val": "thirst" }, ">", { "const": 40 } ] },
-          { "compare_int": [ { "u_val": "thirst" }, "<=", { "const": 80 } ] }
+          { "compare_num": [ { "u_val": "thirst" }, ">", { "const": 40 } ] },
+          { "compare_num": [ { "u_val": "thirst" }, "<=", { "const": 80 } ] }
         ]
       }
     },
@@ -517,8 +517,8 @@ The below widget is a prime example of a text widget, and is used to display a p
       "color": "white",
       "condition": {
         "and": [
-          { "compare_int": [ { "u_val": "thirst" }, ">=", { "const": 0 } ] },
-          { "compare_int": [ { "u_val": "thirst" }, "<=", { "const": 40 } ] }
+          { "compare_num": [ { "u_val": "thirst" }, ">=", { "const": 0 } ] },
+          { "compare_num": [ { "u_val": "thirst" }, "<=", { "const": 40 } ] }
         ]
       }
     },
@@ -528,8 +528,8 @@ The below widget is a prime example of a text widget, and is used to display a p
       "color": "green",
       "condition": {
         "and": [
-          { "compare_int": [ { "u_val": "thirst" }, ">=", { "const": -20 } ] },
-          { "compare_int": [ { "u_val": "thirst" }, "<", { "const": 0 } ] }
+          { "compare_num": [ { "u_val": "thirst" }, ">=", { "const": -20 } ] },
+          { "compare_num": [ { "u_val": "thirst" }, "<", { "const": 0 } ] }
         ]
       }
     },
@@ -539,8 +539,8 @@ The below widget is a prime example of a text widget, and is used to display a p
       "color": "green",
       "condition": {
         "and": [
-          { "compare_int": [ { "u_val": "thirst" }, ">=", { "const": -60 } ] },
-          { "compare_int": [ { "u_val": "thirst" }, "<", { "const": -20 } ] }
+          { "compare_num": [ { "u_val": "thirst" }, ">=", { "const": -60 } ] },
+          { "compare_num": [ { "u_val": "thirst" }, "<", { "const": -20 } ] }
         ]
       }
     },
@@ -548,7 +548,7 @@ The below widget is a prime example of a text widget, and is used to display a p
       "id": "turgid",
       "text": "Turgid",
       "color": "green",
-      "condition": { "compare_int": [ { "u_val": "thirst" }, "<", { "const": -60 } ] }
+      "condition": { "compare_num": [ { "u_val": "thirst" }, "<", { "const": -60 } ] }
     }
   ]
 },

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2606,10 +2606,10 @@ void conditional_t<T>::set_has_skill( const JsonObject &jo, const std::string &m
 template<class T>
 void conditional_t<T>::set_roll_contested( const JsonObject &jo, const std::string &member )
 {
-    std::function<int( const T & )> get_check = conditional_t< T >::get_get_int( jo.get_object(
+    std::function<int( const T & )> get_check = conditional_t< T >::get_get_dbl( jo.get_object(
                 member ) );
-    int_or_var<T> difficulty = get_int_or_var<T>( jo, "difficulty", true );
-    int_or_var<T> die_size = get_int_or_var<T>( jo, "die_size", false, 10 );
+    dbl_or_var<T> difficulty = get_dbl_or_var<T>( jo, "difficulty", true );
+    dbl_or_var<T> die_size = get_dbl_or_var<T>( jo, "die_size", false, 10 );
     condition = [get_check, difficulty, die_size]( const T & d ) {
         return rng( 1, die_size.evaluate( d ) ) + get_check( d ) > difficulty.evaluate( d );
     };

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -56,7 +56,7 @@ static const json_character_flag json_flag_MUTATION_THRESHOLD( "MUTATION_THRESHO
 
 template<class T>
 std::string get_talk_varname( const JsonObject &jo, const std::string &member,
-                              bool check_value, int_or_var<T> &default_val )
+                              bool check_value, dbl_or_var<T> &default_val )
 {
     if( check_value && !( jo.has_string( "value" ) || jo.has_member( "time" ) ||
                           jo.has_array( "possible_values" ) ) ) {
@@ -65,12 +65,12 @@ std::string get_talk_varname( const JsonObject &jo, const std::string &member,
     const std::string &var_basename = jo.get_string( member );
     const std::string &type_var = jo.get_string( "type", "" );
     const std::string &var_context = jo.get_string( "context", "" );
-    default_val = get_int_or_var<T>( jo, "default", false );
+    default_val = get_dbl_or_var<T>( jo, "default", false );
     if( jo.has_member( "default_time" ) ) {
-        int_or_var<T> value;
+        dbl_or_var<T> value;
         time_duration max_time;
         mandatory( jo, false, "default_time", max_time );
-        value.min.int_val = to_turns<int>( max_time );
+        value.min.dbl_val = to_turns<int>( max_time );
         default_val = value;
     }
     return "npctalk_var" + ( type_var.empty() ? "" : "_" + type_var ) + ( var_context.empty() ? "" : "_"
@@ -89,13 +89,13 @@ std::string get_talk_var_basename( const JsonObject &jo, const std::string &memb
 }
 
 template<class T>
-int_or_var_part<T> get_int_or_var_part( const JsonValue &jv, const std::string &member,
+dbl_or_var_part<T> get_dbl_or_var_part( const JsonValue &jv, const std::string &member,
                                         bool required,
-                                        int default_val )
+                                        double default_val )
 {
-    int_or_var_part<T> ret_val;
-    if( jv.test_int() ) {
-        ret_val.int_val = jv.get_int();
+    dbl_or_var_part<T> ret_val;
+    if( jv.test_float() ) {
+        ret_val.dbl_val = jv.get_float();
     } else if( jv.test_object() ) {
         JsonObject jo = jv.get_object();
         jo.allow_omitted_members();
@@ -109,28 +109,28 @@ int_or_var_part<T> get_int_or_var_part( const JsonValue &jv, const std::string &
     } else if( required ) {
         jv.throw_error( "No valid value for " + member );
     } else {
-        ret_val.int_val = default_val;
+        ret_val.dbl_val = default_val;
     }
     return ret_val;
 }
 
 template<class T>
-int_or_var<T> get_int_or_var( const JsonObject &jo, std::string member, bool required,
-                              int default_val )
+dbl_or_var<T> get_dbl_or_var( const JsonObject &jo, std::string member, bool required,
+                              double default_val )
 {
-    int_or_var<T> ret_val;
+    dbl_or_var<T> ret_val;
     if( jo.has_array( member ) ) {
         JsonArray ja = jo.get_array( member );
-        ret_val.min = get_int_or_var_part<T>( ja.next_value(), member );
-        ret_val.max = get_int_or_var_part<T>( ja.next_value(), member );
+        ret_val.min = get_dbl_or_var_part<T>( ja.next_value(), member );
+        ret_val.max = get_dbl_or_var_part<T>( ja.next_value(), member );
         ret_val.pair = true;
     } else if( required ) {
-        ret_val.min = get_int_or_var_part<T>( jo.get_member( member ), member, required, default_val );
+        ret_val.min = get_dbl_or_var_part<T>( jo.get_member( member ), member, required, default_val );
     } else {
         if( jo.has_member( member ) ) {
-            ret_val.min = get_int_or_var_part<T>( jo.get_member( member ), member, required, default_val );
+            ret_val.min = get_dbl_or_var_part<T>( jo.get_member( member ), member, required, default_val );
         } else {
-            ret_val.min.int_val = default_val;
+            ret_val.min.dbl_val = default_val;
         }
     }
     return ret_val;
@@ -223,7 +223,7 @@ tripoint_abs_ms get_tripoint_from_var( cata::optional<var_info> var, const T &d 
 var_info read_var_info( const JsonObject &jo )
 {
     std::string default_val;
-    int_or_var<dialogue> empty;
+    dbl_or_var<dialogue> empty;
     var_type type;
     std::string name;
     if( jo.has_string( "default_str" ) ) {
@@ -231,8 +231,8 @@ var_info read_var_info( const JsonObject &jo )
     } else if( jo.has_string( "default" ) ) {
         default_val = std::to_string( to_turns<int>( read_from_json_string<time_duration>
                                       ( jo.get_member( "default" ), time_duration::units ) ) );
-    } else if( jo.has_int( "default" ) ) {
-        default_val = std::to_string( jo.get_int( "default" ) );
+    } else if( jo.has_float( "default" ) ) {
+        default_val = std::to_string( jo.get_float( "default" ) );
     } else if( jo.has_member( "default_time" ) ) {
         time_duration max_time;
         mandatory( jo, false, "default_time", max_time );
@@ -452,9 +452,9 @@ template<class T>
 void conditional_t<T>::set_has_strength( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    condition = [iov, is_npc]( const T & d ) {
-        return d.actor( is_npc )->str_cur() >= iov.evaluate( d );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    condition = [dov, is_npc]( const T & d ) {
+        return d.actor( is_npc )->str_cur() >= dov.evaluate( d );
     };
 }
 
@@ -462,9 +462,9 @@ template<class T>
 void conditional_t<T>::set_has_dexterity( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    condition = [iov, is_npc]( const T & d ) {
-        return d.actor( is_npc )->dex_cur() >= iov.evaluate( d );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    condition = [dov, is_npc]( const T & d ) {
+        return d.actor( is_npc )->dex_cur() >= dov.evaluate( d );
     };
 }
 
@@ -472,9 +472,9 @@ template<class T>
 void conditional_t<T>::set_has_intelligence( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    condition = [iov, is_npc]( const T & d ) {
-        return d.actor( is_npc )->int_cur() >= iov.evaluate( d );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    condition = [dov, is_npc]( const T & d ) {
+        return d.actor( is_npc )->int_cur() >= dov.evaluate( d );
     };
 }
 
@@ -482,21 +482,21 @@ template<class T>
 void conditional_t<T>::set_has_perception( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    condition = [iov, is_npc]( const T & d ) {
-        return d.actor( is_npc )->per_cur() >= iov.evaluate( d );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    condition = [dov, is_npc]( const T & d ) {
+        return d.actor( is_npc )->per_cur() >= dov.evaluate( d );
     };
 }
 
 template<class T>
 void conditional_t<T>::set_has_hp( const JsonObject &jo, const std::string &member, bool is_npc )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
     cata::optional<bodypart_id> bp;
     optional( jo, false, "bodypart", bp );
-    condition = [iov, bp, is_npc]( const T & d ) {
+    condition = [dov, bp, is_npc]( const T & d ) {
         bodypart_id bid = bp.value_or( get_bp_from_str( d.reason ) );
-        return d.actor( is_npc )->get_cur_hp( bid ) >= iov.evaluate( d );
+        return d.actor( is_npc )->get_cur_hp( bid ) >= dov.evaluate( d );
     };
 }
 
@@ -504,12 +504,12 @@ template<class T>
 void conditional_t<T>::set_has_part_temp( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
     cata::optional<bodypart_id> bp;
     optional( jo, false, "bodypart", bp );
-    condition = [iov, bp, is_npc]( const T & d ) {
+    condition = [dov, bp, is_npc]( const T & d ) {
         bodypart_id bid = bp.value_or( get_bp_from_str( d.reason ) );
-        return d.actor( is_npc )->get_cur_part_temp( bid ) >= iov.evaluate( d );
+        return d.actor( is_npc )->get_cur_part_temp( bid ) >= dov.evaluate( d );
     };
 }
 
@@ -545,8 +545,8 @@ void conditional_t<T>::set_has_items( const JsonObject &jo, const std::string &m
         };
     } else {
         str_or_var<T> item_id = get_str_or_var<T>( has_items.get_member( "item" ), "item", true );
-        int_or_var<T> count = get_int_or_var<T>( has_items, "count", false );
-        int_or_var<T> charges = get_int_or_var<T>( has_items, "charges", false );
+        dbl_or_var<T> count = get_dbl_or_var<T>( has_items, "count", false );
+        dbl_or_var<T> charges = get_dbl_or_var<T>( has_items, "charges", false );
         condition = [item_id, count, charges, is_npc]( const T & d ) {
             const talker *actor = d.actor( is_npc );
             itype_id id = itype_id( item_id.evaluate( d ) );
@@ -617,7 +617,7 @@ void conditional_t<T>::set_has_effect( const JsonObject &jo, const std::string &
                                        bool is_npc )
 {
     str_or_var<T> effect_id = get_str_or_var<T>( jo.get_member( member ), member, true );
-    int_or_var<T> intensity = get_int_or_var<T>( jo, "intensity", false, -1 );
+    dbl_or_var<T> intensity = get_dbl_or_var<T>( jo, "intensity", false, -1 );
     str_or_var<T> bp;
     if( jo.has_member( "bodypart" ) ) {
         bp = get_str_or_var<T>( jo.get_member( "target_part" ), "target_part", true );
@@ -636,21 +636,21 @@ template<class T>
 void conditional_t<T>::set_need( const JsonObject &jo, const std::string &member, bool is_npc )
 {
     str_or_var<T> need = get_str_or_var<T>( jo.get_member( member ), member, true );
-    int_or_var<T> iov;
+    dbl_or_var<T> dov;
     if( jo.has_int( "amount" ) ) {
-        iov.min.int_val = jo.get_int( "amount" );
+        dov.min.dbl_val = jo.get_int( "amount" );
     } else if( jo.has_object( "amount" ) ) {
-        iov = get_int_or_var<T>( jo, "amount" );
+        dov = get_dbl_or_var<T>( jo, "amount" );
     } else if( jo.has_string( "level" ) ) {
         const std::string &level = jo.get_string( "level" );
         auto flevel = fatigue_level_strs.find( level );
         if( flevel != fatigue_level_strs.end() ) {
-            iov.min.int_val = static_cast<int>( flevel->second );
+            dov.min.dbl_val = static_cast<int>( flevel->second );
         }
     }
-    condition = [need, iov, is_npc]( const T & d ) {
+    condition = [need, dov, is_npc]( const T & d ) {
         const talker *actor = d.actor( is_npc );
-        int amount = iov.evaluate( d );
+        int amount = dov.evaluate( d );
         return ( actor->get_fatigue() > amount && need.evaluate( d ) == "fatigue" ) ||
                ( actor->get_hunger() > amount && need.evaluate( d ) == "hunger" ) ||
                ( actor->get_thirst() > amount && need.evaluate( d ) == "thirst" );
@@ -687,7 +687,7 @@ void conditional_t<T>::set_near_om_location( const JsonObject &jo, const std::st
         bool is_npc )
 {
     str_or_var<T> location = get_str_or_var<T>( jo.get_member( member ), member, true );
-    const int_or_var<T> range = get_int_or_var<T>( jo, "range", false, 1 );
+    const dbl_or_var<T> range = get_dbl_or_var<T>( jo, "range", false, 1 );
     condition = [location, range, is_npc]( const T & d ) {
         const tripoint_abs_omt omt_pos = d.actor( is_npc )->global_omt_location();
         for( const tripoint_abs_omt &curr_pos : points_in_radius( omt_pos,
@@ -721,7 +721,7 @@ void conditional_t<T>::set_near_om_location( const JsonObject &jo, const std::st
 template<class T>
 void conditional_t<T>::set_has_var( const JsonObject &jo, const std::string &member, bool is_npc )
 {
-    int_or_var<dialogue> empty;
+    dbl_or_var<dialogue> empty;
     const std::string var_name = get_talk_varname( jo, member, false, empty );
     const std::string &value = jo.has_member( "value" ) ? jo.get_string( "value" ) : std::string();
     const bool time_check = jo.has_member( "time" ) && jo.get_bool( "time" );
@@ -738,17 +738,17 @@ template<class T>
 void conditional_t<T>::set_compare_var( const JsonObject &jo, const std::string &member,
                                         bool is_npc )
 {
-    int_or_var<dialogue> empty;
+    dbl_or_var<dialogue> empty;
     const std::string var_name = get_talk_varname( jo, member, false, empty );
     const std::string &op = jo.get_string( "op" );
 
-    int_or_var<T> iov = get_int_or_var<T>( jo, "value" );
-    condition = [var_name, op, iov, is_npc]( const T & d ) {
-        int stored_value = 0;
-        int value = iov.evaluate( d );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, "value" );
+    condition = [var_name, op, dov, is_npc]( const T & d ) {
+        double stored_value = 0;
+        double value = dov.evaluate( d );
         const std::string &var = d.actor( is_npc )->get_value( var_name );
         if( !var.empty() ) {
-            stored_value = std::stoi( var );
+            stored_value = std::stof( var );
         }
 
         if( op == "==" ) {
@@ -778,7 +778,7 @@ template<class T>
 void conditional_t<T>::set_compare_time_since_var( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    int_or_var<dialogue> empty;
+    dbl_or_var<dialogue> empty;
     const std::string var_name = get_talk_varname( jo, member, false, empty );
     const std::string &op = jo.get_string( "op" );
     const int value = to_turns<int>( read_from_json_string<time_duration>( jo.get_member( "time" ),
@@ -789,7 +789,7 @@ void conditional_t<T>::set_compare_time_since_var( const JsonObject &jo, const s
         if( var.empty() ) {
             return false;
         } else {
-            stored_value = std::stoi( var );
+            stored_value = std::stof( var );
         }
         stored_value += value;
         int now = to_turn<int>( calendar::turn );
@@ -834,42 +834,42 @@ void conditional_t<T>::set_npc_role_nearby( const JsonObject &jo, const std::str
 template<class T>
 void conditional_t<T>::set_npc_allies( const JsonObject &jo, const std::string &member )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    condition = [iov]( const T & d ) {
-        return g->allies().size() >= static_cast<std::vector<npc *>::size_type>( iov.evaluate( d ) );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    condition = [dov]( const T & d ) {
+        return g->allies().size() >= static_cast<std::vector<npc *>::size_type>( dov.evaluate( d ) );
     };
 }
 
 template<class T>
 void conditional_t<T>::set_npc_allies_global( const JsonObject &jo, const std::string &member )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    condition = [iov]( const T & d ) {
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    condition = [dov]( const T & d ) {
         const auto all_npcs = overmap_buffer.get_overmap_npcs();
         const size_t count = std::count_if( all_npcs.begin(),
         all_npcs.end(), []( const shared_ptr_fast<npc> &ptr ) {
             return ptr.get()->is_player_ally() && !ptr.get()->hallucination && !ptr.get()->is_dead();
         } );
 
-        return count >= static_cast<size_t>( iov.evaluate( d ) );
+        return count >= static_cast<size_t>( dov.evaluate( d ) );
     };
 }
 
 template<class T>
 void conditional_t<T>::set_u_has_cash( const JsonObject &jo, const std::string &member )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    condition = [iov]( const T & d ) {
-        return d.actor( false )->cash() >= iov.evaluate( d );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    condition = [dov]( const T & d ) {
+        return d.actor( false )->cash() >= dov.evaluate( d );
     };
 }
 
 template<class T>
 void conditional_t<T>::set_u_are_owed( const JsonObject &jo, const std::string &member )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    condition = [iov]( const T & d ) {
-        return d.actor( true )->debt() >= iov.evaluate( d );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    condition = [dov]( const T & d ) {
+        return d.actor( true )->debt() >= dov.evaluate( d );
     };
 }
 
@@ -935,9 +935,9 @@ void conditional_t<T>::set_npc_override( const JsonObject &jo, const std::string
 template<class T>
 void conditional_t<T>::set_days_since( const JsonObject &jo, const std::string &member )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    condition = [iov]( const T & d ) {
-        return calendar::turn >= calendar::start_of_cataclysm + 1_days * iov.evaluate( d );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    condition = [dov]( const T & d ) {
+        return calendar::turn >= calendar::start_of_cataclysm + 1_days * dov.evaluate( d );
     };
 }
 
@@ -1190,9 +1190,9 @@ void conditional_t<T>::set_is_underwater( bool is_npc )
 template<class T>
 void conditional_t<T>::set_one_in_chance( const JsonObject &jo, const std::string &member )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    condition = [iov]( const T & d ) {
-        return one_in( iov.evaluate( d ) );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    condition = [dov]( const T & d ) {
+        return one_in( dov.evaluate( d ) );
     };
 }
 
@@ -1216,11 +1216,11 @@ template<class T>
 void conditional_t<T>::set_x_in_y_chance( const JsonObject &jo, const std::string &member )
 {
     const JsonObject &var_obj = jo.get_object( member );
-    int_or_var<T> iovx = get_int_or_var<T>( var_obj, "x" );
-    int_or_var<T> iovy = get_int_or_var<T>( var_obj, "y" );
-    condition = [iovx, iovy]( const T & d ) {
-        return x_in_y( iovx.evaluate( d ),
-                       iovy.evaluate( d ) );
+    dbl_or_var<T> dovx = get_dbl_or_var<T>( var_obj, "x" );
+    dbl_or_var<T> dovy = get_dbl_or_var<T>( var_obj, "y" );
+    condition = [dovx, dovy]( const T & d ) {
+        return x_in_y( dovx.evaluate( d ),
+                       dovy.evaluate( d ) );
     };
 }
 
@@ -1251,9 +1251,9 @@ void conditional_t<T>::set_mod_is_loaded( const JsonObject &jo, const std::strin
 template<class T>
 void conditional_t<T>::set_has_faction_trust( const JsonObject &jo, const std::string &member )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    condition = [iov]( const T & d ) {
-        return d.actor( true )->get_faction()->trusts_u >= iov.evaluate( d );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    condition = [dov]( const T & d ) {
+        return d.actor( true )->get_faction()->trusts_u >= dov.evaluate( d );
     };
 }
 
@@ -1265,7 +1265,7 @@ static std::string get_string_from_input( const JsonArray &objects, int index )
             return type;
         }
     }
-    int_or_var<dialogue> empty;
+    dbl_or_var<dialogue> empty;
     JsonObject object = objects.get_object( index );
     if( object.has_string( "u_val" ) ) {
         return "u_" + get_talk_varname( object, "u_val", false, empty );
@@ -1339,7 +1339,7 @@ void conditional_t<T>::set_compare_string( const JsonObject &jo, const std::stri
 }
 
 template<class T>
-void conditional_t<T>::set_compare_int( const JsonObject &jo, const std::string &member )
+void conditional_t<T>::set_compare_num( const JsonObject &jo, const std::string &member )
 {
     JsonArray objects = jo.get_array( member );
     if( objects.size() != 3 ) {
@@ -1349,35 +1349,35 @@ void conditional_t<T>::set_compare_int( const JsonObject &jo, const std::string 
         };
         return;
     }
-    std::function<int( const T & )> get_first_int = objects.has_object( 0 ) ? get_get_int(
-                objects.get_object( 0 ) ) : get_get_int( objects.get_string( 0 ), jo );
-    std::function<int( const T & )> get_second_int = objects.has_object( 2 ) ? get_get_int(
-                objects.get_object( 2 ) ) : get_get_int( objects.get_string( 2 ), jo );
+    std::function<double( const T & )> get_first_dbl = objects.has_object( 0 ) ? get_get_dbl(
+                objects.get_object( 0 ) ) : get_get_dbl( objects.get_string( 0 ), jo );
+    std::function<double( const T & )> get_second_dbl = objects.has_object( 2 ) ? get_get_dbl(
+                objects.get_object( 2 ) ) : get_get_dbl( objects.get_string( 2 ), jo );
     const std::string &op = objects.get_string( 1 );
 
     if( op == "==" || op == "=" ) {
-        condition = [get_first_int, get_second_int]( const T & d ) {
-            return get_first_int( d ) == get_second_int( d );
+        condition = [get_first_dbl, get_second_dbl]( const T & d ) {
+            return get_first_dbl( d ) == get_second_dbl( d );
         };
     } else if( op == "!=" ) {
-        condition = [get_first_int, get_second_int]( const T & d ) {
-            return get_first_int( d ) != get_second_int( d );
+        condition = [get_first_dbl, get_second_dbl]( const T & d ) {
+            return get_first_dbl( d ) != get_second_dbl( d );
         };
     } else if( op == "<=" ) {
-        condition = [get_first_int, get_second_int]( const T & d ) {
-            return get_first_int( d ) <= get_second_int( d );
+        condition = [get_first_dbl, get_second_dbl]( const T & d ) {
+            return get_first_dbl( d ) <= get_second_dbl( d );
         };
     } else if( op == ">=" ) {
-        condition = [get_first_int, get_second_int]( const T & d ) {
-            return get_first_int( d ) >= get_second_int( d );
+        condition = [get_first_dbl, get_second_dbl]( const T & d ) {
+            return get_first_dbl( d ) >= get_second_dbl( d );
         };
     } else if( op == "<" ) {
-        condition = [get_first_int, get_second_int]( const T & d ) {
-            return get_first_int( d ) < get_second_int( d );
+        condition = [get_first_dbl, get_second_dbl]( const T & d ) {
+            return get_first_dbl( d ) < get_second_dbl( d );
         };
     } else if( op == ">" ) {
-        condition = [get_first_int, get_second_int]( const T & d ) {
-            return get_first_int( d ) > get_second_int( d );
+        condition = [get_first_dbl, get_second_dbl]( const T & d ) {
+            return get_first_dbl( d ) > get_second_dbl( d );
         };
     } else {
         jo.throw_error( "unexpected operator " + jo.get_string( "op" ) + " in " + jo.str() );
@@ -1388,10 +1388,10 @@ void conditional_t<T>::set_compare_int( const JsonObject &jo, const std::string 
 }
 
 template<class T>
-std::function<int( const T & )> conditional_t<T>::get_get_int( const JsonObject &jo )
+std::function<double( const T & )> conditional_t<T>::get_get_dbl( const JsonObject &jo )
 {
     if( jo.has_member( "const" ) ) {
-        const int const_value = jo.get_int( "const" );
+        const double const_value = jo.get_float( "const" );
         return [const_value]( const T & ) {
             return const_value;
         };
@@ -1536,21 +1536,21 @@ std::function<int( const T & )> conditional_t<T>::get_get_int( const JsonObject 
                 std::string var = read_var_value( info, d );
                 if( !var.empty() ) {
                     // NOLINTNEXTLINE(cert-err34-c)
-                    return std::atoi( var.c_str() );
+                    return std::atof( var.c_str() );
                 } else if( !info.default_val.empty() ) {
                     // NOLINTNEXTLINE(cert-err34-c)
-                    return std::atoi( info.default_val.c_str() );
+                    return std::atof( info.default_val.c_str() );
                 }
-                return 0;
+                return 0.0;
             };
         } else if( checked_value == "time_since_var" ) {
-            int_or_var<dialogue> empty;
+            dbl_or_var<dialogue> empty;
             const std::string var_name = get_talk_varname( jo, "var_name", false, empty );
             return [is_npc, var_name]( const T & d ) {
                 int stored_value = 0;
                 const std::string &var = d.actor( is_npc )->get_value( var_name );
                 if( !var.empty() ) {
-                    stored_value = std::stoi( var );
+                    stored_value = std::stof( var );
                 }
                 return to_turn<int>( calendar::turn ) - stored_value;
             };
@@ -1816,9 +1816,9 @@ std::function<int( const T & )> conditional_t<T>::get_get_int( const JsonObject 
             } else {
                 id.str_val = "";
             }
-            int_or_var<T> radius_iov = get_int_or_var<T>( jo, "radius", false, 10000 );
-            int_or_var<T> number_iov = get_int_or_var<T>( jo, "number", false, 1 );
-            return [target_var, radius_iov, id, number_iov, is_npc]( const T & d ) {
+            dbl_or_var<T> radius_dov = get_dbl_or_var<T>( jo, "radius", false, 10000 );
+            dbl_or_var<T> number_dov = get_dbl_or_var<T>( jo, "number", false, 1 );
+            return [target_var, radius_dov, id, number_dov, is_npc]( const T & d ) {
                 tripoint_abs_ms loc;
                 if( target_var.has_value() ) {
                     loc = get_tripoint_from_var( target_var, d );
@@ -1826,7 +1826,7 @@ std::function<int( const T & )> conditional_t<T>::get_get_int( const JsonObject 
                     loc = d.actor( is_npc )->global_pos();
                 }
 
-                int radius = radius_iov.evaluate( d );
+                int radius = radius_dov.evaluate( d );
                 std::vector<Creature *> targets = g->get_creatures_if( [&radius, id, &d,
                          loc]( const Creature & critter ) {
                     if( critter.is_monster() ) {
@@ -1947,21 +1947,21 @@ std::function<int( const T & )> conditional_t<T>::get_get_int( const JsonObject 
             var_info info = var_info( var_type::global, "temp_var" );
             std::string val = read_var_value( info, d );
             if( !val.empty() ) {
-                return std::stoi( val );
+                return std::stof( val );
             } else {
                 debugmsg( "No valid value." );
-                return 0;
+                return 0.0f;
             }
         };
     }
-    jo.throw_error( "unrecognized integer source in " + jo.str() );
+    jo.throw_error( "unrecognized number source in " + jo.str() );
     return []( const T & ) {
-        return 0;
+        return 0.0;
     };
 }
 
 template<class T>
-std::function<int( const T & )> conditional_t<T>::get_get_int( const std::string &value,
+std::function<double( const T & )> conditional_t<T>::get_get_dbl( const std::string &value,
         const JsonObject &jo )
 {
     if( value == "moon" ) {
@@ -1973,35 +1973,35 @@ std::function<int( const T & )> conditional_t<T>::get_get_int( const std::string
             return to_hours<int>( time_past_midnight( calendar::turn ) );
         };
     }
-    jo.throw_error( "unrecognized integer source in " + value );
+    jo.throw_error( "unrecognized number source in " + value );
     return []( const T & ) {
-        return 0;
+        return 0.0;
     };
 }
 
 template<class T>
-static int handle_min_max( const T &d, int input, cata::optional<int_or_var_part<T>> min,
-                           cata::optional<int_or_var_part<T>> max )
+static double handle_min_max( const T &d, double input, cata::optional<dbl_or_var_part<T>> min,
+                              cata::optional<dbl_or_var_part<T>> max )
 {
     if( min.has_value() ) {
-        int min_val = min.value().evaluate( d );
+        double min_val = min.value().evaluate( d );
         input = std::max( min_val, input );
     }
     if( max.has_value() ) {
-        int max_val = max.value().evaluate( d );
+        double max_val = max.value().evaluate( d );
         input = std::min( max_val, input );
     }
     return input;
 }
 
 template<class T>
-static std::function<void( const T &, int )> get_set_int( const JsonObject &jo,
-        const cata::optional<int_or_var_part<T>> &min, const cata::optional<int_or_var_part<T>> &max,
+static std::function<void( const T &, double )> get_set_dbl( const JsonObject &jo,
+        const cata::optional<dbl_or_var_part<T>> &min, const cata::optional<dbl_or_var_part<T>> &max,
         bool temp_var )
 {
     if( temp_var ) {
         jo.allow_omitted_members();
-        return [min, max]( const T & d, int input ) {
+        return [min, max]( const T & d, double input ) {
             write_var_value( var_type::global, "temp_var", d.actor( false ),
                              std::to_string( handle_min_max<T>( d,
                                              input, min,
@@ -2029,7 +2029,7 @@ static std::function<void( const T &, int )> get_set_int( const JsonObject &jo,
                 jo.throw_error( "unrecognized time unit in " + jo.str() );
             }
         }
-        return [given_unit, min, max]( const T & d, int input ) {
+        return [given_unit, min, max]( const T & d, double input ) {
             calendar::turn = time_point( handle_min_max<T>( d, input, min,
                                          max ) * to_turns<int>( given_unit ) );
         };
@@ -2038,24 +2038,24 @@ static std::function<void( const T &, int )> get_set_int( const JsonObject &jo,
     } else if( jo.has_member( "weather" ) ) {
         std::string weather_aspect = jo.get_string( "weather" );
         if( weather_aspect == "temperature" ) {
-            return [min, max]( const T & d, int input ) {
+            return [min, max]( const T & d, double input ) {
                 const int new_temperature = handle_min_max<T>( d, input, min, max );
                 get_weather().weather_precise->temperature = units::from_fahrenheit( new_temperature );
                 get_weather().temperature = units::from_fahrenheit( new_temperature );
                 get_weather().clear_temp_cache();
             };
         } else if( weather_aspect == "windpower" ) {
-            return [min, max]( const T & d, int input ) {
+            return [min, max]( const T & d, double input ) {
                 get_weather().weather_precise->windpower = handle_min_max<T>( d, input, min, max );
                 get_weather().clear_temp_cache();
             };
         } else if( weather_aspect == "humidity" ) {
-            return [min, max]( const T & d, int input ) {
+            return [min, max]( const T & d, double input ) {
                 get_weather().weather_precise->humidity = handle_min_max<T>( d, input, min, max );
                 get_weather().clear_temp_cache();
             };
         } else if( weather_aspect == "pressure" ) {
-            return [min, max]( const T & d, int input ) {
+            return [min, max]( const T & d, double input ) {
                 get_weather().weather_precise->pressure = handle_min_max<T>( d, input, min, max );
                 get_weather().clear_temp_cache();
             };
@@ -2085,50 +2085,50 @@ static std::function<void( const T &, int )> get_set_int( const JsonObject &jo,
 
         const bool is_npc = type == var_type::npc;
         if( checked_value == "strength_base" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_str_max( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "dexterity_base" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_dex_max( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "intelligence_base" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_int_max( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "perception_base" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_per_max( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "strength_bonus" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_str_max( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "dexterity_bonus" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_dex_max( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "intelligence_bonus" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_int_max( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "perception_bonus" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_per_max( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "var" ) {
-            int_or_var<dialogue> empty;
+            dbl_or_var<dialogue> empty;
             const std::string var_name = get_talk_varname( jo, "var_name", false, empty );
-            return [is_npc, var_name, type, min, max]( const T & d, int input ) {
+            return [is_npc, var_name, type, min, max]( const T & d, double input ) {
                 write_var_value( type, var_name, d.actor( is_npc ), std::to_string( handle_min_max<T>( d, input,
                                  min,
                                  max ) ) );
             };
         } else if( checked_value == "time_since_var" ) {
             // This is a strange thing to want to adjust. But we allow it nevertheless.
-            int_or_var<dialogue> empty;
+            dbl_or_var<dialogue> empty;
             const std::string var_name = get_talk_varname( jo, "var_name", false, empty );
-            return [is_npc, var_name, min, max]( const T & d, int input ) {
+            return [is_npc, var_name, min, max]( const T & d, double input ) {
                 int storing_value = to_turn<int>( calendar::turn ) - handle_min_max<T>( d, input, min, max );
                 d.actor( is_npc )->set_value( var_name, std::to_string( storing_value ) );
             };
@@ -2143,7 +2143,7 @@ static std::function<void( const T &, int )> get_set_int( const JsonObject &jo,
             if( is_npc ) {
                 jo.throw_error( "owed amount not supported for NPCs.  In " + jo.str() );
             } else {
-                return [min, max]( const T & d, int input ) {
+                return [min, max]( const T & d, double input ) {
                     d.actor( true )->add_debt( handle_min_max<T>( d, input, min, max ) - d.actor( true )->debt() );
                 };
             }
@@ -2151,80 +2151,80 @@ static std::function<void( const T &, int )> get_set_int( const JsonObject &jo,
             if( is_npc ) {
                 jo.throw_error( "sold amount not supported for NPCs.  In " + jo.str() );
             } else {
-                return [min, max]( const T & d, int input ) {
+                return [min, max]( const T & d, double input ) {
                     d.actor( true )->add_sold( handle_min_max<T>( d, input, min, max ) - d.actor( true )->sold() );
                 };
             }
         } else if( checked_value == "skill_level" ) {
             const skill_id skill( jo.get_string( "skill" ) );
-            return [is_npc, skill, min, max]( const T & d, int input ) {
+            return [is_npc, skill, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_skill_level( skill, handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "pos_x" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_pos( tripoint( handle_min_max<T>( d, input, min, max ),
                                                       d.actor( is_npc )->posy(),
                                                       d.actor( is_npc )->posz() ) );
             };
         } else if( checked_value == "pos_y" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_pos( tripoint( d.actor( is_npc )->posx(), handle_min_max<T>( d, input, min,
                                                       max ),
                                                       d.actor( is_npc )->posz() ) );
             };
         } else if( checked_value == "pos_z" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_pos( tripoint( d.actor( is_npc )->posx(), d.actor( is_npc )->posy(),
                                                       handle_min_max<T>( d, input, min, max ) ) );
             };
         } else if( checked_value == "pain" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->mod_pain( handle_min_max<T>( d, input, min,
                                              max ) - d.actor( is_npc )->pain_cur() );
             };
         } else if( checked_value == "power" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 // Energy in milijoule
                 d.actor( is_npc )->set_power_cur( 1_mJ * handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "power_max" ) {
             jo.throw_error( "altering max power this way is currently not supported.  In " + jo.str() );
         } else if( checked_value == "power_percentage" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 // Energy in milijoule
                 d.actor( is_npc )->set_power_cur( ( d.actor( is_npc )->power_max() * handle_min_max<T>( d, input,
                                                     min,
                                                     max ) ) / 100 );
             };
         } else if( checked_value == "focus" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->mod_focus( handle_min_max<T>( d, input, min,
                                               max ) - d.actor( is_npc )->focus_cur() );
             };
         } else if( checked_value == "mana" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_mana_cur( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "mana_max" ) {
             jo.throw_error( "altering max mana this way is currently not supported.  In " + jo.str() );
         } else if( checked_value == "mana_percentage" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_mana_cur( ( d.actor( is_npc )->mana_max() * handle_min_max<T>( d, input, min,
                                                    max ) ) / 100 );
             };
         } else if( checked_value == "hunger" ) {
             jo.throw_error( "altering hunger this way is currently not supported.  In " + jo.str() );
         } else if( checked_value == "thirst" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_thirst( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "stored_kcal" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_stored_kcal( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "stored_kcal_percentage" ) {
             // 100% is 55'000 kcal, which is considered healthy.
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_stored_kcal( handle_min_max<T>( d, input, min, max ) * 5500 );
             };
         } else if( checked_value == "item_count" ) {
@@ -2233,91 +2233,91 @@ static std::function<void( const T &, int )> get_set_int( const JsonObject &jo,
             jo.throw_error( "altering max exp this way is currently not supported.  In " + jo.str() );
         } else if( checked_value == "addiction_turns" ) {
             const addiction_id add_id( jo.get_string( "addiction" ) );
-            return [is_npc, min, max, add_id]( const T & d, int input ) {
+            return [is_npc, min, max, add_id]( const T & d, double input ) {
                 d.actor( is_npc )->set_addiction_turns( add_id, handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "stim" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_stim( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "pkill" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_pkill( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "rad" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_rad( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "fatigue" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_fatigue( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "stamina" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_stamina( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "sleep_deprivation" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_sleep_deprivation( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "anger" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_anger( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "morale" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_morale( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "friendly" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_friendly( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "exp" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_kill_xp( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "vitamin" ) {
             std::string vitamin_name = jo.get_string( "name" );
-            return [is_npc, min, max, vitamin_name]( const T & d, int input ) {
+            return [is_npc, min, max, vitamin_name]( const T & d, double input ) {
                 Character *you = d.actor( is_npc )->get_character();
                 if( you ) {
                     you->vitamin_set( vitamin_id( vitamin_name ), handle_min_max<T>( d, input, min, max ) );
                 }
             };
         } else if( checked_value == "age" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_age( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "height" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_height( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "npc_trust" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_npc_trust( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "npc_fear" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_npc_fear( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "npc_value" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_npc_value( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "npc_anger" ) {
-            return [is_npc, min, max]( const T & d, int input ) {
+            return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_npc_anger( handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "spell_level" ) {
             const std::string spell_name = jo.get_string( "spell" );
             const spell_id this_spell_id( spell_name );
-            return [is_npc, min, max, this_spell_id]( const T & d, int input ) {
+            return [is_npc, min, max, this_spell_id]( const T & d, double input ) {
                 d.actor( is_npc )->set_spell_level( this_spell_id, handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "spell_exp" ) {
             const std::string spell_name = jo.get_string( "spell" );
             const spell_id this_spell_id( spell_name );
-            return [is_npc, min, max, this_spell_id]( const T & d, int input ) {
+            return [is_npc, min, max, this_spell_id]( const T & d, double input ) {
                 d.actor( is_npc )->set_spell_exp( this_spell_id, handle_min_max<T>( d, input, min, max ) );
             };
         } else if( checked_value == "proficiency" ) {
@@ -2325,28 +2325,28 @@ static std::function<void( const T &, int )> get_set_int( const JsonObject &jo,
             const proficiency_id the_proficiency_id( proficiency_name );
             if( jo.has_int( "format" ) ) {
                 const int format = jo.get_int( "format" );
-                return [is_npc, format, the_proficiency_id]( const T & d, int input ) {
+                return [is_npc, format, the_proficiency_id]( const T & d, double input ) {
                     d.actor( is_npc )->set_proficiency_practiced_time( the_proficiency_id,
                             to_turns<int>( the_proficiency_id->time_to_learn() * input ) / format );
                 };
             } else if( jo.has_member( "format" ) ) {
                 const std::string format = jo.get_string( "format" );
                 if( format == "time_spent" ) {
-                    return [is_npc, the_proficiency_id]( const T & d, int input ) {
+                    return [is_npc, the_proficiency_id]( const T & d, double input ) {
                         d.actor( is_npc )->set_proficiency_practiced_time( the_proficiency_id, input );
                     };
                 } else if( format == "percent" ) {
-                    return [is_npc, the_proficiency_id]( const T & d, int input ) {
+                    return [is_npc, the_proficiency_id]( const T & d, double input ) {
                         d.actor( is_npc )->set_proficiency_practiced_time( the_proficiency_id,
                                 to_turns<int>( the_proficiency_id->time_to_learn()* input ) / 100 );
                     };
                 } else if( format == "permille" ) {
-                    return [is_npc, the_proficiency_id]( const T & d, int input ) {
+                    return [is_npc, the_proficiency_id]( const T & d, double input ) {
                         d.actor( is_npc )->set_proficiency_practiced_time( the_proficiency_id,
                                 to_turns<int>( the_proficiency_id->time_to_learn() * input ) / 1000 );
                     };
                 } else if( format == "time_left" ) {
-                    return [is_npc, the_proficiency_id]( const T & d, int input ) {
+                    return [is_npc, the_proficiency_id]( const T & d, double input ) {
                         d.actor( is_npc )->set_proficiency_practiced_time( the_proficiency_id,
                                 to_turns<int>( the_proficiency_id->time_to_learn() ) - input );
                     };
@@ -2356,8 +2356,8 @@ static std::function<void( const T &, int )> get_set_int( const JsonObject &jo,
             }
         }
     }
-    jo.throw_error( "error setting integer destination in " + jo.str() );
-    return []( const T &, int ) {};
+    jo.throw_error( "error setting double destination in " + jo.str() );
+    return []( const T &, double ) {};
 }
 
 #if defined(__GNUC__) && defined(__MINGW32__) && !defined(__clang__)
@@ -2369,29 +2369,29 @@ void talk_effect_fun_t<T>::set_arithmetic( const JsonObject &jo, const std::stri
         bool no_result )
 {
     JsonArray objects = jo.get_array( member );
-    cata::optional<int_or_var_part<T>> min;
-    cata::optional<int_or_var_part<T>> max;
+    cata::optional<dbl_or_var_part<T>> min;
+    cata::optional<dbl_or_var_part<T>> max;
     if( jo.has_member( "min" ) ) {
-        min = get_int_or_var_part<T>( jo.get_member( "min" ), "min" );
+        min = get_dbl_or_var_part<T>( jo.get_member( "min" ), "min" );
     } else if( jo.has_member( "min_time" ) ) {
-        int_or_var_part<T> value;
+        dbl_or_var_part<T> value;
         time_duration min_time;
         mandatory( jo, false, "min_time", min_time );
-        value.int_val = to_turns<int>( min_time );
+        value.dbl_val = to_turns<int>( min_time );
         min = value;
     }
     if( jo.has_member( "max" ) ) {
-        max = get_int_or_var_part<T>( jo.get_member( "max" ), "max" );
+        max = get_dbl_or_var_part<T>( jo.get_member( "max" ), "max" );
     } else if( jo.has_member( "max_time" ) ) {
-        int_or_var_part<T> value;
+        dbl_or_var_part<T> value;
         time_duration max_time;
         mandatory( jo, false, "max_time", max_time );
-        value.int_val = to_turns<int>( max_time );
+        value.dbl_val = to_turns<int>( max_time );
         max = value;
     }
     std::string op = "none";
     std::string result = "none";
-    std::function<void( const T &, int )> set_int = get_set_int( objects.get_object( 0 ), min,
+    std::function<void( const T &, double )> set_dbl = get_set_dbl( objects.get_object( 0 ), min,
             max, no_result );
     int no_result_mod = no_result ? 2 : 0; //In the case of a no result we have fewer terms.
     // Normal full version
@@ -2406,49 +2406,49 @@ void talk_effect_fun_t<T>::set_arithmetic( const JsonObject &jo, const std::stri
                 };
             }
         }
-        std::function<int( const T & )> get_first_int = conditional_t< T >::get_get_int(
+        std::function<double( const T & )> get_first_dbl = conditional_t< T >::get_get_dbl(
                     objects.get_object( 2 - no_result_mod ) );
-        std::function<int( const T & )> get_second_int = conditional_t< T >::get_get_int(
+        std::function<double( const T & )> get_second_dbl = conditional_t< T >::get_get_dbl(
                     objects.get_object( 4 - no_result_mod ) );
         if( op == "*" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) * get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, get_first_dbl( d ) * get_second_dbl( d ) );
             };
         } else if( op == "/" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) / get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, get_first_dbl( d ) / get_second_dbl( d ) );
             };
         } else if( op == "+" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) + get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, get_first_dbl( d ) + get_second_dbl( d ) );
             };
         } else if( op == "-" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) - get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, get_first_dbl( d ) - get_second_dbl( d ) );
             };
         } else if( op == "%" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) % get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, static_cast<int>( get_first_dbl( d ) ) % static_cast<int>( get_second_dbl( d ) ) );
             };
         } else if( op == "&" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) & get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, static_cast<int>( get_first_dbl( d ) ) & static_cast<int>( get_second_dbl( d ) ) );
             };
         } else if( op == "|" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) | get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, static_cast<int>( get_first_dbl( d ) ) | static_cast<int>( get_second_dbl( d ) ) );
             };
         } else if( op == "<<" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) << get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, static_cast<int>( get_first_dbl( d ) ) << static_cast<int>( get_second_dbl( d ) ) );
             };
         } else if( op == ">>" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) >> get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, static_cast<int>( get_first_dbl( d ) ) >> static_cast<int>( get_second_dbl( d ) ) );
             };
         } else if( op == "^" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) ^ get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, static_cast<int>( get_first_dbl( d ) ) ^ static_cast<int>( get_second_dbl( d ) ) );
             };
         } else {
             jo.throw_error( "unexpected operator " + op + " in " + jo.str() );
@@ -2466,11 +2466,11 @@ void talk_effect_fun_t<T>::set_arithmetic( const JsonObject &jo, const std::stri
                 return false;
             };
         }
-        std::function<int( const T & )> get_first_int = conditional_t< T >::get_get_int(
+        std::function<double( const T & )> get_first_dbl = conditional_t< T >::get_get_dbl(
                     objects.get_object( 2 ) );
         if( op == "~" ) {
-            function = [get_first_int, set_int]( const T & d ) {
-                set_int( d, ~get_first_int( d ) );
+            function = [get_first_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, ~static_cast<int>( get_first_dbl( d ) ) );
             };
         } else {
             jo.throw_error( "unexpected operator " + op + " in " + jo.str() );
@@ -2482,33 +2482,33 @@ void talk_effect_fun_t<T>::set_arithmetic( const JsonObject &jo, const std::stri
         // =, -=, +=, *=, and /=
     } else if( objects.size() == 3 && !no_result ) {
         result = objects.get_string( 1 );
-        std::function<int( const T & )> get_first_int = conditional_t< T >::get_get_int(
+        std::function<double( const T & )> get_first_dbl = conditional_t< T >::get_get_dbl(
                     objects.get_object( 0 ) );
-        std::function<int( const T & )> get_second_int = conditional_t< T >::get_get_int(
+        std::function<double( const T & )> get_second_dbl = conditional_t< T >::get_get_dbl(
                     objects.get_object( 2 ) );
         if( result == "+=" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) + get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, get_first_dbl( d ) + get_second_dbl( d ) );
             };
         } else if( result == "-=" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) - get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, get_first_dbl( d ) - get_second_dbl( d ) );
             };
         } else if( result == "*=" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) * get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, get_first_dbl( d ) * get_second_dbl( d ) );
             };
         } else if( result == "/=" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) / get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, get_first_dbl( d ) / get_second_dbl( d ) );
             };
         } else if( result == "%=" ) {
-            function = [get_first_int, get_second_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) % get_second_int( d ) );
+            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, static_cast<int>( get_first_dbl( d ) ) % static_cast<int>( get_second_dbl( d ) ) );
             };
         } else if( result == "=" ) {
-            function = [get_second_int, set_int]( const T & d ) {
-                set_int( d, get_second_int( d ) );
+            function = [get_second_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, get_second_dbl( d ) );
             };
         } else {
             jo.throw_error( "unexpected result " + result + " in " + jo.str() );
@@ -2519,15 +2519,15 @@ void talk_effect_fun_t<T>::set_arithmetic( const JsonObject &jo, const std::stri
         // ++ and --
     } else if( objects.size() == 2 && !no_result ) {
         op = objects.get_string( 1 );
-        std::function<int( const T & )> get_first_int = conditional_t< T >::get_get_int(
+        std::function<double( const T & )> get_first_dbl = conditional_t< T >::get_get_dbl(
                     objects.get_object( 0 ) );
         if( op == "++" ) {
-            function = [get_first_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) + 1 );
+            function = [get_first_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, get_first_dbl( d ) + 1 );
             };
         } else if( op == "--" ) {
-            function = [get_first_int, set_int]( const T & d ) {
-                set_int( d, get_first_int( d ) - 1 );
+            function = [get_first_dbl, set_dbl]( const T & d ) {
+                set_dbl( d, get_first_dbl( d ) - 1 );
             };
         } else {
             jo.throw_error( "unexpected operator " + op + " in " + jo.str() );
@@ -2536,10 +2536,10 @@ void talk_effect_fun_t<T>::set_arithmetic( const JsonObject &jo, const std::stri
             };
         }
     } else if( objects.size() == 1 && no_result ) {
-        std::function<int( const T & )> get_first_int = conditional_t< T >::get_get_int(
+        std::function<double( const T & )> get_first_dbl = conditional_t< T >::get_get_dbl(
                     objects.get_object( 0 ) );
-        function = [get_first_int, set_int]( const T & d ) {
-            set_int( d, get_first_int( d ) );
+        function = [get_first_dbl, set_dbl]( const T & d ) {
+            set_dbl( d, get_first_dbl( d ) );
         };
     } else {
         jo.throw_error( "Invalid number of args in " + jo.str() );
@@ -2596,7 +2596,7 @@ void conditional_t<T>::set_has_skill( const JsonObject &jo, const std::string &m
         };
     } else {
         str_or_var<T> skill = get_str_or_var<T>( has_skill.get_member( "skill" ), "skill", true );
-        int_or_var<T> level = get_int_or_var<T>( has_skill, "level", true );
+        dbl_or_var<T> level = get_dbl_or_var<T>( has_skill, "level", true );
         condition = [skill, level, is_npc]( const T & d ) {
             return d.actor( is_npc )->get_skill_level( skill_id( skill.evaluate( d ) ) ) >= level.evaluate( d );
         };
@@ -2974,7 +2974,9 @@ conditional_t<T>::conditional_t( const JsonObject &jo )
     } else if( jo.has_int( "u_has_faction_trust" ) || jo.has_object( "u_has_faction_trust" ) ) {
         set_has_faction_trust( jo, "u_has_faction_trust" );
     } else if( jo.has_member( "compare_int" ) ) {
-        set_compare_int( jo, "compare_int" );
+        set_compare_num( jo, "compare_int" );
+    } else if( jo.has_member( "compare_num" ) ) {
+        set_compare_num( jo, "compare_num" );
     } else if( jo.has_member( "compare_string" ) ) {
         set_compare_string( jo, "compare_string" );
     } else {
@@ -3134,7 +3136,7 @@ template void read_condition<dialogue>( const JsonObject &jo, const std::string 
 template duration_or_var<dialogue> get_duration_or_var( const JsonObject &jo, std::string member,
         bool required, time_duration default_val );
 template std::string get_talk_varname<dialogue>( const JsonObject &jo, const std::string &member,
-        bool check_value, int_or_var<dialogue> &default_val );
+        bool check_value, dbl_or_var<dialogue> &default_val );
 #if !defined(MACOSX)
 template struct conditional_t<mission_goal_condition_context>;
 #endif

--- a/src/condition.h
+++ b/src/condition.h
@@ -49,7 +49,7 @@ const std::unordered_set<std::string> complex_conds = { {
         "u_has_worn_with_flag", "npc_has_worn_with_flag", "u_has_wielded_with_flag", "npc_has_wielded_with_flag",
         "u_has_pain", "npc_has_pain", "u_has_power", "npc_has_power", "u_has_focus", "npc_has_focus", "u_has_morale",
         "npc_has_morale", "u_is_on_terrain", "npc_is_on_terrain", "u_is_in_field", "npc_is_in_field", "compare_int",
-        "compare_string", "roll_contested"
+        "compare_string", "roll_contested", "compare_num"
     }
 };
 } // namespace dialogue_data
@@ -73,12 +73,12 @@ template<class T>
 str_or_var<T> get_str_or_var( const JsonValue &jv, const std::string &member, bool required = true,
                               const std::string &default_val = "" );
 template<class T>
-int_or_var<T> get_int_or_var( const JsonObject &jo, std::string member, bool required = true,
-                              int default_val = 0 );
+dbl_or_var<T> get_dbl_or_var( const JsonObject &jo, std::string member, bool required = true,
+                              double default_val = 0.0 );
 template<class T>
-int_or_var_part<T> get_int_or_var_part( const JsonValue &jv, const std::string &member,
+dbl_or_var_part<T> get_dbl_or_var_part( const JsonValue &jv, const std::string &member,
                                         bool required = true,
-                                        int default_val = 0 );
+                                        double default_val = 0.0 );
 template<class T>
 duration_or_var<T> get_duration_or_var( const JsonObject &jo, std::string member,
                                         bool required = true,
@@ -94,7 +94,7 @@ void write_var_value( var_type type, const std::string &name, talker *talk,
                       const std::string &value );
 template<class T>
 std::string get_talk_varname( const JsonObject &jo, const std::string &member,
-                              bool check_value, int_or_var<T> &default_val );
+                              bool check_value, dbl_or_var<T> &default_val );
 std::string get_talk_var_basename( const JsonObject &jo, const std::string &member,
                                    bool check_value );
 // the truly awful declaration for the conditional_t loading helper_function
@@ -211,9 +211,9 @@ struct conditional_t {
         void set_mission_has_generic_rewards();
         void set_can_see( bool is_npc = false );
         void set_compare_string( const JsonObject &jo, const std::string &member );
-        void set_compare_int( const JsonObject &jo, const std::string &member );
-        static std::function<int( const T & )> get_get_int( const JsonObject &jo );
-        static std::function<int( const T & )> get_get_int( const std::string &value,
+        void set_compare_num( const JsonObject &jo, const std::string &member );
+        static std::function<double( const T & )> get_get_dbl( const JsonObject &jo );
+        static std::function<double( const T & )> get_get_dbl( const std::string &value,
                 const JsonObject &jo );
         bool operator()( const T &d ) const {
             if( !condition ) {
@@ -233,7 +233,7 @@ extern template duration_or_var<dialogue> get_duration_or_var( const JsonObject 
         bool required, time_duration default_val );
 extern template std::string get_talk_varname<dialogue>( const JsonObject &jo,
         const std::string &member,
-        bool check_value, int_or_var<dialogue> &default_val );
+        bool check_value, dbl_or_var<dialogue> &default_val );
 extern template struct conditional_t<mission_goal_condition_context>;
 extern template void read_condition<mission_goal_condition_context>( const JsonObject &jo,
         const std::string &member_name,

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -186,18 +186,18 @@ struct str_or_var {
 };
 
 template<class T>
-struct int_or_var_part {
-    cata::optional<int> int_val;
+struct dbl_or_var_part {
+    cata::optional<double> dbl_val;
     cata::optional<var_info> var_val;
-    cata::optional<int> default_val;
+    cata::optional<double> default_val;
     cata::optional<talk_effect_fun_t<T>> arithmetic_val;
-    int evaluate( const T &d ) const {
-        if( int_val.has_value() ) {
-            return int_val.value();
+    double evaluate( const T &d ) const {
+        if( dbl_val.has_value() ) {
+            return dbl_val.value();
         } else if( var_val.has_value() ) {
             std::string val = read_var_value( var_val.value(), d );
             if( !val.empty() ) {
-                return std::stoi( val );
+                return std::stof( val );
             }
             if( default_val.has_value() ) {
                 return default_val.value();
@@ -206,7 +206,7 @@ struct int_or_var_part {
                 if( var_name.find( "npctalk_var" ) != std::string::npos ) {
                     var_name = var_name.substr( 12 );
                 }
-                debugmsg( "No default value provided for int_or_var_part while encountering unused variable %s.  Add a \"default\" member to prevent this.",
+                debugmsg( "No default value provided for dbl_or_var_part while encountering unused variable %s.  Add a \"default\" member to prevent this.",
                           var_name );
                 return 0;
             }
@@ -215,24 +215,24 @@ struct int_or_var_part {
             var_info info = var_info( var_type::global, "temp_var" );
             std::string val = read_var_value( info, d );
             if( !val.empty() ) {
-                return std::stoi( val );
+                return std::stof( val );
             } else {
-                debugmsg( "No valid arithmetic value for int_or_var_part." );
+                debugmsg( "No valid arithmetic value for dbl_or_var_part." );
                 return 0;
             }
         } else {
-            debugmsg( "No valid value for int_or_var_part." );
+            debugmsg( "No valid value for dbl_or_var_part." );
             return 0;
         }
     }
 };
 
 template<class T>
-struct int_or_var {
+struct dbl_or_var {
     bool pair = false;
-    int_or_var_part<T> min;
-    int_or_var_part<T> max;
-    int evaluate( const T &d ) const {
+    dbl_or_var_part<T> min;
+    dbl_or_var_part<T> max;
+    double evaluate( const T &d ) const {
         if( pair ) {
             return rng( min.evaluate( d ), max.evaluate( d ) );
         } else {

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -23,7 +23,7 @@ class JsonOut;
 class item;
 struct dialogue;
 template<class T>
-struct int_or_var;
+struct dbl_or_var;
 namespace enchant_vals
 {
 // the different types of values that can be modified by enchantments
@@ -195,14 +195,14 @@ class enchantment
         cata::optional<emit_id> emitter;
         std::map<efftype_id, int> ench_effects;
         // values that add to the base value
-        std::map<enchant_vals::mod, int_or_var<dialogue>> values_add; // NOLINT(cata-serialize)
+        std::map<enchant_vals::mod, dbl_or_var<dialogue>> values_add; // NOLINT(cata-serialize)
         // values that get multiplied to the base value
         // multipliers add to each other instead of multiply against themselves
-        std::map<enchant_vals::mod, int_or_var<dialogue>> values_multiply; // NOLINT(cata-serialize)
+        std::map<enchant_vals::mod, dbl_or_var<dialogue>> values_multiply; // NOLINT(cata-serialize)
 
         // the exact same as above, though specifically for skills
-        std::map<skill_id, int_or_var<dialogue>> skill_values_add; // NOLINT(cata-serialize)
-        std::map<skill_id, int_or_var<dialogue>> skill_values_multiply; // NOLINT(cata-serialize)
+        std::map<skill_id, dbl_or_var<dialogue>> skill_values_add; // NOLINT(cata-serialize)
+        std::map<skill_id, dbl_or_var<dialogue>> skill_values_multiply; // NOLINT(cata-serialize)
 
         std::vector<fake_spell> hit_me_effect;
         std::vector<fake_spell> hit_you_effect;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2060,7 +2060,7 @@ void talk_effect_fun_t<T>::set_add_effect( const JsonObject &jo, const std::stri
     bool permanent = false;
     bool force = false;
     duration_or_var<T> dov_duration;
-    int_or_var<T> iov_intensity;
+    dbl_or_var<T> dov_intensity;
     if( jo.has_string( "duration" ) ) {
         const std::string dur_string = jo.get_string( "duration" );
         if( dur_string == "PERMANENT" ) {
@@ -2072,7 +2072,7 @@ void talk_effect_fun_t<T>::set_add_effect( const JsonObject &jo, const std::stri
     } else {
         dov_duration = get_duration_or_var<T>( jo, "duration", true );
     }
-    iov_intensity = get_int_or_var<T>( jo, "intensity", false, 0 );
+    dov_intensity = get_dbl_or_var<T>( jo, "intensity", false, 0 );
     if( jo.has_bool( "force" ) ) {
         force = jo.get_bool( "force" );
     }
@@ -2083,11 +2083,11 @@ void talk_effect_fun_t<T>::set_add_effect( const JsonObject &jo, const std::stri
         target.str_val = "bp_null";
     }
     function = [is_npc, new_effect, dov_duration, target, permanent, force,
-            iov_intensity]( const T & d ) {
+            dov_intensity]( const T & d ) {
         d.actor( is_npc )->add_effect( efftype_id( new_effect.evaluate( d ) ),
                                        dov_duration.evaluate( d ),
                                        target.evaluate( d ), permanent, force,
-                                       iov_intensity.evaluate( d ) );
+                                       dov_intensity.evaluate( d ) );
     };
 }
 
@@ -2125,7 +2125,7 @@ template<class T>
 void talk_effect_fun_t<T>::set_mutate( const JsonObject &jo, const std::string &member,
                                        bool is_npc )
 {
-    int_or_var<T> highest_cat = get_int_or_var<T>( jo, member, true, 0 );
+    dbl_or_var<T> highest_cat = get_dbl_or_var<T>( jo, member, true, 0 );
     const bool use_vitamins = jo.get_bool( "use_vitamins", true );
     function = [is_npc, highest_cat, use_vitamins]( const T & d ) {
         d.actor( is_npc )->mutate( highest_cat.evaluate( d ), use_vitamins );
@@ -2167,7 +2167,7 @@ template<class T>
 void talk_effect_fun_t<T>::set_add_var( const JsonObject &jo, const std::string &member,
                                         bool is_npc )
 {
-    int_or_var<dialogue> empty;
+    dbl_or_var<dialogue> empty;
     const std::string var_name = get_talk_varname<dialogue>( jo, member, false, empty );
     const std::string var_base_name = get_talk_var_basename( jo, member, false );
     const bool time_check = jo.has_member( "time" ) && jo.get_bool( "time" );
@@ -2192,7 +2192,7 @@ template<class T>
 void talk_effect_fun_t<T>::set_remove_var( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    int_or_var<dialogue> empty;
+    dbl_or_var<dialogue> empty;
     const std::string var_name = get_talk_varname<dialogue>( jo, member, false, empty );
     function = [is_npc, var_name]( const T & d ) {
         d.actor( is_npc )->remove_value( var_name );
@@ -2203,12 +2203,12 @@ template<class T>
 void talk_effect_fun_t<T>::set_adjust_var( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    int_or_var<dialogue> empty;
+    dbl_or_var<dialogue> empty;
     const std::string var_name = get_talk_varname<dialogue>( jo, member, false, empty );
     const std::string var_base_name = get_talk_var_basename( jo, member, false );
-    int_or_var<T> iov = get_int_or_var<T>( jo, "adjustment" );
-    function = [is_npc, var_base_name, var_name, iov]( const T & d ) {
-        int adjusted_value = iov.evaluate( d );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, "adjustment" );
+    function = [is_npc, var_base_name, var_name, dov]( const T & d ) {
+        int adjusted_value = dov.evaluate( d );
 
         const std::string &var = d.actor( is_npc )->get_value( var_name );
         if( !var.empty() ) {
@@ -2275,12 +2275,12 @@ void talk_effect_fun_t<T>::set_u_spawn_item( const JsonObject &jo, const std::st
         container_name.str_val = "";
     }
     bool use_item_group = jo.get_bool( "use_item_group", false );
-    int_or_var<T> cost = get_int_or_var<T>( jo, "cost", false, 0 );
-    int_or_var<T> count;
+    dbl_or_var<T> cost = get_dbl_or_var<T>( jo, "cost", false, 0 );
+    dbl_or_var<T> count;
     if( !jo.has_int( "charges" ) ) {
-        count = get_int_or_var<T>( jo, "count", false, 1 );
+        count = get_dbl_or_var<T>( jo, "count", false, 1 );
     } else {
-        count = get_int_or_var<T>( jo, "count", false, 0 );
+        count = get_dbl_or_var<T>( jo, "count", false, 0 );
     }
     function = [item_name, count, container_name, use_item_group]( const T & d ) {
         itype_id iname = itype_id( item_name.evaluate( d ) );
@@ -2296,12 +2296,12 @@ void talk_effect_fun_t<T>::set_u_buy_item( const JsonObject &jo, const std::stri
 {
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
-    int_or_var<T> cost = get_int_or_var<T>( jo, "cost", false, 0 );
-    int_or_var<T> count;
+    dbl_or_var<T> cost = get_dbl_or_var<T>( jo, "cost", false, 0 );
+    dbl_or_var<T> count;
     if( !jo.has_int( "charges" ) ) {
-        count = get_int_or_var<T>( jo, "count", false, 1 );
+        count = get_dbl_or_var<T>( jo, "count", false, 1 );
     } else {
-        count = get_int_or_var<T>( jo, "count", false, 0 );
+        count = get_dbl_or_var<T>( jo, "count", false, 0 );
     }
     bool use_item_group = jo.get_bool( "use_item_group", false );
     str_or_var<T> container_name;
@@ -2330,12 +2330,12 @@ void talk_effect_fun_t<T>::set_u_sell_item( const JsonObject &jo, const std::str
 {
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
-    int_or_var<T> cost = get_int_or_var<T>( jo, "cost", false, 0 );
-    int_or_var<T> count;
+    dbl_or_var<T> cost = get_dbl_or_var<T>( jo, "cost", false, 0 );
+    dbl_or_var<T> count;
     if( !jo.has_int( "charges" ) ) {
-        count = get_int_or_var<T>( jo, "count", false, 1 );
+        count = get_dbl_or_var<T>( jo, "count", false, 1 );
     } else {
-        count = get_int_or_var<T>( jo, "count", false, 0 );
+        count = get_dbl_or_var<T>( jo, "count", false, 0 );
     }
     str_or_var<T> item_name = get_str_or_var<T>( jo.get_member( member ), member, true );
     function = [item_name, cost, count, true_eocs, false_eocs]( const T & d ) {
@@ -2375,12 +2375,12 @@ void talk_effect_fun_t<T>::set_consume_item( const JsonObject &jo, const std::st
         bool is_npc )
 {
     str_or_var<T> item_name = get_str_or_var<T>( jo.get_member( member ), member, true );
-    int_or_var<T> charges = get_int_or_var<T>( jo, "charges", false, 0 );
-    int_or_var<T> count;
+    dbl_or_var<T> charges = get_dbl_or_var<T>( jo, "charges", false, 0 );
+    dbl_or_var<T> count;
     if( !jo.has_int( "charges" ) ) {
-        count = get_int_or_var<T>( jo, "count", false, 1 );
+        count = get_dbl_or_var<T>( jo, "count", false, 1 );
     } else {
-        count = get_int_or_var<T>( jo, "count", false, 0 );
+        count = get_dbl_or_var<T>( jo, "count", false, 0 );
     }
     const bool do_popup = jo.get_bool( "popup", false );
     function = [do_popup, is_npc, item_name, count, charges]( const T & d ) {
@@ -2442,7 +2442,7 @@ void talk_effect_fun_t<T>::set_remove_item_with( const JsonObject &jo, const std
 template<class T>
 void talk_effect_fun_t<T>::set_u_spend_cash( const JsonObject &jo, const std::string &member )
 {
-    int_or_var<T> amount = get_int_or_var<T>( jo, member );
+    dbl_or_var<T> amount = get_dbl_or_var<T>( jo, member );
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
     function = [amount, true_eocs, false_eocs]( const T & d ) {
@@ -2475,7 +2475,7 @@ void talk_effect_fun_t<T>::set_npc_change_class( const JsonObject &jo, const std
 template<class T>
 void talk_effect_fun_t<T>::set_change_faction_rep( const JsonObject &jo, const std::string &member )
 {
-    int_or_var<T> rep_change = get_int_or_var<T>( jo, member );
+    dbl_or_var<T> rep_change = get_dbl_or_var<T>( jo, member );
     function = [rep_change]( const T & d ) {
         d.actor( true )->add_faction_rep( rep_change.evaluate( d ) );
     };
@@ -2567,11 +2567,11 @@ template<class T>
 void talk_effect_fun_t<T>::set_location_variable( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    int_or_var<T> iov_min_radius = get_int_or_var<T>( jo, "min_radius", false, 0 );
-    int_or_var<T> iov_max_radius = get_int_or_var<T>( jo, "max_radius", false, 0 );
-    int_or_var<T> iov_z_adjust = get_int_or_var<T>( jo, "z_adjust", false, 0 );
-    int_or_var<T> iov_x_adjust = get_int_or_var<T>( jo, "x_adjust", false, 0 );
-    int_or_var<T> iov_y_adjust = get_int_or_var<T>( jo, "y_adjust", false, 0 );
+    dbl_or_var<T> dov_min_radius = get_dbl_or_var<T>( jo, "min_radius", false, 0 );
+    dbl_or_var<T> dov_max_radius = get_dbl_or_var<T>( jo, "max_radius", false, 0 );
+    dbl_or_var<T> dov_z_adjust = get_dbl_or_var<T>( jo, "z_adjust", false, 0 );
+    dbl_or_var<T> dov_x_adjust = get_dbl_or_var<T>( jo, "x_adjust", false, 0 );
+    dbl_or_var<T> dov_y_adjust = get_dbl_or_var<T>( jo, "y_adjust", false, 0 );
     bool z_override = jo.get_bool( "z_override", false );
     const bool outdoor_only = jo.get_bool( "outdoor_only", false );
     cata::optional<mission_target_params> target_params;
@@ -2587,21 +2587,21 @@ void talk_effect_fun_t<T>::set_location_variable( const JsonObject &jo, const st
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
 
-    function = [iov_min_radius, iov_max_radius, var_name, outdoor_only, target_params,
-                                is_npc, type, iov_x_adjust, iov_y_adjust, iov_z_adjust, z_override, true_eocs,
+    function = [dov_min_radius, dov_max_radius, var_name, outdoor_only, target_params,
+                                is_npc, type, dov_x_adjust, dov_y_adjust, dov_z_adjust, z_override, true_eocs,
                     false_eocs]( const T & d ) {
         talker *target = d.actor( is_npc );
         tripoint talker_pos = get_map().getabs( target->pos() );
         tripoint target_pos = talker_pos;
 
-        int max_radius = iov_max_radius.evaluate( d );
+        int max_radius = dov_max_radius.evaluate( d );
         if( target_params.has_value() ) {
             const tripoint_abs_omt omt_pos = mission_util::get_om_terrain_pos( target_params.value() );
             target_pos = tripoint( project_to<coords::ms>( omt_pos ).x(), project_to<coords::ms>( omt_pos ).y(),
                                    project_to<coords::ms>( omt_pos ).z() );
         } else if( max_radius > 0 ) {
             bool found = false;
-            int min_radius = iov_min_radius.evaluate( d );
+            int min_radius = dov_min_radius.evaluate( d );
             for( int attempts = 0; attempts < 25; attempts++ ) {
                 target_pos = talker_pos + tripoint( rng( -max_radius, max_radius ), rng( -max_radius, max_radius ),
                                                     0 );
@@ -2618,14 +2618,14 @@ void talk_effect_fun_t<T>::set_location_variable( const JsonObject &jo, const st
         }
 
         // move the found value by the adjusts
-        target_pos = target_pos + tripoint( iov_x_adjust.evaluate( d ), iov_y_adjust.evaluate( d ), 0 );
+        target_pos = target_pos + tripoint( dov_x_adjust.evaluate( d ), dov_y_adjust.evaluate( d ), 0 );
 
         if( z_override ) {
             target_pos = tripoint( target_pos.xy(),
-                                   iov_z_adjust.evaluate( d ) );
+                                   dov_z_adjust.evaluate( d ) );
         } else {
             target_pos = target_pos + tripoint( 0, 0,
-                                                iov_z_adjust.evaluate( d ) );
+                                                dov_z_adjust.evaluate( d ) );
         }
         write_var_value( type, var_name, d.actor( type == var_type::npc ), target_pos.to_string() );
         run_eoc_vector( true_eocs, d );
@@ -2638,7 +2638,7 @@ void talk_effect_fun_t<T>::set_transform_radius( const JsonObject &jo, const std
 {
     str_or_var<T> transform = get_str_or_var<T>( jo.get_member( "ter_furn_transform" ),
                               "ter_furn_transform", true );
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
     duration_or_var<T> dov_time_in_future = get_duration_or_var<T>( jo, "time_in_future", false,
                                             0_seconds );
     cata::optional<var_info> target_var;
@@ -2651,13 +2651,13 @@ void talk_effect_fun_t<T>::set_transform_radius( const JsonObject &jo, const std
     } else {
         key.str_val = "";
     }
-    function = [iov, transform, target_var, dov_time_in_future, key, is_npc]( const T & d ) {
+    function = [dov, transform, target_var, dov_time_in_future, key, is_npc]( const T & d ) {
         tripoint_abs_ms target_pos = d.actor( is_npc )->global_pos();
         if( target_var.has_value() ) {
             target_pos = get_tripoint_from_var<T>( target_var, d );
         }
 
-        int radius = iov.evaluate( d );
+        int radius = dov.evaluate( d );
         time_duration future = dov_time_in_future.evaluate( d );
         if( future > 0_seconds ) {
             get_timed_events().add( timed_event_type::TRANSFORM_RADIUS,
@@ -2845,18 +2845,18 @@ template<class T>
 void talk_effect_fun_t<T>::set_bulk_trade_accept( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    int_or_var<T> iov_quantity;
+    dbl_or_var<T> dov_quantity;
     if( jo.has_member( member ) ) {
-        iov_quantity = get_int_or_var<T>( jo, member, false, -1 );
+        dov_quantity = get_dbl_or_var<T>( jo, member, false, -1 );
     } else {
-        iov_quantity.min.int_val = -1;
+        dov_quantity.min.dbl_val = -1;
     }
     bool is_trade = member == "u_bulk_trade_accept" || member == "npc_bulk_trade_accept";
-    function = [is_trade, is_npc, iov_quantity]( const T & d ) {
+    function = [is_trade, is_npc, dov_quantity]( const T & d ) {
         talker *seller = d.actor( is_npc );
         talker *buyer = d.actor( !is_npc );
         item tmp( d.cur_item );
-        int quantity = iov_quantity.evaluate( d );
+        int quantity = dov_quantity.evaluate( d );
         int seller_has = 0;
         if( tmp.count_by_charges() ) {
             seller_has = seller->charges_of( d.cur_item );
@@ -2942,8 +2942,8 @@ template<class T>
 void talk_effect_fun_t<T>::set_u_buy_monster( const JsonObject &jo, const std::string &member )
 {
     str_or_var<T> monster_type_id = get_str_or_var<T>( jo.get_member( member ), member, true );
-    int_or_var<T> cost = get_int_or_var<T>( jo, "cost", false, 0 );
-    int_or_var<T> count = get_int_or_var<T>( jo, "count", false, 1 );
+    dbl_or_var<T> cost = get_dbl_or_var<T>( jo, "cost", false, 0 );
+    dbl_or_var<T> count = get_dbl_or_var<T>( jo, "count", false, 1 );
     const bool pacified = jo.get_bool( "pacified", false );
     str_or_var<T> name;
     if( jo.has_member( "name" ) ) {
@@ -3128,11 +3128,11 @@ template<class T>
 void talk_effect_fun_t<T>::set_add_wet( const JsonObject &jo, const std::string &member,
                                         bool is_npc )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    function = [is_npc, iov]( const T & d ) {
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    function = [is_npc, dov]( const T & d ) {
         Character *target = d.actor( is_npc )->get_character();
         if( target ) {
-            wet_character( *target, iov.evaluate( d ) );
+            wet_character( *target, dov.evaluate( d ) );
         }
     };
 }
@@ -3207,11 +3207,11 @@ void talk_effect_fun_t<T>::set_sound_effect( const JsonObject &jo, const std::st
     str_or_var<T> variant = get_str_or_var<T>( jo.get_member( member ), member, true );
     str_or_var<T> id = get_str_or_var<T>( jo.get_member( "id" ), "id", true );
     const bool outdoor_event = jo.get_bool( "outdoor_event", false );
-    int_or_var<T> volume;
+    dbl_or_var<T> volume;
     if( jo.has_member( "volume" ) ) {
-        volume = get_int_or_var<T>( jo, "volume", false, -1 );
+        volume = get_dbl_or_var<T>( jo, "volume", false, -1 );
     } else {
-        volume.min.int_val = -1;
+        volume.min.dbl_val = -1;
     }
     function = [variant, id, outdoor_event, volume]( const T & d ) {
         map &here = get_map();
@@ -3240,12 +3240,12 @@ template<class T>
 void talk_effect_fun_t<T>::set_mod_healthy( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    int_or_var<T> iov_amount = get_int_or_var<T>( jo, member );
-    int_or_var<T> iov_cap = get_int_or_var<T>( jo, "cap" );
+    dbl_or_var<T> dov_amount = get_dbl_or_var<T>( jo, member );
+    dbl_or_var<T> dov_cap = get_dbl_or_var<T>( jo, "cap" );
 
-    function = [is_npc, iov_amount, iov_cap]( const T & d ) {
-        d.actor( is_npc )->mod_daily_health( iov_amount.evaluate( d ),
-                                             iov_cap.evaluate( d ) );
+    function = [is_npc, dov_amount, dov_cap]( const T & d ) {
+        d.actor( is_npc )->mod_daily_health( dov_amount.evaluate( d ),
+                                             dov_cap.evaluate( d ) );
     };
 }
 
@@ -3253,7 +3253,7 @@ template<class T>
 void talk_effect_fun_t<T>::set_hp( const JsonObject &jo, const std::string &member,
                                    bool is_npc )
 {
-    int_or_var<T> new_hp = get_int_or_var<T>( jo, member, true );
+    dbl_or_var<T> new_hp = get_dbl_or_var<T>( jo, member, true );
     cata::optional<str_or_var<T>> target_part;
     if( jo.has_string( "target_part" ) ) {
         target_part = get_str_or_var<T>( jo.get_member( "target_part" ), "target_part", true );
@@ -3618,7 +3618,7 @@ void talk_effect_fun_t<T>::set_weighted_list_eocs( const JsonObject &jo,
         JsonValue eoc = ja.next_value();
         JsonObject weight = ja.next_object();
         eoc_pairs.emplace_back( effect_on_conditions::load_inline_eoc( eoc, "" ),
-                                conditional_t< dialogue >::get_get_int( weight ) );
+                                conditional_t< dialogue >::get_get_dbl( weight ) );
     }
     function = [eoc_pairs]( const T & d ) {
         weighted_int_list<effect_on_condition_id> eocs;
@@ -3636,19 +3636,19 @@ template<class T>
 void talk_effect_fun_t<T>::set_switch( const JsonObject &jo,
                                        const std::string &member )
 {
-    std::function<int( const T & )> eoc_switch = conditional_t< T >::get_get_int(
+    std::function<int( const T & )> eoc_switch = conditional_t< T >::get_get_dbl(
                 jo.get_object( member ) );
-    std::vector<std::pair<int_or_var<T>, talk_effect_t<T>>> case_pairs;
+    std::vector<std::pair<dbl_or_var<T>, talk_effect_t<T>>> case_pairs;
     for( const JsonValue jv : jo.get_array( "cases" ) ) {
         JsonObject array_case = jv.get_object();
         talk_effect_t<T> case_effect;
         case_effect.load_effect( array_case, "effect" );
-        case_pairs.emplace_back( get_int_or_var<T>( array_case, "case" ), case_effect );
+        case_pairs.emplace_back( get_dbl_or_var<T>( array_case, "case" ), case_effect );
     }
     function = [eoc_switch, case_pairs]( const T & d ) {
         int switch_int = eoc_switch( d );
         talk_effect_t<T> case_effect;
-        for( const std::pair<int_or_var<T>, talk_effect_t<T>> &case_pair :
+        for( const std::pair<dbl_or_var<T>, talk_effect_t<T>> &case_pair :
              case_pairs ) {
             if( switch_int >= case_pair.first.evaluate( d ) ) {
                 case_effect = case_pair.second;
@@ -3719,16 +3719,16 @@ void talk_effect_fun_t<T>::set_add_morale( const JsonObject &jo, const std::stri
         bool is_npc )
 {
     str_or_var<T> new_type = get_str_or_var<T>( jo.get_member( member ), member, true );
-    int_or_var<T> iov_bonus = get_int_or_var<T>( jo, "bonus" );
-    int_or_var<T> iov_max_bonus = get_int_or_var<T>( jo, "max_bonus" );
+    dbl_or_var<T> dov_bonus = get_dbl_or_var<T>( jo, "bonus" );
+    dbl_or_var<T> dov_max_bonus = get_dbl_or_var<T>( jo, "max_bonus" );
     duration_or_var<T> dov_duration = get_duration_or_var<T>( jo, "duration", false, 1_hours );
     duration_or_var<T> dov_decay_start = get_duration_or_var<T>( jo, "decay_start", false, 30_minutes );
     const bool capped = jo.get_bool( "capped", false );
-    function = [is_npc, new_type, iov_bonus, iov_max_bonus, dov_duration, dov_decay_start,
+    function = [is_npc, new_type, dov_bonus, dov_max_bonus, dov_duration, dov_decay_start,
             capped]( const T & d ) {
         d.actor( is_npc )->add_morale( morale_type( new_type.evaluate( d ) ),
-                                       iov_bonus.evaluate( d ),
-                                       iov_max_bonus.evaluate( d ),
+                                       dov_bonus.evaluate( d ),
+                                       dov_max_bonus.evaluate( d ),
                                        dov_duration.evaluate( d ),
                                        dov_decay_start.evaluate( d ),
                                        capped );
@@ -3748,9 +3748,9 @@ void talk_effect_fun_t<T>::set_lose_morale( const JsonObject &jo, const std::str
 template<class T>
 void talk_effect_fun_t<T>::set_add_faction_trust( const JsonObject &jo, const std::string &member )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    function = [iov]( const T & d ) {
-        d.actor( true )->get_faction()->trusts_u += iov.evaluate( d );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    function = [dov]( const T & d ) {
+        d.actor( true )->get_faction()->trusts_u += dov.evaluate( d );
     };
 }
 
@@ -3758,9 +3758,9 @@ template<class T>
 void talk_effect_fun_t<T>::set_lose_faction_trust( const JsonObject &jo,
         const std::string &member )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member );
-    function = [iov]( const T & d ) {
-        d.actor( true )->get_faction()->trusts_u -= iov.evaluate( d );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    function = [dov]( const T & d ) {
+        d.actor( true )->get_faction()->trusts_u -= dov.evaluate( d );
     };
 }
 
@@ -3768,7 +3768,7 @@ template<class T>
 void talk_effect_fun_t<T>::set_custom_light_level( const JsonObject &jo,
         const std::string &member )
 {
-    int_or_var<T> iov = get_int_or_var<T>( jo, member, true );
+    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member, true );
     duration_or_var<T> dov_length = get_duration_or_var<T>( jo, "length", false, 0_seconds );
     str_or_var<T> key;
     if( jo.has_member( "key" ) ) {
@@ -3776,11 +3776,11 @@ void talk_effect_fun_t<T>::set_custom_light_level( const JsonObject &jo,
     } else {
         key.str_val = "";
     }
-    function = [dov_length, iov, key]( const T & d ) {
+    function = [dov_length, dov, key]( const T & d ) {
         get_timed_events().add( timed_event_type::CUSTOM_LIGHT_LEVEL,
                                 calendar::turn + dov_length.evaluate( d ) +
                                 1_seconds/*We add a second here because this will get ticked on the turn its applied before it has an effect*/,
-                                -1, iov.evaluate( d ), key.evaluate( d ) );
+                                -1, dov.evaluate( d ), key.evaluate( d ) );
     };
 }
 
@@ -3827,11 +3827,11 @@ void talk_effect_fun_t<T>::set_spawn_monster( const JsonObject &jo, const std::s
     } else {
         new_monster = mtype_id( jo.get_string( member ) );
     }
-    int_or_var<T> iov_target_range = get_int_or_var<T>( jo, "target_range", false, 0 );
-    int_or_var<T> iov_hallucination_count = get_int_or_var<T>( jo, "hallucination_count", false, 0 );
-    int_or_var<T> iov_real_count = get_int_or_var<T>( jo, "real_count", false, 0 );
-    int_or_var<T> iov_min_radius = get_int_or_var<T>( jo, "min_radius", false, 1 );
-    int_or_var<T> iov_max_radius = get_int_or_var<T>( jo, "max_radius", false, 10 );
+    dbl_or_var<T> dov_target_range = get_dbl_or_var<T>( jo, "target_range", false, 0 );
+    dbl_or_var<T> dov_hallucination_count = get_dbl_or_var<T>( jo, "hallucination_count", false, 0 );
+    dbl_or_var<T> dov_real_count = get_dbl_or_var<T>( jo, "real_count", false, 0 );
+    dbl_or_var<T> dov_min_radius = get_dbl_or_var<T>( jo, "min_radius", false, 1 );
+    dbl_or_var<T> dov_max_radius = get_dbl_or_var<T>( jo, "max_radius", false, 10 );
 
     const bool outdoor_only = jo.get_bool( "outdoor_only", false );
     const bool open_air_allowed = jo.get_bool( "open_air_allowed", false );
@@ -3846,8 +3846,8 @@ void talk_effect_fun_t<T>::set_spawn_monster( const JsonObject &jo, const std::s
     std::string spawn_message_plural = jo.get_string( "spawn_message_plural", "" );
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
-    function = [new_monster, iov_target_range, iov_hallucination_count, iov_real_count,
-                             iov_min_radius, iov_max_radius, outdoor_only, group_id, dov_lifespan, target_var,
+    function = [new_monster, dov_target_range, dov_hallucination_count, dov_real_count,
+                             dov_min_radius, dov_max_radius, outdoor_only, group_id, dov_lifespan, target_var,
                              spawn_message, spawn_message_plural, true_eocs, false_eocs, open_air_allowed,
                  friendly, is_npc]( const T & d ) {
         monster target_monster;
@@ -3855,7 +3855,7 @@ void talk_effect_fun_t<T>::set_spawn_monster( const JsonObject &jo, const std::s
         if( group_id.is_valid() ) {
             target_monster = monster( MonsterGroupManager::GetRandomMonsterFromGroup( group_id ) );
         } else if( new_monster.is_empty() ) {
-            int target_range = iov_target_range.evaluate( d );
+            int target_range = dov_target_range.evaluate( d );
             //grab a random nearby hostile creature to create a hallucination or copy of
             Creature *copy = g->get_creature_if( [target_range]( const Creature & critter ) -> bool {
                 bool not_self = get_player_character().pos() != critter.pos();
@@ -3871,10 +3871,10 @@ void talk_effect_fun_t<T>::set_spawn_monster( const JsonObject &jo, const std::s
         } else {
             target_monster = monster( new_monster );
         }
-        int min_radius = iov_min_radius.evaluate( d );
-        int max_radius = iov_max_radius.evaluate( d );
-        int real_count = iov_real_count.evaluate( d );
-        int hallucination_count = iov_hallucination_count.evaluate( d );
+        int min_radius = dov_min_radius.evaluate( d );
+        int max_radius = dov_max_radius.evaluate( d );
+        int real_count = dov_real_count.evaluate( d );
+        int hallucination_count = dov_hallucination_count.evaluate( d );
         cata::optional<time_duration> lifespan;
         tripoint target_pos = d.actor( is_npc )->pos();
         if( target_var.has_value() ) {
@@ -3939,9 +3939,9 @@ void talk_effect_fun_t<T>::set_field( const JsonObject &jo, const std::string &m
                                       bool is_npc )
 {
     str_or_var<T> new_field = get_str_or_var<T>( jo.get_member( member ), member, true );
-    int_or_var<T> iov_intensity = get_int_or_var<T>( jo, "intensity", false, 1 );
+    dbl_or_var<T> dov_intensity = get_dbl_or_var<T>( jo, "intensity", false, 1 );
     duration_or_var<T> dov_age = get_duration_or_var<T>( jo, "age", false, 1_turns );
-    int_or_var<T> iov_radius = get_int_or_var<T>( jo, "radius", false, 10000000 );
+    dbl_or_var<T> dov_radius = get_dbl_or_var<T>( jo, "radius", false, 10000000 );
 
     const bool outdoor_only = jo.get_bool( "outdoor_only", false );
     const bool indoor_only = jo.get_bool( "indoor_only", false );
@@ -3951,10 +3951,10 @@ void talk_effect_fun_t<T>::set_field( const JsonObject &jo, const std::string &m
     if( jo.has_member( "target_var" ) ) {
         target_var = read_var_info( jo.get_object( "target_var" ) );
     }
-    function = [new_field, iov_intensity, dov_age, iov_radius, outdoor_only,
+    function = [new_field, dov_intensity, dov_age, dov_radius, outdoor_only,
                hit_player, target_var, is_npc, indoor_only]( const T & d ) {
-        int radius = iov_radius.evaluate( d );
-        int intensity = iov_intensity.evaluate( d );
+        int radius = dov_radius.evaluate( d );
+        int intensity = dov_intensity.evaluate( d );
 
         tripoint_abs_ms target_pos = d.actor( is_npc )->global_pos();
         if( target_var.has_value() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #62133
More json power
Allow multiplying by decimal values to ease things.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed use of ints for EOCs into doubles.  Should make no difference in vast majority of cases, most places will simply chop off any decimal places and still use an int.  Also fixed a few minor portal storm dungeon json value errors found during testing.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Used this json and printing variables to confirm are stored decimals.  Run older EOCs to confirm no changes.
```
  {
    "type": "effect_on_condition",
    "id": "TEST",
    "effect": [
      { "arithmetic": [ { "global_val": "var", "var_name": "test" }, "=", { "const": 15 } ] },
      { "arithmetic": [ { "global_val": "var", "var_name": "test" }, "*=", { "const": 2.7 } ] }
    ]
  },
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
