### PR TITLE
Finer-grained mapgen flags for terrain wiping

### DIFF
--- a/data/json/mapgen/basecamps/expansion/modular_farm/version_1/primitive_farm.json
+++ b/data/json/mapgen/basecamps/expansion/modular_farm/version_1/primitive_farm.json
@@ -36,6 +36,7 @@
         "      ",
         "      "
       ],
+      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "acidia_camp_palette" ]
     }
   },
@@ -43,10 +44,15 @@
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "bc_prim_farm_short_fields",
-    "object": { "mapgensize": [ 2, 2 ], "rows": [
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
         "mm",
         "mm"
-      ], "palettes": [ "acidia_camp_palette" ] }
+      ],
+      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "acidia_camp_palette" ]
+    }
   },
   {
     "type": "mapgen",

--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -417,22 +417,45 @@ Example:
 ```
 
 Currently the defined flags are as follows:
+- Clearing flags for layered mapgens: see [dedicated section below](#clearing-flags-for-layered-mapgens)
+- `NO_UNDERLYING_ROTATE` The map won't be rotated even if the underlying tile is.
+- `AVOID_CREATURES` If a creature is present, terrain, furniture and traps won't be placed.
 
-* `ERASE_ALL_BEFORE_PLACING_TERRAIN` and `ALLOW_TERRAIN_UNDER_OTHER_DATA` are
-  mutually exclusive flags that can be used with any mapgen which is layered on
-  top of existing terrain.  This can be update mapgen, nested mapgen, or
-  regular mapgen with a predecessor.  It specifies the behaviour to follow when
-  an existing terrain is changed by the update, but the tile has existing
-  items, trap, or furniture on it.  If neither flag is provided this is an
-  error.  If `ERASE_ALL_BEFORE_PLACING_TERRAIN` is given then any items, trap,
-  or furniture will be removed before changing the terrain.  If
-  `ALLOW_TERRAIN_UNDER_OTHER_DATA` is given then they will be retained without
-  an error.  If you require more fine-grained control over this behaviour than
-  can be provided by these flags, then each of these things can be removed
-  either individually or together.  See the other entries below, such as
-  `remove_all`.
-  `NO_UNDERLYING_ROTATE` The map won't be rotated even if the underlying tile is.
-  `AVOID_CREATURES` If a creature is present terrain, furniture and traps won't be placed.
+### Clearing flags for layered mapgens
+Some mapgens are intended to be layered on top of existing terrain.  This can be update mapgen,
+nested mapgen, or regular mapgen with a predecessor.  When the mapgen changes an existing terrain,
+the tile may already contain preexisting furniture, traps and items.  The following flags provide
+a mechanism for specifying the behaviour to follow in such situations.  It is an error if existing
+furniture, traps or items are encountered but no behaviour has been given.
+
+A blanket policy can be set using one of these three (mutually exclusive) shorthand flags:
+- `ALLOW_TERRAIN_UNDER_OTHER_DATA` retains preexisting furniture, traps and items without triggering
+  an error.
+- `DISMANTLE_ALL_BEFORE_PLACING_TERRAIN` causes any furniture to be deconstructed or bashed, while
+  traps are disarmed.  The outputs, along with any other preexisting items, are then retained.
+- `ERASE_ALL_BEFORE_PLACING_TERRAIN` removes all preexisting furniture, traps and items before
+  changing the terrain.
+
+For finer-grained control, the following flags can be used to set different behaviors for furniture, traps and items:
+- `ALLOW_TERRAIN_UNDER_FURNITURE`, `DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN` and `ERASE_FURNITURE_BEFORE_PLACING_TERRAIN`
+  are mutually exclusive flags for determining the disposition of furniture.
+- `ALLOW_TERRAIN_UNDER_TRAP`, `DISMANTLE_TRAP_BEFORE_PLACING_TERRAIN` and `ERASE_TRAP_BEFORE_PLACING_TERRAIN`
+  are mutually exclusive flags for determining the disposition of traps.
+- `ALLOW_TERRAIN_UNDER_ITEMS` and `ERASE_ITEMS_BEFORE_PLACING_TERRAIN`
+  are mutually exclusive flags for determining the disposition of items.
+
+The fine-grained flags can be used in conjunction with any of the three shorthand flags to override
+behavior for furniture/traps/items specifically.  Alternatively, the shorthand flags can be omitted
+entirely, and all behavior specified using a combination of fine-grained flags.  
+Not all combinations necessarily make sense; illogical settings will trigger a warning output.
+
+**Note:** depending on the new terrain being set by the mapgen, furniture, traps and items may still
+be "stomped out" by the new terrain, regardless of these settings.
+
+For targeted removal of things from specific tiles or areas, further options are available below:
+- `trap_remove` and `item_remove` can be applied to a [point](#set-things-at-a-point), [line](#set-things-in-a-line) or [square](#set-things-in-a-square) regions.
+- [`remove_all`](#remove-everything-with-remove_all) can be used to remove all fields, items, traps, graffiti, and furniture from a specific tile.
+
 
 ## Set terrain, furniture, or traps with a "set" array
 **optional** Specific commands to set terrain, furniture, traps, radiation, etc. Array is processed in order.

--- a/src/jmapgen_flags.h
+++ b/src/jmapgen_flags.h
@@ -3,7 +3,16 @@
 
 enum class jmapgen_flags {
     allow_terrain_under_other_data,
+    dismantle_all_before_placing_terrain,
     erase_all_before_placing_terrain,
+    allow_terrain_under_furniture,
+    dismantle_furniture_before_placing_terrain,
+    erase_furniture_before_placing_terrain,
+    allow_terrain_under_trap,
+    dismantle_trap_before_placing_terrain,
+    erase_trap_before_placing_terrain,
+    allow_terrain_under_items,
+    erase_items_before_placing_terrain,
     no_underlying_rotate,
     avoid_creatures,
     last

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1467,8 +1467,23 @@ std::string enum_to_string<jmapgen_flags>( jmapgen_flags v )
     switch( v ) {
         // *INDENT-OFF*
         case jmapgen_flags::allow_terrain_under_other_data: return "ALLOW_TERRAIN_UNDER_OTHER_DATA";
+        case jmapgen_flags::dismantle_all_before_placing_terrain:
+            return "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN";
         case jmapgen_flags::erase_all_before_placing_terrain:
             return "ERASE_ALL_BEFORE_PLACING_TERRAIN";
+        case jmapgen_flags::allow_terrain_under_furniture: return "ALLOW_TERRAIN_UNDER_FURNITURE";
+        case jmapgen_flags::dismantle_furniture_before_placing_terrain:
+            return "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN";
+        case jmapgen_flags::erase_furniture_before_placing_terrain:
+            return "ERASE_FURNITURE_BEFORE_PLACING_TERRAIN";
+        case jmapgen_flags::allow_terrain_under_trap: return "ALLOW_TERRAIN_UNDER_TRAP";
+        case jmapgen_flags::dismantle_trap_before_placing_terrain:
+            return "DISMANTLE_TRAP_BEFORE_PLACING_TERRAIN";
+        case jmapgen_flags::erase_trap_before_placing_terrain:
+            return "ERASE_TRAP_BEFORE_PLACING_TERRAIN";
+        case jmapgen_flags::allow_terrain_under_items: return "ALLOW_TERRAIN_UNDER_ITEMS";
+        case jmapgen_flags::erase_items_before_placing_terrain:
+            return "ERASE_ITEMS_BEFORE_PLACING_TERRAIN";
         case jmapgen_flags::no_underlying_rotate: return "NO_UNDERLYING_ROTATE";
         case jmapgen_flags::avoid_creatures: return "AVOID_CREATURES";
         // *INDENT-ON*
@@ -2731,6 +2746,10 @@ class jmapgen_furniture : public jmapgen_piece
  */
 class jmapgen_terrain : public jmapgen_piece
 {
+    private:
+        enum apply_action {
+            act_unknown, act_ignore, act_dismantle, act_erase
+        };
     public:
         mapgen_value<ter_id> id;
         jmapgen_terrain( const JsonObject &jsi, const std::string &/*context*/ ) :
@@ -2759,25 +2778,113 @@ class jmapgen_terrain : public jmapgen_piece
             const bool place_item = chosen_ter.has_flag( ter_furn_flag::TFLAG_PLACE_ITEM );
             const bool is_boring_wall = is_wall && !place_item;
 
-            if( is_boring_wall
-                || dat.has_flag( jmapgen_flags::erase_all_before_placing_terrain ) ) {
+            apply_action act_furn = apply_action::act_unknown;
+            apply_action act_trap = apply_action::act_unknown;
+            apply_action act_item = apply_action::act_unknown;
+
+            // shorthand flags
+            if( dat.has_flag( jmapgen_flags::allow_terrain_under_other_data ) ) {
+                act_furn = apply_action::act_ignore;
+                act_trap = apply_action::act_ignore;
+                act_item = apply_action::act_ignore;
+            } else if( dat.has_flag( jmapgen_flags::dismantle_all_before_placing_terrain ) ) {
+                act_furn = apply_action::act_dismantle;
+                act_trap = apply_action::act_dismantle;
+                act_item = apply_action::act_ignore;
+            } else if( dat.has_flag( jmapgen_flags::erase_all_before_placing_terrain ) ) {
+                act_furn = apply_action::act_erase;
+                act_trap = apply_action::act_erase;
+                act_item = apply_action::act_erase;
+            }
+
+            // specific flags override shorthand flags
+            if( dat.has_flag( jmapgen_flags::allow_terrain_under_furniture ) ) {
+                act_furn = apply_action::act_ignore;
+            } else if( dat.has_flag( jmapgen_flags::dismantle_furniture_before_placing_terrain ) ) {
+                act_furn = apply_action::act_dismantle;
+            } else if( dat.has_flag( jmapgen_flags::erase_furniture_before_placing_terrain ) ) {
+                act_furn = apply_action::act_erase;
+            }
+            if( dat.has_flag( jmapgen_flags::allow_terrain_under_trap ) ) {
+                act_trap = apply_action::act_ignore;
+            } else if( dat.has_flag( jmapgen_flags::dismantle_trap_before_placing_terrain ) ) {
+                act_trap = apply_action::act_dismantle;
+            } else if( dat.has_flag( jmapgen_flags::erase_trap_before_placing_terrain ) ) {
+                act_trap = apply_action::act_erase;
+            }
+            if( dat.has_flag( jmapgen_flags::allow_terrain_under_items ) ) {
+                act_item = apply_action::act_ignore;
+            } else if( dat.has_flag( jmapgen_flags::erase_items_before_placing_terrain ) ) {
+                act_item = apply_action::act_erase;
+            }
+
+            if( act_item == apply_action::act_erase &&
+                ( act_furn == apply_action::act_dismantle || act_trap == apply_action::act_dismantle ) ) {
+                debugmsg( "In %s on %s, the mapgen is configured to dismantle preexisting furniture "
+                          "and/or traps, but will also erase preexisting items.  This is probably a "
+                          "mistake, as any dismantle outputs will not be preserved.",
+                          context, dat.terrain_type().id().str() );
+            }
+
+            if( is_boring_wall || act_furn == apply_action::act_erase ) {
                 dat.m.furn_clear( p );
-                dat.m.i_clear( tp );
+                // remove sign writing data from the submap
+                dat.m.delete_signage( tp );
+            } else if( act_furn == apply_action::act_dismantle ) {
+                int max_recurse = 10; // insurance against infinite looping
+                std::string initial_furn = dat.m.furn( p ) != f_null ? dat.m.furn( p ).id().str() : "";
+                while( dat.m.has_furn( p ) && max_recurse-- > 0 ) {
+                    const furn_t &f = dat.m.furn( p ).obj();
+                    if( f.deconstruct.can_do ) {
+                        if( f.deconstruct.furn_set.str().empty() ) {
+                            dat.m.furn_clear( p );
+                        } else {
+                            dat.m.furn_set( p, f.deconstruct.furn_set );
+                        }
+                        dat.m.spawn_items( p, item_group::items_from( f.deconstruct.drop_group, calendar::turn ) );
+                    } else {
+                        if( f.bash.furn_set.str().empty() ) {
+                            dat.m.furn_clear( p );
+                        } else {
+                            dat.m.furn_set( p, f.bash.furn_set );
+                        }
+                        dat.m.spawn_items( p, item_group::items_from( f.bash.drop_group, calendar::turn ) );
+                    }
+                }
+                if( !max_recurse ) {
+                    dat.m.furn_clear( p );
+                    debugmsg( "In %s on %s, the mapgen failed to arrive at an empty tile after "
+                              "dismantling preexisting furniture %s at %s 10 times in succession.",
+                              context, dat.terrain_type().id().str(), initial_furn, p.to_string() );
+                }
+                // remove sign writing data from the submap
+                dat.m.delete_signage( tp );
+            }
+
+            if( is_boring_wall || act_trap == apply_action::act_erase ) {
                 dat.m.remove_trap( tp );
-            } else if( !dat.has_flag( jmapgen_flags::allow_terrain_under_other_data )
-                       && chosen_id != terrain_here ) {
+            } else if( act_trap == apply_action::act_dismantle ) {
+                dat.m.tr_at( tp ).on_disarmed( dat.m, tp );
+            }
+
+            if( is_boring_wall || act_item == apply_action::act_erase ) {
+                dat.m.i_clear( tp );
+            }
+
+            if( chosen_id != terrain_here ) {
                 std::string error;
                 trap_str_id trap_here = dat.m.tr_at( tp ).id;
-                if( dat.m.furn( p ) != f_null ) {
+                if( act_furn != apply_action::act_ignore && dat.m.furn( p ) != f_null ) {
                     // NOLINTNEXTLINE(cata-translate-string-literal)
                     error = string_format( "furniture was %s", dat.m.furn( p ).id().str() );
-                } else if( !dat.m.i_at( p ).empty() ) {
+                } else if( act_trap != apply_action::act_ignore && !trap_here.is_null() &&
+                           trap_here.id() != terrain_here->trap ) {
+                    // NOLINTNEXTLINE(cata-translate-string-literal)
+                    error = string_format( "trap %s existed", trap_here.str() );
+                } else if( act_item != apply_action::act_ignore && !dat.m.i_at( p ).empty() ) {
                     // NOLINTNEXTLINE(cata-translate-string-literal)
                     error = string_format( "item %s existed",
                                            dat.m.i_at( p ).begin()->typeId().str() );
-                } else if( !trap_here.is_null() && trap_here.id() != terrain_here->trap ) {
-                    // NOLINTNEXTLINE(cata-translate-string-literal)
-                    error = string_format( "trap %s existed", trap_here.str() );
                 }
                 if( !error.empty() ) {
                     debugmsg( "In %s on %s, setting terrain to %s (from %s) at %s when %s.  "
@@ -4309,10 +4416,32 @@ static bool check_furn( const furn_id &id, const std::string &context )
 
 void mapgen_function_json_base::check_common() const
 {
-    if( flags_.test( jmapgen_flags::allow_terrain_under_other_data ) &&
-        flags_.test( jmapgen_flags::erase_all_before_placing_terrain ) ) {
-        debugmsg( "In %s, flags ERASE_ALL_BEFORE_PLACING_TERRAIN and "
-                  "ALLOW_TERRAIN_UNDER_OTHER_DATA cannot be used together", context_ );
+    if( static_cast <int>( flags_.test( jmapgen_flags::allow_terrain_under_other_data ) ) +
+        flags_.test( jmapgen_flags::dismantle_all_before_placing_terrain ) +
+        flags_.test( jmapgen_flags::erase_all_before_placing_terrain ) > 1 ) {
+        debugmsg( "In %s, the mutually exclusive flags ERASE_ALL_BEFORE_PLACING_TERRAIN, "
+                  "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN and ALLOW_TERRAIN_UNDER_OTHER_DATA "
+                  "cannot be used together", context_ );
+    }
+    if( static_cast <int>( flags_.test( jmapgen_flags::allow_terrain_under_furniture ) ) +
+        flags_.test( jmapgen_flags::dismantle_furniture_before_placing_terrain ) +
+        flags_.test( jmapgen_flags::erase_furniture_before_placing_terrain ) > 1 ) {
+        debugmsg( "In %s, the mutually exclusive flags ALLOW_TERRAIN_UNDER_FURNITURE, "
+                  "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN and ERASE_FURNITURE_BEFORE_PLACING_TERRAIN "
+                  "cannot be used together", context_ );
+    }
+    if( static_cast <int>( flags_.test( jmapgen_flags::allow_terrain_under_trap ) ) +
+        flags_.test( jmapgen_flags::dismantle_trap_before_placing_terrain ) +
+        flags_.test( jmapgen_flags::erase_trap_before_placing_terrain ) > 1 ) {
+        debugmsg( "In %s, the mutually exclusive flags ALLOW_TERRAIN_UNDER_TRAP, "
+                  "DISMANTLE_TRAP_BEFORE_PLACING_TERRAIN and ERASE_TRAP_BEFORE_PLACING_TERRAIN "
+                  "cannot be used together", context_ );
+    }
+    if( static_cast <int>( flags_.test( jmapgen_flags::allow_terrain_under_items ) ) +
+        flags_.test( jmapgen_flags::erase_items_before_placing_terrain ) > 1 ) {
+        debugmsg( "In %s, the mutually exclusive flags "
+                  "ALLOW_TERRAIN_UNDER_ITEMS and ERASE_ITEMS_BEFORE_PLACING_TERRAIN "
+                  "cannot be used together", context_ );
     }
     for( const jmapgen_setmap &setmap : setmap_points ) {
         if( setmap.op != JMAPGEN_SETMAP_FURN &&

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2889,11 +2889,9 @@ class jmapgen_terrain : public jmapgen_piece
                 if( !error.empty() ) {
                     debugmsg( "In %s on %s, setting terrain to %s (from %s) at %s when %s.  "
                               "Resolve this either by removing the terrain from this mapgen, "
-                              "adding suitable removal commands to the mapgen, or "
-                              "by adding a suitable flag to the innermost mapgen: either "
-                              "ERASE_ALL_BEFORE_PLACING_TERRAIN if you wish terrain to replace "
-                              "everything previously on the tile or ALLOW_TERRAIN_UNDER_OTHER_DATA "
-                              "if you wish the other items to be preserved",
+                              "adding suitable removal commands to the mapgen, or by adding an"
+                              "appropriate clearing flag to the innermost layered mapgen.  "
+                              "Consult the \"mapgen flags\" section in MAPGEN.md for options.",
                               context, dat.terrain_type().id().str(), chosen_id.id().str(),
                               terrain_here.id().str(), p.to_string(), error );
                 }


### PR DESCRIPTION
#### Summary
Infrastructure "Finer-grained mapgen flags for terrain wiping"

#### Purpose of change
There are multiple outstanding issues related to this debug message:
https://github.com/CleverRaven/Cataclysm-DDA/blob/7216560e9acd3cbe7d2976a3489965fb3f481ada/src/mapgen.cpp#L2783-L2791

More options beyond "allow all" and "erase all" would allow finer grained control over the disposition of preexisting furniture, traps and items on tiles that are being changed in a mapgen.

Resolves #57418, resolves #63281

#### Describe the solution

A tile being changed by mapgen may contain preexisting furniture, traps and items. Existing infrastructure from #54344 provides flags `ALLOW_TERRAIN_UNDER_OTHER_DATA` and `ERASE_ALL_BEFORE_PLACING_TERRAIN` to either ignore all of them, or erase all of them before setting the new terrain.

Besides ignore/erase, this PR adds the possibility to "dismantle" furniture and traps. With this option, furniture would be deconstructed or bashed (preferring the former) while traps are disarmed; this would yield some items as compared to the outright magical deletion of the "erase" option.

A new flag `DISMANTLE_ALL_BEFORE_PLACING_TERRAIN` will tell mapgen to use the dismantle option on furniture and traps, and ignore (allow) items, including those produced from dismantling stuff.

The three aforementioned flags ("shorthand flags") are mutually exclusive.

A further eight flags allow finer control by setting the behavior for furniture, traps and items individually:
- `ALLOW_TERRAIN_UNDER_FURNITURE`, `DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN` and `ERASE_FURNITURE_BEFORE_PLACING_TERRAIN` are mutually exclusive.
- `ALLOW_TERRAIN_UNDER_TRAP`, `DISMANTLE_TRAP_BEFORE_PLACING_TERRAIN` and `ERASE_TRAP_BEFORE_PLACING_TERRAIN` are mutually exclusive.
- `ALLOW_TERRAIN_UNDER_ITEMS` and `ERASE_ITEMS_BEFORE_PLACING_TERRAIN` are mutually exclusive.

These eight flags can be used in conjunction with any of the three shorthand flags to override behavior for furniture/traps/items specifically. Alternatively, omit the shorthand flags and specify the behavior for furniture/traps/items individually using a combination of the finer grained flags.

Not all combinations necessarily make sense, so a warning will be output via debugmsg if they are encountered.

As was already the case before, if there is no explicit behavior defined and mapgen encounters existing furniture/traps/items, it will trigger a debugmsg.

#### Additional details

Dismantle option ignores any tool/skill/strength/etc requirements for deconstruct/bash of furniture and disarming of traps; it is guaranteed to succeed.

Deconstruct/bash of furniture may result in a different furniture. To avoid any unexpected looping, dismantle will make at most 10 successive attempts, after which outright erasure is used if the tile still contains furniture. This should be more than enough even for multi-step deconstructions.

Added call to `map::delete_signage` when furniture is erased/dismantled, in case it was a sign. This is needed because signs actually store their writing data in submap, not in the furniture, so that needs to be removed to prevent the writing from mysteriously reappearing if/when a sign is rebuilt in the same spot later.

#### Todo
- [x] add/update documentation
- [x] apply to camp farm plot mission mapgens

#### Describe alternatives you've considered
Add only `DISMANTLE_ALL_BEFORE_PLACING_TERRAIN` to the existing two flags.

#### Testing
Unit tests aren't complaining.

Save files provided in #57418 and #63281 were tested, and no longer trigger a debug message.  
#63281 demonstrates successful removal of `f_flower_spurge` by bashing (no yield)  
#57418 demonstrates items (ash) allowed to remain on plowed farm plots


