### PR TITLE
item: expand contents name if they're all of the same type

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -275,6 +275,20 @@ struct scoped_goes_bad_cache {
 
 const int item::INFINITE_CHARGES = INT_MAX;
 
+namespace
+{
+
+bool contents_only_one_type( item const *it )
+{
+    std::list<const item *> const contents = it->all_items_top();
+    return contents.size() == 1 ||
+    std::all_of( ++contents.begin(), contents.end(), [&contents]( item const * e ) {
+        return e->stacks_with( *contents.front() );
+    } );
+}
+
+} // namespace
+
 item::item() : bday( calendar::start_of_cataclysm )
 {
     type = nullitem();
@@ -6315,7 +6329,7 @@ std::string item::degradation_symbol() const
 }
 
 std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int truncate,
-                         bool with_contents, bool with_collapsed ) const
+                         bool with_contents_full, bool with_collapsed, bool with_contents_abbrev ) const
 {
     // item damage and/or fouling level
     std::string damtext;
@@ -6397,18 +6411,19 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     }
 
     /* only expand full contents name if with_contents == true */
-    if( with_contents && contents.num_item_stacks() == 1 ) {
-        const item &contents_item = contents.only_item();
+    if( with_contents_full && !contents.empty() && contents_only_one_type( this ) ) {
+        const item &contents_item = contents.first_item();
         const unsigned contents_count =
             ( ( contents_item.made_of( phase_id::LIQUID ) ||
                 contents_item.is_food() || contents_item.count_by_charges() ) &&
               contents_item.charges > 1 )
             ? contents_item.charges
-            : 1;
+            : contents.num_item_stacks();
 
         if( !contents_item.is_null() ) {
             // with_contents=false for nested items to prevent excessively long names
-            const std::string contents_tname = contents_item.tname( contents_count, true, 0, false );
+            const std::string contents_tname = contents_item.tname( contents_count, true, 0, false, false,
+                                               contents_count == 1 );
             std::string const ctnc = colorize( contents_tname, contents_item.color_in_inventory() );
             if( contents_count == 1 || !ammo_types().empty() ) {
                 // Don't append an item count for single items, or items that are ammo-exclusive
@@ -6427,7 +6442,8 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
                 contents_suffix_text += string_format( " %s", _( "hidden" ) );
             }
         }
-    } else if( !contents.empty_container() && contents.num_item_stacks() != 0 ) {
+    } else if( with_contents_abbrev && !contents.empty_container() &&
+               contents.num_item_stacks() != 0 ) {
         std::string const suffix =
             npgettext( "item name",
                        //~ [container item name] " > [count] item"

--- a/src/item.h
+++ b/src/item.h
@@ -388,7 +388,8 @@ class item : public visitable
          * of this item (if with_contents = false and item is not empty, "n items" will be added)
          */
         std::string tname( unsigned int quantity = 1, bool with_prefix = true,
-                           unsigned int truncate = 0, bool with_contents = true, bool with_collapsed = true ) const;
+                           unsigned int truncate = 0, bool with_contents_full = true,
+                           bool with_collapsed = true, bool with_contents_abbrev = true ) const;
         std::string display_money( unsigned int quantity, unsigned int total,
                                    const cata::optional<unsigned int> &selected = cata::nullopt ) const;
         /**

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1391,12 +1391,8 @@ bool item_contents::is_single_restricted_container() const
     return contained_pockets.size() == 1 && contained_pockets[0]->is_restricted();
 }
 
-item &item_contents::only_item()
+item &item_contents::first_item()
 {
-    if( num_item_stacks() != 1 ) {
-        debugmsg( "ERROR: item_contents::only_item called with %d items contained", num_item_stacks() );
-        return null_item_reference();
-    }
     for( item_pocket &pocket : contents ) {
         if( pocket.empty() || !pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
             continue;
@@ -1407,12 +1403,17 @@ item &item_contents::only_item()
     return null_item_reference();
 }
 
-const item &item_contents::only_item() const
+item &item_contents::only_item()
 {
     if( num_item_stacks() != 1 ) {
         debugmsg( "ERROR: item_contents::only_item called with %d items contained", num_item_stacks() );
         return null_item_reference();
     }
+    return first_item();
+}
+
+const item &item_contents::first_item() const
+{
     for( const item_pocket &pocket : contents ) {
         if( pocket.empty() || !( pocket.is_type( item_pocket::pocket_type::CONTAINER ) ||
                                  pocket.is_type( item_pocket::pocket_type::SOFTWARE ) ) ) {
@@ -1423,6 +1424,15 @@ const item &item_contents::only_item() const
     }
 
     return null_item_reference();
+}
+
+const item &item_contents::only_item() const
+{
+    if( num_item_stacks() != 1 ) {
+        debugmsg( "ERROR: item_contents::only_item called with %d items contained", num_item_stacks() );
+        return null_item_reference();
+    }
+    return first_item();
 }
 
 item *item_contents::get_item_with( const std::function<bool( const item &it )> &filter )

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -304,7 +304,9 @@ class item_contents
 
         // gets the item contained IFF one item is contained (CONTAINER pocket), otherwise a null item reference
         item &only_item();
+        item &first_item();
         const item &only_item() const;
+        const item &first_item() const;
         item *get_item_with( const std::function<bool( const item & )> &filter );
         void remove_items_if( const std::function<bool( item & )> &filter );
 

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -559,7 +559,8 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
             backpack_hiking.put_in( purse, item_pocket::pocket_type::CONTAINER );
             backpack_hiking.put_in( purse, item_pocket::pocket_type::CONTAINER );
 
-            CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym + " 2 items" );
+            CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym +
+                   " " + purse_color + color_pref + "purses" + color_end_tag + " (2)" );
         }
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Container names are expanded only if they contain a single item. With the upcoming demise of charges, container names become significantly less informative.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Expand the container name if all of its contents are of the same type

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I wrote this for #60885 but it's occasionally useful in current master too:

Before: the container has to be uncollapsed to see its single-type contents

![Screenshot from 2023-02-13 20-31-57](https://user-images.githubusercontent.com/68240139/218545189-4659d288-28b2-4e64-83a2-6ad716c6b3e4.png)

After:  the container offers more information at a glance when it makes sense, even for contents without charges
![Screenshot from 2023-02-13 20-31-51](https://user-images.githubusercontent.com/68240139/218545278-f085e764-093f-407b-b741-7a12dfca328d.png)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Testing shows this has a negligible performance impact.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
