### PR TITLE
Don't display unrepairable entries in repair ui

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2239,8 +2239,8 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
         // Print message explaining why we stopped
         // But only if we didn't destroy the item (because then it's obvious)
         const bool destroyed = attempt == repair_item_actor::AS_DESTROYED;
-        const bool cannot_continue_repair = attempt == repair_item_actor::AS_CANT ||
-                                            destroyed || !actor->can_repair_target( *you, *fix_location, !destroyed );
+        const bool cannot_continue_repair = attempt == repair_item_actor::AS_CANT || destroyed ||
+                                            !actor->can_repair_target( *you, *fix_location, !destroyed, true );
         if( cannot_continue_repair ) {
             // Cannot continue to repair target, select another target.
             // **Warning**: as soon as the item is popped back, it is destroyed and can't be used anymore!
@@ -2284,7 +2284,7 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
             act->set_to_null();
             return;
         }
-        if( actor->can_repair_target( *you, *item_loc, true ) ) {
+        if( actor->can_repair_target( *you, *item_loc, true, true ) ) {
             act->targets.emplace_back( item_loc );
             repeat = repeat_type::INIT;
         }

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1764,16 +1764,14 @@ item_location game_menus::inv::salvage( Character &you, const salvage_actor *act
 class repair_inventory_preset: public inventory_selector_preset
 {
     public:
-        repair_inventory_preset( const repair_item_actor *actor, const item *main_tool,
-                                 const Character &you ) :
-            actor( actor ), main_tool( main_tool ) {
+        repair_inventory_preset( const repair_item_actor *actor, const item *main_tool, Character &you ) :
+            actor( actor ), main_tool( main_tool ), character( you ) {
 
             _indent_entries = false;
 
             append_cell( [actor, &you]( const item_location & loc ) {
                 const int comp_needed = std::max<int>( 1,
                                                        std::ceil( loc->base_volume() / 250_ml * actor->cost_scaling ) );
-                std::set<itype_id> valid_entries = actor->get_valid_repair_materials( *loc );
                 const inventory &crafting_inv = you.crafting_inventory();
                 std::function<bool( const item & )> filter;
                 if( loc->is_filthy() ) {
@@ -1784,7 +1782,7 @@ class repair_inventory_preset: public inventory_selector_preset
                     filter = is_crafting_component;
                 }
                 std::vector<std::string> material_list;
-                for( const auto &component_id : valid_entries ) {
+                for( const itype_id &component_id : actor->get_valid_repair_materials( *loc ) ) {
                     if( item::count_by_charges( component_id ) ) {
                         if( crafting_inv.has_charges( component_id, 1 ) ) {
                             const int num_comp = crafting_inv.charges_of( component_id );
@@ -1826,13 +1824,13 @@ class repair_inventory_preset: public inventory_selector_preset
         }
 
         bool is_shown( const item_location &loc ) const override {
-            return loc->made_of_any( actor->materials ) && !loc->count_by_charges() && !loc->is_firearm() &&
-                   &*loc != main_tool;
+            return actor->can_repair_target( character, *loc, false, false ) && ( &*loc != main_tool );
         }
 
     private:
         const repair_item_actor *actor;
         const item *main_tool;
+        Character &character;
 };
 
 static std::string get_repair_hint( const Character &you, const repair_item_actor *actor,

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2652,7 +2652,7 @@ std::set<itype_id> repair_item_actor::get_valid_repair_materials( const item &fi
 }
 
 bool repair_item_actor::handle_components( Character &pl, const item &fix,
-        bool print_msg, bool just_check ) const
+        bool print_msg, bool just_check, bool check_consumed_available ) const
 {
     // Entries valid for repaired items
     std::set<itype_id> valid_entries = get_valid_repair_materials( fix );
@@ -2692,7 +2692,7 @@ bool repair_item_actor::handle_components( Character &pl, const item &fix,
 
     // Go through all discovered repair items and see if we have any of them available
     std::vector<item_comp> comps;
-    for( const auto &component_id : valid_entries ) {
+    for( const itype_id &component_id : valid_entries ) {
         if( item::count_by_charges( component_id ) ) {
             if( crafting_inv.has_charges( component_id, items_needed ) ) {
                 comps.emplace_back( component_id, items_needed );
@@ -2702,9 +2702,9 @@ bool repair_item_actor::handle_components( Character &pl, const item &fix,
         }
     }
 
-    if( comps.empty() ) {
+    if( check_consumed_available && comps.empty() ) {
         if( print_msg ) {
-            for( const auto &mat_comp : valid_entries ) {
+            for( const itype_id &mat_comp : valid_entries ) {
                 pl.add_msg_if_player( m_info,
                                       _( "You don't have enough %s to do that.  Have: %d, need: %d" ),
                                       item::nname( mat_comp, 2 ),
@@ -2826,8 +2826,8 @@ int repair_item_actor::repair_recipe_difficulty( const Character &pl,
     return diff;
 }
 
-bool repair_item_actor::can_repair_target( Character &pl, const item &fix,
-        bool print_msg ) const
+bool repair_item_actor::can_repair_target( Character &pl, const item &fix, bool print_msg,
+        bool check_consumed_available ) const
 {
     // In some rare cases (indices getting scrambled after inventory overflow)
     //  our `fix` can be a different item.
@@ -2860,7 +2860,7 @@ bool repair_item_actor::can_repair_target( Character &pl, const item &fix,
         return false;
     }
 
-    if( !handle_components( pl, fix, print_msg, true ) ) {
+    if( !handle_components( pl, fix, print_msg, true, check_consumed_available ) ) {
         return false;
     }
 
@@ -3023,7 +3023,7 @@ repair_item_actor::attempt_hint repair_item_actor::repair( Character &pl, item &
     if( !can_use_tool( pl, tool, true ) ) {
         return AS_CANT_USE_TOOL;
     }
-    if( !can_repair_target( pl, *fix, true ) ) {
+    if( !can_repair_target( pl, *fix, true, true ) ) {
         return AS_CANT;
     }
 
@@ -3087,7 +3087,7 @@ repair_item_actor::attempt_hint repair_item_actor::repair( Character &pl, item &
         if( roll == SUCCESS ) {
             const std::string startdurability = fix->durability_indicator( true );
             const int damage = fix->damage();
-            handle_components( pl, *fix, false, false );
+            handle_components( pl, *fix, false, false, true );
 
             int dmg = fix->damage() + 1;
             for( const int lvl = fix->damage_level(); lvl == fix->damage_level() && dmg != fix->damage(); ) {
@@ -3118,7 +3118,7 @@ repair_item_actor::attempt_hint repair_item_actor::repair( Character &pl, item &
 
                 pl.calc_encumbrance();
             }
-            handle_components( pl, *fix, false, false );
+            handle_components( pl, *fix, false, false, true );
             return AS_SUCCESS;
         }
 
@@ -3132,7 +3132,7 @@ repair_item_actor::attempt_hint repair_item_actor::repair( Character &pl, item &
                                   fix->tname().c_str() );
             fix->set_flag( flag_UNDERSIZE );
             pl.calc_encumbrance();
-            handle_components( pl, *fix, false, false );
+            handle_components( pl, *fix, false, false, true );
             return AS_SUCCESS;
         }
         return AS_RETRY;
@@ -3145,7 +3145,7 @@ repair_item_actor::attempt_hint repair_item_actor::repair( Character &pl, item &
                                   fix->tname().c_str() );
             fix->unset_flag( flag_UNDERSIZE );
             pl.calc_encumbrance();
-            handle_components( pl, *fix, false, false );
+            handle_components( pl, *fix, false, false, true );
             return AS_SUCCESS;
         }
         return AS_RETRY;
@@ -3161,7 +3161,7 @@ repair_item_actor::attempt_hint repair_item_actor::repair( Character &pl, item &
         if( roll == SUCCESS ) {
             pl.add_msg_if_player( m_good, _( "You make your %s extra sturdy." ), fix->tname() );
             fix->mod_damage( -itype::damage_scale );
-            handle_components( pl, *fix, false, false );
+            handle_components( pl, *fix, false, false, true );
             return AS_SUCCESS;
         }
 

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -799,16 +799,29 @@ class repair_item_actor : public iuse_actor
 
         /** Attempts to repair target item with selected tool */
         attempt_hint repair( Character &pl, item &tool, item_location &fix, bool refit_only = false ) const;
-        /** Checks if repairs on target item are possible. Excludes checks on tool.
-          * Doesn't just estimate - should not return true if repairs are not possible or false if they are. */
-        bool can_repair_target( Character &pl, const item &fix, bool print_msg ) const;
+        /// Checks if repairs on target item are possible. Excludes checks on tool.
+        /// Doesn't just estimate - should not return true if repairs are not possible or false if they are.
+        /// @param pl character performing the fix
+        /// @param fix item to repair
+        /// @param print_msg prints message to player if check fails
+        /// @param check_consumed_available if true check materials consumed by repair are available for `pl`
+        /// @return true if check succeeds
+        bool can_repair_target( Character &pl, const item &fix, bool print_msg,
+                                bool check_consumed_available ) const;
         /** Checks if we are allowed to use the tool. */
         bool can_use_tool( const Character &p, const item &tool, bool print_msg ) const;
 
         /** Returns a list of items that can be used to repair this item. */
         std::set<itype_id> get_valid_repair_materials( const item &fix ) const;
-        /** Returns if components are available. Consumes them if `just_check` is false. */
-        bool handle_components( Character &pl, const item &fix, bool print_msg, bool just_check ) const;
+        /// Returns if components are available. Consumes them if `just_check` is false.
+        /// @param pl character performing the fix
+        /// @param fix item to repair
+        /// @param print_msg prints message to player if check fails
+        /// @param just_check only checks, doesn't consume
+        /// @param check_consumed_available if false skips checking if materials consumed by repair are available for `pl`
+        /// @return true if check succeeds
+        bool handle_components( Character &pl, const item &fix, bool print_msg, bool just_check,
+                                bool check_consumed_available ) const;
         /** Returns the chance to repair and to damage an item. */
         std::pair<float, float> repair_chance(
             const Character &pl, const item &fix, repair_type action_type ) const;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #63585

#### Describe the solution

Use repair_item_actor to perform the check

#### Describe alternatives you've considered

#### Testing

Spawn tailor kit + cloth item - like a t-shirt, debug wish high tailor skill, reinforce an item, see it disappears from repair menu

#### Additional context
