### PR TITLE
item: limit stacks_with recursion to useful depth

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1296,10 +1296,11 @@ bool item::same_for_rle( const item &rhs ) const
           itype_variant().id != rhs.itype_variant().id ) ) {
         return false;
     }
-    return stacks_with( rhs, true, false );
+    return stacks_with( rhs, true, false, 0, 9 );
 }
 
-bool item::stacks_with( const item &rhs, bool check_components, bool combine_liquid ) const
+bool item::stacks_with( const item &rhs, bool check_components, bool combine_liquid, int depth,
+                        int maxdepth ) const
 {
     if( type != rhs.type ) {
         return false;
@@ -1451,7 +1452,7 @@ bool item::stacks_with( const item &rhs, bool check_components, bool combine_liq
             return false;
         }
     }
-    return contents.stacks_with( rhs.contents );
+    return contents.stacks_with( rhs.contents, depth, maxdepth );
 }
 
 bool item::same_contents( const item &rhs ) const

--- a/src/item.h
+++ b/src/item.h
@@ -591,7 +591,7 @@ class item : public visitable
          */
         bool display_stacked_with( const item &rhs, bool check_components = false ) const;
         bool stacks_with( const item &rhs, bool check_components = false,
-                          bool combine_liquid = false ) const;
+                          bool combine_liquid = false, int depth = 0, int maxdepth = 2 ) const;
 
         /**
          * Whether the two items have same contents.

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1338,7 +1338,7 @@ bool item_contents::has_any_with( const std::function<bool( const item &it )> &f
     return false;
 }
 
-bool item_contents::stacks_with( const item_contents &rhs ) const
+bool item_contents::stacks_with( const item_contents &rhs, int depth, int maxdepth ) const
 {
     if( contents.size() != rhs.contents.size() ) {
         return false;
@@ -1346,8 +1346,8 @@ bool item_contents::stacks_with( const item_contents &rhs ) const
     return ( empty() && rhs.empty() ) ||
            std::equal( contents.begin(), contents.end(),
                        rhs.contents.begin(),
-    []( const item_pocket & a, const item_pocket & b ) {
-        return a.stacks_with( b );
+    [depth, maxdepth]( const item_pocket & a, const item_pocket & b ) {
+        return a.stacks_with( b, depth, maxdepth );
     } );
 }
 

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -324,7 +324,7 @@ class item_contents
         void leak( map &here, Character *carrier, const tripoint &pos, item_pocket *pocke = nullptr );
 
         bool item_has_uses_recursive() const;
-        bool stacks_with( const item_contents &rhs ) const;
+        bool stacks_with( const item_contents &rhs, int depth = 0, int maxdepth = 2 ) const;
         bool same_contents( const item_contents &rhs ) const;
         // can this item be used as a funnel?
         bool is_funnel_container( units::volume &bigger_than ) const;

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -405,15 +405,16 @@ bool item_pocket::better_pocket( const item_pocket &rhs, const item &it, bool ne
     return rhs.obtain_cost( it ) < obtain_cost( it );
 }
 
-bool item_pocket::stacks_with( const item_pocket &rhs ) const
+bool item_pocket::stacks_with( const item_pocket &rhs, int depth, int maxdepth ) const
 {
     if( _sealed != rhs._sealed ) {
         return false;
     }
     return ( empty() && rhs.empty() ) || std::equal( contents.begin(), contents.end(),
             rhs.contents.begin(), rhs.contents.end(),
-    []( const item & a, const item & b ) {
-        return a.charges == b.charges && a.stacks_with( b );
+    [depth, maxdepth]( const item & a, const item & b ) {
+        return depth < maxdepth && a.charges == b.charges &&
+               a.stacks_with( b, false, false, depth + 1, maxdepth );
     } );
 }
 

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -131,7 +131,7 @@ class item_pocket
         item_pocket() = default;
         explicit item_pocket( const pocket_data *data ) : data( data ) {}
 
-        bool stacks_with( const item_pocket &rhs ) const;
+        bool stacks_with( const item_pocket &rhs, int depth = 0, int maxdepth = 2 ) const;
         bool is_funnel_container( units::volume &bigger_than ) const;
         bool is_restricted() const;
         bool has_any_with( const std::function<bool( const item & )> &filter ) const;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Increase Inventory UI performance some more by discounting some edge cases
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Don't try to stack items with more than 2 levels of nested contents. Not only is it highly unlikely that they're stackable at that point, but stacking them is also not terribly useful.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Using #63580 as a baseline with [City of the Dalles.zip](https://github.com/CleverRaven/Cataclysm-DDA/files/10725265/City.of.the.Dalles.zip), where there are a lot of deeply stacked MREs and IFAKs:

Opening the pick up all menu, before:
![before](https://user-images.githubusercontent.com/68240139/218795165-b9343a67-3706-4732-9e6f-60add92abebc.png)

After:
![after](https://user-images.githubusercontent.com/68240139/218795204-e82a695d-e3e8-4c42-8b70-2f0114573067.png)

These MRE bags still stack:
![stack test](https://user-images.githubusercontent.com/68240139/218795247-c63c361b-6fac-4d5a-a07e-010c908d1dc8.png)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This will have minimal impact in the average case as naturally-spawned nested items with contents more than 2 levels deep are uncommon.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
