### PR TITLE
fix mutate_towards not accounting CANCELS bionics

### DIFF
--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1374,6 +1374,11 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
         if( bid->mutation_conflicts.count( mut ) != 0 ) {
             return false;
         }
+        for( const trait_id &mid : bid->canceled_mutations ) {
+            if( mid == mut ) {
+                return false;
+            }
+        }
     }
 
     for( size_t i = 0; !c_has_threshreq && i < threshreq.size(); i++ ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "mutate_towards accounts for bionics which CANCEL but don't CONFLICT with mutations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #63526
If the game picks a mutation which one of your bionics cancels (different from conflicts, conflicts prevents bionic from being installed at all while cancels lets you install the bionic to remove the mutation) it does not allow it to be acquired. However, if it picks a mutation which is valid to your character but has a prerequisite that a bionic cancels, it gives you the mutation the bionic would cancel anyways because mutate_towards unlike mutate_ok only checks for a bionic which "conflicts" and not "cancels".
One such example of this was the predator mutations, because while having the Expanded Digestive bionic prevents you from getting Carnivore and thus theoretically would also prevent you from developing predatory tendencies, it logically wouldn't fix your brain getting scrambled by mutations even though it let you eat fruits and grains again. However that means that the game would see culler/hunter/predator as a valid mutation to give you and then give you Carnivore despite having the bionic.
There might be other examples of this with bionics that cancel but Expanded Digestive is the only one I'm aware of.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make mutate_towards check for cancels in addition to conflicts.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Just give expanded digestive conflicts with the predator mutations as if you reach that point you're too far gone to cyborgize your digestive system (maybe) which would prevent you from mutating Carnivore while you had Expanded Digestive also.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled and tested this. Confirmed I can still get Carnivore without the expanded digestive bionic. Then tried adding the bionic and completely maxed out a tree (no valid mutations left) without getting Carnivore+.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
