### PR TITLE
Misc nested mapgen clearing fixes

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_missions.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_missions.json
@@ -117,6 +117,7 @@
           "                        ",
           "                        "
         ],
+        "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
         "terrain": {
           "g": "t_region_groundcover",
           ".": "t_region_groundcover_barren",

--- a/data/mods/No_Hope/Mapgen/house_nested.json
+++ b/data/mods/No_Hope/Mapgen/house_nested.json
@@ -1526,6 +1526,7 @@
         "D2R3Dc",
         "BBCBB "
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "house_w_nest_garden_palette" ],
       "terrain": { "s": "t_concrete" },
       "place_items": [
@@ -1551,6 +1552,7 @@
         "D9R8Dc",
         "BBCBB "
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "house_w_nest_garden_palette" ],
       "terrain": { "s": "t_concrete" },
       "place_items": [
@@ -1576,6 +1578,7 @@
         "|SzzQ|",
         "||||||"
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "house_w_nest_palette" ],
       "terrain": {
         "|": "t_wall_metal",
@@ -1610,6 +1613,7 @@
         "|GEEB|",
         "||oo||"
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": {
         "|": "t_wall_wood",
         "+": "t_door_locked",
@@ -1654,6 +1658,7 @@
         "+   S|",
         "||||||"
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": {
         "|": "t_scrap_wall",
         "+": "t_door_metal_pickable",
@@ -1682,6 +1687,7 @@
         "  Kcc ",
         "   cZ "
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "house_w_nest_garden_palette" ]
     }
   },
@@ -1808,6 +1814,7 @@
         "PPP",
         "PPP"
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "house_w_nest_garden_palette" ],
       "place_items": [
         { "item": "farming_tools", "x": [ 0, 2 ], "y": [ 0, 2 ], "chance": 5, "repeat": [ 1, 3 ] },
@@ -1828,6 +1835,7 @@
         "   ",
         "111"
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "house_w_nest_garden_palette" ],
       "place_items": [
         { "item": "farming_tools", "x": [ 0, 2 ], "y": [ 0, 2 ], "chance": 5, "repeat": [ 1, 3 ] },
@@ -1848,6 +1856,7 @@
         "1Z1",
         "111"
       ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
       "palettes": [ "house_w_nest_garden_palette" ]
     }
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Misc nested mapgen clearing fixes"

#### Purpose of change
Resolves #57071
Resolves #57797

#### Describe the solution
`ERASE_ALL_BEFORE_PLACING_TERRAIN` and `ALLOW_TERRAIN_UNDER_OTHER_DATA` applied as appropriate.

---

For #57071:
Issue originates from anonymous update mapgen in `data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_missions.json` This mapgen is applied on top of `field` omt with the intent of creating a bivoac site in a clearing -- any tree terrains would be overwritten by open ground. Any flowers (furniture) or litter/detritus (items) prexisting from the original `field` omt can be retained, so `ALLOW_TERRAIN_UNDER_OTHER_DATA` seems to be the most apt choice here.

#62441 mentions the same error message, but the actual problem there appears to be more severe, as there seems to have been a failure to locate a suitable overmap location.

---

For #57797:
`data/json/mapgen/nested/house_nested.json` had flags set in #54344, but `data/mods/No_Hope/Mapgen/house_nested.json` was overlooked.

