### PR TITLE
Debug menu: Add popup when no NPCs available to control

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -217,6 +217,7 @@ void avatar::control_npc_menu()
         }
     }
     if( followers.empty() ) {
+        popup( _( "There's no one to take control of!" ) );
         return;
     }
     charmenu.w_y_setup = 0;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fix a minor UI niggle.

From the debug menu, there is no feedback if you pick `p` Player -> `x` Control NPC follower when you have no followers.
(Cannot proceed as there is no one to pick from to take control of.)

#### Describe the solution
Add a popup to indicate failure + reason.

#### Describe alternatives you've considered
Disable or hide the "Control NPC follower" option when there are no followers.

#### Testing
New world, new character, no followers, debug menu, pick the option, see the popup.