### PR TITLE
item: colorize container contents

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -533,8 +533,8 @@ nc_color inventory_entry::get_invlet_color() const
 
 void inventory_entry::update_cache()
 {
-    cached_name = any_item()->tname( 1, false, 0, true, false );
-    cached_name_full = any_item()->tname( 1, true, 0, true, false );
+    cached_name = remove_color_tags( any_item()->tname( 1, false, 0, true, false ) );
+    cached_name_full = remove_color_tags( any_item()->tname( 1, true, 0, true, false ) );
 }
 
 const item_category *inventory_entry::get_category_ptr() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6406,21 +6406,21 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
             ? contents_item.charges
             : 1;
 
-        // with_contents=false for nested items to prevent excessively long names
-        const std::string contents_tname = contents_item.tname( contents_count, true, 0, false );
-
-        if( contents_tname != "none" ) {
+        if( !contents_item.is_null() ) {
+            // with_contents=false for nested items to prevent excessively long names
+            const std::string contents_tname = contents_item.tname( contents_count, true, 0, false );
+            std::string const ctnc = colorize( contents_tname, contents_item.color_in_inventory() );
             if( contents_count == 1 || !ammo_types().empty() ) {
                 // Don't append an item count for single items, or items that are ammo-exclusive
                 // (eg: quivers), as they format their own counts.
                 contents_suffix_text = string_format( pgettext( "item name",
                                                       //~ [container item name] " > [inner item name]
-                                                      " > %1$s" ), contents_tname );
+                                                      " > %1$s" ), ctnc );
             } else if( contents_count != 0 ) {
                 // Otherwise, add a contents count!
                 contents_suffix_text = string_format( pgettext( "item name",
                                                       //~ [container item name] " > [inner item name] (qty)
-                                                      " > %1$s (%2$zd)" ), contents_tname, contents_count );
+                                                      " > %1$s (%2$zd)" ), ctnc, contents_count );
             }
 
             if( is_collapsed() && with_collapsed ) {

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -510,13 +510,17 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
 
         backpack_hiking.put_in( rock, item_pocket::pocket_type::CONTAINER );
 
+        std::string const rock_nested_tname = colorize( rock.tname(), rock.color_in_inventory() );
+        std::string const rocks_nested_tname = colorize( rock.tname( 2 ), rock.color_in_inventory() );
+        REQUIRE( rock_nested_tname == "<color_c_light_gray>TEST rock</color>" );
         SECTION( "single rock" ) {
-            CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym + " TEST rock" );
+            CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym + " " +
+                   rock_nested_tname );
         }
         SECTION( "several rocks" ) {
             backpack_hiking.put_in( rock, item_pocket::pocket_type::CONTAINER );
             CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym +
-                   " TEST rocks (2)" );
+                   " " + rocks_nested_tname + " (2)" );
         }
         SECTION( "several stacks" ) {
             backpack_hiking.put_in( rock, item_pocket::pocket_type::CONTAINER );
@@ -525,14 +529,18 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
         }
     }
 
+    std::string const purse_color = get_tag_from_color( purse.color_in_inventory() );
+    std::string const color_end_tag = "</color>";
     SECTION( "multi-level nesting" ) {
         purse.put_in( rock, item_pocket::pocket_type::CONTAINER );
 
         SECTION( "single rock" ) {
             backpack_hiking.put_in( purse, item_pocket::pocket_type::CONTAINER );
             CHECK( backpack_hiking.tname( 1 ) ==
-                   color_pref + "hiking backpack " + nesting_sym + " " + color_pref + "purse " + nesting_sym +
-                   " 1 item" );
+                   color_pref + "hiking backpack " +
+                   nesting_sym + " " + purse_color + color_pref + "purse " +
+                   nesting_sym + " 1 item" +
+                   color_end_tag );
         }
 
         SECTION( "several rocks" ) {
@@ -541,8 +549,10 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
             backpack_hiking.put_in( purse, item_pocket::pocket_type::CONTAINER );
 
             CHECK( backpack_hiking.tname( 1 ) ==
-                   color_pref + "hiking backpack " + nesting_sym + " " + color_pref + "purse " + nesting_sym +
-                   " 2 items" );
+                   color_pref + "hiking backpack " +
+                   nesting_sym + " " + purse_color + color_pref + "purse " +
+                   nesting_sym + " 2 items" +
+                   color_end_tag );
         }
 
         SECTION( "several purses" ) {

--- a/tests/itemname_test.cpp
+++ b/tests/itemname_test.cpp
@@ -151,8 +151,9 @@ TEST_CASE( "display name includes item contents", "[item][display_name][contents
     quiver.put_in( arrow, item_pocket::pocket_type::CONTAINER );
     // Expect 1 arrow remaining and displayed
     CHECK( quiver.ammo_remaining() == 10 );
+    std::string const arrow_color = get_tag_from_color( arrow.color_in_inventory() );
+    std::string const color_end_tag = "</color>";
     CHECK( quiver.display_name() ==
            "<color_c_light_green>||</color>\u00A0"
-           "test quiver > test wooden broadhead arrows (10)" );
+           "test quiver > " + arrow_color + "test wooden broadhead arrows" + color_end_tag + " (10)" );
 }
-


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Improve recognition of container contents.
<details>
<summary>It's not easy to tell at a glance that these containers contain food.</summary>

![Screenshot from 2023-02-16 13-50-46](https://user-images.githubusercontent.com/68240139/219359017-f312e699-355c-48af-9b7c-d63da2613796.png)

It's even worse in hierarchy mode where you don't have the helpful category header.
</details>

 Maybe convince even one person that putting pasta in your pocket is not necessary or better.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Colorize the name of the contents
![Screenshot from 2023-02-16 13-50-30](https://user-images.githubusercontent.com/68240139/219358899-42e6d50b-b460-4f45-b48a-beeaa9997def.png)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Further de-emphasizing the container by using a muted color for its name? Maybe later.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Other than the color, inventory UIs should look exactly the same.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
