### PR TITLE
Improve obstacle sounds sequencing

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9989,7 +9989,11 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
                 sfx::do_obstacle( displayed_part->part().info().get_id().str() );
             } else {
                 add_msg( m_warning, _( "Moving onto this %s is slow!" ), m.name( dest_loc ) );
-                sfx::do_obstacle( m.ter( dest_loc ).id().str() );
+                if( m.has_furn( dest_loc ) ) {
+                    sfx::do_obstacle( m.furn( dest_loc ).id().str() );
+                } else {
+                    sfx::do_obstacle( m.ter( dest_loc ).id().str() );
+                }
             }
         } else {
             if( auto displayed_part = vp_here.part_displayed() ) {
@@ -9998,7 +10002,11 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
                 sfx::do_obstacle( displayed_part->part().info().get_id().str() );
             } else {
                 add_msg( m_warning, _( "Moving off of this %s is slow!" ), m.name( u.pos() ) );
-                sfx::do_obstacle( m.ter( u.pos() ).id().str() );
+                if( m.has_furn( u.pos() ) ) {
+                    sfx::do_obstacle( m.furn( u.pos() ).id().str() );
+                } else {
+                    sfx::do_obstacle( m.ter( u.pos() ).id().str() );
+                }
             }
         }
     }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1839,26 +1839,30 @@ void sfx::do_obstacle( const std::string &obst )
         return;
     }
 
-    const Character &player_character = get_player_character();
-    const season_type seas = season_of_year( calendar::turn );
-    const std::string seas_str = season_str( seas );
-    const bool indoors = !is_creature_outside( player_character );
-    const bool night = is_night( calendar::turn );
-    int heard_volume = sfx::get_heard_volume( player_character.pos() );
-    if( sfx::has_variant_sound( "plmove", obst, seas_str, indoors, night ) ) {
-        play_variant_sound( "plmove", obst, seas_str, indoors, night,
-                            heard_volume, 0_degrees, 0.8, 1.2 );
-    } else if( ter_str_id( obst ).is_valid() &&
-               ( ter_id( obst )->has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER ) ||
-                 ter_id( obst )->has_flag( ter_furn_flag::TFLAG_DEEP_WATER ) ) ) {
-        play_variant_sound( "plmove", "walk_water", seas_str, indoors, night,
-                            heard_volume, 0_degrees, 0.8, 1.2 );
-    } else {
-        play_variant_sound( "plmove", "clear_obstacle", seas_str, indoors,
-                            night, heard_volume, 0_degrees, 0.8, 1.2 );
+    end_sfx_timestamp = std::chrono::high_resolution_clock::now();
+    sfx_time = end_sfx_timestamp - start_sfx_timestamp;
+    if( std::chrono::duration_cast<std::chrono::milliseconds> ( sfx_time ).count() > 400 ) {
+        const Character &player_character = get_player_character();
+        const season_type seas = season_of_year( calendar::turn );
+        const std::string seas_str = season_str( seas );
+        const bool indoors = !is_creature_outside( player_character );
+        const bool night = is_night( calendar::turn );
+        int heard_volume = sfx::get_heard_volume( player_character.pos() );
+        if( sfx::has_variant_sound( "plmove", obst, seas_str, indoors, night ) ) {
+            play_variant_sound( "plmove", obst, seas_str, indoors, night,
+                                heard_volume, 0_degrees, 0.8, 1.2 );
+        } else if( ter_str_id( obst ).is_valid() &&
+                   ( ter_id( obst )->has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER ) ||
+                     ter_id( obst )->has_flag( ter_furn_flag::TFLAG_DEEP_WATER ) ) ) {
+            play_variant_sound( "plmove", "walk_water", seas_str, indoors, night,
+                                heard_volume, 0_degrees, 0.8, 1.2 );
+        } else {
+            play_variant_sound( "plmove", "clear_obstacle", seas_str, indoors,
+                                night, heard_volume, 0_degrees, 0.8, 1.2 );
+        }
+        // prevent footsteps from triggering
+        start_sfx_timestamp = std::chrono::high_resolution_clock::now();
     }
-    // prevent footsteps from triggering
-    start_sfx_timestamp = std::chrono::high_resolution_clock::now();
 }
 
 void sfx::play_activity_sound( const std::string &id, const std::string &variant, int volume )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "No cooldown in sfx::do_obstacle(); furniture-specific obstacle sounds not used"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Noticed some inconsistency in footstep sounds on some tiles with movement penalties (no sound played when moving over long/tall grass, benches etc). This was caused by a combination of some issues in the code and some issues in my soundpack (I use @ soundpack).

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The priority of the 'obstactle sound to play' was [vehicle part -> terrain]. The furniture id in the tile was not used. 
Changed this so that if furniture exists in the tile, then its sound will be attempted to play instead of terrain. So now it is [vehicle part -> furniture -> terrain]. 
As usual, if no tile-specific (terrain or furniture) sound exists in json, the default obstacle sound will be attempted ("id" : "plmove",  "variant" : "clear_obstacle").

Additionally I noticed that sfx::do_obstacle() was missing the 400ms cooldown (that the sfx::do_footstep has), so it was executing repeatedly if you run through 'difficult' terrain. Made it behave similar to sfx::do_footstep()


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I see there are a lot of hardcoded references to the various terrains in the sfx::do_footstep() sound code. At the same time the terrain is json-ed, and the movement sounds can be configured through json.
Maybe the hardcoded lists should be removed from the footsteps code, the code could be simplified, and soundpacks should carry the responsibility of having correct sound configuration for movement on diffirent tiles?

#### Testing

Added the following chunk into my soundpack:

<details>
  <summary>JSON</summary>

```json
[
    {
        "type": "sound_effect",
        "id" : "plmove",
        "variant" : "clear_obstacle",
        "volume" : 50,
        "files" : [
            "env/walk/clear_obstacle1.ogg",
            "env/walk/clear_obstacle2.ogg",
            "env/walk/clear_obstacle3.ogg",
            "env/walk/clear_obstacle4.ogg"

        ]
    },
    {
        "type": "sound_effect",
        "id" : "plmove",
        "variant" : "t_grass_long",
        "volume" : 30,
        "files" : [
            "env/walk/walk_grass1.ogg",
            "env/walk/walk_grass2.ogg",
            "env/walk/walk_grass3.ogg",
            "env/walk/walk_grass4.ogg",
            "env/walk/walk_grass5.ogg",
            "env/walk/walk_grass6.ogg"
        ]
    },
	{
        "type": "sound_effect",
        "id" : "plmove",
        "variant" : "t_grass_tall",
        "volume" : 30,
        "files" : [
            "env/walk/walk_grass1.ogg",
            "env/walk/walk_grass2.ogg",
            "env/walk/walk_grass3.ogg",
            "env/walk/walk_grass4.ogg",
            "env/walk/walk_grass5.ogg",
            "env/walk/walk_grass6.ogg"
        ]
    }
]
```
</details>

Ran around in the game. With the above c++ changes the walking sounds are much more consistent now. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
