### PR TITLE
lang/parser: fix for examine_action EOC referenced by id

### DIFF
--- a/lang/string_extractor/parse.py
+++ b/lang/string_extractor/parse.py
@@ -33,6 +33,7 @@ def parse_json_file(file_path):
         for json_object in json_objects:
             parse_json_object(json_object, file_path)
     except Exception as E:
-        print("Error in JSON file: '{0}'".format(file_path))
+        print("Error in JSON object\n'{0}'\nfrom file: '{1}'".format(
+            json.dumps(json_object, indent=2), file_path))
         print(E)
         exit(1)

--- a/lang/string_extractor/parsers/examine_action.py
+++ b/lang/string_extractor/parsers/examine_action.py
@@ -14,4 +14,5 @@ def parse_examine_action(json, origin, name):
                    comment="Redundant message of {}".format(name))
     if "effect_on_conditions" in json:
         for eoc in json["effect_on_conditions"]:
-            parse_effect_on_condition(eoc, origin)
+            if type(eoc) is dict:
+                parse_effect_on_condition(eoc, origin)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
`examine_action` string extractor chokes on `effect_on_conditions` referenced by id, but the game loads them fine.
As seen in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4194694373/jobs/7273200682#step:5:17

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Support this case
Marginally improve error message
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Parser doesn't choke on the furniture definition from https://github.com/MNG-cataclysm/Cataclysm-DDA/commit/cbd1ffe034754531c44fbd79a7b7932cf509369f#diff-b97267f43baf23f2ccb454d51d270bb997c93c0aae2efb0073e0fa6d7ce40938R49
Strings from inline EOC definitions are still extracted
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
