### PR TITLE
Allow randomizing starting hour through options

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2490,7 +2490,7 @@ void options_manager::add_options_world_default()
     add_empty_line();
 
     add( "INITIAL_TIME", "world_default", to_translation( "Initial time" ),
-         to_translation( "Initial starting time of day on character generation." ),
+         to_translation( "Initial starting time of day on character generation. Value -1 randomizes the starting time and overrides scenario setting." ),
          -1, 23, 8
        );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2491,7 +2491,7 @@ void options_manager::add_options_world_default()
 
     add( "INITIAL_TIME", "world_default", to_translation( "Initial time" ),
          to_translation( "Initial starting time of day on character generation." ),
-         0, 23, 8
+         -1, 23, 8
        );
 
     add( "INITIAL_DAY", "world_default", to_translation( "Initial day" ),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2490,7 +2490,7 @@ void options_manager::add_options_world_default()
     add_empty_line();
 
     add( "INITIAL_TIME", "world_default", to_translation( "Initial time" ),
-         to_translation( "Initial starting time of day on character generation. Value -1 randomizes the starting time and overrides scenario setting." ),
+         to_translation( "Initial starting time of day on character generation.  Value -1 randomizes the starting time and overrides scenario setting." ),
          -1, 23, 8
        );
 

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -547,9 +547,15 @@ time_point scenario::start_of_game() const
 {
     time_point ret;
 
+    int options_start_hour = get_option<int>( "INITIAL_TIME" );
+    bool override_start_hour = options_start_hour == -1;
+    if( override_start_hour ) {
+        options_start_hour = rng( 0, 23 );
+    }
+
     if( custom_start_date() ) {
         ret = calendar::turn_zero
-              + 1_hours * start_hour()
+              + 1_hours * ( override_start_hour ? options_start_hour : start_hour() )
               + 1_days * start_day()
               + 1_days * get_option<int>( "SEASON_LENGTH" ) * start_season()
               + calendar::year_length() * ( start_year() - 1 );
@@ -560,7 +566,7 @@ time_point scenario::start_of_game() const
         }
     } else {
         ret = start_of_cataclysm()
-              + 1_hours * get_option<int>( "INITIAL_TIME" )
+              + 1_hours * options_start_hour
               + 1_days * get_option<int>( "SPAWN_DELAY" );
     }
     return ret;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -547,15 +547,11 @@ time_point scenario::start_of_game() const
 {
     time_point ret;
 
-    int options_start_hour = get_option<int>( "INITIAL_TIME" );
-    bool override_start_hour = options_start_hour == -1;
-    if( override_start_hour ) {
-        options_start_hour = rng( 0, 23 );
-    }
+    const int options_start_hour = get_option<int>( "INITIAL_TIME" );
 
     if( custom_start_date() ) {
         ret = calendar::turn_zero
-              + 1_hours * ( override_start_hour ? options_start_hour : start_hour() )
+              + 1_hours * ( options_start_hour == -1 ? rng( 0, 23 ) : start_hour() )
               + 1_days * start_day()
               + 1_days * get_option<int>( "SEASON_LENGTH" ) * start_season()
               + calendar::year_length() * ( start_year() - 1 );
@@ -566,7 +562,7 @@ time_point scenario::start_of_game() const
         }
     } else {
         ret = start_of_cataclysm()
-              + 1_hours * options_start_hour
+              + 1_hours * ( options_start_hour == -1 ? rng( 0, 23 ) : options_start_hour )
               + 1_days * get_option<int>( "SPAWN_DELAY" );
     }
     return ret;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Setting 'Initial time' world option to -1 randomizes that value"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

We could randomize player character and starting day but not the starting time. This PR adds such possibility.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Allow setting the 'Initial time' world option to -1 (same as starting day). This forces the game to randomize the starting time, overriding scenario starting time (if necessary).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Generated several worlds with option set to -1 and to something else. Seems to behave properly.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<details>
<summary>(done)</summary>
<del>I did not change the option text label. I'm not entirely clear on that 'string freeze' thing (would that prevent the PR to be merged?) and how the text is translated to other languages etc, so I set this PR currently as draft. Please let me know what else is needed here, or can I just update this line at options.cpp?</del>

```
to_translation( "Initial starting time of day on character generation." ),
```
</details>

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
