### PR TITLE
Revamps the swollen wretch.

### DIFF
--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -140,6 +140,22 @@
   },
   {
     "type": "SPELL",
+    "id": "wretch_raptor_spawn",
+    "name": { "str": "Summon Raptor" },
+    "description": "Summons a flesh raptor while dealing some damage to the zombie.",
+    "flags": [ "HOSTILE_SUMMON", "RANDOM_DAMAGE", "PERMANENT", "NO_EXPLOSION_SFX" ],
+    "valid_targets": [ "ground", "self" ],
+    "min_damage": 5,
+    "max_damage": 10,
+    "min_aoe": 3,
+    "max_aoe": 3,
+    "base_casting_time": 100,
+    "shape": "blast",
+    "effect": "summon",
+    "effect_str": "mon_spawn_raptor"
+  },
+  {
+    "type": "SPELL",
     "id": "hive_raptor_spawn",
     "name": { "str": "Summon Raptor" },
     "description": "Summons a zombie-spawn raptor without killing the zombie.",
@@ -170,6 +186,22 @@
     "shape": "blast",
     "effect": "summon",
     "effect_str": "mon_spawn_raptor_shady"
+  },
+  {
+    "type": "SPELL",
+    "id": "wretch_fungal_raptor_spawn",
+    "name": { "str": "Summon Raptor" },
+    "description": "Summons a fungal flesh raptor while dealing some damage to the zombie.",
+    "flags": [ "HOSTILE_SUMMON", "RANDOM_DAMAGE", "PERMANENT", "NO_EXPLOSION_SFX" ],
+    "valid_targets": [ "ground", "self" ],
+    "min_damage": 5,
+    "max_damage": 10,
+    "min_aoe": 2,
+    "max_aoe": 2,
+    "base_casting_time": 500,
+    "shape": "blast",
+    "effect": "summon",
+    "effect_str": "mon_fungal_raptor"
   },
   {
     "type": "SPELL",

--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -284,7 +284,6 @@
     "melee_dice_sides": 2,
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "armor_elec": 1,
-    "dodge": 0,
     "vision_day": 2,
     "vision_night": 2,
     "emit_fields": [ { "emit_id": "emit_fungal_leak", "delay": "1 s" } ],

--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -266,13 +266,12 @@
     "id": "mon_fungal_wretch",
     "type": "MONSTER",
     "name": { "str": "fungal wretch", "str_pl": "fungal wretches" },
-    "description": "Were it not for the head, its orifices sealed by clumps of fungal growth, which limply crowns this massively swollen corpse, it’d be impossible to tell that this was once a human, let alone a child or adolescent.  The beast’s skin, stretched to paper-thin levels by what you can only assume to be lighter than air decomposition caused gasses built up within it, has turned into a spongy fungal covering with intermittent hair-line cracks which let out spores.  Like a nightmarish balloon the abomination is suspended off the floor with a faint glow emanating from within its guts, more than likely a result of the burning putrid gasses which keep it afloat.  At irregular intervals, you can see its form bulge and shift, a hint of something moving within its mass.",
+    "description": "This severely deformed child lies on its back, its ribs exposed to the sky.  With its limbs contorted in ways only possible through a lack of bones, the child’s ribcage stretches far beyond the boundaries of human biology, appearing akin to a bony hive coated in quivering fungal matter.  Spoors occasionally waft from its hollowed interior, and, periodically, you can catch sight of weakened movement staring within the abomination’s guts.",
     "default_faction": "fungus",
     "bodytype": "blob",
     "species": [ "FUNGUS" ],
-    "volume": "120000 ml",
+    "volume": "30000 ml",
     "weight": "45000 g",
-    "//": "Weight is more than its zombie counterpart cause of the fungal elements. It’s still rather slow, but it also has more health cause the fungus acts as a sort of makeshift armour.",
     "hp": 45,
     "speed": 20,
     "material": [ "flesh" ],
@@ -280,47 +279,28 @@
     "color": "pink",
     "aggression": 100,
     "morale": 100,
-    "melee_skill": 2,
+    "melee_skill": 1,
     "melee_dice": 2,
     "melee_dice_sides": 2,
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "armor_elec": 1,
-    "dodge": 1,
+    "dodge": 0,
     "vision_day": 2,
     "vision_night": 2,
-    "harvest": "exempt",
-    "luminance": 5,
     "emit_fields": [ { "emit_id": "emit_fungal_leak", "delay": "1 s" } ],
-    "weakpoints": [
-      {
-        "id": "Belly",
-        "name": "the stretched skin of the abdomen",
-        "crit_mult": { "all": 0.75 },
-        "difficulty": { "ranged": 2, "melee": 1 },
-        "coverage_mult": { "broad": 0.5 },
-        "effects": [
-          {
-            "effect": "staggered",
-            "chance": 15,
-            "message": "The %s gargles as it’s sent wobbling!",
-            "damage_required": [ 10, 100 ]
-          }
-        ],
-        "coverage": 40
-      }
-    ],
+    "bleed_rate": 0,
+    "harvest": "zombie",
     "special_attacks": [
       {
         "type": "spell",
-        "spell_data": { "id": "small_fungal_raptor_spawn", "hit_self": true },
+        "spell_data": { "id": "wretch_fungal_raptor_spawn", "hit_self": true },
         "cooldown": 50,
-        "monster_message": "With a high-pitched shriek, the wretch's belly splits open, and gore-smeared winged beasts climb out of the corpse!"
+        "monster_message": "Through a plume of fungal spores, a small beast struggles to take wing from the wretch’s abdomen!"
       }
     ],
-    "death_function": { "effect": { "id": "death_boomer", "hit_self": true }, "message": "A %s explodes!", "corpse_type": "NO_CORPSE" },
-    "death_drops": "child_items",
+    "death_drops": { "subtype": "collection", "groups": [ [ "default_zombie_children_clothes", 100 ], [ "child_items", 65 ] ] },
     "burn_into": "mon_zombie_child_scorched",
-    "flags": [ "HEARS", "SMELLS", "STUMBLES", "WARM", "POISON", "NO_BREATHE", "REVIVES", "FLIES", "FILTHY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "IMMOBILE", "WARM", "POISON", "NO_BREATHE", "FILTHY" ]
   },
   {
     "id": "mon_fungal_raptor",

--- a/data/json/monsters/zed_children.json
+++ b/data/json/monsters/zed_children.json
@@ -285,10 +285,9 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "armor_elec": 1,
     "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_child_body", "wps_humanoid_head_big" ],
-    "dodge": 0,
     "vision_day": 20,
     "vision_night": 3,
-    "bleed_rate": 50,
+    "bleed_rate": 0,
     "harvest": "zombie",
     "special_attacks": [
       {

--- a/data/json/monsters/zed_children.json
+++ b/data/json/monsters/zed_children.json
@@ -265,64 +265,42 @@
   {
     "id": "mon_zombie_wretch",
     "type": "MONSTER",
-    "name": { "str": "swollen wretch", "str_pl": "swollen wretches" },
-    "description": "The hideously deformed corpse of what, you hesitate to guess, was once either a mere child or adolescent.  Its skin has detached from its skeletal and muscular structure and has overgrown into a malformed fleshy chrysalis containing its rotting innards, with a faint glow emanating from within the creature’s swollen body as various lighter than air decomposing gasses are created and burned in a chain reaction.  This has caused its flesh, like a nightmarish balloon, to distend to obscene proportions, causing its overtaxed skin to become translucent and for the abomination to hover a few feet off the floor at any given moment.  All of the orifices in its head have sealed over into a transparent membrane, save for its narrow slit of a maw, from which a stream of noxious gas escapes; seemingly allowing the monstrosity to regulate its buoyancy.  From within its immensely swollen body, you can just make out faint shadowy forms moving about.",
+    "name": { "str": "promethean wretch", "str_pl": "promethean wretches" },
+    "description": "Lethargically resting on its back, this hideous mass of sagging flesh and writhing organs, which used to be a child, twitches feebly as its midsection churns.  Almost bursting from its skin, the child’s ribcage has arched outward, forming a hive-like construct covered by severely stretched epidermis.  Through the wretched organism’s taut abdominal flesh, you witness small forms swarming within its ribcage—its guts roiling as new beings are sculpted from pilfered flesh and bone.  The creature’s limbs rest haphazardly on the ground, contorted in ways that suggest the absence of bones or any interior construct.",
     "default_faction": "zombie",
     "bodytype": "blob",
     "species": [ "ZOMBIE", "HUMAN" ],
-    "volume": "120000 ml",
+    "volume": "40000 ml",
     "weight": "30000 g",
-    "//": "Since it’s essentially a floating human balloon held up by decomposition related gasses, it’s got a large volume but is comparatively very light. Also very fragile and slow.",
-    "hp": 20,
+    "hp": 40,
     "speed": 20,
     "material": [ "flesh" ],
     "symbol": "z",
     "color": "pink",
-    "aggression": 60,
+    "aggression": 100,
     "morale": 100,
-    "melee_skill": 2,
+    "melee_skill": 1,
     "melee_dice": 2,
     "melee_dice_sides": 2,
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "armor_elec": 1,
     "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_child_body", "wps_humanoid_head_big" ],
-    "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_child" ],
-    "dodge": 1,
+    "dodge": 0,
     "vision_day": 20,
     "vision_night": 3,
-    "harvest": "exempt",
-    "emit_fields": [ { "emit_id": "emit_toxic_leak", "delay": "1 s" } ],
-    "luminance": 15,
-    "weakpoints": [
-      {
-        "id": "Belly",
-        "name": "the stretched skin of the abdomen",
-        "crit_mult": { "all": 0.75 },
-        "difficulty": { "ranged": 2, "melee": 1 },
-        "coverage_mult": { "broad": 0.5 },
-        "effects": [
-          {
-            "effect": "staggered",
-            "chance": 15,
-            "message": "The %s gargles as it’s sent wobbling!",
-            "damage_required": [ 10, 100 ]
-          }
-        ],
-        "coverage": 40
-      }
-    ],
+    "bleed_rate": 50,
+    "harvest": "zombie",
     "special_attacks": [
       {
         "type": "spell",
-        "spell_data": { "id": "small_raptor_spawn", "hit_self": true },
+        "spell_data": { "id": "wretch_raptor_spawn", "hit_self": true },
         "cooldown": 50,
-        "monster_message": "With a high-pitched shriek, the bloated wretch bursts, and gore-smeared winged beasts climb out of the corpse!"
+        "monster_message": "Ripping and tearing, a small beast burrows free of the wretch’s abdomen!"
       }
     ],
-    "death_function": { "effect": { "id": "death_boomer", "hit_self": true }, "message": "A %s explodes!", "corpse_type": "NO_CORPSE" },
-    "death_drops": "child_items",
+    "death_drops": { "subtype": "collection", "groups": [ [ "default_zombie_children_clothes", 100 ], [ "child_items", 65 ] ] },
     "burn_into": "mon_zombie_child_scorched",
     "fungalize_into": "mon_fungal_wretch",
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "POISON", "NO_BREATHE", "REVIVES", "FLIES", "FILTHY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "IMMOBILE", "WARM", "POISON", "NO_BREATHE", "FILTHY" ]
   }
 ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
In PR #56914, I added a new evolved child zombie dubbed the "swollen wretch." Largely speaking, this zombie had many, many flaws in both its overall design and implementation. To name but a few, issues included:
1.	It laughs heartily at physics and basic biology concepts.
2.	It’s simply a mishmash of all the cool features I thought would be cool in a new zombie variant, which I stapled together based on a Discord joke without actually considering the enemy in question or even trying to make it sensible... or really even trying to make something that wasn’t just an edgy cartoon balloon. This resulted in a flying, gas-spewing, glowing, raptor-spawning giant meat balloon that, for some ungodly reason, also exploded upon death.
3.	Its description is no less than 159 words long, which literally means it trails off screen for a good chunk and is simply the pinnacle example of edgy zombie descriptions that are overly long for the sake of being edgy.
4.	It's so out of place with reality that the graphics for it are difficult to create in such a way that it doesn't look like a cartoon hot air balloon.
For these and other reasons, I was always inclined to change the enemy to make it more in line with the theme of the game, rescuing it from being the dumbest, meme-worthy bag of floating skin this side of cataclysmic New England.
#### Describe the solution
I have reworked the enemy to become an immobile flesh raptor hatchery, adopting a similar style and principle to the bone hive SCP, although a comparison with the latter only came to mind after the rework had been completed. Fundamentally, the zombie makes use of its biomass to formulate flesh raptors within its chest cavity, utilizing organs, bones, and extraneous bits and pieces to put the raptors together. To this end, I have sawed away the zombie’s flying capabilities and explosive tendencies and removed its gas-producing potential. These changes hold true for the fungal variant as well.
#### Describe alternatives you've considered
I considered leaving the zombie as it is, but I simply hated it with a deep, deep passion.
#### Testing
As of yet, I haven’t observed the newly adjusted zombie within a game scenario, though I believe that all should be working fine.
#### Additional context
