### PR TITLE
Randomize freshness of comestibles on game start

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7644,15 +7644,6 @@ void item::calc_rot( units::temperature temp, const float spoil_modifier,
         temp = std::min( temperatures::fridge, temp );
     }
 
-    // simulation of different age of food at the start of the game and good/bad storage
-    // conditions by applying starting variation bonus/penalty of +/- 20% of base shelf-life
-    // positive = food was produced some time before calendar::start and/or bad storage
-    // negative = food was stored in good conditions before calendar::start
-    if( last_temp_check <= calendar::start_of_cataclysm ) {
-        time_duration spoil_variation = get_shelf_life() * 0.2f;
-        rot += rng( -spoil_variation, spoil_variation );
-    }
-
     rot += factor * time_delta / 1_hours * calc_hourly_rotpoints_at_temp( temp ) * 1_turns;
 }
 

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -720,8 +720,8 @@ std::size_t Item_group::create( Item_spawn_data::ItemList &list,
 
     if( birthday == calendar::start_of_cataclysm ) {
         // randomize rot value for comestibles generated at the 'start of cataclysm'
-        for( item &e: list ) {
-            e.visit_items( []( item *visit_itm, item * ) {
+        for( item &e : list ) {
+            e.visit_items( []( item * visit_itm, item * ) {
                 if( visit_itm->is_comestible() && visit_itm->get_comestible()->spoils > 0_turns ) {
                     const double x_input = rng_float( 0.0, 1.0 );
                     const double k_rot = ( 1.0 - x_input ) / ( 1.0 + 2 * x_input );

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -717,6 +717,25 @@ std::size_t Item_group::create( Item_spawn_data::ItemList &list,
     }
     const std::size_t items_created = list.size() - prev_list_size;
     put_into_container( list, items_created, container_item, birthday, on_overflow, context() );
+
+    if( birthday == calendar::start_of_cataclysm ) {
+        // randomize rot value for comestibles generated at the 'start of cataclysm'
+        for( item &e: list ) {
+            e.visit_items( []( item *visit_itm, item * ) {
+                if( visit_itm->is_comestible() && visit_itm->get_comestible()->spoils > 0_turns ) {
+                    const double x_input = rng_float( 0.0, 1.0 );
+                    const double k_rot = ( 1.0 - x_input ) / ( 1.0 + 2 * x_input );
+                    visit_itm->set_rot( visit_itm->get_shelf_life() * k_rot );
+                    return VisitResponse::SKIP;
+                } else  if( visit_itm->is_container() && visit_itm->all_pockets_sealed() ) {
+                    return VisitResponse::SKIP;
+                }
+
+                return VisitResponse::NEXT;
+            } );
+        }
+    }
+
     return list.size() - prev_list_size;
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Randomize age/freshness of comestibles generated at calendar::start_of_cataclysm"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Currently all food generated on the map or dropped from monsters is considered to be created at the calendar::start_of_cataclysm: that is usually right before the game starts (unless you delay the start by scenario or world options). This is fine for canned/sealed food (it is reasonable to assume it was canned in a fresh state, and it doesn't spoil), but strange for everything else that can spoil/rot.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

When comestibles ar created on map generation, or on monster death (and probably any time the item_group creation is executed), and the item 'birthday' is calendar::start_of_cataclysm, the rot level of food (freshness) is randomized within the item's shelf_life range. The following distribution is used:
 
![rot_distr](https://user-images.githubusercontent.com/1553853/219792680-9d37860f-58be-4e4c-80df-07f6a17a92ca.png)

On average we should expect the following results:
50% of the food will have 25% rot (or less)
75% of the food will have 50% rot (or less)
 

#### Describe alternatives you've considered

Continue eating only butter for the first few weeks.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Generated new world, teleported into town, killed zombies and looted kitchens. Sealed/canned food is not affected, so I didn't pick it up for the screenshot. 

<details>
  <summary>Results:</summary>

![list](https://user-images.githubusercontent.com/1553853/219794142-09ffd737-02d4-4ff1-9ee0-29056e69d173.png)

</details>

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
