### PR TITLE
Sane person's lifespan

### DIFF
--- a/data/json/portal_storm_effect_on_condition.json
+++ b/data/json/portal_storm_effect_on_condition.json
@@ -504,7 +504,7 @@
       "outdoor_only": true,
       "min_radius": 40,
       "max_radius": 50,
-      "lifespan": [ "40 minutes", "60 minutes" ]
+      "lifespan": [ "12 minutes", "15 minutes" ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Lifespan of person's was too long, and lot of people spotted they are often live long after the end of portal storm
#### Describe the solution
decrease their lifetime from 40- 60 minutes to 12-15
#### Describe alternatives you've considered
i'd like to make something so they can live only when portal storm exist, and instantly die after the end, but it seems not possible