### PR TITLE
Add limb strength hint to veh interact

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2249,6 +2249,10 @@ std::pair<bool, std::string> veh_interact::calc_lift_requirements( const vpart_i
         str_suffix = string_format( _( "(Bad Back reduced usable strength by %d)" ),
                                     lift_strength - player_character.get_str() );
     }
+    if( player_character.get_str() > lift_strength ) {
+        str_suffix += str_suffix.empty() ? "" : "  ";
+        str_suffix += string_format( _( "(Effective lifting strength is %d)" ), lift_strength );
+    }
 
     nc_color aid_color = use_aid ? c_green : ( use_str ? c_dark_gray : c_red );
     nc_color str_color = use_str ? c_green : ( use_aid ? c_dark_gray : c_red );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #63658

#### Describe the solution

#53746 made vehicle interactions use limb scores but the vehicle screen doesn't show any sign of it, this adds a hint if effective limb strength is lower than "global" strength

#### Describe alternatives you've considered

#### Testing

Test the save from #63658

#### Additional context

![image](https://user-images.githubusercontent.com/6560075/219901016-6b65f8f3-c708-4476-b1fc-850270608145.png)
