### PR TITLE
Ferrous spawn revamp

### DIFF
--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -184,10 +184,11 @@
     "name": "GROUP_FERROUS_UPGRADE",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie_rust", "weight": 700 },
-      { "monster": "mon_zombie_plated", "weight": 100, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_urchin", "weight": 100, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_hammer_hands", "weight": 100, "cost_multiplier": 2 }
+      { "monster": "mon_zombie_rust", "weight": 600 },
+      { "monster": "mon_zombie_shell", "weight": 175 },
+      { "monster": "mon_zombie_plated", "weight": 75, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_urchin", "weight": 75, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_hammer_hands", "weight": 75, "cost_multiplier": 2 }
     ]
   },
   {

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -577,11 +577,12 @@
       { "monster": "mon_zombie", "weight": 1, "cost_multiplier": 7, "pack_size": [ 5, 10 ] },
       { "monster": "mon_zombie", "weight": 1, "cost_multiplier": 13, "pack_size": [ 15, 20 ] },
       { "monster": "mon_zombie", "weight": 1, "cost_multiplier": 20, "pack_size": [ 25, 30 ] },
-      { "monster": "mon_zombie", "weight": 75, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_fat", "weight": 75, "cost_multiplier": 2 },
+      { "monster": "mon_zombie", "weight": 50, "cost_multiplier": 2 },
+      { "group": "GROUP_FERROUS", "weight": 100, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_fat", "weight": 50, "cost_multiplier": 2 },
       { "monster": "mon_zombie_fat", "weight": 3, "cost_multiplier": 7, "pack_size": [ 3, 5 ] },
-      { "monster": "mon_zombie_tough", "weight": 75, "cost_multiplier": 3 },
-      { "monster": "mon_zombie_rot", "weight": 50, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_tough", "weight": 50, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_rot", "weight": 25, "cost_multiplier": 3 },
       { "monster": "mon_zombie_crawler", "weight": 25, "cost_multiplier": 3 },
       { "monster": "mon_zombie_soldier", "weight": 10, "cost_multiplier": 2 },
       { "monster": "mon_zombie_hazmat", "weight": 10, "cost_multiplier": 3 },
@@ -672,6 +673,7 @@
       { "monster": "mon_zombie_fat", "weight": 150 },
       { "monster": "mon_zombie_wretched", "weight": 120, "starts": "5 days" },
       { "monster": "mon_zombie_crawler", "weight": 505 },
+      { "group": "GROUP_FERROUS", "weight": 50, "cost_multiplier": 2 },
       { "monster": "mon_zombie_regenerating", "weight": 5, "starts": "5 days" },
       { "monster": "mon_zombie_survivor", "weight": 70, "starts": "270 hours" },
       { "monster": "mon_zombie_survivor_elite", "weight": 10, "starts": "540 hours" },
@@ -770,16 +772,30 @@
     ]
   },
   {
+    "name": "GROUP_CIVILIAN_NO_FERAL",
+    "//": "Civilians/Normal people that died, represents a lot of different common professions.",
+    "type": "monstergroup",
+    "monsters": [
+      { "monster": "mon_zombie", "weight": 500 },
+      { "monster": "mon_zombie_fat", "weight": 250 },
+      { "monster": "mon_zombie_tough", "weight": 100 },
+      { "monster": "mon_zombie_runner", "weight": 50 },
+      { "monster": "mon_zombie_brainless", "weight": 40 },
+      { "monster": "mon_zombie_crawler", "weight": 40 },
+      { "monster": "mon_zombie_rot", "weight": 20 }
+    ]
+  },
+  {
     "name": "GROUP_FERROUS",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie", "weight": 300, "ends": "14 days" },
-      { "monster": "mon_zombie_crawler", "weight": 10 },
-      { "monster": "mon_zombie_fat", "weight": 25, "ends": "14 days" },
-      { "monster": "mon_zombie_tough", "weight": 25, "ends": "24 days" },
-      { "monster": "mon_zombie_rust", "weight": 300, "starts": "10 days" },
-      { "monster": "mon_zombie_plated", "weight": 50, "starts": "20 days" },
-      { "monster": "mon_zombie_shell", "weight": 20, "starts": "40 days" }
+      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 100 },
+      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 50, "ends": "14 days" },
+      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 150, "ends": "28 days" },
+      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 225, "ends": "42 days" },
+      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 325, "ends": "56 days" },
+      { "monster": "mon_zombie_rust", "weight": 200, "starts": "7 days" },
+      { "monster": "mon_zombie_rust", "weight": 200, "starts": "21 days" }
     ]
   },
   {

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -578,21 +578,21 @@
       { "monster": "mon_zombie", "weight": 1, "cost_multiplier": 13, "pack_size": [ 15, 20 ] },
       { "monster": "mon_zombie", "weight": 1, "cost_multiplier": 20, "pack_size": [ 25, 30 ] },
       { "monster": "mon_zombie", "weight": 50, "cost_multiplier": 2 },
-      { "group": "GROUP_FERROUS", "weight": 100, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_fat", "weight": 50, "cost_multiplier": 2 },
+      { "group": "GROUP_FERROUS", "weight": 170, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_fat", "weight": 45, "cost_multiplier": 2 },
       { "monster": "mon_zombie_fat", "weight": 3, "cost_multiplier": 7, "pack_size": [ 3, 5 ] },
       { "monster": "mon_zombie_tough", "weight": 50, "cost_multiplier": 3 },
       { "monster": "mon_zombie_rot", "weight": 25, "cost_multiplier": 3 },
-      { "monster": "mon_zombie_crawler", "weight": 25, "cost_multiplier": 3 },
-      { "monster": "mon_zombie_soldier", "weight": 10, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_hazmat", "weight": 10, "cost_multiplier": 3 },
-      { "monster": "mon_zombie_static", "weight": 10, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_crawler", "weight": 15, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_soldier", "weight": 5, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_hazmat", "weight": 5, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_static", "weight": 5, "cost_multiplier": 5 },
       { "monster": "mon_zombie_survivor", "weight": 1, "cost_multiplier": 25 },
       { "monster": "mon_zombie_survivor_elite", "weight": 1, "cost_multiplier": 25, "starts": "60 days" },
       { "monster": "mon_zombie_technician", "weight": 1, "cost_multiplier": 12 },
       { "monster": "mon_feral_human_tool", "weight": 1, "cost_multiplier": 5 },
-      { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
-      { "monster": "mon_zombie_brainless", "weight": 55 }
+      { "monster": "mon_zombie_runner", "weight": 10, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_zombie_brainless", "weight": 25 }
     ]
   },
   {
@@ -673,7 +673,7 @@
       { "monster": "mon_zombie_fat", "weight": 150 },
       { "monster": "mon_zombie_wretched", "weight": 120, "starts": "5 days" },
       { "monster": "mon_zombie_crawler", "weight": 505 },
-      { "group": "GROUP_FERROUS", "weight": 50, "cost_multiplier": 2 },
+      { "group": "GROUP_FERROUS", "weight": 350, "cost_multiplier": 2 },
       { "monster": "mon_zombie_regenerating", "weight": 5, "starts": "5 days" },
       { "monster": "mon_zombie_survivor", "weight": 70, "starts": "270 hours" },
       { "monster": "mon_zombie_survivor_elite", "weight": 10, "starts": "540 hours" },
@@ -790,12 +790,12 @@
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 100 },
-      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 50, "ends": "14 days" },
-      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 150, "ends": "28 days" },
-      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 225, "ends": "42 days" },
-      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 325, "ends": "56 days" },
-      { "monster": "mon_zombie_rust", "weight": 200, "starts": "7 days" },
-      { "monster": "mon_zombie_rust", "weight": 200, "starts": "21 days" }
+      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 100, "ends": "14 days" },
+      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 200, "ends": "28 days" },
+      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 150, "ends": "42 days" },
+      { "group": "GROUP_CIVILIAN_NO_FERAL", "weight": 150, "ends": "56 days" },
+      { "monster": "mon_zombie_rust", "weight": 250, "starts": "7 days" },
+      { "monster": "mon_zombie_rust", "weight": 250, "starts": "21 days" }
     ]
   },
   {

--- a/data/json/monsters/zed_ferrous.json
+++ b/data/json/monsters/zed_ferrous.json
@@ -79,7 +79,6 @@
     "attack_effs": [ { "id": "tetanus", "duration": 300, "chance": 10 } ],
     "death_drops": "default_zombie_death_drops",
     "burn_into": "mon_zombie_scorched",
-    "upgrades": { "half_life": 42, "into_group": "GROUP_FERROUS_UPGRADE" },
     "flags": [
       "SEES",
       "HEARS",


### PR DESCRIPTION
#### Summary
Balance "Revamps the spawns of ferrous/rust zombies"

#### Purpose of change
Rust zombies currently are in a weird spot where their monstergroup spawns them as an all or nothing monster, where after a certain time every monster is a rust monster, but in early days they do not exist until that specific point in time where they replace all the other zombies.

#### Describe the solution
A small revamp of spawning for these monsters, making it a gradual process the replacement of normal zombies by rust ones, also changing the rust shell zombie into an evolution of the rust zombie, it seems like a reasonable outcome to a possible evolution of a zombie integrating metal into its body, losing ability to move and gaining a strong armor in its place... The zombies were also included in the steel mill and dump locations, makes sense.

#### Describe alternatives you've considered
To change the spawns of several locations that could make use of these kind of zombies other than the steel mill, but maybe later.

#### Testing
It works!

#### Additional context
The locations in which these monsters appear need a spawn revision in general, but I can't do it right now, maybe in another time, in another PR. 
