### PR TITLE
Limbify escaping effects. Again.

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3788,6 +3788,11 @@ int Character::get_arm_str() const
     return str_cur * get_modifier( character_modifier_limb_str_mod );
 }
 
+int Character::get_arm_str() const
+{
+    return str_cur * get_modifier( character_modifier_limb_str_mod );
+}
+
 int Character::get_eff_per() const
 {
     return Character::get_per() * get_limb_score( limb_score_vision ) + int( Character::has_proficiency(

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3788,11 +3788,6 @@ int Character::get_arm_str() const
     return str_cur * get_modifier( character_modifier_limb_str_mod );
 }
 
-int Character::get_arm_str() const
-{
-    return str_cur * get_modifier( character_modifier_limb_str_mod );
-}
-
 int Character::get_eff_per() const
 {
     return Character::get_per() * get_limb_score( limb_score_vision ) + int( Character::has_proficiency(

--- a/src/character.h
+++ b/src/character.h
@@ -852,7 +852,7 @@ class Character : public Creature, public visitable
         void try_remove_webs();
         void try_remove_impeding_effect();
         // Calculate generic trap escape chance
-        const bool can_escape_trap( int difficulty, bool manip );
+        bool can_escape_trap( int difficulty, bool manip ) const;
 
         /** Check against the character's current movement mode */
         bool movement_mode_is( const move_mode_id &mode ) const;

--- a/src/character.h
+++ b/src/character.h
@@ -852,7 +852,7 @@ class Character : public Creature, public visitable
         void try_remove_webs();
         void try_remove_impeding_effect();
         // Calculate generic trap escape chance
-        bool can_escape_trap( int difficulty, bool manip );
+        const bool can_escape_trap( int difficulty, bool manip );
 
         /** Check against the character's current movement mode */
         bool movement_mode_is( const move_mode_id &mode ) const;

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -27,7 +27,7 @@ static const limb_score_id limb_score_balance( "balance" );
 static const limb_score_id limb_score_grip( "grip" );
 static const limb_score_id limb_score_manip( "manip" );
 
-const bool Character::can_escape_trap( int difficulty, bool manip = false )
+bool Character::can_escape_trap( int difficulty, bool manip = false ) const
 {
     int chance = get_arm_str();
     chance *= manip ? get_limb_score( limb_score_manip ) : get_limb_score( limb_score_grip );

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -27,7 +27,7 @@ static const limb_score_id limb_score_balance( "balance" );
 static const limb_score_id limb_score_grip( "grip" );
 static const limb_score_id limb_score_manip( "manip" );
 
-bool Character::can_escape_trap( int difficulty, bool manip = false )
+const bool Character::can_escape_trap( int difficulty, bool manip = false )
 {
     int chance = get_arm_str();
     chance *= manip ? get_limb_score( limb_score_manip ) : get_limb_score( limb_score_grip );

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -23,6 +23,17 @@ static const itype_id itype_rope_6( "rope_6" );
 static const itype_id itype_snare_trigger( "snare_trigger" );
 static const itype_id itype_string_36( "string_36" );
 
+static const limb_score_id limb_score_balance( "balance" );
+static const limb_score_id limb_score_grip( "grip" );
+static const limb_score_id limb_score_manip( "manip" );
+
+bool Character::can_escape_trap( int difficulty, bool manip = false )
+{
+    int chance = get_arm_str();
+    chance *= manip ? get_limb_score( limb_score_manip ) : get_limb_score( limb_score_grip );
+    return x_in_y( chance, difficulty );
+}
+
 void Character::try_remove_downed()
 {
 
@@ -45,7 +56,6 @@ void Character::try_remove_bear_trap()
        (at which point the player could later remove it from the leg with the right tools).
        As such we are currently making it a bit easier for players and NPC's to get out of bear traps.
     */
-    /** @EFFECT_STR increases chance to escape bear trap */
     // If is riding, then despite the character having the effect, it is the mounted creature that escapes.
     if( is_avatar() && is_mounted() ) {
         auto *mon = mounted_creature.get();
@@ -60,7 +70,7 @@ void Character::try_remove_bear_trap()
             }
         }
     } else {
-        if( x_in_y( get_str(), 100 ) ) {
+        if( can_escape_trap( 100 ) ) {
             remove_effect( effect_beartrap );
             add_msg_player_or_npc( m_good, _( "You free yourself from the bear trap!" ),
                                    _( "<npcname> frees themselves from the bear trap!" ) );
@@ -84,10 +94,7 @@ void Character::try_remove_lightsnare()
             add_msg( _( "The %s escapes the light snare!" ), mon->get_name() );
         }
     } else {
-        /** @EFFECT_STR increases chance to escape light snare */
-
-        /** @EFFECT_DEX increases chance to escape light snare */
-        if( x_in_y( get_str(), 12 ) || x_in_y( get_dex(), 8 ) ) {
+        if( can_escape_trap( 12 ) ) {
             remove_effect( effect_lightsnare );
             add_msg_player_or_npc( m_good, _( "You free yourself from the light snare!" ),
                                    _( "<npcname> frees themselves from the light snare!" ) );
@@ -117,10 +124,7 @@ void Character::try_remove_heavysnare()
             }
         }
     } else {
-        /** @EFFECT_STR increases chance to escape heavy snare, slightly */
-
-        /** @EFFECT_DEX increases chance to escape light snare */
-        if( x_in_y( get_str(), 32 ) || x_in_y( get_dex(), 16 ) ) {
+        if( can_escape_trap( 32 - dex_cur, true ) ) {
             remove_effect( effect_heavysnare );
             add_msg_player_or_npc( m_good, _( "You free yourself from the heavy snare!" ),
                                    _( "<npcname> frees themselves from the heavy snare!" ) );
@@ -137,10 +141,7 @@ void Character::try_remove_heavysnare()
 
 void Character::try_remove_crushed()
 {
-    /** @EFFECT_STR increases chance to escape crushing rubble */
-
-    /** @EFFECT_DEX increases chance to escape crushing rubble, slightly */
-    if( x_in_y( get_str() + get_dex() / 4.0, 100 ) ) {
+    if( can_escape_trap( 100 ) ) {
         remove_effect( effect_crushed );
         add_msg_player_or_npc( m_good, _( "You free yourself from the rubble!" ),
                                _( "<npcname> frees themselves from the rubble!" ) );
@@ -184,8 +185,13 @@ bool Character::try_remove_grab()
 
         /** @EFFECT_STR increases chance to escape grab */
         /** @EFFECT_DEX increases chance to escape grab */
-        int defender_check = rng( 0, std::max( get_str(), get_dex() ) );
+        int defender_check = rng( 0, std::max( get_arm_str(), get_dex() ) );
         int attacker_check = rng( get_effect_int( effect_grabbed, body_part_torso ), 8 );
+
+       // Defender check is modified by the relevant scores
+       defender_check *= get_limb_score(limb_score_balance);
+       // Monster check is modified by number
+        attacker_check *= zed_number;
 
         if( has_grab_break_tec() ) {
             defender_check = defender_check + 2;
@@ -200,7 +206,7 @@ bool Character::try_remove_grab()
         }
 
         if( get_effect_int( effect_downed ) ) {
-            defender_check = defender_check - 2;
+            defender_check /= 2;
         }
 
         if( zed_number == 0 ) {
@@ -258,8 +264,7 @@ void Character::try_remove_webs()
             mon->remove_effect( effect_webbed );
             remove_effect( effect_webbed );
         }
-        /** @EFFECT_STR increases chance to escape webs */
-    } else if( x_in_y( get_str(), 6 * get_effect_int( effect_webbed ) ) ) {
+    } else if( can_escape_trap( 6 * get_effect_int( effect_webbed ) ) ) {
         add_msg_player_or_npc( m_good, _( "You free yourself from the webs!" ),
                                _( "<npcname> frees themselves from the webs!" ) );
         remove_effect( effect_webbed );
@@ -281,7 +286,7 @@ void Character::try_remove_impeding_effect()
                 remove_effect( eff_id );
             }
             /** @EFFECT_STR increases chance to escape webs */
-        } else if( x_in_y( get_str(), 6 * get_effect_int( eff_id ) ) ) {
+        } else if( can_escape_trap( 6 * get_effect_int( eff_id ) ) ) {
             add_msg_player_or_npc( m_good, _( "You free yourself!" ),
                                    _( "<npcname> frees themselves!" ) );
             remove_effect( eff_id );
@@ -328,10 +333,8 @@ bool Character::move_effects( bool attacking )
     // Currently we only have one thing that forces movement if you succeed, should we get more
     // than this will need to be reworked to only have success effects if /all/ checks succeed
     if( has_effect( effect_in_pit ) ) {
-        /** @EFFECT_STR increases chance to escape pit */
-
         /** @EFFECT_DEX increases chance to escape pit, slightly */
-        if( rng( 0, 40 ) > get_str() + get_dex() / 2 ) {
+        if( !can_escape_trap( 40 - dex_cur / 2 ) ) {
             add_msg_if_player( m_bad, _( "You try to escape the pit, but slip back in." ) );
             return false;
         } else {

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -188,9 +188,9 @@ bool Character::try_remove_grab()
         int defender_check = rng( 0, std::max( get_arm_str(), get_dex() ) );
         int attacker_check = rng( get_effect_int( effect_grabbed, body_part_torso ), 8 );
 
-       // Defender check is modified by the relevant scores
-       defender_check *= get_limb_score(limb_score_balance);
-       // Monster check is modified by number
+        // Defender check is modified by the relevant scores
+        defender_check *= get_limb_score( limb_score_balance );
+        // Monster check is modified by number
         attacker_check *= zed_number;
 
         if( has_grab_break_tec() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Adjust grab logic, re-limbify escaping"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
#52799 silently reverted a number of changes from #53746 that merged before it. This unreverts those and adjusts the grab break calculations to both care about scores and about the number of enemies grabbing the character at the time.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
- Cherry-pick the relevant changes
- Add `balance` scaling to the character's grab escape check
- Multiply the monster save by the number of enemies grabbing you

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Add some unit tests, we'll see if I get around to it.


#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
