### PR TITLE
snails are in food category now

### DIFF
--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -1029,7 +1029,7 @@
   {
     "type": "COMESTIBLE",
     "id": "snail_garden",
-    "category": "other",
+    "category": "food",
     "name": { "str": "snail" },
     "weight": "15 g",
     "color": "brown",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #63640
#### Describe the solution
replace the `category` for snails to `food`