### PR TITLE
Display IME candidate list and composition text correctly on Windows

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -169,9 +169,9 @@ jobs:
             sound: 1
             localize: 1
             libbacktrace: 1
-            title: GCC 11, Ubuntu cross-compile to MinGW-Win64, Tiles, Sound
+            title: GCC 12, Ubuntu cross-compile to MinGW-Win64, Tiles, Sound
             ldflags: -static-libgcc -static-libstdc++
-            mxe_target: x86_64-w64-mingw32.static.gcc11
+            mxe_target: x86_64-w64-mingw32.static.gcc12
             wine: wine
             # ~285MB in a clean build
             # ~36MB compressed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,13 +246,13 @@ jobs:
       - name: Install MXE
         if: matrix.mxe != 'none'
         run: |
-          curl -L -o mxe-${{ matrix.mxe }}.tar.xz https://github.com/BrettDong/MXE-GCC/releases/download/mxe-gcc-11.2/mxe-${{ matrix.mxe }}.tar.xz
-          curl -L -o mxe-${{ matrix.mxe }}.tar.xz.sha256 https://github.com/BrettDong/MXE-GCC/releases/download/mxe-gcc-11.2/mxe-${{ matrix.mxe }}.tar.xz.sha256
+          curl -L -o mxe-${{ matrix.mxe }}.tar.xz https://github.com/BrettDong/MXE-GCC/releases/download/mxe-sdl-2-0-20/mxe-${{ matrix.mxe }}.tar.xz
+          curl -L -o mxe-${{ matrix.mxe }}.tar.xz.sha256 https://github.com/BrettDong/MXE-GCC/releases/download/mxe-sdl-2-0-20/mxe-${{ matrix.mxe }}.tar.xz.sha256
           shasum -a 256 -c ./mxe-${{ matrix.mxe }}.tar.xz.sha256
           sudo tar xJf mxe-${{ matrix.mxe }}.tar.xz -C /opt
           curl -L -o libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz https://github.com/Qrox/libbacktrace/releases/download/2020-01-03/libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz
           shasum -a 256 -c ./build-scripts/libbacktrace-${{ matrix.mxe }}-w64-mingw32-sha256
-          sudo tar -xzf libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz --exclude=LICENSE -C /opt/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static.gcc11
+          sudo tar -xzf libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz --exclude=LICENSE -C /opt/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static.gcc12
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none' 
         run: |
@@ -286,7 +286,7 @@ jobs:
       - name: Build CDDA (windows mxe)
         if: matrix.mxe != 'none'
         env:
-          PLATFORM: /opt/mxe/usr/bin/${{ matrix.mxe }}-w64-mingw32.static.gcc11-
+          PLATFORM: /opt/mxe/usr/bin/${{ matrix.mxe }}-w64-mingw32.static.gcc12-
         run: |
           make -j$((`nproc`+0)) CROSS="${PLATFORM}" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 PCH=0 bindist
           mv cataclysmdda-0.F.zip cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,6 +250,9 @@ jobs:
           curl -L -o mxe-${{ matrix.mxe }}.tar.xz.sha256 https://github.com/BrettDong/MXE-GCC/releases/download/mxe-sdl-2-0-20/mxe-${{ matrix.mxe }}.tar.xz.sha256
           shasum -a 256 -c ./mxe-${{ matrix.mxe }}.tar.xz.sha256
           sudo tar xJf mxe-${{ matrix.mxe }}.tar.xz -C /opt
+          curl -L -o SDL2-devel-2.26.2-mingw.tar.gz https://github.com/libsdl-org/SDL/releases/download/release-2.26.2/SDL2-devel-2.26.2-mingw.tar.gz
+          shasum -a 256 -c ./build-scripts/SDL2-devel-2.26.2-mingw.tar.gz.sha256
+          sudo tar -xzf SDL2-devel-2.26.2-mingw.tar.gz -C /opt/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static.gcc12 --strip-components=2 SDL2-2.26.2/${{ matrix.mxe }}-w64-mingw32
           curl -L -o libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz https://github.com/Qrox/libbacktrace/releases/download/2020-01-03/libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz
           shasum -a 256 -c ./build-scripts/libbacktrace-${{ matrix.mxe }}-w64-mingw32-sha256
           sudo tar -xzf libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz --exclude=LICENSE -C /opt/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static.gcc12

--- a/build-scripts/SDL2-devel-2.26.2-mingw.tar.gz.sha256
+++ b/build-scripts/SDL2-devel-2.26.2-mingw.tar.gz.sha256
@@ -1,0 +1,1 @@
+fd2b7ac21d1c487b87fd6c0a9fc87cfb6936c528c3ec197f6127bf925eb38356 *SDL2-devel-2.26.2-mingw.tar.gz

--- a/build-scripts/requirements.sh
+++ b/build-scripts/requirements.sh
@@ -67,7 +67,7 @@ if [ -n "${MXE_TARGET}" ]; then
   set +e
   retry=0
   until [[ "$retry" -ge 5 ]]; do
-    curl -L -o mxe-x86_64.tar.xz https://github.com/BrettDong/MXE-GCC/releases/download/mxe-gcc-11.2/mxe-x86_64.tar.xz && curl -L -o mxe-x86_64.tar.xz.sha256 https://github.com/BrettDong/MXE-GCC/releases/download/mxe-gcc-11.2/mxe-x86_64.tar.xz.sha256 && shasum -a 256 -c ./mxe-x86_64.tar.xz.sha256 && break
+    curl -L -o mxe-x86_64.tar.xz https://github.com/BrettDong/MXE-GCC/releases/download/mxe-sdl-2-0-20/mxe-x86_64.tar.xz && curl -L -o mxe-x86_64.tar.xz.sha256 https://github.com/BrettDong/MXE-GCC/releases/download/mxe-sdl-2-0-20/mxe-x86_64.tar.xz.sha256 && shasum -a 256 -c ./mxe-x86_64.tar.xz.sha256 && break
     retry=$((retry+1))
     rm -f mxe-x86_64.tar.xz mxe-x86_64.tar.xz.sha256
     sleep 10

--- a/build-scripts/requirements.sh
+++ b/build-scripts/requirements.sh
@@ -88,6 +88,21 @@ if [ -n "${MXE_TARGET}" ]; then
   set +e
   retry=0
   until [[ "$retry" -ge 5 ]]; do
+    curl -L -o SDL2-devel-2.26.2-mingw.tar.gz https://github.com/libsdl-org/SDL/releases/download/release-2.26.2/SDL2-devel-2.26.2-mingw.tar.gz && shasum -a 256 -c ./build-scripts/SDL2-devel-2.26.2-mingw.tar.gz.sha256 && break
+    retry=$((retry+1))
+    rm -f SDL2-devel-2.26.2-mingw.tar.gz
+    sleep 10
+  done
+  if [[ "$retry" -ge 5 ]]; then
+    echo "Error downloading or checksum failed for SDL2-devel-2.26.2-mingw.tar.gz"
+    exit 1
+  fi
+  set -e
+  sudo tar -xzf SDL2-devel-2.26.2-mingw.tar.gz -C ${MXE_DIR}/usr/${MXE_TARGET} --strip-components=2 SDL2-2.26.2/x86_64-w64-mingw32
+
+  set +e
+  retry=0
+  until [[ "$retry" -ge 5 ]]; do
     curl -L -o libbacktrace-x86_64-w64-mingw32.tar.gz https://github.com/Qrox/libbacktrace/releases/download/2020-01-03/libbacktrace-x86_64-w64-mingw32.tar.gz && shasum -a 256 -c ./build-scripts/libbacktrace-x86_64-w64-mingw32-sha256 && break
     retry=$((retry+1))
     rm -f libbacktrace-x86_64-w64-mingw32.tar.gz

--- a/doc/USER_INTERFACE_AND_ACCESSIBILITY.md
+++ b/doc/USER_INTERFACE_AND_ACCESSIBILITY.md
@@ -12,6 +12,15 @@ files:
 
 Details on how to use `ui_adaptor` can be found within `ui_manager.h`.
 
+## SDL version requirement of the tiles build 
+
+In theory, any version of SDL2 is supported. However, newer versions of SDL adds
+several hints that are used to fix some incorrect behaviors of older SDL versions.
+These hints and the minimum SDL version requirements can be found within `InitSDL`
+in `sdltiles.cpp`. For example, SDL 2.0.20 is required for IME candidate list
+to show correctly on Windows, and SDL 2.0.22 is required for long IME composition
+text to show correctly.
+
 ## Compatibility with screen readers
 
 There are people who use screen readers to play Cataclysm DDA. In order for screen

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -174,7 +174,15 @@ static void InitSDL()
     int ret;
 
 #if defined(SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING)
+    // Requires SDL 2.0.5. Disables thread naming so that gdb works correctly
+    // with the game.
     SDL_SetHint( SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING, "1" );
+#endif
+
+#if defined(_WIN32) && defined(SDL_HINT_IME_SHOW_UI)
+    // Requires SDL 2.0.20. Shows the native IME UI instead of using SDL's
+    // broken implementation on Windows which does not show.
+    SDL_SetHint( SDL_HINT_IME_SHOW_UI, "1" );
 #endif
 
 #if defined(__linux__)

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -186,7 +186,7 @@ static void InitSDL()
 #endif
 
 #if defined(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT)
-    // Support long IME composition text
+    // Requires SDL 2.0.22. Support long IME composition text.
     SDL_SetHint( SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, "1" );
 #endif
 
@@ -2532,9 +2532,8 @@ bool is_string_input( input_context &ctx )
 {
     std::string &category = ctx.get_category();
     return category == "STRING_INPUT"
-           || category == "HELP_KEYBINDINGS"
-           || category == "NEW_CHAR_DESCRIPTION"
-           || category == "WORLDGEN_CONFIRM_DIALOG";
+           || category == "STRING_EDITOR"
+           || category == "HELP_KEYBINDINGS";
 }
 
 int get_key_event_from_string( const std::string &str )
@@ -3217,7 +3216,9 @@ static void CheckMessages()
                     last_input = input_event();
                     last_input.type = input_event_t::keyboard_char;
                 }
-                last_input.edit = ev.edit.text;
+                // Convert to string explicitly to avoid accidentally using
+                // the array out of scope.
+                last_input.edit = std::string( ev.edit.text );
                 last_input.edit_refresh = true;
                 text_refresh = true;
                 break;


### PR DESCRIPTION
#### Summary
Bugfixes "Display IME candidate list and composition text correctly on Windows"

#### Purpose of change
SDL 2.0.20 has added a new hint `SDL_HINT_IME_SHOW_UI` that lets the IME UI show correctly on Windows. (Technically it was 2.0.18, but it seems it was not correctly implemented in that version)

SDL 2.0.22 also added a `SDL_HINT_IME_SUPPORT_EXTENDED_TEXT` hint to provide the full composition text when it is too long to be contained within the old text editing event.

Also should fix android soft keyboard in string editor (diary) window closing on keypress (#62247).

#### Describe the solution
Set the hints. Use SDL 2.26.2 in the MXE builds to be consistent with the MSVC builds. Update documentation.

#### Describe alternatives you've considered

#### Testing
Tested the game built by the release action [here](https://github.com/Qrox/Cataclysm-DDA/releases/tag/cdda-experimental-2023-02-21-1511). The MSVC and MinGW versions now display the candidate list in the lower right corner of the game window and also display long composition text correctly.

Credits to @BrettDong for building the updated MXE.

I can't get the android build to work in my repo so I'm going to test it after this is merged.

#### Additional context
I suppose this could be shipped with 0.G?
