### PR TITLE
Fix npc needs pathfinding taking unreasonable amount of time

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4111,6 +4111,11 @@ void npc::set_omt_destination()
             // those having equal minimal distance
             find_params.search_range = 75;
             find_params.existing_only = false;
+            // force finding goal on the same zlevel (for random spawned NPCs that's z=0), otherwise
+            // we may target unreachable overmap tiles (no ramp up/down) which makes
+            // overmap_buffer.get_travel_path waste a lot of time
+            find_params.min_z = surface_omt_loc.z();
+            find_params.max_z = surface_omt_loc.z();
             goal = overmap_buffer.find_closest( surface_omt_loc, find_params );
             npc_need_goal_cache &cache = goal_cache[fulfill];
             cache.goal = goal;

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1196,20 +1196,20 @@ tripoint_abs_omt overmapbuffer::find_closest( const tripoint_abs_omt &origin,
     const int max_dist = params.search_range ? params.search_range : OMAPX * 5;
 
     std::vector<tripoint_abs_omt> result;
-    cata::optional<int> found_dist;
+    int found_dist = std::numeric_limits<int>::max();
 
     for( const point_abs_omt &loc_xy : closest_points_first( origin.xy(), min_dist, max_dist ) ) {
         const int dist_xy = square_dist( origin.xy(), loc_xy );
 
-        if( found_dist && *found_dist < dist_xy ) {
+        if( found_dist < dist_xy ) {
             break;
         }
 
-        for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+        for( int z = params.min_z; z <= params.max_z; z++ ) {
             const tripoint_abs_omt loc( loc_xy, z );
             const int dist = square_dist( origin, loc );
 
-            if( found_dist && *found_dist < dist ) {
+            if( found_dist < dist ) {
                 continue;
             }
 

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -137,6 +137,8 @@ struct omt_find_params {
     bool must_see = false;
     bool cant_see = false;
     bool existing_only = false;
+    int min_z = -OVERMAP_DEPTH;
+    int max_z = OVERMAP_HEIGHT;
     cata::optional<overmap_special_id> om_special = cata::nullopt;
 };
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix hangs caused by npc pathfinding

Fixes #54683
Fixes #59912
Fixes #63202


There's probably a ton of "mystery hang" issues related to this because it's caused by random NPC spawns which will most often occur during activities and player sleep where turns advance quickly, I propose closing the likely earlier issues, especially considering most of them don't have much actionable information; for the player the game window just froze before spinner was added in an earlier PR 62985:
Fixes #58533
Fixes #60371

How npc needs pathfinding works;
`npc::set_omt_destination` can set random goal matching the npc's needs, it then tries to find nearest overmap tiles that can fulfill the need. To do so it calls `overmap_buffer.find_closest`, this function may randomly return tiles that are on zlevels other than z=0. After that `overmap_buffer.get_travel_path` is called, and it tries to pathfind exact route to the selected OM tile.

The problem is - the pathfinding scorer function is only able to travel up/down zlevels via ramp overmap tiles (currently those are bridge head tiles), so when the NPC is on z=0 (random npcs only spawn on z=0) and the target OM tile is in the basement or upstairs it cannot be reached, causing `pf::find_overmap_path` to run until it exhausts the search space (or it reaches max_search_count=100000) which can take unreasonable amount of time

#### Describe the solution

This PR limits `overmap_buffer.find_closest` to search on just z=0 when pathfinding to fulfill npc needs, this will almost always produce a reachable tile.

#### Describe alternatives you've considered

The alternative is making sure the overmap tiles are VERY carefully set to correct SOURCE_* flags, but for example house_farm_roof inherits flags from generic_rural_building causing a roof to be a valid target for npc needs pathfinding, and enforcing this seems close to impossible to be automated and improbable to be 100% correct if done by reviewers.

#### Testing

Apply the patch from #63067 - this will allow debug menu to spawn random NPCs and spawn 20 random NPCs.
Alternatively; set npc spawn rate to 0.01, wait 20 hours.

You will most likely see a spinner multiple times before applying this patch, with this patch applied pathfinding should be near instant.

#### Additional context

Before (notice how the pathfinding that takes 60+ seconds are trying to pathfind to a different zlevel, since they're trying to look for a non existent route via a ramp up/down):
![image](https://user-images.githubusercontent.com/6560075/219960472-f42d8dd4-ab09-4ef3-a5e9-87481f633426.png)

After:
![image](https://user-images.githubusercontent.com/6560075/219960037-8c1b933a-2c30-40fa-8061-f63c7c1cf205.png)
