### PR TITLE
Fix: "Failed to Create Starting Location" Exception does not flush Buffers.

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -827,11 +827,12 @@ bool game::start_game()
             omtstart = start_loc.find_player_initial_location( u.world_origin.value_or( point_abs_om() ) );
         }
         if( omtstart == overmap::invalid_tripoint ) {
-            if( query_yn(
+
+            MAPBUFFER.clear();
+            overmap_buffer.clear();
+
+            if( !query_yn(
                     _( "Try again?\n\nIt may require several attempts until the game finds a valid starting location." ) ) ) {
-                MAPBUFFER.clear();
-                overmap_buffer.clear();
-            } else {
                 return false;
             }
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -832,6 +832,8 @@ bool game::start_game()
                 MAPBUFFER.clear();
                 overmap_buffer.clear();
             } else {
+                MAPBUFFER.clear();
+                overmap_buffer.clear();
                 return false;
             }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.




Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

Bugfixes "Flush map buffers after failing to create starting location"


<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->


Fixes #63601


Steps to Repro:

> I can confirm and repro the issue: Reposting steps here for further clarity.
> 
> Create a world with city size 0 ![image](https://user-images.githubusercontent.com/8581536/219815650-11a8e85a-2311-4120-ae7a-f23cbbe67dec.png)
> 
> Make a character in the wilderness scenario with desert island starting location and confirm ![image](https://user-images.githubusercontent.com/8581536/219815700-8ce31177-71e0-4da2-865b-f6315ff73313.png)
> 
> Failed to generate starting location ![image](https://user-images.githubusercontent.com/8581536/219815728-5418fc43-47e9-4b14-9f70-73e0687c5558.png)
> 
> Select "no" when asked to try again ![image](https://user-images.githubusercontent.com/8581536/219815753-7b00c70b-6ef2-4194-9d24-edfab7417b09.png)
> 
> - Load template from previous attempt (not sure if that's necessary, but that's what I did to reproduce) **Change starting location** to one of the other options and confirm Crash
> 
 




#### Describe the solution


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- I put the flush Mapbuffer and Overmap_buffer in the Else statement as well; not just the If statement.

![image](https://user-images.githubusercontent.com/8581536/219961501-34f4f5a8-24cd-47f8-af2d-00f9a95cedc5.png)
---

A greater breakdown of why this was needed is here:

> ## Potential Fix:
> Hitting “NO” executes the else portion of code which DOES NOT flush the MAPBUFFER and Overmap_buffer (I added the highlighted yellow portion of code)
> ![image](https://user-images.githubusercontent.com/8581536/219903454-b587bf61-9bc7-4942-91fe-28bc09f3647b.png)
> ![image](https://user-images.githubusercontent.com/8581536/219903459-0b6ec2ee-2680-4d5f-887e-916faf446d87.png)
> If user later decides to attempt rebuilding the world after making changes to the Starting point; then the logic will occasionally use ‘unflushed’ values from the previous failed attempt to create the world:
> 
> Here is an Example of this behavior; a gigantic number was passed to boosted_percent_str which would later cause a failure in other functions
> 
> ![image](https://user-images.githubusercontent.com/8581536/219903475-4080ba4f-9e91-49d0-b818-bd0949515926.png)
> 
> See a regular session in comparison that does not pass strange values
> 
> ![image](https://user-images.githubusercontent.com/8581536/219903488-23673a72-f906-413c-9ee3-6a73bf937517.png)
> 
> After I made the highlighted changes; I **was able to change the starting location without any crash**
> 




#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

At first I was trying to see if I could fix the Exception that was causing users to potentially run into the crash to begin with; 


![image](https://user-images.githubusercontent.com/8581536/219961874-f507f979-332d-42dc-8e1f-6df3ca5bdc79.png)

I was not able to find an appropriate solution to this; it would require me to wrap my head around how mapgen is working - in particular the logic around Desert Island as a start point. This seems to have been a known issue; https://github.com/CleverRaven/Cataclysm-DDA/pull/41269#issuecomment-643844040

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Some context:

This code path is a unique scenario;
- In order for a user to run into this portion of code they would need to fail to acquire a valid starting location that they have chosen
- That being said I exhausted the test from the repro steps provided

I performed the following tests:

During World Creation I changed-up the Spacing across 4 worlds 


- Ran into the exception when I chose a Desert Island start
- Refused to retry 
- Attempted to recreate a start using a different point (Once for each environment)
- Confirmed Start Point Success

![image](https://user-images.githubusercontent.com/8581536/219978069-3636e900-3dcf-44b8-af87-c126c93ab28d.png)

I repeated the 4 steps above across all 7 locations with Wilderness startpoint and was able to get them all to work, with the exception of 'Desert Island' which - if Set to City Size 0 will always fail at each attempt. But the root problem of this issue was the crash -> And this is no longer occurring.


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
