### PR TITLE
Reword existing trap message

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3769,8 +3769,11 @@ bool place_trap_actor::is_allowed( Character &p, const tripoint &pos,
     const trap &existing_trap = here.tr_at( pos );
     if( !existing_trap.is_null() ) {
         if( existing_trap.can_see( pos, p ) ) {
-            p.add_msg_if_player( m_info, _( "You can't place a %s there.  It contains %s already." ),
-                                 name, existing_trap.is_benign() ? _( "a deployed object" ) : _( "a trap" ) );
+            p.add_msg_if_player( m_info,
+                                 existing_trap.is_benign()
+                                     ? _( "You can't place a %s there.  It contains a deployed object already." )
+                                     : _( "You can't place a %s there.  It contains a trap already." ),
+                                 name );
         } else {
             p.add_msg_if_player( m_bad, _( "You trigger a %s!" ), existing_trap.name() );
             existing_trap.trigger( pos, p );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3769,8 +3769,8 @@ bool place_trap_actor::is_allowed( Character &p, const tripoint &pos,
     const trap &existing_trap = here.tr_at( pos );
     if( !existing_trap.is_null() ) {
         if( existing_trap.can_see( pos, p ) ) {
-            p.add_msg_if_player( m_info, _( "You can't place a %s there.  It contains a trap already." ),
-                                 name );
+            p.add_msg_if_player( m_info, _( "You can't place a %s there.  It contains %s already." ),
+                                 name, existing_trap.is_benign() ? _( "a deployed object" ) : _( "a trap" ) );
         } else {
             p.add_msg_if_player( m_bad, _( "You trigger a %s!" ), existing_trap.name() );
             existing_trap.trigger( pos, p );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3771,8 +3771,8 @@ bool place_trap_actor::is_allowed( Character &p, const tripoint &pos,
         if( existing_trap.can_see( pos, p ) ) {
             p.add_msg_if_player( m_info,
                                  existing_trap.is_benign()
-                                     ? _( "You can't place a %s there.  It contains a deployed object already." )
-                                     : _( "You can't place a %s there.  It contains a trap already." ),
+                                 ? _( "You can't place a %s there.  It contains a deployed object already." )
+                                 : _( "You can't place a %s there.  It contains a trap already." ),
                                  name );
         } else {
             p.add_msg_if_player( m_bad, _( "You trigger a %s!" ), existing_trap.name() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Reword existing trap message"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The existing message for attempting to deploy a trap on a deployed trap displays "It contains a trap already" even when the trap is set as benign. Benign traps shouldn't be called "traps" in-game since they're used for deployable furniture and the like.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed the message to say "a deployed object" if the trap is benign.
Changed the message to the more encompassing "It contains a deployed %s."
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Use "It contains a deployed %s." for both traps and benigns. This has incorrect grammar for caltrops, however ("a deployed caltrops"), and there wasn't an simple fix for that.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked, it shows both messages for traps and benigns.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
