### PR TITLE
Fitness improved spawn

### DIFF
--- a/data/json/mapgen/boxing.json
+++ b/data/json/mapgen/boxing.json
@@ -77,6 +77,7 @@
         { "item": "boxing_misc", "x": [ 16, 20 ], "y": [ 22, 22 ], "chance": 60, "repeat": [ 1, 4 ] },
         { "item": "vending_drink", "x": [ 10, 11 ], "y": [ 16, 16 ], "chance": 70 }
       ],
+      "place_monster": [ { "group": "GROUP_DOJO", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 75, "repeat": [ 3, 8 ] } ],
       "vehicles": { "Á": { "vehicle": "parking_garage_short", "chance": 20, "rotation": 90 } }
     }
   },

--- a/data/json/mapgen/dojo.json
+++ b/data/json/mapgen/dojo.json
@@ -259,7 +259,7 @@
         "@": { "item": "bed", "chance": 20, "repeat": [ 1, 2 ] },
         "c": { "item": "cannedfood", "chance": 40, "repeat": [ 1, 2 ] }
       },
-      "place_monster": [ { "group": "GROUP_DOJO", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 75, "repeat": [ 3, 8 ] } ],
+      "place_monster": [ { "group": "GROUP_DOJO", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 75, "repeat": [ 3, 8 ] } ]
     }
   },
   {

--- a/data/json/mapgen/dojo.json
+++ b/data/json/mapgen/dojo.json
@@ -70,10 +70,7 @@
         { "item": "games_dojo", "x": [ 17, 19 ], "y": [ 19, 19 ], "chance": 30 }
       ],
       "place_item": [ { "item": "judo_belt_black", "x": 17, "y": 18 } ],
-      "place_monster": [
-        { "monster": "mon_zombie_tough", "x": [ 9, 12 ], "y": [ 16, 19 ], "repeat": [ 1, 2 ] },
-        { "monster": "mon_zombie", "x": [ 5, 12 ], "y": [ 8, 16 ], "repeat": [ 2, 3 ] }
-      ],
+      "place_monster": [ { "group": "GROUP_DOJO", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 75, "repeat": [ 3, 8 ] } ],
       "vehicles": { "Á": { "vehicle": "parking_garage_short", "chance": 20, "rotation": 90 } }
     }
   },
@@ -262,10 +259,7 @@
         "@": { "item": "bed", "chance": 20, "repeat": [ 1, 2 ] },
         "c": { "item": "cannedfood", "chance": 40, "repeat": [ 1, 2 ] }
       },
-      "place_monster": [
-        { "monster": "mon_zombie_tough", "x": [ 6, 12 ], "y": [ 7, 12 ], "repeat": [ 1, 2 ] },
-        { "monster": "mon_zombie", "x": [ 5, 14 ], "y": [ 5, 14 ], "repeat": [ 2, 3 ] }
-      ]
+      "place_monster": [ { "group": "GROUP_DOJO", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 75, "repeat": [ 3, 8 ] } ],
     }
   },
   {

--- a/data/json/mapgen/field_baseball.json
+++ b/data/json/mapgen/field_baseball.json
@@ -63,10 +63,10 @@
         { "item": "baseball", "x": [ 1, 21 ], "y": [ 31, 46 ], "chance": 90 }
       ],
       "place_monster": [
-        { "group": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 3, 7 ] },
-        { "group": "GROUP_ZOMBIE", "x": [ 26, 45 ], "y": [ 2, 21 ], "repeat": [ 3, 7 ] },
-        { "group": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 26, 45 ], "repeat": [ 3, 7 ] },
-        { "group": "GROUP_ZOMBIE", "x": [ 26, 45 ], "y": [ 26, 45 ], "repeat": [ 3, 7 ] }
+        { "group": "GROUP_SEARCH_FITNESS", "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 3, 7 ] },
+        { "group": "GROUP_SEARCH_FITNESS", "x": [ 26, 45 ], "y": [ 2, 21 ], "repeat": [ 3, 7 ] },
+        { "group": "GROUP_SEARCH_FITNESS", "x": [ 2, 21 ], "y": [ 26, 45 ], "repeat": [ 3, 7 ] },
+        { "group": "GROUP_SEARCH_FITNESS", "x": [ 26, 45 ], "y": [ 26, 45 ], "repeat": [ 3, 7 ] }
       ]
     }
   },

--- a/data/json/mapgen/gym.json
+++ b/data/json/mapgen/gym.json
@@ -68,6 +68,7 @@
         "r": { "item": "snacks", "chance": 20, "repeat": [ 2, 4 ] }
       },
       "nested": { "U": { "chunks": [ [ "roof_6x6_garden_1", 50 ], [ "roof_6x6_garden_2", 50 ] ] } },
+      "place_monster": [ { "group": "GROUP_SEARCH_FITNESS", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 75, "repeat": [ 3, 8 ] } ],
       "place_loot": [ { "group": "cash_register_random", "x": 10, "y": [ 4, 6 ] } ]
     }
   },
@@ -191,7 +192,10 @@
         "T": "f_toilet",
         "t": "f_sink"
       },
-      "place_monster": [ { "group": "GROUP_MAPGEN_POOL", "x": [ 12, 19 ], "y": [ 18, 21 ], "repeat": [ 1, 5 ] } ],
+      "place_monster": [
+        { "group": "GROUP_SEARCH_FITNESS", "x": [ 0, 23 ], "y": [ 0, 15 ], "chance": 75, "repeat": [ 3, 8 ] },
+        { "group": "GROUP_MAPGEN_POOL", "x": [ 12, 19 ], "y": [ 18, 21 ], "chance": 75, "repeat": [ 2, 5 ] }
+      ],
       "toilets": { "T": {  } },
       "items": { "O": { "item": "gym", "chance": 80 }, "H": { "item": "vending_drink", "chance": 75, "repeat": [ 4, 8 ] } },
       "place_loot": [ { "group": "cash_register_random", "x": [ 17, 19 ], "y": 2 } ]
@@ -263,6 +267,7 @@
         { "item": "gym", "x": [ 4, 7 ], "y": [ 16, 18 ], "chance": 30, "repeat": [ 1, 5 ] },
         { "item": "gym", "x": [ 16, 20 ], "y": [ 10, 13 ], "chance": 30, "repeat": [ 1, 5 ] }
       ],
+      "place_monster": [ { "group": "GROUP_SEARCH_FITNESS", "x": [ 4, 20 ], "y": [ 4, 14 ], "chance": 75, "repeat": [ 3, 8 ] } ],
       "items": { "F": { "item": "office_paper", "chance": 30 }, "I": { "item": "softdrugs", "chance": 20, "repeat": [ 2, 4 ] } }
     }
   },

--- a/data/json/mapgen/paintball_field.json
+++ b/data/json/mapgen/paintball_field.json
@@ -33,6 +33,7 @@
         { "chance": 75, "item": "trash", "x": [ 17, 18 ], "y": 2 },
         { "item": "cash_register_random", "x": 8, "y": 1, "chance": 100 }
       ],
+      "place_monster": [ { "group": "GROUP_SEARCH_FITNESS", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 25, "repeat": [ 3, 8 ] } ],
       "rows": [
         "|bbbbbbbbbccccccccccccc|",
         "|bCCCClFCbccccccccccccc|",
@@ -159,6 +160,7 @@
         { "chance": 70, "item": "paintball_items", "x": 20, "y": 9 },
         { "item": "cash_register_random", "x": 16, "y": 2, "chance": 100 }
       ],
+      "place_monster": [ { "group": "GROUP_SEARCH_FITNESS", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 25, "repeat": [ 3, 8 ] } ],
       "rows": [
         "ssssssssssssssssssssssss",
         "&sbbsssssssssss||||||||s",

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -704,6 +704,39 @@
     ]
   },
   {
+    "name": "GROUP_SEARCH_FITNESS",
+    "//": "Civilians that died/went crazy while trying to improve their bodies doing exercise. Lesser improved chance of brute/hulk.",
+    "type": "monstergroup",
+    "monsters": [
+      { "monster": "mon_zombie", "weight": 250 },
+      { "monster": "mon_zombie_fat", "weight": 250 },
+      { "monster": "mon_zombie_tough", "weight": 400 },
+      { "monster": "mon_zombie_brute", "weight": 25, "starts": "28 days", "cost_multiplier": 2 },
+      { "monster": "mon_zombie_hulk", "weight": 10, "starts": "49 days", "cost_multiplier": 3 },
+      { "monster": "mon_zombie_runner", "weight": 350 },
+      { "monster": "mon_feral_human_pipe", "weight": 60 },
+      { "monster": "mon_feral_human_crowbar", "weight": 30 },
+      { "monster": "mon_feral_human_axe", "weight": 5, "cost_multiplier": 2 }
+    ]
+  },
+  {
+    "name": "GROUP_DOJO",
+    "//": "Civilians that died/went crazy while in a dojo, no runner and less fat zombies. Improved chance of brute/wrestler/hulk.",
+    "type": "monstergroup",
+    "monsters": [
+      { "monster": "mon_zombie", "weight": 350 },
+      { "monster": "mon_zombie_tough", "weight": 500 },
+      { "monster": "mon_zombie_brute", "weight": 50, "starts": "21 days", "cost_multiplier": 2 },
+      { "monster": "mon_zombie_brute_grappler", "weight": 20, "starts": "42 days", "cost_multiplier": 3 },
+      { "monster": "mon_zombie_brute_ninja", "weight": 5, "starts": "42 days", "cost_multiplier": 3 },
+      { "monster": "mon_zombie_hulk", "weight": 20, "starts": "42 days", "cost_multiplier": 3 },
+      { "monster": "mon_zombie_fat", "weight": 100 },
+      { "monster": "mon_feral_human_pipe", "weight": 40 },
+      { "monster": "mon_feral_human_crowbar", "weight": 20 },
+      { "monster": "mon_feral_human_axe", "weight": 2, "cost_multiplier": 2 }
+    ]
+  },
+  {
     "name": "GROUP_POOL_NOKIDS",
     "type": "monstergroup",
     "monsters": [


### PR DESCRIPTION
#### Summary
Balance "Revamps the monster spawns in fitness related places"

#### Purpose of change
Currently gyms and dojos do not spawn appropriately themed monsters for their locations, this seeks to remedy that.

#### Describe the solution
Adds 2 new monster groups for fitness and dojo/martial combat related places, and use them when appropriate. 

#### Describe alternatives you've considered

#### Testing
It works!

#### Additional context
![imagen](https://user-images.githubusercontent.com/53200489/220009899-39846011-defc-48cb-a75e-9361374d2967.png)
![imagen](https://user-images.githubusercontent.com/53200489/220010048-1d045559-0a7b-4ce0-a2c0-9f3d7d3c3426.png)


