### PR TITLE
[Magiclysm] +1 and +2 pickaxe can mine now

### DIFF
--- a/data/mods/Magiclysm/items/enchanted_melee.json
+++ b/data/mods/Magiclysm/items/enchanted_melee.json
@@ -517,6 +517,7 @@
     "copy-from": "pickaxe",
     "name": { "str": "pickaxe +1", "str_pl": "pickaxes +1" },
     "proportional": { "price": 3.0, "price_postapoc": 3.0, "bashing": 1.1, "cutting": 1.1, "weight": 0.9 },
+    "use_action": [ "PICKAXE" ],
     "relative": { "to_hit": 1 }
   },
   {
@@ -525,6 +526,7 @@
     "copy-from": "pickaxe",
     "name": { "str": "pickaxe +2", "str_pl": "pickaxes +2" },
     "proportional": { "price": 6.0, "price_postapoc": 6.0, "bashing": 1.2, "cutting": 1.2, "weight": 0.8 },
+    "use_action": [ "PICKAXE" ],
     "relative": { "to_hit": 2 }
   },
   {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
+1 and +2 pickaxes were not able to mine, because inheritanse do not pick up use_actions
#### Describe the solution
Manually add use_action
#### Describe alternatives you've considered
Make copy-from pick up use_action (don't think its a good idea actually)