### PR TITLE
Change shark_suit[_faraday] Materials

### DIFF
--- a/data/json/items/armor/swimming.json
+++ b/data/json/items/armor/swimming.json
@@ -993,13 +993,13 @@
         "encumbrance": 30,
         "coverage": 100,
         "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
-        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ]
+        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1 } ]
       },
       {
         "coverage": 100,
         "covers": [ "foot_l", "foot_r", "head" ],
         "encumbrance": 25,
-        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 1.2 } ]
+        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 1 } ]
       }
     ]
   },
@@ -1026,13 +1026,13 @@
         "encumbrance": 30,
         "coverage": 100,
         "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
-        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ]
+        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1 } ]
       },
       {
         "coverage": 100,
         "covers": [ "foot_l", "foot_r", "head" ],
         "encumbrance": 25,
-        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 1.2 } ]
+        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 1 } ]
       }
     ]
   },

--- a/data/json/items/armor/swimming.json
+++ b/data/json/items/armor/swimming.json
@@ -993,7 +993,7 @@
         "encumbrance": 30,
         "coverage": 100,
         "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
-        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1 } ]
+        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ]
       },
       {
         "coverage": 100,
@@ -1026,7 +1026,7 @@
         "encumbrance": 30,
         "coverage": 100,
         "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
-        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1 } ]
+        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ]
       },
       {
         "coverage": 100,

--- a/data/json/items/armor/swimming.json
+++ b/data/json/items/armor/swimming.json
@@ -976,12 +976,12 @@
     "type": "ARMOR",
     "name": { "str": "faraday sharksuit" },
     "description": "A one-piece chainmail suit used by SCUBA divers for protection against shark bites.  It has been conductively interconnected, protecting against electricity.",
-    "weight": "3250 g",
+    "weight": "8164 g",
     "volume": "3500 ml",
     "price": 35000,
     "price_postapoc": 6000,
     "to_hit": -1,
-    "material": [ "steel", "plastic" ],
+    "material": [ "lc_steel_chain", "plastic" ],
     "symbol": "[",
     "looks_like": "chainmail_hauberk",
     "color": "light_red",
@@ -992,7 +992,14 @@
       {
         "encumbrance": 30,
         "coverage": 100,
-        "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+        "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
+        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ]
+      },
+      {
+        "coverage": 100,
+        "covers": [ "foot_l", "foot_r", "head" ],
+        "encumbrance": 25,
+        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 1.2 } ]
       }
     ]
   },
@@ -1002,12 +1009,12 @@
     "type": "ARMOR",
     "name": { "str": "sharksuit" },
     "description": "A-one piece chainmail suit used by SCUBA divers for protection against shark bites.  It comes with attached plastic helmet and booties.",
-    "weight": "3150 g",
+    "weight": "8164 g",
     "volume": "3500 ml",
     "price": 35000,
     "price_postapoc": 5000,
     "to_hit": -1,
-    "material": [ "steel", "plastic" ],
+    "material": [ "lc_steel_chain", "plastic" ],
     "symbol": "[",
     "looks_like": "chainmail_suit",
     "color": "light_red",
@@ -1018,7 +1025,14 @@
       {
         "encumbrance": 30,
         "coverage": 100,
-        "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+        "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
+        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ]
+      },
+      {
+        "coverage": 100,
+        "covers": [ "foot_l", "foot_r", "head" ],
+        "encumbrance": 25,
+        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 1.2 } ]
       }
     ]
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Changed shark_suit and shark_suit_faraday materials to plastic for the head/feet and lc_steel_chain in other slots. Also updated their weights to 18lbs."

#### Purpose of change
Fixes #63604

#### Testing
Viewed the new suits in the "Spawn Item" menu and verified that they are no longer fully rigid.

#### Additional context
Plastic encumbrance and thickness match "cleansuit". I verified the 18lb weight with a quick search for a modern, steel-chain anti-shark suit.
