### PR TITLE
Separate unused casings from used casings pool

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -713,7 +713,6 @@
     "entries": [
       { "item": "10mm_casing", "prob": 60 },
       { "item": "22_casing", "prob": 80 },
-      
       { "item": "223_casing", "prob": 100 },
       { "item": "270win_casing", "prob": 60 },
       { "item": "300_casing", "prob": 80 },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -713,6 +713,7 @@
     "entries": [
       { "item": "10mm_casing", "prob": 60 },
       { "item": "22_casing", "prob": 80 },
+      
       { "item": "223_casing", "prob": 100 },
       { "item": "270win_casing", "prob": 60 },
       { "item": "300_casing", "prob": 80 },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -813,6 +813,17 @@
     ]
   },
   {
+    "id": "ammo_casings_gunsmith_bulk",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "ammo_casings_gunsmith", "prob": 25, "charges-min": 50, "charges-max": 50 },
+      { "group": "ammo_casings_gunsmith", "prob": 10, "charges-min": 100, "charges-max": 100 },
+      { "group": "ammo_casings_gunsmith", "prob": 2, "charges-min": 250, "charges-max": 250 },
+      { "group": "ammo_casings_gunsmith", "prob": 1, "charges-min": 500, "charges-max": 500 }
+    ]
+  },
+  {
     "type": "item_group",
     "id": "ammo_light_batteries",
     "subtype": "distribution",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -712,7 +712,7 @@
     "subtype": "distribution",
     "entries": [
       { "item": "10mm_casing", "prob": 60 },
-      { "item": "22_casing_new", "prob": 80 },
+      { "item": "22_casing", "prob": 80 },
       { "item": "223_casing", "prob": 100 },
       { "item": "270win_casing", "prob": 60 },
       { "item": "300_casing", "prob": 80 },
@@ -765,6 +765,13 @@
       { "item": "50_casing", "prob": 25, "count": [ 1, 3 ] },
       { "item": "shot_hull", "prob": 50, "count": [ 1, 3 ] }
     ]
+  },
+  {
+    "id": "ammo_casings_gunsmith",
+    "//": "Casings found in prepper/gunsmith locations, including primed casings",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "group": "ammo_casings", "prob": 98 }, { "item": "22_casing_new", "prob": 2 } ]
   },
   {
     "id": "casings",

--- a/data/json/mapgen/house/house_garage_prepper.json
+++ b/data/json/mapgen/house/house_garage_prepper.json
@@ -90,7 +90,7 @@
         { "group": "mischw", "x": [ 14, 16 ], "y": [ 11, 11 ], "chance": 65, "repeat": [ 1, 3 ] },
         { "group": "tools_gunsmith", "x": [ 17, 21 ], "y": [ 11, 11 ], "chance": 90, "repeat": [ 1, 2 ] },
         { "group": "ammo_parts", "x": [ 21, 21 ], "y": [ 6, 11 ], "chance": 95, "repeat": [ 1, 6 ] },
-        { "group": "ammo_casings_bulk", "x": [ 21, 21 ], "y": [ 6, 11 ], "chance": 90, "repeat": [ 1, 3 ] },
+        { "group": "ammo_casings_gunsmith_bulk", "x": [ 21, 21 ], "y": [ 6, 11 ], "chance": 90, "repeat": [ 1, 3 ] },
         { "group": "gunmod_common", "x": [ 21, 21 ], "y": [ 6, 11 ], "chance": 80, "repeat": [ 1, 3 ] },
         { "item": "stepladder", "x": 21, "y": 3 },
         {

--- a/data/json/mapgen_palettes/gunstore.json
+++ b/data/json/mapgen_palettes/gunstore.json
@@ -192,7 +192,11 @@
         "chance": 45
       },
       "Q": {
-        "item": { "subtype": "collection", "//": "bulk casing on racks in the FoH", "entries": [ { "group": "ammo_casings_bulk" } ] },
+        "item": {
+          "subtype": "collection",
+          "//": "bulk casing on racks in the FoH",
+          "entries": [ { "group": "ammo_casings_gunsmith_bulk" } ]
+        },
         "repeat": 15,
         "chance": 35
       },

--- a/data/mods/No_Hope/Mapgen/house_garage_prepper.json
+++ b/data/mods/No_Hope/Mapgen/house_garage_prepper.json
@@ -90,7 +90,7 @@
         { "group": "mischw", "x": [ 14, 16 ], "y": [ 11, 11 ], "chance": 25, "repeat": [ 1, 3 ] },
         { "group": "tools_gunsmith", "x": [ 17, 21 ], "y": [ 11, 11 ], "chance": 20, "repeat": [ 1, 2 ] },
         { "group": "ammo_parts", "x": [ 21, 21 ], "y": [ 6, 11 ], "chance": 25, "repeat": [ 1, 6 ] },
-        { "group": "ammo_casings_bulk", "x": [ 21, 21 ], "y": [ 6, 11 ], "chance": 20, "repeat": [ 1, 3 ] },
+        { "group": "ammo_casings_gunsmith_bulk", "x": [ 21, 21 ], "y": [ 6, 11 ], "chance": 20, "repeat": [ 1, 3 ] },
         { "group": "gunmod_common", "x": [ 21, 21 ], "y": [ 6, 11 ], "chance": 20, "repeat": [ 1, 3 ] },
         { "item": "stepladder", "x": 21, "y": 3, "chance": 20 },
         {

--- a/data/mods/No_Hope/palettes.json
+++ b/data/mods/No_Hope/palettes.json
@@ -1345,7 +1345,11 @@
         "chance": 45
       },
       "Q": {
-        "item": { "subtype": "collection", "//": "bulk casing on racks in the FoH", "entries": [ { "group": "ammo_casings_bulk" } ] },
+        "item": {
+          "subtype": "collection",
+          "//": "bulk casing on racks in the FoH",
+          "entries": [ { "group": "ammo_casings_gunsmith_bulk" } ]
+        },
         "chance": 25
       },
       "=": {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Separate unused casings from used casings pool"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Sometimes in the fields and roads, the game generates a human corpse and some ammo casings to realistically portray events that happened during the cataclysm.  Unused .22 casings were being spawned in these groups. It doesn't make sense that unused rimfire casings would be spawning here; used casings should spawn instead.

Fixes #63000
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This separates out the unused .22 casings from the pool of used casings into its own pool.  The use case for a separate pool was to allow gunsmith stores (`s_gun_4`) to have unused casings, as a gunsmith would realistically have primed casings available for sale.  Prepper garages use the same item group for ammo casings as gunsmith stores, so I let unused casings spawn there as well. Prepper garages can also spawn gunsmith's tools at the same rate; a prepper would also realistically be (or at least practicing) handloading ammo.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I thought about adding the unused casings directly to the `ammo_casings_bulk` item group, but I couldn't get the probability in a spot where casings were an uncommon enough spawn.  Adding more entries to the bulk casings group would throw off the rates. Also, custom mods may use that item group for situations where unused casings shouldn't be spawned.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
* Created a new world, debug spawned in `s_gun_4` and `house_garage_prepper` specials, verified unused casings spawned.
* Debug tested item group `field`, `forest`, `forest_trash` to ensure unused casings did not spawn.
* Debug tested item group `ammo_casings_gunsmith_bulk` to ensure unused casings were dropping at the same rates as a used .22 casing were before in `ammo_casings_bulk` (~2%).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
