### PR TITLE
item: fix category for contents without charges

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -275,20 +275,6 @@ struct scoped_goes_bad_cache {
 
 const int item::INFINITE_CHARGES = INT_MAX;
 
-namespace
-{
-
-bool contents_only_one_type( item const *it )
-{
-    std::list<const item *> const contents = it->all_items_top();
-    return contents.size() == 1 ||
-    std::all_of( ++contents.begin(), contents.end(), [&contents]( item const * e ) {
-        return e->stacks_with( *contents.front() );
-    } );
-}
-
-} // namespace
-
 item::item() : bday( calendar::start_of_cataclysm )
 {
     type = nullitem();
@@ -6412,7 +6398,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     }
 
     /* only expand full contents name if with_contents == true */
-    if( with_contents_full && !contents.empty() && contents_only_one_type( this ) ) {
+    if( with_contents_full && !contents.empty() && contents_only_one_type() ) {
         const item &contents_item = contents.first_item();
         const unsigned contents_count =
             ( ( contents_item.made_of( phase_id::LIQUID ) ||
@@ -12317,8 +12303,8 @@ const item_category &item::get_category_shallow() const
 
 const item_category &item::get_category_of_contents() const
 {
-    if( type->category_force == item_category_container && contents.num_item_stacks() == 1 ) {
-        return contents.only_item().get_category_of_contents();
+    if( type->category_force == item_category_container && contents_only_one_type() ) {
+        return contents.first_item().get_category_of_contents();
     } else {
         return this->get_category_shallow();
     }
@@ -14302,8 +14288,19 @@ std::list<item *> item::all_items_top( item_pocket::pocket_type pk_type, bool un
 
 item const *item::this_or_single_content() const
 {
-    return type->category_force == item_category_container && num_item_stacks() == 1 ? &only_item()
+    return type->category_force == item_category_container && contents_only_one_type()
+           ? &contents.first_item()
            : this;
+}
+
+bool item::contents_only_one_type() const
+{
+    std::list<const item *> const items = all_items_top();
+    return items.size() == 1 ||
+           ( items.size() > 1 &&
+    std::all_of( ++items.begin(), items.end(), [&items]( item const * e ) {
+        return e->stacks_with( *items.front() );
+    } ) );
 }
 
 std::list<const item *> item::all_items_ptr() const

--- a/src/item.h
+++ b/src/item.h
@@ -2721,6 +2721,7 @@ class item : public visitable
         std::list<item *> all_items_top( item_pocket::pocket_type pk_type, bool unloading = false );
 
         item const *this_or_single_content() const;
+        bool contents_only_one_type() const;
 
         /**
          * returns a list of pointers to all items inside recursively

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -30,6 +30,9 @@ static const flag_id json_flag_FILTHY( "FILTHY" );
 static const flag_id json_flag_FIX_NEARSIGHT( "FIX_NEARSIGHT" );
 static const flag_id json_flag_HOT( "HOT" );
 
+static const item_category_id item_category_container( "container" );
+static const item_category_id item_category_food( "food" );
+
 static const itype_id itype_test_backpack( "test_backpack" );
 static const itype_id itype_test_duffelbag( "test_duffelbag" );
 static const itype_id itype_test_mp3( "test_mp3" );
@@ -879,4 +882,23 @@ TEST_CASE( "rigid_splint_compliance", "[item][armor]" )
     // should be able to wear the arm is open
     REQUIRE( guy.wield( third_splint ) );
     REQUIRE( guy.wear( guy.used_weapon(), false ) );
+}
+
+TEST_CASE( "item_single_type_contents", "[item]" )
+{
+    item walnut( "walnut" );
+    item nail( "nail" );
+    item bag( "bag_plastic" );
+    REQUIRE( bag.get_category_of_contents().id == item_category_container );
+    int const num = GENERATE( 1, 2 );
+    bool ret = true;
+    for( int i = 0; i < num; i++ ) {
+        ret &= bag.put_in( walnut, item_pocket::pocket_type::CONTAINER ).success();
+    }
+    REQUIRE( ret );
+    CAPTURE( num, bag.display_name() );
+    CHECK( bag.get_category_of_contents() == *item_category_food );
+    REQUIRE( nail.get_category_of_contents().id != walnut.get_category_of_contents().id );
+    REQUIRE( bag.put_in( nail, item_pocket::pocket_type::CONTAINER ).success() );
+    CHECK( bag.get_category_of_contents().id == item_category_container );
 }

--- a/tests/npc_shopkeeper_item_groups_test.cpp
+++ b/tests/npc_shopkeeper_item_groups_test.cpp
@@ -113,11 +113,16 @@ TEST_CASE( "npc_shopkeeper_item_groups", "[npc][trade]" )
         }
     }
 
-    GIVEN( "containter with single item and conditions only for contents" ) {
+    GIVEN( "containter with single item type and conditions only for contents" ) {
         item multitool( "test_multitool" );
         item bag( "bag_plastic" );
-        ret_val<void> const ret = bag.put_in( multitool, item_pocket::pocket_type::CONTAINER );
-        REQUIRE( ret.success() );
+        int const num = GENERATE( 1, 2 );
+        bool ret = true;
+        for( int i = 0; i < num; i++ ) {
+            ret &= bag.put_in( multitool, item_pocket::pocket_type::CONTAINER ).success();
+        }
+        CAPTURE( num, bag.display_name() );
+        REQUIRE( ret );
         bag.set_owner( guy );
         item_location const loc( map_cursor{ tripoint_zero}, &bag );
         WHEN( "condition for contents not met" ) {

--- a/tests/zones_custom_test.cpp
+++ b/tests/zones_custom_test.cpp
@@ -24,7 +24,11 @@ TEST_CASE( "zones_custom", "[zones]" )
         item batt( "test_battery_disposable" );
         item bag_plastic( "bag_plastic" );
         item nested_batt( "test_battery_disposable" );
-        bag_plastic.put_in( nested_batt, item_pocket::pocket_type::CONTAINER );
+        int const num = GENERATE( 1, 2 );
+        for( int i = 0; i < num; i++ ) {
+            bag_plastic.put_in( nested_batt, item_pocket::pocket_type::CONTAINER );
+        }
+        CAPTURE( num, bag_plastic.display_name() );
 
         mapgen_place_zone( zone_loc + tripoint_north_west, zone_loc + tripoint_south_east,
                            zone_type_LOOT_CUSTOM, your_fac, {}, "completely unrelated overlap" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Containers with a single type of non-charged contents are treated as containers
Followup for #63579 to make it functional and not just visual
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Move `contents_only_one_type()` to `item` and use it for `get_category_of_contents()` and `this_or_single_content()` as well.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
New and updated test units

Before: plastic bag with spare parts is categorized as container and sorts in container zones
![Screenshot from 2023-02-21 09-51-44](https://user-images.githubusercontent.com/68240139/220285194-6c657e5d-a6ba-43a5-a9f8-c9e283e27008.png)
After: plastic bag with spare parts is categorized as spare parts and sorts in spare parts zones
![Screenshot from 2023-02-21 09-52-42](https://user-images.githubusercontent.com/68240139/220285286-3bfd6e43-04e6-4755-9799-b652a619c522.png)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This is mostly important for food containers after #60885, or bandage containers after #63434, but it has some uses already.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
