### PR TITLE
item: colorize medicine and healing tools

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5919,6 +5919,8 @@ nc_color item::color_in_inventory( const Character *const ch ) const
     } else if( ( active && !has_temperature() &&  !is_corpse() ) || ( is_corpse() && can_revive() ) ) {
         // Active items show up as yellow (corpses only if reviving)
         ret = c_yellow;
+    } else if( is_medication() || is_medical_tool() ) {
+        ret = c_light_blue;
     } else if( is_food() ) {
         // Give color priority to allergy (allergy > inedible by freeze or other conditions)
         // TODO: refactor u.will_eat to let this section handle coloring priority without duplicating code.
@@ -9763,6 +9765,11 @@ bool item::is_medication() const
         return false;
     }
     return get_comestible()->comesttype == "MED";
+}
+
+bool item::is_medical_tool() const
+{
+    return type->get_use( "heal" ) != nullptr;
 }
 
 bool item::is_brewable() const

--- a/src/item.h
+++ b/src/item.h
@@ -1474,6 +1474,7 @@ class item : public visitable
         bool is_food_container() const;      // Ignoring the ability to eat batteries, etc.
         bool is_ammo_container() const; // does this item contain ammo? (excludes magazines)
         bool is_medication() const;            // Is it a medication that only pretends to be food?
+        bool is_medical_tool() const;
         bool is_bionic() const;
         bool is_magazine() const;
         bool is_battery() const;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Followup for #63617 to add color to the last major item category without one: drugs
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Color drugs and healing tools light blue because it's a decent color with no real conflicts
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Color them orange because prescription bottles are orange: orange is not an ncurses color. Yellow is used for active items. Light yellow is brown and used for filthy items. Light red is used for ammo and books. Solid red is used for allergies and bad morale. And so on...

Color them light green because scrubs are light green and it's apparently the color of medicine: it's used for radioactive items.

Color them white because bandages are white: conflicts with favorite items. Kind of an eye sore IMO

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Before:
![Screenshot from 2023-02-21 10-33-25](https://user-images.githubusercontent.com/68240139/220291726-e120b588-cd25-45a2-b729-4c3d63769d99.png)

After:
![Screenshot from 2023-02-21 10-34-04](https://user-images.githubusercontent.com/68240139/220291760-f73950f4-390b-488d-95d0-63e59f8695cc.png)

Sometimes it can be surprising though:
![Screenshot from 2023-02-21 10-31-38](https://user-images.githubusercontent.com/68240139/220291800-ed5bd85f-6b7f-4b06-909d-ac98ed2ecbc6.png)
(cotton patch is a healing tool that stops bleeding)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
