### PR TITLE
Document automatic json linting when using Visual Studio

### DIFF
--- a/doc/JSON_STYLE.md
+++ b/doc/JSON_STYLE.md
@@ -64,7 +64,17 @@ commands to format all of the JSON in the project.
 1. Build the JsonFormatter project by either building the entire solution or
    just that project. This will create a `tools/format/json_formatter.exe`
    binary.
-2. Add a new external tool entry ( `Tools` > `External Tools..` > `Add` ) and
+2. To automatically lint json you need to define an MSBuild variable ( this is similar to setting up ccache in Visual Studio compiling doc ).
+If done correctly then trying to build or run the solution will trigger linter and the `Output` and `Error List` windows will show the linted files if any.
+One of the easier methods to do so is creating a `Directory.Build.props` file in the root of cataclysm project repository with the following contents:
+```xml
+<Project>
+  <PropertyGroup>
+    <CDDA_POST_BUILD_JSON_LINT>true</CDDA_POST_BUILD_JSON_LINT>
+  </PropertyGroup>
+</Project>
+```
+3. To add an entry to manually run the json linter tool; Add a new external tool entry ( `Tools` > `External Tools..` > `Add` ) and
    configure it as follows:
    * Title: `Lint All JSON`
    * Command: `C:\windows\system32\windowspowershell\v1.0\powershell.exe`


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Document the method to enable Visual Studio automatically trigger json linter on project build/run

#### Describe the solution

https://github.com/CleverRaven/Cataclysm-DDA/pull/61825 made the linting process fairly fast and added auto-linting trigger disabled behind an MSBuild variable.

I've tested it fairly well and I think others may prefer this over running it manually - this PR puts instructions on enabling the flag in the json style docs

#### Describe alternatives you've considered

#### Testing

Follow the described steps, when building or running the project should produce something similar to the screenshot below

#### Additional context

![image](https://user-images.githubusercontent.com/6560075/220378814-f634d26d-08d4-407f-9063-c2e613e72d27.png)
