### PR TITLE
debug/tgz: trim overmapbuffer in minimized archive

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -244,6 +244,10 @@ struct fake_tripoint { // NOLINT(cata-xy)
     int x = 0, y = 0, z = 0;
 };
 
+struct OM_point { // NOLINT(cata-xy)
+    int x = 0, y = 0;
+};
+
 std::istream &operator>>( std::istream &is, fake_tripoint &pos )
 {
     char c = 0;
@@ -251,16 +255,36 @@ std::istream &operator>>( std::istream &is, fake_tripoint &pos )
     return is;
 }
 
-tripoint _from_fs_string( const std::string &s )
+std::istream &operator>>( std::istream &is, OM_point &pos )
+{
+    char c = 0;
+    is >> pos.x &&is.get( c ) &&c == '.' &&is >> pos.y;
+    return is;
+}
+
+template<typename T>
+T _from_fs_string( std::string const &s )
 {
     std::istringstream is( s );
     is.imbue( std::locale::classic() );
-    fake_tripoint result;
+    T result;
     is >> result;
     if( !is ) {
-        return tripoint_zero;
+        return T{};
     }
-    return { result.x, result.y, result.z };
+    return result;
+}
+
+tripoint _from_map_string( std::string const &s )
+{
+    fake_tripoint const ft = _from_fs_string<fake_tripoint>( s );
+    return { ft.x, ft.y, ft.z };
+}
+
+tripoint _from_OM_string( std::string const &s )
+{
+    OM_point const om = _from_fs_string<OM_point>( s );
+    return { om.x, om.y, 0 };
 }
 
 using rdi_t = fs::recursive_directory_iterator;
@@ -292,17 +316,35 @@ bool _trim_mapbuffer( fs::path const &dep, rdi_t &iter, tripoint_range<tripoint>
 {
     // discard map memory outside of current region
     if( dep.parent_path().extension() == ".mm1" &&
-        _from_fs_string( dep.stem().string() ).xy() != reg ) {
+        _from_map_string( dep.stem().string() ).xy() != reg ) {
         return false;
     }
     // discard map buffer outside of current and adjacent segments
     if( dep.parent_path().filename() == "maps" &&
         !segs.is_point_inside(
-            tripoint{ _from_fs_string( dep.filename().string() ).xy(), 0 } ) ) {
+            tripoint{ _from_map_string( dep.filename().string() ).xy(), 0 } ) ) {
         iter.disable_recursion_pending();
         return false;
     }
     return true;
+}
+
+bool _trim_overmapbuffer( fs::path const &dep, tripoint_range<tripoint> const &oms )
+{
+    std::string const fname = dep.filename().generic_u8string();
+
+    std::string::size_type const seenpos = fname.find( ".seen." );
+    if( seenpos != std::string::npos ) {
+        return oms.is_point_inside( _from_OM_string( fname.substr( seenpos + 6 ) ) );
+    }
+
+    return fname.size() < 4 || fname[0] != 'o' || fname[1] != '.' ||
+           oms.is_point_inside( _from_OM_string( fname.substr( 2 ) ) );
+}
+
+bool _discard_temporary( fs::path const &dep )
+{
+    return !dep.has_extension() || dep.extension() != ".temp";
 }
 
 void write_min_archive()
@@ -311,14 +353,17 @@ void write_min_archive()
     tripoint_range<tripoint> const segs = points_in_radius( seg.raw(), 1 );
     point sm = project_to<coords::sm>( get_avatar().get_location() ).raw().xy();
     point const reg = sm_to_mmr_remain( sm.x, sm.y );
+    tripoint_abs_om const om = project_to<coords::om>( get_avatar().get_location() );
+    tripoint_range<tripoint> const oms = points_in_radius( tripoint{ om.raw().xy(), 0 }, 1 );
 
     fs::path const save_root( PATH_INFO::world_base_save_path_path() );
     std::string const ofile = save_root.string() + "-trimmed.tar.gz";
 
     tgz_archiver tgz( ofile );
 
-    f_validate_t const mb_validate = [&segs, &reg]( fs::path const & dep, rdi_t & iter ) {
-        return _trim_mapbuffer( dep, iter, segs, reg );
+    f_validate_t const mb_validate = [&segs, &reg, &oms]( fs::path const & dep, rdi_t & iter ) {
+        return _discard_temporary( dep ) && _trim_mapbuffer( dep, iter, segs, reg ) &&
+               _trim_overmapbuffer( dep, oms );
     };
 
     if( _add_dir( tgz, save_root, mb_validate ) &&

--- a/src/tgz_archiver.cpp
+++ b/src/tgz_archiver.cpp
@@ -8,6 +8,7 @@
 #include <numeric>
 #include <sstream>
 
+#include "debug.h"
 #include "filesystem.h"
 #include "zlib.h"
 
@@ -16,21 +17,22 @@ tgz_archiver::~tgz_archiver()
     finalize();
 }
 
-std::string tgz_archiver::_gen_tar_header( char const *name,
-        fs::directory_entry const &path )
+std::string tgz_archiver::_gen_tar_header( fs::path const &file_name, fs::path const &prefix,
+        fs::path const &real_path )
 {
-    unsigned const size = path.is_regular_file() ? path.file_size() : 0;
-    unsigned const type = path.is_directory() ? 5 : 0;
-    unsigned const perms = path.is_directory() ? 0775 : 0664;
+    unsigned const size = fs::is_regular_file( real_path ) ? fs::file_size( real_path ) : 0;
+    unsigned const type = fs::is_directory( real_path ) ? 5 : 0;
+    unsigned const perms = fs::is_directory( real_path ) ? 0775 : 0664;
     // https://stackoverflow.com/a/61067330
-    std::time_t const mtime = std::chrono::system_clock::to_time_t(
+    std::time_t const mtime = !fs::is_symlink( real_path ) || fs::exists( real_path )
+                              ? std::chrono::system_clock::to_time_t(
                                   std::chrono::time_point_cast<std::chrono::system_clock::duration>(
-                                      path.last_write_time() - _fsnow + _sysnow ) );
+                                      fs::last_write_time( real_path ) - _fsnow + _sysnow ) ) : std::time_t{};
 
     std::string buf( tar_block_size, '\0' );
     std::ostringstream ss( buf );
     ss.imbue( std::locale::classic() );
-    ss << name;
+    ss << file_name.generic_u8string();
     ss.seekp( 100 );
     ss << std::oct << std::setfill( '0' );
     ss << std::setw( 7 ) << perms << '\0';
@@ -42,6 +44,8 @@ std::string tgz_archiver::_gen_tar_header( char const *name,
     ss << type;
     ss.seekp( 257 );
     ss << "ustar" << '\0' << "00";
+    ss.seekp( 345 );
+    ss << prefix.generic_u8string();
     std::string const tmp = ss.str();
     unsigned const checksum = std::accumulate( tmp.cbegin(), tmp.cend(), 0 );
     ss.seekp( 148 );
@@ -55,11 +59,36 @@ bool tgz_archiver::add_file( fs::path const &real_path, fs::path const &archived
         return false;
     }
 
-    fs::directory_entry const de( real_path );
-    std::string const header = _gen_tar_header( archived_path.generic_u8string().c_str(), de );
+    std::size_t const archived_path_size = archived_path.generic_u8string().size();
+    std::size_t const prefix_len = archived_path_size > 100 ? archived_path_size - 100 : 0;
+
+    if( archived_path.filename().generic_u8string().size() > 100 ||
+        prefix_len > 150 ) {
+        DebugLog( DebugLevel::D_WARNING, DebugClass::D_MAIN )
+                << "file skipped (path too long): " << archived_path << std::endl;
+        return false;
+    }
+
+    fs::path prefix;
+    fs::path file_name;
+    if( prefix_len > 0 ) {
+        std::size_t len = 0;
+        for( fs::path const &it : archived_path ) {
+            prefix /= it;
+            len += it.generic_u8string().size() + 1;
+            if( len >= prefix_len ) {
+                break;
+            }
+        }
+        file_name = archived_path.lexically_relative( prefix );
+    } else {
+        file_name = archived_path;
+    }
+
+    std::string const header = _gen_tar_header( file_name, prefix, real_path );
     bool ret = gzwrite( fd, header.c_str(), tar_block_size ) != 0;
 
-    if( !ret || !de.is_regular_file() ) {
+    if( !ret || !fs::is_regular_file( real_path ) ) {
         return ret;
     }
 

--- a/src/tgz_archiver.h
+++ b/src/tgz_archiver.h
@@ -13,7 +13,8 @@ class tgz_archiver
     private:
         static constexpr std::size_t tar_block_size = 512;
         using tar_block_t = std::array<char, tar_block_size>;
-        std::string _gen_tar_header( char const *name, fs::directory_entry const &path );
+        std::string _gen_tar_header( fs::path const &file_name, fs::path const &prefix,
+                                     fs::path const &real_path );
 
         gzFile fd = nullptr;
         std::string const output;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The debug minimized archive is not trimmed enough for long-running games - specifically the overmap is not trimmed at all.

Some edge cases aren't handled correctly: broken symlinks and paths longer than 100 chars.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Trim the overmap buffer to current and adjacent overmaps and drop temporary files too.

Handle the edge cases even though we're unlikely to see them occur naturally.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The save folder from #63715 packs to a file smaller than 25Mb (~15Mb in this case). Verify that the visible overmap looks the same on reload.

Game doesn't crash when packing a save folder with broken symlinks.

Really long (100+ chars) paths and filenames are handled correctly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
