### PR TITLE
Exodii quadruped fixes

### DIFF
--- a/data/json/monster_special_attacks/weapon_spells.json
+++ b/data/json/monster_special_attacks/weapon_spells.json
@@ -57,7 +57,7 @@
     "name": { "str": "Exodii Multipurpose Weapon Pod" },
     "description": "Randomly selects one of several weapons.",
     "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "NO_EXPLOSION_SFX" ],
+    "flags": [ "NO_EXPLOSION_SFX", "WONDER" ],
     "effect": "attack",
     "shape": "blast",
     "base_casting_time": 200,

--- a/data/json/monsters/cyborgs.json
+++ b/data/json/monsters/cyborgs.json
@@ -166,7 +166,7 @@
       {
         "type": "spell",
         "spell_data": { "id": "exodii_weapon_pod", "min_level": 1 },
-        "cooldown": 200,
+        "cooldown": 2,
         "monster_message": "The Exodii quadruped fires its weapon pod!"
       },
       {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone in discord mentioned error
#### Describe the solution
Added `WONDER` flag to exodii quadruped melee attack - the game thought its an attacking spell, and yelled it has no damage type. Also, instead of "pick one and shoot" type of attack, lack of flag caused the game to shoot whole arsenal at once. It was not a problem though, because..
Decreased `cooldown` of attack from 200 (3,5 minutes) to 2 (2 seconds)
#### Testing
Now this thing is not afraid of melee, yeah