### PR TITLE
Fix "detect translation file changes" workflow

### DIFF
--- a/.github/workflows/detect-translation-file-changes.yml
+++ b/.github/workflows/detect-translation-file-changes.yml
@@ -2,9 +2,7 @@ name: Detect translation file changes
 
 
 on:
-  pull_request:
-    branches:
-      - master
+  pull_request_target:
     paths:
       - lang/po/*.po
       - lang/po/*.pot


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes the "detect translation file changes" workflow. Closes #59029.

#### Describe the solution
Use `pull_request_target` instead of `pull_request` event to run the workflow.

#### Describe alternatives you've considered

#### Testing
https://github.com/Qrox/Cataclysm-DDA/pull/8 does not have the skip phrase so a comment was added automatically.

https://github.com/Qrox/Cataclysm-DDA/pull/9 has the skip phrase so no comment was added.

The changes in these PRs included a new line of logging code which was not executed in the respective workflows so the workflows were indeed run on the target branch instead of the PR branch, which means the workflows should not require approval for new contributers anymore.

#### Additional context
