### PR TITLE
Fix vehicle::discharge_battery charging

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5280,12 +5280,12 @@ int vehicle::discharge_battery( int amount, bool recurse )
     while( amount > 0 && !dischargeable_parts.empty() ) {
         // Grab first part, discharge until it reaches the next %, then re-insert with new % key.
         auto iter = std::prev( dischargeable_parts.end() );
-        int charge_level = iter->first;
+        const int prev_charge_level = iter->first - 1;
         vehicle_part *p = iter->second;
         dischargeable_parts.erase( iter );
         // Calculate number of charges to reach the previous %.
-        int prev_charge_level = ( ( charge_level - 1 ) * p->ammo_capacity( ammo_battery ) ) / 100;
-        int amount_to_discharge = std::min( p->ammo_remaining() - prev_charge_level, amount );
+        int prev_charge_amount = std::max( 0, prev_charge_level * p->ammo_capacity( ammo_battery ) ) / 100;
+        int amount_to_discharge = std::min( p->ammo_remaining() - prev_charge_amount, amount );
         p->ammo_consume( amount_to_discharge, global_part_pos3( *p ) );
         amount -= amount_to_discharge;
         if( p->ammo_remaining() > 0 ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fi*es https://github.com/CleverRaven/Cataclysm-DDA/issues/63649

Not sure this should close the issue as I couldn't replicate the `Tops empty large storage battery after 1-2 uses of oven` part
The only battery charge increases I seen happens at the first call to "use oven", using oven again doesn't affect charge

andrei8l's confirmation video shows the fixed issue as well - ~400 charges on a 100000 capacity battery is under 1%, going to over 1% after using oven, but repeatedly trying to use oven doesn't seem to "top" a storage battery

#### Describe the solution

There's an odd mechanic where battery charge is attempted to keep "even" when charging/discharging and jumping across connected vehicles, when charge is very low ~0% the code underflows and instead returns charges for -1%

"using" oven or water purifier does the pseudo-battery discharge-charge-remainder dance which triggers this behavior

This PR clamps the charges value to 0 minimum so it's not going negative and producing charge instead

#### Describe alternatives you've considered

#### Testing

Load attached save, use water purifier or oven - see battery charge rises by around 500~1000 kJ (depending on which battery is connected)
Apply patch - repeat, there should be no extra battery charge appearing

#### Additional context
[Test AFS Mgc XED_copy.zip](https://github.com/CleverRaven/Cataclysm-DDA/files/10806562/Test.AFS.Mgc.XED_copy.zip)

