### PR TITLE
Drag much heavier vehicles

### DIFF
--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -79,18 +79,19 @@ bool game::grabbed_veh_move( const tripoint &dp )
 
     //vehicle movement: strength check
     int mc = 0;
-    int str_req = grabbed_vehicle->total_mass() / 25_kilogram; //strength required to move vehicle.
+    int str_req = grabbed_vehicle->total_mass() / 75_kilogram; //strength required to move vehicle.
+    
     // ARM_STR governs dragging heavy things
     int str = u.get_arm_str();
 
     //if vehicle is rollable we modify str_req based on a function of movecost per wheel.
 
-    // Vehicle just too big to grab & move; 41-45 lets folks have a bit of a window
-    // (Roughly 1.1K kg = danger zone; cube vans are about the max)
-    if( str_req > 45 ) {
+    // Very strong humans can even drag multiple fire trucks around, but orientation would be difficult.
+    // hard limit of 5000 kg here since mutants, hydraulic muscles, artifacts etc can get str quite high
+    if( str_req > 66 ) {
         add_msg( m_info, _( "The %s is too bulky for you to move by hand." ),
                  grabbed_vehicle->name );
-        return true; // No shoving around an RV.
+        return true; // No shoving around an APC.
     }
 
     const auto &wheel_indices = grabbed_vehicle->wheelcache;
@@ -110,7 +111,8 @@ bool game::grabbed_veh_move( const tripoint &dp )
             str_req = mc / wheel_indices.size() + 1;
         }
     } else {
-        str_req++;
+        //massive penalty if it doesn't have wheels
+        str_req*=4;
         //if vehicle has no wheels str_req make a noise.
         if( str_req <= str ) {
             sounds::sound( grabbed_vehicle->global_pos3(), str_req * 2, sounds::sound_t::movement,
@@ -125,7 +127,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
         ///\EFFECT_STR increases speed of dragging vehicles
         u.moves -= 100 * str_req / std::max( 1, str );
         const int ex = dice( 1, 3 ) - 1 + str_req;
-        if( ex > str + 1 ) {
+        if( ex > str + 3 ) {
             // Pain and movement penalty if exertion exceeds character strength
             add_msg( m_bad, _( "You strain yourself to move the %s!" ), grabbed_vehicle->name );
             u.moves -= 200;

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -80,7 +80,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
     //vehicle movement: strength check
     int mc = 0;
     int str_req = grabbed_vehicle->total_mass() / 75_kilogram; //strength required to move vehicle.
-    
+
     // ARM_STR governs dragging heavy things
     int str = u.get_arm_str();
 
@@ -112,7 +112,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
         }
     } else {
         //massive penalty if it doesn't have wheels
-        str_req*=4;
+        str_req *= 4;
         //if vehicle has no wheels str_req make a noise.
         if( str_req <= str ) {
             sounds::sound( grabbed_vehicle->global_pos3(), str_req * 2, sounds::sound_t::movement,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "You can drag heavier vehicles"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Vehicle weight drag limits were unrealistically low. There was also a hardcoded limit to max weight that was too easy to reach.
https://www.thearmwrestlingarchives.com/the-origin-of-the-wheelbarrow-contest.html
The article linked involves moving a wheelbarrow full of lead ingots over 25 feet without the wheelbarrow tipping over. This is an ideal scenario to map in-game vehicles to real life as the wheelbarrow has to be lifted and kept steady, thus giving us a "worst case" scenario as a wagon or a shopping cart would be much easier.
Vehicles in neutral are extremely easy to move also. While it's not as easy to actually angle the direction of a vehicle, the wheelbarrow example means you have to be able to lift one end of the vehicle you are dragging so it presents a sane limit (pick up the car by the bumper and rotate it just as you would a wheelbarrow full of lead) 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The heaviest wheelbarrow pushed in the above example was over 4,000 lbs, though I'll lower it to 3,000 to account for more sustainable action and possible bumpy terrain. If we assume that person is a 20 strength individual then that would give us a required_strength of (vehicle weight in kg) / 75 instead of the current (vehicle weight in kg) / 25. There are examples in the article of people moving lighter loads (2,000 lbs) over as much as 1/3 a mile. In the extremely likely event that person is not 20 strength, it would be an even more generous formula such as (vehicle weight in kg)  / 100 or (vehicle weight in kg)  / 150 and I think there's a strong case to be made that should be the case especially if 20 is no longer the literal human limit.

 I also raised the max weight of vehicles from 1000 kg to 5000 kg. People in real life can drag firetrucks behind them so 1000 kg was absurdly low. 
 
 I also raised the range in which you can barely drag the vehicle, previously it was only 1 str point, now it is 3 str points of room to get slowdown while dragging a vehicle.
 
 Finally whether a vehicle had wheels or not had very little effect on whether it was draggable, only causing the strength requirement to increase by 1. I changed this to being 4x the strength requirement because wheels make a massive difference in your ability to move heavy loads.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Increase the strength limit even more.
Implement a more granular and harsher slowdown since the people moving 3000 lbs of lead in a wheelbarrow weren't moving very quickly. In game you'd be moving about 1 mph assuming you could barely move the vehicle.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested this out and confirmed the new weight limits are working as intended.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
