### PR TITLE
Add real dark gray from the 256 color palette

### DIFF
--- a/src/color.cpp
+++ b/src/color.cpp
@@ -511,7 +511,6 @@ void init_colors()
     init_pair( 86, yellow,     dark_gray );
     init_pair( 87, white,      dark_gray );
 
-
     all_colors.load_default();
     all_colors.load_custom( {} );
 

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -384,8 +384,7 @@ void color_manager::load_default()
                def_c_light_cyan_cyan );
 
     // Allow real dark gray for terminals that support it
-    // TODO add settings toggle
-    if (true) {
+    if (enable_256_colors) {
         add_color( def_c256_dark_gray_red, "c_dark_gray_red", color_pair( 73 ), def_c256_red_dark_gray );
         add_color( def_c256_dark_gray_blue, "h_dark_gray", color_pair( 75 ), def_c256_blue_dark_gray );
         add_color( def_c256_dark_gray_black, "c_dark_gray", color_pair( 72 ), def_c256_dark_gray_black );

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -213,11 +213,12 @@ void color_manager::load_default()
     static const auto color_pair = []( const int n ) {
         return nc_color::from_color_pair_index( n );
     };
+
     //        Color         Name      Color Pair      Invert
     add_color( def_c_black, "c_black", color_pair( 30 ), def_i_black );
     add_color( def_c_white, "c_white", color_pair( 1 ).bold(), def_i_white );
     add_color( def_c_light_gray, "c_light_gray", color_pair( 1 ), def_i_light_gray );
-    add_color( def_c_dark_gray, "c_dark_gray", color_pair( 30 ).bold(), def_i_dark_gray );
+
     add_color( def_c_red, "c_red", color_pair( 2 ), def_i_red );
     add_color( def_c_green, "c_green", color_pair( 3 ), def_i_green );
     add_color( def_c_blue, "c_blue", color_pair( 4 ), def_i_blue );
@@ -234,7 +235,6 @@ void color_manager::load_default()
     add_color( def_h_black, "h_black", color_pair( 20 ), def_c_blue );
     add_color( def_h_white, "h_white", color_pair( 15 ).bold(), def_c_light_blue_white );
     add_color( def_h_light_gray, "h_light_gray", color_pair( 15 ), def_c_blue_white );
-    add_color( def_h_dark_gray, "h_dark_gray", color_pair( 20 ).bold(), def_c_light_blue );
     add_color( def_h_red, "h_red", color_pair( 16 ), def_c_blue_red );
     add_color( def_h_green, "h_green", color_pair( 17 ), def_c_blue_green );
     add_color( def_h_blue, "h_blue", color_pair( 20 ), def_h_blue );
@@ -265,10 +265,9 @@ void color_manager::load_default()
     add_color( def_i_pink, "i_pink", color_pair( 13 ).blink(), def_c_pink );
     add_color( def_i_yellow, "i_yellow", color_pair( 14 ).blink(), def_c_yellow );
 
-    add_color( def_c_black_red, "c_black_red", color_pair( 9 ).bold(), def_c_red );
+    add_color( def_c_black_red, "c_black_red", color_pair( 9 ), def_c_red );
     add_color( def_c_white_red, "c_white_red", color_pair( 23 ).bold(), def_c_red_white );
     add_color( def_c_light_gray_red, "c_light_gray_red", color_pair( 23 ), def_c_light_red_white );
-    add_color( def_c_dark_gray_red, "c_dark_gray_red", color_pair( 9 ), def_c_dark_gray_red );
     add_color( def_c_red_red, "c_red_red", color_pair( 9 ), def_c_red_red );
     add_color( def_c_green_red, "c_green_red", color_pair( 25 ), def_c_red_green );
     add_color( def_c_blue_red, "c_blue_red", color_pair( 26 ), def_h_red );
@@ -287,7 +286,6 @@ void color_manager::load_default()
     add_color( def_c_unset, "c_unset", color_pair( 31 ), def_c_unset );
 
     add_color( def_c_black_white, "c_black_white", color_pair( 32 ), def_c_light_gray );
-    add_color( def_c_dark_gray_white, "c_dark_gray_white", color_pair( 32 ).bold(), def_c_white );
     add_color( def_c_light_gray_white, "c_light_gray_white", color_pair( 33 ), def_c_light_gray_white );
     add_color( def_c_white_white, "c_white_white", color_pair( 33 ).bold(), def_c_white_white );
     add_color( def_c_red_white, "c_red_white", color_pair( 34 ), def_c_white_red );
@@ -307,7 +305,6 @@ void color_manager::load_default()
                def_c_white_cyan );
 
     add_color( def_c_black_green, "c_black_green", color_pair( 40 ), def_c_green );
-    add_color( def_c_dark_gray_green, "c_dark_gray_green", color_pair( 40 ).bold(), def_c_light_green );
     add_color( def_c_light_gray_green, "c_light_gray_green", color_pair( 41 ), def_c_green_white );
     add_color( def_c_white_green, "c_white_green", color_pair( 41 ).bold(), def_c_light_green_white );
     add_color( def_c_red_green, "c_red_green", color_pair( 42 ), def_c_green_red );
@@ -329,7 +326,6 @@ void color_manager::load_default()
                def_c_light_green_cyan );
 
     add_color( def_c_black_yellow, "c_black_yellow", color_pair( 48 ), def_c_brown );
-    add_color( def_c_dark_gray_yellow, "c_dark_gray_yellow", color_pair( 48 ).bold(), def_c_yellow );
     add_color( def_c_light_gray_yellow, "c_light_gray_yellow", color_pair( 49 ), def_c_brown_white );
     add_color( def_c_white_yellow, "c_white_yellow", color_pair( 49 ).bold(), def_c_yellow_white );
     add_color( def_c_red_yellow, "c_red_yellow", color_pair( 50 ), def_c_yellow_red );
@@ -349,7 +345,6 @@ void color_manager::load_default()
                def_c_yellow_cyan );
 
     add_color( def_c_black_magenta, "c_black_magenta", color_pair( 56 ), def_c_magenta );
-    add_color( def_c_dark_gray_magenta, "c_dark_gray_magenta", color_pair( 56 ).bold(), def_c_pink );
     add_color( def_c_light_gray_magenta, "c_light_gray_magenta", color_pair( 57 ),
                def_c_magenta_white );
     add_color( def_c_white_magenta, "c_white_magenta", color_pair( 57 ).bold(), def_c_pink_white );
@@ -370,7 +365,6 @@ void color_manager::load_default()
                def_c_pink_cyan );
 
     add_color( def_c_black_cyan, "c_black_cyan", color_pair( 64 ), def_c_cyan );
-    add_color( def_c_dark_gray_cyan, "c_dark_gray_cyan", color_pair( 64 ).bold(), def_c_light_cyan );
     add_color( def_c_light_gray_cyan, "c_light_gray_cyan", color_pair( 65 ), def_c_cyan_white );
     add_color( def_c_white_cyan, "c_white_cyan", color_pair( 65 ).bold(), def_c_light_cyan_white );
     add_color( def_c_red_cyan, "c_red_cyan", color_pair( 66 ), def_c_cyan_red );
@@ -388,6 +382,29 @@ void color_manager::load_default()
     add_color( def_c_cyan_cyan, "c_cyan_cyan", color_pair( 71 ), def_c_cyan_cyan );
     add_color( def_c_light_cyan_cyan, "c_light_cyan_cyan", color_pair( 71 ).bold(),
                def_c_light_cyan_cyan );
+
+    // Allow real dark gray for terminals that support it
+    // TODO add settings toggle
+    if (true) {
+        add_color( def_c256_dark_gray_red, "c_dark_gray_red", color_pair( 73 ), def_c256_red_dark_gray );
+        add_color( def_c256_dark_gray_blue, "h_dark_gray", color_pair( 75 ), def_c256_blue_dark_gray );
+        add_color( def_c256_dark_gray_black, "c_dark_gray", color_pair( 72 ), def_c256_dark_gray_black );
+        add_color( def_c256_dark_gray_white, "c_dark_gray_white", color_pair( 79 ), def_c256_white_dark_gray );
+        add_color( def_c256_dark_gray_green, "c_dark_gray_green", color_pair( 74 ), def_c256_green_dark_gray );
+        add_color( def_c256_dark_gray_yellow, "c_dark_gray_yellow", color_pair( 78 ), def_c256_yellow_dark_gray );
+        add_color( def_c256_dark_gray_magenta, "c_dark_gray_magenta", color_pair( 77 ), def_c256_magenta_dark_gray );
+        add_color( def_c256_dark_gray_cyan, "c_dark_gray_cyan", color_pair( 76 ), def_c256_cyan_dark_gray );
+    }
+    else {
+        add_color( def_c_dark_gray_red, "c_dark_gray_red", color_pair( 9 ).bold(), def_c_dark_gray_red );
+        add_color( def_h_dark_gray, "h_dark_gray", color_pair( 20 ).bold(), def_c_light_blue );
+        add_color( def_c_dark_gray, "c_dark_gray", color_pair( 30 ).bold(), def_i_dark_gray );
+        add_color( def_c_dark_gray_white, "c_dark_gray_white", color_pair( 32 ).bold(), def_c_white );
+        add_color( def_c_dark_gray_green, "c_dark_gray_green", color_pair( 40 ).bold(), def_c_light_green );
+        add_color( def_c_dark_gray_yellow, "c_dark_gray_yellow", color_pair( 48 ).bold(), def_c_yellow );
+        add_color( def_c_dark_gray_magenta, "c_dark_gray_magenta", color_pair( 56 ).bold(), def_c_pink );
+        add_color( def_c_dark_gray_cyan, "c_dark_gray_cyan", color_pair( 64 ).bold(), def_c_light_cyan );
+    }
 }
 
 void init_colors()
@@ -476,6 +493,24 @@ void init_colors()
     init_pair( 69, blue,       cyan );
     init_pair( 70, magenta,    cyan );
     init_pair( 71, cyan,       cyan );
+
+    init_pair( 72, dark_gray,  black   );
+    init_pair( 73, dark_gray,  red     );
+    init_pair( 74, dark_gray,  green   );
+    init_pair( 75, dark_gray,  blue    );
+    init_pair( 76, dark_gray,  cyan    );
+    init_pair( 77, dark_gray,  magenta );
+    init_pair( 78, dark_gray,  yellow  );
+    init_pair( 79, dark_gray,  white   );
+    init_pair( 80, black,      dark_gray );
+    init_pair( 81, red,        dark_gray );
+    init_pair( 82, green,      dark_gray );
+    init_pair( 83, blue,       dark_gray );
+    init_pair( 84, cyan,       dark_gray );
+    init_pair( 85, magenta,    dark_gray );
+    init_pair( 86, yellow,     dark_gray );
+    init_pair( 87, white,      dark_gray );
+
 
     all_colors.load_default();
     all_colors.load_custom( {} );

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -384,17 +384,20 @@ void color_manager::load_default()
                def_c_light_cyan_cyan );
 
     // Allow real dark gray for terminals that support it
-    if (enable_256_colors) {
+    if( enable_256_colors ) {
         add_color( def_c256_dark_gray_red, "c_dark_gray_red", color_pair( 73 ), def_c256_red_dark_gray );
         add_color( def_c256_dark_gray_blue, "h_dark_gray", color_pair( 75 ), def_c256_blue_dark_gray );
         add_color( def_c256_dark_gray_black, "c_dark_gray", color_pair( 72 ), def_c256_dark_gray_black );
-        add_color( def_c256_dark_gray_white, "c_dark_gray_white", color_pair( 79 ), def_c256_white_dark_gray );
-        add_color( def_c256_dark_gray_green, "c_dark_gray_green", color_pair( 74 ), def_c256_green_dark_gray );
-        add_color( def_c256_dark_gray_yellow, "c_dark_gray_yellow", color_pair( 78 ), def_c256_yellow_dark_gray );
-        add_color( def_c256_dark_gray_magenta, "c_dark_gray_magenta", color_pair( 77 ), def_c256_magenta_dark_gray );
+        add_color( def_c256_dark_gray_white, "c_dark_gray_white", color_pair( 79 ),
+                   def_c256_white_dark_gray );
+        add_color( def_c256_dark_gray_green, "c_dark_gray_green", color_pair( 74 ),
+                   def_c256_green_dark_gray );
+        add_color( def_c256_dark_gray_yellow, "c_dark_gray_yellow", color_pair( 78 ),
+                   def_c256_yellow_dark_gray );
+        add_color( def_c256_dark_gray_magenta, "c_dark_gray_magenta", color_pair( 77 ),
+                   def_c256_magenta_dark_gray );
         add_color( def_c256_dark_gray_cyan, "c_dark_gray_cyan", color_pair( 76 ), def_c256_cyan_dark_gray );
-    }
-    else {
+    } else {
         add_color( def_c_dark_gray_red, "c_dark_gray_red", color_pair( 9 ).bold(), def_c_dark_gray_red );
         add_color( def_h_dark_gray, "h_dark_gray", color_pair( 20 ).bold(), def_c_light_blue );
         add_color( def_c_dark_gray, "c_dark_gray", color_pair( 30 ).bold(), def_i_dark_gray );
@@ -493,14 +496,14 @@ void init_colors()
     init_pair( 70, magenta,    cyan );
     init_pair( 71, cyan,       cyan );
 
-    init_pair( 72, dark_gray,  black   );
-    init_pair( 73, dark_gray,  red     );
-    init_pair( 74, dark_gray,  green   );
-    init_pair( 75, dark_gray,  blue    );
-    init_pair( 76, dark_gray,  cyan    );
+    init_pair( 72, dark_gray,  black );
+    init_pair( 73, dark_gray,  red );
+    init_pair( 74, dark_gray,  green );
+    init_pair( 75, dark_gray,  blue );
+    init_pair( 76, dark_gray,  cyan );
     init_pair( 77, dark_gray,  magenta );
-    init_pair( 78, dark_gray,  yellow  );
-    init_pair( 79, dark_gray,  white   );
+    init_pair( 78, dark_gray,  yellow );
+    init_pair( 79, dark_gray,  white );
     init_pair( 80, black,      dark_gray );
     init_pair( 81, red,        dark_gray );
     init_pair( 82, green,      dark_gray );

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -251,7 +251,6 @@ void color_manager::load_default()
     add_color( def_i_black, "i_black", color_pair( 32 ), def_c_black );
     add_color( def_i_white, "i_white", color_pair( 8 ).blink(), def_c_white );
     add_color( def_i_light_gray, "i_light_gray", color_pair( 8 ), def_c_light_gray );
-    add_color( def_i_dark_gray, "i_dark_gray", color_pair( 32 ).blink(), def_c_dark_gray );
     add_color( def_i_red, "i_red", color_pair( 9 ), def_c_red );
     add_color( def_i_green, "i_green", color_pair( 10 ), def_c_green );
     add_color( def_i_blue, "i_blue", color_pair( 11 ), def_c_blue );
@@ -385,22 +384,20 @@ void color_manager::load_default()
 
     // Allow real dark gray for terminals that support it
     if( catacurses::supports_256_colors() ) {
-        add_color( def_c256_dark_gray_red, "c_dark_gray_red", color_pair( 73 ), def_c256_red_dark_gray );
-        add_color( def_c256_dark_gray_blue, "h_dark_gray", color_pair( 75 ), def_c256_blue_dark_gray );
-        add_color( def_c256_dark_gray_black, "c_dark_gray", color_pair( 72 ), def_c256_dark_gray_black );
-        add_color( def_c256_dark_gray_white, "c_dark_gray_white", color_pair( 79 ),
-                   def_c256_white_dark_gray );
-        add_color( def_c256_dark_gray_green, "c_dark_gray_green", color_pair( 74 ),
-                   def_c256_green_dark_gray );
-        add_color( def_c256_dark_gray_yellow, "c_dark_gray_yellow", color_pair( 78 ),
-                   def_c256_yellow_dark_gray );
-        add_color( def_c256_dark_gray_magenta, "c_dark_gray_magenta", color_pair( 77 ),
-                   def_c256_magenta_dark_gray );
-        add_color( def_c256_dark_gray_cyan, "c_dark_gray_cyan", color_pair( 76 ), def_c256_cyan_dark_gray );
+        add_color( def_c_dark_gray, "c_dark_gray", color_pair( 72 ), def_i_dark_gray );
+        add_color( def_h_dark_gray, "h_dark_gray", color_pair( 75 ), def_c_light_blue );
+        add_color( def_i_dark_gray, "i_dark_gray", color_pair( 79 ).blink(), def_c_dark_gray );
+        add_color( def_c_dark_gray_red, "c_dark_gray_red", color_pair( 73 ), def_c_dark_gray_red );
+        add_color( def_c_dark_gray_white, "c_dark_gray_white", color_pair( 79 ), def_c_white );
+        add_color( def_c_dark_gray_green, "c_dark_gray_green", color_pair( 74 ), def_c_light_green );
+        add_color( def_c_dark_gray_yellow, "c_dark_gray_yellow", color_pair( 78 ), def_c_yellow );
+        add_color( def_c_dark_gray_magenta, "c_dark_gray_magenta", color_pair( 77 ), def_c_pink );
+        add_color( def_c_dark_gray_cyan, "c_dark_gray_cyan", color_pair( 76 ), def_c_light_cyan );
     } else {
-        add_color( def_c_dark_gray_red, "c_dark_gray_red", color_pair( 9 ).bold(), def_c_dark_gray_red );
-        add_color( def_h_dark_gray, "h_dark_gray", color_pair( 20 ).bold(), def_c_light_blue );
         add_color( def_c_dark_gray, "c_dark_gray", color_pair( 30 ).bold(), def_i_dark_gray );
+        add_color( def_h_dark_gray, "h_dark_gray", color_pair( 20 ).bold(), def_c_light_blue );
+        add_color( def_i_dark_gray, "i_dark_gray", color_pair( 32 ).blink(), def_c_dark_gray );
+        add_color( def_c_dark_gray_red, "c_dark_gray_red", color_pair( 9 ).bold(), def_c_dark_gray_red );
         add_color( def_c_dark_gray_white, "c_dark_gray_white", color_pair( 32 ).bold(), def_c_white );
         add_color( def_c_dark_gray_green, "c_dark_gray_green", color_pair( 40 ).bold(), def_c_light_green );
         add_color( def_c_dark_gray_yellow, "c_dark_gray_yellow", color_pair( 48 ).bold(), def_c_yellow );

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -265,7 +265,7 @@ void color_manager::load_default()
     add_color( def_i_pink, "i_pink", color_pair( 13 ).blink(), def_c_pink );
     add_color( def_i_yellow, "i_yellow", color_pair( 14 ).blink(), def_c_yellow );
 
-    add_color( def_c_black_red, "c_black_red", color_pair( 9 ), def_c_red );
+    add_color( def_c_black_red, "c_black_red", color_pair( 9 ).bold(), def_c_red );
     add_color( def_c_white_red, "c_white_red", color_pair( 23 ).bold(), def_c_red_white );
     add_color( def_c_light_gray_red, "c_light_gray_red", color_pair( 23 ), def_c_light_red_white );
     add_color( def_c_red_red, "c_red_red", color_pair( 9 ), def_c_red_red );
@@ -388,14 +388,10 @@ void color_manager::load_default()
         add_color( def_c256_dark_gray_red, "c_dark_gray_red", color_pair( 73 ), def_c256_red_dark_gray );
         add_color( def_c256_dark_gray_blue, "h_dark_gray", color_pair( 75 ), def_c256_blue_dark_gray );
         add_color( def_c256_dark_gray_black, "c_dark_gray", color_pair( 72 ), def_c256_dark_gray_black );
-        add_color( def_c256_dark_gray_white, "c_dark_gray_white", color_pair( 79 ),
-                   def_c256_white_dark_gray );
-        add_color( def_c256_dark_gray_green, "c_dark_gray_green", color_pair( 74 ),
-                   def_c256_green_dark_gray );
-        add_color( def_c256_dark_gray_yellow, "c_dark_gray_yellow", color_pair( 78 ),
-                   def_c256_yellow_dark_gray );
-        add_color( def_c256_dark_gray_magenta, "c_dark_gray_magenta", color_pair( 77 ),
-                   def_c256_magenta_dark_gray );
+        add_color( def_c256_dark_gray_white, "c_dark_gray_white", color_pair( 79 ), def_c256_white_dark_gray );
+        add_color( def_c256_dark_gray_green, "c_dark_gray_green", color_pair( 74 ), def_c256_green_dark_gray );
+        add_color( def_c256_dark_gray_yellow, "c_dark_gray_yellow", color_pair( 78 ), def_c256_yellow_dark_gray );
+        add_color( def_c256_dark_gray_magenta, "c_dark_gray_magenta", color_pair( 77 ), def_c256_magenta_dark_gray );
         add_color( def_c256_dark_gray_cyan, "c_dark_gray_cyan", color_pair( 76 ), def_c256_cyan_dark_gray );
     } else {
         add_color( def_c_dark_gray_red, "c_dark_gray_red", color_pair( 9 ).bold(), def_c_dark_gray_red );

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -388,10 +388,14 @@ void color_manager::load_default()
         add_color( def_c256_dark_gray_red, "c_dark_gray_red", color_pair( 73 ), def_c256_red_dark_gray );
         add_color( def_c256_dark_gray_blue, "h_dark_gray", color_pair( 75 ), def_c256_blue_dark_gray );
         add_color( def_c256_dark_gray_black, "c_dark_gray", color_pair( 72 ), def_c256_dark_gray_black );
-        add_color( def_c256_dark_gray_white, "c_dark_gray_white", color_pair( 79 ), def_c256_white_dark_gray );
-        add_color( def_c256_dark_gray_green, "c_dark_gray_green", color_pair( 74 ), def_c256_green_dark_gray );
-        add_color( def_c256_dark_gray_yellow, "c_dark_gray_yellow", color_pair( 78 ), def_c256_yellow_dark_gray );
-        add_color( def_c256_dark_gray_magenta, "c_dark_gray_magenta", color_pair( 77 ), def_c256_magenta_dark_gray );
+        add_color( def_c256_dark_gray_white, "c_dark_gray_white", color_pair( 79 ),
+                   def_c256_white_dark_gray );
+        add_color( def_c256_dark_gray_green, "c_dark_gray_green", color_pair( 74 ),
+                   def_c256_green_dark_gray );
+        add_color( def_c256_dark_gray_yellow, "c_dark_gray_yellow", color_pair( 78 ),
+                   def_c256_yellow_dark_gray );
+        add_color( def_c256_dark_gray_magenta, "c_dark_gray_magenta", color_pair( 77 ),
+                   def_c256_magenta_dark_gray );
         add_color( def_c256_dark_gray_cyan, "c_dark_gray_cyan", color_pair( 76 ), def_c256_cyan_dark_gray );
     } else {
         add_color( def_c_dark_gray_red, "c_dark_gray_red", color_pair( 9 ).bold(), def_c_dark_gray_red );

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -384,7 +384,7 @@ void color_manager::load_default()
                def_c_light_cyan_cyan );
 
     // Allow real dark gray for terminals that support it
-    if( enable_256_colors ) {
+    if( catacurses::supports_256_colors() ) {
         add_color( def_c256_dark_gray_red, "c_dark_gray_red", color_pair( 73 ), def_c256_red_dark_gray );
         add_color( def_c256_dark_gray_blue, "h_dark_gray", color_pair( 75 ), def_c256_blue_dark_gray );
         add_color( def_c256_dark_gray_black, "c_dark_gray", color_pair( 72 ), def_c256_dark_gray_black );

--- a/src/color.h
+++ b/src/color.h
@@ -166,6 +166,24 @@
 #define c_cyan_cyan all_colors.get(def_c_cyan_cyan)
 #define c_light_cyan_cyan all_colors.get(def_c_light_cyan_cyan)
 
+#define c256_dark_gray_black allcolors.get(def_c256_dark_gray_black)
+#define c256_dark_gray_red allcolors.get(def_c256_dark_gray_red)
+#define c256_dark_gray_green allcolors.get(def_c256_dark_gray_green)
+#define c256_dark_gray_blue allcolors.get(def_c256_dark_gray_blue)
+#define c256_dark_gray_cyan allcolors.get(def_c256_dark_gray_cyan)
+#define c256_dark_gray_magenta allcolors.get(def_c256_dark_gray_magenta)
+#define c256_dark_gray_yellow allcolors.get(def_c256_dark_gray_yellow)
+#define c256_dark_gray_white allcolors.get(def_c256_dark_gray_white)
+
+#define c256_black_dark_gray allcolors.get(def_c256_black_dark_gray)
+#define c256_red_dark_gray allcolors.get(def_c256_red_dark_gray)
+#define c256_green_dark_gray allcolors.get(def_c256_green_dark_gray)
+#define c256_blue_dark_gray allcolors.get(def_c256_blue_dark_gray)
+#define c256_cyan_dark_gray allcolors.get(def_c256_cyan_dark_gray)
+#define c256_magenta_dark_gray allcolors.get(def_c256_magenta_dark_gray)
+#define c256_yellow_dark_gray allcolors.get(def_c256_yellow_dark_gray)
+#define c256_white_dark_gray allcolors.get(def_c256_white_dark_gray)
+
 // def_x is a color that maps to x with default settings
 enum color_id {
     def_c_black = 0,
@@ -322,6 +340,24 @@ enum color_id {
     def_c_pink_cyan,
     def_c_cyan_cyan,
     def_c_light_cyan_cyan,
+
+    def_c256_dark_gray_black,
+    def_c256_dark_gray_red,
+    def_c256_dark_gray_green,
+    def_c256_dark_gray_blue,
+    def_c256_dark_gray_cyan,
+    def_c256_dark_gray_magenta,
+    def_c256_dark_gray_yellow,
+    def_c256_dark_gray_white,
+
+    def_c256_black_dark_gray,
+    def_c256_red_dark_gray,
+    def_c256_green_dark_gray,
+    def_c256_blue_dark_gray,
+    def_c256_cyan_dark_gray,
+    def_c256_magenta_dark_gray,
+    def_c256_yellow_dark_gray,
+    def_c256_white_dark_gray,
 
     num_colors
 };

--- a/src/color.h
+++ b/src/color.h
@@ -472,6 +472,8 @@ class color_manager
     public:
         color_manager() = default;
 
+        bool enable_256_colors = false;
+
         nc_color get( color_id id ) const;
 
         nc_color get_invert( const nc_color &color ) const;

--- a/src/color.h
+++ b/src/color.h
@@ -472,8 +472,6 @@ class color_manager
     public:
         color_manager() = default;
 
-        bool enable_256_colors = false;
-
         nc_color get( color_id id ) const;
 
         nc_color get_invert( const nc_color &color ) const;

--- a/src/color.h
+++ b/src/color.h
@@ -166,24 +166,6 @@
 #define c_cyan_cyan all_colors.get(def_c_cyan_cyan)
 #define c_light_cyan_cyan all_colors.get(def_c_light_cyan_cyan)
 
-#define c256_dark_gray_black allcolors.get(def_c256_dark_gray_black)
-#define c256_dark_gray_red allcolors.get(def_c256_dark_gray_red)
-#define c256_dark_gray_green allcolors.get(def_c256_dark_gray_green)
-#define c256_dark_gray_blue allcolors.get(def_c256_dark_gray_blue)
-#define c256_dark_gray_cyan allcolors.get(def_c256_dark_gray_cyan)
-#define c256_dark_gray_magenta allcolors.get(def_c256_dark_gray_magenta)
-#define c256_dark_gray_yellow allcolors.get(def_c256_dark_gray_yellow)
-#define c256_dark_gray_white allcolors.get(def_c256_dark_gray_white)
-
-#define c256_black_dark_gray allcolors.get(def_c256_black_dark_gray)
-#define c256_red_dark_gray allcolors.get(def_c256_red_dark_gray)
-#define c256_green_dark_gray allcolors.get(def_c256_green_dark_gray)
-#define c256_blue_dark_gray allcolors.get(def_c256_blue_dark_gray)
-#define c256_cyan_dark_gray allcolors.get(def_c256_cyan_dark_gray)
-#define c256_magenta_dark_gray allcolors.get(def_c256_magenta_dark_gray)
-#define c256_yellow_dark_gray allcolors.get(def_c256_yellow_dark_gray)
-#define c256_white_dark_gray allcolors.get(def_c256_white_dark_gray)
-
 // def_x is a color that maps to x with default settings
 enum color_id {
     def_c_black = 0,
@@ -340,24 +322,6 @@ enum color_id {
     def_c_pink_cyan,
     def_c_cyan_cyan,
     def_c_light_cyan_cyan,
-
-    def_c256_dark_gray_black,
-    def_c256_dark_gray_red,
-    def_c256_dark_gray_green,
-    def_c256_dark_gray_blue,
-    def_c256_dark_gray_cyan,
-    def_c256_dark_gray_magenta,
-    def_c256_dark_gray_yellow,
-    def_c256_dark_gray_white,
-
-    def_c256_black_dark_gray,
-    def_c256_red_dark_gray,
-    def_c256_green_dark_gray,
-    def_c256_blue_dark_gray,
-    def_c256_cyan_dark_gray,
-    def_c256_magenta_dark_gray,
-    def_c256_yellow_dark_gray,
-    def_c256_white_dark_gray,
 
     num_colors
 };

--- a/src/cursesdef.h
+++ b/src/cursesdef.h
@@ -84,6 +84,9 @@ enum base_color : short {
     magenta = 0x05,  // RGB{196, 0, 180}
     cyan = 0x06,     // RGB{0, 170, 200}
     white = 0x07,    // RGB{196, 196, 196}
+
+    // 256 Color Support
+    dark_gray = 235,
 };
 
 using chtype = int;

--- a/src/cursesdef.h
+++ b/src/cursesdef.h
@@ -86,7 +86,7 @@ enum base_color : short {
     white = 0x07,    // RGB{196, 196, 196}
 
     // 256 Color Support
-    dark_gray = 235,
+    dark_gray = 237,
 };
 
 using chtype = int;

--- a/src/cursesdef.h
+++ b/src/cursesdef.h
@@ -139,6 +139,7 @@ int getbegx( const window &win );
 int getbegy( const window &win );
 int getcurx( const window &win );
 int getcury( const window &win );
+bool supports_256_colors();
 } // namespace catacurses
 
 #endif // CATA_SRC_CURSESDEF_H

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -425,23 +425,6 @@ int nc_color::to_color_pair_index() const
 
 nc_color nc_color::bold() const
 {
-    // TODO check toggleable setting
-    // if (COLORS >= 256)
-    // {   
-    //     short fg, bg;
-    //     int color_pair_index = to_color_pair_index();
-    //     pair_content(color_pair_index, &fg, &bg);
-    //     if (fg == black)
-    //     {
-    //         switch (bg)
-    //         {
-    //         case:
-                
-
-    //         }
-    //     }
-    // }
-
     return nc_color( attribute_value | A_BOLD );
 }
 

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -262,11 +262,11 @@ void catacurses::init_interface()
     set_escdelay( 10 ); // Make Escape actually responsive
     // TODO: error checking
     start_color();
-    init_colors();
-
+    // creates the color_manager and sets 256 color mode if available
     if (COLORS >= 256) {
         get_all_colors().enable_256_colors = true;
     }
+    init_colors();
 }
 
 void input_manager::pump_events()

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -421,6 +421,23 @@ int nc_color::to_color_pair_index() const
 
 nc_color nc_color::bold() const
 {
+    // TODO check toggleable setting
+    // if (COLORS >= 256)
+    // {   
+    //     short fg, bg;
+    //     int color_pair_index = to_color_pair_index();
+    //     pair_content(color_pair_index, &fg, &bg);
+    //     if (fg == black)
+    //     {
+    //         switch (bg)
+    //         {
+    //         case:
+                
+
+    //         }
+    //     }
+    // }
+
     return nc_color( attribute_value | A_BOLD );
 }
 

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -263,6 +263,10 @@ void catacurses::init_interface()
     // TODO: error checking
     start_color();
     init_colors();
+
+    if (COLORS >= 256) {
+        get_all_colors().enable_256_colors = true;
+    }
 }
 
 void input_manager::pump_events()

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -263,7 +263,7 @@ void catacurses::init_interface()
     // TODO: error checking
     start_color();
     // creates the color_manager and sets 256 color mode if available
-    if ( COLORS >= 256 ) {
+    if( COLORS >= 256 ) {
         get_all_colors().enable_256_colors = true;
     }
     init_colors();

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -263,7 +263,7 @@ void catacurses::init_interface()
     // TODO: error checking
     start_color();
     // creates the color_manager and sets 256 color mode if available
-    if (COLORS >= 256) {
+    if ( COLORS >= 256 ) {
         get_all_colors().enable_256_colors = true;
     }
     init_colors();

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -267,7 +267,7 @@ void catacurses::init_interface()
 
 bool catacurses::supports_256_colors()
 {
-    return( COLORS >= 256 );
+    return COLORS >= 256;
 }
 
 void input_manager::pump_events()

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -262,11 +262,12 @@ void catacurses::init_interface()
     set_escdelay( 10 ); // Make Escape actually responsive
     // TODO: error checking
     start_color();
-    // creates the color_manager and sets 256 color mode if available
-    if( COLORS >= 256 ) {
-        get_all_colors().enable_256_colors = true;
-    }
     init_colors();
+}
+
+bool catacurses::supports_256_colors()
+{
+    return( COLORS >= 256 );
 }
 
 void input_manager::pump_events()

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -4023,7 +4023,7 @@ bool is_draw_tiles_mode()
 bool catacurses::supports_256_colors()
 {
     // trust SDL to do the right thing instead
-    return( false );
+    return false;
 }
 
 /** Saves a screenshot of the current viewport, as a PNG file, to the given location.

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -4022,8 +4022,8 @@ bool is_draw_tiles_mode()
 
 bool catacurses::supports_256_colors()
 {
-    // a terminal running tiles should always support 256 colors.. right?
-    return( true );
+    // trust SDL to do the right thing instead
+    return( false );
 }
 
 /** Saves a screenshot of the current viewport, as a PNG file, to the given location.

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -4020,6 +4020,12 @@ bool is_draw_tiles_mode()
     return use_tiles;
 }
 
+bool catacurses::supports_256_colors()
+{
+    // a terminal running tiles should always support 256 colors.. right?
+    return( true );
+}
+
 /** Saves a screenshot of the current viewport, as a PNG file, to the given location.
 * @param file_path: A full path to the file where the screenshot should be saved.
 * @returns `true` if the screenshot generation was successful, `false` otherwise.

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -658,7 +658,7 @@ void catacurses::init_interface()
 
 bool catacurses::supports_256_colors()
 {
-    return( COLORS >= 256 );
+    return COLORS >= 256;
 }
 
 // A very accurate and responsive timer (NEVER use GetTickCount)

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -656,6 +656,11 @@ void catacurses::init_interface()
     initialized = true;
 }
 
+bool catacurses::supports_256_colors()
+{
+    return( COLORS >= 256 );
+}
+
 // A very accurate and responsive timer (NEVER use GetTickCount)
 static uint64_t GetPerfCount()
 {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix dark gray in the ncurses client for terminal emulators that support 256 colors."

#### Purpose of change
Fixes #57385

#### Describe the solution
The ncurses client now uses number 237 on the 256 color palette (if available in the terminal emulator) for dark gray instead of using black with the intensity bit set. This makes it so many terminal emulators will no longer require using the "interpret bold colors as bright" setting globally. The ncurses client does this by detecting if the terminal emulator being used supports >= 256 colors and this is exposed in the catacurses namespace.

#### Describe alternatives you've considered
The dark gray color could realistically be anywhere in the range of like 235-239. I like 237 the best.

#### Testing
Opened the client and checked both Settings->Colors and a road in game to make sure the dark gray displayed correctly. I also verified a few other places like inside a dark house and the crafting menu.

#### Additional context
We have a color pair budget of 256 from ncurses, and this change adds the 88th. 
