### PR TITLE
Add melee_training_cap into monsters.md

### DIFF
--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1345,6 +1345,7 @@
     "vision_night": 60,
     "path_settings": { "max_dist": 60 },
     "death_function": { "corpse_type": "NO_CORPSE", "message": "it just disappeared." },
+    "melee_training_cap": 0,
     "flags": [
       "NO_BREATHE",
       "SEES",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1345,7 +1345,6 @@
     "vision_night": 60,
     "path_settings": { "max_dist": 60 },
     "death_function": { "corpse_type": "NO_CORPSE", "message": "it just disappeared." },
-    "melee_training_cap": 0,
     "flags": [
       "NO_BREATHE",
       "SEES",

--- a/doc/MONSTERS.md
+++ b/doc/MONSTERS.md
@@ -105,6 +105,7 @@ Monsters may also have any of these optional properties:
 | `absorb_move_cost_max`   | (int) For monsters with the `ABSORB_ITEMS` special attack. Sets a maximum movement cost for absorbing items regardless of the volume of the consumed item. -1 for no limit. Default -1.
 | `absorb_material`        | (array of string) For monsters with the `ABSORB_ITEMS` special attack. Specifies the types of materials that the monster will seek to absorb. Items with multiple materials will be matched as long as it is made of at least one of the materials in this list. If not specified the monster will absorb all materials.
 | `split_move_cost`        | (int) For monsters with the `SPLIT` special attack. Determines the move cost when splitting into a copy of itself.
+| `melee_training_cap `    | (int) how much you can train your melee skill by attack this monster. 10 by default.
 
 Properties in the above tables are explained in more detail in the sections below.
 

--- a/doc/MONSTERS.md
+++ b/doc/MONSTERS.md
@@ -105,7 +105,7 @@ Monsters may also have any of these optional properties:
 | `absorb_move_cost_max`   | (int) For monsters with the `ABSORB_ITEMS` special attack. Sets a maximum movement cost for absorbing items regardless of the volume of the consumed item. -1 for no limit. Default -1.
 | `absorb_material`        | (array of string) For monsters with the `ABSORB_ITEMS` special attack. Specifies the types of materials that the monster will seek to absorb. Items with multiple materials will be matched as long as it is made of at least one of the materials in this list. If not specified the monster will absorb all materials.
 | `split_move_cost`        | (int) For monsters with the `SPLIT` special attack. Determines the move cost when splitting into a copy of itself.
-| `melee_training_cap `    | (int) how much you can train your melee skill by attack this monster. 10 by default.
+| `melee_training_cap `    | (int) How much you can train your melee skill by attacking this monster. 10 by default.
 
 Properties in the above tables are explained in more detail in the sections below.
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
melee_training_cap is not documented anywhere 
#### Describe the solution
Document `melee_training_cap` in our docs