### PR TITLE
submap: lazily allocate uniform submaps

### DIFF
--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -155,7 +155,7 @@ bool map::build_transparency_cache( const int zlev )
                 return std::make_pair( value, value_wo_fields );
             };
 
-            if( cur_submap->is_uniform ) {
+            if( cur_submap->is_uniform() ) {
                 float value;
                 float dummy;
                 std::tie( value, dummy ) = calc_transp( sm_offset );

--- a/src/map.h
+++ b/src/map.h
@@ -2256,6 +2256,8 @@ template<int SIZE, int MULTIPLIER>
 void shift_bitset_cache( std::bitset<SIZE *SIZE> &cache, const point &s );
 
 bool ter_furn_has_flag( const ter_t &ter, const furn_t &furn, ter_furn_flag flag );
+bool generate_uniform( const tripoint_abs_sm &p, const oter_id &oter );
+bool generate_uniform_omt( const tripoint_abs_sm &p, const oter_id &terrain_type );
 class tinymap : public map
 {
         friend class editmap;

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -18,6 +18,7 @@
 #include "json.h"
 #include "map.h"
 #include "output.h"
+#include "overmapbuffer.h"
 #include "path_info.h"
 #include "popup.h"
 #include "string_formatter.h"
@@ -193,7 +194,7 @@ void mapbuffer::save_quad(
         submap_addr += offsets_offset;
         submap_addrs.push_back( submap_addr );
         submap *sm = submaps[submap_addr].get();
-        if( sm != nullptr && !sm->is_uniform ) {
+        if( sm != nullptr && !sm->is_uniform() ) {
             all_uniform = false;
         }
     }
@@ -280,9 +281,12 @@ submap *mapbuffer::unserialize_submaps( const tripoint_abs_sm &p )
         // If it doesn't exist, trigger generating it.
         return nullptr;
     }
+    // fill in uniform submaps that were not serialized
+    oter_id const oid = overmap_buffer.ter( om_addr );
+    generate_uniform_omt( project_to<coords::sm>( om_addr ), oid );
     if( submaps.count( p ) == 0 ) {
-        debugmsg( "file %s did not contain the expected submap %s", quad_path.generic_u8string(),
-                  p.to_string() );
+        debugmsg( "file %s did not contain the expected submap %s for non-uniform terrain %s",
+                  quad_path.generic_u8string(), p.to_string(), oid.id().str() );
         return nullptr;
     }
     return submaps[ p ].get();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6446,8 +6446,8 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint &p, const units
                       placed_vehicle->sm_pos.x, placed_vehicle->sm_pos.y, placed_vehicle->sm_pos.z );
             return placed_vehicle;
         }
+        place_on_submap->ensure_nonuniform();
         place_on_submap->vehicles.push_back( std::move( placed_vehicle_up ) );
-        place_on_submap->is_uniform = false;
         invalidate_max_populated_zlev( p.z );
 
         level_cache &ch = get_cache( placed_vehicle->sm_pos.z );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1547,7 +1547,7 @@ void timed_event_manager::unserialize_all( const JsonArray &ja )
         tripoint_abs_sm map_point;
         std::string string_id;
         std::string key;
-        submap_revert revert;
+        submap revert;
         jo.read( "faction", faction_id );
         jo.read( "map_point", map_point );
         jo.read( "map_square", map_square, false );
@@ -1557,29 +1557,33 @@ void timed_event_manager::unserialize_all( const JsonArray &ja )
         jo.read( "when", when );
         jo.read( "key", key );
         point pt;
-        for( JsonObject jp : jo.get_array( "revert" ) ) {
-            if( jp.has_member( "point" ) ) {
-                jp.get_member( "point" ).read( pt, false );
-            }
-            revert.set_furn( pt, furn_id( jp.get_string( "furn" ) ) );
-            revert.set_ter( pt, ter_id( jp.get_string( "ter" ) ) );
-            revert.set_trap( pt, trap_id( jp.get_string( "trap" ) ) );
-            if( jp.has_member( "items" ) ) {
-                cata::colony<item> itm;
-                jp.get_member( "items" ).read( itm, false );
-                revert.set_items( pt, itm );
-            }
-            // We didn't always save the point, this is the original logic, it doesn't work right but for older saves at least they won't crash
-            if( !jp.has_member( "point" ) ) {
-                if( pt.x++ < SEEX ) {
-                    pt.x = 0;
-                    pt.y++;
+        if( jo.has_string( "revert" ) ) {
+            revert.set_all_ter( ter_id( jo.get_string( "revert" ) ), true );
+        } else {
+            for( JsonObject jp : jo.get_array( "revert" ) ) {
+                if( jp.has_member( "point" ) ) {
+                    jp.get_member( "point" ).read( pt, false );
+                }
+                revert.set_furn( pt, furn_id( jp.get_string( "furn" ) ) );
+                revert.set_ter( pt, ter_id( jp.get_string( "ter" ) ) );
+                revert.set_trap( pt, trap_id( jp.get_string( "trap" ) ) );
+                if( jp.has_member( "items" ) ) {
+                    cata::colony<item> itm;
+                    jp.get_member( "items" ).read( itm, false );
+                    revert.get_items( pt ) = std::move( itm );
+                }
+                // We didn't always save the point, this is the original logic, it doesn't work right but for older saves at least they won't crash
+                if( !jp.has_member( "point" ) ) {
+                    if( pt.x++ < SEEX ) {
+                        pt.x = 0;
+                        pt.y++;
+                    }
                 }
             }
         }
         get_timed_events().add( static_cast<timed_event_type>( type ), when, faction_id, map_square,
                                 strength,
-                                string_id, revert, key );
+                                string_id, std::move( revert ), key );
     }
 }
 
@@ -1640,21 +1644,25 @@ void timed_event_manager::serialize_all( JsonOut &jsout )
         jsout.member( "type", elem.type );
         jsout.member( "when", elem.when );
         jsout.member( "key", elem.key );
-        jsout.member( "revert" );
-        jsout.start_array();
-        for( int y = 0; y < SEEY; y++ ) {
-            for( int x = 0; x < SEEX; x++ ) {
-                jsout.start_object();
-                point pt( x, y );
-                jsout.member( "point", pt );
-                jsout.member( "furn", elem.revert.get_furn( pt ) );
-                jsout.member( "ter", elem.revert.get_ter( pt ) );
-                jsout.member( "trap", elem.revert.get_trap( pt ) );
-                jsout.member( "items", elem.revert.get_items( pt ) );
-                jsout.end_object();
+        if( elem.revert.is_uniform() ) {
+            jsout.member( "revert", elem.revert.get_ter( point_zero ) );
+        } else {
+            jsout.member( "revert" );
+            jsout.start_array();
+            for( int y = 0; y < SEEY; y++ ) {
+                for( int x = 0; x < SEEX; x++ ) {
+                    jsout.start_object();
+                    point pt( x, y );
+                    jsout.member( "point", pt );
+                    jsout.member( "furn", elem.revert.get_furn( pt ) );
+                    jsout.member( "ter", elem.revert.get_ter( pt ) );
+                    jsout.member( "trap", elem.revert.get_trap( pt ) );
+                    jsout.member( "items", elem.revert.get_items( pt ) );
+                    jsout.end_object();
+                }
             }
+            jsout.end_array();
         }
-        jsout.end_array();
         jsout.end_object();
     }
     jsout.end_array();

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -26,17 +26,6 @@ void maptile_soa::swap_soa_tile( const point &p1, const point &p2 )
     std::swap( rad[p1.x][p1.y], rad[p2.x][p2.y] );
 }
 
-submap::submap()
-{
-    std::uninitialized_fill_n( &ter[0][0], elements, t_null );
-    std::uninitialized_fill_n( &frn[0][0], elements, f_null );
-    std::uninitialized_fill_n( &lum[0][0], elements, 0 );
-    std::uninitialized_fill_n( &trp[0][0], elements, tr_null );
-    std::uninitialized_fill_n( &rad[0][0], elements, 0 );
-
-    is_uniform = false;
-}
-
 submap::submap( submap && ) noexcept( map_is_noexcept ) = default;
 submap::~submap() = default;
 
@@ -92,7 +81,7 @@ const std::string &submap::get_graffiti( const point &p ) const
 
 void submap::set_graffiti( const point &p, const std::string &new_graffiti )
 {
-    is_uniform = false;
+    ensure_nonuniform();
     // Find signage at p if available
     const cosmetic_find_result fresult = find_cosmetic( cosmetics, p, COSMETICS_GRAFFITI );
     if( fresult.result ) {
@@ -104,16 +93,16 @@ void submap::set_graffiti( const point &p, const std::string &new_graffiti )
 
 void submap::delete_graffiti( const point &p )
 {
-    is_uniform = false;
     const cosmetic_find_result fresult = find_cosmetic( cosmetics, p, COSMETICS_GRAFFITI );
     if( fresult.result ) {
+        ensure_nonuniform();
         cosmetics[ fresult.ndx ] = cosmetics.back();
         cosmetics.pop_back();
     }
 }
 bool submap::has_signage( const point &p ) const
 {
-    if( frn[p.x][p.y].obj().has_flag( ter_furn_flag::TFLAG_SIGN ) ) {
+    if( !is_uniform() && m->frn[p.x][p.y].obj().has_flag( ter_furn_flag::TFLAG_SIGN ) ) {
         return find_cosmetic( cosmetics, p, COSMETICS_SIGNAGE ).result;
     }
 
@@ -121,7 +110,7 @@ bool submap::has_signage( const point &p ) const
 }
 std::string submap::get_signage( const point &p ) const
 {
-    if( frn[p.x][p.y].obj().has_flag( ter_furn_flag::TFLAG_SIGN ) ) {
+    if( !is_uniform() && m->frn[p.x][p.y].obj().has_flag( ter_furn_flag::TFLAG_SIGN ) ) {
         const cosmetic_find_result fresult = find_cosmetic( cosmetics, p, COSMETICS_SIGNAGE );
         if( fresult.result ) {
             return cosmetics[ fresult.ndx ].str;
@@ -132,7 +121,7 @@ std::string submap::get_signage( const point &p ) const
 }
 void submap::set_signage( const point &p, const std::string &s )
 {
-    is_uniform = false;
+    ensure_nonuniform();
     // Find signage at p if available
     const cosmetic_find_result fresult = find_cosmetic( cosmetics, p, COSMETICS_SIGNAGE );
     if( fresult.result ) {
@@ -143,9 +132,9 @@ void submap::set_signage( const point &p, const std::string &s )
 }
 void submap::delete_signage( const point &p )
 {
-    is_uniform = false;
     const cosmetic_find_result fresult = find_cosmetic( cosmetics, p, COSMETICS_SIGNAGE );
     if( fresult.result ) {
+        ensure_nonuniform();
         cosmetics[ fresult.ndx ] = cosmetics.back();
         cosmetics.pop_back();
     }
@@ -153,10 +142,10 @@ void submap::delete_signage( const point &p )
 
 void submap::update_legacy_computer()
 {
-    if( legacy_computer ) {
+    if( !is_uniform() && legacy_computer ) {
         for( int x = 0; x < SEEX; ++x ) {
             for( int y = 0; y < SEEY; ++y ) {
-                if( frn[x][y] == furn_f_console ) {
+                if( m->frn[x][y] == furn_f_console ) {
                     computers.emplace( point( x, y ), *legacy_computer );
                 }
             }
@@ -167,8 +156,8 @@ void submap::update_legacy_computer()
 
 bool submap::has_computer( const point &p ) const
 {
-    return computers.find( p ) != computers.end() || ( legacy_computer && frn[p.x][p.y]
-            == furn_f_console );
+    return !is_uniform() && ( computers.find( p ) != computers.end() ||
+                              ( legacy_computer && m->frn[p.x][p.y] == furn_f_console ) );
 }
 
 const computer *submap::get_computer( const point &p ) const
@@ -179,7 +168,7 @@ const computer *submap::get_computer( const point &p ) const
     if( it != computers.end() ) {
         return &it->second;
     }
-    if( legacy_computer && frn[p.x][p.y] == furn_f_console ) {
+    if( !is_uniform() && legacy_computer && m->frn[p.x][p.y] == furn_f_console ) {
         return legacy_computer.get();
     }
     return nullptr;
@@ -232,6 +221,9 @@ bool submap::is_open_air( const point &p ) const
 
 void submap::rotate( int turns )
 {
+    if( is_uniform() ) {
+        return;
+    }
     turns = turns % 4;
 
     if( turns == 0 ) {
@@ -249,14 +241,14 @@ void submap::rotate( int turns )
         // Swap horizontal stripes.
         for( int j = 0, je = SEEY / 2; j < je; ++j ) {
             for( int i = j, ie = SEEX - j; i < ie; ++i ) {
-                swap_soa_tile( { i, j }, rotate_point( { i, j } ) );
+                m->swap_soa_tile( { i, j }, rotate_point( { i, j } ) );
             }
         }
         // Swap vertical stripes so that they don't overlap with
         // the already swapped horizontals.
         for( int i = 0, ie = SEEX / 2; i < ie; ++i ) {
             for( int j = i + 1, je = SEEY - i - 1; j < je; ++j ) {
-                swap_soa_tile( { i, j }, rotate_point( { i, j } ) );
+                m->swap_soa_tile( { i, j }, rotate_point( { i, j } ) );
             }
         }
     } else {
@@ -269,7 +261,7 @@ void submap::rotate( int turns )
                 for( int k = 0; k < 3; ++k ) {
                     p = pp;
                     pp = rotate_point_ccw( pp );
-                    swap_soa_tile( p, pp );
+                    m->swap_soa_tile( p, pp );
                 }
             }
         }
@@ -306,12 +298,15 @@ void submap::rotate( int turns )
 
 void submap::mirror( bool horizontally )
 {
+    if( is_uniform() ) {
+        return;
+    }
     std::map<point, computer> mirror_comp;
 
     if( horizontally ) {
         for( int i = 0, ie = SEEX / 2; i < ie; i++ ) {
             for( int k = 0; k < SEEY; k++ ) {
-                swap_soa_tile( { i, k }, { SEEX - 1 - i, k } );
+                m->swap_soa_tile( { i, k }, { SEEX - 1 - i, k } );
             }
         }
 
@@ -328,7 +323,7 @@ void submap::mirror( bool horizontally )
     } else {
         for( int k = 0, ke = SEEY / 2; k < ke; k++ ) {
             for( int i = 0; i < SEEX; i++ ) {
-                swap_soa_tile( { i, k }, { i, SEEY - 1 - k } );
+                m->swap_soa_tile( { i, k }, { i, SEEY - 1 - k } );
             }
         }
 
@@ -347,14 +342,15 @@ void submap::mirror( bool horizontally )
 
 void submap::revert_submap( submap_revert &sr )
 {
+    ensure_nonuniform();
     for( int x = 0; x < SEEX; x++ ) {
         for( int y = 0; y < SEEY; y++ ) {
             point pt( x, y );
-            frn[x][y] = sr.get_furn( pt );
-            ter[x][y] = sr.get_ter( pt );
-            trp[x][y] = sr.get_trap( pt );
-            itm[x][y] = sr.get_items( pt );
-            for( item &itm : itm[x][y] ) {
+            m->frn[x][y] = sr.get_furn( pt );
+            m->ter[x][y] = sr.get_ter( pt );
+            m->trp[x][y] = sr.get_trap( pt );
+            m->itm[x][y] = sr.get_items( pt );
+            for( item &itm : m->itm[x][y] ) {
                 if( itm.is_emissive() ) {
                     this->update_lum_add( pt, itm );
                 }
@@ -368,14 +364,17 @@ void submap::revert_submap( submap_revert &sr )
 
 submap_revert submap::get_revert_submap() const
 {
+    if( is_uniform() ) {
+        return {};
+    }
     submap_revert ret;
     for( int x = 0; x < SEEX; x++ ) {
         for( int y = 0; y < SEEY; y++ ) {
             point pt( x, y );
-            ret.set_furn( pt, frn[x][y] );
-            ret.set_ter( pt, ter[x][y] );
-            ret.set_trap( pt, trp[x][y] );
-            ret.set_items( pt, itm[x][y] );
+            ret.set_furn( pt, m->frn[x][y] );
+            ret.set_ter( pt, m->ter[x][y] );
+            ret.set_trap( pt, m->trp[x][y] );
+            ret.set_items( pt, m->itm[x][y] );
         }
     }
     return ret;
@@ -383,24 +382,24 @@ submap_revert submap::get_revert_submap() const
 
 void submap::update_lum_rem( const point &p, const item &i )
 {
-    is_uniform = false;
+    ensure_nonuniform();
     if( !i.is_emissive() ) {
         return;
-    } else if( lum[p.x][p.y] && lum[p.x][p.y] < 255 ) {
-        lum[p.x][p.y]--;
+    } else if( m->lum[p.x][p.y] && m->lum[p.x][p.y] < 255 ) {
+        m->lum[p.x][p.y]--;
         return;
     }
 
     // Have to scan through all items to be sure removing i will actually lower
     // the count below 255.
     int count = 0;
-    for( const item &it : itm[p.x][p.y] ) {
+    for( const item &it : m->itm[p.x][p.y] ) {
         if( it.is_emissive() ) {
             count++;
         }
     }
 
     if( count <= 256 ) {
-        lum[p.x][p.y] = static_cast<uint8_t>( count - 1 );
+        m->lum[p.x][p.y] = static_cast<uint8_t>( count - 1 );
     }
 }

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -340,8 +340,14 @@ void submap::mirror( bool horizontally )
     }
 }
 
-void submap::revert_submap( submap_revert &sr )
+void submap::revert_submap( submap &sr )
 {
+    if( sr.is_uniform() ) {
+        m.reset();
+        set_all_ter( sr.get_ter( point_zero ), true );
+        return;
+    }
+
     ensure_nonuniform();
     for( int x = 0; x < SEEX; x++ ) {
         for( int y = 0; y < SEEY; y++ ) {
@@ -362,21 +368,14 @@ void submap::revert_submap( submap_revert &sr )
     }
 }
 
-submap_revert submap::get_revert_submap() const
+submap submap::get_revert_submap() const
 {
-    if( is_uniform() ) {
-        return {};
+    submap ret;
+    ret.uniform_ter = uniform_ter;
+    if( !is_uniform() ) {
+        ret.m = std::make_unique<maptile_soa>( *m );
     }
-    submap_revert ret;
-    for( int x = 0; x < SEEX; x++ ) {
-        for( int y = 0; y < SEEY; y++ ) {
-            point pt( x, y );
-            ret.set_furn( pt, m->frn[x][y] );
-            ret.set_ter( pt, m->ter[x][y] );
-            ret.set_trap( pt, m->trp[x][y] );
-            ret.set_items( pt, m->itm[x][y] );
-        }
-    }
+
     return ret;
 }
 

--- a/src/submap.h
+++ b/src/submap.h
@@ -66,50 +66,6 @@ struct maptile_soa {
     void swap_soa_tile( const point &p1, const point &p2 );
 };
 
-struct maptile_revert {
-    cata::mdarray<ter_id, point_sm_ms>             ter; // Terrain on each square
-    cata::mdarray<furn_id, point_sm_ms>            frn; // Furniture on each square
-    cata::mdarray<trap_id, point_sm_ms>            trp; // Trap on each square
-    cata::mdarray<cata::colony<item>, point_sm_ms> itm; // Items on each square
-};
-
-class submap_revert : maptile_revert
-{
-
-    public:
-        furn_id get_furn( const point &p ) const {
-            return frn[p.x][p.y];
-        }
-
-        void set_furn( const point &p, furn_id furn ) {
-            frn[p.x][p.y] = furn;
-        }
-
-        ter_id get_ter( const point &p ) const {
-            return ter[p.x][p.y];
-        }
-
-        void set_ter( const point &p, ter_id terr ) {
-            ter[p.x][p.y] = terr;
-        }
-
-        trap_id get_trap( const point &p ) const {
-            return trp[p.x][p.y];
-        }
-
-        void set_trap( const point &p, trap_id trap ) {
-            trp[p.x][p.y] = trap;
-        }
-
-        cata::colony<item> get_items( const point &p ) const {
-            return itm[p.x][p.y];
-        }
-
-        void set_items( const point &p, cata::colony<item> revert_item ) {
-            itm[p.x][p.y] = std::move( revert_item );
-        }
-};
-
 class submap
 {
     public:
@@ -130,9 +86,9 @@ class submap
             }
         }
 
-        void revert_submap( submap_revert &sr );
+        void revert_submap( submap &sr );
 
-        submap_revert get_revert_submap() const;
+        submap get_revert_submap() const;
 
         trap_id get_trap( const point &p ) const {
             if( is_uniform() ) {

--- a/src/submap.h
+++ b/src/submap.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "active_item_cache.h"
+#include "basecamp.h"
 #include "calendar.h"
 #include "cata_type_traits.h"
 #include "colony.h"
@@ -25,15 +26,15 @@
 #include "mapgen.h"
 #include "mdarray.h"
 #include "point.h"
+#include "trap.h"
 #include "type_id.h"
+#include "vehicle.h"
 
 class JsonOut;
-class basecamp;
 class map;
 class vehicle;
 struct furn_t;
 struct ter_t;
-struct trap;
 
 struct spawn_point {
     point pos;
@@ -109,80 +110,115 @@ class submap_revert : maptile_revert
         }
 };
 
-class submap : maptile_soa
+class submap
 {
     public:
-        submap();
+        submap() = default;
         submap( submap && ) noexcept( map_is_noexcept );
         ~submap();
 
         submap &operator=( submap && ) noexcept;
+
+        void ensure_nonuniform() {
+            if( is_uniform() ) {
+                m = std::make_unique<maptile_soa>();
+                std::uninitialized_fill_n( &m->ter[0][0], elements, uniform_ter );
+                std::uninitialized_fill_n( &m->frn[0][0], elements, f_null );
+                std::uninitialized_fill_n( &m->lum[0][0], elements, 0 );
+                std::uninitialized_fill_n( &m->trp[0][0], elements, tr_null );
+                std::uninitialized_fill_n( &m->rad[0][0], elements, 0 );
+            }
+        }
 
         void revert_submap( submap_revert &sr );
 
         submap_revert get_revert_submap() const;
 
         trap_id get_trap( const point &p ) const {
-            return trp[p.x][p.y];
+            if( is_uniform() ) {
+                return tr_null;
+            }
+            return m->trp[p.x][p.y];
         }
 
         void set_trap( const point &p, trap_id trap ) {
-            is_uniform = false;
-            trp[p.x][p.y] = trap;
+            ensure_nonuniform();
+            m->trp[p.x][p.y] = trap;
         }
 
         void set_all_traps( const trap_id &trap ) {
-            std::uninitialized_fill_n( &trp[0][0], elements, trap );
+            ensure_nonuniform();
+            std::uninitialized_fill_n( &m->trp[0][0], elements, trap );
         }
 
         furn_id get_furn( const point &p ) const {
-            return frn[p.x][p.y];
+            if( is_uniform() ) {
+                return f_null;
+            }
+            return m->frn[p.x][p.y];
         }
 
         void set_furn( const point &p, furn_id furn ) {
-            is_uniform = false;
-            frn[p.x][p.y] = furn;
+            ensure_nonuniform();
+            m->frn[p.x][p.y] = furn;
         }
 
         void set_all_furn( const furn_id &furn ) {
-            std::uninitialized_fill_n( &frn[0][0], elements, furn );
+            ensure_nonuniform();
+            std::uninitialized_fill_n( &m->frn[0][0], elements, furn );
         }
 
         ter_id get_ter( const point &p ) const {
-            return ter[p.x][p.y];
+            if( is_uniform() ) {
+                return uniform_ter;
+            }
+            return m->ter[p.x][p.y];
         }
 
         void set_ter( const point &p, ter_id terr ) {
-            is_uniform = false;
-            ter[p.x][p.y] = terr;
+            ensure_nonuniform();
+            m->ter[p.x][p.y] = terr;
         }
 
-        void set_all_ter( const ter_id &terr ) {
-            std::uninitialized_fill_n( &ter[0][0], elements, terr );
+        void set_all_ter( const ter_id &terr, bool uniform_ok = false ) {
+            if( !uniform_ok ) {
+                ensure_nonuniform();
+            }
+            if( is_uniform() ) {
+                uniform_ter = terr;
+            } else {
+                std::uninitialized_fill_n( &m->ter[0][0], elements, terr );
+            }
         }
 
         int get_radiation( const point &p ) const {
-            return rad[p.x][p.y];
+            if( is_uniform() ) {
+                return 0;
+            }
+            return m->rad[p.x][p.y];
         }
 
         void set_radiation( const point &p, const int radiation ) {
-            is_uniform = false;
-            rad[p.x][p.y] = radiation;
+            ensure_nonuniform();
+            m->rad[p.x][p.y] = radiation;
         }
 
         uint8_t get_lum( const point &p ) const {
-            return lum[p.x][p.y];
+            if( is_uniform() ) {
+                return 0;
+            }
+            return m->lum[p.x][p.y];
         }
 
         void set_lum( const point &p, uint8_t luminance ) {
-            is_uniform = false;
-            lum[p.x][p.y] = luminance;
+            ensure_nonuniform();
+            m->lum[p.x][p.y] = luminance;
         }
 
         void update_lum_add( const point &p, const item &i ) {
-            is_uniform = false;
-            if( i.is_emissive() && lum[p.x][p.y] < 255 ) {
-                lum[p.x][p.y]++;
+            ensure_nonuniform();
+            if( i.is_emissive() && m->lum[p.x][p.y] < 255 ) {
+                m->lum[p.x][p.y]++;
             }
         }
 
@@ -190,20 +226,36 @@ class submap : maptile_soa
 
         // TODO: Replace this as it essentially makes itm public
         cata::colony<item> &get_items( const point &p ) {
-            return itm[p.x][p.y];
+            if( is_uniform() ) {
+                cata::colony<item> static noitems;
+                return noitems;
+            }
+            return m->itm[p.x][p.y];
         }
 
         const cata::colony<item> &get_items( const point &p ) const {
-            return itm[p.x][p.y];
+            if( is_uniform() ) {
+                cata::colony<item> static noitems;
+                return noitems;
+            }
+            return m->itm[p.x][p.y];
         }
 
         // TODO: Replace this as it essentially makes fld public
         field &get_field( const point &p ) {
-            return fld[p.x][p.y];
+            if( is_uniform() ) {
+                field static nofield;
+                return nofield;
+            }
+            return m->fld[p.x][p.y];
         }
 
         const field &get_field( const point &p ) const {
-            return fld[p.x][p.y];
+            if( is_uniform() ) {
+                field static nofield;
+                return nofield;
+            }
+            return m->fld[p.x][p.y];
         }
 
         void clear_fields( const point &p );
@@ -266,7 +318,9 @@ class submap : maptile_soa
 
         // If is_uniform is true, this submap is a solid block of terrain
         // Uniform submaps aren't saved/loaded, because regenerating them is faster
-        bool is_uniform = false;
+        bool is_uniform() const {
+            return !static_cast<bool>( m );
+        }
 
         std::vector<cosmetic_t> cosmetics; // Textual "visuals" for squares
 
@@ -287,6 +341,8 @@ class submap : maptile_soa
     private:
         std::map<point, computer> computers;
         std::unique_ptr<computer> legacy_computer;
+        std::unique_ptr<maptile_soa> m;
+        ter_id uniform_ter = t_null;
         int temperature_mod = 0; // delta in F
 
         void update_legacy_computer();

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -80,7 +80,7 @@ timed_event::timed_event( timed_event_type e_t, const time_point &w, int f_id, t
 }
 
 timed_event::timed_event( timed_event_type e_t, const time_point &w, int f_id, tripoint_abs_ms p,
-                          int s, std::string s_id, submap_revert &sr, std::string key )
+                          int s, std::string s_id, submap sr, std::string key )
     : type( e_t )
     , when( w )
     , faction_id( f_id )
@@ -88,9 +88,9 @@ timed_event::timed_event( timed_event_type e_t, const time_point &w, int f_id, t
     , strength( s )
     , string_id( std::move( s_id ) )
     , key( std::move( key ) )
+    , revert( std::move( sr ) )
 {
     map_point = project_to<coords::sm>( map_square );
-    revert = sr;
 }
 
 void timed_event::actualize()
@@ -433,10 +433,10 @@ void timed_event_manager::add( timed_event_type type, const time_point &when,
 void timed_event_manager::add( timed_event_type type, const time_point &when,
                                const int faction_id,
                                const tripoint_abs_ms &where,
-                               int strength, const std::string &string_id, submap_revert sr,
+                               int strength, const std::string &string_id, submap sr,
                                const std::string &key )
 {
-    events.emplace_back( type, when, faction_id, where, strength, string_id, sr, key );
+    events.emplace_back( type, when, faction_id, where, strength, string_id, std::move( sr ), key );
 }
 
 bool timed_event_manager::queued( const timed_event_type type ) const
@@ -464,7 +464,7 @@ timed_event *timed_event_manager::get( const timed_event_type type, const std::s
     return nullptr;
 }
 
-std::list<timed_event> timed_event_manager::get_all() const
+std::list<timed_event> const &timed_event_manager::get_all() const
 {
     return events;
 }

--- a/src/timed_event.h
+++ b/src/timed_event.h
@@ -48,13 +48,13 @@ struct timed_event {
     /** key to alter this event later */
     std::string key;
 
-    submap_revert revert;
+    submap revert;
     timed_event( timed_event_type e_t, const time_point &w, int f_id, tripoint_abs_ms p, int s,
                  std::string key );
     timed_event( timed_event_type e_t, const time_point &w, int f_id, tripoint_abs_ms p, int s,
                  std::string s_id, std::string key );
     timed_event( timed_event_type e_t, const time_point &w, int f_id, tripoint_abs_ms p, int s,
-                 std::string s_id, submap_revert &sr, std::string key );
+                 std::string s_id, submap sr, std::string key );
 
     // When the time runs out
     void actualize();
@@ -84,7 +84,7 @@ class timed_event_manager
                   const tripoint_abs_ms &where, int strength, const std::string &string_id,
                   const std::string &key = "" );
         void add( timed_event_type type, const time_point &when, int faction_id,
-                  const tripoint_abs_ms &where, int strength, const std::string &string_id, submap_revert sr,
+                  const tripoint_abs_ms &where, int strength, const std::string &string_id, submap sr,
                   const std::string &key = "" );
         /// @returns Whether at least one element of the given type is queued.
         bool queued( timed_event_type type ) const;
@@ -92,7 +92,7 @@ class timed_event_manager
         /// if no event of that type is queued.
         timed_event *get( timed_event_type type );
         timed_event *get( timed_event_type type, const std::string &key );
-        std::list<timed_event> get_all() const;
+        std::list<timed_event> const &get_all() const;
         void set_all( const std::string &key, time_duration time_in_future );
         /// Process all queued events, potentially altering the game state and
         /// modifying the event queue.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Heap profiling shows that uniform submaps dominate memory usage.

See #63759 and #63018
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Allocate submap data only if/when changes are needed.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Virtual submap with 2 implementations: too much boilerplate
Sparse arrays: probably the better solution but I'm not convinced it's worth the code complexity for 12x12 arrays
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Uniform submaps are still uniform.
Tests still pass.
Saving and reloading with mixed quads still works (ex: dig down then save).
Verify that mixed mapgen chunks/OM tiles like `office_tower_open_air_corner` save and reload without error.
Verify that submap reversion (portal storm dungeon) still works, including after a save/reload cycle.

Using [Groveville-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/10822040/Groveville-trimmed.tar.gz) from #63759 and profiling with `heaptrack` by autodriving to the nearby ranch with autosave off.

<details>
<summary>Flame graph before</summary>

![before](https://user-images.githubusercontent.com/68240139/221127913-5572248a-958a-4b6a-b3cc-05bb3c624016.png)

</details>

<details>
<summary>Flame graph after</summary>

![after](https://user-images.githubusercontent.com/68240139/221127935-53f708ba-eeec-4136-b12f-7fef25210e81.png)

</details>


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I had to simplify submap reversion to prevent duplicating effort there.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
