### PR TITLE
Automatically cap melee skill gain from monsters

### DIFF
--- a/doc/MONSTERS.md
+++ b/doc/MONSTERS.md
@@ -56,6 +56,7 @@ Monsters may also have any of these optional properties:
 | `melee_dice`             | (integer) Number of dice rolled on monster melee attack to determine bash damage
 | `melee_dice_sides`       | (integer) Number of sides on each die rolled by `melee_dice`
 | `grab_strength`          | (integer) Intensity of grab effect, from `1` to `n`, simulating `n` regular zombie grabs
+| `melee_training_cap`     | (integer) The maximum melee skill levels learnable by fighting this monster. If not defined defaults to `melee_skill + 2`.
 | `armor_bash`             | (integer) Monster's protection from bash damage
 | `armor_bullet`           | (integer) Monster's protection from bullet damage
 | `armor_cut`              | (integer) Monster's protection from cut damage

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1003,7 +1003,6 @@ void mtype::load( const JsonObject &jo, const std::string &src )
 
     optional( jo, was_loaded, "speed_description", speed_desc, speed_description_DEFAULT );
     optional( jo, was_loaded, "death_function", mdeath_effect );
-    optional( jo, was_loaded, "melee_training_cap", melee_training_cap, MAX_SKILL );
 
     if( jo.has_array( "emit_fields" ) ) {
         JsonArray jar = jo.get_array( "emit_fields" );
@@ -1051,6 +1050,8 @@ void mtype::load( const JsonObject &jo, const std::string &src )
             remove_special_attacks( tmp, "special_attacks", src );
         }
     }
+    optional( jo, was_loaded, "melee_training_cap", melee_training_cap, std::min( melee_skill + 2,
+              MAX_SKILL ) );
     optional( jo, was_loaded, "chat_topics", chat_topics );
     // Disable upgrading when JSON contains `"upgrades": false`, but fallback to the
     // normal behavior (including error checking) if "upgrades" is not boolean or not `false`.
@@ -1148,6 +1149,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
                  ( difficulty_base + special_attacks.size() + 8 * emit_fields.size() );
     difficulty *= ( hp + speed - attack_cost + ( morale + agro ) * 0.1 ) * 0.01 +
                   ( vision_day + 2 * vision_night ) * 0.01;
+
 }
 
 void MonsterGenerator::load_species( const JsonObject &jo, const std::string &src )

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -18,7 +18,6 @@
 static const efftype_id effect_sleep( "sleep" );
 
 static const mtype_id debug_mon( "debug_mon" );
-static const mtype_id debug_mon_trainer( "debug_mon_trainer" );
 static const mtype_id mon_manhack( "mon_manhack" );
 static const mtype_id mon_zombie( "mon_zombie" );
 static const mtype_id mon_zombie_hulk( "mon_zombie_hulk" );

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -293,25 +293,25 @@ TEST_CASE( "Melee skill training caps", "[melee], [melee_training_cap], [skill]"
     REQUIRE( level.knowledgeExperience( true ) == 0 );
 
     SECTION( "Monster's melee training cap is calculated correctly" ) {
-        REQUIRE( dummy_1.get_melee() == 0 );
-        REQUIRE( dummy_1.type->melee_training_cap == 2 );
-        REQUIRE( zed.get_melee() == 4 );
-        REQUIRE( zed.type->melee_training_cap == 6 );
+        CHECK( dummy_1.get_melee() == 0 );
+        CHECK( dummy_1.type->melee_training_cap == 2 );
+        CHECK( zed.get_melee() == 4 );
+        CHECK( zed.type->melee_training_cap == 6 );
     }
 
     SECTION( "Attacking a monster when above its traing cap will not cause further skill gain" ) {
         dude.melee_attack_abstract( dummy_1, false, matec_id( "" ) );
-        REQUIRE( level.knowledgeLevel() == 4 );
-        REQUIRE( level.knowledgeExperience( true ) == 0 );
+        CHECK( level.knowledgeLevel() == 4 );
+        CHECK( level.knowledgeExperience( true ) == 0 );
     }
     SECTION( "Attacking a monster when below the traing cap will train the skill up to the cap" ) {
         dude.melee_attack_abstract( zed, false, matec_id( "" ) );
-        REQUIRE( level.knowledgeLevel() == 4 );
-        REQUIRE( level.knowledgeExperience( true ) > 0 );
+        CHECK( level.knowledgeLevel() == 4 );
+        CHECK( level.knowledgeExperience( true ) > 0 );
         // Training stops if we get above the cap
         dude.set_skill_level( skill_melee, 7 );
         int prev_xp = level.knowledgeExperience( true );
         dude.melee_attack_abstract( zed, false, matec_id( "" ) );
-        REQUIRE( level.knowledgeExperience( true ) == prev_xp );
+        CHECK( level.knowledgeExperience( true ) == prev_xp );
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Cap melee skill gain based on monster melee skill"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Attacking monsters can train melee skills without limit unless explicitly specified by `melee_training_cap`, but that leads to whack-a-exploit with increasingly asspully reasonings for why monster X should give exactly Y skill XP. This introduces an automatic calculation for the cap unless otherwise specified.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
`melee_training_cap` defaults to `melee_skill + 2`.

TODO:
- [x] Force myself to add some unit tests, we'll see if I manage.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Base it on dodge, but that leads to some small critters like kittens becoming you ticket to the phat XP gainz.
Base it on difficulty but the difficulty calculation is very wonky (and has a way too broad range in any case).
Take the average of melee skill and dodge into account, but as a rule melee skill correlates way better with melee lethality (and presumably "things to learn while fighting this") than dodge.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Checked that the training cap does what it's supposed to. Added the automatic default, when not specified the cap is set to the desired level (checked both in debugger and with a debug mode readout I didn't commit because it technically adds a string).

Also did a unit test! A pretty clunky one, but hey.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->