### PR TITLE
Add ingested calories to the calorie diary only when the player is doing the eating

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1545,7 +1545,9 @@ bool Character::consume_effects( item &food )
     stomach.ingest( ingested );
 
     // update speculative values
-    get_avatar().add_ingested_kcal( ingested.nutr.calories / 1000 );
+    if( is_avatar() ) {
+        get_avatar().add_ingested_kcal( ingested.nutr.calories / 1000 );
+    }
     for( const auto &v : ingested.nutr.vitamins ) {
         // update the estimated values for daily vitamins
         // actual vitamins happen during digestion


### PR DESCRIPTION
#### Summary
Bugfixes "Add ingested calories to the calorie diary only when the player is doing the eating"

#### Purpose of change

Small fix to prevent food consumed by NPCs to be added to the avatar's calorie diary.

#### Describe the solution

Check if `is_avatar()` before adding calories to the diary.

#### Describe alternatives you've considered

None

#### Testing

Spawned in an NPC, a leather journal (calorie tracking) and a vegetable sandwich. Before the fix, giving the sandwich to the NPC ("I want you to use this item") and them consuming it caused the calorie diary to increase with 202 kcal. After the fix it didn't increase anymore. If the player eats the sandwich the calories still increase correctly.

#### Additional context

I'm playing with NPC needs on, which made me aware of this bug.