### PR TITLE
Fix NPCs unable to trade items away if they have no pockets

### DIFF
--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -343,7 +343,7 @@ bool npc_trading::npc_can_fit_items( npc const &np, trade_selector::select_t con
 {
     std::vector<item> avail_pockets = np.worn.available_pockets();
 
-    if( avail_pockets.empty() ) {
+    if( !to_trade.empty() && avail_pockets.empty() ) {
         return false;
     }
     for( trade_selector::entry_t const &it : to_trade ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix NPCs unable to trade items away if they have no pockets"

#### Purpose of change

NPCs are unable to trade at all if they have zero pockets (a common situation in innawoods), they can't even give items away to the player. The game always shows the "\<npcname\> doesn't have the appropriate pockets to accept that" message. This PR fixes that.

#### Describe the solution

Allow the trade if an NPC has no pockets but doesn't receive any items in the trade.

#### Describe alternatives you've considered

None

#### Testing

Spawned an NPC, removed all their items with pockets, and traded away their weapon. Before the fix, got the "no pockets" message, after the fix the trade succeeded. Trading items to the NPC still failed with that message.