### PR TITLE
Fix IFF edge case for unseen player

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -499,11 +499,11 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
     boo_hoo = 0;         // how many targets were passed due to IFF. Tragically.
     bool self_area_iff = false; // Need to check if the target is near the vehicle we're a part of
     bool area_iff = false;      // Need to check distance from target to player
-    bool angle_iff = true;      // Need to check if player is in a cone between us and target
+    bool angle_iff = sees( player_character ); // Need to check if player is in cone to target
     int pldist = rl_dist( pos(), player_pos );
     map &here = get_map();
     vehicle *in_veh = is_fake() ? veh_pointer_or_null( here.veh_at( pos() ) ) : nullptr;
-    if( pldist < iff_dist && sees( player_character ) ) {
+    if( pldist < iff_dist && angle_iff ) {
         area_iff = area > 0;
         // Player inside vehicle won't be hit by shots from the roof,
         // so we can fire "through" them just fine.


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix edgecase where `Creature::auto_find_hostile_target` doesn't correctly check angle iff when targeter doesn't "sees()" the player

#### Describe the solution

(for example's sakes i'll write 'turret' but this fits for any fake/real creature that invokes the function)
When turret doesn't see player - `u_angle` local var isn't initialized so it's at angle=0 , if the monster position is at +/- 15 degree difference from angle=0 (so, to the right of the turret) it's counted as if the player is in line of fire regardless of player position.

This PR sets angle_iff to be checked only if turret sees the player (and therefore either initializes u_angle correctly or turns off angle_iff if player is inside the turret's vehicle)

#### Describe alternatives you've considered

#### Testing

Load attached save or make a setup similar to the screenshot
Skip a turn - turret will do IFF beep and not shoot
Apply patch - repeat - turret should kill zombie

#### Additional context

[Strawberry-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/10831960/Strawberry-trimmed.tar.gz)

![image](https://user-images.githubusercontent.com/6560075/221373473-acfc404c-de77-487a-9749-037abcd90d3c.png)
