### PR TITLE
map: downgrade deprecated overlap debug message

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7293,17 +7293,12 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle,
                 const bool pump_events )
 {
     map &main_map = get_map();
-    if( this != &main_map ) {
-        // It's unsafe to load a map that overlaps with the primary map;
-        // various caches get confused.  So make sure we're not doing that.
-        // FIXME: Currently this happens for scripted update_mapgen, scenario
-        // start update mapgen, and faction camp construction update mapgen.
-        // None of those are easily fixable, so give the warning message only
-        // in test mode for now since it's just causing noise.
-        if( test_mode && main_map.inbounds( project_to<coords::ms>( w ) ) ) {
-            debugmsg( "loading non-main map at %s which overlaps with main map (abs_sub = %s) "
-                      "is not supported", w.to_string(), main_map.abs_sub.to_string() );
-        }
+    // It used to be unsafe to load a map that overlaps with the primary map;
+    // Show an info line in tests to help track new errors
+    if( test_mode && this != &main_map && main_map.inbounds( project_to<coords::ms>( w ) ) ) {
+        DebugLog( D_INFO, DC_ALL )
+                << "loading non-main map at " << w.to_string()
+                << " which overlaps with main map (abs_sub = " << main_map.abs_sub.to_string() << ")";
     }
     for( auto &traps : traplocs ) {
         traps.clear();

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -53,10 +53,6 @@ TEST_CASE( "EOC_teleport", "[eoc]" )
 
 TEST_CASE( "EOC_transform_radius", "[eoc][timed_event]" )
 {
-    // FIXME: remove once the overlap warning in `map::load()` has been fully solved
-    restore_on_out_of_scope<bool> restore_test_mode( test_mode );
-    test_mode = false;
-
     // no introspection :(
     constexpr int eoc_range = 5;
     constexpr time_duration delay = 30_seconds;
@@ -81,10 +77,6 @@ TEST_CASE( "EOC_transform_radius", "[eoc][timed_event]" )
 
 TEST_CASE( "EOC_transform_line", "[eoc][timed_event]" )
 {
-    // FIXME: remove once the overlap warning in `map::load()` has been fully solved
-    restore_on_out_of_scope<bool> restore_test_mode( test_mode );
-    test_mode = false;
-
     clear_avatar();
     clear_map();
     standard_npc npc( "Mr. Testerman" );

--- a/tests/mapgen_helpers.h
+++ b/tests/mapgen_helpers.h
@@ -19,10 +19,6 @@ template<typename F, typename ID>
 void manual_mapgen( tripoint_abs_omt const &where, F const &fmg, ID const &id,
                     fprep_t const &prep = {} )
 {
-    // FIXME: remove once the overlap warning in `map::load()` has been fully solved
-    restore_on_out_of_scope<bool> restore_test_mode( test_mode );
-    test_mode = false;
-
     common_mapgen_prep( where, prep );
     fmg( where, id );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There's a deprecated overlap warning in `map::load()` for a set of issues that I believe I've fixed in #58546 and its followups.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Downgrade the debug error to an info line
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Keep living in fear
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
`../build/cata_test --min-duration 0.2 --rng-seed time --use-colour yes --option_overrides=24_HOUR:12h EOC_teleport,EOC_transform_radius` shows the INFO line about overlapping maps.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Spotted in the wild here https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4273527160/jobs/7439497630#step:17:271
The test was fine other than that one warning.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
