### PR TITLE
inv_ui: defer calculating denial

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -923,7 +923,7 @@ inventory_column::entry_cell_cache_t inventory_column::make_entry_cell_cache(
 
     result.assigned = true;
     result.color = preset.get_color( entry );
-    result.denial = &entry.denial;
+    result.denial = &*entry.denial;
     result.text.resize( preset.get_cells_count() );
 
     for( size_t i = 0, n = preset.get_cells_count(); i < n; ++i ) {
@@ -998,14 +998,19 @@ void inventory_column::set_height( size_t new_height )
     }
 }
 
-void inventory_column::expand_to_fit( const inventory_entry &entry, bool with_denial )
+void inventory_column::expand_to_fit( inventory_entry &entry, bool with_denial )
 {
     if( !entry ) {
         return;
     }
 
+    if( !entry.denial ) {
+        entry.denial = { preset.get_denial( entry ) };
+        entry.enabled = entry.denial->empty();
+    }
+
     // Don't use cell cache here since the entry may not yet be placed into the vector of entries.
-    const std::string &denial = entry.denial;
+    const std::string &denial = *entry.denial;
 
     for( size_t i = 0, num = with_denial && denial.empty() ? cells.size() : 1; i < num; ++i ) {
         auto &cell = cells[i];
@@ -1239,8 +1244,6 @@ inventory_entry *inventory_column::add_entry( const inventory_entry &entry )
     dest.emplace_back( entry );
     inventory_entry &newent = dest.back();
     newent.update_cache();
-    newent.denial = preset.get_denial( newent );
-    newent.enabled = newent.denial.empty();
 
     return &newent;
 }
@@ -1622,7 +1625,7 @@ void selection_column::reset_width( const std::vector<inventory_column *> &all_c
 
     for( const inventory_column *const col : all_columns ) {
         if( col && !dynamic_cast<const selection_column *>( col ) ) {
-            for( const inventory_entry *const ent : col->get_entries( always_yes ) ) {
+            for( inventory_entry *const ent : col->get_entries( always_yes ) ) {
                 if( ent ) {
                     expand_to_fit( *ent, false );
                 }

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -166,7 +166,7 @@ class inventory_entry
         size_t generation = 0;
         bool chevron = false;
         int indent = 0;
-        std::string denial;
+        cata::optional<std::string> denial;
         bool enabled = true;
 
         void set_custom_category( const item_category *category ) {
@@ -392,7 +392,7 @@ class inventory_column
         size_t get_width() const;
         size_t get_height() const;
         /** Expands the column to fit the new entry. */
-        void expand_to_fit( const inventory_entry &entry, bool with_denial = true );
+        void expand_to_fit( inventory_entry &entry, bool with_denial = true );
         /** Resets width to original (unchanged). */
         virtual void reset_width( const std::vector<inventory_column *> &all_columns );
         /** Returns next custom inventory letter. */


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Squeeze some more performance out of Inventory UI by calculating denial only for visible entries
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Opening the `pickup_all` UI in [City of the Dalles.zip](https://github.com/CleverRaven/Cataclysm-DDA/files/10725265/City.of.the.Dalles.zip)

<details>
<summary>Before</summary>

![before](https://user-images.githubusercontent.com/68240139/221425101-f784e6df-98f7-4e90-9d06-8a1d564f7f70.png)

total time ~3.5s

![before_perf](https://user-images.githubusercontent.com/68240139/221425109-6c0c579d-17fb-42bc-ad33-8c687ac5c5e7.png)

</details>

<details>
<summary>After</summary>

![after](https://user-images.githubusercontent.com/68240139/221425115-45c16e7e-5d58-42dc-bdfc-f71e124d88b3.png)

total time ~2.4s

![after-perf](https://user-images.githubusercontent.com/68240139/221425119-4ff829ec-d9c2-4c9d-8b77-1a81f00462f8.png)

</details>



This has a significant benefit only when there are a lot of collapsed containers. Floor pasta enthusiasts will not gain anything.

Sanity is easy to check this time - the game doesn't crash when uncollapsing containers.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
To be clear: this is not "real" performance improvement. The calculation is simply deferred and, if the player uncollapses everything, the entire process will end up taking longer. However, startup is faster and I think this will still be an improvement in the average case.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
