### PR TITLE
fix: github astyle code style suggestions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -31,10 +31,11 @@ jobs:
 
     - run: sudo apt-get install astyle
 
-    - run: make astyle-check && make astyle-fast && make style-all-json-parallel
+    - run: make astyle-fast
+    - run: make style-all-json-parallel
 
     - name: 'suggester / JSON & C++'
       uses: reviewdog/action-suggester@v1
-      if: ${{ failure() }}
+      if: ${{ always() }}
       with:
         tool_name: 'JSON & C++ formatters'


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
fix the code style reviewer, specifically it didn't do github suggestions for the cpp styler; big facepalm moment, I was like "just run the json and cpp styler commands in any order with a `&&`, no-brainer it just works"

```yml
    - run: make astyle-fast # always returns a 1, beware easy to trip on this one
    - run: make style-all-json-parallel 
    # these two just lint all the relevant code, always; don't need to care about the results
    # we'll just run the magic reviewer step on `always()` such that we attempt to post
    # a suggestion if possible always after formatting, no need to know if the code style is correct
    # this avoids logic mistakes on my part
      uses: reviewdog/action-suggester@v1
      if: ${{ always() }}
```
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
https://github.com/casswedson/Cataclysm-DDA/pull/98 github suggestion for json and cpp code style work
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
