### PR TITLE
M1 mac fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,15 @@ jobs:
             artifact: osx-tiles-x64
             ext: dmg
             content: application/x-apple-diskimage
+          - name: OSX Tiles arm64
+            os: macos-11
+            arch: arm64
+            mxe: none
+            tiles: 1
+            sound: 0
+            artifact: osx-tiles-arm64
+            ext: dmg
+            content: application/x-apple-diskimage
           - name: Android x64
             os: ubuntu-latest
             mxe: none
@@ -262,8 +271,12 @@ jobs:
       - name: Install dependencies (mac)
         if: runner.os == 'macOS'
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext ccache parallel
+          brew install gettext ccache parallel
+          ~/build-script/get-mac-sdl2-framework.sh
           pip3 install mac_alias==2.2.0 dmgbuild==1.4.2 biplist
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
       - name: Create VERSION.TXT
         shell: bash
         run: |
@@ -301,7 +314,12 @@ jobs:
       - name: Build CDDA (osx)
         if: runner.os == 'macOS'
         run: |
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 OSX_MIN=10.12 dmgdist
+          if [[ ${{ matrix.arch }} == 'arm64' ]]; then
+            OSX_MIN=11.0
+          else
+            OSX_MIN=10.12
+          fi
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 OSX_MIN=$OSX_MIN FRAMEWORK=1 ARCH=${{ matrix.arch }} dmgdist
           mv Cataclysm.dmg cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Set up JDK 8 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install gettext ccache parallel
-          ~/build-script/get-mac-sdl2-framework.sh
+          ~/build-scripts/get-mac-sdl2-framework.sh
           pip3 install mac_alias==2.2.0 dmgbuild==1.4.2 biplist
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/Makefile
+++ b/Makefile
@@ -543,6 +543,10 @@ ifeq ($(NATIVE), osx)
   DEFINES += -DMACOSX
   CXXFLAGS += -mmacosx-version-min=$(OSX_MIN)
   LDFLAGS += -mmacosx-version-min=$(OSX_MIN) -framework CoreFoundation -Wl,-headerpad_max_install_names
+  ifeq ($(ARCH),arm64)
+    CXXFLAGS += -arch arm64
+    LDFLAGS += -arch arm64
+  endif
   ifdef FRAMEWORK
     ifeq ($(FRAMEWORKSDIR),)
       FRAMEWORKSDIR := $(strip $(if $(shell [ -d $(HOME)/Library/Frameworks ] && echo 1), \

--- a/build-scripts/get-mac-sdl2-framework.sh
+++ b/build-scripts/get-mac-sdl2-framework.sh
@@ -1,0 +1,35 @@
+#/bin/bash
+
+# This script downloads the SDL2 framework for macOS
+set -u
+
+SDL2_VERSION=2.26.3
+SDL2_TTF_VERSION=2.20.2
+SDL2_IMAGE_VERSION=2.6.3
+SDL2_MIXER_VERSION=2.6.3
+TARGET_PATH=~/Library/Frameworks
+
+function download_sdl_framework {
+  local project_id=$1
+  local version=$2
+
+  local github_id=${project_id%2}
+  local url=https://github.com/libsdl-org/$github_id/releases/download/release-$version/$project_id-$version.dmg
+  local output_file=$project_id-$version.dmg
+  
+  echo "Downloading $project_id"
+  curl -L -o $output_file $url
+  hdiutil attach $output_file
+  cp -R /Volumes/$project_id/$project_id.framework $TARGET_PATH
+  hdiutil detach /Volumes/$project_id
+  rm $output_file
+}
+
+pushd $(mktemp -d)
+
+download_sdl_framework SDL2 $SDL2_VERSION
+download_sdl_framework SDL2_ttf $SDL2_TTF_VERSION
+download_sdl_framework SDL2_image $SDL2_IMAGE_VERSION
+download_sdl_framework SDL2_mixer $SDL2_MIXER_VERSION
+
+popd


### PR DESCRIPTION
#### Summary
Build "Restore M1 build"

#### Purpose of change

Restores M1 build from #63702 with typo fixed

#### Describe the solution

Restores M1 build from #63702 and applies typo fix suggested by [kebkaldanil](https://github.com/kebkaldanil)

#### Describe alternatives you've considered

Remove homebrew environment variables entirely because I think they're redundant, remove new .sh script that isn't working

#### Testing

Appears to work and passes checks

#### Additional context

Part of push to get the new stable build working