### PR TITLE
Make adhesive bandages recipe craft multiples.

### DIFF
--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -70,9 +70,8 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "firstaid",
     "difficulty": 1,
-    "time": "1 m",
+    "time": "20 m",
     "charges": 30,
-    "batch_time_factors": [ 50, 2 ],
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "medical_gauze", 1 ] ], [ [ "duct_tape", 8 ], [ "medical_tape", 10 ] ] ]

--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -71,7 +71,7 @@
     "skill_used": "firstaid",
     "difficulty": 1,
     "time": "1 m",
-    "charges": 30
+    "charges": 30,
     "batch_time_factors": [ 50, 2 ],
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 2 } ],

--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -75,7 +75,7 @@
     "batch_time_factors": [ 50, 2 ],
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "medical_gauze", 1 ] ], [ [ "duct_tape", 1 ], [ "medical_tape", 1 ] ] ]
+    "components": [ [ [ "medical_gauze", 1 ] ], [ [ "duct_tape", 8 ], [ "medical_tape", 10 ] ] ]
   },
   {
     "result": "tourniquet_upper",

--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -71,6 +71,7 @@
     "skill_used": "firstaid",
     "difficulty": 1,
     "time": "1 m",
+    "charges": 30
     "batch_time_factors": [ 50, 2 ],
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 2 } ],

--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -71,7 +71,7 @@
     "skill_used": "firstaid",
     "difficulty": 1,
     "time": "20 m",
-    "charges": 30,
+    "result_mult": 30,
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "medical_gauze", 1 ] ], [ [ "duct_tape", 8 ], [ "medical_tape", 10 ] ] ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Crafting adhesive bandages from medical gauze causes >95% of the gauze to be wasted. This changes things so that only ~33% is wasted. By contrast, crafting bandages from medical gauze wastes ~22% of the material, so for multiple smaller cuts, ~33% seems reasonable wastage.

#### Describe the solution
Edited the adhesive bandage crafting recipe to craft 30 bandages instead of 1.

#### Describe alternatives you've considered
Changing the recipe to use something other than medical gauze (perhaps a cotton patch? That would make these a field-craftable dressing, now that makeshift bandages are more difficult to craft on the spot)

#### Testing
Created new character with Health Care 2.
Checked crafting screen, found Adhesive Bandage recipe.
Recipe indicates 30 will be created.
Grabbed first aid kit from evac shelter basement.
Crafted adhesive bandages.
30 were crafted.

#### Additional context
