### PR TITLE
Validate bionic_data::mutation_conflicts consistency

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -239,7 +239,7 @@
       "MUZZLE_BEAR",
       "MUZZLE_RAT",
       "MUZZLE_LONG",
-      "PROBISCIS",
+      "PROBOSCIS",
       "MOUTH_FLAPS",
       "MOUTH_TENTACLES",
       "MANDIBLES",

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -520,11 +520,14 @@ void bionic_data::check_bionic_consistency()
                           bio.id.c_str(), pseudo.c_str() );
             }
         }
-
+        for( const trait_id &mid : bio.mutation_conflicts ) {
+            if( !mid.is_valid() ) {
+                debugmsg( "Bionic %s conflicts with undefined mutation %s", bio.id.c_str(), mid.c_str() );
+            }
+        }
         for( const trait_id &mid : bio.canceled_mutations ) {
             if( !mid.is_valid() ) {
-                debugmsg( "Bionic %s cancels undefined mutation %s",
-                          bio.id.c_str(), mid.c_str() );
+                debugmsg( "Bionic %s cancels undefined mutation %s", bio.id.c_str(), mid.c_str() );
             }
         }
         for( const enchantment_id &eid : bio.id->enchantments ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Make automated check for #63826

#### Describe the solution

Validate bionic_data::mutation_conflicts trait_ids in check_bionic_consistency

Fix another typo'ed id

#### Describe alternatives you've considered

#### Testing

Revert the json change for "PROBISCIS", debugmsg should pop

#### Additional context
