### PR TITLE
prevent stored cal integer overflow

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4046,7 +4046,7 @@ void Character::mod_stored_calories( int ncal, const bool ignore_weariness )
     if( !ignore_weariness ) {
         activity_history.calorie_adjust( ncal );
     }
-    if( ncal < 0 || ncal + stored_calories > 0 ) {
+    if( ncal < 0 || std::numeric_limits<int>::max() - ncal > stored_calories ) {
         set_stored_calories( stored_calories + ncal );
     }
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4046,7 +4046,9 @@ void Character::mod_stored_calories( int ncal, const bool ignore_weariness )
     if( !ignore_weariness ) {
         activity_history.calorie_adjust( ncal );
     }
-    set_stored_calories( std::min( 2147000000, std::abs( stored_calories + ncal ) ) );
+    if( ncal < 0 || ncal + stored_calories > 0 ) {
+        set_stored_calories( stored_calories + ncal );
+    }
 }
 
 void Character::set_stored_kcal( int kcal )

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4046,7 +4046,7 @@ void Character::mod_stored_calories( int ncal, const bool ignore_weariness )
     if( !ignore_weariness ) {
         activity_history.calorie_adjust( ncal );
     }
-    set_stored_calories( stored_calories + ncal );
+    set_stored_calories( std::min( 2147483645, stored_calories + ncal ) );
 }
 
 void Character::set_stored_kcal( int kcal )

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4046,7 +4046,7 @@ void Character::mod_stored_calories( int ncal, const bool ignore_weariness )
     if( !ignore_weariness ) {
         activity_history.calorie_adjust( ncal );
     }
-    set_stored_calories( std::min( 2147483645, stored_calories + ncal ) );
+    set_stored_calories( std::min( 2147000000, std::abs( stored_calories + ncal ) ) );
 }
 
 void Character::set_stored_kcal( int kcal )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "stored calories cap instead of integer overflowing"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #63727
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Simply limit max stored calories in the function that adjusts stored calories.
Should go along just fine with #60597.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled and tested this by setting stored kcal to 2 million and guts kcal to 2 million and didn't see stored kcal exceed ~2.14 million after waiting over 24 hours repeatedly refreshing guts kcal to 2 million whenever it fell below 1 million kcal.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
