### PR TITLE
fix release version numbers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 0.G-branch
     paths:
       - '.github/workflows/release.yml'
       - 'android/**'

--- a/build-scripts/windist.ps1
+++ b/build-scripts/windist.ps1
@@ -13,4 +13,4 @@ $extras = "data", "doc", "gfx", "LICENSE.txt", "LICENSE-OFL-Terminus-Font.txt", 
 ForEach ($extra in $extras) {
 	cp -r $extra bindist
 }
-Compress-Archive -Force -Path bindist/* -DestinationPath "cataclysmdda-0.F.zip"
+Compress-Archive -Force -Path bindist/* -DestinationPath "cataclysmdda-0.G.zip"

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -3,7 +3,7 @@
 #if (defined(_WIN32) || defined(MINGW)) && !defined(GIT_VERSION) && !defined(CROSS_LINUX) && !defined(_MSC_VER)
 
 #ifndef VERSION
-#define VERSION "0.F"
+#define VERSION "0.G"
 #endif
 
 #else


### PR DESCRIPTION
#### Summary
 None

#### Purpose of change
The existing tag based versioning system broke at some point, so the version of the 0.G executables is just the commit hash. This PR does some quiche and dirty changes to produce the correct version number. 