### PR TITLE
Fix MSVC template warnings

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2068,7 +2068,7 @@ static std::function<void( const T &, double )> get_set_dbl( const JsonObject &j
         }
     } else if( jo.has_member( "faction_trust" ) ) {
         str_or_var<T> name = get_str_or_var<T>( jo.get_member( "faction_trust" ), "faction_trust" );
-        return [name, min, max]( const T & d, int input ) {
+        return [name, min, max]( const T & d, double input ) {
             faction *fac = g->faction_manager_ptr->get( faction_id( name.evaluate( d ) ) );
             fac->trusts_u += handle_min_max<T>( d, input, min, max );
         };
@@ -2618,7 +2618,7 @@ void conditional_t<T>::set_has_skill( const JsonObject &jo, const std::string &m
 template<class T>
 void conditional_t<T>::set_roll_contested( const JsonObject &jo, const std::string &member )
 {
-    std::function<int( const T & )> get_check = conditional_t< T >::get_get_dbl( jo.get_object(
+    std::function<double( const T & )> get_check = conditional_t< T >::get_get_dbl( jo.get_object(
                 member ) );
     dbl_or_var<T> difficulty = get_dbl_or_var<T>( jo, "difficulty", true );
     dbl_or_var<T> die_size = get_dbl_or_var<T>( jo, "die_size", false, 10 );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2316,7 +2316,6 @@ void talk_effect_fun_t<T>::set_u_spawn_item( const JsonObject &jo, const std::st
         container_name.str_val = "";
     }
     bool use_item_group = jo.get_bool( "use_item_group", false );
-    dbl_or_var<T> cost = get_dbl_or_var<T>( jo, "cost", false, 0 );
     dbl_or_var<T> count;
     if( !jo.has_int( "charges" ) ) {
         count = get_dbl_or_var<T>( jo, "count", false, 1 );
@@ -2329,7 +2328,8 @@ void talk_effect_fun_t<T>::set_u_spawn_item( const JsonObject &jo, const std::st
                       container_name.evaluate( d ), d, use_item_group );
     };
     dialogue d( get_talker_for( get_avatar() ), nullptr );
-    likely_rewards.emplace_back( count.evaluate( d ), itype_id( item_name.evaluate( d ) ) );
+    likely_rewards.emplace_back( static_cast<int>( count.evaluate( d ) ),
+                                 itype_id( item_name.evaluate( d ) ) );
 }
 
 template<class T>
@@ -3654,7 +3654,7 @@ template<class T>
 void talk_effect_fun_t<T>::set_weighted_list_eocs( const JsonObject &jo,
         const std::string &member )
 {
-    std::vector<std::pair<effect_on_condition_id, std::function<int( const dialogue & )>>> eoc_pairs;
+    std::vector<std::pair<effect_on_condition_id, std::function<double( const dialogue & )>>> eoc_pairs;
     for( JsonArray ja : jo.get_array( member ) ) {
         JsonValue eoc = ja.next_value();
         JsonObject weight = ja.next_object();
@@ -3663,7 +3663,7 @@ void talk_effect_fun_t<T>::set_weighted_list_eocs( const JsonObject &jo,
     }
     function = [eoc_pairs]( const T & d ) {
         weighted_int_list<effect_on_condition_id> eocs;
-        for( const std::pair<effect_on_condition_id, std::function<int( const dialogue & )>> &eoc_pair :
+        for( const std::pair<effect_on_condition_id, std::function<double( const dialogue & )>> &eoc_pair :
              eoc_pairs ) {
             eocs.add( eoc_pair.first, eoc_pair.second( d ) );
         }
@@ -3677,7 +3677,7 @@ template<class T>
 void talk_effect_fun_t<T>::set_switch( const JsonObject &jo,
                                        const std::string &member )
 {
-    std::function<int( const T & )> eoc_switch = conditional_t< T >::get_get_dbl(
+    std::function<double( const T & )> eoc_switch = conditional_t< T >::get_get_dbl(
                 jo.get_object( member ) );
     std::vector<std::pair<dbl_or_var<T>, talk_effect_t<T>>> case_pairs;
     for( const JsonValue jv : jo.get_array( "cases" ) ) {
@@ -3687,7 +3687,7 @@ void talk_effect_fun_t<T>::set_switch( const JsonObject &jo,
         case_pairs.emplace_back( get_dbl_or_var<T>( array_case, "case" ), case_effect );
     }
     function = [eoc_switch, case_pairs]( const T & d ) {
-        int switch_int = eoc_switch( d );
+        const double switch_int = eoc_switch( d );
         talk_effect_t<T> case_effect;
         for( const std::pair<dbl_or_var<T>, talk_effect_t<T>> &case_pair :
              case_pairs ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Clear out template type errors so MSVC output list is normally clean

#### Describe the solution

Use the correct types

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Build in MSVC, warnings should be clean

#### Additional context

![image](https://user-images.githubusercontent.com/6560075/222559802-6db187e2-3754-4e5f-913d-515f4def4fd6.png)