### PR TITLE
Prompt player on where he wants to climb down to when pressed 'move down' button

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11112,8 +11112,7 @@ cata::optional<tripoint> game::point_selection_menu( const std::vector<tripoint>
         const std::string &up_or_down = up ? _( "Climb up %s (%s)" ) : _( "Climb down %s (%s)" );
         // TODO: Inform player what is on said tile
         // But don't just print terrain name (in many cases it will be "open air")
-        pmenu.addentry( num++, true, MENU_AUTOASSIGN, _( "Climb %s %s (%s)" ), up_or_down, dir_name,
-                        dir_arrow );
+        pmenu.addentry( num++, true, MENU_AUTOASSIGN, up_or_down, dir_name, dir_arrow );
     }
 
     pmenu.query();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11109,10 +11109,11 @@ cata::optional<tripoint> game::point_selection_menu( const std::vector<tripoint>
         // TODO: Sort the menu so that it can be used with numpad directions
         const std::string &dir_arrow = direction_arrow( direction_from( upos.xy(), pt.xy() ) );
         const std::string &dir_name = direction_name( direction_from( upos.xy(), pt.xy() ) );
-        const std::string &up_or_down = up ? _( "Climb up %s (%s)" ) : _( "Climb down %s (%s)" );
+        const std::string &up_or_down = up ? _( "Climb up %s (%s)" ), dir_name, dir_arrow :
+                                        _( "Climb down %s (%s)" ), dir_name, dir_arrow;
         // TODO: Inform player what is on said tile
         // But don't just print terrain name (in many cases it will be "open air")
-        pmenu.addentry( num++, true, MENU_AUTOASSIGN, up_or_down, dir_name, dir_arrow );
+        pmenu.addentry( num++, true, MENU_AUTOASSIGN, up_or_down );
     }
 
     pmenu.query();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11090,7 +11090,7 @@ void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
     }
 }
 
-static cata::optional<tripoint> point_selection_menu( const std::vector<tripoint> &pts )
+cata::optional<tripoint> game::point_selection_menu( const std::vector<tripoint> &pts, bool up )
 {
     if( pts.empty() ) {
         debugmsg( "point_selection_menu called with empty point set" );
@@ -11109,9 +11109,11 @@ static cata::optional<tripoint> point_selection_menu( const std::vector<tripoint
         // TODO: Sort the menu so that it can be used with numpad directions
         const std::string &dir_arrow = direction_arrow( direction_from( upos.xy(), pt.xy() ) );
         const std::string &dir_name = direction_name( direction_from( upos.xy(), pt.xy() ) );
+        const std::string &up_or_down = up ? _( "up" ) : _( "down" );
         // TODO: Inform player what is on said tile
         // But don't just print terrain name (in many cases it will be "open air")
-        pmenu.addentry( num++, true, MENU_AUTOASSIGN, _( "Climb %s (%s)" ), dir_name, dir_arrow );
+        pmenu.addentry( num++, true, MENU_AUTOASSIGN, _( "Climb %s %s (%s)" ), up_or_down, dir_name,
+                        dir_arrow );
     }
 
     pmenu.query();
@@ -12441,6 +12443,125 @@ bool game::slip_down( bool check_for_traps )
         return true;
     }
     return false;
+}
+
+void game::climb_down( const tripoint &examp )
+{
+    map &here = get_map();
+    Character &you = get_player_character();
+
+    // Weariness scaling
+    float weary_mult = 1.0f;
+
+    // If player is grabbed, trapped, or somehow otherwise movement-impeded, first try to break free
+    if( !you.move_effects( false ) ) {
+        you.moves -= 100;
+        return;
+    }
+
+    if( !here.valid_move( you.pos(), examp, false, true ) ) {
+        // Covered with something
+        return;
+    }
+
+    tripoint where = examp;
+    tripoint below = examp;
+    below.z--;
+    while( here.valid_move( where, below, false, true ) ) {
+        where.z--;
+        below.z--;
+    }
+
+    const int height = examp.z - where.z;
+    add_msg_debug( debugmode::DF_IEXAMINE, "Ledge height %d", height );
+    if( height == 0 ) {
+        you.add_msg_if_player( _( "You can't climb down there." ) );
+        return;
+    }
+
+    bool has_grapnel = you.has_amount( itype_grapnel, 1 );
+    bool web_rappel = you.has_flag( json_flag_WEB_RAPPEL );
+    const int climb_cost = you.climbing_cost( where, examp );
+    const float fall_mod = you.fall_damage_mod();
+    add_msg_debug( debugmode::DF_IEXAMINE, "Climb cost %d", climb_cost );
+    add_msg_debug( debugmode::DF_IEXAMINE, "Fall damage modifier %.2f", fall_mod );
+    const char *query_str;
+    if( !web_rappel ) {
+        query_str = n_gettext( "Looks like %d story.  Jump down?",
+                               "Looks like %d stories.  Jump down?",
+                               height );
+    } else {
+        query_str = n_gettext( "Looks like %d story.  Nothing your webs can't handle.  Descend?",
+                               "Looks like %d stories.  Nothing your webs can't handle.  Descend?", height );
+    }
+
+    if( height > 1 && !query_yn( query_str, height ) ) {
+        return;
+    } else if( height == 1 ) {
+        you.set_activity_level( ACTIVE_EXERCISE );
+        weary_mult = 1.0f / you.exertion_adjusted_move_multiplier( ACTIVE_EXERCISE );
+
+        if( has_grapnel ) {
+            if( !query_yn( _( "Use your grappling hook to climb down?" ) ) ) {
+                has_grapnel = false;
+            } else {
+                web_rappel = false;
+            }
+        }
+
+        if( !has_grapnel ) {
+            const char *query;
+            if( web_rappel ) {
+                query = _( "Use your webs to descend?" );
+            } else {
+                if( climb_cost <= 0 && fall_mod > 0.8 ) {
+                    query = _( "You probably won't be able to get up and jumping down may hurt.  Jump?" );
+                } else if( climb_cost <= 0 ) {
+                    query = _( "You probably won't be able to get back up.  Climb down?" );
+                } else if( climb_cost < 200 ) {
+                    query = _( "You should be able to climb back up easily if you climb down there.  Climb down?" );
+                } else {
+                    query = _( "You may have problems climbing back up.  Climb down?" );
+                }
+            }
+
+            if( !query_yn( query ) ) {
+                return;
+            }
+        }
+    }
+
+    you.moves -= to_moves<int>( 1_seconds + 1_seconds * fall_mod ) * weary_mult;
+    you.setpos( examp );
+
+    if( web_rappel ) {
+        you.add_msg_if_player(
+            _( "You affix a long, sticky strand on the ledge and begin your descent." ) );
+        tripoint web = examp;
+        web.z--;
+        // Leave a web rope on each step
+        for( int i = 0; i < height; i++ ) {
+            here.furn_set( web, furn_f_web_up );
+            web.z--;
+        }
+        g->vertical_move( -height, true );
+    } else if( has_grapnel ) {
+        you.add_msg_if_player( _( "You tie the rope around your waist and begin to climb down." ) );
+        g->vertical_move( -1, true );
+        you.use_amount( itype_grapnel, 1 );
+        here.furn_set( you.pos(), furn_f_rope_up );
+    } else if( !g->slip_down( true ) ) {
+        // One tile of falling less (possibly zero)
+        add_msg_debug( debugmode::DF_IEXAMINE, "Safe movement down one Z-level" );
+        g->vertical_move( -1, true );
+    } else {
+        return;
+    }
+    if( here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, you.pos() ) ) {
+        you.set_underwater( true );
+        g->water_affect_items( you );
+        you.add_msg_if_player( _( "You climb down and dive underwater." ) );
+    }
 }
 
 namespace cata_event_dispatch

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11109,11 +11109,10 @@ cata::optional<tripoint> game::point_selection_menu( const std::vector<tripoint>
         // TODO: Sort the menu so that it can be used with numpad directions
         const std::string &dir_arrow = direction_arrow( direction_from( upos.xy(), pt.xy() ) );
         const std::string &dir_name = direction_name( direction_from( upos.xy(), pt.xy() ) );
-        const std::string &up_or_down = up ? _( "Climb up %s (%s)" ), dir_name, dir_arrow :
-                                        _( "Climb down %s (%s)" ), dir_name, dir_arrow;
+        const std::string &up_or_down = up ? _( "Climb up %s (%s)" ) : _( "Climb down %s (%s)" );
         // TODO: Inform player what is on said tile
         // But don't just print terrain name (in many cases it will be "open air")
-        pmenu.addentry( num++, true, MENU_AUTOASSIGN, up_or_down );
+        pmenu.addentry( num++, true, MENU_AUTOASSIGN, string_format( up_or_down, dir_name, dir_arrow ) );
     }
 
     pmenu.query();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11109,7 +11109,7 @@ cata::optional<tripoint> game::point_selection_menu( const std::vector<tripoint>
         // TODO: Sort the menu so that it can be used with numpad directions
         const std::string &dir_arrow = direction_arrow( direction_from( upos.xy(), pt.xy() ) );
         const std::string &dir_name = direction_name( direction_from( upos.xy(), pt.xy() ) );
-        const std::string &up_or_down = up ? _( "up" ) : _( "down" );
+        const std::string &up_or_down = up ? _( "Climb up %s (%s)" ) : _( "Climb down %s (%s)" );
         // TODO: Inform player what is on said tile
         // But don't just print terrain name (in many cases it will be "open air")
         pmenu.addentry( num++, true, MENU_AUTOASSIGN, _( "Climb %s %s (%s)" ), up_or_down, dir_name,

--- a/src/game.h
+++ b/src/game.h
@@ -280,6 +280,10 @@ class game
         */
         cata::optional<tripoint> find_or_make_stairs( map &mp, int z_after, bool &rope_ladder,
                 bool peeking, const tripoint &pos );
+        /*
+        * Prompt player on direction they want to climb up or down.
+        */
+        cata::optional<tripoint> point_selection_menu( const std::vector<tripoint> &pts, bool up = true );
         /** Actual z-level movement part of vertical_move. Doesn't include stair finding, traps etc.
          *  Returns true if the z-level changed.
          */
@@ -1198,6 +1202,11 @@ class game
         @return whether player has slipped down
         */
         bool slip_down( bool check_for_traps = false );
+
+        /**
+        * Climb down from a ledge using grappling hooks or spider webs if appropriate.
+        */
+        void climb_down( const tripoint &examp );
 };
 
 // Returns temperature modifier from direct heat radiation of nearby sources

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2013,7 +2013,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                 }
             }
             break;
-        case ACTION_MOVE_DOWN:
+        case ACTION_MOVE_DOWN: {
             if( player_character.is_mounted() ) {
                 auto *mon = player_character.mounted_creature.get();
                 if( !mon->has_flag( MF_RIDEABLE_MECH ) ) {
@@ -2021,6 +2021,29 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     break;
                 }
             }
+
+            std::vector<tripoint> pts;
+            bool climbed = false;
+            for( const tripoint &p : m.points_in_radius( player_character.pos(), 1 ) ) {
+                if( m.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, p ) ) {
+                    pts.push_back( p );
+                }
+            }
+
+            if( !pts.empty() ) {
+                const cata::optional<tripoint> pnt = point_selection_menu( pts, false );
+                if( !pnt ) {
+                    break;
+                }
+
+                climb_down( *pnt );
+                climbed = true;
+            }
+
+            if( climbed ) {
+                break;
+            }
+
             if( !player_character.in_vehicle ) {
                 vertical_move( -1, false );
             } else if( has_vehicle_control( player_character ) ) {
@@ -2030,6 +2053,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                 }
             }
             break;
+        }
 
         case ACTION_MOVE_UP:
             if( player_character.is_mounted() ) {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4920,8 +4920,6 @@ void iexamine::ledge( Character &you, const tripoint &examp )
 
     cmenu.query();
 
-    // Weariness scaling
-    float weary_mult = 1.0f;
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
     switch( cmenu.ret ) {
@@ -4954,116 +4952,7 @@ void iexamine::ledge( Character &you, const tripoint &examp )
             break;
         }
         case 2: {
-            // If player is grabbed, trapped, or somehow otherwise movement-impeded, first try to break free
-            if( !you.move_effects( false ) ) {
-                you.moves -= 100;
-                return;
-            }
-
-            if( !here.valid_move( you.pos(), examp, false, true ) ) {
-                // Covered with something
-                return;
-            }
-
-            tripoint where = examp;
-            tripoint below = examp;
-            below.z--;
-            while( here.valid_move( where, below, false, true ) ) {
-                where.z--;
-                below.z--;
-            }
-
-            const int height = examp.z - where.z;
-            add_msg_debug( debugmode::DF_IEXAMINE, "Ledge height %d", height );
-            if( height == 0 ) {
-                you.add_msg_if_player( _( "You can't climb down there." ) );
-                return;
-            }
-
-            bool has_grapnel = you.has_amount( itype_grapnel, 1 );
-            bool web_rappel = you.has_flag( json_flag_WEB_RAPPEL );
-            const int climb_cost = you.climbing_cost( where, examp );
-            const float fall_mod = you.fall_damage_mod();
-            add_msg_debug( debugmode::DF_IEXAMINE, "Climb cost %d", climb_cost );
-            add_msg_debug( debugmode::DF_IEXAMINE, "Fall damage modifier %.2f", fall_mod );
-            const char *query_str;
-            if( !web_rappel ) {
-                query_str = n_gettext( "Looks like %d story.  Jump down?",
-                                       "Looks like %d stories.  Jump down?",
-                                       height );
-            } else {
-                query_str = n_gettext( "Looks like %d story.  Nothing your webs can't handle.  Descend?",
-                                       "Looks like %d stories.  Nothing your webs can't handle.  Descend?", height );
-            }
-
-            if( height > 1 && !query_yn( query_str, height ) ) {
-                return;
-            } else if( height == 1 ) {
-                you.set_activity_level( ACTIVE_EXERCISE );
-                weary_mult = 1.0f / you.exertion_adjusted_move_multiplier( ACTIVE_EXERCISE );
-
-                if( has_grapnel ) {
-                    if( !query_yn( _( "Use your grappling hook to climb down?" ) ) ) {
-                        has_grapnel = false;
-                    } else {
-                        web_rappel = false;
-                    }
-                }
-
-                if( !has_grapnel ) {
-                    const char *query;
-                    if( web_rappel ) {
-                        query = _( "Use your webs to descend?" );
-                    } else {
-                        if( climb_cost <= 0 && fall_mod > 0.8 ) {
-                            query = _( "You probably won't be able to get up and jumping down may hurt.  Jump?" );
-                        } else if( climb_cost <= 0 ) {
-                            query = _( "You probably won't be able to get back up.  Climb down?" );
-                        } else if( climb_cost < 200 ) {
-                            query = _( "You should be able to climb back up easily if you climb down there.  Climb down?" );
-                        } else {
-                            query = _( "You may have problems climbing back up.  Climb down?" );
-                        }
-                    }
-
-                    if( !query_yn( query ) ) {
-                        return;
-                    }
-                }
-            }
-
-            you.moves -= to_moves<int>( 1_seconds + 1_seconds * fall_mod ) * weary_mult;
-            you.setpos( examp );
-
-            if( web_rappel ) {
-                you.add_msg_if_player(
-                    _( "You affix a long, sticky strand on the ledge and begin your descent." ) );
-                tripoint web = examp;
-                web.z--;
-                // Leave a web rope on each step
-                for( int i = 0; i < height; i++ ) {
-                    here.furn_set( web, furn_f_web_up );
-                    web.z--;
-                }
-                g->vertical_move( -height, true );
-            } else if( has_grapnel ) {
-                you.add_msg_if_player( _( "You tie the rope around your waist and begin to climb down." ) );
-                g->vertical_move( -1, true );
-                you.use_amount( itype_grapnel, 1 );
-                here.furn_set( you.pos(), furn_f_rope_up );
-            } else if( !g->slip_down( true ) ) {
-                // One tile of falling less (possibly zero)
-                add_msg_debug( debugmode::DF_IEXAMINE, "Safe movement down one Z-level" );
-                g->vertical_move( -1, true );
-            } else {
-                return;
-            }
-            if( here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, you.pos() ) ) {
-                you.set_underwater( true );
-                g->water_affect_items( you );
-                you.add_msg_if_player( _( "You climb down and dive underwater." ) );
-            }
-
+            g->climb_down( examp );
             break;
         }
         case 3: {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -137,11 +137,9 @@ static const furn_str_id furn_f_diesel_tank( "f_diesel_tank" );
 static const furn_str_id furn_f_gas_tank( "f_gas_tank" );
 static const furn_str_id furn_f_metal_smoking_rack( "f_metal_smoking_rack" );
 static const furn_str_id furn_f_metal_smoking_rack_active( "f_metal_smoking_rack_active" );
-static const furn_str_id furn_f_rope_up( "f_rope_up" );
 static const furn_str_id furn_f_smoking_rack_active( "f_smoking_rack_active" );
 static const furn_str_id furn_f_water_mill( "f_water_mill" );
 static const furn_str_id furn_f_water_mill_active( "f_water_mill_active" );
-static const furn_str_id furn_f_web_up( "f_web_up" );
 static const furn_str_id furn_f_wind_mill( "f_wind_mill" );
 static const furn_str_id furn_f_wind_mill_active( "f_wind_mill_active" );
 
@@ -162,7 +160,6 @@ static const itype_id itype_fire( "fire" );
 static const itype_id itype_foodperson_mask( "foodperson_mask" );
 static const itype_id itype_foodperson_mask_on( "foodperson_mask_on" );
 static const itype_id itype_fungal_seeds( "fungal_seeds" );
-static const itype_id itype_grapnel( "grapnel" );
 static const itype_id itype_hickory_root( "hickory_root" );
 static const itype_id itype_id_science( "id_science" );
 static const itype_id itype_leg_splint( "leg_splint" );
@@ -183,7 +180,6 @@ static const itype_id itype_unfinished_charcoal( "unfinished_charcoal" );
 static const json_character_flag json_flag_ATTUNEMENT( "ATTUNEMENT" );
 static const json_character_flag json_flag_SUPER_HEARING( "SUPER_HEARING" );
 static const json_character_flag json_flag_WALL_CLING( "WALL_CLING" );
-static const json_character_flag json_flag_WEB_RAPPEL( "WEB_RAPPEL" );
 
 static const material_id material_bone( "bone" );
 static const material_id material_cac2powder( "cac2powder" );


### PR DESCRIPTION
#### Summary
Features "Prompt player on where he wants to climb down to when pressed 'move down' button"

#### Purpose of change
* Closes #50940 (despite it's already closed).

#### Describe the solution
When player presses `MOVE_DOWN` button, prompt him on direction he wants to climb down to.

#### Describe alternatives you've considered
Make player character automatically prefer downspout tiles when pressed climb down. In my testing I found this behavior rather confusing despite I knew what was gonna happen. Also there are some rare situations when player might prefer climbing down not on downspout, but to some other place - for example, if there's monster standing adjacent to downspout.

#### Testing
While on the roof and standing next to ledge, pressed climb down. Was able to successfully climb down using this button.
Stepped away from the ledge, pressed climb down. Got "You can't go down here" message.

#### Additional context
![изображение](https://user-images.githubusercontent.com/11132525/222689921-ac0efe29-10e8-47a8-a64c-e8e6a1191884.png)

