### PR TITLE
New Radiophile mutation

### DIFF
--- a/data/json/morale_types.json
+++ b/data/json/morale_types.json
@@ -264,6 +264,11 @@
     "type": "morale_type",
     "text": "Masochism"
   },
+   {
+    "id": "morale_perm_radsense",
+    "type": "morale_type",
+    "text": "Tingly feeling"
+  },
   {
     "id": "morale_perm_noface",
     "type": "morale_type",

--- a/data/json/morale_types.json
+++ b/data/json/morale_types.json
@@ -264,7 +264,7 @@
     "type": "morale_type",
     "text": "Masochism"
   },
-   {
+  {
     "id": "morale_perm_radsense",
     "type": "morale_type",
     "text": "Tingly feeling"

--- a/data/json/morale_types.json
+++ b/data/json/morale_types.json
@@ -265,7 +265,7 @@
     "text": "Masochism"
   },
   {
-    "id": "morale_perm_radsense",
+    "id": "morale_perm_radiophile",
     "type": "morale_type",
     "text": "Tingly feeling"
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3355,11 +3355,11 @@
   {
     "type": "mutation",
     "id": "RADSENSE",
-    "name": { "str": "Radiation Detection" },
+    "name": { "str": "Radiophile" },
     "points": 1,
     "description": "Your flesh has developed a unique reaction to radiation that lets you sense when ambient radiation is abnormally high.  Turn off to ignore messages.",
     "prereqs": [ "RADIOGENIC" ],
-    "category": [ "MEDICAL" ],
+    "category": [ "SLIME", "MEDICAL" ],
     "active": true,
     "starts_active": true
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -205,6 +205,7 @@
       "POISONOUS",
       "POISONOUS2",
       "RADIOGENIC",
+      "RADIOPHILE",
       "RESISTCHILL",
       "RESISTWARM",
       "ROBUST",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3354,6 +3354,17 @@
   },
   {
     "type": "mutation",
+    "id": "RADSENSE",
+    "name": { "str": "Radiation Detection" },
+    "points": 1,
+    "description": "Your flesh has developed a unique reaction to radiation that lets you sense when ambient radiation is abnormally high.  Turn off to ignore messages.",
+    "prereqs": [ "RADIOGENIC" ],
+    "category": [ "MEDICAL" ],
+    "active": true,
+    "starts_active": true
+  },
+  {
+    "type": "mutation",
     "id": "MARLOSS",
     "name": { "str": "Marloss Carrier" },
     "points": 4,

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3354,7 +3354,7 @@
   },
   {
     "type": "mutation",
-    "id": "RADSENSE",
+    "id": "RADIOPHILE",
     "name": { "str": "Radiophile" },
     "points": 1,
     "description": "Your flesh has developed a unique reaction to radiation that lets you sense when ambient radiation is abnormally high.  Turn off to ignore messages.",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6227,10 +6227,8 @@ int Character::get_rad() const
 
 void Character::set_rad( int new_rad )
 {
-    if( radiation != new_rad ) {
-        radiation = new_rad;
-        on_stat_change( "radiation", radiation );
-    }
+    radiation = new_rad;
+    on_stat_change( "radiation", radiation );
 }
 
 void Character::mod_rad( int mod )

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6227,7 +6227,10 @@ int Character::get_rad() const
 
 void Character::set_rad( int new_rad )
 {
-    radiation = new_rad;
+    if (radiation != new_rad) {
+        radiation = new_rad;
+        on_stat_change("radiation", radiation);
+    }
 }
 
 void Character::mod_rad( int mod )

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6227,8 +6227,10 @@ int Character::get_rad() const
 
 void Character::set_rad( int new_rad )
 {
-    radiation = new_rad;
-    on_stat_change( "radiation", radiation );
+    if ( radiation != new_rad ) {
+        radiation = new_rad;
+        on_stat_change( "radiation", radiation );
+    }
 }
 
 void Character::mod_rad( int mod )

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6227,7 +6227,7 @@ int Character::get_rad() const
 
 void Character::set_rad( int new_rad )
 {
-    if ( radiation != new_rad ) {
+    if( radiation != new_rad ) {
         radiation = new_rad;
         on_stat_change( "radiation", radiation );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -539,7 +539,7 @@ Character::Character() :
     sleep_deprivation = 0;
     daily_sleep = 0_turns;
     continuous_sleep = 0_turns;
-    set_rad( 0 );
+    radiation = 0;
     slow_rad = 0;
     set_stim( 0 );
     set_stamina( 10000 ); //Temporary value for stamina. It will be reset later from external json option.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6227,9 +6227,9 @@ int Character::get_rad() const
 
 void Character::set_rad( int new_rad )
 {
-    if (radiation != new_rad) {
+    if( radiation != new_rad ) {
         radiation = new_rad;
-        on_stat_change("radiation", radiation);
+        on_stat_change( "radiation", radiation );
     }
 }
 

--- a/src/character_morale.cpp
+++ b/src/character_morale.cpp
@@ -171,6 +171,7 @@ void Character::check_and_recover_morale()
     test_morale.on_stat_change( "pain", get_pain() );
     test_morale.on_stat_change( "pkill", get_painkiller() );
     test_morale.on_stat_change( "perceived_pain", get_perceived_pain() );
+    test_morale.on_stat_change("radiation", get_rad());
 
     apply_persistent_morale();
 

--- a/src/character_morale.cpp
+++ b/src/character_morale.cpp
@@ -171,7 +171,7 @@ void Character::check_and_recover_morale()
     test_morale.on_stat_change( "pain", get_pain() );
     test_morale.on_stat_change( "pkill", get_painkiller() );
     test_morale.on_stat_change( "perceived_pain", get_perceived_pain() );
-    test_morale.on_stat_change("radiation", get_rad());
+    test_morale.on_stat_change( "radiation", get_rad() );
 
     apply_persistent_morale();
 

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -1102,7 +1102,7 @@ void player_morale::update_radiophile_bonus()
     int bonus = 0;
 
     if( is_radiophile ) {
-        bonus = radiation / 8;
+        bonus = radiation / 20;
     }
     set_permanent( MORALE_PERM_RADIOPHILE, bonus );
 }

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -43,7 +43,7 @@ static const trait_id trait_MASOCHIST( "MASOCHIST" );
 static const trait_id trait_MASOCHIST_MED( "MASOCHIST_MED" );
 static const trait_id trait_NUMB( "NUMB" );
 static const trait_id trait_OPTIMISTIC( "OPTIMISTIC" );
-static const trait_id trait_RADSENSE( "RADSENSE" );
+static const trait_id trait_RADIOPHILE( "RADIOPHILE" );
 static const trait_id trait_ROOTS1( "ROOTS1" );
 static const trait_id trait_ROOTS2( "ROOTS2" );
 static const trait_id trait_ROOTS3( "ROOTS3" );
@@ -63,7 +63,7 @@ bool is_permanent_morale( const morale_type &id )
             MORALE_PERM_CONSTRAINED,
             MORALE_PERM_FILTHY,
             MORALE_PERM_DEBUG,
-            MORALE_PERM_RADSENSE
+            MORALE_PERM_RADIOPHILE
         }
     };
 
@@ -315,7 +315,7 @@ player_morale::player_morale() :
     mutations[trait_MASOCHIST]     = mutation_data( update_masochist );
     mutations[trait_MASOCHIST_MED] = mutation_data( update_masochist );
     mutations[trait_CENOBITE]      = mutation_data( update_masochist );
-    mutations[trait_RADSENSE]      = mutation_data( update_radiophile );
+    mutations[trait_RADIOPHILE]      = mutation_data( update_radiophile );
 }
 
 void player_morale::add( const morale_type &type, int bonus, int max_bonus,
@@ -1097,14 +1097,14 @@ void player_morale::update_masochist_bonus()
 
 void player_morale::update_radiophile_bonus()
 {
-    const bool is_radiophile = has_mutation( trait_RADSENSE );
+    const bool is_radiophile = has_mutation( trait_RADIOPHILE );
 
     int bonus = 0;
 
     if( is_radiophile ) {
         bonus = radiation / 8;
     }
-    set_permanent( MORALE_PERM_RADSENSE, bonus );
+    set_permanent( MORALE_PERM_RADIOPHILE, bonus );
 }
 
 void player_morale::update_bodytemp_penalty( const time_duration &ticks )

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -43,6 +43,7 @@ static const trait_id trait_MASOCHIST( "MASOCHIST" );
 static const trait_id trait_MASOCHIST_MED( "MASOCHIST_MED" );
 static const trait_id trait_NUMB( "NUMB" );
 static const trait_id trait_OPTIMISTIC( "OPTIMISTIC" );
+static const trait_id trait_RADSENSE("RADSENSE");
 static const trait_id trait_ROOTS1( "ROOTS1" );
 static const trait_id trait_ROOTS2( "ROOTS2" );
 static const trait_id trait_ROOTS3( "ROOTS3" );
@@ -61,7 +62,8 @@ bool is_permanent_morale( const morale_type &id )
             MORALE_PERM_MASOCHIST,
             MORALE_PERM_CONSTRAINED,
             MORALE_PERM_FILTHY,
-            MORALE_PERM_DEBUG
+            MORALE_PERM_DEBUG,
+            MORALE_PERM_RADSENSE
         }
     };
 
@@ -249,7 +251,8 @@ player_morale::player_morale() :
     took_prozac( false ),
     took_prozac_bad( false ),
     stylish( false ),
-    perceived_pain( 0 )
+    perceived_pain( 0 ),
+    radiation( 0 )
 {
     // Cannot use 'this' because the object is copyable
     const auto set_optimist = []( player_morale * pm, int bonus ) {
@@ -269,6 +272,9 @@ player_morale::player_morale() :
     };
     const auto update_masochist = []( player_morale * pm ) {
         pm->update_masochist_bonus();
+    };
+    const auto update_radiophile = [](player_morale* pm) {
+        pm->update_radiophile_bonus();
     };
 
     mutations[trait_OPTIMISTIC] =
@@ -309,6 +315,7 @@ player_morale::player_morale() :
     mutations[trait_MASOCHIST]     = mutation_data( update_masochist );
     mutations[trait_MASOCHIST_MED] = mutation_data( update_masochist );
     mutations[trait_CENOBITE]      = mutation_data( update_masochist );
+    mutations[trait_RADSENSE]      = mutation_data(update_radiophile);
 }
 
 void player_morale::add( const morale_type &type, int bonus, int max_bonus,
@@ -846,6 +853,9 @@ bool player_morale::consistent_with( const player_morale &morale ) const
     } else if( perceived_pain != morale.perceived_pain ) {
         debugmsg( "player_morale::perceived_pain is inconsistent." );
         return false;
+    } else if (radiation != morale.radiation) {
+        debugmsg("player_morale::radiation is inconsistent.");
+        return false;
     }
 
     return test_points( *this, morale ) && test_points( morale, *this );
@@ -906,6 +916,10 @@ void player_morale::on_stat_change( const std::string &stat, int value )
     if( stat == "perceived_pain" ) {
         perceived_pain = value;
         update_masochist_bonus();
+    }
+    if (stat == "radiation") {
+        radiation = value;
+        update_radiophile_bonus();
     }
 }
 
@@ -1079,6 +1093,18 @@ void player_morale::update_masochist_bonus()
         }
     }
     set_permanent( MORALE_PERM_MASOCHIST, bonus );
+}
+
+void player_morale::update_radiophile_bonus()
+{
+    const bool is_radiophile = has_mutation(trait_RADSENSE);
+
+    int bonus = 0;
+
+    if (is_radiophile) {
+        bonus = radiation/8;
+    }
+    set_permanent(MORALE_PERM_RADSENSE, bonus);
 }
 
 void player_morale::update_bodytemp_penalty( const time_duration &ticks )

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -315,7 +315,7 @@ player_morale::player_morale() :
     mutations[trait_MASOCHIST]     = mutation_data( update_masochist );
     mutations[trait_MASOCHIST_MED] = mutation_data( update_masochist );
     mutations[trait_CENOBITE]      = mutation_data( update_masochist );
-    mutations[trait_RADIOPHILE]      = mutation_data( update_radiophile );
+    mutations[trait_RADIOPHILE]    = mutation_data( update_radiophile );
 }
 
 void player_morale::add( const morale_type &type, int bonus, int max_bonus,

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -43,7 +43,7 @@ static const trait_id trait_MASOCHIST( "MASOCHIST" );
 static const trait_id trait_MASOCHIST_MED( "MASOCHIST_MED" );
 static const trait_id trait_NUMB( "NUMB" );
 static const trait_id trait_OPTIMISTIC( "OPTIMISTIC" );
-static const trait_id trait_RADSENSE("RADSENSE");
+static const trait_id trait_RADSENSE( "RADSENSE" );
 static const trait_id trait_ROOTS1( "ROOTS1" );
 static const trait_id trait_ROOTS2( "ROOTS2" );
 static const trait_id trait_ROOTS3( "ROOTS3" );
@@ -273,7 +273,7 @@ player_morale::player_morale() :
     const auto update_masochist = []( player_morale * pm ) {
         pm->update_masochist_bonus();
     };
-    const auto update_radiophile = [](player_morale* pm) {
+    const auto update_radiophile = []( player_morale * pm ) {
         pm->update_radiophile_bonus();
     };
 
@@ -315,7 +315,7 @@ player_morale::player_morale() :
     mutations[trait_MASOCHIST]     = mutation_data( update_masochist );
     mutations[trait_MASOCHIST_MED] = mutation_data( update_masochist );
     mutations[trait_CENOBITE]      = mutation_data( update_masochist );
-    mutations[trait_RADSENSE]      = mutation_data(update_radiophile);
+    mutations[trait_RADSENSE]      = mutation_data( update_radiophile );
 }
 
 void player_morale::add( const morale_type &type, int bonus, int max_bonus,
@@ -853,8 +853,8 @@ bool player_morale::consistent_with( const player_morale &morale ) const
     } else if( perceived_pain != morale.perceived_pain ) {
         debugmsg( "player_morale::perceived_pain is inconsistent." );
         return false;
-    } else if (radiation != morale.radiation) {
-        debugmsg("player_morale::radiation is inconsistent.");
+    } else if( radiation != morale.radiation ) {
+        debugmsg( "player_morale::radiation is inconsistent." );
         return false;
     }
 
@@ -917,7 +917,7 @@ void player_morale::on_stat_change( const std::string &stat, int value )
         perceived_pain = value;
         update_masochist_bonus();
     }
-    if (stat == "radiation") {
+    if( stat == "radiation" ) {
         radiation = value;
         update_radiophile_bonus();
     }
@@ -1097,14 +1097,14 @@ void player_morale::update_masochist_bonus()
 
 void player_morale::update_radiophile_bonus()
 {
-    const bool is_radiophile = has_mutation(trait_RADSENSE);
+    const bool is_radiophile = has_mutation( trait_RADSENSE );
 
     int bonus = 0;
 
-    if (is_radiophile) {
-        bonus = radiation/8;
+    if( is_radiophile ) {
+        bonus = radiation / 8;
     }
-    set_permanent(MORALE_PERM_RADSENSE, bonus);
+    set_permanent( MORALE_PERM_RADSENSE, bonus );
 }
 
 void player_morale::update_bodytemp_penalty( const time_duration &ticks )

--- a/src/morale.h
+++ b/src/morale.h
@@ -154,6 +154,7 @@ class player_morale
         void update_stylish_bonus();
         void update_squeamish_penalty();
         void update_masochist_bonus();
+        void update_radiophile_bonus();
         void update_bodytemp_penalty( const time_duration &ticks );
         void update_constrained_penalty();
 
@@ -207,6 +208,7 @@ class player_morale
         bool took_prozac_bad;
         bool stylish;
         int perceived_pain;
+        int radiation;
 };
 
 #endif // CATA_SRC_MORALE_H

--- a/src/morale_types.cpp
+++ b/src/morale_types.cpp
@@ -78,6 +78,7 @@ const morale_type MORALE_PERM_NOFACE( "morale_perm_noface" );
 const morale_type MORALE_PERM_NOMAD( "morale_perm_nomad" );
 const morale_type MORALE_PERM_NUMB( "morale_perm_numb" );
 const morale_type MORALE_PERM_OPTIMIST( "morale_perm_optimist" );
+const morale_type MORALE_PERM_RADSENSE("morale_perm_radsense");
 const morale_type MORALE_PHOTOS( "morale_photos" );
 const morale_type MORALE_PLAY_WITH_PET( "morale_play_with_pet" );
 const morale_type MORALE_PYROMANIA_NEARFIRE( "morale_pyromania_nearfire" );

--- a/src/morale_types.cpp
+++ b/src/morale_types.cpp
@@ -78,7 +78,7 @@ const morale_type MORALE_PERM_NOFACE( "morale_perm_noface" );
 const morale_type MORALE_PERM_NOMAD( "morale_perm_nomad" );
 const morale_type MORALE_PERM_NUMB( "morale_perm_numb" );
 const morale_type MORALE_PERM_OPTIMIST( "morale_perm_optimist" );
-const morale_type MORALE_PERM_RADSENSE("morale_perm_radsense");
+const morale_type MORALE_PERM_RADSENSE( "morale_perm_radsense" );
 const morale_type MORALE_PHOTOS( "morale_photos" );
 const morale_type MORALE_PLAY_WITH_PET( "morale_play_with_pet" );
 const morale_type MORALE_PYROMANIA_NEARFIRE( "morale_pyromania_nearfire" );

--- a/src/morale_types.cpp
+++ b/src/morale_types.cpp
@@ -78,7 +78,7 @@ const morale_type MORALE_PERM_NOFACE( "morale_perm_noface" );
 const morale_type MORALE_PERM_NOMAD( "morale_perm_nomad" );
 const morale_type MORALE_PERM_NUMB( "morale_perm_numb" );
 const morale_type MORALE_PERM_OPTIMIST( "morale_perm_optimist" );
-const morale_type MORALE_PERM_RADSENSE( "morale_perm_radsense" );
+const morale_type MORALE_PERM_RADIOPHILE( "morale_perm_radiophile" );
 const morale_type MORALE_PHOTOS( "morale_photos" );
 const morale_type MORALE_PLAY_WITH_PET( "morale_play_with_pet" );
 const morale_type MORALE_PYROMANIA_NEARFIRE( "morale_pyromania_nearfire" );

--- a/src/morale_types.h
+++ b/src/morale_types.h
@@ -100,6 +100,7 @@ extern const morale_type MORALE_PERM_BADTEMPER;
 extern const morale_type MORALE_PERM_NUMB;
 extern const morale_type MORALE_PERM_CONSTRAINED;
 extern const morale_type MORALE_PERM_NOMAD;
+extern const morale_type MORALE_PERM_RADSENSE;
 extern const morale_type MORALE_GAME_FOUND_KITTEN;
 extern const morale_type MORALE_HAIRCUT;
 extern const morale_type MORALE_SHAVE;

--- a/src/morale_types.h
+++ b/src/morale_types.h
@@ -100,7 +100,7 @@ extern const morale_type MORALE_PERM_BADTEMPER;
 extern const morale_type MORALE_PERM_NUMB;
 extern const morale_type MORALE_PERM_CONSTRAINED;
 extern const morale_type MORALE_PERM_NOMAD;
-extern const morale_type MORALE_PERM_RADSENSE;
+extern const morale_type MORALE_PERM_RADIOPHILE;
 extern const morale_type MORALE_GAME_FOUND_KITTEN;
 extern const morale_type MORALE_HAIRCUT;
 extern const morale_type MORALE_SHAVE;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1034,6 +1034,7 @@ void Character::load( const JsonObject &data )
     on_stat_change( "sleep_deprivation", sleep_deprivation );
     on_stat_change( "pkill", pkill );
     on_stat_change( "perceived_pain", get_perceived_pain() );
+    on_stat_change( "radiation", get_rad() );
     recalc_sight_limits();
     calc_encumbrance();
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1312,15 +1312,16 @@ void suffer::from_radiation( Character &you )
     // Used to control vomiting from radiation to make it not-annoying
     bool radiation_increasing = you.irradiate( rads );
 
-    if( radiation_increasing && calendar::once_every( 3_minutes ) && you.has_bionic( bio_geiger ) ) {
+    if (radiation_increasing && calendar::once_every(3_minutes) ) {
+        if( you.has_bionic( bio_geiger ) ) {
         you.add_msg_if_player( m_warning,
                                _( "You feel an anomalous sensation coming from "
                                   "your radiation sensors." ) );
-    } else if( radiation_increasing && calendar::once_every( 3_minutes ) &&
-               you.has_active_mutation( trait_RADSENSE ) ) {
+    } else if( you.has_active_mutation( trait_RADSENSE ) ) {
         you.add_msg_if_player( m_warning,
-                               _( "You feel a peculiar sensation from within.  "
-                                  "Perhaps you should get out of here." ) );
+                               _( "Your flesh tingles.  You sense danger, "
+                                  "but it feels good." ) );
+        }
     }
 
     if( calendar::once_every( 15_minutes ) ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -162,7 +162,7 @@ static const trait_id trait_RADIOACTIVE1( "RADIOACTIVE1" );
 static const trait_id trait_RADIOACTIVE2( "RADIOACTIVE2" );
 static const trait_id trait_RADIOACTIVE3( "RADIOACTIVE3" );
 static const trait_id trait_RADIOGENIC( "RADIOGENIC" );
-static const trait_id trait_RADSENSE( "RADSENSE" );
+static const trait_id trait_RADIOPHILE( "RADIOPHILE" );
 static const trait_id trait_SCHIZOPHRENIC( "SCHIZOPHRENIC" );
 static const trait_id trait_SHARKTEETH( "SHARKTEETH" );
 static const trait_id trait_SHELL2( "SHELL2" );
@@ -1317,10 +1317,10 @@ void suffer::from_radiation( Character &you )
             you.add_msg_if_player( m_warning,
                                    _( "You feel an anomalous sensation coming from "
                                       "your radiation sensors." ) );
-        } else if( you.has_active_mutation( trait_RADSENSE ) ) {
+        } else if( you.has_active_mutation( trait_RADIOPHILE ) ) {
             you.add_msg_if_player( m_warning,
-                                   _( "Your flesh tingles.  You sense danger, "
-                                      "but it feels good." ) );
+                                   _( "Your flesh tingles with an air of danger, "
+                                      "yet it is strangely pleasurable." ) );
         }
     }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1312,15 +1312,15 @@ void suffer::from_radiation( Character &you )
     // Used to control vomiting from radiation to make it not-annoying
     bool radiation_increasing = you.irradiate( rads );
 
-    if (radiation_increasing && calendar::once_every(3_minutes) ) {
+    if( radiation_increasing && calendar::once_every( 3_minutes ) ) {
         if( you.has_bionic( bio_geiger ) ) {
-        you.add_msg_if_player( m_warning,
-                               _( "You feel an anomalous sensation coming from "
-                                  "your radiation sensors." ) );
-    } else if( you.has_active_mutation( trait_RADSENSE ) ) {
-        you.add_msg_if_player( m_warning,
-                               _( "Your flesh tingles.  You sense danger, "
-                                  "but it feels good." ) );
+            you.add_msg_if_player( m_warning,
+                                   _( "You feel an anomalous sensation coming from "
+                                      "your radiation sensors." ) );
+        } else if( you.has_active_mutation( trait_RADSENSE ) ) {
+            you.add_msg_if_player( m_warning,
+                                   _( "Your flesh tingles.  You sense danger, "
+                                      "but it feels good." ) );
         }
     }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1316,11 +1316,11 @@ void suffer::from_radiation( Character &you )
         you.add_msg_if_player( m_warning,
                                _( "You feel an anomalous sensation coming from "
                                   "your radiation sensors." ) );
-    }
-    else if ( radiation_increasing && calendar::once_every( 3_minutes ) && you.has_active_mutation( trait_RADSENSE ) ) {
+    } else if( radiation_increasing && calendar::once_every( 3_minutes ) &&
+               you.has_active_mutation( trait_RADSENSE ) ) {
         you.add_msg_if_player( m_warning,
-            _( "You feel a peculiar sensation from within.  " 
-                "Perhaps you should get out of here." ) );
+                               _( "You feel a peculiar sensation from within.  "
+                                  "Perhaps you should get out of here." ) );
     }
 
     if( calendar::once_every( 15_minutes ) ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -162,6 +162,7 @@ static const trait_id trait_RADIOACTIVE1( "RADIOACTIVE1" );
 static const trait_id trait_RADIOACTIVE2( "RADIOACTIVE2" );
 static const trait_id trait_RADIOACTIVE3( "RADIOACTIVE3" );
 static const trait_id trait_RADIOGENIC( "RADIOGENIC" );
+static const trait_id trait_RADSENSE( "RADSENSE" );
 static const trait_id trait_SCHIZOPHRENIC( "SCHIZOPHRENIC" );
 static const trait_id trait_SHARKTEETH( "SHARKTEETH" );
 static const trait_id trait_SHELL2( "SHELL2" );
@@ -1315,6 +1316,11 @@ void suffer::from_radiation( Character &you )
         you.add_msg_if_player( m_warning,
                                _( "You feel an anomalous sensation coming from "
                                   "your radiation sensors." ) );
+    }
+    else if ( radiation_increasing && calendar::once_every( 3_minutes ) && you.has_active_mutation( trait_RADSENSE ) ) {
+        you.add_msg_if_player( m_warning,
+            _( "You feel a peculiar sensation from within.  " 
+                "Perhaps you should get out of here." ) );
     }
 
     if( calendar::once_every( 15_minutes ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Radiophile mutation"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I had the experience that the Integrated Dosimeter was the only way to have a completely passive method of knowing when to put on the cleansuit. This new mutation would, in addition to solving the dependence on the Exodii regarding this need, would fit into the mishmash of miscellaneous augments that is the Medical mutation tree.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
New mutation:
- In the Medical and Slime mutation line
- Will warn you if you're currently being irradiated (argue about cosmic rays if you must)
- Gives a small bonus to morale for current absorbed dose
- Can be turned off to not spam the log
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Make the Integrated Dosimeter less annoying to use, such as making it passively tell you your absorbed dose instead of your having to check (might actually get around to doing that anyway)
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
It properly gives me a log message exactly every three minutes any time there's ambient rads to be had, and turning it off works as expected. Also gives morale as expected.
Mutating it properly works through the standard method.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
