### PR TITLE
Trapdoor spider den mapgen clearing flags

### DIFF
--- a/data/json/mapgen/map_extras/trapdoor_spider_den.json
+++ b/data/json/mapgen/map_extras/trapdoor_spider_den.json
@@ -44,7 +44,8 @@
     "object": {
       "mapgensize": [ 3, 3 ],
       "place_nested": [ { "chunks": [ [ "null", 2 ], [ "wasp_gibs", 1 ] ], "x": [ 0, 2 ], "y": [ 0, 2 ], "repeat": [ 3, 8 ] } ],
-      "place_traps": [ { "trap": "tr_spider", "x": 1, "y": 1 } ]
+      "place_traps": [ { "trap": "tr_spider", "x": 1, "y": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -55,7 +56,8 @@
     "object": {
       "mapgensize": [ 3, 3 ],
       "place_nested": [ { "chunks": [ [ "null", 2 ], [ "wasp_gibs", 1 ] ], "x": [ 0, 2 ], "y": [ 0, 2 ], "repeat": [ 3, 8 ] } ],
-      "place_terrain": [ { "ter": "t_dirtmound", "x": 1, "y": 1 } ]
+      "place_terrain": [ { "ter": "t_dirtmound", "x": 1, "y": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   }
 ]

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -911,7 +911,7 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```mx_shrubbery``` ... All trees and shrubs become a single species of shrub.
 - ```mx_spider``` ... A big spider web, complete with spiders and eggs.
 - ```mx_supplydrop``` ... Crates with some military items in it.
-- ```mx_Trapdoor_spider_den``` ... Chunk of a forest with a spider spawning out of nowhere.
+- ```mx_Trapdoor_spider_den``` ... A spider spawning out of nowhere.
 - ```mx_trees``` ... A small chunk of forest with puddles with fresh water.
 - ```mx_trees_2``` ... A small chunk of forest with puddles with fresh water.
 


### PR DESCRIPTION
#### Summary
Bugfixes "Trapdoor spider den mapgen clearing flags"

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4323951625/jobs/7548161056#step:19:314

> ERROR : D:\a\Cataclysm-DDA\Cataclysm-DDA\src\mapgen.cpp:2899 [apply] In nested mapgen trapdoor_trap in update mapgen mx_Trapdoor_spider_den on 2farm_17_south, setting terrain to t_dirtmound (from t_dirt) at (17,8) when furniture was f_plant_seedling.  Resolve this either by removing the terrain from this mapgen, adding suitable removal commands to the mapgen, or by adding an appropriate clearing flag to the innermost layered mapgen.  Consult the "mapgen flags" section in MAPGEN.md for options.

#### Describe the solution
Mapgen clearing flags need to be added to innermost mapgen. This was missed in #63853. Added the required flags.

#### Other changes
Update the description in `JSON_FLAGS.md`, as trees had been removed in #62425.

#### Testing
Debug spawn the map extra a bunch of times with no error message.
