### PR TITLE
Add rudimentary bionics migrations

### DIFF
--- a/data/json/bionics_migrations.json
+++ b/data/json/bionics_migrations.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "bionic_migration",
+    "//": "obsoleted for integrated armor https://github.com/CleverRaven/Cataclysm-DDA/pull/62819",
+    "from": "bio_tools_extend",
+    "to": null
+  }
+]

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -5101,21 +5101,25 @@ Migration is used, when we want to remove one item by replacing it with another 
 
 // it seems MIGRATION accept any field actually, but i need someone to confirm it
 
-For vehicle parts, you should use `vehicle_part_migration` inside `data/json/vehicleparts/migration.json`
+Migrating vehicle parts is done using `vehicle_part_migration` type, in the example below - when loading the vehicle any part with id `from` will have it's id switched to `to`.
 
 ```json
-
   {
     "type": "vehicle_part_migration",
     "from": "old_vpart_id",
     "to": "new_vpart_id"
-  },
-  {
-    "type": "vehicle_part_migration",
-    "from": "lit_aisle",
-    "to": "aisle"
   }
 
+```
+
+For bionics, you should use `bionic_migration` type. The migration happens when character is loaded; if `to` is `null` the bionic will be deleted, if `to` is not null the id will be changed to the provided value.
+
+```json
+  {
+    "type": "bionic_migration",
+    "from": "bio_tools_extend",
+    "to": null
+  }
 ```
 
 Obsoletion is used, when we want to remove the item entirely from the game, without any migration. For this you, again, **do not remove item** from the game.

--- a/lang/string_extractor/parser.py
+++ b/lang/string_extractor/parser.py
@@ -103,6 +103,7 @@ parsers = {
     "behavior": dummy_parser,
     "bionic": parse_bionic,
     "bionic_item": parse_generic,
+    "bionic_migration": dummy_parser,
     "body_graph": dummy_parser,
     "body_part": parse_body_part,
     "book": parse_generic,

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -188,6 +188,9 @@ struct bionic_data {
     static void load_bionic( const JsonObject &jo, const std::string &src );
     static const std::vector<bionic_data> &get_all();
     static void check_bionic_consistency();
+
+    static std::map<bionic_id, bionic_id> migrations;
+    static void load_bionic_migration( const JsonObject &jo, const std::string & );
 };
 
 struct bionic {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -258,6 +258,7 @@ void DynamicDataLoader::initialize()
     add( "vitamin", &vitamin::load_vitamin );
     add( "material", &materials::load );
     add( "bionic", &bionic_data::load_bionic );
+    add( "bionic_migration", &bionic_data::load_bionic_migration );
     add( "profession", &profession::load_profession );
     add( "profession_item_substitutions", &profession::load_item_substitutions );
     add( "proficiency", &proficiency::load_proficiencies );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -838,6 +838,10 @@ void Character::load( const JsonObject &data )
     recalculate_size();
 
     data.read( "my_bionics", *my_bionics );
+    my_bionics->erase( std::remove_if( my_bionics->begin(), my_bionics->end(),
+    []( const bionic & it ) {
+        return it.id.is_null(); // remove obsoleted bionics
+    } ), my_bionics->end() );
 
     data.read( "known_monsters", known_monsters );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

#62819 removed a bionic - but any character that had `bio_tools_extend` already installed will get spammed with the message in screenshot until they press 'i' to ignore, passive bionics will still show "bad bionic"

It is also not resolved with a save/load cycle

#### Describe the solution

Add rudimentary bionic migrations, and adjust some migration docs

#### Describe alternatives you've considered

#### Testing

Load a save with integrated toolset installed - should see debugmsg spam on load
Apply patch, load the save where character has integrated toolset already installed, errors should be gone

#### Additional context
![image](https://user-images.githubusercontent.com/6560075/222856771-83136a46-bd7d-4ef2-8a73-6a22feb9da35.png)

![image](https://user-images.githubusercontent.com/6560075/222856675-5396eef4-17ca-4b6d-9a70-886f471ada0b.png)
