### PR TITLE
Point `JSON_FLAGS.md` to `MAPGEN.md` for mapgen flags

### DIFF
--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -850,15 +850,15 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```SPEEDLOADER``` Acts like a magazine, except it transfers rounds to the emptied target gun or magazine instead of being inserted into it.
 - ```SPEEDLOADER_CLIP``` Acts like a ```SPEEDLOADER```, except the target gun or magazine don't have to be emptied to oocur the transferments.
 
-    
+
 ## Mapgen
-    
+
 - ```ERASE_ALL_BEFORE_PLACING_TERRAIN``` Clear items, traps, or furniture before placing terrain tile. See also [`remove_all`](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/MAPGEN.md#remove-everything-with-remove_all). Mutually exclusive with `ALLOW_TERRAIN_UNDER_OTHER_DATA `.
 - ```ALLOW_TERRAIN_UNDER_OTHER_DATA``` Keep items, traps, or furniture before placing terrain tile. Mutually exclusive with `ERASE_ALL_BEFORE_PLACING_TERRAIN`.
 - ```NO_UNDERLYING_ROTATE``` The map won't be rotated even if the underlying tile is.
 - ```AVOID_CREATURES``` If a creature is present on terrain, furniture and traps won't be placed.
 
-    
+
 ## Map Specials
 
 - ```mx_bandits_block``` ...  Road block made by bandits from tree logs, caltrops, or nailboards.
@@ -1384,7 +1384,7 @@ Those flags are added by the game code to specific items (for example, that spec
 - ```USE_UPS``` The tool has the UPS mod and is charged from an UPS.
 - ```WARM``` A hidden flag used to track an item's journey to/from hot, buffers between HOT and cold.
 - ```WET``` Item is wet and will slowly dry off (e.g. towel).
-    
+
 ### Use actions
 
 These flags apply to the `use_action` field, instead of the `flags` field.

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -853,10 +853,7 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 
 ## Mapgen
 
-- ```ERASE_ALL_BEFORE_PLACING_TERRAIN``` Clear items, traps, or furniture before placing terrain tile. See also [`remove_all`](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/MAPGEN.md#remove-everything-with-remove_all). Mutually exclusive with `ALLOW_TERRAIN_UNDER_OTHER_DATA `.
-- ```ALLOW_TERRAIN_UNDER_OTHER_DATA``` Keep items, traps, or furniture before placing terrain tile. Mutually exclusive with `ERASE_ALL_BEFORE_PLACING_TERRAIN`.
-- ```NO_UNDERLYING_ROTATE``` The map won't be rotated even if the underlying tile is.
-- ```AVOID_CREATURES``` If a creature is present on terrain, furniture and traps won't be placed.
+See [Mapgen flags](MAPGEN.md#mapgen-flags).
 
 
 ## Map Specials


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
In #63559 `MAPGEN.md` was updated to reflect new information, but missed a copy of the information that resided in `JSON_FLAGS.md`.

#### Describe the solution
Delete from `JSON_FLAGS.md` and redirect to `MAPGEN.md`, so that the information resides in one place.

#### Describe alternatives you've considered
Update `JSON_FLAGS.md` so that it is once again a full copy of the same info as `MAPGEN.md`. However, this would be prone to the same issue occurring again in future, where one of them is updated and the other gets missed.

#### Bonus
Deleted some stray whitespace.