### PR TITLE
Migration: remove temperature tracking for former comestibles

### DIFF
--- a/data/json/obsoletion/charge_removal.json
+++ b/data/json/obsoletion/charge_removal.json
@@ -307,5 +307,24 @@
       "wearable_light_on",
       "welder"
     ]
+  },
+  {
+    "type": "temperature_removal_blacklist",
+    "list": [
+      "napkin",
+      "cardboard",
+      "adhesive_bandages",
+      "alcohol_wipes",
+      "bandages",
+      "bandages_makeshift",
+      "bandages_makeshift_bleached",
+      "bandages_makeshift_boiled",
+      "cotton_ball",
+      "disinrag",
+      "disincotton_ball",
+      "medical_gauze"
+    ],
+    "//1": "CAUTION: this list is for items that are safe for straightforward deactivation",
+    "//2": "items that may be active for additional reasons other than temperature tracking should use separate special case handling"
   }
 ]

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -5198,6 +5198,21 @@ For recipes, deleting the recipe is enough.
 
 For mods, you need to add an `"obsolete": true,` boolean into MOD_INFO, which prevent the mod from showing into the mod list.
 
+## Charge and temperature removal
+
+If an item that used to have charges (e.g. `AMMO` or `COMESTIBLE` types) is changed to another type that does not use charges, migration is needed to ensure correct behavior when loading from existing save files, and prevent spurious error messages from being shown to the player.  Migration lists for this are found in `data/json/obsoletion/charge_removal.json`.
+
+Such items may be added to one of the following:
+
+* `charge_migration_blacklist`: items in existing save files with `n` charges will be converted to `n` items with no charges.  This will preserve item count.
+* `charge_removal_blacklist`: items will simply have charges removed.
+
+Additionally, `COMESTIBLE` items have temperature and rot processing, and are thus set as always activated.  When an item is changed from `COMESTIBLE` to a different type, migration is needed to check and unset this if applicable:
+
+* In most cases, the item has no other features that require it to remain activated, in which case it can be simply added to `temperature_removal_blacklist`.  Items in this list will be deactivated and have temperature-related data cleared *without any further checks performed*.
+* In case of an item that may be active for additional reasons other than temperature/rot tracking, an instance of the item loaded from existing save file cannot be blindly deactivated -- additional checks are required to see if it should remain active.  Instead of adding to the above list, a separate special case should be added in `src/savegame_json.cpp` to implement the necessary item-specific deactivation logic.
+
+
 # Field types
 
 Fields can exist on top of terrain/furniture, and support different intensity levels. Each intensity level inherits its properties from the lower one, so any field not explicitly overwritten will carry over. They affect both characters and monsters, but a lot of fields have hardcoded effects that are potentially different for both (found in `map_field.cpp:creature_in_field`). Gaseous fields that have a chance to do so are spread depending on the local wind force when outside, preferring spreading down to on the same Z-level, which is preferred to spreading upwards. Indoors and by weak winds fields spread randomly.

--- a/lang/string_extractor/parser.py
+++ b/lang/string_extractor/parser.py
@@ -220,6 +220,7 @@ parsers = {
     "sub_body_part": parse_sub_body_part,
     "talk_topic": parse_talk_topic,
     "technique": parse_technique,
+    "temperature_removal_blacklist": dummy_parser,
     "ter_furn_transform": parse_ter_furn_transform,
     "terrain": parse_terrain,
     "trait_blacklist": dummy_parser,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -375,6 +375,7 @@ void DynamicDataLoader::initialize()
 
     add( "charge_removal_blacklist", load_charge_removal_blacklist );
     add( "charge_migration_blacklist", load_charge_migration_blacklist );
+    add( "temperature_removal_blacklist", load_temperature_removal_blacklist );
     add( "test_data", &test_data::load );
 
     add( "MONSTER", []( const JsonObject & jo, const std::string & src ) {

--- a/src/itype.h
+++ b/src/itype.h
@@ -1416,5 +1416,6 @@ struct itype {
 
 void load_charge_removal_blacklist( const JsonObject &jo, const std::string &src );
 void load_charge_migration_blacklist( const JsonObject &jo, const std::string &src );
+void load_temperature_removal_blacklist( const JsonObject &jo, const std::string &src );
 
 #endif // CATA_SRC_ITYPE_H

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2894,6 +2894,16 @@ void load_charge_migration_blacklist( const JsonObject &jo, const std::string &/
     charge_migration_blacklist.insert( new_blacklist.begin(), new_blacklist.end() );
 }
 
+static std::set<itype_id> temperature_removal_blacklist;
+
+void load_temperature_removal_blacklist( const JsonObject &jo, const std::string &/*src*/ )
+{
+    jo.allow_omitted_members();
+    std::set<itype_id> new_blacklist;
+    jo.read( "list", new_blacklist );
+    temperature_removal_blacklist.insert( new_blacklist.begin(), new_blacklist.end() );
+}
+
 template<typename Archive>
 void item::io( Archive &archive )
 {
@@ -3047,6 +3057,32 @@ void item::io( Archive &archive )
         // Some hot/cold items from legacy saves may be inactive
         active = true;
     }
+
+    // Former comestibles that no longer need temperature tracking
+    if( !has_temperature() && ( last_temp_check != calendar::turn_zero || has_own_flag( flag_HOT ) ||
+                                has_own_flag( flag_COLD ) || has_own_flag( flag_FROZEN ) ) ) {
+        bool abort = false;
+        if( active ) {
+            if( temperature_removal_blacklist.count( type->get_id() ) != 0 ) {
+                // list of items that are safe for straightforward deactivation
+                // NOTE: items that may be active for additional reasons other than temperature tracking
+                // should be handled in separate special cases containing item-specific deactivation logic
+                active = false;
+            } else {
+                // warn and bail in unexpected cases -- should be investigated
+                debugmsg( "Item %s is active and tracking temperature, but it should not!", type->get_id().str() );
+                // erroneous unsetting of last_temp_check/flags is hard to detect/rectify, so do not proceed
+                abort = true;
+            }
+        }
+        if( !abort ) {
+            last_temp_check = calendar::turn_zero;
+            unset_flag( flag_HOT );
+            unset_flag( flag_COLD );
+            unset_flag( flag_FROZEN );
+        }
+    }
+
     std::string mode;
     if( archive.read( "mode", mode ) ) {
         // only for backward compatibility (nowadays mode is stored in item_vars)


### PR DESCRIPTION
#### Summary
Bugfixes "Migration: remove temperature tracking for former comestibles"

#### Purpose of change
Resolve #63922 

#### Describe the solution
Add migration code to check for items that `!has_temperature()` but also non-default `last_temp_check` value or one of the flags `HOT`, `COLD` or `FROZEN`, which indicates it used to have temperature tracking but is no longer a comestible.

Before deactivating the item, check against `temperature_removal_blacklist` which lists former comestible items for which it is safe to do a straightforward `active = false;`. However, if a former comestible item can also be active for other reasons, then special case handling will be needed -- no such item so far, but it's good to future-proof for that possibility.

If an unexpected item matches the criteria but isn't covered by the migration list (or future special cases) then print a warning and abort migration without changing `last_temp_check` or clearing the temperature flags. This maintains the ability to detect and migrate the item later while also avoid messing with unforeseen items that shouldn't be migrated.

#### Describe alternatives you've considered
Not have the blacklist, which opens up the possibility for:
- some item gets incorrectly migrated (without required special case handling), which gets harder to solve
- unexpected item that shouldn't be migrated matches the criteria and gets its `active`, `last_temp_check` and flags mangled

#### Testing
Former comestibles preexisting in older saves no longer show up as "(active)"