### PR TITLE
Prevent infinite focus from mi-go biotech

### DIFF
--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -1413,7 +1413,7 @@
         {
           "id": "EOC_MIGO_BIO_TECH_FOCUS",
           "condition": { "npc_has_var": "function", "type": "mbt", "context": "f", "value": "focus" },
-          "effect": [ { "u_message": "You feel incredibly focused!" }, { "arithmetic": [ { "u_val": "focus" }, "+=", { "const": 30 } ] } ]
+          "effect": [ { "u_message": "You feel incredibly focused!" }, { "arithmetic": [ { "u_val": "focus" }, "+=", { "const": 30 } ], "max": 130 } ]
         },
         {
           "id": "EOC_MIGO_BIO_TECH_PAIN",

--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -1413,7 +1413,10 @@
         {
           "id": "EOC_MIGO_BIO_TECH_FOCUS",
           "condition": { "npc_has_var": "function", "type": "mbt", "context": "f", "value": "focus" },
-          "effect": [ { "u_message": "You feel incredibly focused!" }, { "arithmetic": [ { "u_val": "focus" }, "+=", { "const": 30 } ], "max": 130 } ]
+          "effect": [
+            { "u_message": "You feel incredibly focused!" },
+            { "arithmetic": [ { "u_val": "focus" }, "+=", { "const": 30 } ], "max": 130 }
+          ]
         },
         {
           "id": "EOC_MIGO_BIO_TECH_PAIN",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
fix #63805
#### Describe the solution
Slap `"max": 130` to `EOC_MIGO_BIO_TECH_FOCUS`
#### Describe alternatives you've considered
Make some sort of delay between activations, but i don't actually know how to do it
#### Testing
Yep, focus is limited with +30 now - still kinda busted, but not infinite learning
#### Additional context
i was not able to limit another effects in any way, sadly