### PR TITLE
Makes earthshaper cestus nonconductive

### DIFF
--- a/data/mods/Magiclysm/items/enchanted_unarmed.json
+++ b/data/mods/Magiclysm/items/enchanted_unarmed.json
@@ -94,7 +94,7 @@
     "to_hit": 1,
     "qualities": [ [ "HAMMER", 1 ] ],
     "techniques": [ "WBLOCK_1", "BRUTAL" ],
-    "flags": [ "DURABLE_MELEE", "TRADER_AVOID", "MAGIC_FOCUS" ],
+    "flags": [ "DURABLE_MELEE", "TRADER_AVOID", "MAGIC_FOCUS", "NONCONDUCTIVE" ],
     "armor": [ { "encumbrance": 5, "coverage": 20, "covers": [ "hand_r" ] } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Makes earthshaper cestus nonconductive"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Normal cestus is non conductive. Nail knuckles are non conductive. I don't know where the scrap goes (probably into runes?), but it does not make sense for earthshaper cestus to be conductive. And with the added stone, its probably even less conductive than nail knuckles could be.

#### Describe the solution

Add nonconductive flag to earthshaper cestus.

#### Describe alternatives you've considered

idk

#### Testing

add flag, check in game, works.

#### Additional context

Nope