### PR TITLE
Allow mutations to remove starting traits, unhardcode more mutation functionality

### DIFF
--- a/data/json/mutations/mutation_category.json
+++ b/data/json/mutations/mutation_category.json
@@ -13,7 +13,9 @@
     "threshold_mut": "",
     "skip_test": true,
     "mutagen_message": "You feel the aberrance fade.",
-    "vitamin": "mutagen_human"
+    "vitamin": "mutagen_human",
+    "//": "Starting trait removal: Human-but categories: 20% chance 3x cost multiplier, vertebrates: 33% chance 2,5x cost, invertebrates: 50% chance 2x cost, non-Animalia: 75% chance 1.5x cost, extradimensional/generally a mess: 100% at base cost",
+    "base_removal_chance": 0
   },
   {
     "type": "mutation_category",
@@ -22,7 +24,9 @@
     "threshold_mut": "THRESH_PLANT",
     "mutagen_message": "You feel much closer to nature.  Your breath and thoughts slow.",
     "memorial_message": "Bloomed forth.",
-    "vitamin": "mutagen_plant"
+    "vitamin": "mutagen_plant",
+    "base_removal_chance": 75,
+    "base_removal_cost_mul": 1.5
   },
   {
     "type": "mutation_category",
@@ -31,7 +35,9 @@
     "threshold_mut": "THRESH_INSECT",
     "mutagen_message": "You hear buzzing, and feel your body harden.",
     "memorial_message": "Metamorphosed.",
-    "vitamin": "mutagen_insect"
+    "vitamin": "mutagen_insect",
+    "base_removal_chance": 50,
+    "base_removal_cost_mul": 2.0
   },
   {
     "type": "mutation_category",
@@ -40,7 +46,9 @@
     "threshold_mut": "THRESH_SPIDER",
     "mutagen_message": "You feel insidious, and your vision fragments for a moment.",
     "memorial_message": "Found a place in the web of life.",
-    "vitamin": "mutagen_spider"
+    "vitamin": "mutagen_spider",
+    "base_removal_chance": 50,
+    "base_removal_cost_mul": 2.0
   },
   {
     "type": "mutation_category",
@@ -49,7 +57,8 @@
     "threshold_mut": "THRESH_SLIME",
     "mutagen_message": "Your body loses all rigidity for a moment.",
     "memorial_message": "Gave up on rigid human norms.",
-    "vitamin": "mutagen_slime"
+    "vitamin": "mutagen_slime",
+    "base_removal_cost_mul": 1.0
   },
   {
     "type": "mutation_category",
@@ -58,7 +67,9 @@
     "threshold_mut": "THRESH_FISH",
     "mutagen_message": "You are overcome by an overwhelming longing for the ocean.",
     "memorial_message": "Went deep.",
-    "vitamin": "mutagen_fish"
+    "vitamin": "mutagen_fish",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",
@@ -67,7 +78,9 @@
     "threshold_mut": "THRESH_GASTROPOD",
     "mutagen_message": "Your split lower body starts to come back together.",
     "memorial_message": "Left a trail.",
-    "vitamin": "mutagen_gastropod"
+    "vitamin": "mutagen_gastropod",
+    "base_removal_chance": 75,
+    "base_removal_cost_mul": 1.5
   },
   {
     "type": "mutation_category",
@@ -76,7 +89,9 @@
     "threshold_mut": "THRESH_RAT",
     "mutagen_message": "You feel a momentary nausea.",
     "memorial_message": "Found that survival *is* everything.",
-    "vitamin": "mutagen_rat"
+    "vitamin": "mutagen_rat",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",
@@ -85,7 +100,9 @@
     "threshold_mut": "THRESH_BEAST",
     "mutagen_message": "Your heart races and you see blood for a moment.",
     "memorial_message": "Embraced their bestial nature.",
-    "vitamin": "mutagen_beast"
+    "vitamin": "mutagen_beast",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",
@@ -94,7 +111,9 @@
     "threshold_mut": "THRESH_URSINE",
     "mutagen_message": "You feel an urge to… patrol?  The forests?",
     "memorial_message": "Became one with the bears.",
-    "vitamin": "mutagen_ursine"
+    "vitamin": "mutagen_ursine",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",
@@ -103,7 +122,9 @@
     "threshold_mut": "THRESH_FELINE",
     "mutagen_message": "Your back arches and the hair stands up on the back of your neck.",
     "memorial_message": "Realized the dream.",
-    "vitamin": "mutagen_feline"
+    "vitamin": "mutagen_feline",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",
@@ -112,7 +133,9 @@
     "threshold_mut": "THRESH_LUPINE",
     "mutagen_message": "You feel an urge to mark your territory.  But then it passes.",
     "memorial_message": "Wolfed out.",
-    "vitamin": "mutagen_lupine"
+    "vitamin": "mutagen_lupine",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",
@@ -121,7 +144,9 @@
     "threshold_mut": "THRESH_CATTLE",
     "mutagen_message": "Your mind and body slow down.  You feel peaceful.",
     "memorial_message": "Stopped worrying and learned to love the cowbell.",
-    "vitamin": "mutagen_cattle"
+    "vitamin": "mutagen_cattle",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",
@@ -130,7 +155,9 @@
     "threshold_mut": "THRESH_CEPHALOPOD",
     "mutagen_message": "Your mind is overcome by images of eldritch horrors… and then they pass.",
     "memorial_message": "Began living the dreams.",
-    "vitamin": "mutagen_cephalopod"
+    "vitamin": "mutagen_cephalopod",
+    "base_removal_chance": 50,
+    "base_removal_cost_mul": 2.0
   },
   {
     "type": "mutation_category",
@@ -139,7 +166,9 @@
     "threshold_mut": "THRESH_BIRD",
     "mutagen_message": "Your body lightens and you long for the sky.",
     "memorial_message": "Broke free of humanity.",
-    "vitamin": "mutagen_bird"
+    "vitamin": "mutagen_bird",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",
@@ -148,7 +177,9 @@
     "threshold_mut": "THRESH_LIZARD",
     "mutagen_message": "For a heartbeat, your blood cools down.",
     "memorial_message": "Shed the ugly human skin.",
-    "vitamin": "mutagen_lizard"
+    "vitamin": "mutagen_lizard",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",
@@ -157,7 +188,9 @@
     "threshold_mut": "THRESH_BATRACHIAN",
     "mutagen_message": "Like a tadpole you must transform.",
     "memorial_message": "Found a bigger pond.",
-    "vitamin": "mutagen_batrachian"
+    "vitamin": "mutagen_batrachian",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",
@@ -166,7 +199,8 @@
     "threshold_mut": "THRESH_TROGLOBITE",
     "mutagen_message": "You yearn for a cool, dark place to hide.",
     "memorial_message": "Adapted to underground living.",
-    "vitamin": "mutagen_troglobite"
+    "vitamin": "mutagen_troglobite",
+    "base_removal_chance": 20
   },
   {
     "type": "mutation_category",
@@ -175,7 +209,8 @@
     "threshold_mut": "THRESH_ALPHA",
     "mutagen_message": "You feel… better.  Somehow.",
     "memorial_message": "Started representing.",
-    "vitamin": "mutagen_alpha"
+    "vitamin": "mutagen_alpha",
+    "base_removal_chance": 20
   },
   {
     "type": "mutation_category",
@@ -184,7 +219,8 @@
     "threshold_mut": "THRESH_MEDICAL",
     "mutagen_message": "You can feel the blood rushing through your veins and a strange, medicated feeling washes over your senses.",
     "memorial_message": "Resumed clinical trials.",
-    "vitamin": "mutagen_medical"
+    "vitamin": "mutagen_medical",
+    "base_removal_chance": 20
   },
   {
     "type": "mutation_category",
@@ -193,7 +229,8 @@
     "threshold_mut": "THRESH_CHIMERA",
     "mutagen_message": "You need to roar, bask, bite, and flap.  NOW.",
     "memorial_message": "United disunity.",
-    "vitamin": "mutagen_chimera"
+    "vitamin": "mutagen_chimera",
+    "base_removal_cost_mul": 1.0
   },
   {
     "type": "mutation_category",
@@ -202,7 +239,8 @@
     "threshold_mut": "THRESH_ELFA",
     "mutagen_message": "Everything goes green for a second.  Nature is becoming one with you…",
     "memorial_message": "Accepted a more natural way of life.",
-    "vitamin": "mutagen_elfa"
+    "vitamin": "mutagen_elfa",
+    "base_removal_chance": 20
   },
   {
     "type": "mutation_category",
@@ -211,7 +249,9 @@
     "threshold_mut": "THRESH_RAPTOR",
     "mutagen_message": "You're struck by a primordial flashback… and then it passes.",
     "memorial_message": "Hatched.",
-    "vitamin": "mutagen_raptor"
+    "vitamin": "mutagen_raptor",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",
@@ -220,7 +260,9 @@
     "threshold_mut": "THRESH_MOUSE",
     "mutagen_message": "You feel a desire to curl up in a nice, warm pile of… shredded paper.",
     "memorial_message": "Found the cheese.",
-    "vitamin": "mutagen_mouse"
+    "vitamin": "mutagen_mouse",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",
@@ -229,7 +271,9 @@
     "threshold_mut": "THRESH_RABBIT",
     "mutagen_message": "Walking is overrated.  It's time to start hopping.",
     "memorial_message": "Acquired a taste for carrots.",
-    "vitamin": "mutagen_rabbit"
+    "vitamin": "mutagen_rabbit",
+    "base_removal_chance": 33,
+    "base_removal_cost_mul": 2.5
   },
   {
     "type": "mutation_category",

--- a/data/mods/TEST_DATA/mutations.json
+++ b/data/mods/TEST_DATA/mutations.json
@@ -319,6 +319,14 @@
     "wip": true
   },
   {
+    "type": "mutation",
+    "id": "THRESH_TEST_REMOVAL",
+    "name": { "str": "Test threshold mutations" },
+    "points": 0,
+    "valid": true,
+    "description": "Test threshold for removal test"
+  },
+  {
     "id": "mutagen_test_removal",
     "type": "vitamin",
     "vit_type": "counter",
@@ -326,6 +334,16 @@
     "min": 0,
     "max": 2500,
     "rate": "1 h"
+  },
+  {
+    "type": "mutation",
+    "id": "TEST_REMOVAL_0",
+    "name": { "str": "Removal test zeroth (non-purifiable)" },
+    "points": 1,
+    "valid": false,
+    "purifiable": false,
+    "description": "Test mutation for the starting trait removal test",
+    "category": [ "INST_TEST" ]
   },
   {
     "type": "mutation",
@@ -342,7 +360,7 @@
     "name": { "str": "Removal test second" },
     "points": 1,
     "valid": true,
-    "cancels": [ "TEST_REMOVAL_1" ],
+    "cancels": [ "TEST_REMOVAL_1", "TEST_REMOVAL_0" ],
     "description": "Test good mutation for startin trait removal test",
     "category": [ "REMOVAL_TEST" ]
   }

--- a/data/mods/TEST_DATA/mutations.json
+++ b/data/mods/TEST_DATA/mutations.json
@@ -20,7 +20,9 @@
       "TEST_BAD3",
       "TEST_BAD4",
       "TEST_BAD5",
-      "TEST_BAD6"
+      "TEST_BAD6",
+      "TEST_REMOVAL_1",
+      "TEST_REMOVAL_2"
     ],
     "description": "For legal reasons, you are the regular amount of human."
   },
@@ -304,5 +306,44 @@
     "min": 0,
     "max": 2500,
     "rate": "1 h"
+  },
+  {
+    "type": "mutation_category",
+    "id": "REMOVAL_TEST",
+    "name": "Removal test",
+    "vitamin": "mutagen_test_removal",
+    "threshold_mut": "THRESH_TEST_REMOVAL",
+    "mutagen_message": "Removal test message",
+    "base_removal_chance": 100,
+    "base_removal_cost_mul": 2.0,
+    "wip": true
+  },
+  {
+    "id": "mutagen_test_removal",
+    "type": "vitamin",
+    "vit_type": "counter",
+    "name": { "str": "Removal test mutagen" },
+    "min": 0,
+    "max": 2500,
+    "rate": "1 h"
+  },
+  {
+    "type": "mutation",
+    "id": "TEST_REMOVAL_1",
+    "name": { "str": "Removal test first" },
+    "points": 1,
+    "valid": true,
+    "description": "Test mutation for the starting trait removal test",
+    "category": [ "INST_TEST" ]
+  },
+  {
+    "type": "mutation",
+    "id": "TEST_REMOVAL_2",
+    "name": { "str": "Removal test second" },
+    "points": 1,
+    "valid": true,
+    "cancels": [ "TEST_REMOVAL_1" ],
+    "description": "Test good mutation for startin trait removal test",
+    "category": [ "REMOVAL_TEST" ]
   }
 ]

--- a/doc/MUTATIONS.md
+++ b/doc/MUTATIONS.md
@@ -316,8 +316,12 @@ A Mutation Category identifies a set of interrelated mutations that as a whole e
 | `id`               | Unique ID. Must be one continuous word, use underscores when necessary.
 | `name`             | Human readable name for the category of mutations.
 | `threshold_mut`    | A special mutation that marks the point at which the identity of the character is changed by the extent of mutation they have experienced.
+| `threshold_min`    | Amount of primer the character needs to have in their body to attempt breaking the threshold.  Default 2200.
 | `mutagen_message`  | A message displayed to the player when they mutate in this category.
 | `memorial_message` | The memorial message to display when a character crosses the associated mutation threshold.
+| `vitamin`          | The vitamin id of the primer of this category. The character's vitamin level will act as the weight of this category when selecting which category to try and mutate towards, and gets decreased on successful mutation by the trait's mutagen cost.
+| `base_removal_chance`| Int, percent chance for a mutation of this category removing a conflicting base (starting) trait, rolled per `Character::mutate_towards` attempts.  Default 100%.  Removed base traits will **NOT** be considered base traits from here on, even if you regain them later. 
+| `base_removal_cost_mul` | Float, multiplier on the primer cost of the trait that removed a canceled starting trait, down to 0.0 for free mutations as long as a starting trait was given up.  Default 3.0, used for human-like categories and lower as categories become more inhuman.
 | `wip`              | A flag indicating that a mutation category is unfinished and shouldn't have consistency tests run on it. See tests/mutation_test.cpp.
 | `skip_test`        | If true, this mutation category will be skipped in consistency tests; this should only be used if you know what you're doing. See tests/mutation_test.cpp.
 

--- a/doc/MUTATIONS.md
+++ b/doc/MUTATIONS.md
@@ -89,6 +89,7 @@ Note that **all new traits that can be obtained through mutation must be purifia
   "id": "LIGHTEATER",                         // Unique ID.
   "name": "Optimist",                         // In-game name displayed.
   "points": 2,                                // Point cost of the trait.  Positive values cost points and negative values give points.
+  "vitamin_cost"                              // Category vitamin cost of gaining this trait (default: 100)
   "visibility": 0,                            // Visibility of the trait for purposes of NPC interaction (default: 0).
   "ugliness": 0,                              // Ugliness of the trait for purposes of NPC interaction (default: 0).
   "cut_dmg_bonus": 3,                         // Bonus to unarmed cut damage (default: 0).

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7064,6 +7064,8 @@ weighted_int_list<mutation_category_id> Character::get_vitamin_weighted_categori
     const std::map<mutation_category_id, mutation_category_trait> &mutation_categories =
         mutation_category_trait::get_all();
     for( const auto &elem : mutation_categories ) {
+        add_msg_debug( debugmode::DF_MUTATION, "get_vitamin_weighted_categories: category %s weight %d",
+                       elem.second.id.c_str(), vitamin_get( elem.second.vitamin ) );
         weighted_output.add( elem.first, vitamin_get( elem.second.vitamin ) );
     }
     return weighted_output;

--- a/src/character.h
+++ b/src/character.h
@@ -1376,10 +1376,11 @@ class Character : public Creature, public visitable
         void mutate_category( const mutation_category_id &mut_cat );
         /** Mutates toward one of the given mutations, upgrading or removing conflicts if necessary */
         bool mutate_towards( std::vector<trait_id> muts, const mutation_category_id &mut_cat,
-                             int num_tries = INT_MAX, bool use_vitamins = true );
+                             int num_tries = INT_MAX, bool use_vitamins = true, bool removed_base_trait = false );
         /** Mutates toward the entered mutation, upgrading or removing conflicts if necessary */
         bool mutate_towards( const trait_id &mut, const mutation_category_id &mut_cat,
-                             const mutation_variant *chosen_var = nullptr, bool use_vitamins = true );
+                             const mutation_variant *chosen_var = nullptr, bool use_vitamins = true,
+                             bool removed_base_trait = false );
         bool mutate_towards( const trait_id &mut, const mutation_variant *chosen_var = nullptr );
         /** Removes a mutation, downgrading to the previous level if possible */
         void remove_mutation( const trait_id &mut, bool silent = false );

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -242,6 +242,7 @@ std::string filter_name( debug_filter value )
         case DF_MATTACK: return "DF_MATTACK";
         case DF_MELEE: return "DF_MELEE";
         case DF_MONSTER: return "DF_MONSTER";
+        case DF_MUTATION: return "DF_MUTATION";
         case DF_NPC: return "DF_NPC";
         case DF_OVERMAP: return "DF_OVERMAP";
         case DF_RADIO: return "DF_RADIO";

--- a/src/debug.h
+++ b/src/debug.h
@@ -261,6 +261,7 @@ enum debug_filter : int {
     DF_MATTACK, // monster attack generic
     DF_MELEE, // melee generic
     DF_MONSTER, // monster generic
+    DF_MUTATION, // mutation/purification logic
     DF_NPC, // npc generic
     DF_OVERMAP, // overmap generic
     DF_RADIO, // radio stuff

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -235,9 +235,14 @@ void Character::unset_mutation( const trait_id &trait_ )
     // Take copy of argument because it might be a reference into a container
     // we're about to erase from.
     // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    add_msg_debug( debugmode::DF_MUTATION, "unset_mutation: attempting to unset trait %s",
+                   trait_.c_str() );
     const trait_id trait = trait_;
+    add_msg_debug( debugmode::DF_MUTATION, "unset_mutation: Or are we attempting to unset trait %s",
+                   trait.c_str() );
     const auto iter = my_mutations.find( trait );
     if( iter == my_mutations.end() ) {
+        add_msg_debug( debugmode::DF_MUTATION, "unset_mutation: didn't find trait %s", trait.c_str() );
         return;
     }
     const mutation_branch &mut = *trait;
@@ -665,6 +670,8 @@ bool Character::is_category_allowed( const mutation_category_id &category ) cons
     if( !restricted ) {
         allowed = true;
     }
+    add_msg_debug( debugmode::DF_MUTATION, "is_category_allowed (single category) %s",
+                   allowed ? "true" : "false" );
     return allowed;
 }
 
@@ -952,6 +959,8 @@ bool Character::mutation_ok( const trait_id &mutation, bool allow_good, bool all
 {
     if( mut_vit != vitamin_id::NULL_ID() && vitamin_get( mut_vit ) < mutation->vitamin_cost ) {
         // We don't have the required mutagen vitamins
+        add_msg_debug( debugmode::DF_MUTATION, "mutation_ok( %s ) failed: not enough vitamins",
+                       mutation.c_str() );
         return false;
     }
     return mutation_ok( mutation, allow_good, allow_bad, allow_neutral );
@@ -968,31 +977,45 @@ bool Character::mutation_ok( const trait_id &mutation, bool allow_good, bool all
     }
     if( has_trait( mutation ) || has_child_flag( mutation ) ) {
         // We already have this mutation or something that replaces it.
+        add_msg_debug( debugmode::DF_MUTATION, "mutation_ok( %s ): failed, trait or child already present",
+                       mutation.c_str() );
         return false;
     }
 
     for( const bionic_id &bid : get_bionics() ) {
         for( const trait_id &mid : bid->canceled_mutations ) {
             if( mid == mutation ) {
+                add_msg_debug( debugmode::DF_MUTATION,
+                               "mutation_ok( %s ): failed, bionic conflict (canceled mutation on %s)", mutation.c_str(),
+                               bid.c_str() );
                 return false;
             }
         }
 
         if( bid->mutation_conflicts.count( mutation ) != 0 ) {
+            add_msg_debug( debugmode::DF_MUTATION,
+                           "mutation_ok( %s ): failed, bionic conflict (conflicting mutation on %s)", mutation.c_str(),
+                           bid.c_str() );
             return false;
         }
     }
 
     const mutation_branch &mdata = mutation.obj();
     if( !allow_good && mdata.points > 0 ) {
+        add_msg_debug( debugmode::DF_MUTATION, "mutation_ok( %s ): good mutations not allowed",
+                       mutation.c_str() );
         return false;
     }
 
     if( !allow_bad && mdata.points < 0 ) {
+        add_msg_debug( debugmode::DF_MUTATION, "mutation_ok( %s ): failed, bad mutations not allowed",
+                       mutation.c_str() );
         return false;
     }
 
     if( !allow_neutral && mdata.points == 0 ) {
+        add_msg_debug( debugmode::DF_MUTATION, "mutation_ok( %s ): failed, neutral mutations not allowed",
+                       mutation.c_str() );
         return false;
     }
 
@@ -1001,6 +1024,7 @@ bool Character::mutation_ok( const trait_id &mutation, bool allow_good, bool all
 
 bool Character::roll_bad_mutation() const
 {
+    bool ret = false;
     //Instability value at which bad mutations become possible
     const float I0 = 900.0;
     //Instability value at which good and bad mutations are equally likely
@@ -1010,11 +1034,16 @@ bool Character::roll_bad_mutation() const
     static const float exp = std::log( 2 ) / std::log( I50 / I0 );
 
     if( vitamin_get( vitamin_instability ) == 0 ) {
-        return false;
+        add_msg_debug( debugmode::DF_MUTATION, "No instability, no bad mutations allowed" );
+        return ret;
     } else {
         //A curve that is 0 until I0, crosses 0.5 at I50, then slowly approaches 1
         float chance = std::max( 0.0f, 1 - std::pow( I0 / vitamin_get( vitamin_instability ), exp ) );
-        return rng_float( 0, 1 ) < chance;
+        ret = rng_float( 0, 1 ) < chance;
+        add_msg_debug( debugmode::DF_MUTATION,
+                       "Bad mutation chance caused by instability %.1f, roll_bad_mutation returned %s", chance,
+                       ret ? "true" : "false" );
+        return ret;
     }
 }
 
@@ -1033,6 +1062,8 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
     bool allow_neutral = true;
 
     if( true_random_chance > 0 && one_in( true_random_chance ) ) {
+        add_msg_debug( debugmode::DF_MUTATION, "True random chance %d, random roll succeeded",
+                       true_random_chance );
         cat = mutation_category_ANY;
         allow_good = true; // because i'm WILD YEAH
         allow_bad = true;
@@ -1040,6 +1071,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
     } else if( cat_list.get_weight() > 0 ) {
         cat = *cat_list.pick();
         cat_list.add_or_replace( cat, 0 );
+        add_msg_debug( debugmode::DF_MUTATION, "Picked category %s", cat.c_str() );
     } else {
         // This is fairly direct in explaining why it fails - hopefully it'll help folks to learn the system without needing to read docs
         add_msg_if_player( m_bad,
@@ -1074,11 +1106,15 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             // ...those we don't have are valid.
             if( base_mdata.valid && is_category_allowed( base_mdata.category ) &&
                 !has_trait( base_mutation ) && !base_mdata.dummy ) {
+                add_msg_debug( debugmode::DF_MUTATION, "Trait %s added to valid trait list",
+                               base_mdata.id.c_str() );
                 valid.push_back( base_mdata.id );
             }
 
             // ...dummy traits are cached.
             if( base_mdata.dummy && is_category_allowed( base_mdata.category ) ) {
+                add_msg_debug( debugmode::DF_MUTATION, "Trait %s added to dummy trait list",
+                               base_mdata.id.c_str() );
                 dummies.push_back( base_mdata.id );
             }
 
@@ -1090,6 +1126,9 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                     if( mutation->valid &&
                         mutation_ok( mutation, allow_good, allow_bad, allow_neutral, mut_vit ) &&
                         mutation_is_in_category( mutation, cat ) ) {
+                        add_msg_debug( debugmode::DF_MUTATION,
+                                       "Trait %s found, replacement trait %s pushed to upgrades list", base_mutation.c_str(),
+                                       mutation.c_str() );
                         upgrades.push_back( mutation );
                     }
                 }
@@ -1099,6 +1138,8 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                     if( mutation->valid &&
                         mutation_ok( mutation, allow_good, allow_bad, allow_neutral, mut_vit ) &&
                         mutation_is_in_category( mutation, cat ) ) {
+                        add_msg_debug( debugmode::DF_MUTATION, "Trait %s found, addition trait %s pushed to upgrades list",
+                                       base_mutation.c_str(), mutation.c_str() );
                         upgrades.push_back( mutation );
                     }
                 }
@@ -1112,6 +1153,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                 size_t roll = rng( 0, upgrades.size() + 4 );
                 if( roll < upgrades.size() ) {
                     // We got a valid upgrade index, so use it and return.
+                    add_msg_debug( debugmode::DF_MUTATION, "Upgrade roll succeeded" );
                     mutate_towards( upgrades[roll], cat, nullptr, use_vitamins );
                     return;
                 }
@@ -1123,6 +1165,8 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
         for( size_t i = 0; i < valid.size(); i++ ) {
             if( ( !mutation_ok( valid[i], allow_good, allow_bad, allow_neutral, mut_vit ) ) ||
                 ( !valid[i]->valid ) ) {
+                add_msg_debug( debugmode::DF_MUTATION, "Trait %s removed from valid trait list",
+                               ( valid.begin() + i )->c_str() );
                 valid.erase( valid.begin() + i );
                 i--;
             }
@@ -1144,6 +1188,8 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             if( cat_list.get_weight() > 0 ) {
                 // try to pick again
                 cat = *cat_list.pick();
+                add_msg_debug( debugmode::DF_MUTATION, "No valid traits in category found, new category %s",
+                               cat.c_str() );
                 cat_list.add_or_replace( cat, 0 );
             } else {
                 // every option we have vitamins for is invalid
@@ -1174,6 +1220,7 @@ void Character::mutate_category( const mutation_category_id &cat, const bool use
     // Hacky ID comparison is better than separate hardcoded branch used before
     // TODO: Turn it into the null id
     if( cat == mutation_category_ANY ) {
+        add_msg_debug( debugmode::DF_MUTATION, "mutate_category: random category" );
         mutate( 0, use_vitamins );
         return;
     }
@@ -1194,11 +1241,14 @@ void Character::mutate_category( const mutation_category_id &cat, const bool use
     // goes against our intention of a good/bad mutation
     for( size_t i = 0; i < valid.size(); i++ ) {
         if( !mutation_ok( valid[i], allow_good, allow_bad, allow_neutral, mut_vit ) ) {
+            add_msg_debug( debugmode::DF_MUTATION, "mutate_category: trait %s excluded from valid trait list",
+                           ( valid.begin() + i )->c_str() );
             valid.erase( valid.begin() + i );
             i--;
         }
     }
 
+    add_msg_debug( debugmode::DF_MUTATION, "mutate_category: mutate_towards category %s", cat.c_str() );
     mutate_towards( valid, cat, 2, use_vitamins );
 }
 
@@ -1228,6 +1278,9 @@ bool Character::mutate_towards( std::vector<trait_id> muts, const mutation_categ
 {
     while( !muts.empty() && num_tries > 0 ) {
         int i = rng( 0, muts.size() - 1 );
+        add_msg_debug( debugmode::DF_MUTATION,
+                       "mutate_towards: %d tries left, attempting to mutate towards valid trait %s", num_tries,
+                       muts[i].c_str() );
 
         if( mutate_towards( muts[i], mut_cat, nullptr, use_vitamins ) ) {
             return true;
@@ -1247,6 +1300,8 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
         remove_child_flag( mut );
         return true;
     }
+    add_msg_debug( debugmode::DF_MUTATION, "mutate_towards: %s attempting to mutate %s", name,
+                   mut.c_str() );
     const mutation_branch &mdata = mut.obj();
     // character has...
     bool c_has_both_prereqs = false;
@@ -1265,6 +1320,8 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
     // Check mutations of the same type - except for the ones we might need for pre-reqs
     for( const auto &consider : same_type ) {
         if( std::find( all_prereqs.begin(), all_prereqs.end(), consider ) == all_prereqs.end() ) {
+            add_msg_debug( debugmode::DF_MUTATION, "mutate_towards: same-typed trait %s added to cancel list",
+                           consider.c_str() );
             cancel.push_back( consider );
         }
     }
@@ -1277,6 +1334,8 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
             i--;
         } else if( has_base_trait( cancel[i] ) || !purifiable( cancel[i] ) ) {
             //If we have the trait, but it's a base trait, don't allow it to be removed normally
+            add_msg_debug( debugmode::DF_MUTATION,
+                           "mutate_towards: cancelled trait %s is a base trait, moving to canceltrait", cancel[i].c_str() );
             canceltrait.push_back( cancel[i] );
             cancel.erase( cancel.begin() + i );
             i--;
@@ -1286,6 +1345,8 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
     for( size_t i = 0; i < cancel.size(); i++ ) {
         if( !cancel.empty() ) {
             trait_id removed = cancel[i];
+            add_msg_debug( debugmode::DF_MUTATION, "mutate_towards: attempting to remove canceled trait %s",
+                           removed.c_str() );
             remove_mutation( removed );
             cancel.erase( cancel.begin() + i );
             i--;
@@ -1296,12 +1357,16 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
     //If we still have anything to cancel, we aren't done pruning, but should stop for now
     for( const trait_id &trait : cancel_recheck ) {
         if( has_trait( trait ) ) {
+            add_msg_debug( debugmode::DF_MUTATION,
+                           "mutate_towards: bailed out on cancel_recheck because of trait %s still existing", trait.c_str() );
             return true;
         }
     }
 
     for( auto &m : canceltrait ) {
         if( !purifiable( m ) ) {
+            add_msg_debug( debugmode::DF_MUTATION, "mutate_towards: canceltrait %s is not purifiable",
+                           m.c_str() );
             // We can't cancel unpurifiable mutations
             return false;
         }
@@ -1360,6 +1425,8 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
     // It shouldn't pick a Threshold anyway--they're supposed to be non-Valid
     // and aren't categorized. This can happen if someone makes a threshold mutation into a prerequisite.
     if( mut_is_threshold ) {
+        add_msg_debug( debugmode::DF_MUTATION, "mutate_towards: failed, rolled threshold trait %s",
+                       mdata.id.c_str() );
         add_msg_if_player( _( "You feel something straining deep inside you, yearning to be free…" ) );
         return false;
     }
@@ -1372,10 +1439,14 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
     // TODO: Consequences?
     for( const bionic_id &bid : get_bionics() ) {
         if( bid->mutation_conflicts.count( mut ) != 0 ) {
+            add_msg_debug( debugmode::DF_MUTATION,
+                           "mutate_towards: failed, bionic %s prevents mutation (mutation conflict)", bid.c_str() );
             return false;
         }
         for( const trait_id &mid : bid->canceled_mutations ) {
             if( mid == mut ) {
+                add_msg_debug( debugmode::DF_MUTATION,
+                               "mutate_towards: failed, bionic %s prevents mutation (canceled mutation)", bid.c_str() );
                 return false;
             }
         }
@@ -1383,6 +1454,8 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
 
     for( size_t i = 0; !c_has_threshreq && i < threshreq.size(); i++ ) {
         if( has_trait( threshreq[i] ) ) {
+            add_msg_debug( debugmode::DF_MUTATION, "mutate_towards: necessary threshold %s found",
+                           threshreq[i].c_str() );
             c_has_threshreq = true;
         }
     }
@@ -1398,11 +1471,16 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
                                mutation_category_trait::get_category( mut_cat ).vitamin;
 
     if( mut_vit != vitamin_id::NULL_ID() ) {
-        if( vitamin_get( mut_vit ) >= mdata.vitamin_cost ) {
-            vitamin_mod( mut_vit, -mdata.vitamin_cost );
+        int vitamin_cost = mdata.vitamin_cost;
+        if( vitamin_get( mut_vit ) >= vitamin_cost ) {
+            add_msg_debug( debugmode::DF_MUTATION, "mutate_towards: vitamin %s level %d, vitamin cost %d",
+                           mut_vit.c_str(), vitamin_get( mut_vit ), vitamin_cost );
+            vitamin_mod( mut_vit, -vitamin_cost );
             // No instability necessary for true random mutations - they are, after all, true random
-            vitamin_mod( vitamin_instability, mdata.vitamin_cost );
+            vitamin_mod( vitamin_instability, vitamin_cost );
         } else {
+            add_msg_debug( debugmode::DF_MUTATION, "mutate_towards: vitamin %s level %d below vitamin cost %d",
+                           mut_vit.c_str(), vitamin_get( mut_vit ), vitamin_cost );
             return false;
         }
     }
@@ -1421,6 +1499,8 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
             }
         }
     }
+    add_msg_debug( debugmode::DF_MUTATION,
+                   "mutate_towards: trait %s of prereqs_1 chosen as a replacement candidate", replacing.c_str() );
 
     // Loop through again for prereqs2
     trait_id replacing2 = trait_id::NULL_ID();
@@ -1436,6 +1516,8 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
             }
         }
     }
+    add_msg_debug( debugmode::DF_MUTATION,
+                   "mutate_towards: trait %s of prereqs_2 chosen as a replacement candidate", replacing2.c_str() );
 
     bool mutation_replaced = false;
     bool do_interrupt = true;
@@ -1712,6 +1794,7 @@ std::string Character::get_category_dream( const mutation_category_id &cat,
 
 void Character::remove_mutation( const trait_id &mut, bool silent )
 {
+    add_msg_debug( debugmode::DF_MUTATION, "remove_mutation: removing trait %s", mut.c_str() );
     const mutation_branch &mdata = mut.obj();
     // Check if there's a prerequisite we should shrink back into
     trait_id replacing = trait_id::NULL_ID();
@@ -1940,6 +2023,7 @@ void Character::test_crossing_threshold( const mutation_category_id &mutation_ca
 {
     // Threshold-check.  You only get to cross once!
     if( crossed_threshold() ) {
+        add_msg_debug( debugmode::DF_MUTATION, "test_crossing_treshold failed: already post-threshold" );
         return;
     }
 
@@ -1949,11 +2033,14 @@ void Character::test_crossing_threshold( const mutation_category_id &mutation_ca
     // If there is no threshold for this category, don't check it
     const trait_id &mutation_thresh = m_category.threshold_mut;
     if( mutation_thresh.is_empty() ) {
+        add_msg_debug( debugmode::DF_MUTATION,
+                       "test_crossing_treshold failed: category %s has no threshold defined", m_category.id.c_str() );
         return;
     }
 
     // Threshold-breaching
     int breach_power = mutation_category_level[mutation_category];
+    add_msg_debug( debugmode::DF_MUTATION, "test_crossing_treshold: breach power %d", breach_power );
     // You're required to have hit third-stage dreams first.
     if( breach_power >= 30 ) {
         if( breach_power >= 100 || x_in_y( breach_power, 100 ) ) {

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1464,12 +1464,18 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
         if( bid->mutation_conflicts.count( mut ) != 0 ) {
             add_msg_debug( debugmode::DF_MUTATION,
                            "mutate_towards: failed, bionic %s prevents mutation (mutation conflict)", bid.c_str() );
+            add_msg_if_player(
+                _( "Your churning flesh strains painfully against your %1$s for a moment, then the feeling fades." ),
+                bid->name );
             return false;
         }
         for( const trait_id &mid : bid->canceled_mutations ) {
             if( mid == mut ) {
                 add_msg_debug( debugmode::DF_MUTATION,
                                "mutate_towards: failed, bionic %s prevents mutation (canceled mutation)", bid.c_str() );
+                add_msg_if_player(
+                    _( "Your churning flesh strains painfully against your %1$s for a moment, then the feeling fades." ),
+                    bid->name );
                 return false;
             }
         }

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -573,8 +573,14 @@ struct mutation_category_trait {
         mutation_category_id id;
         // The trait that you gain when you break the threshold for this category
         trait_id threshold_mut;
+        // Amount of vitamin necessary to attempt breaking the threshold
+        int threshold_min = 2200;
         // Mutation vitamin
         vitamin_id vitamin;
+        // Chance to remove base traits
+        int base_removal_chance = 100;
+        // Multiplier of vitamin costs when mutating this category removes starting traits
+        float base_removal_cost_mul = 3.0f;
 
         static const std::map<mutation_category_id, mutation_category_trait> &get_all();
         static const mutation_category_trait &get_category(

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -110,6 +110,9 @@ void mutation_category_trait::load( const JsonObject &jsobj )
     optional( jsobj, false, "memorial_message", new_category.raw_memorial_message,
               text_style_check_reader(), "Crossed a threshold" );
     new_category.vitamin = vitamin_id( jsobj.get_string( "vitamin", "null" ) );
+    optional( jsobj, false, "threshold_min", new_category.threshold_min, 2200 );
+    optional( jsobj, false, "base_removal_chance", new_category.base_removal_chance, 100 );
+    optional( jsobj, false, "base_removal_cost_mul", new_category.base_removal_cost_mul, 3.0f );
 
     mutation_category_traits[new_category.id] = new_category;
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Allow mutations to remove starting traits"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Currently mutations are prevented from removing starting traits (aside from threshold mutations, but none use this functionality currently) - this is both easily gameable and not very flavorful. Change that, and expand the mutation system.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
- Went crazy and slapped a debug mode message on pretty much every single step of the mutation process to facilitate understanding the logic
- Added the `base_removal_chance` and `base_removal_cost_mul` variables to mutation categories - the former governs the chance of removing a conflicting starting trait per mutation attempt, the latter acts as a multiplier on the mutation cost if in the process of gaining the trait you gave up a starting one
- Hooked up the logic to remove the starting traits - traits removed like this will get purged from your starting trait list, so you're not getting them back with purifier after the fact
- Added `threshold_min` to categories to allow hand-picking the necessary primer level to break a threshold, mostly because it was a low-hanging unhardcoding to do

TODO:
- [x] Do some unit tests, probably
- [ ] Potentially unhardcode the message for removing a starting trait, we'll see if I can come up with something fun for Standard Mammal Categories 1-15

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Different chances
Using a flat vitamin cost, but tying it to the end effect sounded more reasonable - as mutation costs get expanded it should differentiate between a huge change rewriting most of you insides and your fingernails not being that sharp
PR the threshold limit separately, but might as well `While I'm Here` it

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Previously couldn't lose a starting trait (BADKNEES in the tests), either with purifier, mutagen, or the debug menu.
The debugmode messages show up and explain the logic in a pretty verbose way.
Post-changes purifier leaves my knees alone, the other options remove them without incident.
Cost multipliers and chances are read and applied as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Purifier can't remove starting traits, human-ish categories only remove 20% of the time at 3x cost multiplier, scaling to 100% chance and no multiplier for Slime/Chimera.

Random-type mutations get to remove starting traits currently, that can go either way but they are usually meant as a penalty for radiation/involuntary mutation.

<details>
  <summary>Debug mode messages</summary>

![grafik](https://user-images.githubusercontent.com/72006894/222980880-070468c2-c27e-42f5-9f82-8b0ede46458a.png)

Too much? Nonsense!

![grafik](https://user-images.githubusercontent.com/72006894/222980909-fc10a60d-08d9-4a48-b583-aab6cda85f81.png)

</details>