### PR TITLE
Remove erroneous `SHALLOW_WATER` flag from `t_swater_dp`

### DIFF
--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -187,7 +187,7 @@
     "looks_like": "t_water_dp",
     "color": "blue",
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "SALT_WATER", "DEEP_WATER", "FISHABLE", "SHALLOW_WATER" ],
+    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "SALT_WATER", "DEEP_WATER", "FISHABLE" ],
     "connect_groups": "WATER",
     "connects_to": "WATER",
     "examine_action": "water_source"


### PR DESCRIPTION
#### Summary
Bugfixes "Remove erroneous `SHALLOW_WATER` flag from `t_swater_dp`"

#### Purpose of change
Deep salt water `t_swater_dp` simultaneously has both `DEEP_WATER` and `SHALLOW_WATER` flags

#### Describe the solution
Delete erroneous flag