### PR TITLE
Allow using flotation in lieu of jacking when working on vehicle

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -178,7 +178,7 @@ player_activity veh_interact::serialize_activity()
     res.values.push_back( veh->index_of_part( vpt ) ); // values[6]
     res.str_values.push_back( vp->get_id().str() );
     res.str_values.push_back( sel_vpart_variant );
-    res.targets.emplace_back( std::move( target ) );
+    res.targets.emplace_back( std::move( refill_target ) );
 
     return res;
 }
@@ -1396,8 +1396,8 @@ void veh_interact::do_refill()
             return false;
         };
 
-        target = g->inv_map_splice( validate, string_format( _( "Refill %s" ), pt.name() ), 1 );
-        if( target ) {
+        refill_target = g->inv_map_splice( validate, string_format( _( "Refill %s" ), pt.name() ), 1 );
+        if( refill_target ) {
             sel_vehicle_part = &pt;
             sel_vpart_info = &pt.info();
             sel_cmd = 'f';

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -64,8 +64,6 @@ class veh_interact
         explicit veh_interact( vehicle &veh, const point &p = point_zero );
         ~veh_interact();
 
-        item_location target;
-
         point dd = point_zero;
         /* starting offset for vehicle parts description display and max offset for scrolling */
         int start_at = 0;
@@ -73,19 +71,23 @@ class veh_interact
         /* starting offset for the overview and the max offset for scrolling */
         int overview_offset = 0;
         int overview_limit = 0;
-        // starting offset for installation scrolling
+        /* starting offset for installation scrolling */
         int w_msg_scroll_offset = 0;
+        /* starting offset for fuels scrolling */
+        int fuel_index = 0;
 
-        const vpart_info *sel_vpart_info = nullptr;
-        std::string sel_vpart_variant;
-        //Command currently being run by the player
-        char sel_cmd = ' ';
+        // target vehicle tank for refill with liquids
+        item_location refill_target;
 
         const vehicle_part *sel_vehicle_part = nullptr;
+        const vpart_info *sel_vpart_info = nullptr;
+        std::string sel_vpart_variant;
+
+        // Command currently being run by the player
+        char sel_cmd = ' ';
 
         int cpart = -1;
         int page_size = 0;
-        int fuel_index = 0; /** Starting index of where to start printing fuels from */
         // height of the stats window
         const int stats_h = 8;
         catacurses::window w_border;
@@ -98,11 +100,12 @@ class veh_interact
         catacurses::window w_details;
         catacurses::window w_name;
 
-        bool ui_hidden = false;
         weak_ptr_fast<ui_adaptor> ui;
 
         cata::optional<std::string> title;
         cata::optional<std::string> msg;
+
+        bool ui_hidden = false;
 
         int highlight_part = -1;
 
@@ -237,8 +240,8 @@ class veh_interact
 
         void count_durability();
 
-        std::string total_durability_text;
         nc_color total_durability_color;
+        std::string total_durability_text;
 
         /** Returns the most damaged part's index, or -1 if they're all healthy. */
         vehicle_part *get_most_damaged_part() const;

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -281,6 +281,10 @@ class veh_interact
          * Updated whenever the cursor moves. */
         std::vector<int> parts_here;
 
+        /* Whether flotation logic is to be used instead of jacking for the current square.
+         * Updated whenever the cursor moves. */
+        bool float_in_lieu_of_jack;
+
         /* called by exec() */
         void cache_tool_availability();
         void allocate_windows();


### PR DESCRIPTION
#### Summary
Features "Allow using flotation in lieu of jacking when working on vehicle"

#### Purpose of change
Resolves #63957

#### Describe the solution

When installing/removing vehicle parts, in general you need enough strength to lift the part in question, or use lifting tools otherwise. The exception is for parts like wheels, with `NEEDS_JACKING` flag, for which it instead checks that you have tools to jack up the vehicle (or outright lift it manually, if small and light enough).

<sup>(As an aside: it doesn't check the weight to handle/lift the part, this is kind of reasonable  -- e.g. when you're changing a tire you'd rather roll/drag it on the ground when you can, instead of hauling it.)</sup>

This PR adds new feature allowing use of flotation in lieu of jacking in situations such as changing the tire on an amphibious DUKW truck while it is floating on water.

Criteria:
- vehicle as a whole is a viable watercraft that can float
- vehicle is in "enough" water, since amphibs can straddle land and water
- the specific vehicle mount point being worked on is a water tile (again, in case of straddling)

Requirements:
- instead of jacking the whole vehicle, it is now fully supported by its own buoyancy
- goes back to requirement of needing enough strength or lifting tools to manhandle the part
- the part's buoyancy contributes to supporting its own weight
  - calculation assumes it is/will be half submerged
  - if part is "too floaty" you instead need strength to force it down

#### Describe alternatives you've considered

Could be made even more complex with other considerations, such as:
- is the mount point being worked on accessible from around the vehicle periphery?  
where would the player character be while doing the thing?
  - is there an unobstructed land or shallow water tile adjacent to the one being worked on, to stand on?
  - would they be able to do the thing while treading water next to the vehicle?
    - does that make the task more difficult / take longer?
  - or is the mount point in the middle of the vehicle underside? On land you could get under the jacked up vehicle; in water this would entail diving underwater
    - do you have ability to breathe underwater for the duration of the task? gills, or enough rebreather cartridges?
    - no problem in deep water, but is there even enough room to get under there in shallow water?

It's a heckuva potential rabbit hole, instead I chose to keep things simple since the on-land case doesn't deal with similar considerations either.

#### Testing
Here is a convenient save with a DUKW in a little pool of water added by debug map edit:
[Sewaren-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/10896340/Sewaren-trimmed.tar.gz)

Check requirements in water, drive onto dry land, check again, compare.

#### Additional context
On land:
![on-land](https://user-images.githubusercontent.com/28502722/223069031-305d34ab-f4c6-4968-9a06-fe597bb231dd.png)

On water:
![in-water](https://user-images.githubusercontent.com/28502722/223069077-e26cc4ad-3624-4288-a12a-c768cdec29b8.png)

-----

#### Summary 2
Performance "Structure packing"

#### Purpose of change
I added a bool and it was the straw that broke the camel's back, causing clang-tidy to [complain about padding inefficiency](../actions/runs/4342661498/jobs/7583766365). So I get to do the chore of a bit of structure packing.

#### Describe the solution
Do a bit of clever rearranging of fields in `veh_interact.h`, reducing the number of padding bytes from 37 to 13.  
(Optimal would have 5 padding bytes, but preserving logical arrangement and code readability is also important.)

Also:
add/adj some comments
rename field `target` to more informative name `refill_target`

#### Additional context
:exclamation: It's probably better for git history / blame purposes to not meld these unrelated refactoring changes into the same commit as the feature addition above, so I would suggest to not do a squash merge for this PR.