### PR TITLE
remove unused variable

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -147,8 +147,6 @@ static const itype_id itype_usb_drive( "usb_drive" );
 
 static const matype_id style_none( "style_none" );
 
-static const relic_procgen_id relic_procgen_data_cult( "cult" );
-
 static const skill_id skill_chemistry( "chemistry" );
 
 static const ter_str_id ter_t_ash( "t_ash" );


### PR DESCRIPTION
#### Summary
None

Silences a clang-tidy warning