### PR TITLE
Fixes for the all entry on armor organize menu

### DIFF
--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -235,7 +235,7 @@ std::vector<std::string> clothing_properties(
         // if there is only one data entry for the armor
         if( worn_item.find_armor_data()->sub_data.size() > 1 ) {
             props.push_back( string_format( "<color_c_red>%s</color>",
-                                            _( "Armor is nonuniform. Specify a limb to get armor data" ) ) );
+                                            _( "Armor is nonuniform.  Specify a limb to get armor data" ) ) );
             return props;
         } else {
             used_bp = *worn_item.get_covered_body_parts().begin();

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -230,32 +230,40 @@ std::vector<std::string> clothing_properties(
     const item &worn_item, const int width, const Character &c, const bodypart_id &bp )
 {
     std::vector<std::string> props;
-    props.reserve( 5 );
+    bodypart_id used_bp = bp;
+    if( bp == bodypart_id( "bp_null" ) ) {
+        // if there is only one data entry for the armor
+        if( worn_item.find_armor_data()->sub_data.size() > 1 ) {
+            props.push_back( string_format( "<color_c_red>%s</color>",
+                                            _( "Armor is nonuniform. Specify a limb to get armor data" ) ) );
+            return props;
+        } else {
+            used_bp = *worn_item.get_covered_body_parts().begin();
+            props.reserve( 6 );
+            props.push_back( string_format( "<color_c_blue>%s</color>",
+                                            _( "Each limb is uniform" ) ) );
+        }
+    } else {
+        props.reserve( 5 );
+    }
+
 
     props.push_back( string_format( "<color_c_green>[%s]</color>", _( "Properties" ) ) );
 
-    int coverage = bp == bodypart_id( "bp_null" ) ? worn_item.get_avg_coverage() :
-                   worn_item.get_coverage( bp );
+    int coverage = worn_item.get_coverage( used_bp );
     add_folded_name_and_value( props, _( "Coverage:" ), string_format( "%3d", coverage ),
                                width );
-    coverage = bp == bodypart_id( "bp_null" ) ? worn_item.get_avg_coverage(
-                   item::cover_type::COVER_MELEE ) :
-               worn_item.get_coverage( bp, item::cover_type::COVER_MELEE );
+    coverage = worn_item.get_coverage( used_bp, item::cover_type::COVER_MELEE );
     add_folded_name_and_value( props, _( "Coverage (Melee):" ), string_format( "%3d",
                                coverage ), width );
-    coverage = bp == bodypart_id( "bp_null" ) ? worn_item.get_avg_coverage(
-                   item::cover_type::COVER_RANGED ) :
-               worn_item.get_coverage( bp, item::cover_type::COVER_RANGED );
+    coverage = worn_item.get_coverage( used_bp, item::cover_type::COVER_RANGED );
     add_folded_name_and_value( props, _( "Coverage (Ranged):" ), string_format( "%3d",
                                coverage ), width );
-    coverage = bp == bodypart_id( "bp_null" ) ? worn_item.get_avg_coverage(
-                   item::cover_type::COVER_VITALS ) :
-               worn_item.get_coverage( bp, item::cover_type::COVER_VITALS );
+    coverage = worn_item.get_coverage( used_bp, item::cover_type::COVER_VITALS );
     add_folded_name_and_value( props, _( "Coverage (Vitals):" ), string_format( "%3d",
                                coverage ), width );
 
-    const int encumbrance = bp == bodypart_id( "bp_null" ) ? worn_item.get_avg_encumber(
-                                c ) : worn_item.get_encumber( c, bp );
+    const int encumbrance = worn_item.get_encumber( c, used_bp );
     add_folded_name_and_value( props, _( "Encumbrance:" ), string_format( "%3d", encumbrance ),
                                width );
     add_folded_name_and_value( props, _( "Warmth:" ), string_format( "%3d",
@@ -314,18 +322,29 @@ std::vector<std::string> clothing_protection( const item &worn_item, const int w
         const bodypart_id &bp )
 {
     std::vector<std::string> prot;
+    bodypart_id used_bp = bp;
+
+    // if bp is null its gonna be impossible to really get good info
+    if( bp == bodypart_id( "bp_null" ) ) {
+        if( worn_item.find_armor_data()->sub_data.size() > 1 ) {
+            return prot;
+        } else {
+            used_bp = *worn_item.get_covered_body_parts().begin();
+        }
+    }
+
     prot.reserve( 6 );
 
     // prebuild and calc some values
     // the rolls are basically a perfect hit for protection and a
     // worst possible and a median hit
-    resistances worst_res = resistances( worn_item, false, 99, bp );
-    resistances best_res = resistances( worn_item, false, 0, bp );
-    resistances median_res = resistances( worn_item, false, 50, bp );
+    resistances worst_res = resistances( worn_item, false, 99, used_bp );
+    resistances best_res = resistances( worn_item, false, 0, used_bp );
+    resistances median_res = resistances( worn_item, false, 50, used_bp );
 
     int percent_best = 100;
     int percent_worst = 0;
-    const armor_portion_data *portion = worn_item.portion_for_bodypart( bp );
+    const armor_portion_data *portion = worn_item.portion_for_bodypart( used_bp );
     // if there isn't a portion this is probably pet armor
     if( portion ) {
         percent_best = portion->best_protection_chance;
@@ -362,7 +381,7 @@ std::vector<std::string> clothing_protection( const item &worn_item, const int w
     add_folded_name_and_value( prot, _( "Environmental:" ),
                                string_format( "%3d", static_cast<int>( worn_item.get_env_resist() ) ), width );
     add_folded_name_and_value( prot, _( "Breathability:" ),
-                               string_format( "%3d", static_cast<int>( worn_item.breathability( bp ) ) ), width );
+                               string_format( "%3d", static_cast<int>( worn_item.breathability( used_bp ) ) ), width );
     return prot;
 }
 

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -1857,6 +1857,7 @@ nonrevealing
 nonromantic
 nonsedated
 nonstandard
+nonuniform
 nonverbally
 noone
 nopal


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #63539
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
As suggested on the discord by @RenechCDDA 

On the all screen armor that has multiple entries just explains it is nonuniform. Armor that only has 1 entry for armor data it uses that limbs data and mentions that the armor is uniform.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![image](https://user-images.githubusercontent.com/4514073/223189960-92143ace-ee1e-432e-b2a6-1ed938bf98a7.png)
![image](https://user-images.githubusercontent.com/4514073/223190021-426f70ff-df43-48ec-94b2-24b1edacf295.png)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
