### PR TITLE
bump ubuntu image and minimum compiler versions

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -89,7 +89,7 @@ jobs:
             native: linux64
             archive-success: basic-build
             dont_skip_data_only_changes: 1
-            title: Basic Build and Test (Clang 7, Ubuntu, Curses)
+            title: Basic Build and Test (Clang 10, Ubuntu, Curses)
             # ~190MB in a clean build
             # ~30MB compressed
             # observed usage: 3.0GB -> 300MB
@@ -226,7 +226,7 @@ jobs:
         CCACHE_FILECLONE: true
         CCACHE_HARDLINK: true
         CCACHE_NOCOMPRESS: true
-        SKIP: ${{ ( github.event.pull_request.draft == true && matrix.title != 'Basic Build and Test (Clang 6, Ubuntu, Curses)' ) || ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates.outputs.should_skip_code == 'true' ) || ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-mods.outputs.should_skip_data == 'true' ) }}
+        SKIP: ${{ ( github.event.pull_request.draft == true && matrix.title != 'Basic Build and Test (Clang 10, Ubuntu, Curses)' ) || ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates.outputs.should_skip_code == 'true' ) || ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-mods.outputs.should_skip_data == 'true' ) }}
         SKIP_TESTS: ${{ needs.matrix-variables.outputs.skip_tests }}
     steps:
     - name: checkout repository

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -78,7 +78,7 @@ jobs:
       max-parallel: ${{ fromJSON(needs.matrix-variables.outputs.max_parallel) }}
       matrix:
         include:
-          - compiler: clang++-7.0
+          - compiler: clang++-10.0
             os: ubuntu-20.04
             tiles: 0
             sound: 0
@@ -178,7 +178,7 @@ jobs:
             # observed usage: 3.0GB -> 350MB
             ccache_limit: 2G
 
-          - compiler: g++-8
+          - compiler: g++-9
             os: ubuntu-20.04
             release: 1
             cmake: 1
@@ -186,7 +186,7 @@ jobs:
             sound: 1
             localize: 0
             native: linux64
-            title: GCC 8, Ubuntu, Tiles, Sound, CMake
+            title: GCC 9, Ubuntu, Tiles, Sound, CMake
             # ~180MB in a clean build
             # ~25MB compressed
             # observed usage: 3.0GB -> 300MB
@@ -243,20 +243,12 @@ jobs:
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && matrix.tiles == 1 }}
       run: |
           sudo apt-get install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev
-    - name: install old GCC (Ubuntu)
-      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'g++-8' || matrix.compiler == 'g++-9') }}
-      run: |
-          sudo apt-get install g++-8 g++-9
     - name: install new GCC (Ubuntu)
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'g++-11') }}
       run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install g++-11
-    - name: install old Clang (Ubuntu)
-      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'clang++-7.0') }}
-      run: |
-          sudo apt-get install clang-7.0
     - name: set up a mock GCC toolchain root for Clang (Ubuntu)
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'clang++-12') }}
       run: |

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -78,7 +78,7 @@ jobs:
       max-parallel: ${{ fromJSON(needs.matrix-variables.outputs.max_parallel) }}
       matrix:
         include:
-          - compiler: clang++-10.0
+          - compiler: clang++-10
             os: ubuntu-20.04
             tiles: 0
             sound: 0

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -78,8 +78,8 @@ jobs:
       max-parallel: ${{ fromJSON(needs.matrix-variables.outputs.max_parallel) }}
       matrix:
         include:
-          - compiler: clang++-6.0
-            os: ubuntu-18.04
+          - compiler: clang++-7.0
+            os: ubuntu-20.04
             tiles: 0
             sound: 0
             release: 1
@@ -89,7 +89,7 @@ jobs:
             native: linux64
             archive-success: basic-build
             dont_skip_data_only_changes: 1
-            title: Basic Build and Test (Clang 6, Ubuntu, Curses)
+            title: Basic Build and Test (Clang 7, Ubuntu, Curses)
             # ~190MB in a clean build
             # ~30MB compressed
             # observed usage: 3.0GB -> 300MB
@@ -178,15 +178,15 @@ jobs:
             # observed usage: 3.0GB -> 350MB
             ccache_limit: 2G
 
-          - compiler: g++-7
-            os: ubuntu-18.04
+          - compiler: g++-8
+            os: ubuntu-20.04
             release: 1
             cmake: 1
             tiles: 1
             sound: 1
             localize: 0
             native: linux64
-            title: GCC 7, Ubuntu, Tiles, Sound, CMake
+            title: GCC 8, Ubuntu, Tiles, Sound, CMake
             # ~180MB in a clean build
             # ~25MB compressed
             # observed usage: 3.0GB -> 300MB
@@ -244,9 +244,9 @@ jobs:
       run: |
           sudo apt-get install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev
     - name: install old GCC (Ubuntu)
-      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'g++-7' || matrix.compiler == 'g++-8') }}
+      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'g++-8' || matrix.compiler == 'g++-9') }}
       run: |
-          sudo apt-get install g++-7 g++-8
+          sudo apt-get install g++-8 g++-9
     - name: install new GCC (Ubuntu)
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'g++-11') }}
       run: |
@@ -254,9 +254,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install g++-11
     - name: install old Clang (Ubuntu)
-      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'clang++-6.0') }}
+      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'clang++-7.0') }}
       run: |
-          sudo apt-get install clang-6.0
+          sudo apt-get install clang-7.0
     - name: set up a mock GCC toolchain root for Clang (Ubuntu)
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'clang++-12') }}
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
             content: application/zip
             sound: 1
           - name: Linux Tiles x64
-            os: ubuntu-18.04
+            os: ubuntu-latest
             mxe: none
             android: none
             tiles: 1
@@ -155,7 +155,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: Linux Tiles Sounds x64
-            os: ubuntu-18.04
+            os: ubuntu-latest
             mxe: none
             android: none
             tiles: 1
@@ -164,7 +164,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: Linux Curses x64
-            os: ubuntu-18.04
+            os: ubuntu-latest
             mxe: none
             android: none
             tiles: 0


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Github is in the process of EOLing ubuntu 18.04 https://github.com/actions/runner-images/issues/6002

In particular, we are seeing brownouts from github actions using this image, which causes waves of basic build failures across all PRs.

We're also already eyeballing newer compiler features, i e. C++17 https://github.com/CleverRaven/Cataclysm-DDA/pull/63970