### PR TITLE
Handle obsolete recipes on items

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -843,7 +843,7 @@ std::unique_ptr<activity_actor> hacking_activity_actor::deserialize( JsonValue &
 
 void bookbinder_copy_activity_actor::start( player_activity &act, Character & )
 {
-    pages = 1 + rec_id->difficulty / 2;
+    pages = bookbinder_copy_activity_actor::pages_for_recipe( *rec_id );
     act.moves_total = to_moves<int>( pages * 10_minutes );
     act.moves_left = to_moves<int>( pages * 10_minutes );
 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -865,8 +865,10 @@ void bookbinder_copy_activity_actor::finish( player_activity &act, Character &p 
         return;
     }
 
-    const bool rec_added = book_binder->eipc_recipe_add( rec_id );
-    if( rec_added ) {
+    std::set<recipe_id> recipes = book_binder->get_saved_recipes();
+
+    if( recipes.emplace( rec_id ).second ) { // if .second is true then recipe was inserted
+        book_binder->set_saved_recipes( recipes );
         p.add_msg_if_player( m_good, _( "You copy the recipe for %1$s into your recipe book." ),
                              rec_id->result_name() );
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -251,6 +251,10 @@ class bookbinder_copy_activity_actor: public activity_actor
             return rec_id == act.rec_id && book_binder == act.book_binder;
         }
 
+        static int pages_for_recipe( const recipe &r ) {
+            return 1 + r.difficulty / 2;
+        }
+
         void start( player_activity &act, Character & ) override;
         void do_turn( player_activity &, Character &p ) override;
         void finish( player_activity &act, Character &p ) override;

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2351,7 +2351,7 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
                                 ammo_remaining, used_tool->ammo_capacity( current_ammo ),
                                 ammo_name,
                                 used_tool->ammo_required() );
-        title += string_format( _( "Materials available: %s\n" ), join( material_list, ", " ) );
+        title += string_format( _( "Materials available: %s\n" ), string_join( material_list, ", " ) );
         title += string_format( _( "Skill used: <color_light_blue>%s (%s)</color>\n" ),
                                 actor->used_skill.obj().name(), level );
         title += string_format( _( "Success chance: <color_light_blue>%.1f</color>%%\n" ),

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -651,19 +651,6 @@ bool string_empty_or_whitespace( const std::string &s )
     } );
 }
 
-std::string join( const std::vector<std::string> &strings, const std::string &joiner )
-{
-    std::ostringstream buffer;
-
-    for( auto a = strings.begin(); a != strings.end(); ++a ) {
-        if( a != strings.begin() ) {
-            buffer << joiner;
-        }
-        buffer << *a;
-    }
-    return buffer.str();
-}
-
 template<>
 std::string io::enum_to_string<holiday>( holiday data )
 {

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -651,6 +651,27 @@ bool string_empty_or_whitespace( const std::string &s )
     } );
 }
 
+std::vector<std::string> string_split( const std::string &string, char delim )
+{
+    std::vector<std::string> elems;
+
+    if( string.empty() ) {
+        return elems; // Well, that was easy.
+    }
+
+    std::stringstream ss( string );
+    std::string item;
+    while( std::getline( ss, item, delim ) ) {
+        elems.push_back( item );
+    }
+
+    if( string.back() == delim ) {
+        elems.emplace_back( "" );
+    }
+
+    return elems;
+}
+
 template<>
 std::string io::enum_to_string<holiday>( holiday data )
 {

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -490,6 +490,10 @@ std::string string_join( const Container &iterable, const std::string &joiner )
     return buffer.str();
 }
 
+/**
+* Splits a string by delimiter into a vector of strings
+*/
+std::vector<std::string> string_split( const std::string &string, char delim );
 
 /**
  * Append all arguments after the first to the first.

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -473,9 +473,23 @@ bool return_false( const T & )
 }
 
 /**
- * Joins a vector of `std::string`s into a single string with a delimiter/joiner
+ * Joins an iterable (class implementing begin() and end()) of elements into a single
+ * string with specified delimiter by using `<<` ostream operator on each element
  */
-std::string join( const std::vector<std::string> &strings, const std::string &joiner );
+template<typename Container>
+std::string string_join( const Container &iterable, const std::string &joiner )
+{
+    std::ostringstream buffer;
+
+    for( auto a = iterable.begin(); a != iterable.end(); ++a ) {
+        if( a != iterable.begin() ) {
+            buffer << joiner;
+        }
+        buffer << *a;
+    }
+    return buffer.str();
+}
+
 
 /**
  * Append all arguments after the first to the first.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9522,7 +9522,7 @@ std::vector<std::string> Character::short_description_parts() const
 
 std::string Character::short_description() const
 {
-    return join( short_description_parts(), ";   " );
+    return string_join( short_description_parts(), ";   " );
 }
 
 void Character::process_one_effect( effect &it, bool is_new )

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1589,7 +1589,7 @@ const requirement_data *Character::select_requirements(
         std::vector<std::string> component_lines =
             req->get_folded_components_list( TERMX - 4, c_light_gray, inv, filter, batch, "",
                                              requirement_display_flags::no_unavailable );
-        menu.addentry_desc( "", join( component_lines, "\n" ) );
+        menu.addentry_desc( "", string_join( component_lines, "\n" ) );
     }
 
     menu.allow_cancel = true;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1803,7 +1803,7 @@ std::string game_info::mods_loaded()
         return string_format( "%s [%s]", mod->name(), mod->ident.str() );
     } );
 
-    return join( mod_names, ",\n    " ); // note: 4 spaces for a slight offset.
+    return string_join( mod_names, ",\n    " ); // note: 4 spaces for a slight offset.
 }
 
 std::string game_info::game_report()

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1809,7 +1809,7 @@ class repair_inventory_preset: public inventory_selector_preset
                                                            num_comp ), num_comp < comp_needed ? c_red : c_unset ) );
                     }
                 }
-                std::string ret = join( material_list, ", " );
+                std::string ret = string_join( material_list, ", " );
                 if( ret.empty() ) {
                     ret = _( "<color_red>NONE</color>" );
                 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9892,6 +9892,32 @@ void item::mark_chapter_as_read( const Character &u )
     set_var( var, remain );
 }
 
+std::set<recipe_id> item::get_saved_recipes() const
+{
+    if( is_broken_on_active() ) {
+        return {};
+    }
+    std::set<recipe_id> result;
+    for( const std::string &rid_str : string_split( get_var( "EIPC_RECIPES" ), ',' ) ) {
+        const recipe_id rid( rid_str );
+        if( rid.is_empty() ) {
+            continue;
+        }
+        if( !rid.is_valid() ) {
+            DebugLog( D_WARNING, D_GAME ) << type->get_id().str() <<
+                                          " contained invalid recipe id '" << rid.str() << "'";
+            continue;
+        }
+        result.emplace( rid );
+    }
+    return result;
+}
+
+void item::set_saved_recipes( const std::set<recipe_id> &recipes )
+{
+    set_var( "EIPC_RECIPES", string_join( recipes, "," ) );
+}
+
 std::vector<std::pair<const recipe *, int>> item::get_available_recipes(
             const Character &u ) const
 {

--- a/src/item.h
+++ b/src/item.h
@@ -2196,6 +2196,15 @@ class item : public visitable
          */
         void mark_chapter_as_read( const Character &u );
         /**
+         * Returns recipes stored on the item (laptops, smartphones, sd cards etc)
+         * Filters out !is_valid() recipes
+         */
+        std::set<recipe_id> get_saved_recipes() const;
+        /**
+        * Sets recipes stored on the item (laptops, smartphones, sd cards etc)
+        */
+        void set_saved_recipes( const std::set<recipe_id> &recipes );
+        /**
          * Enumerates recipes available from this book and the skill level required to use them.
          */
         std::vector<std::pair<const recipe *, int>> get_available_recipes( const Character &u ) const;

--- a/src/item.h
+++ b/src/item.h
@@ -2211,13 +2211,6 @@ class item : public visitable
         /*@}*/
 
         /**
-         * Add a recipe to the EIPC_RECIPES variable.
-         *
-         * @return true if the recipe was added, false if it is a duplicate
-         */
-        bool eipc_recipe_add( const recipe_id &recipe_id );
-
-        /**
          * @name Martial art techniques
          *
          * See martialarts.h for further info.

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5933,27 +5933,17 @@ static bool einkpc_download_memory_card( Character &p, item &eink, item &mc )
                 }
             }
 
+            std::set<recipe_id> saved_recipes = eink.get_saved_recipes();
             for( const recipe *r : new_recipes ) {
                 const recipe_id &rident = r->ident();
-
-                const auto old_recipes = eink.get_var( "EIPC_RECIPES" );
-                if( old_recipes.empty() ) {
-                    something_downloaded = true;
-                    eink.set_var( "EIPC_RECIPES", "," + rident.str() + "," );
-
+                if( saved_recipes.emplace( rident ).second ) { // recipe added
+                    eink.set_saved_recipes( saved_recipes );
                     p.add_msg_if_player( m_good, _( "You download a recipe for %s into the tablet's memory." ),
                                          r->result_name() );
+                    something_downloaded = true;
                 } else {
-                    if( old_recipes.find( "," + rident.str() + "," ) == std::string::npos ) {
-                        something_downloaded = true;
-                        eink.set_var( "EIPC_RECIPES", old_recipes + rident.str() + "," );
-
-                        p.add_msg_if_player( m_good, _( "You download a recipe for %s into the tablet's memory." ),
-                                             r->result_name() );
-                    } else {
-                        p.add_msg_if_player( m_good, _( "The recipe for %s is already stored in the tablet's memory." ),
-                                             r->result_name() );
-                    }
+                    p.add_msg_if_player( m_good, _( "The recipe for %s is already stored in the tablet's memory." ),
+                                         r->result_name() );
                 }
             }
         }
@@ -6105,7 +6095,7 @@ cata::optional<int> iuse::einktabletpc( Character *p, item *it, bool t, const tr
             amenu.addentry( ei_music, false, 'm', _( "No music on device" ) );
         }
 
-        if( !it->get_var( "EIPC_RECIPES" ).empty() ) {
+        if( !it->get_saved_recipes().empty() ) {
             amenu.addentry( ei_recipe, true, 'r', _( "List stored recipes" ) );
         }
 
@@ -6190,27 +6180,11 @@ cata::optional<int> iuse::einktabletpc( Character *p, item *it, bool t, const tr
             p->moves -= 50;
 
             uilist rmenu;
-
-            rmenu.text = _( "List recipes:" );
-
-            std::vector<recipe_id> candidate_recipes;
-            std::istringstream f( it->get_var( "EIPC_RECIPES" ) );
-            std::string s;
-            int k = 0;
-            while( getline( f, s, ',' ) ) {
-
-                if( s.empty() ) {
-                    continue;
-                }
-
-                candidate_recipes.emplace_back( s );
-
-                const recipe &recipe = *candidate_recipes.back();
-                if( recipe ) {
-                    rmenu.addentry( k++, true, -1, recipe.result_name( /*decorated=*/true ) );
-                }
+            for( const recipe_id &rid : it->get_saved_recipes() ) {
+                rmenu.addentry( 0, true, 0, rid->result_name( /* decorated = */ true ) );
             }
 
+            rmenu.text = _( "List recipes:" );
             rmenu.query();
 
             return 1;
@@ -9901,46 +9875,6 @@ cata::optional<int> iuse::binder_add_recipe( Character *p, item *binder, bool, c
         return cata::nullopt;
     }
 
-    uilist amenu;
-    amenu.text = _( "Choose menu option:" );
-
-    if( !binder->get_var( "EIPC_RECIPES" ).empty() ) {
-        amenu.addentry( 0, true, 'r', _( "View recipes" ) );
-    }
-    amenu.addentry( 1, true, 'w', _( "Copy a recipe from a book" ) );
-
-    amenu.query();
-    if( amenu.ret < 0 ) {
-        return cata::nullopt;
-    } else if( amenu.ret == 0 ) {
-        uilist rmenu;
-        rmenu.text = _( "List recipes:" );
-
-        std::vector<recipe_id> candidate_recipes;
-        std::istringstream f( binder->get_var( "EIPC_RECIPES" ) );
-        std::string s;
-        int k = 0;
-        while( getline( f, s, ',' ) ) {
-
-            if( s.empty() ) {
-                continue;
-            }
-
-            candidate_recipes.emplace_back( s );
-
-            const recipe &rec = *candidate_recipes.back();
-            const int pages = 1 + rec.difficulty / 2;
-            if( rec ) {
-                rmenu.addentry_col( k++, true, -1, rec.result_name(),
-                                    string_format( n_gettext( "%1$d page", "%1$d pages", pages ), pages ) );
-            }
-        }
-
-        rmenu.query();
-
-        return cata::nullopt;
-    }
-
     const inventory crafting_inv = p->crafting_inventory();
     const std::vector<const item *> writing_tools = crafting_inv.items_with( [&]( const item & it ) {
         return it.has_flag( flag_WRITE_MESSAGE ) && it.ammo_sufficient( p );
@@ -9951,88 +9885,57 @@ cata::optional<int> iuse::binder_add_recipe( Character *p, item *binder, bool, c
         return cata::nullopt;
     }
 
-    const recipe_subset res = p->get_recipes_from_books( crafting_inv );
-    if( !res.size() ) {
-        p->add_msg_if_player( m_info, _( "You do not have any recipes you can copy." ) );
-        return cata::nullopt;
-    }
-
-    std::vector<const recipe *> recipes;
-    recipes.reserve( res.size() );
-
-    uilist menu;
-    menu.text = _( "Choose recipe to copy" );
-
-    // due to way recipe_subset works, I can't a use range-based for loop here
-    // without compiler errors
-    for( auto rec = res.begin(); rec != res.end(); ++rec ) {
-        // bypass clang: use range-based for loop instead [modernize-loop-convert]
-        // because of the issue above
-        if( rec == res.end() ) {
-            continue;
-        }
-        recipes.emplace_back( *rec );
-
-        const int pages = 1 + ( *rec )->difficulty / 2;
-        menu.addentry_col( -1, binder->remaining_ammo_capacity() >= pages, ' ',
-                           ( *rec )->result_name(),
-                           string_format( n_gettext( "%1$d page", "%1$d pages", pages ), pages ) );
-    }
-
-    menu.query();
-    if( menu.ret < 0 ) {
-        return cata::nullopt;
-    }
-
     if( p->fine_detail_vision_mod() > 4.0f ) {
         p->add_msg_if_player( m_info, _( "It's too dark to write!" ) );
         return cata::nullopt;
     }
 
-    const int pages = 1 + recipes[menu.ret]->difficulty / 2;
-    if( !p->has_charges( itype_paper, pages ) ) {
-        p->add_msg_if_player( m_info, _( "You do not have enough paper to copy this recipe." ) );
-        return cata::nullopt;
-    }
-
-    if( binder->remaining_ammo_capacity() <  pages ) {
-        p->add_msg_if_player( m_info, _( "Your recipe book can not fit this recipe." ) );
-        return cata::nullopt;
-    }
-
-    const std::string old_recipes = binder->get_var( "EIPC_RECIPES" );
-    if( old_recipes.find( "," + recipes[menu.ret]->ident().str() + "," ) != std::string::npos ) {
-        p->add_msg_if_player( m_good, _( "Your recipe book already has a recipe for %s." ),
-                              recipes[menu.ret]->result_name() );
-        return cata::nullopt;
-    }
-
-    bool has_enough_charges = false;
-
-    // one charge per page
-    int max_charges = 0;
-    for( const item *it : writing_tools ) {
-        if( it->ammo_required() == 0 ) {
-            has_enough_charges = true;
-            break;
+    const recipe_subset res = p->get_recipes_from_books( crafting_inv );
+    const std::vector<const recipe *> recipes( res.begin(), res.end() );
+    const auto enough_writing_tool_charges = [&writing_tools]( int pages ) {
+        for( const item *it : writing_tools ) {
+            if( it->ammo_required() == 0 ) {
+                return true;
+            }
+            pages -= it->ammo_remaining() / it->ammo_required();
+            if( pages <= 0 ) {
+                return true;
+            }
         }
+        return false;
+    };
 
-        max_charges += it->ammo_remaining() / it->ammo_required();
-        if( max_charges >= pages ) {
-            has_enough_charges = true;
-            break;
+    uilist menu;
+    menu.text = _( "Choose recipe to copy" );
+    menu.hilight_disabled = true;
+    menu.desc_enabled = true;
+    for( const recipe *r : recipes ) {
+        std::string desc;
+        const int pages = 1 + r->difficulty / 2;
+        const std::string pages_str = string_format( n_gettext( "%1$d page", "%1$d pages", pages ), pages );
+
+        if( !p->has_charges( itype_paper, pages ) ) {
+            desc = _( "You do not have enough paper to copy this recipe." );
+        } else if( binder->remaining_ammo_capacity() <  pages ) {
+            desc = _( "Your recipe book can not fit this recipe." );
+        } else if( binder->get_saved_recipes().count( r->ident() ) != 0 ) {
+            desc = string_format( _( "Your recipe book already has a recipe for %s." ), r->result_name() );
+        } else if( !enough_writing_tool_charges( pages ) ) {
+            desc = _( "Your writing tools do not have enough charges." );
         }
+        menu.addentry_col( -1, desc.empty(), cata::nullopt, r->result_name(), pages_str, desc );
     }
-
-    if( !has_enough_charges ) {
-        p->add_msg_if_player( m_info, _( "Your writing tool does not have enough charges." ) );
+    if( menu.entries.empty() ) {
+        p->add_msg_if_player( m_info, _( "You do not have any recipes you can copy." ) );
+        return cata::nullopt;
+    }
+    menu.query();
+    if( menu.ret < 0 ) {
         return cata::nullopt;
     }
 
-    p->assign_activity( player_activity(
-                            bookbinder_copy_activity_actor(
-                                item_location( *p, binder ),
-                                recipes[menu.ret]->ident() ) ) );
+    bookbinder_copy_activity_actor act( item_location( *p, binder ), recipes[menu.ret]->ident() );
+    p->assign_activity( player_activity( act ) );
 
     return cata::nullopt;
 }
@@ -10045,7 +9948,10 @@ cata::optional<int> iuse::binder_manage_recipe( Character *p, item *binder, bool
         return cata::nullopt;
     }
 
-    if( binder->get_var( "EIPC_RECIPES" ).empty() ) {
+    std::set<recipe_id> binder_recipes = binder->get_saved_recipes();
+    const std::vector<recipe_id> recipes( binder_recipes.begin(), binder_recipes.end() );
+
+    if( binder_recipes.empty() ) {
         p->add_msg_if_player( m_info, _( "You have no recipes to manage." ) );
         return cata::nullopt;
     }
@@ -10053,55 +9959,30 @@ cata::optional<int> iuse::binder_manage_recipe( Character *p, item *binder, bool
     uilist rmenu;
     rmenu.text = _( "Manage recipes" );
 
-    int num_recipes = 0;
-    std::vector<recipe_id> recipes;
-
-    // copied from item::get_available_recipes
-    const std::string eipc_recipes = binder->get_var( "EIPC_RECIPES" );
-    // Capture the index one past the delimiter, i.e. start of target string.
-    size_t first_string_index = eipc_recipes.find_first_of( ',' ) + 1;
-    while( first_string_index != std::string::npos ) {
-        size_t next_string_index = eipc_recipes.find_first_of( ',', first_string_index );
-        if( next_string_index == std::string::npos ) {
-            break;
-        }
-        const recipe_id new_recipe( eipc_recipes.substr( first_string_index,
-                                    next_string_index - first_string_index ) );
-
-        if( new_recipe.is_valid() ) {
-            recipes.emplace_back( new_recipe );
-
-            std::string recipe_name = new_recipe->result_name();
-            if( p->knows_recipe( &new_recipe.obj() ) ) {
-                recipe_name += _( " (KNOWN)" );
-            }
-
-            const int pages = 1 + new_recipe->difficulty / 2;
-            rmenu.addentry_col( ++num_recipes, true, ' ',
-                                recipe_name,
-                                string_format( n_gettext( "%1$d page", "%1$d pages", pages ), pages ) );
+    for( const recipe_id &new_recipe : recipes ) {
+        std::string recipe_name = new_recipe->result_name();
+        if( p->knows_recipe( &new_recipe.obj() ) ) {
+            recipe_name += _( " (KNOWN)" );
         }
 
-        first_string_index = next_string_index + 1;
+        const int pages = 1 + new_recipe->difficulty / 2;
+        rmenu.addentry_col( -1, true, ' ', recipe_name,
+                            string_format( n_gettext( "%1$d page", "%1$d pages", pages ), pages ) );
     }
 
     rmenu.query();
-    if( rmenu.ret > 0 ) {
-        const recipe_id &rec = recipes[rmenu.ret - 1];
-        if( !query_yn( _( "Remove the recipe for %1$s?" ), rec->result_name() ) ) {
-            return cata::nullopt;
-        }
-
-        recipes.erase( recipes.begin() + rmenu.ret - 1 );
-        binder->erase_var( "EIPC_RECIPES" );
-
-        for( const recipe_id &book_rec : recipes ) {
-            binder->eipc_recipe_add( book_rec );
-        }
-
-        const int pages = 1 + rec->difficulty / 2;
-        binder->ammo_consume( pages, ipos, p );
+    if( rmenu.ret < 0 ) {
+        return cata::nullopt;
     }
+    const recipe_id &rec = recipes[rmenu.ret];
+    if( !query_yn( _( "Remove the recipe for %1$s?" ), rec->result_name() ) ) {
+        return cata::nullopt;
+    }
+    binder_recipes.erase( rec );
+    binder->set_saved_recipes( binder_recipes );
+
+    const int pages = 1 + rec->difficulty / 2;
+    binder->ammo_consume( pages, ipos, p );
 
     return cata::nullopt;
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9911,7 +9911,7 @@ cata::optional<int> iuse::binder_add_recipe( Character *p, item *binder, bool, c
     menu.desc_enabled = true;
     for( const recipe *r : recipes ) {
         std::string desc;
-        const int pages = 1 + r->difficulty / 2;
+        const int pages = bookbinder_copy_activity_actor::pages_for_recipe( *r );
         const std::string pages_str = string_format( n_gettext( "%1$d page", "%1$d pages", pages ), pages );
 
         if( !p->has_charges( itype_paper, pages ) ) {
@@ -9965,7 +9965,7 @@ cata::optional<int> iuse::binder_manage_recipe( Character *p, item *binder, bool
             recipe_name += _( " (KNOWN)" );
         }
 
-        const int pages = 1 + new_recipe->difficulty / 2;
+        const int pages = bookbinder_copy_activity_actor::pages_for_recipe( *new_recipe );
         rmenu.addentry_col( -1, true, ' ', recipe_name,
                             string_format( n_gettext( "%1$d page", "%1$d pages", pages ), pages ) );
     }
@@ -9981,7 +9981,7 @@ cata::optional<int> iuse::binder_manage_recipe( Character *p, item *binder, bool
     binder_recipes.erase( rec );
     binder->set_saved_recipes( binder_recipes );
 
-    const int pages = 1 + rec->difficulty / 2;
+    const int pages = bookbinder_copy_activity_actor::pages_for_recipe( *rec );
     binder->ammo_consume( pages, ipos, p );
 
     return cata::nullopt;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -6841,7 +6841,7 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
                     pose = _( "stands" );
                 }
                 const std::vector<std::string> vec = guy->short_description_parts();
-                figure_appearance = join( vec, "\n\n" );
+                figure_appearance = string_join( vec, "\n\n" );
                 figure_name = guy->get_name();
                 pronoun_gender = guy->male ? _( "He" ) : _( "She" );
                 creature = guy;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -3142,27 +3142,6 @@ std::string wildcard_trim_rule( const std::string &pattern_in )
     return pattern;
 }
 
-std::vector<std::string> string_split( const std::string &text_in, char delim_in )
-{
-    std::vector<std::string> elems;
-
-    if( text_in.empty() ) {
-        return elems; // Well, that was easy.
-    }
-
-    std::stringstream ss( text_in );
-    std::string item;
-    while( std::getline( ss, item, delim_in ) ) {
-        elems.push_back( item );
-    }
-
-    if( text_in.back() == delim_in ) {
-        elems.emplace_back( "" );
-    }
-
-    return elems;
-}
-
 // find substring (case insensitive)
 int ci_find_substr( const std::string &str1, const std::string &str2, const std::locale &loc )
 {

--- a/src/output.h
+++ b/src/output.h
@@ -1137,7 +1137,6 @@ extern scrollingcombattext SCT;
 
 std::string wildcard_trim_rule( const std::string &pattern_in );
 bool wildcard_match( const std::string &text_in, const std::string &pattern_in );
-std::vector<std::string> string_split( const std::string &text_in, char delim );
 int ci_find_substr( const std::string &str1, const std::string &str2,
                     const std::locale &loc = std::locale() );
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2640,7 +2640,7 @@ struct mutable_overmap_special_data : overmap_special_data {
             debugmsg( "Spawn of mutable special %s had unresolved joins.  Existing terrain "
                       "at %s was %s; joins were %s\nComplete record of placement follows:\n%s",
                       parent_id.str(), p.to_string(), current_terrain.id().str(), joins,
-                      join( descriptions, "\n" ) );
+                      string_join( descriptions, "\n" ) );
 
             om.add_note(
                 p, string_format(

--- a/src/past_games_info.cpp
+++ b/src/past_games_info.cpp
@@ -106,7 +106,7 @@ void past_games_info::ensure_loaded()
         }
 
         components.erase( components.begin(), components.end() - 6 );
-        sortable_filenames.emplace_back( join( components, "-" ), filename );
+        sortable_filenames.emplace_back( string_join( components, "-" ), filename );
     }
 
     std::sort( sortable_filenames.begin(),

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -529,7 +529,7 @@ std::string requirement_data::print_all_objs( const std::string &header,
             return t.to_string();
         } );
         std::sort( alternatives.begin(), alternatives.end(), localized_compare );
-        buffer += join( alternatives, _( " or " ) );
+        buffer += string_join( alternatives, _( " or " ) );
     }
     if( buffer.empty() ) {
         return std::string();
@@ -804,7 +804,7 @@ std::vector<std::string> requirement_data::get_folded_list( int width,
                                list_as_string_unavailable.end() );
 
         const std::string separator = colorize( _( " OR " ), c_white );
-        const std::string unfolded = join( list_as_string, separator );
+        const std::string unfolded = string_join( list_as_string, separator );
         std::vector<std::string> folded = foldstring( unfolded, width - 2 );
 
         for( size_t i = 0; i < folded.size(); i++ ) {

--- a/src/translation_gendered.cpp
+++ b/src/translation_gendered.cpp
@@ -65,6 +65,6 @@ std::string gettext_gendered( const GenderMap &genders, const std::string &msg )
         }
         chosen_genders.push_back( subject_genders.first + ":" + chosen_gender );
     }
-    std::string context = join( chosen_genders, " " );
+    std::string context = string_join( chosen_genders, " " );
     return pgettext( context.c_str(), msg.c_str() );
 }

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -1,5 +1,6 @@
 #include "catch/catch.hpp"
 
+#include "cata_utility.h"
 #include "game.h"
 #include "game_constants.h"
 #include "player_helpers.h"
@@ -1984,7 +1985,7 @@ TEST_CASE( "multi-line overmap text widget", "[widget][overmap]" )
             brown_dot, h_brown_dot, brown_dot, "\n",
             brown_dot, brown_dot, brown_dot
         };
-        CHECK( overmap_w.layout( ava ) == join( field_3x3, "" ) );
+        CHECK( overmap_w.layout( ava ) == string_join( field_3x3, "" ) );
     }
 
     SECTION( "forest" ) {
@@ -1999,7 +2000,7 @@ TEST_CASE( "multi-line overmap text widget", "[widget][overmap]" )
             green_F, h_green_F, red_star, "\n",
             green_F, green_F, green_F
         };
-        CHECK( overmap_w.layout( ava ) == join( forest_3x3, "" ) );
+        CHECK( overmap_w.layout( ava ) == string_join( forest_3x3, "" ) );
     }
 
     SECTION( "central lab" ) {
@@ -2015,7 +2016,7 @@ TEST_CASE( "multi-line overmap text widget", "[widget][overmap]" )
             blue_L, h_blue_L, blue_L, "\n",
             red_star, blue_L, blue_L
         };
-        CHECK( overmap_w.layout( ava ) == join( lab_3x3, "" ) );
+        CHECK( overmap_w.layout( ava ) == string_join( lab_3x3, "" ) );
     }
 
     // TODO: Horde indicators
@@ -2673,7 +2674,7 @@ TEST_CASE( "widget rows in columns", "[widget]" )
     SECTION( "3 columns, multiline/rows/rows" ) {
         const std::string brown_dot = "<color_c_brown>.</color>";
         const std::string h_brown_dot = "<color_h_brown>.</color>";
-        const std::string expected = join( {
+        const std::string expected = string_join( std::vector<std::string> {
             brown_dot, brown_dot, brown_dot, "         MOVE:  0    STR: 8    \n",
             brown_dot, h_brown_dot, brown_dot, "         SPEED: 100  DEX: 8    \n",
             brown_dot, brown_dot, brown_dot, "         FOCUS: 100  INT: 8    \n",
@@ -2689,22 +2690,22 @@ TEST_CASE( "widget rows in columns", "[widget]" )
     SECTION( "3 columns nested in 2 columns, rows/columns, multiline/rows/rows" ) {
         const std::string brown_dot = "<color_c_brown>.</color>";
         const std::string h_brown_dot = "<color_h_brown>.</color>";
-        const std::string expected = join( {
-            join( {
+        const std::string expected = string_join( std::vector<std::string> {
+            string_join( std::vector<std::string> {
                 "CLAUSE: Zero                       ",
                 brown_dot,
                 brown_dot,
                 brown_dot,
                 "         MOVE:  0    STR: 8   \n"
             }, "" ),
-            join( {
+            string_join( std::vector<std::string> {
                 "POOL:   0000                       ",
                 brown_dot,
                 h_brown_dot,
                 brown_dot,
                 "         SPEED: 100  DEX: 8   \n"
             }, "" ),
-            join( {
+            string_join( std::vector<std::string> {
                 "NUM:    0                          ",
                 brown_dot,
                 brown_dot,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Recipes stored on the item (such as bookbinder and recipes downloaded from SD-cards) are saved in `EIPC_RECIPES` item_var as comma separated string of recipe_ids and raise debugmsg if any of the saved recipe_ids are deleted.

#### Describe the solution

Wanted to just ignore recipe_ids which are not is_valid(), but there's 12 different places where strings are parsed into recipe_ids or the other way around and it's done in 3 different ways, so this PR became a refactor to clean up instead;

* Renames `join` -> `string_join` to match other string functions, hopefully easier to discover
* Moves `string_split` from output.h to cata_utility.h, hopefully easier to discover / and included more often
* Makes `string_join` templated so iterable collections can be used without copying to vector
* Added `item::get_saved_recipes()`/`item::set_saved_recipes()` and they are the only places where `EIPC_RECIPES` item_var is touched and strings manipulated into recipe_ids or the other way around
* Refactors everything that touches `EIPC_RECIPES` to use these 2 functions instead

Finally the `item::get_saved_recipes()` simply skips invalid recipe_ids instead of showing a debugmsg

#### Describe alternatives you've considered

#### Testing

Poked a bookbinder and smartphone a bit - didn't seem to have issues

#### Additional context
![image](https://user-images.githubusercontent.com/6560075/223277667-e7d45b00-1f4a-4e0d-8fc0-2d6904052835.png)
Changes menus slightly so failure reasons are displayed immediately rather than fail on choosing
![image](https://user-images.githubusercontent.com/6560075/223591736-bdf571d4-5b2b-4f9d-b8ec-419b09c84cf6.png)

