### PR TITLE
Self-jacking of vehicles with multiple installed jacks

### DIFF
--- a/data/json/items/vehicle/engineering.json
+++ b/data/json/items/vehicle/engineering.json
@@ -68,7 +68,7 @@
     "price": 8500,
     "price_postapoc": 500,
     "volume": "8750 ml",
-    "qualities": [ [ "SELF_JACK", 17 ] ]
+    "qualities": [ [ "SELF_JACK", 2 ] ]
   },
   {
     "type": "GENERIC",

--- a/data/json/vehicleparts/engineering.json
+++ b/data/json/vehicleparts/engineering.json
@@ -168,7 +168,10 @@
       { "item": "scrap", "count": [ 8, 24 ] },
       { "item": "jack", "count": [ 1, 1 ] }
     ],
-    "qualities": [ [ "SELF_JACK", 17 ] ],
+    "qualities": [ [ "SELF_JACK", 2 ] ],
+    "//0": "jacking ability equiv. to 1 ton. compare to:",
+    "//1": "600kg ea @ 12bar -- https://www.nukeperformance.com/category.html/air-jacks",
+    "//2": "675kg ea @ 30bar -- https://apracing.com/race-car/air-jacks",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
@@ -191,6 +194,7 @@
     "description": "A kickstand to keep the bike from falling over.  You could use this to lean it forward or backward to change a tire.",
     "breaks_into": [ { "item": "pipe", "count": [ 1, 3 ] }, { "item": "scrap", "count": [ 1, 3 ] } ],
     "qualities": [ [ "SELF_JACK", 1 ] ],
+    "//": "jacking ability 500kg; heaviest motocycles are 400~500 kg",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -749,14 +749,11 @@ bool veh_interact::is_drive_conflict()
 
 bool veh_interact::can_self_jack()
 {
-    int lvl = jack_quality( *veh );
-
+    int lvl = 0;
     for( const vpart_reference &vp : veh->get_avail_parts( "SELF_JACK" ) ) {
-        if( vp.part().base.has_quality( qual_SELF_JACK, lvl ) ) {
-            return true;
-        }
+        lvl += vp.part().base.get_quality( qual_SELF_JACK );
     }
-    return false;
+    return lvl >= jack_quality( *veh );
 }
 
 bool veh_interact::update_part_requirements()


### PR DESCRIPTION
#### Summary
Features "Self-jacking of vehicles with multiple installed jacks"

#### Purpose of change
Self-jacking code checks for a single self-jacking part capable of supporting the entire vehicle. This is unrealistic, such systems in RL (most commonly seen in motorsports) involve multiple pistons (usu. 3 to 4) per car.

Likewise, the air jack has `SELF_JACK` quality 17, This allows a *single* jack to support *any* vehicle up to *infinite weight*, which is not reasonable.

<details>
<summary>derivation</summary>
Each level of jacking is equiv to 500kg, 17 × 500kg = 8500kg

https://github.com/CleverRaven/Cataclysm-DDA/blob/a0af8a61227b08914ed42e07eb59a2916efece24/src/item.h#L3029-L3030

For jacking purposes, vehicle mass is capped at 8500kg, anything heavier is treated as 8500kg.

https://github.com/CleverRaven/Cataclysm-DDA/blob/a0af8a61227b08914ed42e07eb59a2916efece24/src/veh_interact.cpp#L110-L119
</details>

#### Describe the solution
Modify the self-jacking feature use take the sum of the self-jacking capacity of installed parts. Currently, this doesn't require realistic load distribution so it still works even if you installed all the jacks in one corner of the vehicle.

Rebalancing of `SELF_JACK` capable parts' capacity:

- Air jack part changed, will now support up to 1000kg each. This is still a bit high, as a bit of research into RL systems suggests that the value should be around 600~700kg.

- Motorcycle kickstand jacking capacity looks okay.

#### Testing
One air jack is insufficient for changing the tires on a sports car, but two is enough.

Handy test file: [Sabine-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/10905345/Sabine-trimmed.tar.gz)

#### Potential future work
- Refine air jack capacity down further to around 600\~700kg -- this would better reflect RL values, and a typical car would then require 3\~4 jacks, which is what you'd expect. Doing this would involve changing `TOOL_LIFT_FACTOR` to allow finer granularity (currently in increments of 500kg) and thus requires rescaling of all `JACK`/`LIFT` tool qualities, and I don't feel like tackling that right now.

- `SELF_JACK` is both a flag and a tool quality. Get rid of the redundancy.

- More realistic load-distribution remains an aspirational goal. This was originally discussed in #25193 and would solve issues such as #25285 -- in practice, you don't need to lift the entire weight of a vehicle to change a single tire.
