### PR TITLE
tests/active_items: don't prune stale actives during test

### DIFF
--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -10,15 +10,8 @@
 
 TEST_CASE( "place_active_item_at_various_coordinates", "[item]" )
 {
-    clear_map();
+    clear_map( -OVERMAP_DEPTH, OVERMAP_HEIGHT );
     map &here = get_map();
-    for( int z = -OVERMAP_DEPTH; z < OVERMAP_HEIGHT; ++z ) {
-        for( int x = 0; x < MAPSIZE_X; ++x ) {
-            for( int y = 0; y < MAPSIZE_Y; ++y ) {
-                here.i_clear( { x, y, z } );
-            }
-        }
-    }
     REQUIRE( here.get_submaps_with_active_items().empty() );
     // An arbitrary active item.
     item active( "firecracker_act", calendar::turn_zero, item::default_charges_tag() );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -147,7 +147,7 @@ void map::check_submap_active_item_consistency()
                 tripoint p( x, y, z );
                 submap *s = get_submap_at_grid( p );
                 REQUIRE( s != nullptr );
-                bool submap_has_active_items = !s->active_items.get().empty();
+                bool submap_has_active_items = !s->active_items.empty();
                 bool cache_has_active_items = submaps_with_active_items.count( p + abs_sub.xy() ) != 0;
                 CAPTURE( abs_sub.xy(), p, p + abs_sub.xy() );
                 CHECK( submap_has_active_items == cache_has_active_items );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Active items caches are pruned during processing since #63233 but I missed a couple of lines in tests so they fail occasionally because they still expect instant pruning

Example failures:
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4345567713/jobs/7592022624#step:17:310
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4320522033/jobs/7543059764#step:17:290

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Don't prune active items during `place_player_can_safely_move_multiple_submaps`
Clear the map more thoroughly for `place_active_item_at_various_coordinates`
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Changing `map::process_items()` or `active_item_cache::get_for_processing()` to always fully prune stale items/caches even if they are not scheduled that turn: seems unnecessary
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Ran `while :; do reset && ../build_pkg/cata_test --rng-seed time --option_overrides=24_HOUR:12h --min-duration 0.2 "~[slow] ~[.],starting_items" &> output2;ret=$?;if [[ "$ret" != '0' ]];then break;fi;done` on 8 cores for a few hours
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
