### PR TITLE
Remove hack's phantom melee

### DIFF
--- a/data/json/monsters/drones.json
+++ b/data/json/monsters/drones.json
@@ -14,7 +14,7 @@
     "morale": 100,
     "luminance": 5,
     "death_function": { "message": "The %s's interior compartment sizzles with destructive energy.", "corpse_type": "BROKEN" },
-    "flags": [ "SEES", "FLIES", "NOHEAD", "ELECTRONIC", "NO_BREATHE", "INTERIOR_AMMO", "STUN_IMMUNE" ]
+    "flags": [ "SEES", "FLIES", "NOHEAD", "ELECTRONIC", "NO_BREATHE", "INTERIOR_AMMO", "STUN_IMMUNE", "PACIFIST" ]
   },
   {
     "id": "mon_EMP_hack",
@@ -109,7 +109,8 @@
     "armor_bullet": 6,
     "revert_to_itype": "bot_manhack",
     "death_function": { "corpse_type": "BROKEN" },
-    "extend": { "flags": [ "HIT_AND_RUN" ] }
+    "extend": { "flags": [ "HIT_AND_RUN" ] },
+    "delete": { "flags": [ "PACIFIST" ] }
   },
   {
     "id": "mon_mininuke_hack",

--- a/data/mods/Aftershock/mobs/robots.json
+++ b/data/mods/Aftershock/mobs/robots.json
@@ -249,7 +249,8 @@
     "revert_to_itype": "bot_bloodhound_drone",
     "death_drops": { "groups": [ [ "robots", 4 ], [ "manhack", 1 ], [ "turret_searchlight", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "extend": { "flags": [ "HIT_AND_RUN", "SMELLS" ] }
+    "extend": { "flags": [ "HIT_AND_RUN", "SMELLS" ] },
+    "delete": { "flags": [ "PACIFIST" ] }
   },
   {
     "id": "mon_utilibot",


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Removes phantom melee attack that can disrupt aim from explosive/taser hacks."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Hacks, despite having no damage on their melee and probably not even intended to have melee, will still attempt hit their target. This attack while mostly inconsequential can disrupt survivor aim while issuing no prompt beyond sudden aim reduction. 

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds "PACIFIST" as a default flag to base_drone that all hacks refer to and have actual melee hacks delete it from their flag list. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Adding a prompt or warning that the hack is disrupting your aim, though that seems like it would be better handled by dodge/speed vs aiming mechanics.
Doing the opposite and adding PACIFIST to every explosive hack instead but considering the drones that actually use melee are the outliers it seemed better to make it the default.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested all explosive/taser hacks and was able to maintain full aim until they detonated.
Tested Manhack and Bloodhound Drone from aftershock to make sure they could still melee, both attacked and killed the debug survivor.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Hack melee

https://user-images.githubusercontent.com/106233031/223408549-038a53d1-053d-46c8-844a-d463c3b43579.mp4

Hack pacified 

https://user-images.githubusercontent.com/106233031/223409750-c72a2e9c-8a43-4cb3-b8bb-db076903fc10.mp4


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->



