### PR TITLE
`veh_interact` structure packing refactoring

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -178,7 +178,7 @@ player_activity veh_interact::serialize_activity()
     res.values.push_back( veh->index_of_part( vpt ) ); // values[6]
     res.str_values.push_back( vp->get_id().str() );
     res.str_values.push_back( sel_vpart_variant );
-    res.targets.emplace_back( std::move( target ) );
+    res.targets.emplace_back( std::move( refill_target ) );
 
     return res;
 }
@@ -1396,8 +1396,8 @@ void veh_interact::do_refill()
             return false;
         };
 
-        target = g->inv_map_splice( validate, string_format( _( "Refill %s" ), pt.name() ), 1 );
-        if( target ) {
+        refill_target = g->inv_map_splice( validate, string_format( _( "Refill %s" ), pt.name() ), 1 );
+        if( refill_target ) {
             sel_vehicle_part = &pt;
             sel_vpart_info = &pt.info();
             sel_cmd = 'f';

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -64,8 +64,6 @@ class veh_interact
         explicit veh_interact( vehicle &veh, const point &p = point_zero );
         ~veh_interact();
 
-        item_location target;
-
         point dd = point_zero;
         /* starting offset for vehicle parts description display and max offset for scrolling */
         int start_at = 0;
@@ -73,19 +71,23 @@ class veh_interact
         /* starting offset for the overview and the max offset for scrolling */
         int overview_offset = 0;
         int overview_limit = 0;
-        // starting offset for installation scrolling
+        /* starting offset for installation scrolling */
         int w_msg_scroll_offset = 0;
+        /* starting offset for fuels scrolling */
+        int fuel_index = 0;
 
-        const vpart_info *sel_vpart_info = nullptr;
-        std::string sel_vpart_variant;
-        //Command currently being run by the player
-        char sel_cmd = ' ';
+        // target vehicle tank for refill with liquids
+        item_location refill_target;
 
         const vehicle_part *sel_vehicle_part = nullptr;
+        const vpart_info *sel_vpart_info = nullptr;
+        std::string sel_vpart_variant;
+
+        // Command currently being run by the player
+        char sel_cmd = ' ';
 
         int cpart = -1;
         int page_size = 0;
-        int fuel_index = 0; /** Starting index of where to start printing fuels from */
         // height of the stats window
         const int stats_h = 8;
         catacurses::window w_border;
@@ -98,11 +100,12 @@ class veh_interact
         catacurses::window w_details;
         catacurses::window w_name;
 
-        bool ui_hidden = false;
         weak_ptr_fast<ui_adaptor> ui;
 
         cata::optional<std::string> title;
         cata::optional<std::string> msg;
+
+        bool ui_hidden = false;
 
         int highlight_part = -1;
 
@@ -237,8 +240,8 @@ class veh_interact
 
         void count_durability();
 
-        std::string total_durability_text;
         nc_color total_durability_color;
+        std::string total_durability_text;
 
         /** Returns the most damaged part's index, or -1 if they're all healthy. */
         vehicle_part *get_most_damaged_part() const;


### PR DESCRIPTION
#### Summary
Performance "`veh_interact` structure packing refactoring"

#### Purpose of change
Salvaged from #63992
In that PR, adding a bool was the straw that broke the camel's back, causing clang-tidy to [complain about padding inefficiency](../actions/runs/4342661498/jobs/7583766365). Even without that, it has 30 padding bytes, so it's worth salvaging the structure packing work independent of that PR's rejected feature.

#### Describe the solution
Rearranging of fields in `veh_interact.h`, reducing the number of padding bytes from 30 to 6.

Also add/adj some comments, and rename field `target` to more informative name `refill_target`.


