### PR TITLE
obsolete & move the lobotomizer to No Hope.

### DIFF
--- a/data/json/items/melee/misc.json
+++ b/data/json/items/melee/misc.json
@@ -35,27 +35,6 @@
     "flags": [ "REACH_ATTACK", "WHIP", "NONCONDUCTIVE" ]
   },
   {
-    "id": "lobotomizer",
-    "type": "GENERIC",
-    "category": "weapons",
-    "name": { "str": "lobotomizer" },
-    "description": "A hand-forged collapsible tool with two axe heads and a sharp shovel-like tip on one end.  It can be used as a shovel, or you could chop some zombies with it instead.",
-    "weight": "2722 g",
-    "volume": "1750 ml",
-    "price": 25000,
-    "price_postapoc": 1250,
-    "bashing": 18,
-    "cutting": 37,
-    "to_hit": { "grip": "none", "length": "long", "surface": "line", "balance": "neutral" },
-    "material": [ "steel" ],
-    "symbol": "/",
-    "color": "dark_gray",
-    "qualities": [ [ "DIG", 2 ], [ "AXE", 1 ], [ "CUT", 1 ], [ "BUTCHER", -11 ], [ "COOK", 1 ] ],
-    "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
-    "flags": [ "NEEDS_UNFOLD", "BELT_CLIP", "SHEATH_AXE" ],
-    "weapon_category": [ "HOOKING_WEAPONRY" ]
-  },
-  {
     "id": "tazer",
     "type": "TOOL",
     "category": "weapons",

--- a/data/json/obsolete.json
+++ b/data/json/obsolete.json
@@ -1080,19 +1080,5 @@
     "activity_level": "BRISK_EXERCISE",
     "result": "lobotomizer",
     "obsolete": true,
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_TOOLS",
-    "skill_used": "fabrication",
-    "difficulty": 9,
-    "time": "7 h 20 m",
-    "autolearn": true,
-    "book_learn": [ [ "manual_fabrication", 8 ], [ "textbook_fabrication", 6 ] ],
-    "using": [ [ "blacksmithing_standard", 24 ], [ "steel_standard", 6 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_toolsmithing" }
-    ],
-    "tools": [ [ [ "hotcut", -1 ] ] ]
   }
 ]

--- a/data/json/obsolete.json
+++ b/data/json/obsolete.json
@@ -1079,6 +1079,7 @@
     "type": "recipe",
     "activity_level": "BRISK_EXERCISE",
     "result": "lobotomizer",
+    "obsolete": true,
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
     "skill_used": "fabrication",

--- a/data/json/obsolete.json
+++ b/data/json/obsolete.json
@@ -1053,5 +1053,45 @@
     "points": 0,
     "valid": false,
     "purifiable": false
+  },
+  {
+    "id": "lobotomizer",
+    "type": "GENERIC",
+    "category": "weapons",
+    "name": { "str": "lobotomizer" },
+    "description": "A hand-forged collapsible tool with two axe heads and a sharp shovel-like tip on one end.  It can be used as a shovel, or you could chop some zombies with it instead.",
+    "weight": "2722 g",
+    "volume": "1750 ml",
+    "price": 25000,
+    "price_postapoc": 1250,
+    "bashing": 18,
+    "cutting": 37,
+    "to_hit": { "grip": "none", "length": "long", "surface": "line", "balance": "neutral" },
+    "material": [ "steel" ],
+    "symbol": "/",
+    "color": "dark_gray",
+    "qualities": [ [ "DIG", 2 ], [ "AXE", 1 ], [ "CUT", 1 ], [ "BUTCHER", -11 ], [ "COOK", 1 ] ],
+    "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
+    "flags": [ "NEEDS_UNFOLD", "BELT_CLIP", "SHEATH_AXE" ],
+    "weapon_category": [ "HOOKING_WEAPONRY" ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "BRISK_EXERCISE",
+    "result": "lobotomizer",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 9,
+    "time": "7 h 20 m",
+    "autolearn": true,
+    "book_learn": [ [ "manual_fabrication", 8 ], [ "textbook_fabrication", 6 ] ],
+    "using": [ [ "blacksmithing_standard", 24 ], [ "steel_standard", 6 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_metalworking" },
+      { "proficiency": "prof_blacksmithing" },
+      { "proficiency": "prof_toolsmithing" }
+    ],
+    "tools": [ [ [ "hotcut", -1 ] ] ]
   }
 ]

--- a/data/json/obsolete.json
+++ b/data/json/obsolete.json
@@ -1078,6 +1078,6 @@
   {
     "type": "recipe",
     "result": "lobotomizer",
-    "obsolete": true,
+    "obsolete": true
   }
 ]

--- a/data/json/obsolete.json
+++ b/data/json/obsolete.json
@@ -1077,7 +1077,6 @@
   },
   {
     "type": "recipe",
-    "activity_level": "BRISK_EXERCISE",
     "result": "lobotomizer",
     "obsolete": true,
   }

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -305,25 +305,6 @@
   },
   {
     "type": "recipe",
-    "activity_level": "BRISK_EXERCISE",
-    "result": "lobotomizer",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_TOOLS",
-    "skill_used": "fabrication",
-    "difficulty": 9,
-    "time": "7 h 20 m",
-    "autolearn": true,
-    "book_learn": [ [ "manual_fabrication", 8 ], [ "textbook_fabrication", 6 ] ],
-    "using": [ [ "blacksmithing_standard", 24 ], [ "steel_standard", 6 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_toolsmithing" }
-    ],
-    "tools": [ [ [ "hotcut", -1 ] ] ]
-  },
-  {
-    "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "chipper",
     "category": "CC_OTHER",

--- a/data/mods/No_Hope/items.json
+++ b/data/mods/No_Hope/items.json
@@ -266,26 +266,5 @@
     "name": { "str": "broken laser turret" },
     "weight": "110 kg",
     "copy-from": "broken_turret"
-  },
-  {
-    "id": "lobotomizer",
-    "type": "GENERIC",
-    "category": "weapons",
-    "name": { "str": "lobotomizer" },
-    "description": "A hand-forged collapsible tool with two axe heads and a sharp shovel-like tip on one end.  It can be used as a shovel, or you could chop some zombies with it instead.",
-    "weight": "2722 g",
-    "volume": "1750 ml",
-    "price": 25000,
-    "price_postapoc": 1250,
-    "bashing": 18,
-    "cutting": 37,
-    "to_hit": { "grip": "none", "length": "long", "surface": "line", "balance": "neutral" },
-    "material": [ "steel" ],
-    "symbol": "/",
-    "color": "dark_gray",
-    "qualities": [ [ "DIG", 2 ], [ "AXE", 1 ], [ "CUT", 1 ], [ "BUTCHER", -11 ], [ "COOK", 1 ] ],
-    "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
-    "flags": [ "NEEDS_UNFOLD", "BELT_CLIP", "SHEATH_AXE" ],
-    "weapon_category": [ "HOOKING_WEAPONRY" ]
   }
 ]

--- a/data/mods/No_Hope/items.json
+++ b/data/mods/No_Hope/items.json
@@ -266,5 +266,26 @@
     "name": { "str": "broken laser turret" },
     "weight": "110 kg",
     "copy-from": "broken_turret"
+  },
+  {
+    "id": "lobotomizer",
+    "type": "GENERIC",
+    "category": "weapons",
+    "name": { "str": "lobotomizer" },
+    "description": "A hand-forged collapsible tool with two axe heads and a sharp shovel-like tip on one end.  It can be used as a shovel, or you could chop some zombies with it instead.",
+    "weight": "2722 g",
+    "volume": "1750 ml",
+    "price": 25000,
+    "price_postapoc": 1250,
+    "bashing": 18,
+    "cutting": 37,
+    "to_hit": { "grip": "none", "length": "long", "surface": "line", "balance": "neutral" },
+    "material": [ "steel" ],
+    "symbol": "/",
+    "color": "dark_gray",
+    "qualities": [ [ "DIG", 2 ], [ "AXE", 1 ], [ "CUT", 1 ], [ "BUTCHER", -11 ], [ "COOK", 1 ] ],
+    "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
+    "flags": [ "NEEDS_UNFOLD", "BELT_CLIP", "SHEATH_AXE" ],
+    "weapon_category": [ "HOOKING_WEAPONRY" ]
   }
 ]

--- a/data/mods/No_Hope/recipes.json
+++ b/data/mods/No_Hope/recipes.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "recipe",
+    "activity_level": "BRISK_EXERCISE",
+    "result": "lobotomizer",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 9,
+    "time": "7 h 20 m",
+    "autolearn": true,
+    "book_learn": [ [ "manual_fabrication", 8 ], [ "textbook_fabrication", 6 ] ],
+    "using": [ [ "blacksmithing_standard", 24 ], [ "steel_standard", 6 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_metalworking" },
+      { "proficiency": "prof_blacksmithing" },
+      { "proficiency": "prof_toolsmithing" }
+    ],
+    "tools": [ [ [ "hotcut", -1 ] ] ]
+  }
+]


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

God where to start with this thing?.
The lobotomizer goes back all the way back to PR #9866 when it was added alongside some other tool recipes, it's based on a tool/weapon used in the book World War Z.  I don't want to bash someone else's judgement especially from ten years ago but I have *no idea* why it got in, let alone stayed around this long. The damage in of itself is absurd (37 cut) and there was even [a picture supplied in the PR](http://www.dcicomp.com/world-war-z-zombies-wiki-76.jpg) which looks absolutely ridiculous. After considering rebalancing it I decided it would be better to delete it entirely.

#### Describe the solution

Originally, my plan was to nerf it's damage to 16 cut make it more like it's book counterpart (a tool that can double as an emergency melee weapon for finishing off wounded zombies) but after consideration & some other people's advice I decided it was not worth the hassle, and just ~~obsoleted both the tool and it's recipe.~~ Pryanik asked me to move it to no hope because it fits what that mod's README document says (`Returned some of the cut "sillynonsense" and other inappropriate (for vanilla) content`)

#### Describe alternatives you've considered

There was a suggestion to make it a "mall ninja" esque item, something purposely bad, but I don't like things that are purposely bad.

#### Additional context

Fun fact! this game makes fun of [a book from the series this weapon comes from!](https://nornagon.github.io/cdda-guide/#/item/ZSG)
