### PR TITLE
Refine criteria that prohibit vehicle modification when moving

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -709,7 +709,7 @@ task_reason veh_interact::cant_do( char mode )
             return task_reason::UNKNOWN_TASK;
     }
 
-    if( std::abs( veh->velocity ) > 100 || player_character.controlling_vehicle ) {
+    if( veh->velocity || veh->cruise_velocity || veh->is_flying_in_air() ) {
         return task_reason::MOVING_VEHICLE;
     }
     if( !valid_target ) {
@@ -1010,7 +1010,7 @@ void veh_interact::do_install()
                     msg = _( "It's too dark to see what you are doing…" );
                     return;
                 case task_reason::MOVING_VEHICLE:
-                    msg = _( "You can't install parts while driving." );
+                    msg = _( "You can't install parts while the vehicle is in motion." );
                     return;
                 default:
                     break;
@@ -1205,7 +1205,7 @@ void veh_interact::do_repair()
                 msg = _( "It's too dark to see what you are doing…" );
                 return false;
             case task_reason::MOVING_VEHICLE:
-                msg = _( "You can't repair stuff while driving." );
+                msg = _( "You can't repair stuff while the vehicle is in motion." );
                 return false;
             case task_reason::INVALID_TARGET:
                 msg = _( "There are no damaged parts on this vehicle." );
@@ -1333,7 +1333,7 @@ void veh_interact::do_mend()
             msg = _( "No faulty parts require mending." );
             return;
         case task_reason::MOVING_VEHICLE:
-            msg = _( "You can't mend stuff while driving." );
+            msg = _( "You can't mend stuff while the vehicle is in motion." );
             return;
         default:
             break;
@@ -1925,7 +1925,7 @@ void veh_interact::do_remove()
                     msg = _( "You cannot remove that part while something is attached to it." );
                     return;
                 case task_reason::MOVING_VEHICLE:
-                    msg = _( "Better not remove something while driving." );
+                    msg = _( "Better not remove something while the vehicle is in motion." );
                     return;
                 default:
                     break;


### PR DESCRIPTION
#### Summary
Bugfixes "Refine criteria that prohibit vehicle modification when moving"

#### Purpose of change
This is the current check for whether a vehicle is moving before allowing modifications (e.g. adding / removing parts)
https://github.com/CleverRaven/Cataclysm-DDA/blob/524ad226a60197be93e9edf7e3f5a87ff221024c/src/veh_interact.cpp#L712-L714

It was adapted from the "Dive from moving vehicle?" check, so apparently a small enough non-zero velocity is fine! This should not be the case.

Meanwhile the check for whether the player is controlling the vehicle was intended as a guard against acceleration via cruise control. This isn't sufficient, especially also considering the development of autopilot, autodrive, and eventually looking toward things like NPC driving.

Here are a couple corner cases I can think of that would pass, but shouldn't:
- Drive a vehicle, get it up to a relatively high speed. Stop controlling the vehicle while it is moving; vehicle will continue to coast uncontrolled while gradually slowing down. Per the criteria, you'd be allowed to remove a tire etc, once it reaches a sufficiently low speed, but before it has come to a complete stop. (The window of opportunity to do this will depend on deceleration rate.)
- Some self-driving vehicle (auto-farm or auto-patrol) is moving sufficiently slowly, and you are able to get alongside it and `e`xamine as it passes by...

#### Describe the solution
- require zero velocity
- player controlling vehicle check replaced by actual check on cruise velocity
- additional check to catch aircraft in stationary hover, since helicopters are a thing now
- update the messages displayed to player

#### Describe alternatives you've considered
One could argue for allowing some simple things such as clock or seatbelt. That would to need special casing to flag what kind of work is allowed, with checks such as you actually being on board the vehicle and will continue to be able to access the mount point while vehicle continues to move. Seems pretty low utility, and out of scope.

#### Testing
Absolutely no changes allowed while vehicle is in motion, or aircraft in stationary hover.