### PR TITLE
Labeler: file `src/veh_**` under vehicles

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -269,3 +269,4 @@
 "Vehicles":
   - "**/**vehicle**"
   - "**/vehicle**"
+  - "src/veh_**"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
A number of recent PRs didn't get labeled as vehicle-related

#### Describe the solution
Add `src/veh_**` to the labeler (matches 8 files)