### PR TITLE
Optimization and redundant code removal in `vehicle.cpp`

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6522,14 +6522,12 @@ void vehicle::invalidate_towing( bool first_vehicle )
     if( !is_towing() && !is_towed() ) {
         return;
     }
-    vehicle *other_veh = nullptr;
-    if( is_towing() ) {
-        other_veh = tow_data.get_towed();
-    } else if( is_towed() ) {
-        other_veh = tow_data.get_towed_by();
-    }
-    if( other_veh && first_vehicle ) {
-        other_veh->invalidate_towing();
+    if( first_vehicle ) {
+        vehicle *other_veh = is_towing() ? tow_data.get_towed() :
+                             is_towed() ? tow_data.get_towed_by() : nullptr;
+        if( other_veh ) {
+            other_veh->invalidate_towing();
+        }
     }
     map &here = get_map();
     for( const vpart_reference &vp : get_all_parts() ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6332,10 +6332,6 @@ void vehicle::do_towing_move()
         return;
     }
     bool invalidate = false;
-    if( !tow_data.get_towed() ) {
-        debugmsg( "tried to do towing move, but no towed vehicle!" );
-        invalidate = true;
-    }
     const int tow_index = get_tow_part();
     if( tow_index == -1 ) {
         debugmsg( "tried to do towing move, but no tow part" );
@@ -6356,7 +6352,7 @@ void vehicle::do_towing_move()
         // how the hellicopter did this happen?
         // yes, this can happen when towing over a bridge (see #47293)
         invalidate = true;
-        add_msg( m_info, _( "A towing cable snaps off of %s." ), tow_data.get_towed()->disp_name() );
+        add_msg( m_info, _( "A towing cable snaps off of %s." ), towed_veh->disp_name() );
     }
     if( invalidate ) {
         invalidate_towing( true );


### PR DESCRIPTION
#### Summary
Performance "Optimization and redundant code removal in `vehicle.cpp`"

#### Purpose of change
Eliminate redundancies and optimize code

#### Describe the solution (1)
This snippet
https://github.com/CleverRaven/Cataclysm-DDA/blob/9777f4e4d2b29cc00eefc6d3514a133d8728ab33/src/vehicle.cpp#L6335-L6338

is redundant with this snippet a few lines further down
https://github.com/CleverRaven/Cataclysm-DDA/blob/9777f4e4d2b29cc00eefc6d3514a133d8728ab33/src/vehicle.cpp#L6344-L6349

The latter is better because it has been optimized (068d831a8407c059b6de898393e8ce8cad5e0c64) by static code analysis in #39252 to call `invalidate_towing( /* implicitly false*/ )`; this will save `invalidate_towing()` from checking again for towed vehicle which we know is absent. It also has early return ahead of subsequent checks which assume that there is a non-null `towed_veh`.

By contrast, the former relies on a [`invalidate_towing(true)` call on L6362](https://github.com/CleverRaven/Cataclysm-DDA/blob/9777f4e4d2b29cc00eefc6d3514a133d8728ab33/src/vehicle.cpp#L6362) 


#### Describe the solution (2)
Eliminate a [redundant `tow_data.get_towed()` call](https://github.com/CleverRaven/Cataclysm-DDA/blob/9777f4e4d2b29cc00eefc6d3514a133d8728ab33/src/vehicle.cpp#L6359) since we already have `towed_veh` that can be used instead.


#### Describe the solution (3)
Optimization in `invalidate_towing()`, don't bother to assign `other_veh` unless we intend to work with it (only when `first_vehicle` is true).

