### PR TITLE
Rework Judo's passive bonus, limbify recovering from being downed

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -657,7 +657,7 @@
         "unarmed_allowed": true,
         "melee_allowed": true,
         "unarmed_weapons_allowed": false,
-        "throw_immune": true
+        "flags": [ "DOWNED_RECOVERY" ]
       }
     ],
     "ondodge_buffs": [

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -428,6 +428,7 @@ Some armor flags, such as `WATCH` and `ALARMCLOCK` are compatible with other ite
 - ```COLDBLOOD``` For heat dependent mutations.
 - ```COLDBLOOD2``` For very heat dependent mutations.
 - ```COLDBLOOD3``` For cold-blooded mutations.
+- ```DOWNED_RECOVERY``` Always has 50% chance to recover from downing, regardless of limb scores / stats.
 - ```ECTOTHERM``` For ectothermic mutations, like `COLDBLOOD4` and `DRAGONBLOOD3` (Black Dragon from Magiclysm).
 - ```HEAT_IMMUNE``` Immune to very hot temperatures.
 - ```NO_DISEASE``` This mutation grants immunity to diseases.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5399,7 +5399,7 @@ bool Character::is_elec_immune() const
 bool Character::is_immune_effect( const efftype_id &eff ) const
 {
     if( eff == effect_downed ) {
-        return is_throw_immune() || ( has_trait( trait_LEG_TENT_BRACE ) && is_barefoot() );
+        return ( has_trait( trait_LEG_TENT_BRACE ) && is_barefoot() );
     } else if( eff == effect_onfire ) {
         return is_immune_damage( damage_type::HEAT );
     } else if( eff == effect_deaf ) {
@@ -10573,7 +10573,7 @@ int Character::has_flag( const json_character_flag &flag ) const
 {
     // If this is a performance problem create a map of flags stored for a character and updated on trait, mutation, bionic add/remove, activate/deactivate, effect gain/loss
     return count_trait_flag( flag ) + count_bionic_with_flag( flag ) + has_effect_with_flag(
-               flag ) + count_bodypart_with_flag( flag );
+               flag ) + count_bodypart_with_flag( flag ) + count_mabuff_flag( flag );
 }
 
 bool Character::is_driving() const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5399,7 +5399,7 @@ bool Character::is_elec_immune() const
 bool Character::is_immune_effect( const efftype_id &eff ) const
 {
     if( eff == effect_downed ) {
-        return ( has_trait( trait_LEG_TENT_BRACE ) && is_barefoot() );
+        return has_trait( trait_LEG_TENT_BRACE ) && is_barefoot();
     } else if( eff == effect_onfire ) {
         return is_immune_damage( damage_type::HEAT );
     } else if( eff == effect_deaf ) {

--- a/src/character.h
+++ b/src/character.h
@@ -1354,6 +1354,8 @@ class Character : public Creature, public visitable
         int mabuff_attack_cost_penalty() const;
         /** Returns the multiplier on move cost of attacks. */
         float mabuff_attack_cost_mult() const;
+        /* Returns the number of MA buffs with the flag*/
+        int count_mabuff_flag( const json_character_flag &flag ) const;
 
         /** Handles things like destruction of armor, etc. */
         void mutation_effect( const trait_id &mut, bool worn_destroyed_override );
@@ -2275,8 +2277,6 @@ class Character : public Creature, public visitable
         bool is_immune_damage( damage_type ) const override;
         /** Returns true if the player is protected from radiation */
         bool is_rad_immune() const;
-        /** Returns true if the player is immune to throws */
-        bool is_throw_immune() const;
         /** Returns true if the player's melee skill increases the bash damage weapon cap */
         bool is_melee_bash_damage_cap_bonus() const;
 

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -42,7 +42,7 @@ void Character::try_remove_downed()
     /** @EFFECT_DEX increases chance to stand up when knocked down */
     /** @EFFECT_ARM_STR increases chance to stand up when knocked down, slightly */
     // Downed reduces balance score to 10% unless resisted, multiply to compensate
-    int chance = ( get_dex() + get_arm_str() / 2.0 ) * get_limb_score( limb_score_balance ) * 10. 0;
+    int chance = ( get_dex() + get_arm_str() / 2.0 ) * get_limb_score( limb_score_balance ) * 10.0;
     // Always 2,5% chance to stand up
     chance += has_flag( json_flag_DOWNED_RECOVERY ) ? 20 : 1;
     if( !x_in_y( chance, 40 ) ) {

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -23,6 +23,8 @@ static const itype_id itype_rope_6( "rope_6" );
 static const itype_id itype_snare_trigger( "snare_trigger" );
 static const itype_id itype_string_36( "string_36" );
 
+static const json_character_flag json_flag_DOWNED_RECOVERY( "DOWNED_RECOVERY" );
+
 static const limb_score_id limb_score_balance( "balance" );
 static const limb_score_id limb_score_grip( "grip" );
 static const limb_score_id limb_score_manip( "manip" );
@@ -38,12 +40,17 @@ void Character::try_remove_downed()
 {
 
     /** @EFFECT_DEX increases chance to stand up when knocked down */
-
-    /** @EFFECT_STR increases chance to stand up when knocked down, slightly */
-    if( rng( 0, 40 ) > get_dex() + get_str() / 2 ) {
+    /** @EFFECT_ARM_STR increases chance to stand up when knocked down, slightly */
+    // Downed reduces balance score to 10% unless resisted, multiply to compensate
+    int chance = ( get_dex() + get_arm_str() / 2 ) * get_limb_score( limb_score_balance ) * 10;
+    // Always 2,5% chance to stand up
+    chance += has_flag( json_flag_DOWNED_RECOVERY ) ? 20 : 1;
+    if( !x_in_y( chance, 40 ) ) {
         add_msg_if_player( _( "You struggle to stand." ) );
     } else {
-        add_msg_player_or_npc( m_good, _( "You stand up." ),
+        add_msg_player_or_npc( m_good,
+                               has_flag( json_flag_DOWNED_RECOVERY ) ? _( "You deftly roll to your feet." ) : _( "You stand up." ),
+                               has_flag( json_flag_DOWNED_RECOVERY ) ? _( "<npcname> deftly rolls to their feet." ) :
                                _( "<npcname> stands up." ) );
         remove_effect( effect_downed );
     }
@@ -194,10 +201,6 @@ bool Character::try_remove_grab()
         attacker_check *= zed_number;
 
         if( has_grab_break_tec() ) {
-            defender_check = defender_check + 2;
-        }
-
-        if( is_throw_immune() ) {
             defender_check = defender_check + 2;
         }
 

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -42,7 +42,7 @@ void Character::try_remove_downed()
     /** @EFFECT_DEX increases chance to stand up when knocked down */
     /** @EFFECT_ARM_STR increases chance to stand up when knocked down, slightly */
     // Downed reduces balance score to 10% unless resisted, multiply to compensate
-    int chance = ( get_dex() + get_arm_str() / 2 ) * get_limb_score( limb_score_balance ) * 10;
+    int chance = ( get_dex() + get_arm_str() / 2.0 ) * get_limb_score( limb_score_balance ) * 10. 0;
     // Always 2,5% chance to stand up
     chance += has_flag( json_flag_DOWNED_RECOVERY ) ? 20 : 1;
     if( !x_in_y( chance, 40 ) ) {

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -950,7 +950,7 @@ bool ma_buff::is_stealthy() const
 
 bool ma_buff::has_flag( const json_character_flag &flag ) const
 {
-    for( const json_character_flag q : flags ) {
+    for( const json_character_flag &q : flags ) {
         if( q == flag ) {
             return true;
         }

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -305,9 +305,10 @@ void ma_buff::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "bonus_blocks", blocks_bonus, 0 );
 
     optional( jo, was_loaded, "quiet", quiet, false );
-    optional( jo, was_loaded, "throw_immune", throw_immune, false );
     optional( jo, was_loaded, "stealthy", stealthy, false );
     optional( jo, was_loaded, "melee_bash_damage_cap_bonus", melee_bash_damage_cap_bonus, false );
+
+    optional( jo, was_loaded, "flags", flags );
 
     reqs.load( jo, src );
     bonuses.load( jo );
@@ -861,8 +862,6 @@ ma_buff::ma_buff()
     dodges_bonus = 0; // extra dodges, like karate
     blocks_bonus = 0; // extra blocks, like karate
 
-    throw_immune = false;
-
 }
 
 efftype_id ma_buff::get_effect_id() const
@@ -936,10 +935,6 @@ float ma_buff::damage_mult( const Character &u, damage_type dt ) const
 {
     return bonuses.get_mult( u, affected_stat::DAMAGE, dt );
 }
-bool ma_buff::is_throw_immune() const
-{
-    return throw_immune;
-}
 bool ma_buff::is_melee_bash_damage_cap_bonus() const
 {
     return melee_bash_damage_cap_bonus;
@@ -951,6 +946,16 @@ bool ma_buff::is_quiet() const
 bool ma_buff::is_stealthy() const
 {
     return stealthy;
+}
+
+bool ma_buff::has_flag( const json_character_flag &flag ) const
+{
+    for( const json_character_flag q : flags ) {
+        if( q == flag ) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool ma_buff::can_melee() const
@@ -1682,11 +1687,13 @@ float Character::mabuff_attack_cost_mult() const
     return ret;
 }
 
-bool Character::is_throw_immune() const
+int Character::count_mabuff_flag( const json_character_flag &flag ) const
 {
-    return search_ma_buff_effect( *effects, []( const ma_buff & b, const effect & ) {
-        return b.is_throw_immune();
+    int ret = 0;
+    accumulate_ma_buff_effects( *effects, [&ret, flag, this]( const ma_buff & b, const effect & d ) {
+        ret += b.has_flag( flag );
     } );
+    return ret;
 }
 bool Character::is_melee_bash_damage_cap_bonus() const
 {

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1690,7 +1690,7 @@ float Character::mabuff_attack_cost_mult() const
 int Character::count_mabuff_flag( const json_character_flag &flag ) const
 {
     int ret = 0;
-    accumulate_ma_buff_effects( *effects, [&ret, flag]( const ma_buff & b ) {
+    accumulate_ma_buff_effects( *effects, [&ret, flag]( const ma_buff & b, const effect & ) {
         ret += b.has_flag( flag );
     } );
     return ret;

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1690,7 +1690,7 @@ float Character::mabuff_attack_cost_mult() const
 int Character::count_mabuff_flag( const json_character_flag &flag ) const
 {
     int ret = 0;
-    accumulate_ma_buff_effects( *effects, [&ret, flag, this]( const ma_buff & b, const effect & d ) {
+    accumulate_ma_buff_effects( *effects, [&ret, flag]( const ma_buff & b ) {
         ret += b.has_flag( flag );
     } );
     return ret;

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -237,11 +237,11 @@ class ma_buff
         float damage_mult( const Character &u, damage_type dt ) const;
 
         // returns various boolean flags
-        bool is_throw_immune() const;
         bool is_melee_bash_damage_cap_bonus() const;
         bool is_quiet() const;
         bool can_melee() const;
         bool is_stealthy() const;
+        bool has_flag( const json_character_flag &flag ) const;
 
         // The ID of the effect that is used to store this buff
         efftype_id get_effect_id() const;
@@ -257,6 +257,8 @@ class ma_buff
 
         ma_requirements reqs;
 
+        cata::flat_set<json_character_flag> flags;
+
         // mapped as buff_id -> min stacks of buff
 
         time_duration buff_duration = 0_turns; // total length this buff lasts
@@ -271,7 +273,6 @@ class ma_buff
 
         bool quiet = false;
         bool melee_allowed = false;
-        bool throw_immune = false; // are we immune to throws/grabs?
         bool melee_bash_damage_cap_bonus = false;
         bool strictly_melee = false; // can we only use it with weapons?
         bool stealthy = false; // do we make less noise when moving?

--- a/src/mattack_common.h
+++ b/src/mattack_common.h
@@ -57,10 +57,4 @@ struct mtype_special_attack {
         }
 };
 
-struct grab_data {
-public:
-    int grab_skill = 5;
-    bool pull = false;
-};
-
 #endif // CATA_SRC_MATTACK_COMMON_H

--- a/src/mattack_common.h
+++ b/src/mattack_common.h
@@ -57,4 +57,10 @@ struct mtype_special_attack {
         }
 };
 
+struct grab_data {
+public:
+    int grab_skill = 5;
+    bool pull = false;
+};
+
 #endif // CATA_SRC_MATTACK_COMMON_H

--- a/src/monattack.h
+++ b/src/monattack.h
@@ -101,7 +101,6 @@ bool ranged_pull( monster *z );
 bool grab( monster *z );
 bool grab_drag( monster *z );
 bool suicide( monster *z );
-bool thrown_by_judo( monster *z );    //handles zombie getting thrown when u.is_throw_immune()
 bool riotbot( monster *z );
 bool stretch_attack( monster *z );
 bool stretch_bite( monster *z );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Limbify downed recovery, rework Judo's passive bonus"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Judo's passive bonus conferred grab resistance and being immune to downing, the second of which is hilariously wrong and the first is debatable. Also, more limby things are better than less.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
- Added a limb score component to recovering from being downed
- Deprecated `is_throw_immune` (it hasn't meant being immune to throws for a good while now)
- Added the ability to define and check character flags in MA buffs (no, they are not effects. don't ask why)
- Added the `DOWNED_RECOVERY` flag granting a greatly increased chance to stand up while downed

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Include other scores, but balance+lift works pretty well and the charmod readout is getting busy.
Use a lower recovery bonus for judo, but you do learn how to fall and get up pretty well.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Got downed unencumbered and wearing EOD gear, the latter left me breakdance for a good few turns without getting up.
The flag triggered the custom message and the bonus was applied.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Falling and rolls are of course very much a part of Judo, the reason being *you spend a lot of time on the ground on account of being thrown.*