### PR TITLE
Make both Hub 01 modular defense ponchos' holster pocket compatible with all HWP conversion kits.

### DIFF
--- a/data/json/items/armor/robofac_armor.json
+++ b/data/json/items/armor/robofac_armor.json
@@ -86,7 +86,15 @@
         "moves": 200,
         "holster": true,
         "description": "Strap for a gun barrel.",
-        "item_restriction": [ "robofac_gun_ar", "robofac_gun_smg", "robofac_gun_dmr", "robofac_gun_shotgun", "robofac_gun_exodii" ]
+        "item_restriction": [
+          "robofac_gun_ar",
+          "robofac_gun_smg",
+          "robofac_gun_dmr",
+          "robofac_gun_shotgun",
+          "robofac_gun_exodii",
+          "robofac_gun_57",
+          "robofac_gun_46"
+        ]
       }
     ],
     "armor": [
@@ -179,7 +187,15 @@
         "moves": 200,
         "holster": true,
         "description": "Strap for a gun barrel.",
-        "item_restriction": [ "robofac_gun_ar", "robofac_gun_smg", "robofac_gun_dmr", "robofac_gun_shotgun", "robofac_gun_exodii" ]
+        "item_restriction": [
+          "robofac_gun_ar",
+          "robofac_gun_smg",
+          "robofac_gun_dmr",
+          "robofac_gun_shotgun",
+          "robofac_gun_exodii",
+          "robofac_gun_57",
+          "robofac_gun_46"
+        ]
       },
       { "pocket_type": "MAGAZINE_WELL", "rigid": true, "item_restriction": [ "medium_atomic_battery_cell" ] }
     ],


### PR DESCRIPTION
#### Summary
Bugfixes "Make both Hub 01 modular defense ponchos' holster pocket compatible with all HWP conversion kits."

#### Purpose of change
Making this change because being able to insert every kind of HWP conversion kit (robofac_gun_\*) in the holster pocket of each poncho (robofac_armor_\*) is the expected behavior.

Fixes #61357

Reproduction steps:
1. Use the Debug Menu to spawn a HWP personal 5.7x28mm configuration (robofac_gun_57) and a HWP personal 4.6x30mm configuration (robofac_gun_46).
2. Use the Debug Menu to spawn a Hub 01 modular defense anchor (robofac_armor_anchor) and a Hub 01 modular defense system (robofac_armor_rig).
3. Wear both the defense anchor and defense system.
4. Open your inventory, and try to insert HWP personal 5.7x28mm configuration into each system, notice that it doesn't show up as an option.
5. Repeat step 4 with the HWP personal 4.6x30mm configuration and notice the same.

#### Describe the solution

Self-explanatory

#### Describe alternatives you've considered

None

#### Testing

Followed reproduction steps above and noticed that the bug was fixed!