### PR TITLE
Corrections for transition from fail multiplier to skill penalties

### DIFF
--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -498,7 +498,7 @@ void recipe::finalize()
             rpof.time_multiplier = rpof.id->default_time_multiplier();
         }
 
-        if( rpof.skill_penalty == 0.0f ) {
+        if( !rpof._skill_penalty_assigned ) {
             rpof.skill_penalty = rpof.id->default_skill_penalty();
         }
 
@@ -886,9 +886,9 @@ static float proficiency_skill_malus( const Character &crafter, const recipe_pro
         // The failure malus is not completely eliminated until the proficiency is mastered.
         // Most of the mitigation happens at higher pl. See #49198
         malus *= 1.0 - ( 0.75 * std::pow( pl, 3 ) );
-        return static_cast<float>( 1.0 + malus );
+        return static_cast<float>( malus );
     }
-    return 1.0f;
+    return 0.0f;
 }
 
 float recipe::proficiency_skill_maluses( const Character &crafter ) const
@@ -1270,7 +1270,7 @@ void recipe_proficiency::load( const JsonObject &jo )
     jo.read( "proficiency", id );
     jo.read( "required", required );
     jo.read( "time_multiplier", time_multiplier );
-    jo.read( "skill_penalty", skill_penalty );
+    _skill_penalty_assigned = jo.read( "skill_penalty", skill_penalty );
     jo.read( "learning_time_multiplier", learning_time_mult );
     jo.read( "max_experience", max_experience );
 

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -49,6 +49,7 @@ struct enum_traits<recipe_filter_flags> {
 
 struct recipe_proficiency {
     proficiency_id id;
+    bool _skill_penalty_assigned = false;
     bool required = false;
     float time_multiplier = 0.0f;
     float skill_penalty = 0.0f;

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -725,7 +725,7 @@ TEST_CASE( "crafting_failure_rates_match_calculated", "[crafting][random]" )
     test_chances_for( makeshift_crowbar, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f );
     test_chances_for( meat_cooked, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f );
     test_chances_for( club_wooden_large, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f );
-    test_chances_for( nailboard, 54.f, 54.f, 54.f, 50.f, 54.f, 50.f, 50.f );
+    test_chances_for( nailboard, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f );
     // Recipes requring various degrees of skill and proficiencies
     test_chances_for( cudgel, 82.5, 72.f, 50.f, 50.f, 21.f, 21.f, 2.25 );
     test_chances_for( pumpkin_muffins, 92.5, 82.f, 67.f, 50.f, 43.f, 21.f, 2.25 );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/64092
I didn't do sufficient testing in https://github.com/CleverRaven/Cataclysm-DDA/pull/64079 and missed these things.

There are two fixes here, one ensures that a skill penalty set to 0 is not overwritten, the other makes sure we don't add one to skill penalties for no reason.

#### Describe alternatives you've considered
Leaving this to be merged with https://github.com/CleverRaven/Cataclysm-DDA/pull/46082

#### Testing
Look at one of the "assembly" recipes for plate armor, see that there are no skill penalties for any proficiencies.
Look at any recipe with proficiency skill penalties, see that values are less are in the 0.5-0.1 range, not 1.5-1.1.

#### Additional context
Whoops.