### PR TITLE
Update storage rings to not cause encumberance

### DIFF
--- a/data/mods/Magiclysm/items/enchanted_rings.json
+++ b/data/mods/Magiclysm/items/enchanted_rings.json
@@ -481,7 +481,7 @@
         "holster": true,
         "weight_multiplier": 0.0,
         "volume_multiplier": 0.0,
-    		"volume_encumber_modifier": 0.0
+        "volume_encumber_modifier": 0.0
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stick what into your ring", "holster_msg": "You tuck your %s into your %s" }

--- a/data/mods/Magiclysm/items/enchanted_rings.json
+++ b/data/mods/Magiclysm/items/enchanted_rings.json
@@ -457,7 +457,7 @@
         "holster": true,
         "weight_multiplier": 0.0,
         "volume_multiplier": 0.0,
-    		"volume_encumber_modifier": 0.0
+        "volume_encumber_modifier": 0.0
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stick what into your ring", "holster_msg": "You tuck your %s into your %s" }

--- a/data/mods/Magiclysm/items/enchanted_rings.json
+++ b/data/mods/Magiclysm/items/enchanted_rings.json
@@ -456,7 +456,8 @@
         "moves": 1,
         "holster": true,
         "weight_multiplier": 0.0,
-        "volume_multiplier": 0.0
+        "volume_multiplier": 0.0,
+    		"volume_encumber_modifier": 0.0
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stick what into your ring", "holster_msg": "You tuck your %s into your %s" }
@@ -479,7 +480,8 @@
         "moves": 1,
         "holster": true,
         "weight_multiplier": 0.0,
-        "volume_multiplier": 0.0
+        "volume_multiplier": 0.0,
+    		"volume_encumber_modifier": 0.0
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stick what into your ring", "holster_msg": "You tuck your %s into your %s" }


### PR DESCRIPTION
#### Summary
Mods "Fix Magiclysm's Lesser/Greater Storage Rings causing encumberance"

#### Purpose of change
The Lesser Storage Ring and Greater Storage Ring were causing encumberance on the hands when the holster pockets were filled; given the items are supposed to not count volume or weight in the rings' dimensional pockets, this seemed unintended.

#### Describe the solution
Added '"volume_encumber_modifier"' fields to both rings' pockets, and set them to 0.0.

#### Describe alternatives you've considered
I also took a look at the Dimensional Toolbelts in case they had a similar problem, but it seems the belt itself has a maximum encumberance set, so it doesn't run into the same problem on testing.

#### Testing
Have character with Greater Storage Ring. 
Put katana in ring. 
Ring caused encumberance on hand. 
Closed game. 
Edited ring's json entry to add '"volume_encumber_modifier": 0.0'.
Reloaded game.
Ring no longer causes encumberance.

#### Additional context
