### PR TITLE
Disassembly doesn't return items with UNRECOVERABLE flag

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2806,6 +2806,9 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
     // Roll skill and damage checks for successful recovery of each component
     for( const item_components::type_vector_pair &tvp : components ) {
         for( const item &newit : tvp.second ) {
+            if( newit.has_flag( flag_UNRECOVERABLE ) ) {
+                continue;
+            }
             // Use item type to index recover/destroy tallies
             const itype_id it_type_id = newit.typeId();
             // Chance of failure based on character skill and recipe difficulty

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13517,6 +13517,9 @@ std::vector<item_comp> item::get_uncraft_components() const
         //Make a new vector of components from the registered components
         for( const item_components::type_vector_pair &tvp : components ) {
             for( const item &component : tvp.second ) {
+                if( component.has_flag( flag_UNRECOVERABLE ) ) {
+                    continue;
+                }
                 auto iter = std::find_if( ret.begin(), ret.end(), [component]( item_comp & obj ) {
                     return obj.type == component.typeId();
                 } );


### PR DESCRIPTION
#### Summary
Bugfixes "Disassembly doesn't return items with UNRECOVERABLE flag"

#### Purpose of change

Not sure if I can say it's a fix, but it addresses #51172. Apart from `UNRECOVERABLE` there is also `NO_RECOVER` in recipes which isn't addressed by this.

#### Describe the solution

Skip items with the flag.

#### Describe alternatives you've considered

Not adding them to components in the first place, but I'm not sure if that could cause other issues.

#### Testing

Craft and disassemble hand-crank charger, doesn't return superglue.

#### Additional context

