### PR TITLE
Simplify game do regular action

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1890,12 +1890,40 @@ static void do_deathcam_action( const action_id &act, avatar &player_character )
     }
 }
 
+static const std::map<action_id, std::string> actions_disabled_in_shell {
+    { ACTION_OPEN,               _( "You can't open things while you're in your shell." ) },
+    { ACTION_CLOSE,              _( "You can't close things while you're in your shell." ) },
+    { ACTION_SMASH,              _( "You can't smash things while you're in your shell." ) },
+    { ACTION_EXAMINE,            _( "You can't examine your surroundings while you're in your shell." ) },
+    { ACTION_EXAMINE_AND_PICKUP, _( "You can't examine your surroundings while you're in your shell." ) },
+    { ACTION_ADVANCEDINV,        _( "You can't move mass quantities while you're in your shell." ) },
+    { ACTION_PICKUP,             _( "You can't pick anything up while you're in your shell." ) },
+    { ACTION_PICKUP_ALL,         _( "You can't pick anything up while you're in your shell." ) },
+    { ACTION_GRAB,               _( "You can't grab things while you're in your shell." ) },
+    { ACTION_HAUL,               _( "You can't haul things while you're in your shell." ) },
+    { ACTION_BUTCHER,            _( "You can't butcher while you're in your shell." ) },
+    { ACTION_PEEK,               _( "You can't peek around corners while you're in your shell." ) },
+    { ACTION_DROP,               _( "You can't drop things while you're in your shell." ) },
+    { ACTION_CRAFT,              _( "You can't craft while you're in your shell." ) },
+    { ACTION_RECRAFT,            _( "You can't craft while you're in your shell." ) },
+    { ACTION_LONGCRAFT,          _( "You can't craft while you're in your shell." ) },
+    { ACTION_DISASSEMBLE,        _( "You can't disassemble while you're in your shell." ) },
+    { ACTION_CONSTRUCT,          _( "You can't construct while you're in your shell." ) },
+    { ACTION_CONTROL_VEHICLE,    _( "You can't operate a vehicle while you're in your shell." ) },
+};
+
 bool game::do_regular_action( action_id &act, avatar &player_character,
                               const cata::optional<tripoint> &mouse_target )
 {
     item_location weapon = player_character.get_wielded_item();
-    bool in_shell = player_character.has_active_mutation( trait_SHELL2 ) ||
-                    player_character.has_active_mutation( trait_SHELL3 );
+    const bool in_shell = player_character.has_active_mutation( trait_SHELL2 )
+                          || player_character.has_active_mutation( trait_SHELL3 );
+
+    if( in_shell && actions_disabled_in_shell.count( act ) > 0 ) {
+        add_msg( m_info, actions_disabled_in_shell.at( act ) );
+        return true;
+    }
+
     switch( act ) {
         case ACTION_NULL: // dummy entry
         case NUM_ACTIONS: // dummy entry
@@ -2074,9 +2102,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_OPEN:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't open things while you're in your shell." ) );
-            } else if( player_character.is_mounted() ) {
+            if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't open things while you're riding." ) );
             } else if( u.has_effect( effect_incorporeal ) ) {
                 add_msg( m_info, _( "You lack the substance to affect anything." ) );
@@ -2086,9 +2112,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_CLOSE:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't close things while you're in your shell." ) );
-            } else if( player_character.has_effect( effect_incorporeal ) ) {
+            if( player_character.has_effect( effect_incorporeal ) ) {
                 add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else if( player_character.is_mounted() ) {
                 auto *mon = player_character.mounted_creature.get();
@@ -2105,8 +2129,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_SMASH:
             if( has_vehicle_control( player_character ) ) {
                 handbrake();
-            } else if( in_shell ) {
-                add_msg( m_info, _( "You can't smash things while you're in your shell." ) );
             } else if( u.has_effect( effect_incorporeal ) ) {
                 add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else {
@@ -2116,9 +2138,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_EXAMINE:
         case ACTION_EXAMINE_AND_PICKUP:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't examine your surroundings while you're in your shell." ) );
-            } else if( mouse_target ) {
+            if( mouse_target ) {
                 // Examine including item pickup if ACTION_EXAMINE_AND_PICKUP is used
                 examine( *mouse_target, act == ACTION_EXAMINE_AND_PICKUP );
             } else {
@@ -2127,9 +2147,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_ADVANCEDINV:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't move mass quantities while you're in your shell." ) );
-            } else if( player_character.is_mounted() ) {
+            if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't move mass quantities while you're riding." ) );
             } else if( u.has_effect( effect_incorporeal ) ) {
                 add_msg( m_info, _( "You lack the substance to affect anything." ) );
@@ -2140,9 +2158,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_PICKUP:
         case ACTION_PICKUP_ALL:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't pick anything up while you're in your shell." ) );
-            } else if( player_character.is_mounted() ) {
+            if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't pick anything up while you're riding." ) );
             } else if( u.has_effect( effect_incorporeal ) ) {
                 add_msg( m_info, _( "You lack the substance to affect anything." ) );
@@ -2158,9 +2174,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_GRAB:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't grab things while you're in your shell." ) );
-            } else if( player_character.is_mounted() ) {
+            if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't grab things while you're riding." ) );
             } else if( u.has_effect( effect_incorporeal ) ) {
                 add_msg( m_info, _( "You lack the substance to affect anything." ) );
@@ -2170,9 +2184,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_HAUL:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't haul things while you're in your shell." ) );
-            } else if( player_character.is_mounted() ) {
+            if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't haul things while you're riding." ) );
             } else if( u.has_effect( effect_incorporeal ) ) {
                 add_msg( m_info, _( "You lack the substance to affect anything." ) );
@@ -2182,9 +2194,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_BUTCHER:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't butcher while you're in your shell." ) );
-            } else if( player_character.is_mounted() ) {
+            if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't butcher while you're riding." ) );
             } else if( u.has_effect( effect_incorporeal ) ) {
                 add_msg( m_info, _( "You lack the substance to affect anything." ) );
@@ -2198,9 +2208,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_PEEK:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't peek around corners while you're in your shell." ) );
-            } else if( player_character.is_mounted() ) {
+            if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't peek around corners while you're riding." ) );
             } else {
                 peek();
@@ -2348,12 +2356,12 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
         case ACTION_DIR_DROP:
             if( const cata::optional<tripoint> pnt = choose_adjacent( _( "Drop where?" ) ) ) {
-                if( *pnt != player_character.pos() &&
-                    in_shell ) {
+                if( *pnt != player_character.pos() && in_shell ) {
                     add_msg( m_info, _( "You can't drop things to another tile while you're in your shell." ) );
                 } else {
                     drop_in_direction( *pnt );
                 }
+                drop_in_direction( *pnt );
             }
             break;
         case ACTION_BIONICS:
@@ -2372,9 +2380,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_CRAFT:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't craft while you're in your shell." ) );
-            } else if( player_character.has_effect( effect_incorporeal ) ) {
+            if( player_character.has_effect( effect_incorporeal ) ) {
                 add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't craft while you're riding." ) );
@@ -2384,9 +2390,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_RECRAFT:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't craft while you're in your shell." ) );
-            } else if( player_character.has_effect( effect_incorporeal ) ) {
+            if( player_character.has_effect( effect_incorporeal ) ) {
                 add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't craft while you're riding." ) );
@@ -2396,9 +2400,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_LONGCRAFT:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't craft while you're in your shell." ) );
-            } else if( player_character.is_mounted() ) {
+            if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't craft while you're riding." ) );
             } else if( u.has_effect( effect_incorporeal ) ) {
                 add_msg( m_info, _( "You lack the substance to affect anything." ) );
@@ -2408,9 +2410,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_DISASSEMBLE:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't disassemble while you're in your shell." ) );
-            } else if( player_character.controlling_vehicle ) {
+            if( player_character.controlling_vehicle ) {
                 add_msg( m_info, _( "You can't disassemble items while driving." ) );
             } else if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't disassemble items while you're riding." ) );
@@ -2424,8 +2424,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_CONSTRUCT:
             if( player_character.in_vehicle ) {
                 add_msg( m_info, _( "You can't construct while in a vehicle." ) );
-            } else if( in_shell ) {
-                add_msg( m_info, _( "You can't construct while you're in your shell." ) );
             } else if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't construct while you're riding." ) );
             } else if( u.has_effect( effect_incorporeal ) ) {
@@ -2446,9 +2444,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_CONTROL_VEHICLE:
-            if( in_shell ) {
-                add_msg( m_info, _( "You can't operate a vehicle while you're in your shell." ) );
-            } else if( player_character.is_mounted() ) {
+            if( player_character.is_mounted() ) {
                 player_character.dismount();
             } else if( player_character.has_trait( trait_WAYFARER ) ) {
                 add_msg( m_info, _( "You refuse to take control of this vehicle." ) );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1912,22 +1912,22 @@ static const std::map<action_id, std::string> actions_disabled_in_shell {
     { ACTION_CONTROL_VEHICLE,    _( "You can't operate a vehicle while you're in your shell." ) },
 };
 
-static const std::map<action_id, std::string> actions_disabled_in_incorporeal {
-    { ACTION_OPEN,               _( "You lack the substance to affect anything." ) },
-    { ACTION_CLOSE,              _( "You lack the substance to affect anything." ) },
-    { ACTION_SMASH,              _( "You lack the substance to affect anything." ) },
-    { ACTION_ADVANCEDINV,        _( "You lack the substance to affect anything." ) },
-    { ACTION_PICKUP,             _( "You lack the substance to affect anything." ) },
-    { ACTION_PICKUP_ALL,         _( "You lack the substance to affect anything." ) },
-    { ACTION_GRAB,               _( "You lack the substance to affect anything." ) },
-    { ACTION_HAUL,               _( "You lack the substance to affect anything." ) },
-    { ACTION_BUTCHER,            _( "You lack the substance to affect anything." ) },
-    { ACTION_CRAFT,              _( "You lack the substance to affect anything." ) },
-    { ACTION_RECRAFT,            _( "You lack the substance to affect anything." ) },
-    { ACTION_LONGCRAFT,          _( "You lack the substance to affect anything." ) },
-    { ACTION_DISASSEMBLE,        _( "You lack the substance to affect anything." ) },
-    { ACTION_CONSTRUCT,          _( "You lack the substance to affect anything." ) },
-    { ACTION_CONTROL_VEHICLE,    _( "You lack the substance to affect anything." ) },
+static const std::set<action_id> actions_disabled_in_incorporeal {
+    ACTION_OPEN,
+    ACTION_CLOSE,
+    ACTION_SMASH,
+    ACTION_ADVANCEDINV,
+    ACTION_PICKUP,
+    ACTION_PICKUP_ALL,
+    ACTION_GRAB,
+    ACTION_HAUL,
+    ACTION_BUTCHER,
+    ACTION_CRAFT,
+    ACTION_RECRAFT,
+    ACTION_LONGCRAFT,
+    ACTION_DISASSEMBLE,
+    ACTION_CONSTRUCT,
+    ACTION_CONTROL_VEHICLE,
 };
 
 static const std::map<action_id, std::string> actions_disabled_mounted {
@@ -1959,7 +1959,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
     }
 
     if( u.has_effect( effect_incorporeal ) && actions_disabled_in_incorporeal.count( act ) > 0 ) {
-        add_msg( m_info, actions_disabled_in_incorporeal.at( act ) );
+        add_msg( m_info, _( "You lack the substance to affect anything." ) );
         return true;
     }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1912,6 +1912,24 @@ static const std::map<action_id, std::string> actions_disabled_in_shell {
     { ACTION_CONTROL_VEHICLE,    _( "You can't operate a vehicle while you're in your shell." ) },
 };
 
+static const std::map<action_id, std::string> actions_disabled_in_incorporeal {
+    { ACTION_OPEN,               _( "You lack the substance to affect anything." ) },
+    { ACTION_CLOSE,              _( "You lack the substance to affect anything." ) },
+    { ACTION_SMASH,              _( "You lack the substance to affect anything." ) },
+    { ACTION_ADVANCEDINV,        _( "You lack the substance to affect anything." ) },
+    { ACTION_PICKUP,             _( "You lack the substance to affect anything." ) },
+    { ACTION_PICKUP_ALL,         _( "You lack the substance to affect anything." ) },
+    { ACTION_GRAB,               _( "You lack the substance to affect anything." ) },
+    { ACTION_HAUL,               _( "You lack the substance to affect anything." ) },
+    { ACTION_BUTCHER,            _( "You lack the substance to affect anything." ) },
+    { ACTION_CRAFT,              _( "You lack the substance to affect anything." ) },
+    { ACTION_RECRAFT,            _( "You lack the substance to affect anything." ) },
+    { ACTION_LONGCRAFT,          _( "You lack the substance to affect anything." ) },
+    { ACTION_DISASSEMBLE,        _( "You lack the substance to affect anything." ) },
+    { ACTION_CONSTRUCT,          _( "You lack the substance to affect anything." ) },
+    { ACTION_CONTROL_VEHICLE,    _( "You lack the substance to affect anything." ) },
+};
+
 bool game::do_regular_action( action_id &act, avatar &player_character,
                               const cata::optional<tripoint> &mouse_target )
 {
@@ -1921,6 +1939,11 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
     if( in_shell && actions_disabled_in_shell.count( act ) > 0 ) {
         add_msg( m_info, actions_disabled_in_shell.at( act ) );
+        return true;
+    }
+
+    if( u.has_effect( effect_incorporeal ) && actions_disabled_in_incorporeal.count( act ) > 0 ) {
+        add_msg( m_info, actions_disabled_in_incorporeal.at( act ) );
         return true;
     }
 
@@ -2104,17 +2127,13 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_OPEN:
             if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't open things while you're riding." ) );
-            } else if( u.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else {
                 open();
             }
             break;
 
         case ACTION_CLOSE:
-            if( player_character.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
-            } else if( player_character.is_mounted() ) {
+            if( player_character.is_mounted() ) {
                 auto *mon = player_character.mounted_creature.get();
                 if( !mon->has_flag( MF_RIDEABLE_MECH ) ) {
                     add_msg( m_info, _( "You can't close things while you're riding." ) );
@@ -2129,8 +2148,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_SMASH:
             if( has_vehicle_control( player_character ) ) {
                 handbrake();
-            } else if( u.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else {
                 smash();
             }
@@ -2149,8 +2166,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_ADVANCEDINV:
             if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't move mass quantities while you're riding." ) );
-            } else if( u.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else {
                 create_advanced_inv();
             }
@@ -2160,8 +2175,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_PICKUP_ALL:
             if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't pick anything up while you're riding." ) );
-            } else if( u.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else if( mouse_target ) {
                 pickup( *mouse_target );
             } else {
@@ -2176,8 +2189,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_GRAB:
             if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't grab things while you're riding." ) );
-            } else if( u.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else {
                 grab();
             }
@@ -2186,8 +2197,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_HAUL:
             if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't haul things while you're riding." ) );
-            } else if( u.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else {
                 haul();
             }
@@ -2196,8 +2205,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_BUTCHER:
             if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't butcher while you're riding." ) );
-            } else if( u.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else {
                 butcher();
             }
@@ -2380,9 +2387,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_CRAFT:
-            if( player_character.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
-            } else if( player_character.is_mounted() ) {
+            if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't craft while you're riding." ) );
             } else {
                 player_character.craft();
@@ -2390,9 +2395,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_RECRAFT:
-            if( player_character.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
-            } else if( player_character.is_mounted() ) {
+            if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't craft while you're riding." ) );
             } else {
                 player_character.recraft();
@@ -2402,8 +2405,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_LONGCRAFT:
             if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't craft while you're riding." ) );
-            } else if( u.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else {
                 player_character.long_craft();
             }
@@ -2414,8 +2415,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                 add_msg( m_info, _( "You can't disassemble items while driving." ) );
             } else if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't disassemble items while you're riding." ) );
-            } else if( u.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else {
                 player_character.disassemble();
             }
@@ -2426,8 +2425,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                 add_msg( m_info, _( "You can't construct while in a vehicle." ) );
             } else if( player_character.is_mounted() ) {
                 add_msg( m_info, _( "You can't construct while you're riding." ) );
-            } else if( u.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else {
                 construction_menu( false );
             }
@@ -2448,8 +2445,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                 player_character.dismount();
             } else if( player_character.has_trait( trait_WAYFARER ) ) {
                 add_msg( m_info, _( "You refuse to take control of this vehicle." ) );
-            } else if( u.has_effect( effect_incorporeal ) ) {
-                add_msg( m_info, _( "You lack the substance to affect anything." ) );
             } else {
                 control_vehicle();
             }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1930,6 +1930,22 @@ static const std::map<action_id, std::string> actions_disabled_in_incorporeal {
     { ACTION_CONTROL_VEHICLE,    _( "You lack the substance to affect anything." ) },
 };
 
+static const std::map<action_id, std::string> actions_disabled_mounted {
+    { ACTION_DISASSEMBLE,        _( "You can't disassemble items while you're riding." ) },
+    { ACTION_CONSTRUCT,          _( "You can't construct while you're riding." ) },
+    { ACTION_OPEN,               _( "You can't open things while you're riding." ) },
+    { ACTION_ADVANCEDINV,        _( "You can't move mass quantities while you're riding." ) },
+    { ACTION_PICKUP,             _( "You can't pick anything up while you're riding." ) },
+    { ACTION_PICKUP_ALL,         _( "You can't pick anything up while you're riding." ) },
+    { ACTION_GRAB,               _( "You can't grab things while you're riding." ) },
+    { ACTION_HAUL,               _( "You can't haul things while you're riding." ) },
+    { ACTION_BUTCHER,            _( "You can't butcher while you're riding." ) },
+    { ACTION_PEEK,               _( "You can't peek around corners while you're riding." ) },
+    { ACTION_CRAFT,              _( "You can't craft while you're riding." ) },
+    { ACTION_RECRAFT,            _( "You can't craft while you're riding." ) },
+    { ACTION_LONGCRAFT,          _( "You can't craft while you're riding." ) },
+};
+
 bool game::do_regular_action( action_id &act, avatar &player_character,
                               const cata::optional<tripoint> &mouse_target )
 {
@@ -1944,6 +1960,11 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
     if( u.has_effect( effect_incorporeal ) && actions_disabled_in_incorporeal.count( act ) > 0 ) {
         add_msg( m_info, actions_disabled_in_incorporeal.at( act ) );
+        return true;
+    }
+
+    if( player_character.is_mounted() && actions_disabled_mounted.count( act ) > 0 ) {
+        add_msg( m_info, actions_disabled_mounted.at( act ) );
         return true;
     }
 
@@ -2125,11 +2146,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_OPEN:
-            if( player_character.is_mounted() ) {
-                add_msg( m_info, _( "You can't open things while you're riding." ) );
-            } else {
-                open();
-            }
+            open();
             break;
 
         case ACTION_CLOSE:
@@ -2164,18 +2181,12 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_ADVANCEDINV:
-            if( player_character.is_mounted() ) {
-                add_msg( m_info, _( "You can't move mass quantities while you're riding." ) );
-            } else {
-                create_advanced_inv();
-            }
+            create_advanced_inv();
             break;
 
         case ACTION_PICKUP:
         case ACTION_PICKUP_ALL:
-            if( player_character.is_mounted() ) {
-                add_msg( m_info, _( "You can't pick anything up while you're riding." ) );
-            } else if( mouse_target ) {
+            if( mouse_target ) {
                 pickup( *mouse_target );
             } else {
                 if( act == ACTION_PICKUP_ALL ) {
@@ -2187,27 +2198,15 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_GRAB:
-            if( player_character.is_mounted() ) {
-                add_msg( m_info, _( "You can't grab things while you're riding." ) );
-            } else {
-                grab();
-            }
+            grab();
             break;
 
         case ACTION_HAUL:
-            if( player_character.is_mounted() ) {
-                add_msg( m_info, _( "You can't haul things while you're riding." ) );
-            } else {
-                haul();
-            }
+            haul();
             break;
 
         case ACTION_BUTCHER:
-            if( player_character.is_mounted() ) {
-                add_msg( m_info, _( "You can't butcher while you're riding." ) );
-            } else {
-                butcher();
-            }
+            butcher();
             break;
 
         case ACTION_CHAT:
@@ -2215,11 +2214,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_PEEK:
-            if( player_character.is_mounted() ) {
-                add_msg( m_info, _( "You can't peek around corners while you're riding." ) );
-            } else {
-                peek();
-            }
+            peek();
             break;
 
         case ACTION_LIST_ITEMS:
@@ -2387,34 +2382,20 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_CRAFT:
-            if( player_character.is_mounted() ) {
-                add_msg( m_info, _( "You can't craft while you're riding." ) );
-            } else {
-                player_character.craft();
-            }
+            player_character.craft();
             break;
 
         case ACTION_RECRAFT:
-            if( player_character.is_mounted() ) {
-                add_msg( m_info, _( "You can't craft while you're riding." ) );
-            } else {
-                player_character.recraft();
-            }
+            player_character.recraft();
             break;
 
         case ACTION_LONGCRAFT:
-            if( player_character.is_mounted() ) {
-                add_msg( m_info, _( "You can't craft while you're riding." ) );
-            } else {
-                player_character.long_craft();
-            }
+            player_character.long_craft();
             break;
 
         case ACTION_DISASSEMBLE:
             if( player_character.controlling_vehicle ) {
                 add_msg( m_info, _( "You can't disassemble items while driving." ) );
-            } else if( player_character.is_mounted() ) {
-                add_msg( m_info, _( "You can't disassemble items while you're riding." ) );
             } else {
                 player_character.disassemble();
             }
@@ -2423,8 +2404,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_CONSTRUCT:
             if( player_character.in_vehicle ) {
                 add_msg( m_info, _( "You can't construct while in a vehicle." ) );
-            } else if( player_character.is_mounted() ) {
-                add_msg( m_info, _( "You can't construct while you're riding." ) );
             } else {
                 construction_menu( false );
             }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1890,27 +1890,31 @@ static void do_deathcam_action( const action_id &act, avatar &player_character )
     }
 }
 
-static const std::map<action_id, std::string> actions_disabled_in_shell {
-    { ACTION_OPEN,               _( "You can't open things while you're in your shell." ) },
-    { ACTION_CLOSE,              _( "You can't close things while you're in your shell." ) },
-    { ACTION_SMASH,              _( "You can't smash things while you're in your shell." ) },
-    { ACTION_EXAMINE,            _( "You can't examine your surroundings while you're in your shell." ) },
-    { ACTION_EXAMINE_AND_PICKUP, _( "You can't examine your surroundings while you're in your shell." ) },
-    { ACTION_ADVANCEDINV,        _( "You can't move mass quantities while you're in your shell." ) },
-    { ACTION_PICKUP,             _( "You can't pick anything up while you're in your shell." ) },
-    { ACTION_PICKUP_ALL,         _( "You can't pick anything up while you're in your shell." ) },
-    { ACTION_GRAB,               _( "You can't grab things while you're in your shell." ) },
-    { ACTION_HAUL,               _( "You can't haul things while you're in your shell." ) },
-    { ACTION_BUTCHER,            _( "You can't butcher while you're in your shell." ) },
-    { ACTION_PEEK,               _( "You can't peek around corners while you're in your shell." ) },
-    { ACTION_DROP,               _( "You can't drop things while you're in your shell." ) },
-    { ACTION_CRAFT,              _( "You can't craft while you're in your shell." ) },
-    { ACTION_RECRAFT,            _( "You can't craft while you're in your shell." ) },
-    { ACTION_LONGCRAFT,          _( "You can't craft while you're in your shell." ) },
-    { ACTION_DISASSEMBLE,        _( "You can't disassemble while you're in your shell." ) },
-    { ACTION_CONSTRUCT,          _( "You can't construct while you're in your shell." ) },
-    { ACTION_CONTROL_VEHICLE,    _( "You can't operate a vehicle while you're in your shell." ) },
-};
+
+static std::map<action_id, std::string> get_actions_disabled_in_shell()
+{
+    return std::map<action_id, std::string> {
+        { ACTION_OPEN,               _( "You can't open things while you're in your shell." ) },
+        { ACTION_CLOSE,              _( "You can't close things while you're in your shell." ) },
+        { ACTION_SMASH,              _( "You can't smash things while you're in your shell." ) },
+        { ACTION_EXAMINE,            _( "You can't examine your surroundings while you're in your shell." ) },
+        { ACTION_EXAMINE_AND_PICKUP, _( "You can't examine your surroundings while you're in your shell." ) },
+        { ACTION_ADVANCEDINV,        _( "You can't move mass quantities while you're in your shell." ) },
+        { ACTION_PICKUP,             _( "You can't pick anything up while you're in your shell." ) },
+        { ACTION_PICKUP_ALL,         _( "You can't pick anything up while you're in your shell." ) },
+        { ACTION_GRAB,               _( "You can't grab things while you're in your shell." ) },
+        { ACTION_HAUL,               _( "You can't haul things while you're in your shell." ) },
+        { ACTION_BUTCHER,            _( "You can't butcher while you're in your shell." ) },
+        { ACTION_PEEK,               _( "You can't peek around corners while you're in your shell." ) },
+        { ACTION_DROP,               _( "You can't drop things while you're in your shell." ) },
+        { ACTION_CRAFT,              _( "You can't craft while you're in your shell." ) },
+        { ACTION_RECRAFT,            _( "You can't craft while you're in your shell." ) },
+        { ACTION_LONGCRAFT,          _( "You can't craft while you're in your shell." ) },
+        { ACTION_DISASSEMBLE,        _( "You can't disassemble while you're in your shell." ) },
+        { ACTION_CONSTRUCT,          _( "You can't construct while you're in your shell." ) },
+        { ACTION_CONTROL_VEHICLE,    _( "You can't operate a vehicle while you're in your shell." ) },
+    };
+}
 
 static const std::set<action_id> actions_disabled_in_incorporeal {
     ACTION_OPEN,
@@ -1930,21 +1934,24 @@ static const std::set<action_id> actions_disabled_in_incorporeal {
     ACTION_CONTROL_VEHICLE,
 };
 
-static const std::map<action_id, std::string> actions_disabled_mounted {
-    { ACTION_DISASSEMBLE,        _( "You can't disassemble items while you're riding." ) },
-    { ACTION_CONSTRUCT,          _( "You can't construct while you're riding." ) },
-    { ACTION_OPEN,               _( "You can't open things while you're riding." ) },
-    { ACTION_ADVANCEDINV,        _( "You can't move mass quantities while you're riding." ) },
-    { ACTION_PICKUP,             _( "You can't pick anything up while you're riding." ) },
-    { ACTION_PICKUP_ALL,         _( "You can't pick anything up while you're riding." ) },
-    { ACTION_GRAB,               _( "You can't grab things while you're riding." ) },
-    { ACTION_HAUL,               _( "You can't haul things while you're riding." ) },
-    { ACTION_BUTCHER,            _( "You can't butcher while you're riding." ) },
-    { ACTION_PEEK,               _( "You can't peek around corners while you're riding." ) },
-    { ACTION_CRAFT,              _( "You can't craft while you're riding." ) },
-    { ACTION_RECRAFT,            _( "You can't craft while you're riding." ) },
-    { ACTION_LONGCRAFT,          _( "You can't craft while you're riding." ) },
-};
+static std::map<action_id, std::string> get_actions_disabled_mounted()
+{
+    return std::map<action_id, std::string> {
+        { ACTION_DISASSEMBLE,        _( "You can't disassemble items while you're riding." ) },
+        { ACTION_CONSTRUCT,          _( "You can't construct while you're riding." ) },
+        { ACTION_OPEN,               _( "You can't open things while you're riding." ) },
+        { ACTION_ADVANCEDINV,        _( "You can't move mass quantities while you're riding." ) },
+        { ACTION_PICKUP,             _( "You can't pick anything up while you're riding." ) },
+        { ACTION_PICKUP_ALL,         _( "You can't pick anything up while you're riding." ) },
+        { ACTION_GRAB,               _( "You can't grab things while you're riding." ) },
+        { ACTION_HAUL,               _( "You can't haul things while you're riding." ) },
+        { ACTION_BUTCHER,            _( "You can't butcher while you're riding." ) },
+        { ACTION_PEEK,               _( "You can't peek around corners while you're riding." ) },
+        { ACTION_CRAFT,              _( "You can't craft while you're riding." ) },
+        { ACTION_RECRAFT,            _( "You can't craft while you're riding." ) },
+        { ACTION_LONGCRAFT,          _( "You can't craft while you're riding." ) },
+    };
+}
 
 bool game::do_regular_action( action_id &act, avatar &player_character,
                               const cata::optional<tripoint> &mouse_target )
@@ -1952,6 +1959,9 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
     item_location weapon = player_character.get_wielded_item();
     const bool in_shell = player_character.has_active_mutation( trait_SHELL2 )
                           || player_character.has_active_mutation( trait_SHELL3 );
+
+    const std::map<action_id, std::string> actions_disabled_mounted = get_actions_disabled_mounted();
+    const std::map<action_id, std::string> actions_disabled_in_shell = get_actions_disabled_in_shell();
 
     if( in_shell && actions_disabled_in_shell.count( act ) > 0 ) {
         add_msg( m_info, actions_disabled_in_shell.at( act ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Stop clang tidy fails after #63900

Cut down some repetitive checks from `game::do_regular_action` in hopes of appeasing clang-tidy `readability-function-size` check

#### Describe the solution

Move the trivial checks to std::maps mapping action to denial string

#### Describe alternatives you've considered

#### Testing

#63900 added ~25 lines, this removes ~86 lines, see if clang-tidy barfs edit; it didn't

#### Additional context
