### PR TITLE
make rm13 armor a bit less strong

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1189,7 +1189,8 @@
       "PADDED",
       "USE_UPS",
       "NO_UNLOAD",
-      "COMBAT_TOGGLEABLE"
+      "COMBAT_TOGGLEABLE",
+      "UNBREAKABLE_MELEE"
     ],
     "price": 50000000,
     "price_postapoc": 10000,
@@ -1296,7 +1297,8 @@
       "PADDED",
       "USE_UPS",
       "NO_UNLOAD",
-      "COMBAT_TOGGLEABLE"
+      "COMBAT_TOGGLEABLE",
+      "UNBREAKABLE_MELEE"
     ],
     "material": [ "hyperweave_on", "carbide" ],
     "power_draw": "250 W",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1299,7 +1299,7 @@
       "COMBAT_TOGGLEABLE"
     ],
     "material": [ "hyperweave_on", "carbide" ],
-    "turns_per_charge": 6,
+    "power_draw": "250 W",
     "revert_to": "rm13_armor",
     "use_action": [ "RM13ARMOR_ON" ],
     "environmental_protection": 40,
@@ -1321,7 +1321,7 @@
           { "type": "carbide", "covered_by_mat": 100, "thickness": 1.0 },
           { "type": "hyperweave_on", "covered_by_mat": 100, "thickness": 2.0 }
         ],
-        "encumbrance": 3,
+        "encumbrance": 10,
         "coverage": 100,
         "covers": [ "mouth", "head", "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r" ],
         "volume_encumber_modifier": 0
@@ -1331,7 +1331,7 @@
           { "type": "carbide", "covered_by_mat": 100, "thickness": 1.0 },
           { "type": "hyperweave_on", "covered_by_mat": 100, "thickness": 2.0 }
         ],
-        "encumbrance": 3,
+        "encumbrance": 10,
         "coverage": 100,
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "tone down rm13 a little"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I've tested RM13 on a few long term characters now and I'm feeling that I probably buffed it too much.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Powering it on does not reduce encumbrance anymore. It had always worked like that, but the armor isn't assistive like the power armors so it probably should not be lowering encumbrance. Also, increased its power consumption from 1 charge per 6 turns to 250 W.
I also gave it unbreakable melee so that you won't accidentally destroy it if you try punching things while not wearing soft gloves on top of it (fingerless gloves, rubber gloves, light gloves etc to take the damage in its stead)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Unsure, but I felt that it was overcentralizing and overshadowed the phase immersion suit too much also. This should probably make it a bit less extremely good than it was.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
