### PR TITLE
Fix game crashes in armor sort menu

### DIFF
--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -232,8 +232,12 @@ std::vector<std::string> clothing_properties(
     std::vector<std::string> props;
     bodypart_id used_bp = bp;
     if( bp == bodypart_id( "bp_null" ) ) {
+        const std::vector<armor_portion_data> &sub_data = worn_item.find_armor_data()->sub_data;
+        if( sub_data.empty() ) {
+            return props;
+        }
         // if there is only one data entry for the armor
-        if( worn_item.find_armor_data()->sub_data.size() > 1 ) {
+        if( sub_data.size() > 1 ) {
             props.push_back( string_format( "<color_c_red>%s</color>",
                                             _( "Armor is nonuniform.  Specify a limb to get armor data" ) ) );
             return props;
@@ -326,7 +330,7 @@ std::vector<std::string> clothing_protection( const item &worn_item, const int w
 
     // if bp is null its gonna be impossible to really get good info
     if( bp == bodypart_id( "bp_null" ) ) {
-        if( worn_item.find_armor_data()->sub_data.size() > 1 ) {
+        if( worn_item.find_armor_data()->sub_data.size() != 1 ) {
             return prot;
         } else {
             used_bp = *worn_item.get_covered_body_parts().begin();


### PR DESCRIPTION
#### Summary
Bugfixes "Game crash in armor sort menu"

#### Purpose of change
Fixes #64112

#### Describe the solution
If item does not have armor data don't try to look at it

#### Describe alternatives you've considered
Add armor data to all wearable items

#### Testing
Tested for few items: hairpin, fancy hairpin, pom poms

#### Additional context
![no crash 2](https://user-images.githubusercontent.com/26366742/224402220-e77810f6-d688-441e-b555-6114e4abd31a.png)
![no crash](https://user-images.githubusercontent.com/26366742/224402233-153ceae2-480c-4832-ae1f-88ae8b02027a.png)
