### PR TITLE
vcpkg cache should not be shared between 32 and 64 bit workflows

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -75,9 +75,9 @@ jobs:
       with:
         # run-vcpkg tries to hash vcpkg.json but complans if it finds more than one.
         # That said, we also have our custom vcpkg_triplets to hash, so we keep everything the same.
-        appendedCacheKey: ${{ hashFiles( 'msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/**', '.github/vckg_ports/**' ) }}-x64
+        appendedCacheKey: ${{ hashFiles( 'msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/**', '.github/vckg_ports/**' ) }}
         # Rev this value to drop cache without changing vcpkg commit
-        prependedCacheKey: v0
+        prependedCacheKey: v1-x64
         vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
         # We have to use at least this version of vcpkg to include fixes for yasm-tool's
         # availability only as an x86 host tool. Keep it in sync with the builtin-baseline

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,9 +228,9 @@ jobs:
         uses: lukka/run-vcpkg@v10
         id: runvcpkg
         with:
-          appendedCacheKey: ${{ hashFiles( 'msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/**', '.github/vckg_ports/**' ) }}-x64
+          appendedCacheKey: ${{ hashFiles( 'msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/**', '.github/vckg_ports/**' ) }}
           # Rev this value to drop cache without changing vcpkg commit
-          prependedCacheKey: v0
+          prependedCacheKey: v1-${{ matrix.arch }}
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
           # We have to use at least this version of vcpkg to include fixes for yasm-tool's
           # availability only as an x86 host tool. Keep it in sync with the builtin-baseline


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The vcpkg cache was being shared between 32 bit and 64 bit builds. It's unclear if an update to run-vcpkg made this an issue, or if it was always a race and 64 bit typically won, but after my recent PR it was found to be an issue. As a result, 64 bit builds are stuck fetching 32 bit cached vcpkg artifacts, rebuilding their stuff, and then not saving it because there was a 'cache hit'.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
32 bit release workflow should specify 32 bitness in its vcpkg cache key. Additionally, because of the way github workflow partial cache key hit logic works, the arch needs to be in the 'prepended' cache key, which forms the root of the fallback cache lookup logic. That way if the x64 build misses on its primary key, it will still fail to hit on the 32 bit job's key, because the roots will be different.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Pushed to my repo main branch, visually verified the cache keys and restore keys for the release windows 32 bit job and the PR time job / release 64 bit jobs are different.

Cataclysm Windows Build:
```
  Cache key: 'prependedKey=v1-x64-runnerOS=win1920230307.2-vcpkgGitCommit=d08e708c2111893da3cc7e49b597ee4654c8076e_appendedKey=77eacd3df67540d084e3773685f27827b16fa7cddb28e1514e71075169e775c2'
  Cache restore keys: 'prependedKey=v1-x64-runnerOS=win1920230307.2-vcpkgGitCommit=d08e708c2111893da3cc7e49b597ee4654c8076e'
```

MSVC x64 release build (should match):
```
   Cache key: 'prependedKey=v1-x64-runnerOS=win1920230307.2-vcpkgGitCommit=d08e708c2111893da3cc7e49b597ee4654c8076e_appendedKey=77eacd3df67540d084e3773685f27827b16fa7cddb28e1514e71075169e775c2'
  Cache restore keys: 'prependedKey=v1-x64-runnerOS=win1920230307.2-vcpkgGitCommit=d08e708c2111893da3cc7e49b597ee4654c8076e'
```

MSVC x86 release build (varies by -x86- prefix):
```
   Cache key: 'prependedKey=v1-x86-runnerOS=win1920230307.2-vcpkgGitCommit=d08e708c2111893da3cc7e49b597ee4654c8076e_appendedKey=77eacd3df67540d084e3773685f27827b16fa7cddb28e1514e71075169e775c2'
  Cache restore keys: 'prependedKey=v1-x86-runnerOS=win1920230307.2-vcpkgGitCommit=d08e708c2111893da3cc7e49b597ee4654c8076e'
```

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
