### PR TITLE
Intercom UHMWPE armor consistency

### DIFF
--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
@@ -44,6 +44,7 @@
           { "u_spawn_item": "robofac_military_skirt" },
           { "u_spawn_item": "robofac_military_vambraces" },
           { "u_spawn_item": "robofac_military_greaves" },
+          { "u_spawn_item": "robofac_military_mantle" },
           { "u_spawn_item": "robofac_military_helmet" },
           { "u_add_var": "u_can_buy_armor", "type": "dialogue", "context": "hub_rnd", "value": "no" }
         ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Intercom should sell the same set of UHMWPE armor."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/blob/59c0d6e0eea5502d879c71509433ce6667d378ab/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json#L42-L47

https://github.com/CleverRaven/Cataclysm-DDA/blob/59c0d6e0eea5502d879c71509433ce6667d378ab/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json#L303-L309

It's self-explanatory.

When Hub01 makes the breakthrough in researching UHMWPE, you can immediately buy the set of `robofac_military_***` , or if you choose not to buy them on the spot, you can come back later and buy them. However, if you come back later and buy, you'll not have the `robofac_military_mantle`, as the code suggests. I tend to see it as a little mistake that the original contributor forgot to add `robofac_military_mantle` to the list, rather than a punitive measures for pc not buying them on the spot.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The two sets of UHMWPE armor should be the same.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
All tests good.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
