### PR TITLE
greatly reduce the severity of nyctophobia, also removing hallucinations from it

### DIFF
--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1675,56 +1675,30 @@ void suffer::from_tourniquet( Character &you )
 
 void suffer::from_nyctophobia( Character &you )
 {
-    std::vector<tripoint> dark_places;
     const float nyctophobia_threshold = LIGHT_AMBIENT_LIT - 3.0f;
 
-    for( const tripoint &dark_place : points_in_radius( you.pos(), 5 ) ) {
-        if( !you.sees( dark_place ) || get_map().ambient_light_at( dark_place ) >= nyctophobia_threshold ) {
-            continue;
-        }
-        dark_places.push_back( dark_place );
-    }
-
     const bool in_darkness = get_map().ambient_light_at( you.pos() ) < nyctophobia_threshold;
-    const int chance = in_darkness ? 10 : 50;
-
-    if( you.is_avatar() && !dark_places.empty() && one_in( chance ) ) {
-        g->spawn_hallucination( random_entry( dark_places ) );
-    }
-
     if( in_darkness ) {
+        if( one_in( 80 ) && !you.has_effect( effect_shakes ) ) {
+            you.add_msg_if_player( m_bad,
+                                   _( "Your fear of the dark is so intense that your hands start shaking uncontrollably." ) );
+            you.add_effect( effect_shakes, rng( 1_minutes, 3_minutes ) );
+
+            return;
+        }
+
+        if( one_in( 80 ) ) {
+            you.add_msg_if_player( m_bad,
+                                   _( "Your fear of the dark is so intense that you start breathing rapidly, and you feel like your heart is ready to jump out of your chest." ) );
+            you.mod_stamina( -500 * rng( 1, 3 ) );
+
+            return;
+        }
+
         if( one_turn_in( 5_minutes ) ) {
             you.add_msg_if_player( m_bad, _( "You feel a twinge of panic as darkness engulfs you." ) );
         }
 
-        if( one_in( 2 ) && one_turn_in( 30_seconds ) ) {
-            you.sound_hallu();
-        }
-
-        if( one_in( 50 ) && !you.is_on_ground() ) {
-            you.add_msg_if_player( m_bad,
-                                   _( "Your fear of the dark is so intense that your trembling legs fail you, and you fall to the ground." ) );
-            you.add_effect( effect_downed, rng( 1_minutes, 2_minutes ) );
-        }
-
-        if( one_in( 50 ) && !you.has_effect( effect_shakes ) ) {
-            you.add_msg_if_player( m_bad,
-                                   _( "Your fear of the dark is so intense that your hands start shaking uncontrollably." ) );
-            you.add_effect( effect_shakes, rng( 1_minutes, 2_minutes ) );
-        }
-
-        if( one_in( 50 ) ) {
-            you.add_msg_if_player( m_bad,
-                                   _( "Your fear of the dark is so intense that you start breathing rapidly, and you feel like your heart is ready to jump out of your chest." ) );
-            you.mod_stamina( -500 * rng( 1, 3 ) );
-        }
-
-        if( one_in( 50 ) && !you.has_effect( effect_fearparalyze ) ) {
-            you.add_msg_if_player( m_bad,
-                                   _( "Your fear of the dark is so intense that you stand paralyzed." ) );
-            you.add_effect( effect_fearparalyze, 5_turns );
-            you.mod_moves( -4 * you.get_speed() );
-        }
     }
 }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -85,7 +85,6 @@ static const efftype_id effect_deaf( "deaf" );
 static const efftype_id effect_disabled( "disabled" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_drunk( "drunk" );
-static const efftype_id effect_fearparalyze( "fearparalyze" );
 static const efftype_id effect_formication( "formication" );
 static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_hallu( "hallu" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "greatly reduce the severity of nyctophobia, also removing hallucinations from it"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

nyctophobia as implemented in #[59061](https://github.com/CleverRaven/Cataclysm-DDA/pull/59061) is far more crippling than warranted, especially for its apparent intended severity.

most notably, many of the effects that can trigger can be fairly immediately lethal in a lot of circumstances, the mitigation available (via medication) isn't reliable (especially for an early game character), and the hallucinations in particular are extremely problematic: just being near darkness can result in arbitrary hallucinations, even if standing in full sunlight.

further, the standard scenario (evacuee) is always in darkness, which can instantly trigger multiple effects (and is all but certain to result in at least one hallucination) even if the player immediately turns on a light source.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

remove the hallucination effects from the trait entirely, alongside the downed and paralyzed effect.

slightly reduce the frequency of the shakes/stamina impacts (but also increase the maximum shakes duration).

ensured that the stamina impact cannot also occur in the same turn as shakes, also ensured the periodic fear notification won't occur in the same turn as shakes or the stamina impact.

maintained the movement restrictions unmodified; this at least was working in a reasonable fashion.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

considered adjusting the point value of the trait down (from 3 to 2), but given the long-term plans to discard point values, and the highly subjective impact of the changes, it seemed superfluous.

considered adding a second, more severe version of the trait, but per kevin this isn't desirable.

longer term a more staged progression (using one of our many systems: vitamins, eocs, etc) could be beneficial (to allow the player to reliably spend just a turn or two running through a dark area without immediately being impacted), as well as allowing some of the effects to scale upwards. it could be unhardcoded at the same time; there is nothing about this trait that strictly requires c++. for now, as this is a 0.G candidate, i've opted to not do anything that could cause string shuffling (beyond the removed strings).

for anyone working on this in the future: please do not reintroduce visual hallucinations, they are too problematic from a gameplay standpoint for what this is clearly intended to represent. if auditory hallucinations or the other effects (downed/paralyzed) are reintroduced, they should be only at a high fear intensity (i.e. a long time spent in the dark).

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

made a character with nyctophobia, on the evacuee scenario. waited. done in 30 minute increments, a few shorter increments, and simply holding down `.`

notably, even waiting in place with the reduced frequency of the stamina impacts, it's possible for stamina to get fairly low. a character actively moving through darkness (which still _requires_ running) is very likely to have severe stamina problems in short order.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
screenshot showing incidence rate of remaining events in 30 minute wait time:
![image](https://user-images.githubusercontent.com/1569754/224477207-ab37267c-071c-4e1a-84f3-ac8a1749fb90.png)

one of the lower stamina values observed while waiting.
![image](https://user-images.githubusercontent.com/1569754/224477971-4f2be016-f2dc-4d02-8906-4e879b0b3947.png)
