### PR TITLE
Fix nested sealed containers rot

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7592,6 +7592,22 @@ void item::set_rot( time_duration val )
     rot = val;
 }
 
+void item::randomize_rot()
+{
+    visit_items( []( item * visit_itm, item * ) {
+        if( visit_itm->is_container() && visit_itm->all_pockets_sealed() ) {
+            return VisitResponse::SKIP;
+        } else if( visit_itm->is_comestible() && visit_itm->get_comestible()->spoils > 0_turns ) {
+            const double x_input = rng_float( 0.0, 1.0 );
+            const double k_rot = ( 1.0 - x_input ) / ( 1.0 + 2 * x_input );
+            visit_itm->set_rot( visit_itm->get_shelf_life() * k_rot );
+            return VisitResponse::SKIP;
+        }
+
+        return VisitResponse::NEXT;
+    } );
+}
+
 int item::spoilage_sort_order() const
 {
     int bottom = std::numeric_limits<int>::max();

--- a/src/item.h
+++ b/src/item.h
@@ -1048,6 +1048,12 @@ class item : public visitable
         void set_rot( time_duration val );
 
         /**
+         * Set item @ref rot to a random value. If the item is a container 
+         * (such as MRE) - processes its contents recursively.
+         */
+        void randomize_rot();
+
+        /**
          * Get minimum time for this item or any of its contents to rot, ignoring
          * fridge. If this item is a container, its spoil multiplier is taken into
          * account, but the spoil multiplier of the parent container of this item,

--- a/src/item.h
+++ b/src/item.h
@@ -1048,7 +1048,7 @@ class item : public visitable
         void set_rot( time_duration val );
 
         /**
-         * Set item @ref rot to a random value. If the item is a container 
+         * Set item @ref rot to a random value. If the item is a container
          * (such as MRE) - processes its contents recursively.
          */
         void randomize_rot();

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -718,24 +718,6 @@ std::size_t Item_group::create( Item_spawn_data::ItemList &list,
     const std::size_t items_created = list.size() - prev_list_size;
     put_into_container( list, items_created, container_item, birthday, on_overflow, context() );
 
-    if( birthday == calendar::start_of_cataclysm ) {
-        // randomize rot value for comestibles generated at the 'start of cataclysm'
-        for( item &e : list ) {
-            e.visit_items( []( item * visit_itm, item * ) {
-                if( visit_itm->is_comestible() && visit_itm->get_comestible()->spoils > 0_turns ) {
-                    const double x_input = rng_float( 0.0, 1.0 );
-                    const double k_rot = ( 1.0 - x_input ) / ( 1.0 + 2 * x_input );
-                    visit_itm->set_rot( visit_itm->get_shelf_life() * k_rot );
-                    return VisitResponse::SKIP;
-                } else  if( visit_itm->is_container() && visit_itm->all_pockets_sealed() ) {
-                    return VisitResponse::SKIP;
-                }
-
-                return VisitResponse::NEXT;
-            } );
-        }
-    }
-
     return list.size() - prev_list_size;
 }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6488,6 +6488,7 @@ std::vector<item *> map::place_items(
             }
         }
 
+        e->randomize_rot();
         e->set_owner( faction_id( faction ) );
     }
     return res;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2798,6 +2798,10 @@ void monster::drop_items_on_death( item *corpse )
                                   calendar::start_of_cataclysm,
                                   spawn_flags::use_spawn_rate );
 
+    for( item &e : new_items ) {
+        e.randomize_rot();
+    }
+
     // for non corpses this is much simpler
     if( !corpse ) {
         for( item &it : new_items ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "#64138"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #64138 
Nested item_groups could change the comestibles rot value before being placed in a higher level sealed container, so sealed MREs were getting old and rotten food inside.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Apply rot randomization only on top-level containers after the item_group has been generated and assembled into its containers. Rot randomization is now called explicitly in mapgen's map::place_items and in monster::drop_items_on_death.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Debug-spawned zombie soldiers and killed them. Checked their MREs. Sealed ones now contain only 'fresh' food. Not sealed MREs can have the 'past midlife' / 'old' food.

Teleported into town, checked ~20 kitchens: sealed food was all 'fresh', non-sealed has varying freshness.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
