### PR TITLE
Soldier drop tweaks

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -149,6 +149,19 @@
     "subtype": "collection",
     "entries": [ { "item": "suppressor" }, { "item": "rifle_scope" }, { "item": "bipod" } ]
   },
+	{
+		"type": "item_group",
+		"id": "military_grenadier_mods",
+		"//": "Default mods for m4 carbines issued with grenade launchers",
+		"subtype": "distribution",
+		"entries": [{
+			"item": "m203",
+			"prob": 40
+		}, {
+			"item": "m320_mod",
+			"prob": 60
+		}]
+	},
   {
     "type": "item_group",
     "id": "vz58v_mods",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -149,19 +149,13 @@
     "subtype": "collection",
     "entries": [ { "item": "suppressor" }, { "item": "rifle_scope" }, { "item": "bipod" } ]
   },
-	{
-		"type": "item_group",
-		"id": "military_grenadier_mods",
-		"//": "Default mods for m4 carbines issued with grenade launchers",
-		"subtype": "distribution",
-		"entries": [{
-			"item": "m203",
-			"prob": 40
-		}, {
-			"item": "m320_mod",
-			"prob": 60
-		}]
-	},
+  {
+    "type": "item_group",
+    "id": "military_grenadier_mods",
+    "//": "Default mods for m4 carbines issued with grenade launchers",
+    "subtype": "distribution",
+    "entries": [ { "item": "m203", "prob": 40 }, { "item": "m320_mod", "prob": 60 } ]
+  },
   {
     "type": "item_group",
     "id": "vz58v_mods",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -17,6 +17,28 @@
     ]
   },
   {
+    "type": "item_group",
+    "id": "military_standard_assault_rifles_sighted",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "m4_carbine", "variant": "m4a1", "prob": 88, "charges": [ 0, 30 ], "contents-item": "acog_scope" },
+      {
+        "item": "m27_assault_rifle",
+        "variant": "m27iar",
+        "prob": 10,
+        "charges": [ 0, 30 ],
+        "contents-item": "acog_scope"
+      },
+      { "item": "m16a4", "prob": 2, "charges": [ 0, 30 ], "contents-item": "acog_scope" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "military_grenadier_assault_rifles",
+    "subtype": "distribution",
+    "entries": [ { "item": "m4_carbine", "contents-group": "military_grenadier_mods", "prob": 100, "charges": [ 0, 30 ] } ]
+  },
+  {
     "id": "armor_plates",
     "type": "item_group",
     "//": "a list of all plates that could be sold in stores",
@@ -431,7 +453,7 @@
     "type": "item_group",
     "id": "military_standard_grenades",
     "subtype": "distribution",
-    "entries": [ { "item": "grenade", "prob": 100 } ]
+    "entries": [ { "item": "grenade", "prob": 80 }, { "item": "smokebomb", "prob": 20 } ]
   },
   {
     "type": "item_group",

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -17,14 +17,42 @@
           {
             "group": "military_standard_assault_rifles",
             "contents-item": "shoulder_strap",
-            "prob": 75,
+            "prob": 25,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          },
+          {
+            "group": "military_standard_assault_rifles_sighted",
+            "contents-item": "shoulder_strap",
+            "prob": 40,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          },
+          {
+            "group": "military_grenadier_assault_rifles",
+            "contents-item": "shoulder_strap",
+            "prob": 4,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          },
+          {
+            "group": "military_grenadier_assault_rifles",
+            "contents-item": [ "shoulder_strap", "acog_scope" ],
+            "prob": 6,
             "damage": [ 0, 4 ],
             "dirt": [ 0, 6000 ]
           },
           {
             "group": "military_standard_lmgs",
             "contents-item": "shoulder_strap",
-            "prob": 10,
+            "prob": 4,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          },
+          {
+            "group": "military_standard_lmgs",
+            "contents-item": [ "shoulder_strap", "acog_scope" ],
+            "prob": 6,
             "damage": [ 0, 4 ],
             "dirt": [ 0, 6000 ]
           },
@@ -39,7 +67,13 @@
         "prob": 10
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
+      {
+        "distribution": [
+          { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 80 },
+          { "item": "40x46mm_m433", "charges": [ 1, 3 ], "prob": 20 }
+        ],
+        "prob": 20
+      },
       { "group": "military_patrol_food" },
       { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },
       { "group": "wallets", "prob": 10 },
@@ -59,14 +93,42 @@
           {
             "group": "military_standard_assault_rifles",
             "contents-item": "shoulder_strap",
-            "prob": 75,
+            "prob": 25,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          },
+          {
+            "group": "military_standard_assault_rifles_sighted",
+            "contents-item": [ "shoulder_strap", "acog_scope" ],
+            "prob": 40,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          },
+          {
+            "group": "military_grenadier_assault_rifles",
+            "contents-item": "shoulder_strap",
+            "prob": 4,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          },
+          {
+            "group": "military_grenadier_assault_rifles",
+            "contents-item": [ "shoulder_strap", "acog_scope" ],
+            "prob": 6,
             "damage": [ 0, 4 ],
             "dirt": [ 0, 6000 ]
           },
           {
             "group": "military_standard_lmgs",
             "contents-item": "shoulder_strap",
-            "prob": 10,
+            "prob": 4,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          },
+          {
+            "group": "military_standard_lmgs",
+            "contents-item": [ "shoulder_strap", "acog_scope" ],
+            "prob": 6,
             "damage": [ 0, 4 ],
             "dirt": [ 0, 6000 ]
           },
@@ -82,7 +144,13 @@
       },
       { "group": "clothing_soldier_heavy_set", "damage": [ 0, 2 ] },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
+      {
+        "distribution": [
+          { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 80 },
+          { "item": "40x46mm_m433", "charges": [ 1, 3 ], "prob": 20 }
+        ],
+        "prob": 20
+      },
       { "group": "military_patrol_food" },
       { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },
       { "group": "wallets", "prob": 10 },
@@ -125,7 +193,14 @@
           {
             "group": "military_standard_lmgs",
             "contents-item": "shoulder_strap",
-            "prob": 10,
+            "prob": 4,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          },
+          {
+            "group": "military_standard_lmgs",
+            "contents-item": [ "shoulder_strap", "acog_scope" ],
+            "prob": 6,
             "damage": [ 0, 4 ],
             "dirt": [ 0, 6000 ]
           },
@@ -140,7 +215,13 @@
         "prob": 10
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
+      {
+        "distribution": [
+          { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 80 },
+          { "item": "40x46mm_m433", "charges": [ 1, 3 ], "prob": 20 }
+        ],
+        "prob": 20
+      },
       { "group": "military_patrol_food" },
       {
         "collection": [ { "group": "infantry_officer_gear", "prob": 90 }, { "group": "infantry_medical_gear", "prob": 80 } ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance  "Give zombie soldier drops attachments & 40mm grenades"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Make zombie soldiers drop weapons with attachments that match US Army doctrine more closely. Most of the soldiers we find after the Cataclysm probably belonged to infantry squads and would generally be equipped appropriately given the US' stockpiles of materiel. Each squad has two grenadiers out of nine troops, but none of the zombies drop weapons matching the grenadier role, and they don't drop weapons that have attachments that are ubiquitous - particularly the ACOG scope.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Retaining the current rate of weapon drops for zombie soldiers and related monsters, modify drop rates and item groups to include M4 carbines with grenade launchers and a better than average chance for all dropped rifles and machine guns to have ACOG sights. Allow them also to drop 40mm HEDP grenades and smoke grenades in place of regular grenades. Grenade launchers are made as common as M249s, as a similar proportion of troops should have them.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Also add chances for soldiers to drop holographic sights and magnifiers, as well as small chances to drop M72 or other missile launchers (see pages 44 and 644 of below PDF) and to add the M145 Machine Gun Optic for the M249 instead of the ACOG, but I wanted to stick to the basics and focus on the most common weapons and attachments without adding confusion and redundancy.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Spawned several hundred zombie soldiers and sifted through their drops. Found M16 and M27 rifles with and without ACOG scopes, M4s with ACOGs and/or M203/M320 launchers. Found smoke bombs and regular grenades as well as 40mm HEDP in expected proportions.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I got a lot of the information I based this change on from a US Army field manual currently available here: https://armypubs.army.mil/epubs/DR_pubs/DR_a/ARN13842-ATP_3-21.8-001-WEB-4.pdf
It contains squad composition and equipment information for an Army infantry platoon, and so seemed like a logical thing to base soldier drops on.
