### PR TITLE
Fix far-sighted butlers spawning without reading glasses

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -628,8 +628,11 @@ void avatar::add_profession_items()
                 inv->push_back( it );
             }
         } else if( it.is_armor() ) {
-            // TODO: debugmsg if wearing fails
-            wear_item( it, false, false );
+            if( can_wear( it ).success() ) {
+                wear_item( it, false, false );
+            } else {
+                inv->push_back( it );
+            }
         } else {
             inv->push_back( it );
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

Bugfixes "Fix far-sighted butlers spawning without reading glasses"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
If there are wear conflicts on profession starting items without `no_auto_equip`, the second item would be silently dropped from inventory. This is noticeable with a far-sighted butler, the butler's default monocle would conflict with the reading glasses and cause the reading glasses to be deleted. The monocle only corrects near-sighted, so the character can't read until they find glasses. The same will occur with near-sighted Butlers, but the since the monocle corrects Near-Sighted its not an issue.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change the `add_profession_items` to fall-back to putting items in inventory if we can't auto-wear them instead of silently deleting the items. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

This change does mean that "Near-Sighted" Butler's will spawn with both a monocle and redundant glasses now. We could simply remove the monocle from the Butler instead.

Or, better we could remove the monocle from the default profession items list and modify `profession_item_substitutions` to allow thematic profession substitutions so that "Near-Sighted" butlers spawn with a monocle instead of regular glasses.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

