### PR TITLE
Fixed pocket contents displaying each item seperately

### DIFF
--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1244,7 +1244,7 @@ void item_pocket::contents_info( std::vector<iteminfo> &info, int pocket_number,
                 }
             }
         }
-        for( auto &content : counted_contents ) {
+        for( std::pair<const std::string, int> &content : counted_contents ) {
             if( content.second > 1 ) {
                 info.emplace_back( "DESCRIPTION", space + std::to_string( content.second ) + " " + content.first );
             } else {

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1213,7 +1213,7 @@ void item_pocket::contents_info( std::vector<iteminfo> &info, int pocket_number,
 
     // ablative pockets have their contents displayed earlier in the UI
     if( !is_ablative() ) {
-        // Create map here for item contents, use name is key and value as number held, after traversing the entire inventory dump the map into the vector.
+        // Create map here for item contents, use name as key and value as number held, after traversing the entire pocket dump the map into the vector.
         std::unordered_map<std::string, int> counted_contents;
         bool contents_header = false;
         for( const item &contents_item : contents ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Fixed pocket contents displaying each item seperately"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When in the pocket settings management window pocket contents displayed each item in a stack individually which could cause the contents to go off the bottom of the screen.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Display the stack of items as a stack when in that window.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Do a quick and dirty solution that didn't show the plurals of item names.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Opened up the pocket settings window and looked at contents of the pocket.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
![image](https://user-images.githubusercontent.com/9900620/224514279-3e100d75-44a0-495b-8027-f4186fe51459.png)
![image](https://user-images.githubusercontent.com/9900620/224514285-aa670f92-fc22-4f7f-b952-1208589c57d5.png)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
