### PR TITLE
Remove find_part and engine_fuel_current

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1125,10 +1125,11 @@ std::pair<std::string, nc_color> display::vehicle_fuel_percent_text_color( const
         itype_id fuel_type = itype_id::NULL_ID();
         // FIXME: Move this to a vehicle helper function like get_active_engine
         for( size_t e = 0; e < veh->engines.size(); e++ ) {
+            const vehicle_part &vp = veh->part( veh->engines[e] );
             if( veh->is_engine_on( e ) &&
                 !( veh->is_perpetual_type( e ) || veh->is_engine_type( e, fuel_type_muscle ) ) ) {
                 // Get the fuel type of the first engine that is turned on
-                fuel_type = veh->engine_fuel_current( e );
+                fuel_type = vp.fuel_current();
             }
         }
         int max_fuel = veh->fuel_capacity( fuel_type );

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -411,7 +411,7 @@ void veh_app_interact::siphon()
 
     // Setup liquid handling activity
     const item &base = pt->get_base();
-    const int idx = veh->find_part( base );
+    const int idx = veh->index_of_part( pt );
     item liquid( base.legacy_front() );
     const int liq_charges = liquid.charges;
     if( liquid_handler::handle_liquid( liquid, nullptr, 1, nullptr, veh, idx ) ) {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1988,7 +1988,7 @@ void veh_interact::do_siphon()
         } );
         hide_ui( true );
         const item &base = pt.get_base();
-        const int idx = veh->find_part( base );
+        const int idx = veh->index_of_part( &pt );
         item liquid( base.legacy_front() );
         const int liq_charges = liquid.charges;
         if( liquid_handler::handle_liquid( liquid, nullptr, 1, nullptr, veh, idx ) ) {
@@ -3133,7 +3133,7 @@ void act_vehicle_siphon( vehicle *veh )
     vehicle_part &tank = veh_interact::select_part( *veh, sel, title );
     if( tank ) {
         const item &base = tank.get_base();
-        const int idx = veh->find_part( base );
+        const int idx = veh->index_of_part( &tank );
         item liquid( base.legacy_front() );
         const int liq_charges = liquid.charges;
         if( liquid_handler::handle_liquid( liquid, nullptr, 1, nullptr, veh, idx ) ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2414,18 +2414,6 @@ item_location vehicle::part_base( int p )
     return item_location( vehicle_cursor( *this, p ), &parts[ p ].base );
 }
 
-int vehicle::find_part( const item &it ) const
-{
-    int index = INT_MIN;
-    for( const vpart_reference &vpr : get_all_parts() ) {
-        if( &vpr.part().base == &it ) {
-            index = vpr.part_index();
-            break;
-        }
-    }
-    return index;
-}
-
 item_group::ItemList vehicle_part::pieces_for_broken_part() const
 {
     const item_group_id &group = info().breaks_into_group;
@@ -3393,11 +3381,6 @@ int vehicle::engine_fuel_left( const int e, bool recurse ) const
         return fuel_left( parts[ engines[ e ] ].fuel_current(), recurse );
     }
     return 0;
-}
-
-itype_id vehicle::engine_fuel_current( int e ) const
-{
-    return parts[ engines[ e ] ].fuel_current();
 }
 
 int vehicle::fuel_capacity( const itype_id &ftype ) const

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1040,9 +1040,6 @@ class vehicle
         /** Get handle for base item of part */
         item_location part_base( int p );
 
-        /** Get index of part with matching base item or INT_MIN if not found */
-        int find_part( const item &it ) const;
-
         /**
          * Remove a part from a targeted remote vehicle. Useful for, e.g. power cables that have
          * a vehicle part on both sides.
@@ -1275,8 +1272,6 @@ class vehicle
         const;
         // Checks how much of an engine's current fuel is left in the tanks.
         int engine_fuel_left( int e, bool recurse = false ) const;
-        // Returns what type of fuel an engine uses
-        itype_id engine_fuel_current( int e ) const;
         // Returns total vehicle fuel capacity for the given fuel type
         int fuel_capacity( const itype_id &ftype ) const;
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Remove awkward functions off vehicle class

#### Describe the solution

Working on a bigger PR for vehicle code I'd like to get these 2 out of the way;

`vehicle::find_part` - goes on a roundabout searching via comparing base part pointers when a reference to the vehicle_part is directly available and `vehicle::index_of_part` exists

`vehicle::engine_fuel_current` - used once, seems to only exist because engine part indexing is awkward, and no reuse potential after the PR i'm working on

#### Describe alternatives you've considered

#### Testing

#### Additional context
