### PR TITLE
Add two travel-related overmap keybinds for a better UX

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1209,6 +1209,18 @@
   },
   {
     "type": "keybinding",
+    "id": "GO_TO_DESTINATION",
+    "name": "Go to destination",
+    "bindings": [ { "input_method": "keyboard_char", "key": "g" }, { "input_method": "keyboard_code", "key": "g" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "CENTER_ON_DESTINATION",
+    "name": "Center on destination",
+    "bindings": [ { "input_method": "keyboard_char", "key": "c" }, { "input_method": "keyboard_code", "key": "c" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "FIRE",
     "category": "TARGET",
     "name": "Fire weapon",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1211,13 +1211,13 @@
     "type": "keybinding",
     "id": "GO_TO_DESTINATION",
     "name": "Go to destination",
-    "bindings": [ { "input_method": "keyboard_char", "key": "g" }, { "input_method": "keyboard_code", "key": "g" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
   },
   {
     "type": "keybinding",
     "id": "CENTER_ON_DESTINATION",
     "name": "Center on destination",
-    "bindings": [ { "input_method": "keyboard_char", "key": "c" }, { "input_method": "keyboard_code", "key": "c" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
   },
   {
     "type": "keybinding",

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1183,6 +1183,8 @@ static void draw_om_sidebar(
         print_hint( "LEVEL_UP" );
         print_hint( "LEVEL_DOWN" );
         print_hint( "CENTER" );
+        print_hint( "CENTER_ON_DESTINATION" );
+        print_hint( "GO_TO_DESTINATION" );
         print_hint( "SEARCH" );
         print_hint( "CREATE_NOTE" );
         print_hint( "DELETE_NOTE" );
@@ -1695,6 +1697,44 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
 
 static int overmap_zoom_level = DEFAULT_TILESET_ZOOM;
 
+static std::string try_travel_to_destination( avatar &player_character, const tripoint_abs_omt curs,
+        const bool driving )
+{
+    std::vector<tripoint_abs_omt> path = get_overmap_path_to( curs, driving );
+    bool same_path_selected = false;
+    if( path == player_character.omt_path ) {
+        same_path_selected = true;
+    }
+    std::string confirm_msg;
+    if( !driving && player_character.weight_carried() > player_character.weight_capacity() ) {
+        confirm_msg = _( "You are overburdened, are you sure you want to travel (it may be painful)?" );
+    } else if( !driving && player_character.in_vehicle ) {
+        confirm_msg = _( "You are in a vehicle but not driving.  Are you sure you want to walk?" );
+    } else if( driving ) {
+        if( same_path_selected ) {
+            confirm_msg = _( "Drive to this point?" );
+        } else {
+            confirm_msg = _( "Drive to your destination?" );
+        }
+    } else {
+        if( same_path_selected ) {
+            confirm_msg = _( "Travel to this point?" );
+        } else {
+            confirm_msg = _( "Travel to your destination?" );
+        }
+    }
+    if( query_yn( confirm_msg ) ) {
+        if( driving ) {
+            player_character.assign_activity( player_activity( autodrive_activity_actor() ) );
+        } else {
+            player_character.reset_move_mode();
+            player_character.assign_activity( ACT_TRAVELLING );
+        }
+        return "QUIT";
+    }
+    return nullptr;
+}
+
 static tripoint_abs_omt display( const tripoint_abs_omt &orig,
                                  const draw_data_t &data = draw_data_t() )
 {
@@ -1748,6 +1788,9 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
     ictxt.register_action( "MOUSE_MOVE" );
     ictxt.register_action( "SELECT" );
     ictxt.register_action( "CHOOSE_DESTINATION" );
+    ictxt.register_action( "CENTER_ON_DESTINATION" );
+    ictxt.register_action( "GO_TO_DESTINATION" );
+
 
     // Actions whose keys we want to display.
     ictxt.register_action( "CENTER" );
@@ -1840,6 +1883,19 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
                 curs.x() = p.x();
                 curs.y() = p.y();
             }
+        } else if( action == "GO_TO_DESTINATION" ) {
+            avatar &player_character = get_avatar();
+            if( !player_character.omt_path.empty() ) {
+                const bool driving = player_character.in_vehicle && player_character.controlling_vehicle;
+                action = try_travel_to_destination( player_character, curs, driving );
+            }
+        } else if( action == "CENTER_ON_DESTINATION" ) {
+            avatar &player_character = get_avatar();
+            if( !player_character.omt_path.empty() ) {
+                tripoint_abs_omt p = player_character.omt_path[0];
+                curs.x() = p.x();
+                curs.y() = p.y();
+            }
         } else if( action == "CHOOSE_DESTINATION" ) {
             avatar &player_character = get_avatar();
             const bool driving = player_character.in_vehicle && player_character.controlling_vehicle;
@@ -1851,25 +1907,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
                 player_character.omt_path.swap( path );
             }
             if( same_path_selected && !player_character.omt_path.empty() ) {
-                std::string confirm_msg;
-                if( !driving && player_character.weight_carried() > player_character.weight_capacity() ) {
-                    confirm_msg = _( "You are overburdened, are you sure you want to travel (it may be painful)?" );
-                } else if( !driving && player_character.in_vehicle ) {
-                    confirm_msg = _( "You are in a vehicle but not driving.  Are you sure you want to walk?" );
-                } else if( driving ) {
-                    confirm_msg = _( "Drive to this point?" );
-                } else {
-                    confirm_msg = _( "Travel to this point?" );
-                }
-                if( query_yn( confirm_msg ) ) {
-                    if( driving ) {
-                        player_character.assign_activity( player_activity( autodrive_activity_actor() ) );
-                    } else {
-                        player_character.reset_move_mode();
-                        player_character.assign_activity( ACT_TRAVELLING );
-                    }
-                    action = "QUIT";
-                }
+                action = try_travel_to_destination( player_character, curs, driving );
             }
         } else if( action == "TOGGLE_BLINKING" ) {
             uistate.overmap_blinking = !uistate.overmap_blinking;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Add two travel-related overmap keybinds for a better UX"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

Add two new keybinds GO_TO_DESTINATION and CENTER_ON_DESTINATION that allow the player to:
- Go to the current travel destination without the cursor needing to be on it.
- Move the cursor to the current travel destination.

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

I was getting annoyed about constantly having to open the overmap and pan over to my destination over and over again when traveling somewhere to resume traveling after enemies showed up.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- Added the keybinds
- Refactored the code used by the CHOOSE_DESTINATION keybind into a function so that I can call it from the GO_TO_DESTINATION keybind code.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

For next steps, I'd like to make the GO_TO_DESTINATION keybind work directly from the game world as well as the overmap. Although that seems like a bigger change.

Let me know if you've got a better idea for the default values for the keybinds.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

- Tested the two keybinds and ensured that they're doing what's expected.
- Checked that the UI hints were displaying well.
- Ensured that the two keybinds' default values aren't overlapping with any other overmap keybinds. 

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Overmap screen with new keybinds being displayed:
![cataclysm-tiles_kzvH8Yd1ed](https://user-images.githubusercontent.com/2420411/224518869-f7abf3ac-80b0-47f6-9457-12f01e3873b6.png)

GO_TO_DESTINATION key pressed when the cursor is NOT on the destination:
![cataclysm-tiles_4fe0I3zeD3](https://user-images.githubusercontent.com/2420411/224518871-9480f40c-a5db-41fb-8682-937da2f57c22.png)


GO_TO_DESTINATION or CHOOSE_DESTINATION key pressed when the cursor is already on the destination:
![cataclysm-tiles_Ue8uNhXXyb](https://user-images.githubusercontent.com/2420411/224518872-0c52b2e9-4d24-4202-978b-1fab6d8c2e17.png)
