### PR TITLE
item_location: add a parent_pocket() helper

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1150,7 +1150,7 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
 
         // Get the parent pocket before the item is obtained.
         if( loc.has_parent() ) {
-            parent_pocket = loc.parent_item().get_item()->contained_where( *loc );
+            parent_pocket = loc.parent_pocket();
         }
 
         loc = loc.obtain( you, 1 );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9098,11 +9098,11 @@ const pathfinding_settings &Character::get_pathfinding_settings() const
     return *path_settings;
 }
 
-ret_val<crush_tool_type> Character::can_crush_frozen_liquid( item_location loc ) const
+ret_val<crush_tool_type> Character::can_crush_frozen_liquid( item_location const &loc ) const
 {
     crush_tool_type tool_type = CRUSH_NO_TOOL;
     bool success = false;
-    if( !loc.has_parent() || !loc.parent_item()->contained_where( *loc )->get_pocket_data()->rigid ) {
+    if( !loc.has_parent() || !loc.parent_pocket()->get_pocket_data()->rigid ) {
         tool_type = CRUSH_HAMMER;
         success = has_quality( qual_HAMMER );
     } else {

--- a/src/character.h
+++ b/src/character.h
@@ -2813,7 +2813,7 @@ class Character : public Creature, public visitable
         /** Checks to see if the player is using floor items to keep warm, and return the name of one such item if so */
         std::string is_snuggling() const;
 
-        ret_val<crush_tool_type> can_crush_frozen_liquid( item_location loc ) const;
+        ret_val<crush_tool_type> can_crush_frozen_liquid( item_location const &loc ) const;
         /** Prompts user about crushing item at item_location loc, for harvesting of frozen liquids
         * @param loc Location for item to crush */
         bool crush_frozen_liquid( item_location loc );

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -89,7 +89,7 @@ void Character::handle_contents_changed( const std::vector<item_location> &conta
         if( loc.has_parent() ) {
             item_location parent_loc = loc.parent_item();
             item_loc_with_depth parent( parent_loc );
-            item_pocket *const pocket = parent_loc->contained_where( *loc );
+            item_pocket *const pocket = loc.parent_pocket();
             pocket->unseal();
             bool exists = false;
             auto it = sorted_containers.lower_bound( parent );

--- a/src/contents_change_handler.cpp
+++ b/src/contents_change_handler.cpp
@@ -12,7 +12,7 @@ void contents_change_handler::unseal_pocket_containing( const item_location &loc
 {
     if( loc.has_parent() ) {
         item_location parent = loc.parent_item();
-        item_pocket *const pocket = parent->contained_where( *loc );
+        item_pocket *const pocket = loc.parent_pocket();
         if( pocket ) {
             // on_contents_changed restacks the pocket and should be called later
             // in Character::handle_contents_changed

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2135,7 +2135,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     oThisItem.is_favorite = !oThisItem.is_favorite;
                     if( locThisItem.has_parent() ) {
                         item_location parent = locThisItem.parent_item();
-                        item_pocket *const pocket = parent->contained_where( oThisItem );
+                        item_pocket *const pocket = locThisItem.parent_pocket();
                         if( pocket ) {
                             pocket->restack();
                         } else {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -707,7 +707,7 @@ class comestible_inventory_preset : public inventory_selector_preset
                 item_location temp = loc;
                 // check if at least one parent container is sealed
                 while( temp.has_parent() ) {
-                    item_pocket *pocket = temp.parent_item()->contained_where( *temp.get_item() );
+                    item_pocket *pocket = temp.parent_pocket();
                     if( pocket->sealed() ) {
                         sealed = _( "sealed" );
                         break;
@@ -795,7 +795,7 @@ class comestible_inventory_preset : public inventory_selector_preset
             } else if( time == 0_turns ) {
                 return 4;
             } else if( loc.has_parent() &&
-                       loc.parent_item()->contained_where( *loc )->spoil_multiplier() == 0.0f ) {
+                       loc.parent_pocket()->spoil_multiplier() == 0.0f ) {
                 return 3;
             } else {
                 return 2;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -177,7 +177,7 @@ bool is_worn_ablative( item_location const &container, item_location const &chil
     // if the item is in an ablative pocket then put it with the item it is in
     // first do a short circuit test if the parent has ablative pockets at all
     return container->is_ablative() && container->is_worn_by_player() &&
-           container->contained_where( *child )->get_pocket_data()->ablative;
+           child.parent_pocket()->get_pocket_data()->ablative;
 }
 
 /** The maximum distance from the screen edge, to snap a window to it */
@@ -508,11 +508,10 @@ bool inventory_entry::is_hidden( cata::optional<bool> const &hide_entries_overri
         return *hide_entries_override;
     }
     while( item.has_parent() && item != topmost_parent ) {
-        item_location parent = item.parent_item();
-        if( parent.get_item()->contained_where( *item )->settings.is_collapsed() ) {
+        if( item.parent_pocket()->settings.is_collapsed() ) {
             return true;
         }
-        item = parent;
+        item = item.parent_item();
     }
     return false;
 }

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -85,6 +85,9 @@ class item_location::impl
         virtual item_location parent_item() const {
             return item_location();
         }
+        virtual item_pocket *parent_pocket() const {
+            return nullptr;
+        }
         virtual tripoint position() const = 0;
         virtual std::string describe( const Character * ) const = 0;
         virtual item_location obtain( Character &, int ) = 0;
@@ -564,6 +567,7 @@ class item_location::impl::item_in_container : public item_location::impl
 {
     private:
         item_location container;
+        mutable item_pocket *container_pkt = nullptr; // NOLINT(cata-serialize)
 
         // figures out the index for the item, which is where it is in the total list of contents
         // note: could be a better way of handling this?
@@ -586,6 +590,18 @@ class item_location::impl::item_in_container : public item_location::impl
     public:
         item_location parent_item() const override {
             return container;
+        }
+
+        item_pocket *parent_pocket() const override {
+            if( container_pkt == nullptr ) {
+                std::vector<item_pocket *> const pkts = parent_item()->get_all_standard_pockets();
+                if( pkts.size() == 1 ) {
+                    container_pkt = pkts.front();
+                } else {
+                    container_pkt = parent_item()->contained_where( *target() );
+                }
+            }
+            return container_pkt;
         }
 
         item_in_container( const item_location &container, item *which ) :
@@ -718,11 +734,11 @@ class item_location::impl::item_in_container : public item_location::impl
         }
 
         units::volume volume_capacity() const override {
-            return container->contained_where( *target() )->remaining_volume();
+            return parent_pocket()->remaining_volume();
         }
 
         units::mass weight_capacity() const override {
-            return container->contained_where( *target() )->remaining_weight();
+            return parent_pocket()->remaining_weight();
         }
 
         bool check_parent_capacity_recursive() const override {
@@ -846,6 +862,14 @@ item_location item_location::parent_item() const
     return item_location::nowhere;
 }
 
+item_pocket *item_location::parent_pocket() const
+{
+    if( where() == type::container ) {
+        return ptr->parent_pocket();
+    }
+    return nullptr;
+}
+
 bool item_location::has_parent() const
 {
     if( where() == type::container ) {
@@ -861,7 +885,7 @@ bool item_location::parents_can_contain_recursive( item *it ) const
     }
 
     item_location parent = parent_item();
-    item_pocket *pocket = parent->contained_where( *get_item() );
+    item_pocket *pocket = parent_pocket();
 
     if( pocket->can_contain( *it ).success() ) {
         return parent.parents_can_contain_recursive( it );
@@ -877,7 +901,7 @@ int item_location::max_charges_by_parent_recursive( const item &it ) const
     }
 
     item_location parent = parent_item();
-    item_pocket *pocket = parent->contained_where( *get_item() );
+    item_pocket *pocket = parent_pocket();
 
     return std::min( { it.charges_per_volume( pocket->remaining_volume() ),
                        it.charges_per_weight( pocket->remaining_weight() ),

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -14,6 +14,7 @@ class character_id;
 class JsonObject;
 class JsonOut;
 class item;
+class item_pocket;
 class map_cursor;
 class vehicle_cursor;
 class talker;
@@ -106,6 +107,7 @@ class item_location
 
         /** returns the parent item, or an invalid location if it has no parent */
         item_location parent_item() const;
+        item_pocket *parent_pocket() const;
 
         /** returns true if the item is in the inventory of the given character **/
         bool held_by( Character const &who ) const;

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -256,7 +256,7 @@ void match( Parent &&parent, Container &&contents,
                     match( content_loc, content_result );
                     item_location container = container_from_parent( parent );
                     if( container ) {
-                        item_pocket *pocket = container->contained_where( *content );
+                        item_pocket *pocket = content_loc.parent_pocket();
                         REQUIRE( pocket );
                         CHECK( content_result.parent_pocket_sealed == pocket->sealed() );
                     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Squeeze some more performance out of the inventory UI for the very common case of containers with only one pocket.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add an `item_location::parent_pocket()` helper that caches the parent pocket and uses a shortcut instead of running the very expensive `item::contained_where()` in the common case of only one pocket.

Use this helper wherever possible, most notably in `inventory_entry::is_hidden()`
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<details>
<summary>

Using [Eagle Mountain-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/10949976/Eagle.Mountain-trimmed.tar.gz) that recreates the scenario from https://github.com/CleverRaven/Cataclysm-DDA/issues/64139#issuecomment-1464895672</summary>

![scen](https://user-images.githubusercontent.com/68240139/224524719-3bc03b85-bb0c-4641-9f35-e56eca3dc931.png)


</details>

Verify that the inventory UI still looks and functions exactly the same (collapsing etc)

Before:
![before](https://user-images.githubusercontent.com/68240139/224524733-6094f759-99e8-4dd3-8ff6-d6ff9977dcee.png)
<details>
<summary>perf</summary>

![before-perf](https://user-images.githubusercontent.com/68240139/224524743-1b1f94ed-7fa7-42d2-8844-2816e63c2805.png)

</details>


After:
![after](https://user-images.githubusercontent.com/68240139/224524736-7a36a04d-38a0-4d93-a44b-70d2ded1655b.png)

<details>
<summary>perf</summary>

![after-perf](https://user-images.githubusercontent.com/68240139/224524752-b914b398-c127-4006-8dbd-cf88a38c370d.png)

</details>

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
