### PR TITLE
Vehicle engine functions cleanup

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2005,7 +2005,8 @@ void activity_handlers::start_engines_finish( player_activity *act, Character *y
     const bool take_control = act->values[0];
 
     for( size_t e = 0; e < veh->engines.size(); ++e ) {
-        if( veh->is_engine_on( e ) ) {
+        const vehicle_part &vp = veh->part( veh->engines[e] );
+        if( veh->is_engine_on( vp ) ) {
             attempted++;
             if( !veh->is_engine_type( e, itype_muscle ) &&
                 !veh->is_engine_type( e, itype_animal ) ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2008,14 +2008,14 @@ void activity_handlers::start_engines_finish( player_activity *act, Character *y
         const vehicle_part &vp = veh->part( veh->engines[e] );
         if( veh->is_engine_on( vp ) ) {
             attempted++;
-            if( !veh->is_engine_type( e, itype_muscle ) &&
-                !veh->is_engine_type( e, itype_animal ) ) {
+            if( !veh->is_engine_type( vp, itype_muscle ) &&
+                !veh->is_engine_type( vp, itype_animal ) ) {
                 non_muscle_attempted++;
             }
             if( veh->start_engine( e ) ) {
                 started++;
-                if( !veh->is_engine_type( e, itype_muscle ) &&
-                    !veh->is_engine_type( e, itype_animal ) ) {
+                if( !veh->is_engine_type( vp, itype_muscle ) &&
+                    !veh->is_engine_type( vp, itype_animal ) ) {
                     non_muscle_started++;
                 } else {
                     non_combustion_started++;

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2004,15 +2004,15 @@ void activity_handlers::start_engines_finish( player_activity *act, Character *y
     int non_combustion_started = 0;
     const bool take_control = act->values[0];
 
-    for( size_t e = 0; e < veh->engines.size(); ++e ) {
-        const vehicle_part &vp = veh->part( veh->engines[e] );
+    for( const int p : veh->engines ) {
+        vehicle_part &vp = veh->part( p );
         if( veh->is_engine_on( vp ) ) {
             attempted++;
             if( !veh->is_engine_type( vp, itype_muscle ) &&
                 !veh->is_engine_type( vp, itype_animal ) ) {
                 non_muscle_attempted++;
             }
-            if( veh->start_engine( e ) ) {
+            if( veh->start_engine( vp ) ) {
                 started++;
                 if( !veh->is_engine_type( vp, itype_muscle ) &&
                     !veh->is_engine_type( vp, itype_animal ) ) {

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1128,7 +1128,7 @@ std::pair<std::string, nc_color> display::vehicle_fuel_percent_text_color( const
             const vehicle_part &vp = veh->part( veh->engines[e] );
             if( veh->is_engine_on( vp )
                 && !veh->is_perpetual_type( e )
-                && !veh->is_engine_type( e, fuel_type_muscle ) ) {
+                && !veh->is_engine_type( vp, fuel_type_muscle ) ) {
                 // Get the fuel type of the first engine that is turned on
                 fuel_type = vp.fuel_current();
             }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1125,10 +1125,11 @@ std::pair<std::string, nc_color> display::vehicle_fuel_percent_text_color( const
         itype_id fuel_type = itype_id::NULL_ID();
         // FIXME: Move this to a vehicle helper function like get_active_engine
         for( size_t e = 0; e < veh->engines.size(); e++ ) {
+            const vehicle_part &vp = veh->part( veh->engines[e] );
             if( veh->is_engine_on( e ) &&
                 !( veh->is_perpetual_type( e ) || veh->is_engine_type( e, fuel_type_muscle ) ) ) {
                 // Get the fuel type of the first engine that is turned on
-                fuel_type = veh->engine_fuel_current( e );
+                fuel_type = vp.fuel_current();
             }
         }
         int max_fuel = veh->fuel_capacity( fuel_type );

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1126,8 +1126,9 @@ std::pair<std::string, nc_color> display::vehicle_fuel_percent_text_color( const
         // FIXME: Move this to a vehicle helper function like get_active_engine
         for( size_t e = 0; e < veh->engines.size(); e++ ) {
             const vehicle_part &vp = veh->part( veh->engines[e] );
-            if( veh->is_engine_on( e ) &&
-                !( veh->is_perpetual_type( e ) || veh->is_engine_type( e, fuel_type_muscle ) ) ) {
+            if( veh->is_engine_on( vp )
+                && !veh->is_perpetual_type( e )
+                && !veh->is_engine_type( e, fuel_type_muscle ) ) {
                 // Get the fuel type of the first engine that is turned on
                 fuel_type = vp.fuel_current();
             }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1124,10 +1124,10 @@ std::pair<std::string, nc_color> display::vehicle_fuel_percent_text_color( const
     if( veh && veh->cruise_on ) {
         itype_id fuel_type = itype_id::NULL_ID();
         // FIXME: Move this to a vehicle helper function like get_active_engine
-        for( size_t e = 0; e < veh->engines.size(); e++ ) {
-            const vehicle_part &vp = veh->part( veh->engines[e] );
+        for( const int p : veh->engines ) {
+            const vehicle_part &vp = veh->part( p );
             if( veh->is_engine_on( vp )
-                && !veh->is_perpetual_type( e )
+                && !veh->is_perpetual_type( vp )
                 && !veh->is_engine_type( vp, fuel_type_muscle ) ) {
                 // Get the fuel type of the first engine that is turned on
                 fuel_type = vp.fuel_current();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5142,7 +5142,7 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
 {
     bool washing_machine_finished = false;
 
-    const bool washer_here = cur_veh.is_part_on( part ) &&
+    const bool washer_here = cur_veh.part( part ).enabled &&
                              ( cur_veh.part_flag( part, VPFLAG_WASHING_MACHINE ) ||
                                cur_veh.part_flag( part, VPFLAG_DISHWASHER ) );
 
@@ -5171,7 +5171,7 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
     }
 
     const bool autoclave_here = cur_veh.part_flag( part, VPFLAG_AUTOCLAVE ) &&
-                                cur_veh.is_part_on( part );
+                                cur_veh.part( part ).enabled;
     bool autoclave_finished = false;
     if( autoclave_here ) {
         for( item &n : cur_veh.get_items( part ) ) {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -878,21 +878,21 @@ void sfx::do_vehicle_engine_sfx()
     const bool night = is_night( calendar::turn );
 
     for( size_t e = 0; e < veh->engines.size(); ++e ) {
-        if( veh->is_engine_on( e ) ) {
-            if( sfx::has_variant_sound( "engine_working_internal",
-                                        veh->part_info( veh->engines[ e ] ).get_id().str(),
-                                        seas_str, indoors, night ) ) {
-                id_and_variant = std::make_pair( "engine_working_internal",
-                                                 veh->part_info( veh->engines[ e ] ).get_id().str() );
-            } else if( veh->is_engine_type( e, fuel_type_muscle ) ) {
-                id_and_variant = std::make_pair( "engine_working_internal", "muscle" );
-            } else if( veh->is_engine_type( e, fuel_type_wind ) ) {
-                id_and_variant = std::make_pair( "engine_working_internal", "wind" );
-            } else if( veh->is_engine_type( e, fuel_type_battery ) ) {
-                id_and_variant = std::make_pair( "engine_working_internal", "electric" );
-            } else {
-                id_and_variant = std::make_pair( "engine_working_internal", "combustion" );
-            }
+        const vehicle_part &vp = veh->part( veh->engines[e] );
+        const std::string vp_id_str = vp.info().get_id().str();
+        if( !veh->is_engine_on( vp ) ) {
+            continue;
+        }
+        if( sfx::has_variant_sound( "engine_working_internal", vp_id_str, seas_str, indoors, night ) ) {
+            id_and_variant = std::make_pair( "engine_working_internal", vp_id_str );
+        } else if( veh->is_engine_type( e, fuel_type_muscle ) ) {
+            id_and_variant = std::make_pair( "engine_working_internal", "muscle" );
+        } else if( veh->is_engine_type( e, fuel_type_wind ) ) {
+            id_and_variant = std::make_pair( "engine_working_internal", "wind" );
+        } else if( veh->is_engine_type( e, fuel_type_battery ) ) {
+            id_and_variant = std::make_pair( "engine_working_internal", "electric" );
+        } else {
+            id_and_variant = std::make_pair( "engine_working_internal", "combustion" );
         }
     }
 
@@ -1021,21 +1021,21 @@ void sfx::do_vehicle_exterior_engine_sfx()
     const bool night = is_night( calendar::turn );
 
     for( size_t e = 0; e < veh->engines.size(); ++e ) {
-        if( veh->is_engine_on( e ) ) {
-            if( sfx::has_variant_sound( "engine_working_external",
-                                        veh->part_info( veh->engines[ e ] ).get_id().str(),
-                                        seas_str, indoors, night ) ) {
-                id_and_variant = std::make_pair( "engine_working_external",
-                                                 veh->part_info( veh->engines[ e ] ).get_id().str() );
-            } else if( veh->is_engine_type( e, fuel_type_muscle ) ) {
-                id_and_variant = std::make_pair( "engine_working_external", "muscle" );
-            } else if( veh->is_engine_type( e, fuel_type_wind ) ) {
-                id_and_variant = std::make_pair( "engine_working_external", "wind" );
-            } else if( veh->is_engine_type( e, fuel_type_battery ) ) {
-                id_and_variant = std::make_pair( "engine_working_external", "electric" );
-            } else {
-                id_and_variant = std::make_pair( "engine_working_external", "combustion" );
-            }
+        const vehicle_part &vp = veh->part( veh->engines[e] );
+        const std::string vp_id_str = vp.info().get_id().str();
+        if( !veh->is_engine_on( vp ) ) {
+            continue;
+        }
+        if( sfx::has_variant_sound( "engine_working_external", vp_id_str, seas_str, indoors, night ) ) {
+            id_and_variant = std::make_pair( "engine_working_external", vp_id_str );
+        } else if( veh->is_engine_type( e, fuel_type_muscle ) ) {
+            id_and_variant = std::make_pair( "engine_working_external", "muscle" );
+        } else if( veh->is_engine_type( e, fuel_type_wind ) ) {
+            id_and_variant = std::make_pair( "engine_working_external", "wind" );
+        } else if( veh->is_engine_type( e, fuel_type_battery ) ) {
+            id_and_variant = std::make_pair( "engine_working_external", "electric" );
+        } else {
+            id_and_variant = std::make_pair( "engine_working_external", "combustion" );
         }
     }
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -877,23 +877,24 @@ void sfx::do_vehicle_engine_sfx()
     const bool indoors = !is_creature_outside( player_character );
     const bool night = is_night( calendar::turn );
 
-    for( size_t e = 0; e < veh->engines.size(); ++e ) {
-        const vehicle_part &vp = veh->part( veh->engines[e] );
-        const std::string vp_id_str = vp.info().get_id().str();
+    for( const int p : veh->engines ) {
+        const vehicle_part &vp = veh->part( p );
         if( !veh->is_engine_on( vp ) ) {
             continue;
         }
-        if( sfx::has_variant_sound( "engine_working_internal", vp_id_str, seas_str, indoors, night ) ) {
-            id_and_variant = std::make_pair( "engine_working_internal", vp_id_str );
+        std::string variant = vp.info().get_id().str();
+        if( sfx::has_variant_sound( "engine_working_internal", variant, seas_str, indoors, night ) ) {
+            // has special sound variant for this vpart id
         } else if( veh->is_engine_type( vp, fuel_type_muscle ) ) {
-            id_and_variant = std::make_pair( "engine_working_internal", "muscle" );
+            variant = "muscle";
         } else if( veh->is_engine_type( vp, fuel_type_wind ) ) {
-            id_and_variant = std::make_pair( "engine_working_internal", "wind" );
+            variant = "wind";
         } else if( veh->is_engine_type( vp, fuel_type_battery ) ) {
-            id_and_variant = std::make_pair( "engine_working_internal", "electric" );
+            variant = "electric";
         } else {
-            id_and_variant = std::make_pair( "engine_working_internal", "combustion" );
+            variant = "combustion";
         }
+        id_and_variant = std::make_pair( "engine_working_internal", variant );
     }
 
     if( !is_channel_playing( ch ) ) {
@@ -1020,23 +1021,24 @@ void sfx::do_vehicle_exterior_engine_sfx()
     const bool indoors = !is_creature_outside( player_character );
     const bool night = is_night( calendar::turn );
 
-    for( size_t e = 0; e < veh->engines.size(); ++e ) {
-        const vehicle_part &vp = veh->part( veh->engines[e] );
-        const std::string vp_id_str = vp.info().get_id().str();
+    for( const int p : veh->engines ) {
+        const vehicle_part &vp = veh->part( p );
         if( !veh->is_engine_on( vp ) ) {
             continue;
         }
-        if( sfx::has_variant_sound( "engine_working_external", vp_id_str, seas_str, indoors, night ) ) {
-            id_and_variant = std::make_pair( "engine_working_external", vp_id_str );
+        std::string variant = vp.info().get_id().str();
+        if( sfx::has_variant_sound( "engine_working_external", variant, seas_str, indoors, night ) ) {
+            // has special sound variant for this vpart id
         } else if( veh->is_engine_type( vp, fuel_type_muscle ) ) {
-            id_and_variant = std::make_pair( "engine_working_external", "muscle" );
+            variant = "muscle";
         } else if( veh->is_engine_type( vp, fuel_type_wind ) ) {
-            id_and_variant = std::make_pair( "engine_working_external", "wind" );
+            variant = "wind";
         } else if( veh->is_engine_type( vp, fuel_type_battery ) ) {
-            id_and_variant = std::make_pair( "engine_working_external", "electric" );
+            variant = "electric";
         } else {
-            id_and_variant = std::make_pair( "engine_working_external", "combustion" );
+            variant = "combustion";
         }
+        id_and_variant = std::make_pair( "engine_working_external", variant );
     }
 
     if( is_channel_playing( ch ) ) {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -885,11 +885,11 @@ void sfx::do_vehicle_engine_sfx()
         }
         if( sfx::has_variant_sound( "engine_working_internal", vp_id_str, seas_str, indoors, night ) ) {
             id_and_variant = std::make_pair( "engine_working_internal", vp_id_str );
-        } else if( veh->is_engine_type( e, fuel_type_muscle ) ) {
+        } else if( veh->is_engine_type( vp, fuel_type_muscle ) ) {
             id_and_variant = std::make_pair( "engine_working_internal", "muscle" );
-        } else if( veh->is_engine_type( e, fuel_type_wind ) ) {
+        } else if( veh->is_engine_type( vp, fuel_type_wind ) ) {
             id_and_variant = std::make_pair( "engine_working_internal", "wind" );
-        } else if( veh->is_engine_type( e, fuel_type_battery ) ) {
+        } else if( veh->is_engine_type( vp, fuel_type_battery ) ) {
             id_and_variant = std::make_pair( "engine_working_internal", "electric" );
         } else {
             id_and_variant = std::make_pair( "engine_working_internal", "combustion" );
@@ -1028,11 +1028,11 @@ void sfx::do_vehicle_exterior_engine_sfx()
         }
         if( sfx::has_variant_sound( "engine_working_external", vp_id_str, seas_str, indoors, night ) ) {
             id_and_variant = std::make_pair( "engine_working_external", vp_id_str );
-        } else if( veh->is_engine_type( e, fuel_type_muscle ) ) {
+        } else if( veh->is_engine_type( vp, fuel_type_muscle ) ) {
             id_and_variant = std::make_pair( "engine_working_external", "muscle" );
-        } else if( veh->is_engine_type( e, fuel_type_wind ) ) {
+        } else if( veh->is_engine_type( vp, fuel_type_wind ) ) {
             id_and_variant = std::make_pair( "engine_working_external", "wind" );
-        } else if( veh->is_engine_type( e, fuel_type_battery ) ) {
+        } else if( veh->is_engine_type( vp, fuel_type_battery ) ) {
             id_and_variant = std::make_pair( "engine_working_external", "electric" );
         } else {
             id_and_variant = std::make_pair( "engine_working_external", "combustion" );

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -411,7 +411,7 @@ void veh_app_interact::siphon()
 
     // Setup liquid handling activity
     const item &base = pt->get_base();
-    const int idx = veh->find_part( base );
+    const int idx = veh->index_of_part( pt );
     item liquid( base.legacy_front() );
     const int liq_charges = liquid.charges;
     if( liquid_handler::handle_liquid( liquid, nullptr, 1, nullptr, veh, idx ) ) {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1988,7 +1988,7 @@ void veh_interact::do_siphon()
         } );
         hide_ui( true );
         const item &base = pt.get_base();
-        const int idx = veh->find_part( base );
+        const int idx = veh->index_of_part( &pt );
         item liquid( base.legacy_front() );
         const int liq_charges = liquid.charges;
         if( liquid_handler::handle_liquid( liquid, nullptr, 1, nullptr, veh, idx ) ) {
@@ -3133,7 +3133,7 @@ void act_vehicle_siphon( vehicle *veh )
     vehicle_part &tank = veh_interact::select_part( *veh, sel, title );
     if( tank ) {
         const item &base = tank.get_base();
-        const int idx = veh->find_part( base );
+        const int idx = veh->index_of_part( &tank );
         item liquid( base.legacy_front() );
         const int liq_charges = liquid.charges;
         if( liquid_handler::handle_liquid( liquid, nullptr, 1, nullptr, veh, idx ) ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -543,8 +543,8 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
         smash( placed_on, 0.5 );
     }
 
-    for( size_t i = 0; i < engines.size(); i++ ) {
-        auto_select_fuel( parts[engines[i]] );
+    for( const int p : engines ) {
+        auto_select_fuel( parts[p] );
     }
 
     invalidate_mass();
@@ -910,8 +910,8 @@ bool vehicle::is_engine_type_on( const vehicle_part &vp, const itype_id &ft ) co
 
 bool vehicle::has_engine_type( const itype_id &ft, const bool enabled ) const
 {
-    for( size_t e = 0; e < engines.size(); ++e ) {
-        const vehicle_part &vp = parts[engines[e]];
+    for( const int p : engines ) {
+        const vehicle_part &vp = parts[p];
         if( is_engine_type( vp, ft ) && ( !enabled || is_engine_on( vp ) ) ) {
             return true;
         }
@@ -920,8 +920,8 @@ bool vehicle::has_engine_type( const itype_id &ft, const bool enabled ) const
 }
 bool vehicle::has_engine_type_not( const itype_id &ft, const bool enabled ) const
 {
-    for( size_t e = 0; e < engines.size(); ++e ) {
-        const vehicle_part &vp = parts[engines[e]];
+    for( const int p : engines ) {
+        const vehicle_part &vp = parts[p];
         if( !is_engine_type( vp, ft ) && ( !enabled || is_engine_on( vp ) ) ) {
             return true;
         }
@@ -940,8 +940,9 @@ bool vehicle::has_engine_conflict( const vpart_info *possible_conflict,
 
     bool has_conflict = false;
 
-    for( int engine : engines ) {
-        std::vector<std::string> install_excludes = part_info( engine ).engine_excludes();
+    for( const int p : engines ) {
+        const vehicle_part &vp = parts[p];
+        std::vector<std::string> install_excludes = vp.info().engine_excludes();
         std::vector<std::string> conflicts;
         std::set_intersection( new_excludes.begin(), new_excludes.end(), install_excludes.begin(),
                                install_excludes.end(), back_inserter( conflicts ) );
@@ -2117,10 +2118,9 @@ bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts,
         here.dirty_vehicle_list.insert( this );
         part_removal_cleanup();
         new_vehicle->enable_refresh();
-        for( int idx : new_vehicle->engines ) {
-            if( !new_vehicle->parts[idx].is_broken() ) {
-                new_vehicle->parts[idx].enabled = true;
-            }
+        for( const int p : new_vehicle->engines ) {
+            vehicle_part &vp = new_vehicle->parts[p];
+            vp.enabled = !vp.is_broken();
         }
         here.invalidate_map_cache( here.get_abs_sub().z() );
         here.rebuild_vehicle_level_caches();
@@ -3475,8 +3475,7 @@ units::power vehicle::total_power( const bool fueled, const bool safe ) const
     units::power pwr = 0_W;
     int count = 0;
 
-    for( size_t e = 0; e < engines.size(); e++ ) {
-        const int p = engines[e];
+    for( const int p : engines ) {
         const vehicle_part &vp = parts[p];
         if( is_engine_on( vp ) && ( !fueled || engine_fuel_left( vp ) ) ) {
             int m2c = safe ? vp.info().engine_m2c() : 100;
@@ -4571,8 +4570,8 @@ units::power vehicle::engine_fuel_usage( const vehicle_part &vp ) const
 std::map<itype_id, units::power> vehicle::fuel_usage() const
 {
     std::map<itype_id, units::power> ret;
-    for( size_t i = 0; i < engines.size(); i++ ) {
-        const vehicle_part &vp = parts[engines[i]];
+    for( const int p : engines ) {
+        const vehicle_part &vp = parts[p];
         ret[vp.fuel_current()] += engine_fuel_usage( vp );
     }
     return ret;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4741,22 +4741,22 @@ std::pair<int, int> vehicle::connected_battery_power_level() const
     return std::make_pair( remaining_epower, total_epower_capacity );
 }
 
-bool vehicle::start_engine( int e, bool turn_on )
+bool vehicle::start_engine( vehicle_part &vp, bool turn_on )
 {
-    if( parts[engines[e]].enabled == turn_on ) {
+    if( vp.enabled == turn_on ) {
         return false;
     }
     bool res = false;
     if( turn_on ) {
-        toggle_specific_engine( e, true );
+        vp.enabled = true;
         // prevent starting of the faulty engines
-        if( ! start_engine( e ) ) {
-            toggle_specific_engine( e, false );
+        if( !start_engine( vp ) ) {
+            vp.enabled = false;
         } else {
             res = true;
         }
     } else {
-        toggle_specific_engine( e, false );
+        vp.enabled = false;
         res = true;
     }
     return res;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2414,18 +2414,6 @@ item_location vehicle::part_base( int p )
     return item_location( vehicle_cursor( *this, p ), &parts[ p ].base );
 }
 
-int vehicle::find_part( const item &it ) const
-{
-    int index = INT_MIN;
-    for( const vpart_reference &vpr : get_all_parts() ) {
-        if( &vpr.part().base == &it ) {
-            index = vpr.part_index();
-            break;
-        }
-    }
-    return index;
-}
-
 item_group::ItemList vehicle_part::pieces_for_broken_part() const
 {
     const item_group_id &group = info().breaks_into_group;
@@ -3393,11 +3381,6 @@ int vehicle::engine_fuel_left( const int e, bool recurse ) const
         return fuel_left( parts[ engines[ e ] ].fuel_current(), recurse );
     }
     return 0;
-}
-
-itype_id vehicle::engine_fuel_current( int e ) const
-{
-    return parts[ engines[ e ] ].fuel_current();
 }
 
 int vehicle::fuel_capacity( const itype_id &ftype ) const

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -967,9 +967,9 @@ bool vehicle::is_engine_type( const vehicle_part &vp, const itype_id  &ft ) cons
     return vp.ammo_current().is_null() ? vp.fuel_current() == ft : vp.ammo_current() == ft;
 }
 
-bool vehicle::is_combustion_engine_type( const int e ) const
+bool vehicle::is_engine_type_combustion( const vehicle_part &vp ) const
 {
-    return parts[engines[e]].info().has_flag( flag_E_COMBUSTION );
+    return vp.info().has_flag( flag_E_COMBUSTION );
 }
 
 bool vehicle::is_perpetual_type( const vehicle_part &vp ) const
@@ -3837,7 +3837,7 @@ void vehicle::noise_and_smoke( int load, time_duration time )
             cur_stress = std::max( cur_stress, 1.0 );
             double part_noise = cur_stress * part_info( p ).engine_noise_factor();
 
-            if( part_info( p ).has_flag( "E_COMBUSTION" ) ) {
+            if( is_engine_type_combustion( vp ) ) {
                 combustion = true;
                 double health = parts[p].health_percent();
                 if( parts[ p ].has_fault_flag( "ENG_BACKFIRE" ) ) {
@@ -5271,14 +5271,13 @@ int vehicle::discharge_battery( int amount, bool recurse )
     return amount; // non-zero if we weren't able to fulfill demand.
 }
 
-void vehicle::do_engine_damage( size_t e, int strain )
+void vehicle::do_engine_damage( vehicle_part &vp, int strain )
 {
-    vehicle_part &vp = parts[engines[e]];
     strain = std::min( 25, strain );
     if( is_engine_on( vp ) && !is_perpetual_type( vp ) && engine_fuel_left( vp ) &&
         rng( 1, 100 ) < strain ) {
         const int dmg = rng( 0, strain * 4 );
-        damage_direct( get_map(), engines[e], dmg );
+        damage_direct( get_map(), index_of_part( &vp ), dmg );
         if( one_in( 2 ) ) {
             add_msg( _( "Your engine emits a high pitched whine." ) );
         } else {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1825,7 +1825,7 @@ class vehicle
         //returns whether the engine is enabled or not, and has fueltype
         bool is_engine_type_on( int e, const itype_id &ft ) const;
         //returns whether the engine is enabled or not
-        bool is_engine_on( int e ) const;
+        bool is_engine_on( const vehicle_part &vp ) const;
         //returns whether the part is enabled or not
         bool is_part_on( int p ) const;
         //returns whether the engine uses specified fuel type

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1831,7 +1831,7 @@ class vehicle
         //returns whether the engine uses one of specific "combustion" fuel types (gas, diesel and diesel substitutes)
         bool is_engine_type_combustion( const vehicle_part &vp ) const;
         //returns whether the alternator is operational
-        bool is_alternator_on( int a ) const;
+        bool is_alternator_on( const vehicle_part &vp ) const;
         // try to turn engine on or off
         // (tries to start it and toggles it on if successful, shutdown is always a success)
         // returns true if engine status was changed

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -946,7 +946,7 @@ class vehicle
         // Try select any fuel for engine, returns true if some fuel is available
         bool auto_select_fuel( vehicle_part &vp );
         // Attempt to start an engine
-        bool start_engine( int e );
+        bool start_engine( vehicle_part &vp );
         // stop all engines
         void stop_engines();
         // Attempt to start the vehicle's active engines
@@ -1839,7 +1839,7 @@ class vehicle
         // try to turn engine on or off
         // (tries to start it and toggles it on if successful, shutdown is always a success)
         // returns true if engine status was changed
-        bool start_engine( int e, bool turn_on );
+        bool start_engine( vehicle_part &vp, bool turn_on );
         void toggle_specific_part( int p, bool on );
         //true if an engine exists with specified type
         //If enabled true, this engine must be enabled to return true

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1831,7 +1831,7 @@ class vehicle
         //returns whether the engine uses specified fuel type
         bool is_engine_type( const vehicle_part &vp, const itype_id &ft ) const;
         //returns whether the engine uses one of specific "combustion" fuel types (gas, diesel and diesel substitutes)
-        bool is_combustion_engine_type( int e ) const;
+        bool is_engine_type_combustion( const vehicle_part &vp ) const;
         //returns whether the alternator is operational
         bool is_alternator_on( int a ) const;
         //turn engine as on or off (note: doesn't perform checks if engine can start)
@@ -1854,7 +1854,7 @@ class vehicle
         //returns true if the engine doesn't consume fuel
         bool is_perpetual_type( const vehicle_part &vp ) const;
         //if necessary, damage this engine
-        void do_engine_damage( size_t e, int strain );
+        void do_engine_damage( vehicle_part &vp, int strain );
         //remotely open/close doors
         void control_doors();
         // return a vector w/ 'direction' & 'magnitude', in its own sense of the words.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -787,10 +787,10 @@ class vehicle
                                    bool verbose = false, bool desc = false );
 
         // Calculate how long it takes to attempt to start an engine
-        int engine_start_time( int e ) const;
+        int engine_start_time( const vehicle_part &vp ) const;
 
         // How much does the temperature effect the engine starting (0.0 - 1.0)
-        double engine_cold_factor( int e ) const;
+        double engine_cold_factor( const vehicle_part &vp ) const;
 
         // refresh pivot_cache, clear pivot_dirty
         void refresh_pivot() const;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1040,9 +1040,6 @@ class vehicle
         /** Get handle for base item of part */
         item_location part_base( int p );
 
-        /** Get index of part with matching base item or INT_MIN if not found */
-        int find_part( const item &it ) const;
-
         /**
          * Remove a part from a targeted remote vehicle. Useful for, e.g. power cables that have
          * a vehicle part on both sides.
@@ -1275,8 +1272,6 @@ class vehicle
         const;
         // Checks how much of an engine's current fuel is left in the tanks.
         int engine_fuel_left( int e, bool recurse = false ) const;
-        // Returns what type of fuel an engine uses
-        itype_id engine_fuel_current( int e ) const;
         // Returns total vehicle fuel capacity for the given fuel type
         int fuel_capacity( const itype_id &ftype ) const;
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -766,7 +766,7 @@ class vehicle
         //damages vehicle controls and security system
         void smash_security_system();
         // get vpart powerinfo for part number, accounting for variable-sized parts and hps.
-        units::power part_vpower_w( int index, bool at_full_hp = false ) const;
+        units::power part_vpower_w( const vehicle_part &vp, bool at_full_hp = false ) const;
 
         // Get part power consumption/production for part number.
         units::power part_epower( int index ) const;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -769,7 +769,7 @@ class vehicle
         units::power part_vpower_w( const vehicle_part &vp, bool at_full_hp = false ) const;
 
         // Get part power consumption/production for part number.
-        units::power part_epower( int index ) const;
+        units::power part_epower( const vehicle_part &vp ) const;
 
         // convert watts over time to battery energy (kJ)
         int power_to_energy_bat( units::power power, const time_duration &d ) const;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1826,21 +1826,16 @@ class vehicle
         bool is_engine_type_on( const vehicle_part &vp, const itype_id &ft ) const;
         //returns whether the engine is enabled or not
         bool is_engine_on( const vehicle_part &vp ) const;
-        //returns whether the part is enabled or not
-        bool is_part_on( int p ) const;
         //returns whether the engine uses specified fuel type
         bool is_engine_type( const vehicle_part &vp, const itype_id &ft ) const;
         //returns whether the engine uses one of specific "combustion" fuel types (gas, diesel and diesel substitutes)
         bool is_engine_type_combustion( const vehicle_part &vp ) const;
         //returns whether the alternator is operational
         bool is_alternator_on( int a ) const;
-        //turn engine as on or off (note: doesn't perform checks if engine can start)
-        void toggle_specific_engine( int e, bool on );
         // try to turn engine on or off
         // (tries to start it and toggles it on if successful, shutdown is always a success)
         // returns true if engine status was changed
         bool start_engine( vehicle_part &vp, bool turn_on );
-        void toggle_specific_part( int p, bool on );
         //true if an engine exists with specified type
         //If enabled true, this engine must be enabled to return true
         bool has_engine_type( const itype_id &ft, bool enabled ) const;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1823,13 +1823,13 @@ class vehicle
         //main method for the control of individual engines
         void control_engines();
         //returns whether the engine is enabled or not, and has fueltype
-        bool is_engine_type_on( int e, const itype_id &ft ) const;
+        bool is_engine_type_on( const vehicle_part &vp, const itype_id &ft ) const;
         //returns whether the engine is enabled or not
         bool is_engine_on( const vehicle_part &vp ) const;
         //returns whether the part is enabled or not
         bool is_part_on( int p ) const;
         //returns whether the engine uses specified fuel type
-        bool is_engine_type( int e, const itype_id &ft ) const;
+        bool is_engine_type( const vehicle_part &vp, const itype_id &ft ) const;
         //returns whether the engine uses one of specific "combustion" fuel types (gas, diesel and diesel substitutes)
         bool is_combustion_engine_type( int e ) const;
         //returns whether the alternator is operational

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -944,7 +944,7 @@ class vehicle
         void connect( const tripoint &source_pos, const tripoint &target_pos );
 
         // Try select any fuel for engine, returns true if some fuel is available
-        bool auto_select_fuel( int e );
+        bool auto_select_fuel( vehicle_part &vp );
         // Attempt to start an engine
         bool start_engine( int e );
         // stop all engines
@@ -1271,7 +1271,7 @@ class vehicle
                            const std::function<bool( const vehicle_part & )> &filter = return_true<const vehicle_part &> )
         const;
         // Checks how much of an engine's current fuel is left in the tanks.
-        int engine_fuel_left( int e, bool recurse = false ) const;
+        int engine_fuel_left( const vehicle_part &vp, bool recurse = false ) const;
         // Returns total vehicle fuel capacity for the given fuel type
         int fuel_capacity( const itype_id &ftype ) const;
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -787,7 +787,7 @@ class vehicle
                                    bool verbose = false, bool desc = false );
 
         // Calculate how long it takes to attempt to start an engine
-        int engine_start_time( const vehicle_part &vp ) const;
+        time_duration engine_start_time( const vehicle_part &vp ) const;
 
         // How much does the temperature effect the engine starting (0.0 - 1.0)
         double engine_cold_factor( const vehicle_part &vp ) const;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -953,7 +953,7 @@ class vehicle
         void start_engines( bool take_control = false, bool autodrive = false );
 
         // Engine backfire, making a loud noise
-        void backfire( int e ) const;
+        void backfire( const vehicle_part &vp ) const;
 
         // get vpart type info for part number (part at given vector index)
         const vpart_info &part_info( int index, bool include_removed = false ) const;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1304,7 +1304,7 @@ class vehicle
         * Fuel usage for specific engine
         * @param e is the index of the engine in the engines array
         */
-        units::power engine_fuel_usage( int e ) const;
+        units::power engine_fuel_usage( const vehicle_part &vp ) const;
         /**
          * Get all vehicle lights (excluding any that are destroyed)
          * @param active if true return only lights which are enabled
@@ -1852,7 +1852,7 @@ class vehicle
         //the exclusion
         bool has_engine_conflict( const vpart_info *possible_conflict, std::string &conflict_type ) const;
         //returns true if the engine doesn't consume fuel
-        bool is_perpetual_type( int e ) const;
+        bool is_perpetual_type( const vehicle_part &vp ) const;
         //if necessary, damage this engine
         void do_engine_damage( size_t e, int strain );
         //remotely open/close doors

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -373,7 +373,7 @@ void vehicle::print_fuel_indicators( const catacurses::window &win, const point 
             const vehicle_part &vp = parts[engines[e]];
             // if only one display, print the first engine that's on and consumes power
             if( is_engine_on( vp ) &&
-                !( is_perpetual_type( e ) || is_engine_type( e, fuel_type_muscle ) ) ) {
+                !( is_perpetual_type( e ) || is_engine_type( vp, fuel_type_muscle ) ) ) {
                 print_fuel_indicator( win, p, vp.fuel_current(), verbose, desc );
                 return;
             }

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -370,11 +370,11 @@ void vehicle::print_fuel_indicators( const catacurses::window &win, const point 
     }
     if( !fullsize ) {
         for( size_t e = 0; e < engines.size(); e++ ) {
+            const vehicle_part &vp = parts[engines[e]];
             // if only one display, print the first engine that's on and consumes power
-            if( is_engine_on( e ) &&
+            if( is_engine_on( vp ) &&
                 !( is_perpetual_type( e ) || is_engine_type( e, fuel_type_muscle ) ) ) {
-                print_fuel_indicator( win, p, parts[ engines [ e ] ].fuel_current(), verbose,
-                                      desc );
+                print_fuel_indicator( win, p, vp.fuel_current(), verbose, desc );
                 return;
             }
         }

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -369,11 +369,10 @@ void vehicle::print_fuel_indicators( const catacurses::window &win, const point 
         return;
     }
     if( !fullsize ) {
-        for( size_t e = 0; e < engines.size(); e++ ) {
-            const vehicle_part &vp = parts[engines[e]];
+        for( const int part_idx : engines ) {
+            const vehicle_part &vp = parts[part_idx];
             // if only one display, print the first engine that's on and consumes power
-            if( is_engine_on( vp ) &&
-                !( is_perpetual_type( e ) || is_engine_type( vp, fuel_type_muscle ) ) ) {
+            if( is_engine_on( vp ) && !is_perpetual_type( vp ) && !is_engine_type( vp, fuel_type_muscle ) ) {
                 print_fuel_indicator( win, p, vp.fuel_current(), verbose, desc );
                 return;
             }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -249,7 +249,7 @@ void vehicle::smart_controller_handle_turn( bool thrusting,
         if( is_engine_on( vp ) ) {
             const bool is_electric = is_engine_type( vp, fuel_type_battery );
             prev_mask |= 1 << i;
-            units::power fu = engine_fuel_usage( c_engines[i] ) * ( cur_load_approx + ( is_electric ? 0 :
+            units::power fu = engine_fuel_usage( vp ) * ( cur_load_approx + ( is_electric ? 0 :
                               cur_load_alternator ) );
             opt_fuel_usage += fu;
             if( is_electric ) {
@@ -330,7 +330,7 @@ void vehicle::smart_controller_handle_turn( bool thrusting,
         for( int e : c_engines ) {
             const vehicle_part &vp = parts[engines[e]];
             const bool is_electric = is_engine_type( vp, fuel_type_battery );
-            units::power fu = engine_fuel_usage( e ) * ( load_approx + ( is_electric ? 0 :
+            units::power fu = engine_fuel_usage( vp ) * ( load_approx + ( is_electric ? 0 :
                               load_approx_alternator ) );
             fuel_usage += fu;
             if( is_electric ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -376,10 +376,10 @@ void vehicle::smart_controller_handle_turn( bool thrusting,
         bool failed_to_start = false;
         bool turned_on_gas_engine = false;
         for( size_t i = 0; i < c_engines.size(); ++i ) {
-            const vehicle_part &vp = parts[engines[c_engines[i]]];
+            vehicle_part &vp = parts[engines[c_engines[i]]];
             // ..0.. < ..1..  was off, new state on
             if( ( prev_mask & ( 1 << i ) ) < ( opt_mask & ( 1 << i ) ) ) {
-                if( !start_engine( c_engines[i], true ) ) {
+                if( !start_engine( vp, true ) ) {
                     failed_to_start = true;
                 }
                 turned_on_gas_engine |= !is_engine_type( vp, fuel_type_battery );
@@ -402,9 +402,10 @@ void vehicle::smart_controller_handle_turn( bool thrusting,
 
         } else {  //successfully changed engines state
             for( size_t i = 0; i < c_engines.size(); ++i ) {
+                vehicle_part &vp = parts[engines[c_engines[i]]];
                 // was on, needs to be off
                 if( ( prev_mask & ( 1 << i ) ) > ( opt_mask & ( 1 << i ) ) ) {
-                    start_engine( c_engines[i], false );
+                    start_engine( vp, false );
                 }
             }
             if( turned_on_gas_engine ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -145,9 +145,8 @@ void vehicle::smart_controller_handle_turn( bool thrusting,
     for( int i = 0; i < static_cast<int>( engines.size() ); ++i ) {
         const vehicle_part &vp = parts[engines[i]];
         const bool is_electric = is_engine_type( vp, fuel_type_battery );
-        if( ( is_electric || is_combustion_engine_type( i ) ) &&
-            ( ( vp.is_available() && engine_fuel_left( vp ) ) ||
-              is_part_on( engines[ i ] ) ) ) {
+        if( ( is_electric || is_engine_type_combustion( vp ) ) &&
+            ( ( vp.is_available() && engine_fuel_left( vp ) ) || vp.enabled ) ) {
             c_engines.push_back( i );
             if( is_electric ) {
                 has_electric_engine = true;
@@ -563,9 +562,9 @@ void vehicle::thrust( int thd, int z )
             requested_z_change = z;
         }
         //break the engines a bit, if going too fast.
-        int strn = static_cast<int>( strain() * strain() * 100 );
-        for( size_t e = 0; e < engines.size(); e++ ) {
-            do_engine_damage( e, strn );
+        const int strn = static_cast<int>( strain() * strain() * 100 );
+        for( const int p : engines ) {
+            do_engine_damage( parts[p], strn );
         }
     }
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -143,9 +143,10 @@ void vehicle::smart_controller_handle_turn( bool thrusting,
     std::vector<int> c_engines;
     bool has_electric_engine = false;
     for( int i = 0; i < static_cast<int>( engines.size() ); ++i ) {
+        const vehicle_part &vp = parts[engines[i]];
         const bool is_electric = is_engine_type( i, fuel_type_battery );
         if( ( is_electric || is_combustion_engine_type( i ) ) &&
-            ( ( parts[ engines[ i ] ].is_available() && engine_fuel_left( i ) > 0 ) ||
+            ( ( vp.is_available() && engine_fuel_left( vp ) ) ||
               is_part_on( engines[ i ] ) ) ) {
             c_engines.push_back( i );
             if( is_electric ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -245,7 +245,8 @@ void vehicle::smart_controller_handle_turn( bool thrusting,
     float cur_load_alternator = std::min( 0.01f, static_cast<float>( alternator_load ) / 1000 );
 
     for( size_t i = 0; i < c_engines.size(); ++i ) {
-        if( is_engine_on( c_engines[i] ) ) {
+        const vehicle_part &vp = parts[c_engines[i]];
+        if( is_engine_on( vp ) ) {
             bool is_electric = is_engine_type( c_engines[i], fuel_type_battery );
             prev_mask |= 1 << i;
             units::power fu = engine_fuel_usage( c_engines[i] ) * ( cur_load_approx + ( is_electric ? 0 :

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -303,11 +303,11 @@ void vehicle::smart_controller_handle_turn( bool thrusting,
 
         bool gas_engine_to_shut_down = false;
         for( size_t i = 0; i < c_engines.size(); ++i ) {
-            const vehicle_part &vp = parts[engines[c_engines[i]]];
+            vehicle_part &vp = parts[engines[c_engines[i]]];
             bool old_state = ( prev_mask & ( 1 << i ) ) != 0;
             bool new_state = ( mask & ( 1 << i ) ) != 0;
             // switching enabled flag temporarily to perform calculations below
-            toggle_specific_engine( c_engines[i], new_state );
+            vp.enabled = new_state;
 
             if( old_state && !new_state && !is_engine_type( vp, fuel_type_battery ) ) {
                 gas_engine_to_shut_down = true;
@@ -369,7 +369,8 @@ void vehicle::smart_controller_handle_turn( bool thrusting,
     }
 
     for( size_t i = 0; i < c_engines.size(); ++i ) { // return to prev state
-        toggle_specific_engine( c_engines[i], static_cast<bool>( prev_mask & ( 1 << i ) ) );
+        vehicle_part &vp = parts[engines[c_engines[i]]];
+        vp.enabled = static_cast<bool>( prev_mask & ( 1 << i ) );
     }
 
     if( opt_mask != prev_mask ) { // we found new configuration
@@ -389,7 +390,8 @@ void vehicle::smart_controller_handle_turn( bool thrusting,
             this->smart_controller_state = cata::nullopt;
 
             for( size_t i = 0; i < c_engines.size(); ++i ) { // return to prev state
-                toggle_specific_engine( c_engines[i], static_cast<bool>( prev_mask & ( 1 << i ) ) );
+                vehicle_part &vp = parts[engines[c_engines[i]]];
+                vp.enabled = static_cast<bool>( prev_mask & ( 1 << i ) );
             }
             for( const vpart_reference &vp : get_avail_parts( "SMART_ENGINE_CONTROLLER" ) ) {
                 vp.part().enabled = false;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -646,7 +646,7 @@ bool vehicle::start_engine( const int e )
     if( einfo.engine_backfire_threshold() ) {
         if( ( 1 - dmg ) < einfo.engine_backfire_threshold() &&
             one_in( einfo.engine_backfire_freq() ) ) {
-            backfire( e );
+            backfire( eng );
         } else {
             sounds::sound( pos, start_moves / 10, sounds::sound_t::movement,
                            string_format( _( "the %s bang as it starts!" ), eng.name() ), true, "vehicle",

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -586,7 +586,7 @@ int vehicle::engine_start_time( const vehicle_part &vp ) const
 
     // divided by magic 16 = watts / 6000
     const double watts_per_time = 6000;
-    const double engine_watts = units::to_watt( part_vpower_w( index_of_part( &vp ), true ) );
+    const double engine_watts = units::to_watt( part_vpower_w( vp, true ) );
     return engine_watts / watts_per_time + 100 * dmg + cold;
 }
 

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -342,8 +342,8 @@ void vehicle::control_engines()
             const int engine_idx = engines[e];
             const vehicle_part &vp = parts[engine_idx];
             for( const itype_id &fuel_type : vp.info().engine_fuel_opts() ) {
-                bool is_active = vp.enabled && vp.fuel_current() == fuel_type;
-                bool has_fuel = is_perpetual_type( e ) || fuel_left( fuel_type );
+                const bool is_active = vp.enabled && vp.fuel_current() == fuel_type;
+                const bool has_fuel = is_perpetual_type( vp ) || fuel_left( fuel_type );
                 menu.add( string_format( "[%s] %s %s", is_active ? "x" : " ", vp.name(), fuel_type->nname( 1 ) ) )
                 .enable( vp.is_available() && has_fuel )
                 .keep_menu_open()

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -351,7 +351,7 @@ void vehicle::control_engines()
                     vehicle_part &vp = parts[engine_idx];
                     if( vp.fuel_current() == fuel_type )
                     {
-                        toggle_specific_part( engine_idx, !is_part_on( engine_idx ) );
+                        vp.enabled = !vp.enabled;
                     } else
                     {
                         vp.fuel_set( fuel_type );
@@ -367,8 +367,9 @@ void vehicle::control_engines()
     }
 
     bool engines_were_on = engine_on;
-    for( int e : engines ) {
-        engine_on |= is_part_on( e );
+    for( const int p : engines ) {
+        const vehicle_part &vp = parts[p];
+        engine_on |= vp.enabled;
     }
 
     // if current velocity greater than new configuration safe speed

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -638,7 +638,7 @@ bool vehicle::start_engine( const int e )
     }
 
     const double dmg = eng.damage_percent();
-    const units::power engine_power = -part_epower( engines[e] );
+    const units::power engine_power = -part_epower( eng );
     const double cold_factor = engine_cold_factor( eng );
     const int start_moves = engine_start_time( eng );
     const tripoint pos = global_part_pos3( eng );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -609,9 +609,8 @@ bool vehicle::auto_select_fuel( vehicle_part &vp )
     return false; // not a single fuel type left for this engine
 }
 
-bool vehicle::start_engine( const int e )
+bool vehicle::start_engine( vehicle_part &eng )
 {
-    vehicle_part &eng = parts[engines[e]];
     const vpart_info &einfo = eng.info();
     if( !is_engine_on( eng ) ) {
         return false;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -690,7 +690,7 @@ bool vehicle::start_engine( const int e )
     }
 
     // Damaged non-electric engines have a chance of failing to start
-    if( !is_engine_type( e, fuel_type_battery ) && einfo.fuel_type != fuel_type_muscle &&
+    if( !is_engine_type( eng, fuel_type_battery ) && einfo.fuel_type != fuel_type_muscle &&
         x_in_y( dmg * 100, 120 ) ) {
         sounds::sound( pos, einfo.engine_noise_factor(), sounds::sound_t::movement,
                        string_format( _( "the %s clanking and grinding." ), eng.name() ), true, "vehicle",
@@ -704,9 +704,9 @@ bool vehicle::start_engine( const int e )
         sfx::play_variant_sound( "engine_start", einfo.get_id().str(), einfo.engine_noise_factor() );
     } else if( einfo.fuel_type == fuel_type_muscle ) {
         sfx::play_variant_sound( "engine_start", "muscle", einfo.engine_noise_factor() );
-    } else if( is_engine_type( e, fuel_type_wind ) ) {
+    } else if( is_engine_type( eng, fuel_type_wind ) ) {
         sfx::play_variant_sound( "engine_start", "wind", einfo.engine_noise_factor() );
-    } else if( is_engine_type( e, fuel_type_battery ) ) {
+    } else if( is_engine_type( eng, fuel_type_battery ) ) {
         sfx::play_variant_sound( "engine_start", "electric", einfo.engine_noise_factor() );
     } else {
         sfx::play_variant_sound( "engine_start", "combustion", einfo.engine_noise_factor() );
@@ -732,11 +732,11 @@ void vehicle::stop_engines()
 
         if( sfx::has_variant_sound( "engine_stop", variant ) ) {
             // has special sound variant for this vpart id
-        } else if( is_engine_type( e, fuel_type_battery ) ) {
+        } else if( is_engine_type( epart, fuel_type_battery ) ) {
             variant = "electric";
-        } else if( is_engine_type( e, fuel_type_muscle ) ) {
+        } else if( is_engine_type( epart, fuel_type_muscle ) ) {
             variant = "muscle";
-        } else if( is_engine_type( e, fuel_type_wind ) ) {
+        } else if( is_engine_type( epart, fuel_type_wind ) ) {
             variant = "wind";
         } else {
             variant = "combustion";

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -60,7 +60,7 @@ static vehicle *setup_drag_test( const vproto_id &veh_id )
     // turn everything on
     for( const vpart_reference &vp : veh_ptr->get_all_parts() ) {
         veh_ptr->get_items( vp.part_index() ).clear();
-        veh_ptr->toggle_specific_part( vp.part_index(), true );
+        vp.part().enabled = true;
     }
     // close the doors
     const auto doors = veh_ptr->get_avail_parts( "OPENABLE" );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -119,14 +119,14 @@ TEST_CASE( "starting_bicycle_damaged_pedal", "[vehicle]" )
         veh_ptr->set_hp( pedel, pedel.hp() * 0.25, true );
         // Try starting the engine 100 time because it is random that a combustion engine does fails
         for( int i = 0; i < 100 ; i++ ) {
-            CHECK( veh_ptr->start_engine( 0 ) );
+            CHECK( veh_ptr->start_engine( pedel ) );
         }
     }
 
     SECTION( "when the pedal has 0 hp" ) {
         veh_ptr->set_hp( pedel, 0, true );
 
-        CHECK_FALSE( veh_ptr->start_engine( 0 ) );
+        CHECK_FALSE( veh_ptr->start_engine( pedel ) );
     }
 
     here.detach_vehicle( veh_ptr );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix engine functions being super annoying to work with; instead of using vehicle_part& or an index into parts array they instead use an index into engines array to index into parts array to fetch the vehicle_part&

#### Describe the solution

Refactor to make engine functions a vehicle_part& directly - after this PR no code should need to pass around indexes into engines array

Probably fixed [some bugs](https://github.com/CleverRaven/Cataclysm-DDA/blob/6d664e17d9ad37bedf3d4623eed1098f4824745c/src/vehicle.cpp#L3482), may be added new ones...

Most code that touches engines is now on happy path of references, except smart controller, which probably needs a separate cleaning PR since it sports triple indirections via yet another array that indexes into engines array that indexes... you get the idea, and bitmasking which indexes out of that new array are used...

There's tiny bit of overlap between commits where I added some lines and then remove them next commit mostly to make each commit compile-able

Removes a bunch of odd and a few no longer needed functions (diff vehicle.h across all commits to see which)

#### Describe alternatives you've considered

Trying to solve some of the engine issues while screaming at these functions

#### Testing

Tests should catch a bunch (most) of changes, there should be no player facing changes

#### Additional context
