### PR TITLE
Fixed autoforage doesn't work on furniture with `harvest_furn_nectar` examine function

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2330,7 +2330,7 @@ static bool query_pick( Character &who, const tripoint &target )
 void iexamine::harvest_furn_nectar( Character &you, const tripoint &examp )
 {
     bool auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
-                       get_option<std::string>( "AUTO_FORAGING" ) == "both";
+                       get_option<std::string>( "AUTO_FORAGING" ) == "all";
     if( !auto_forage && !query_pick( you, examp ) ) {
         return;
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Fixed autoforage doesn't work on furniture with `harvest_furn_nectar` examine function"

#### Purpose of change
Fix autoforage not working on furniture with `harvest_furn_nectar` examine function.

#### Describe the solution
In #52207 option value name was changed from `both` to `all` in all forage examine function, except for `harvest_furn_nectar`. Changed option value name in this function too.

#### Describe alternatives you've considered
None.

#### Testing
Turned autoforage on. Set its parameter to `Everything`. Walked adjacent to Japanese knotweed, which has `harvest_furn_nectar` examine function. My character successfully and automatically harvested the plant.

#### Additional context
None.