### PR TITLE
Don't use `cruise_thrust()` on towed vehicles

### DIFF
--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1310,7 +1310,7 @@ void vehicle::selfdrive( const point &p )
     }
     if( p.y != 0 ) {
         int thr_amount = 100 * ( std::abs( velocity ) < 2000 ? 4 : 5 );
-        if( cruise_on ) {
+        if( cruise_on && !is_towed() ) {
             cruise_thrust( -p.y * thr_amount );
         } else {
             thrust( -p.y );


### PR DESCRIPTION
#### Summary
Bugfixes "Don't use `cruise_thrust()` on towed vehicles"

#### Purpose of change
Fix towed vehicles getting their cruise velocity set to ridiculous values, as reported in #51228:

> When taking control of a formerly towed vehicle it tends to start out with a silly speed set, such as a value in the hundreds, rather than the expected 0.

(H/T @PatrikLundell)

#### Describe the solution
Towed vehicles utilize `vehicle::selfdrive()`.
In `vehicle::selfdrive()` check for a towed vehicle in which case set `thrust()` rather than `cruise_thrust()`

#### Describe alternatives you've considered
Towing code could use some work, but this will have to do for now to clear a blocker for #64056

#### Testing
Debug spawn a tow cable and a couple of vehicles of appropriate size -- I picked a road roller and a beetle -- towed the latter with the former, then check that cruise velocity of the latter is zero and not some unexpected number.