### PR TITLE
[Magiclysm] Make the Crusader attunement's Sword of Judgement sheathable

### DIFF
--- a/data/mods/Magiclysm/Spells/attunements/Crusader.json
+++ b/data/mods/Magiclysm/Spells/attunements/Crusader.json
@@ -117,7 +117,7 @@
     "material": [ "concentrated_mana" ],
     "weapon_category": [ "MEDIEVAL_SWORDS", "LONG_SWORDS", "GREAT_SWORDS" ],
     "techniques": [ "RSTRIKE", "WBLOCK_2", "BRUTAL", "RAPID" ],
-    "flags": [ "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_AVOID" ],
+    "flags": [ "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_AVOID", "SHEATH_SWORD" ],
     "weight": "1067 g",
     "volume": "2750 ml",
     "longest_side": "120cm",
@@ -131,7 +131,8 @@
         "target": "dagger_judgement",
         "msg": "Concentrating, you change your sword into a much smaller, quicker blade.",
         "menu_text": "Transform to dagger.",
-        "type": "transform"
+        "type": "transform",
+        "need_wielding": true
       }
     ]
   },
@@ -143,7 +144,7 @@
     "color": "light_gray",
     "looks_like": "kris",
     "description": "A short blade made of glowing, radiant fire.  It explodes with radiance when striking enemies.",
-    "flags": [ "STAB", "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_AVOID" ],
+    "flags": [ "STAB", "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_AVOID", "SHEATH_KNIFE" ],
     "weight": "328 g",
     "volume": "750 ml",
     "longest_side": "50 cm",
@@ -160,7 +161,8 @@
         "target": "zwei_judgement",
         "msg": "Concentrating, you change your dagger into a much larger, more intimidating form.",
         "menu_text": "Transform to great sword.",
-        "type": "transform"
+        "type": "transform",
+        "need_wielding": true
       }
     ]
   },
@@ -180,7 +182,8 @@
       "NO_REPAIR",
       "NO_SALVAGE",
       "MAGIC_FOCUS",
-      "TRADER_AVOID"
+      "TRADER_AVOID",
+      "SHEATH_SWORD" 
     ],
     "weight": "1868 g",
     "volume": "3250 ml",
@@ -198,7 +201,8 @@
         "target": "qiang_judgement",
         "msg": "Concentrating, you change your dagger into a longer, much more precise piercing form.",
         "menu_text": "Transform into spear.",
-        "type": "transform"
+        "type": "transform",
+        "need_wielding": true
       }
     ]
   },
@@ -218,7 +222,8 @@
       "NO_REPAIR",
       "NO_SALVAGE",
       "MAGIC_FOCUS",
-      "TRADER_AVOID"
+      "TRADER_AVOID",
+      "SHEATH_SPEAR"
     ],
     "bashing": 7,
     "cutting": 34,
@@ -236,7 +241,8 @@
         "target": "mace_judgement",
         "msg": "Concentrating, you change your spear into a shorter, more hefty form.",
         "menu_text": "Transform to mace.",
-        "type": "transform"
+        "type": "transform",
+        "need_wielding": true
       }
     ]
   },
@@ -248,7 +254,7 @@
     "color": "light_gray",
     "looks_like": "mace",
     "description": "A short and hefty mace glowing with radiant fire.  It explodes with radiance when striking enemies.",
-    "flags": [ "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_AVOID" ],
+    "flags": [ "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_AVOID", "BELT_CLIP" ],
     "bashing": 45,
     "weight": "882 g",
     "volume": "1250 ml",
@@ -264,7 +270,8 @@
         "target": "longsword_judgement",
         "msg": "Concentrating, you change your spear into a shorter, more robust blade.",
         "menu_text": "Transform to longsword.",
-        "type": "transform"
+        "type": "transform",
+        "need_wielding": true
       }
     ]
   }

--- a/data/mods/Magiclysm/Spells/attunements/Crusader.json
+++ b/data/mods/Magiclysm/Spells/attunements/Crusader.json
@@ -144,7 +144,16 @@
     "color": "light_gray",
     "looks_like": "kris",
     "description": "A short blade made of glowing, radiant fire.  It explodes with radiance when striking enemies.",
-    "flags": [ "STAB", "UNBREAKABLE_MELEE", "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_AVOID", "SHEATH_KNIFE" ],
+    "flags": [
+      "STAB",
+      "UNBREAKABLE_MELEE",
+      "NONCONDUCTIVE",
+      "NO_REPAIR",
+      "NO_SALVAGE",
+      "MAGIC_FOCUS",
+      "TRADER_AVOID",
+      "SHEATH_KNIFE"
+    ],
     "weight": "328 g",
     "volume": "750 ml",
     "longest_side": "50 cm",

--- a/data/mods/Magiclysm/Spells/attunements/Crusader.json
+++ b/data/mods/Magiclysm/Spells/attunements/Crusader.json
@@ -192,7 +192,7 @@
       "NO_SALVAGE",
       "MAGIC_FOCUS",
       "TRADER_AVOID",
-      "SHEATH_SWORD" 
+      "SHEATH_SWORD"
     ],
     "weight": "1868 g",
     "volume": "3250 ml",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Make the Crusader attunement's Sword of Judgement sheathable"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
None of the forms of the Sword of Judgement could fit into the normal sheaths/holsters for weapons of that type. Most summoned weapons can, so I see no reason this shouldn't be the case for the Sword of Judgement.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added the appropriate flags for the various forms. SHEATH_SWORD for the sword and great sword, SHEATH_KNIFE for for the dagger, SHEATH_SPEAR (spear strap) for qiang, BELT_CLIP for mace.

In order to avoid problems with transforming the weapon while it's in a sheath that can't hold its new form, I made the activations require wielding. This is probably a necessary change anyway, because it's already possible to put e.g. the dagger form in a bag and then transform it into a zweihander too big for the bag.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Made sure the various forms fit into appropriate holsters and can't be transformed while holstered or otherwise stored.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Due to #64198, some of the forms can go in nonsensical places, but it seems that by coincidence they still fit in the correct sheathes due to weight and volume. The sword of judgement (longsword sized) needs a baldric or back scabbard, great sword needs a back scabbard, dagger (kukri-ish) fits in a sheath but not an ankle sheath, etc.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
