### PR TITLE
Update `cac2powder` recipe due to coal stat changes

### DIFF
--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -1817,11 +1817,11 @@
     "autolearn": true,
     "qualities": [ { "id": "FINE_GRIND", "level": 1 } ],
     "//0": "Ultimately, cac2powder premix feeds into CaO + 3 C -> CaC2 + CO",
-    "//1": "105g quicklime = 1.8724 moles of CaO (1.8724×3 = 5.6172)",
-    "//2": "75g anthracite coal @ ~90% carbon = 5.620 moles C",
-    "//3": "If no losses, this mix is equivalent to 1.8724 moles of CaC2; but make this grinding process a bit lossy",
+    "//1": "7×15g quicklime = 1.8724 moles of CaO",
+    "//2": "80×931mg anthracite coal @ ~90% carbon = 5.5809 moles C (5.5809/3 = 1.8603)",
+    "//3": "If no losses, this mix is equivalent to 1.86 moles of CaC2; but make this grinding process a bit lossy",
     "charges": 175,
-    "components": [ [ [ "coal_lump", 2 ] ], [ [ "material_quicklime", 7 ] ] ]
+    "components": [ [ [ "coal_lump", 80 ], [ "charcoal", 80 ] ], [ [ "material_quicklime", 7 ] ] ]
   },
   {
     "result": "chem_carbide",


### PR DESCRIPTION
#### Summary
Bugfixes "Update `cac2powder` recipe due to coal stat changes"

#### Purpose of change
Bring #63392 up to date with coal stats changes in #62180

#### Describe the solution
Redo math. Instead of 2×37.5g pieces of coal it will now require 80×931mg.
Add charcoal at parity to coal as source of elemental carbon. This treats `coal_lump` as anthracite coal with 90% carbon content.  
For `charcoal`, picked a fairly generous value of \~80.56% for convenience of 1-for-1 substitution for coal -- carbon content of wood charcoal can vary drastically, with sources giving a wide range 50\~95%.