### PR TITLE
No double unarmed (beginner)

### DIFF
--- a/data/json/recipes/practice/melee.json
+++ b/data/json/recipes/practice/melee.json
@@ -254,7 +254,7 @@
     "activity_level": "BRISK_EXERCISE",
     "category": "CC_PRACTICE",
     "subcategory": "CSC_PRACTICE_COMBAT",
-    "name": "unarmed (beginner)",
+    "name": "unarmed (intermediate)",
     "description": "Learn how to throw a punch without breaking your wrist or kick without falling over with the help of a punching bag or training dummy.",
     "skill_used": "unarmed",
     "time": "1 h",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

There are two ``unarmed(beginner)`` due to #64197.

#### Describe the solution

Change the intermediate one to say it's intermediate.

#### Describe alternatives you've considered

N/A

#### Testing

Look at description ingame.

#### Additional context
