### PR TITLE
Display remaining weight/volume stats of gear/container when inserting into it

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1585,11 +1585,11 @@ drop_locations game_menus::inv::holster( avatar &you, const item_location &holst
 
     inventory_holster_preset holster_preset( holster, &get_avatar() );
 
-    inventory_drop_selector insert_menu( you, holster_preset, _( "ITEMS TO INSERT" ),
-                                         /*warn_liquid=*/false );
+    inventory_insert_selector insert_menu( you, holster_preset, _( "ITEMS TO INSERT" ),
+                                           /*warn_liquid=*/false );
     insert_menu.add_character_items( you );
     insert_menu.add_nearby_items( 1 );
-    insert_menu.set_display_stats( false );
+    insert_menu.set_display_stats( true );
 
     insert_menu.set_title( title );
     insert_menu.set_hint( hint );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -793,6 +793,11 @@ std::string inventory_selector_preset::cell_t::get_text( const inventory_entry &
     return replace_colors( func( entry ) );
 }
 
+const item_location &inventory_holster_preset::get_holster() const
+{
+    return holster;
+}
+
 bool inventory_holster_preset::is_shown( const item_location &contained ) const
 {
     if( contained == holster ) {
@@ -2353,54 +2358,64 @@ inventory_selector::stat display_stat( const std::string &caption, int cur_value
         }};
 }
 
-inventory_selector::stats inventory_selector::get_weight_and_volume_stats(
+inventory_selector::stat inventory_selector::get_weight_and_length_stat(
     units::mass weight_carried, units::mass weight_capacity,
-    const units::volume &volume_carried, const units::volume &volume_capacity,
-    const units::length &longest_length, const units::volume &largest_free_volume,
-    const units::volume &holster_volume, const int used_holsters, const int total_holsters )
+    const units::length &longest_length )
 {
-    // This is a bit of a hack, we're prepending two entries to the weight and length stat blocks.
     std::string length_weight_caption = string_format( _( "Longest Length (%s): %s Weight (%s):" ),
-                                        length_units( longest_length ),
-                                        colorize( std::to_string( convert_length( longest_length ) ), c_light_gray ), weight_units() );
+                                        length_units( longest_length ), colorize( std::to_string( convert_length( longest_length ) ),
+                                                c_light_gray ), weight_units() );
+    return display_stat( length_weight_caption, to_gram( weight_carried ),
+    to_gram( weight_capacity ), []( int w ) {
+        return string_format( "%.1f", round_up( convert_weight( units::from_gram( w ) ), 1 ) );
+    } );
+}
+inventory_selector::stat inventory_selector::get_volume_stat( const units::volume
+        &volume_carried, const units::volume &volume_capacity, const units::volume &largest_free_volume )
+{
     std::string volume_caption = string_format( _( "Free Volume (%s): %s Volume (%s):" ),
                                  volume_units_abbr(),
                                  colorize( format_volume( largest_free_volume ), c_light_gray ),
                                  volume_units_abbr() );
+    return display_stat( volume_caption, units::to_milliliter( volume_carried ),
+    units::to_milliliter( volume_capacity ), []( int v ) {
+        return format_volume( units::from_milliliter( v ) );
+    } );
+}
+inventory_selector::stat inventory_selector::get_holster_stat( const units::volume
+        &holster_volume, int used_holsters, int total_holsters )
+{
 
     std::string holster_caption = string_format( _( "Free Holster Volume (%s): %s Used Holsters:" ),
                                   volume_units_abbr(),
                                   colorize( format_volume( holster_volume ), c_light_gray ) );
-    return {
-        {
-            display_stat( length_weight_caption,
-                          to_gram( weight_carried ),
-                          to_gram( weight_capacity ), []( int w )
-            {
-                return string_format( "%.1f", round_up( convert_weight( units::from_gram( w ) ), 1 ) );
-            } ),
-            display_stat( volume_caption,
-                          units::to_milliliter( volume_carried ),
-                          units::to_milliliter( volume_capacity ), []( int v )
-            {
-                return format_volume( units::from_milliliter( v ) );
-            } ),
-            display_stat( holster_caption,
-                          used_holsters,
-                          total_holsters, []( int v )
-            {
-                return string_format( "%d", v );
-            } )
+
+
+    return display_stat( holster_caption, used_holsters, total_holsters, []( int v ) {
+        return string_format( "%d", v );
+    } );
+}
+
+inventory_selector::stats inventory_selector::get_weight_and_volume_and_holster_stats(
+    units::mass weight_carried, units::mass weight_capacity,
+    const units::volume &volume_carried, const units::volume &volume_capacity,
+    const units::length &longest_length, const units::volume &largest_free_volume,
+    const units::volume &holster_volume, int used_holsters, int total_holsters )
+{
+    return { {
+            get_weight_and_length_stat( weight_carried, weight_capacity, longest_length ),
+            get_volume_stat( volume_carried, volume_capacity, largest_free_volume ),
+            get_holster_stat( holster_volume, used_holsters, total_holsters )
         }
     };
 }
 
 inventory_selector::stats inventory_selector::get_raw_stats() const
 {
-    return get_weight_and_volume_stats( u.weight_carried(), u.weight_capacity(),
-                                        u.volume_carried(), u.volume_capacity(),
-                                        u.max_single_item_length(), u.max_single_item_volume(),
-                                        u.free_holster_volume(), u.used_holsters(), u.total_holsters() );
+    return get_weight_and_volume_and_holster_stats( u.weight_carried(), u.weight_capacity(),
+            u.volume_carried(), u.volume_capacity(),
+            u.max_single_item_length(), u.max_single_item_volume(),
+            u.free_holster_volume(), u.used_holsters(), u.total_holsters() );
 }
 
 std::vector<std::string> inventory_selector::get_stats() const
@@ -3069,12 +3084,12 @@ item_location inventory_pick_selector::execute()
 
 inventory_selector::stats container_inventory_selector::get_raw_stats() const
 {
-    return get_weight_and_volume_stats( loc->get_total_contained_weight(),
-                                        loc->get_total_weight_capacity(),
-                                        loc->get_total_contained_volume(), loc->get_total_capacity(),
-                                        loc->max_containable_length(), loc->max_containable_volume(),
-                                        loc->get_total_holster_volume() - loc->get_used_holster_volume(),
-                                        loc->get_used_holsters(), loc->get_total_holsters() );
+    return get_weight_and_volume_and_holster_stats( loc->get_total_contained_weight(),
+            loc->get_total_weight_capacity(),
+            loc->get_total_contained_volume(), loc->get_total_capacity(),
+            loc->max_containable_length(), loc->max_containable_volume(),
+            loc->get_total_holster_volume() - loc->get_used_holster_volume(),
+            loc->get_used_holsters(), loc->get_total_holsters() );
 }
 
 void inventory_selector::action_examine( const item_location &sitem )
@@ -3424,6 +3439,18 @@ inventory_drop_selector::inventory_drop_selector( Character &p,
 #endif
 }
 
+inventory_insert_selector::inventory_insert_selector( Character &p,
+        const inventory_holster_preset &preset,
+        const std::string &selection_column_title,
+        const bool warn_liquid ) :
+    inventory_drop_selector( p, preset, selection_column_title, warn_liquid )
+{
+#if defined(__ANDROID__)
+    // allow user to type a drop number without dismissing virtual keyboard after each keypress
+    ctxt.allow_text_entry = true;
+#endif
+}
+
 void inventory_multiselector::deselect_contained_items()
 {
     std::vector<item_location> inventory_items;
@@ -3582,7 +3609,7 @@ drop_locations inventory_drop_selector::execute()
 
 inventory_selector::stats inventory_drop_selector::get_raw_stats() const
 {
-    return get_weight_and_volume_stats(
+    return get_weight_and_volume_and_holster_stats(
                u.weight_carried_with_tweaks( to_use ),
                u.weight_capacity(),
                u.volume_carried_with_tweaks( to_use ),
@@ -3590,6 +3617,97 @@ inventory_selector::stats inventory_drop_selector::get_raw_stats() const
                u.max_single_item_length(), u.max_single_item_volume(),
                u.free_holster_volume(), u.used_holsters(), u.total_holsters() );
 }
+
+inventory_selector::stats inventory_insert_selector::get_raw_stats() const
+{
+    units::mass selected_weight = units::mass();
+    units::volume selected_volume = units::volume();
+    const item_location &holster = static_cast<const inventory_holster_preset &>
+                                   ( preset ).get_holster();
+    const std::vector<inventory_column *> &columns = get_all_columns();
+    int holstered_items = 0;
+    units::volume holster_volume = units::volume();
+    units::mass holster_weight = units::mass();
+    std::vector<const item_pocket *> used_pockets = std::vector<const item_pocket *>();
+    for( const inventory_column *c : columns ) {
+        if( c == nullptr ) {
+            continue;
+        }
+        if( c->allows_selecting() ) {
+            const inventory_column::get_entries_t entries = c->get_entries( always_yes );
+            for( const inventory_entry *e : entries ) {
+                if( e == nullptr ) {
+                    continue;
+                }
+                if( e->chosen_count == 0 ) {
+                    continue;
+                }
+                const item *item_to_insert = e->any_item().get_item();
+                if( item_to_insert == nullptr ) {
+                    continue;
+                }
+                units::mass w = item_to_insert->weight();
+                units::volume v = item_to_insert->volume();
+                int overflow_counter = e->chosen_count;
+                for( const item_pocket *p : holster.get_item()->get_all_contained_pockets() ) {
+                    bool pocket_already_used = false;
+                    for( const item_pocket *used_pocket : used_pockets ) {
+                        if( p == used_pocket ) {
+                            pocket_already_used = true;
+                            break;
+                        }
+                    }
+                    if( !pocket_already_used && p->is_holster() && !p->holster_full() ) {
+                        ret_val<item_pocket::contain_code> contain = p->can_contain( *item_to_insert );
+                        if( contain.success() ) {
+                            bool has_better_pocket = false;
+                            for( const item_pocket *other_pocket : holster.get_item()->get_all_contained_pockets() ) {
+                                if( p == other_pocket ) {
+                                    continue;
+                                }
+                                if( p->better_pocket( *other_pocket, *item_to_insert, false ) ) {
+                                    has_better_pocket = true;
+                                }
+                            }
+                            if( has_better_pocket ) {
+                                continue;
+                            }
+                            holstered_items += 1;
+                            holster_weight += w;
+                            holster_volume += v;
+                            used_pockets.push_back( p );
+                            overflow_counter -= 1;
+                            if( overflow_counter <= 0 ) {
+                                break;
+                            }
+                        }
+                    }
+                }
+                selected_weight += w * overflow_counter;
+                selected_volume += v * overflow_counter;
+            }
+        }
+    }
+
+    units::mass contained_weight = holster->get_total_contained_weight() + selected_weight +
+                                   holster_weight +
+                                   holster->get_used_holster_weight();
+    units::mass total_weight = holster->get_total_weight_capacity() + holster_weight;
+    units::volume contained_volume = holster->get_total_contained_volume() + selected_volume +
+                                     holster_volume;
+    units::volume total_volume = holster->get_total_capacity();
+    return get_weight_and_volume_and_holster_stats( contained_weight,
+            total_weight,
+            contained_volume,
+            total_volume,
+            holster->max_containable_length(),
+            holster->max_containable_volume(),
+            holster->get_total_holster_volume() - ( holster->get_used_holster_volume() + holster_volume ),
+            holster->get_used_holsters() + holstered_items,
+            holster->get_total_holsters() );
+}
+
+
 
 pickup_selector::pickup_selector( Character &p, const inventory_selector_preset &preset,
                                   const std::string &selection_column_title, const std::optional<tripoint> &where ) :
@@ -3748,7 +3866,7 @@ inventory_selector::stats pickup_selector::get_raw_stats() const
         }
     }
 
-    return get_weight_and_volume_stats(
+    return get_weight_and_volume_and_holster_stats(
                u.weight_carried() + weight,
                u.weight_capacity(),
                u.volume_carried() + volume,

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -325,7 +325,7 @@ class inventory_holster_preset : public inventory_selector_preset
         explicit inventory_holster_preset( item_location holster, Character *c )
             : holster( std::move( holster ) ), who( c ) {
         }
-
+        const item_location &get_holster() const;
         /** Does this entry satisfy the basic preset conditions? */
         bool is_shown( const item_location &contained ) const override;
         std::string get_denial( const item_location &it ) const override;
@@ -724,7 +724,13 @@ class inventory_selector
         /** Tackles screen overflow */
         virtual void rearrange_columns( size_t client_width );
 
-        static stats get_weight_and_volume_stats(
+        static stat get_weight_and_length_stat( units::mass weight_carried,
+                                                units::mass weight_capacity, const units::length &longest_length );
+        static stat get_volume_stat( const units::volume
+                                     &volume_carried, const units::volume &volume_capacity, const units::volume &largest_free_volume );
+        static stat get_holster_stat( const units::volume
+                                      &holster_volume, int used_holsters, int total_holsters );
+        static stats get_weight_and_volume_and_holster_stats(
             units::mass weight_carried, units::mass weight_capacity,
             const units::volume &volume_carried, const units::volume &volume_capacity,
             const units::length &longest_length, const units::volume &largest_free_volume,
@@ -988,6 +994,18 @@ class inventory_drop_selector : public inventory_multiselector
 
     private:
         bool warn_liquid;
+};
+
+class inventory_insert_selector : public inventory_drop_selector
+{
+    public:
+        explicit inventory_insert_selector(
+            Character &p,
+            const inventory_holster_preset &preset,
+            const std::string &selection_column_title = _( "ITEMS TO INSERT" ),
+            bool warn_liquid = true );
+    protected:
+        stats get_raw_stats() const override;
 };
 
 class pickup_selector : public inventory_multiselector

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11519,6 +11519,14 @@ units::volume item::get_used_holster_volume() const
 {
     return contents.get_used_holster_volume();
 }
+units::mass item::get_total_holster_weight() const
+{
+    return contents.get_total_holster_weight();
+}
+units::mass item::get_used_holster_weight() const
+{
+    return contents.get_used_holster_weight();
+}
 
 int item::get_remaining_capacity_for_liquid( const item &liquid, bool allow_bucket,
         std::string *err ) const

--- a/src/item.h
+++ b/src/item.h
@@ -882,6 +882,9 @@ class item : public visitable
         units::volume get_total_holster_volume() const;
         units::volume get_used_holster_volume() const;
 
+        units::mass get_total_holster_weight() const;
+        units::mass get_used_holster_weight() const;
+
         // recursive function that checks pockets for remaining free space
         units::volume check_for_free_space() const;
         units::volume get_selected_stack_volume( const std::map<const item *, int> &without ) const;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2063,6 +2063,28 @@ units::volume item_contents::get_total_holster_volume() const
     return holster_volume;
 }
 
+units::mass item_contents::get_used_holster_weight() const
+{
+    units::mass holster_weight = units::mass();
+    for( const item_pocket &pocket : contents ) {
+        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) && pocket.is_holster() ) {
+            holster_weight += pocket.contains_weight();
+        }
+    }
+    return holster_weight;
+}
+
+units::mass item_contents::get_total_holster_weight() const
+{
+    units::mass holster_weight = units::mass();
+    for( const item_pocket &pocket : contents ) {
+        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) && pocket.is_holster() ) {
+            holster_weight += pocket.weight_capacity();
+        }
+    }
+    return holster_weight;
+}
+
 units::volume item_contents::total_container_capacity( const bool unrestricted_pockets_only ) const
 {
     units::volume total_vol = 0_ml;

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -172,6 +172,8 @@ class item_contents
         int get_total_holsters() const;
         units::volume get_total_holster_volume() const;
         units::volume get_used_holster_volume() const;
+        units::mass get_total_holster_weight() const;
+        units::mass get_used_holster_weight() const;
 
         // gets all CONTAINER pockets contained in this item
         std::vector<const item_pocket *> get_all_contained_pockets() const;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Display remaining weight/volume stats of gear/container when inserting into it"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Seems like good UX to remind the player how much weight/volume the container they're trying to insert into can handle initially as well as when they start selecting items to insert.

Fixes #64104

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Nothing crazy here, just making use of existing code and displaying the weight/volume stats at the top-right of the insert inventory menu.

I do this by checking to see whether the selected items will be holstered or not and then update all the stats accordingly as the player selects items.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

None although let me know if there's anything I can improve here.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Spawned various containers and tried inserting items into them and checked to see that this was working properly.

I tried inserting containers into each other with and without items, that seemed to work as expected as well.

I inserted plates into a ballistic vest, cross-references the displayed weight/volume values based on what was present in the .json files for the vest's pockets and that also worked as expected.

I inserted plates and other things into the MOLLE rucksack (which has a few different kinds of pockets), and that also worked as expected

Let me know if there are any edge cases you think I should test.

#### Additional context

![cataclysm-tiles_gZctpoBLsw](https://user-images.githubusercontent.com/2420411/225348046-a497dcaa-9df3-49ef-af55-43084771ccbb.gif)
