### PR TITLE
Tiring dodges

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1110,7 +1110,7 @@ ret_val<void> Character::can_try_doge() const
     }
     //If stamina is too low we can't dodge
     if( get_stamina_dodge_modifier() <= 0.11 ) {
-        add_msg_debug( debugmode::DF_MELEE, "Stamina too low to doge. Stamina: %d", get_stamina() );
+        add_msg_debug( debugmode::DF_MELEE, "Stamina too low to doge.  Stamina: %d", get_stamina() );
         add_msg_debug( debugmode::DF_MELEE, "Stamina dodge modifier: %f", get_stamina_dodge_modifier() );
         return ret_val<void>::make_failure( !is_npc() ? _( "Your stamina is too low to attempt to dodge." )
                                             :
@@ -2221,7 +2221,6 @@ void Character::process_turn()
     } else if( moves > 0 ) {
         blocks_left = get_num_blocks();
         set_dodges_left( get_num_dodges() );
-
     }
 
     // auto-learning. This is here because skill-increases happens all over the place:

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1787,6 +1787,11 @@ void Character::on_try_dodge()
 
 void Character::on_dodge( Creature *source, float difficulty )
 {
+    // Make sure we're not practicing dodge in situation where we can't dodge
+    if( !can_try_doge().success() ) {
+        return;
+    }
+
     // dodging throws of our aim unless we are either skilled at dodging or using a small weapon
     if( is_armed() && weapon.is_gun() ) {
         recoil += std::max( weapon.volume() / 250_ml - get_skill_level( skill_dodge ), 0.0f ) * rng( 0,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -516,7 +516,7 @@ Character::Character() :
     int_max = 8;
     per_cur = 8;
     per_max = 8;
-    dodges_left = 1;
+    set_dodges_left(1);
     blocks_left = 1;
     str_bonus = 0;
     dex_bonus = 0;
@@ -1076,6 +1076,28 @@ double Character::aim_per_move( const item &gun, double recoil,
 
     // Never improve by more than the currently used sights permit.
     return std::min( aim_speed, recoil - limit );
+}
+
+int Character::get_dodges_left() const
+{
+    return dodges_left;
+}
+
+void Character::set_dodges_left( int dodges )
+{
+    dodges_left = dodges;
+}
+
+void Character::mod_dodges_left( int mod )
+{
+    dodges_left += mod;
+}
+
+void Character::consume_dodge_attempts()
+{
+    if( get_dodges_left() > 0 ) {
+        mod_dodges_left( -1 );
+    }
 }
 
 int Character::sight_range( float light_level ) const
@@ -1717,7 +1739,7 @@ bool Character::is_dead_state() const
 void Character::on_try_dodge()
 {
     // Each attempt consumes an available dodge
-    dodges_left--;
+    consume_dodge_attempts();
 
     const int base_burn_rate = get_option<int>( STATIC( "PLAYER_BASE_STAMINA_BURN_RATE" ) );
     mod_stamina( -base_burn_rate * 6 );
@@ -2151,10 +2173,11 @@ void Character::process_turn()
     // We can dodge again! Assuming we can actually move...
     if( in_sleep_state() ) {
         blocks_left = 0;
-        dodges_left = 0;
+        set_dodges_left( 0 );
     } else if( moves > 0 ) {
         blocks_left = get_num_blocks();
-        dodges_left = get_num_dodges();
+        set_dodges_left( get_num_dodges() );
+
     }
 
     // auto-learning. This is here because skill-increases happens all over the place:

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1714,6 +1714,13 @@ bool Character::is_dead_state() const
     return false;
 }
 
+void Character::on_try_dodge()
+{
+    const int base_burn_rate = get_option<int>( STATIC( "PLAYER_BASE_STAMINA_BURN_RATE" ) );
+    mod_stamina( -base_burn_rate * 6 );
+    increase_activity_level( EXTRA_EXERCISE );
+}
+
 void Character::on_dodge( Creature *source, float difficulty )
 {
     // Each avoided hit consumes an available dodge

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1108,6 +1108,10 @@ bool Character::can_try_doge() const
         add_msg_debug( debugmode::DF_MELEE, "Unable to dodge (sleeping, winded, or driving)" );
         return false;
     }
+    //If stamina is too low we can't dodge
+    if( get_stamina_dodge_modifier() <= 0.1 ) {
+        return false;
+    }
 
     // Ensure no attempt to dodge without sources of extra dodges, eg martial arts
     if( get_dodges_left() <= 0 ) {
@@ -1115,6 +1119,15 @@ bool Character::can_try_doge() const
         return false;
     }
     return true;
+}
+
+float Character::get_stamina_dodge_modifier() const
+{
+    const double stamina = get_stamina();
+    const double stamina_min = get_stamina_max() * 0.1;
+    const double stamina_max = get_stamina_max() * 0.9;
+    const double stamina_logistic = 1.0 - logarithmic_range( stamina_min, stamina_max, stamina );
+    return stamina_logistic;
 }
 
 int Character::sight_range( float light_level ) const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1718,7 +1718,7 @@ void Character::on_try_dodge()
 {
     const int base_burn_rate = get_option<int>( STATIC( "PLAYER_BASE_STAMINA_BURN_RATE" ) );
     mod_stamina( -base_burn_rate * 6 );
-    increase_activity_level( EXTRA_EXERCISE );
+    set_activity_level( EXTRA_EXERCISE );
 }
 
 void Character::on_dodge( Creature *source, float difficulty )

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1100,6 +1100,23 @@ void Character::consume_dodge_attempts()
     }
 }
 
+bool Character::can_try_doge() const
+{
+    //If we're asleep or busy we can't dodge
+    if( in_sleep_state() || has_effect( effect_narcosis ) ||
+        has_effect( effect_winded ) || is_driving() ) {
+        add_msg_debug( debugmode::DF_MELEE, "Unable to dodge (sleeping, winded, or driving)" );
+        return false;
+    }
+
+    // Ensure no attempt to dodge without sources of extra dodges, eg martial arts
+    if( get_dodges_left() <= 0 ) {
+        add_msg_debug( debugmode::DF_MELEE, "No remaining dodge attempts" );
+        return false;
+    }
+    return true;
+}
+
 int Character::sight_range( float light_level ) const
 {
     if( light_level == 0 ) {
@@ -1738,6 +1755,10 @@ bool Character::is_dead_state() const
 
 void Character::on_try_dodge()
 {
+    if( !can_try_doge() ) {
+        return;
+    }
+
     // Each attempt consumes an available dodge
     consume_dodge_attempts();
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1109,7 +1109,7 @@ bool Character::can_try_doge() const
         return false;
     }
     //If stamina is too low we can't dodge
-    if( get_stamina_dodge_modifier() <= 0.1 ) {
+    if( get_stamina_dodge_modifier() <= 0.11 ) {
         return false;
     }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1716,6 +1716,9 @@ bool Character::is_dead_state() const
 
 void Character::on_try_dodge()
 {
+    // Each attempt consumes an available dodge
+    dodges_left--;
+
     const int base_burn_rate = get_option<int>( STATIC( "PLAYER_BASE_STAMINA_BURN_RATE" ) );
     mod_stamina( -base_burn_rate * 6 );
     set_activity_level( EXTRA_EXERCISE );
@@ -1723,10 +1726,6 @@ void Character::on_try_dodge()
 
 void Character::on_dodge( Creature *source, float difficulty )
 {
-    // Each avoided hit consumes an available dodge
-    // When no more available we are likely to fail player::dodge_roll
-    dodges_left--;
-
     // dodging throws of our aim unless we are either skilled at dodging or using a small weapon
     if( is_armed() && weapon.is_gun() ) {
         recoil += std::max( weapon.volume() / 250_ml - get_skill_level( skill_dodge ), 0.0f ) * rng( 0,

--- a/src/character.h
+++ b/src/character.h
@@ -520,6 +520,8 @@ class Character : public Creature, public visitable
         /** Modifiers to character speed, with descriptions */
         std::vector<speed_bonus_effect> speed_bonus_effects;
 
+        int dodges_left;
+
     public:
         std::vector<speed_bonus_effect> get_speed_bonus_effects() const;
         int get_speed() const override;
@@ -691,8 +693,14 @@ class Character : public Creature, public visitable
         double aim_per_move( const item &gun, double recoil,
                              Target_attributes target_attributes = Target_attributes() ) const;
 
+        int get_dodges_left() const;
+        void set_dodges_left( int dodges );
+        void mod_dodges_left( int mod );
+        void consume_dodge_attempts();
+
         /** Called after the player has successfully dodged an attack */
         void on_dodge( Creature *source, float difficulty ) override;
+        /** Called after the player has tryed to dodge an attack */
         void on_try_dodge() override;
 
         /** Combat getters */
@@ -950,7 +958,6 @@ class Character : public Creature, public visitable
         bool natural_attack_restricted_on( const sub_bodypart_id &bp ) const;
 
         int blocks_left;
-        int dodges_left;
 
         double recoil = MAX_RECOIL;
 

--- a/src/character.h
+++ b/src/character.h
@@ -696,7 +696,9 @@ class Character : public Creature, public visitable
         int get_dodges_left() const;
         void set_dodges_left( int dodges );
         void mod_dodges_left( int mod );
+        /** Returns true if an attempt was consumed */
         void consume_dodge_attempts();
+        bool can_try_doge() const;
 
         /** Called after the player has successfully dodged an attack */
         void on_dodge( Creature *source, float difficulty ) override;

--- a/src/character.h
+++ b/src/character.h
@@ -693,6 +693,7 @@ class Character : public Creature, public visitable
 
         /** Called after the player has successfully dodged an attack */
         void on_dodge( Creature *source, float difficulty ) override;
+        void on_try_dodge() override;
 
         /** Combat getters */
         float get_dodge_base() const override;

--- a/src/character.h
+++ b/src/character.h
@@ -696,9 +696,10 @@ class Character : public Creature, public visitable
         int get_dodges_left() const;
         void set_dodges_left( int dodges );
         void mod_dodges_left( int mod );
-        /** Returns true if an attempt was consumed */
         void consume_dodge_attempts();
         bool can_try_doge() const;
+
+        float get_stamina_dodge_modifier() const;
 
         /** Called after the player has successfully dodged an attack */
         void on_dodge( Creature *source, float difficulty ) override;

--- a/src/character.h
+++ b/src/character.h
@@ -697,7 +697,7 @@ class Character : public Creature, public visitable
         void set_dodges_left( int dodges );
         void mod_dodges_left( int mod );
         void consume_dodge_attempts();
-        bool can_try_doge() const;
+        ret_val<void> can_try_doge() const;
 
         float get_stamina_dodge_modifier() const;
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1171,39 +1171,6 @@ float Character::crafting_failure_roll( const recipe &making ) const
     return std::max( craft_roll, 0.0f );
 }
 
-// Returns the area under a curve with provided standard deviation and center
-// from difficulty to positive to infinity. That is, the chance that a normal roll on
-// said curve will return a value of difficulty or greater.
-static float normal_roll_chance( float center, float stddev, float difficulty )
-{
-    cata_assert( stddev >= 0.f );
-    // We're going to be using them a lot, so let's name our variables.
-    // M = the given "center" of the curve
-    // S = the given standard deviation of the curve
-    // A = the difficulty
-    // So, the equation of the normal curve is...
-    // y = (1.f/(S*std::sqrt(2 * M_PI))) * exp(-(std::pow(x - M, 2))/(2 * std::pow(S, 2)))
-    // Thanks to wolfram alpha, we know the integral of that from A to B to be
-    // 0.5 * (erf((M-A)/(std::sqrt(2) * S)) - erf((M-B)/(std::sqrt(2) * S)))
-    // And since we know B to be infinity, we can simplify that to
-    // 0.5 * (erfc((A-m)/(std::sqrt(2)* S))+sgn(S)-1) (as long as S != 0)
-    // Wait a second, what are erf, erfc and sgn?
-    // Oh, those are the error function, complementary error function, and sign function
-    // Luckily, erf() is provided to us in math.h, and erfc is just 1 - erf
-    // Sign is pretty obvious x > 0 ? x == 0 ? 0 : 1 : -1;
-    // Since we know S will always be > 0, that term vanishes.
-
-    // With no standard deviation, we will always return center
-    if( stddev == 0.f ) {
-        return ( center > difficulty ) ? 1.f : 0.f;
-    }
-
-    float numerator = difficulty - center;
-    float denominator = std::sqrt( 2 ) * stddev;
-    float compl_erf = 1.f - std::erf( numerator / denominator );
-    return 0.5 * compl_erf;
-}
-
 float Character::recipe_success_chance( const recipe &making ) const
 {
     // We calculate the failure chance of a recipe by performing a normal roll with a given

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1415,7 +1415,12 @@ bool Creature::dodge_check( monster *z, bodypart_id bp, damage_instance dam_inst
         potential_damage += dmg.amount - guy_target->worn.damage_resist( dmg.type, bp );
 
     }
-    float dmg_ratio = potential_damage / guy_target->get_part_hp_cur( bp );
+    int part_hp = guy_target->get_part_hp_cur( bp );
+    float dmg_ratio = 0.0f; // if the part is already destroyed it can't take more damage
+    if( part_hp > 0 ) {
+        dmg_ratio = potential_damage / part_hp;
+    }
+
 
     //If attack might remove more than half of the part's hp, dodge no matter the odds
     if( dmg_ratio >= 0.5f ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -723,14 +723,15 @@ float Creature::get_crit_factor( const bodypart_id &bp ) const
 
 int Creature::deal_melee_attack( Creature *source, int hitroll )
 {
+    const float dodge = dodge_roll();
+    int hit_chance = hitroll - size_melee_penalty();
+    int hit_spread = hit_chance - dodge;
+
     add_msg_debug( debugmode::DF_CREATURE, "Base hitroll %d",
                    hitroll );
-
-    float dodge = dodge_roll();
     add_msg_debug( debugmode::DF_CREATURE, "Dodge roll %.1f",
                    dodge );
 
-    int hit_spread = hitroll - dodge - size_melee_penalty();
     if( has_flag( MF_IMMOBILE ) ) {
         // Under normal circumstances, even a clumsy person would
         // not miss a turret.  It should, however, be possible to
@@ -739,9 +740,12 @@ int Creature::deal_melee_attack( Creature *source, int hitroll )
         hit_spread += 40;
     }
 
-    // If attacker missed call targets on_dodge event
-    if( dodge > 0.0 && hit_spread <= 0 && source != nullptr && !source->is_hallucination() ) {
-        on_dodge( source, source->get_melee() );
+    if( hit_chance > 0 && dodge > 0.0 && source != nullptr && !source->is_hallucination() ) {
+        on_try_dodge();
+        // If attacker missed call targets on_dodge event.
+        if( hit_spread <= 0 ) {
+            on_dodge( source, std::max( 0.0, source->get_melee() + hit_spread / 5.0 ) );
+        }
     }
     add_msg_debug( debugmode::DF_CREATURE, "Final hitspread %d",
                    hit_spread );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1383,7 +1383,7 @@ bool Creature::dodge_check( float hit_roll, bool force_try )
         return true;
     }
 
-    const float dodge_ability = get_dodge();
+    const float dodge_ability = dodge_roll();
     // center is 5 - 0 / 2
     // stddev is 5 - 0 / 4
     const float dodge_chance = 1 - normal_roll_chance( 2.5f, 1.25f, dodge_ability - hit_roll );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1376,6 +1376,59 @@ bool Creature::attack_air( const tripoint &p )
         explosion_handler::draw_custom_explosion( p, area_color, "animation_hit" );
     }
 
+bool Creature::dodge_check( monster *z, bodypart_id bp, damage_instance dam_inst )
+{
+
+    if( is_monster() ) {
+        return dodge_check( z );
+    }
+
+    Character *guy_target = as_character();
+    // If successfully uncanny dodged, no need to calculate dodge chance
+    if( guy_target->uncanny_dodge() ) {
+        return true;
+    }
+
+    float potential_damage = 0.0f;
+    for( damage_unit dmg : dam_inst.damage_units ) {
+        potential_damage += dmg.amount - guy_target->worn.damage_resist( dmg.type, bp );
+
+    }
+    float dmg_ratio = potential_damage / guy_target->get_part_hp_cur( bp );
+
+    //If attack might remove more than half hp of the part dodge no matter the odds
+    if( dmg_ratio >= 0.5f ) {
+        guy_target->on_try_dodge();
+        float attack_roll = z->get_hit() + rng_normal( 0, 5 );
+        const float dodge_ability = guy_target->get_dodge();
+        return dodge_ability > attack_roll;
+    } else if( dmg_ratio > 0.0f ) { // else apply usual rules
+        return dodge_check( z );
+    }
+
+    return false;
+}
+
+bool Creature::dodge_check( monster *z )
+{
+    // If successfully uncanny dodged, no need to calculate dodge chance
+    if( uncanny_dodge() ) {
+        return true;
+    }
+
+    const float dodge_ability = get_dodge();
+    // center is 5 - 0 / 2
+    // stddev is 5 - 0 / 4
+    const float dodge_chance = 1 - normal_roll_chance( 2.5f, 1.25f, dodge_ability - z->get_hit() );
+    if( dodge_chance >= 0.8f ) {
+        on_try_dodge();
+        float attack_roll = z->get_hit() + rng_normal( 0, 5 );
+        return dodge_ability > attack_roll;
+    }
+
+    return false;
+}
+
     // Chance to remove last known location
     if( one_in( 2 ) ) {
         get_map().set_field_intensity( p, field_fd_last_known, 0 );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -723,9 +723,11 @@ float Creature::get_crit_factor( const bodypart_id &bp ) const
 
 int Creature::deal_melee_attack( Creature *source, int hitroll )
 {
+
     const float dodge = dodge_roll();
-    int hit_chance = hitroll - size_melee_penalty();
-    int hit_spread = hit_chance - dodge;
+    on_try_dodge();
+
+    int hit_spread = hitroll - dodge - size_melee_penalty();
 
     add_msg_debug( debugmode::DF_CREATURE, "Base hitroll %d",
                    hitroll );
@@ -740,12 +742,9 @@ int Creature::deal_melee_attack( Creature *source, int hitroll )
         hit_spread += 40;
     }
 
-    if( hit_chance > 0 && dodge > 0.0 && source != nullptr && !source->is_hallucination() ) {
-        on_try_dodge();
-        // If attacker missed call targets on_dodge event.
-        if( hit_spread <= 0 ) {
-            on_dodge( source, std::max( 0.0, source->get_melee() + hit_spread / 5.0 ) );
-        }
+    // If attacker missed call targets on_dodge event
+    if( dodge > 0.0 && hit_spread <= 0 && source != nullptr && !source->is_hallucination() ) {
+        on_dodge( source, source->get_melee() );
     }
     add_msg_debug( debugmode::DF_CREATURE, "Final hitspread %d",
                    hit_spread );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1098,6 +1098,7 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
     const bool u_see_this = player_view.sees( *this );
 
     const double goodhit = accuracy_projectile_attack( attack );
+    on_try_dodge(); // There's a doge roll in accuracy_projectile_attack()
 
     if( goodhit >= 1.0 && !magic ) {
         attack.missed_by = 1.0; // Arbitrary value
@@ -1401,6 +1402,8 @@ bool Creature::dodge_check( float hit_roll, bool force_try )
         float attack_roll = hit_roll + rng_normal( 0, 5 );
         return dodge_ability > attack_roll;
     }
+    add_msg_if_player( m_warning,
+                       _( "You don't think you could dodge this attack, and decide to conserve stamina." ) );
 
     return false;
 }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1376,6 +1376,16 @@ bool Creature::attack_air( const tripoint &p )
         explosion_handler::draw_custom_explosion( p, area_color, "animation_hit" );
     }
 
+    // Chance to remove last known location
+    if( one_in( 2 ) ) {
+        get_map().set_field_intensity( p, field_fd_last_known, 0 );
+    }
+
+    add_msg_if_player_sees( *this, _( "%s attacks, but there is nothing there!" ),
+                            disp_name( false, true ) );
+    return true;
+}
+
 bool Creature::dodge_check( float hit_roll, bool force_try )
 {
     // If successfully uncanny dodged, no need to calculate dodge chance
@@ -1432,15 +1442,7 @@ bool Creature::dodge_check( monster *z, bodypart_id bp, damage_instance dam_inst
     return false;
 }
 
-    // Chance to remove last known location
-    if( one_in( 2 ) ) {
-        get_map().set_field_intensity( p, field_fd_last_known, 0 );
-    }
 
-    add_msg_if_player_sees( *this, _( "%s attacks, but there is nothing there!" ),
-                            disp_name( false, true ) );
-    return true;
-}
 /*
  * State check functions
  */

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1413,7 +1413,7 @@ bool Creature::dodge_check( monster *z )
     return dodge_check( z->get_hit() );
 }
 
-bool Creature::dodge_check( monster *z, bodypart_id bp, damage_instance dam_inst )
+bool Creature::dodge_check( monster *z, bodypart_id bp, const damage_instance &dam_inst )
 {
 
     if( is_monster() ) {
@@ -1423,16 +1423,14 @@ bool Creature::dodge_check( monster *z, bodypart_id bp, damage_instance dam_inst
     Character *guy_target = as_character();
 
     float potential_damage = 0.0f;
-    for( damage_unit dmg : dam_inst.damage_units ) {
+    for( const damage_unit &dmg : dam_inst.damage_units ) {
         potential_damage += dmg.amount - guy_target->worn.damage_resist( dmg.type, bp );
-
     }
     int part_hp = guy_target->get_part_hp_cur( bp );
     float dmg_ratio = 0.0f; // if the part is already destroyed it can't take more damage
     if( part_hp > 0 ) {
         dmg_ratio = potential_damage / part_hp;
     }
-
 
     //If attack might remove more than half of the part's hp, dodge no matter the odds
     if( dmg_ratio >= 0.5f ) {
@@ -1443,7 +1441,6 @@ bool Creature::dodge_check( monster *z, bodypart_id bp, damage_instance dam_inst
 
     return false;
 }
-
 
 /*
  * State check functions

--- a/src/creature.h
+++ b/src/creature.h
@@ -489,7 +489,7 @@ class Creature : public viewer
 
         bool dodge_check( float hit_roll, bool force_try = false );
         bool dodge_check( monster *z );
-        bool dodge_check( monster *z, bodypart_id bp, damage_instance dam_inst );
+        bool dodge_check( monster *z, bodypart_id bp, const damage_instance &dam_inst );
 
         // Temporarily reveals an invisible player when a monster tries to enter their location
         bool stumble_invis( const Creature &player, bool stumblemsg = true );

--- a/src/creature.h
+++ b/src/creature.h
@@ -487,7 +487,7 @@ class Creature : public viewer
         */
         void longpull( const std::string &name, const tripoint &p );
 
-        bool dodge_check( float hit_roll, bool force_try = false);
+        bool dodge_check( float hit_roll, bool force_try = false );
         bool dodge_check( monster *z );
         bool dodge_check( monster *z, bodypart_id bp, damage_instance dam_inst );
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -487,8 +487,9 @@ class Creature : public viewer
         */
         void longpull( const std::string &name, const tripoint &p );
 
-        bool dodge_check( monster *z, bodypart_id bp, damage_instance dam_inst );
+        bool dodge_check( float hit_roll, bool force_try = false);
         bool dodge_check( monster *z );
+        bool dodge_check( monster *z, bodypart_id bp, damage_instance dam_inst );
 
         // Temporarily reveals an invisible player when a monster tries to enter their location
         bool stumble_invis( const Creature &player, bool stumblemsg = true );

--- a/src/creature.h
+++ b/src/creature.h
@@ -487,6 +487,9 @@ class Creature : public viewer
         */
         void longpull( const std::string &name, const tripoint &p );
 
+        bool dodge_check( monster *z, bodypart_id bp, damage_instance dam_inst );
+        bool dodge_check( monster *z );
+
         // Temporarily reveals an invisible player when a monster tries to enter their location
         bool stumble_invis( const Creature &player, bool stumblemsg = true );
         // Attack an empty location

--- a/src/creature.h
+++ b/src/creature.h
@@ -498,6 +498,10 @@ class Creature : public viewer
          */
         virtual void on_dodge( Creature *source, float difficulty ) = 0;
         /**
+         * Invoked when the creature attempts to dodge, regardless of success or failure.
+         */
+        virtual void on_try_dodge() = 0;
+        /**
          * This creature just got hit by an attack - possibly special/ranged attack - from source.
          * Players should train dodge, possibly counter-attack somehow.
          */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2669,7 +2669,7 @@ bool game::is_game_over()
         // prevent pain from updating
         u.set_pain( 0 );
         // prevent dodging
-        u.dodges_left = 0;
+        u.set_dodges_left( 0 );
         return false;
     }
     if( uquit == QUIT_DIED ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3874,17 +3874,12 @@ std::optional<int> iuse::tazer( Character *p, item *it, bool, const tripoint &po
         return std::nullopt;
     }
 
-    /** @EFFECT_DEX slightly increases chance of successfully using tazer */
-    /** @EFFECT_MELEE increases chance of successfully using a tazer */
-    int numdice = round( 3 + ( static_cast<float>( p->dex_cur ) / 2.5 ) + p->get_skill_level(
-                             skill_melee ) * 2 );
+    const float hit_roll = p->hit_roll();
     p->moves -= to_moves<int>( 1_seconds );
 
-    /** @EFFECT_DODGE increases chance of dodging a tazer attack */
-    const bool tazer_was_dodged = dice( numdice, 10 ) < dice( target->get_dodge(), 10 );
-    const int tazer_resistance = target->get_armor_type( STATIC( damage_type_id( "bash" ) ),
-                                 bodypart_id( "torso" ) );
-    const bool tazer_was_armored = dice( numdice, 10 ) < dice( tazer_resistance, 10 );
+    const bool tazer_was_dodged = target->dodge_check( p->hit_roll() );
+    const bool tazer_was_armored = hit_roll < target->get_armor_type( STATIC(damage_type_id("bash"),
+                                   bodypart_id( "torso" ) );
     if( tazer_was_dodged ) {
         p->add_msg_player_or_npc( _( "You attempt to shock %s, but miss." ),
                                   _( "<npcname> attempts to shock %s, but misses." ),

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3878,8 +3878,8 @@ std::optional<int> iuse::tazer( Character *p, item *it, bool, const tripoint &po
     p->moves -= to_moves<int>( 1_seconds );
 
     const bool tazer_was_dodged = target->dodge_check( p->hit_roll() );
-    const bool tazer_was_armored = hit_roll < target->get_armor_type( STATIC(damage_type_id("bash"),
-                                   bodypart_id( "torso" ) );
+    const bool tazer_was_armored = hit_roll < target->get_armor_type( STATIC(
+                                       damage_type_id( "bash" ) ), bodypart_id( "torso" ) );
     if( tazer_was_dodged ) {
         p->add_msg_player_or_npc( _( "You attempt to shock %s, but miss." ),
                                   _( "<npcname> attempts to shock %s, but misses." ),

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -341,7 +341,6 @@ static const skill_id skill_electronics( "electronics" );
 static const skill_id skill_fabrication( "fabrication" );
 static const skill_id skill_firstaid( "firstaid" );
 static const skill_id skill_mechanics( "mechanics" );
-static const skill_id skill_melee( "melee" );
 static const skill_id skill_survival( "survival" );
 static const skill_id skill_traps( "traps" );
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -540,7 +540,8 @@ static void damage_targets( const spell &sp, Creature &caster,
             damage_mitigation_multiplier -= ( 1 - 0.05 * std::max( roll, spell_block ) ) / 3.0;
         }
 
-        if( const int spell_dodge = cr->get_dodge() - spell_accuracy > 0 ) {
+        if( cr->dodge_check( spell_accuracy ) ) {
+            const int spell_dodge = cr->get_dodge() - spell_accuracy;
             const int roll = std::round( rng( 1, 20 ) );
             // 5% per point (linear) ranging from 0-33%, capped at block score
             damage_mitigation_multiplier -= ( 1 - 0.05 * std::max( roll, spell_dodge ) ) / 3.0;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -540,7 +540,7 @@ static void damage_targets( const spell &sp, Creature &caster,
             damage_mitigation_multiplier -= ( 1 - 0.05 * std::max( roll, spell_block ) ) / 3.0;
         }
 
-        if( !cr->dodge_check( spell_accuracy ) ) {
+        if( cr->dodge_check( spell_accuracy ) ) {
             const int spell_dodge = cr->get_dodge() - spell_accuracy;
             const int roll = std::round( rng( 1, 20 ) );
             // 5% per point (linear) ranging from 0-33%, capped at block score

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -540,7 +540,7 @@ static void damage_targets( const spell &sp, Creature &caster,
             damage_mitigation_multiplier -= ( 1 - 0.05 * std::max( roll, spell_block ) ) / 3.0;
         }
 
-        if( cr->dodge_check( spell_accuracy ) ) {
+        if( !cr->dodge_check( spell_accuracy ) ) {
             const int spell_dodge = cr->get_dodge() - spell_accuracy;
             const int roll = std::round( rng( 1, 20 ) );
             // 5% per point (linear) ranging from 0-33%, capped at block score

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1176,7 +1176,7 @@ float Character::get_dodge() const
     }
 
     //Dodge decreases linearly to 0 when below 50% stamina.
-    //const float stamina_ratio = static_cast<float>( get_stamina() ) / get_stamina_max();
+    const float stamina_ratio = static_cast<float>( get_stamina() ) / get_stamina_max();
     const double stamina = get_stamina();
     const double stamina_min = get_stamina_max() * 0.1;
     const double stamina_max = get_stamina_max() * 0.9;
@@ -1186,9 +1186,9 @@ float Character::get_dodge() const
         return 0.0f;
     }
     ret *= stamina_logistic;
-    /*
+
     if( stamina_ratio < 0.1 ) {
-    return 0.0f;
+        return 0.0f;
     }
     if( stamina_ratio <= .5 ) {
         ret *= 2 * stamina_ratio;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1138,16 +1138,7 @@ int Character::get_spell_resist() const
 
 float Character::get_dodge() const
 {
-    //If we're asleep or busy we can't dodge
-    if( in_sleep_state() || has_effect( effect_narcosis ) ||
-        has_effect( effect_winded ) || is_driving() ) {
-        add_msg_debug( debugmode::DF_MELEE, "Unable to dodge (sleeping, winded, or driving)" );
-        return 0.0f;
-    }
-
-    // Ensure no attempt to dodge without sources of extra dodges, eg martial arts
-    if( get_dodges_left() <= 0 ) {
-        add_msg_debug( debugmode::DF_MELEE, "No remaining dodge attempts" );
+    if( !can_try_doge() ) {
         return 0.0f;
     }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1166,25 +1166,11 @@ float Character::get_dodge() const
         add_msg_debug( debugmode::DF_MELEE, "Dodge after speed penalty %.1f", ret );
     }
 
-    //Dodge decreases linearly to 0 when below 50% stamina.
-    const float stamina_ratio = static_cast<float>( get_stamina() ) / get_stamina_max();
-    const double stamina = get_stamina();
-    const double stamina_min = get_stamina_max() * 0.1;
-    const double stamina_max = get_stamina_max() * 0.9;
-    const double stamina_logistic = 1.0 - logarithmic_range( stamina_min, stamina_max, stamina );
-    if( stamina_logistic <= 0.1 ) {
-        //Don't attempt to dodge if stamina too low, to avoid getting locked in
-        return 0.0f;
-    }
+    //Dodge decreases logisticaly with stamina.
+    const double stamina_logistic = get_stamina_dodge_modifier();
     ret *= stamina_logistic;
 
-    if( stamina_ratio < 0.1 ) {
-        return 0.0f;
-    }
-    if( stamina_ratio <= .5 ) {
-        ret *= 2 * stamina_ratio;
-        add_msg_debug( debugmode::DF_MELEE, "Dodge after stamina penalty %.1f", ret );
-    }
+    add_msg_debug( debugmode::DF_MELEE, "Dodge after stamina penalty %.1f", ret );
 
     // Reaction score of limbs influences dodge chances
     ret *= get_limb_score( limb_score_reaction );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1146,7 +1146,7 @@ float Character::get_dodge() const
     }
 
     // Ensure no attempt to dodge without sources of extra dodges, eg martial arts
-    if( dodges_left <= 0 ) {
+    if( get_dodges_left() <= 0 ) {
         add_msg_debug( debugmode::DF_MELEE, "No remaining dodge attempts" );
         return 0.0f;
     }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1138,7 +1138,7 @@ int Character::get_spell_resist() const
 
 float Character::get_dodge() const
 {
-    if( !can_try_doge() ) {
+    if( !can_try_doge().success() ) {
         return 0.0f;
     }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1176,7 +1176,20 @@ float Character::get_dodge() const
     }
 
     //Dodge decreases linearly to 0 when below 50% stamina.
-    const float stamina_ratio = static_cast<float>( get_stamina() ) / get_stamina_max();
+    //const float stamina_ratio = static_cast<float>( get_stamina() ) / get_stamina_max();
+    const double stamina = get_stamina();
+    const double stamina_min = get_stamina_max() * 0.1;
+    const double stamina_max = get_stamina_max() * 0.9;
+    const double stamina_logistic = 1.0 - logarithmic_range( stamina_min, stamina_max, stamina );
+    if( stamina_logistic <= 0.1 ) {
+        //Don't attempt to dodge if stamina too low, to avoid getting locked in
+        return 0.0f;
+    }
+    ret *= stamina_logistic;
+    /*
+    if( stamina_ratio < 0.1 ) {
+    return 0.0f;
+    }
     if( stamina_ratio <= .5 ) {
         ret *= 2 * stamina_ratio;
         add_msg_debug( debugmode::DF_MELEE, "Dodge after stamina penalty %.1f", ret );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -20,6 +20,7 @@
 #include "activity_type.h"
 #include "ballistics.h"
 #include "bionics.h"
+#include "bodypart.h"
 #include "calendar.h"
 #include "cata_assert.h"
 #include "character.h"

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -20,7 +20,6 @@
 #include "activity_type.h"
 #include "ballistics.h"
 #include "bionics.h"
-#include "bodypart.h"
 #include "calendar.h"
 #include "cata_assert.h"
 #include "character.h"
@@ -671,8 +670,11 @@ bool mattack::acid_barf( monster *z )
     // Make sure it happens before uncanny dodge
     get_map().add_field( target->pos(), fd_acid, 1 );
 
+    bodypart_id hit = target->get_random_body_part();
+    damage_instance dam_inst = damage_instance( damage_acid, rng( 5, 12 ) );
+
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( dodge_check( z, target, hit, dam_inst ) ) {
         game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
         target->add_msg_player_or_npc( msg_type,
                                        _( "The %s barfs acid at you, but you dodge!" ),
@@ -683,8 +685,6 @@ bool mattack::acid_barf( monster *z )
         return true;
     }
 
-    bodypart_id hit = target->get_random_body_part();
-    damage_instance dam_inst = damage_instance( damage_acid, rng( 5, 12 ) );
     target->block_hit( z, hit, dam_inst );
 
     int dam = target->deal_damage( z,  hit, dam_inst ).total_damage();
@@ -1880,16 +1880,18 @@ bool mattack::fungus_inject( monster *z )
     add_msg( m_warning, _( "The %s jabs at you with a needlelike point!" ), z->name() );
     z->moves -= 150;
 
+    bodypart_id hit = target->get_random_body_part();
+    damage_instance dam_inst = damage_instance( damage_cut, rng( 5, 11 ) );
+
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( dodge_check( z, target, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
         return true;
     }
 
-    bodypart_id hit = target->get_random_body_part();
-    damage_instance dam_inst = damage_instance( damage_cut, rng( 5, 11 ) );
+
     target->block_hit( z, hit, dam_inst );
 
     int dam = player_character.deal_damage( z, hit, dam_inst ).total_damage();
@@ -1934,16 +1936,17 @@ bool mattack::fungus_bristle( monster *z )
              target->disp_name() );
     z->moves -= 150;
 
+    bodypart_id hit = target->get_random_body_part();
+    damage_instance dam_inst = damage_instance( damage_cut, rng( 7, 16 ) );
+
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( dodge_check( z, target, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
         return true;
     }
 
-    bodypart_id hit = target->get_random_body_part();
-    damage_instance dam_inst = damage_instance( damage_cut, rng( 7, 16 ) );
     target->block_hit( z, hit, dam_inst );
 
     int dam = target->deal_damage( z, hit, dam_inst ).total_damage();
@@ -2101,16 +2104,17 @@ bool mattack::fungus_fortify( monster *z )
              z->name() );
     z->moves -= 150;
 
+    bodypart_id hit = target->get_random_body_part();
+    damage_instance dam_inst = damage_instance( damage_stab, rng( 15, 21 ) );
+
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( dodge_check( z, target, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
         return true;
     }
 
-    bodypart_id hit = target->get_random_body_part();
-    damage_instance dam_inst = damage_instance( damage_stab, rng( 15, 21 ) );
     target->block_hit( z, hit, dam_inst );
 
     int dam = player_character.deal_damage( z, hit, dam_inst ).total_damage();
@@ -2143,7 +2147,10 @@ bool mattack::impale( monster *z )
 
     z->moves -= 80;
 
-    if( dodge_check( z, target ) ) {
+    bodypart_id hit = bodypart_id( "torso" );
+    damage_instance dam_inst = damage_instance( damage_stab, rng( 10, 20 ), rng( 5, 15 ), .5 );
+
+    if( dodge_check( z, target, hit, dam_inst ) ) {
         game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
         target->add_msg_player_or_npc( msg_type, _( "The %s lunges at you, but you dodge!" ),
                                        _( "The %s lunges at <npcname>, but they dodge!" ),
@@ -2153,8 +2160,6 @@ bool mattack::impale( monster *z )
         return true;
     }
 
-    bodypart_id hit = bodypart_id( "torso" );
-    damage_instance dam_inst = damage_instance( damage_stab, rng( 10, 20 ), rng( 5, 15 ), .5 );
     target->block_hit( z, hit, dam_inst );
 
     int dam = target->deal_damage( z, hit, dam_inst ).total_damage();
@@ -2638,16 +2643,17 @@ bool mattack::tentacle( monster *z )
                                    z->name() );
     z->moves -= 100;
 
+    bodypart_id hit = target->get_random_body_part();
+    damage_instance dam_inst = damage_instance( damage_bash, rng( 10, 20 ) );
+
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( dodge_check( z, target, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
         return true;
     }
 
-    bodypart_id hit = target->get_random_body_part();
-    damage_instance dam_inst = damage_instance( damage_bash, rng( 10, 20 ) );
     target->block_hit( z, hit, dam_inst );
 
     int dam = target->deal_damage( z, hit, dam_inst ).total_damage();
@@ -4334,8 +4340,11 @@ bool mattack::stretch_bite( monster *z )
         }
     }
 
+    bodypart_id hit = target->get_random_body_part();
+    damage_instance dam_inst = damage_instance( damage_stab, rng( 5, 15 ) );
+
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( dodge_check( z, target, hit, dam_inst ) ) {
         z->moves -= 150;
         z->add_effect( effect_stunned, 3_turns );
         game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
@@ -4348,8 +4357,6 @@ bool mattack::stretch_bite( monster *z )
         return true;
     }
 
-    bodypart_id hit = target->get_random_body_part();
-    damage_instance dam_inst = damage_instance( damage_stab, rng( 5, 15 ) );
     target->block_hit( z, hit, dam_inst );
 
     int dam = target->deal_damage( z, hit, dam_inst ).total_damage();
@@ -4435,16 +4442,17 @@ bool mattack::flesh_golem( monster *z )
                             z->name(), target->disp_name() );
     z->moves -= 100;
 
+    bodypart_id hit = target->get_random_body_part();
+    damage_instance dam_inst = damage_instance( damage_bash, rng( 5, 10 ) );
+
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( dodge_check( z, target, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
         return true;
     }
 
-    bodypart_id hit = target->get_random_body_part();
-    damage_instance dam_inst = damage_instance( damage_bash, rng( 5, 10 ) );
     target->block_hit( z, hit, dam_inst );
 
     int dam = target->deal_damage( z, hit, dam_inst ).total_damage();
@@ -4556,16 +4564,17 @@ bool mattack::lunge( monster *z )
 
     z->moves -= 100;
 
+    bodypart_id hit = target->get_random_body_part();
+    damage_instance dam_inst = damage_instance( damage_bash, rng( 3, 7 ) );
+
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( dodge_check( z, target, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "The %1$s lunges at you, but you sidestep it!" ),
                                        _( "The %1$s lunges at <npcname>, but they sidestep it!" ), z->name() );
         target->on_dodge( z, z->type->melee_skill );
         return true;
     }
 
-    bodypart_id hit = target->get_random_body_part();
-    damage_instance dam_inst = damage_instance( damage_bash, rng( 3, 7 ) );
     target->block_hit( z, hit, dam_inst );
 
     int dam = target->deal_damage( z, hit, dam_inst ).total_damage();
@@ -4629,8 +4638,11 @@ bool mattack::longswipe( monster *z )
 
             z->moves -= 150;
 
+            bodypart_id hit = target->get_random_body_part();
+            damage_instance dam_inst = damage_instance( damage_cut, rng( 3, 7 ) );
+
             // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-            if( dodge_check( z, target ) ) {
+            if( dodge_check( z, target, hit, dam_inst ) ) {
                 target->add_msg_player_or_npc( _( "The %s thrusts a claw at you, but you evade it!" ),
                                                _( "The %s thrusts a claw at <npcname>, but they evade it!" ),
                                                z->name() );
@@ -4638,8 +4650,6 @@ bool mattack::longswipe( monster *z )
                 return true;
             }
 
-            bodypart_id hit = target->get_random_body_part();
-            damage_instance dam_inst = damage_instance( damage_cut, rng( 3, 7 ) );
             target->block_hit( z, hit, dam_inst );
 
             int dam = target->deal_damage( z, hit, dam_inst ).total_damage();
@@ -4665,16 +4675,17 @@ bool mattack::longswipe( monster *z )
     }
     z->moves -= 100;
 
+    bodypart_id hit = bodypart_id( "head" );
+    damage_instance dam_inst = damage_instance( damage_cut, rng( 6, 10 ) );
+
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( dodge_check( z, target, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "The %s slashes at your neck!  You duck!" ),
                                        _( "The %s slashes at <npcname>'s neck!  They duck!" ), z->name() );
         target->on_dodge( z, z->type->melee_skill );
         return true;
     }
 
-    bodypart_id hit = bodypart_id( "head" );
-    damage_instance dam_inst = damage_instance( damage_cut, rng( 6, 10 ) );
     target->block_hit( z, hit, dam_inst );
 
     int dam = target->deal_damage( z, hit, dam_inst ).total_damage();
@@ -5062,7 +5073,12 @@ bool mattack::evolve_kill_strike( monster *z )
 
     z->moves -= 100;
 
-    if( dodge_check( z, target ) ) {
+    damage_instance damage( z->type->melee_damage );
+    damage.mult_damage( 1.33f );
+    damage.add( damage_instance( damage_stab, dice( z->type->melee_dice, z->type->melee_sides ),
+                                 rng( 5, 15 ), 1.0, 0.5 ) );
+
+    if( dodge_check( z, target, bodypart_id( "torso" ), damage ) ) {
         game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
         target->add_msg_player_or_npc( msg_type, _( "The %s lunges at you, but you dodge!" ),
                                        _( "The %s lunges at <npcname>, but they dodge!" ),
@@ -5076,10 +5092,7 @@ bool mattack::evolve_kill_strike( monster *z )
     }
     tripoint const target_pos = target->pos();
     const std::string target_name = target->disp_name();
-    damage_instance damage( z->type->melee_damage );
-    damage.mult_damage( 1.33f );
-    damage.add( damage_instance( damage_stab, dice( z->type->melee_dice, z->type->melee_sides ),
-                                 rng( 5, 15 ), 1.0, 0.5 ) );
+
     int damage_dealt = target->deal_damage( z, bodypart_id( "torso" ), damage ).total_damage();
     if( damage_dealt > 0 ) {
         game_message_type msg_type = target->is_avatar() ? m_bad : m_warning;
@@ -5890,7 +5903,10 @@ bool mattack::stretch_attack( monster *z )
                                    _( "The %s thrusts its arm at <npcname>." ),
                                    z->name() );
 
-    if( dodge_check( z, target ) ) {
+    bodypart_id hit = target->get_random_body_part();
+    damage_instance dam_inst = damage_instance( damage_stab, rng( 5, 10 ) );
+
+    if( dodge_check( z, target, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( msg_type, _( "You evade the stretched arm and it sails past you!" ),
                                        _( "<npcname> evades the stretched arm!" ) );
         target->on_dodge( z, z->type->melee_skill );
@@ -5899,8 +5915,6 @@ bool mattack::stretch_attack( monster *z )
         return true;
     }
 
-    bodypart_id hit = target->get_random_body_part();
-    damage_instance dam_inst = damage_instance( damage_stab, rng( 5, 10 ) );
     target->block_hit( z, hit, dam_inst );
 
     int dam = target->deal_damage( z, hit, dam_inst ).total_damage();
@@ -5991,6 +6005,39 @@ bool mattack::doot( monster *z )
     return true;
 }
 
+bool mattack::dodge_check( monster *z, Creature *target, bodypart_id bp, damage_instance dam_inst )
+{
+
+    if( target->is_monster() ) {
+        return dodge_check( z, target );
+    }
+
+    Character *guy_target = target->as_character();
+    // If successfully uncanny dodged, no need to calculate dodge chance
+    if( guy_target->uncanny_dodge() ) {
+        return true;
+    }
+
+    float potential_damage = 0.0f;
+    for( damage_unit dmg : dam_inst.damage_units ) {
+        potential_damage += dmg.amount - guy_target->worn.damage_resist( dmg.type, bp );
+
+    }
+    float dmg_ratio = potential_damage / guy_target->get_part_hp_cur( bp );
+
+    //If attack might remove more than half hp of the part dodge no matter the odds
+    if( dmg_ratio >= 0.5f ) {
+        guy_target->on_try_dodge();
+        float attack_roll = z->get_hit() + rng_normal( 0, 5 );
+        const float dodge_ability = target->get_dodge();
+        return dodge_ability > attack_roll;
+    } else if( dmg_ratio > 0.0f ) { // else apply usual rules
+        return dodge_check( z, guy_target );
+    }
+
+    return false;
+}
+
 bool mattack::dodge_check( monster *z, Creature *target )
 {
     // If successfully uncanny dodged, no need to calculate dodge chance
@@ -5999,12 +6046,16 @@ bool mattack::dodge_check( monster *z, Creature *target )
     }
 
     const float dodge_ability = target->get_dodge();
-    if( dodge_ability > 0.8f ) {
+    // center is 5 - 0 / 2
+    // stddev is 5 - 0 / 4
+    const float dodge_chance = 1 - normal_roll_chance( 2.5f, 1.25f, dodge_ability - z->get_hit() );
+    if( dodge_chance >= 0.8f ) {
         target->on_try_dodge();
+        float attack_roll = z->get_hit() + rng_normal( 0, 5 );
+        return dodge_ability > attack_roll;
     }
 
-    float attack_roll = z->get_hit() + rng_normal( 0, 5 );
-    return dodge_ability > attack_roll;
+    return false;
 }
 
 bool mattack::speaker( monster *z )

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -679,7 +679,7 @@ bool mattack::acid_barf( monster *z )
                                        _( "The %s barfs acid at <npcname>, but they dodge!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2 );
         return true;
     }
 
@@ -1171,8 +1171,7 @@ bool mattack::smash( monster *z )
         target->add_msg_player_or_npc( _( "The %s takes a powerful swing at you, but you dodge it!" ),
                                        _( "The %s takes a powerful swing at <npcname>, who dodges it!" ),
                                        z->name() );
-
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2 );
         return true;
     }
 
@@ -2150,7 +2149,7 @@ bool mattack::impale( monster *z )
                                        _( "The %s lunges at <npcname>, but they dodge!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2);
         return true;
     }
 
@@ -2725,7 +2724,7 @@ bool mattack::ranged_pull( monster *z )
                                        _( "The %s's arms fly out at <npcname>, but they dodge!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2 );
         return true;
     }
 
@@ -2842,7 +2841,7 @@ bool mattack::grab( monster *z )
                                        _( "The %s gropes at <npcname>, but they dodge!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2 );
         return true;
     }
 
@@ -4345,7 +4344,7 @@ bool mattack::stretch_bite( monster *z )
                                        _( "The %s's head extends to bite <npcname>, but they dodge and the head sails past!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2 );
         return true;
     }
 
@@ -5069,7 +5068,7 @@ bool mattack::evolve_kill_strike( monster *z )
                                        _( "The %s lunges at <npcname>, but they dodge!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill );
+        target->on_dodge( z, z->type->melee_skill * 2 );
         target->add_msg_player_or_npc( msg_type, _( "The %s lunges at you, but you dodge!" ),
                                        _( "The %s lunges at <npcname>, but they dodge!" ),
                                        z->name() );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -674,7 +674,7 @@ bool mattack::acid_barf( monster *z )
     damage_instance dam_inst = damage_instance( damage_acid, rng( 5, 12 ) );
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target, hit, dam_inst ) ) {
+    if( target->dodge_check( z, hit, dam_inst ) ) {
         game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
         target->add_msg_player_or_npc( msg_type,
                                        _( "The %s barfs acid at you, but you dodge!" ),
@@ -1167,7 +1167,7 @@ bool mattack::smash( monster *z )
     z->moves -= 400;
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( target->dodge_check( z ) ) {
         target->add_msg_player_or_npc( _( "The %s takes a powerful swing at you, but you dodge it!" ),
                                        _( "The %s takes a powerful swing at <npcname>, who dodges it!" ),
                                        z->name() );
@@ -1884,7 +1884,7 @@ bool mattack::fungus_inject( monster *z )
     damage_instance dam_inst = damage_instance( damage_cut, rng( 5, 11 ) );
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target, hit, dam_inst ) ) {
+    if( target->dodge_check( z, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
@@ -1940,7 +1940,7 @@ bool mattack::fungus_bristle( monster *z )
     damage_instance dam_inst = damage_instance( damage_cut, rng( 7, 16 ) );
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target, hit, dam_inst ) ) {
+    if( target->dodge_check( z, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
@@ -2108,7 +2108,7 @@ bool mattack::fungus_fortify( monster *z )
     damage_instance dam_inst = damage_instance( damage_stab, rng( 15, 21 ) );
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target, hit, dam_inst ) ) {
+    if( target->dodge_check( z, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
@@ -2150,7 +2150,7 @@ bool mattack::impale( monster *z )
     bodypart_id hit = bodypart_id( "torso" );
     damage_instance dam_inst = damage_instance( damage_stab, rng( 10, 20 ), rng( 5, 15 ), .5 );
 
-    if( dodge_check( z, target, hit, dam_inst ) ) {
+    if( target->dodge_check( z, hit, dam_inst ) ) {
         game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
         target->add_msg_player_or_npc( msg_type, _( "The %s lunges at you, but you dodge!" ),
                                        _( "The %s lunges at <npcname>, but they dodge!" ),
@@ -2208,7 +2208,7 @@ bool mattack::dermatik( monster *z )
     }
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( target->dodge_check( z ) ) {
         if( target->is_avatar() ) {
             add_msg( _( "The %s tries to land on you, but you dodge." ), z->name() );
         }
@@ -2647,7 +2647,7 @@ bool mattack::tentacle( monster *z )
     damage_instance dam_inst = damage_instance( damage_bash, rng( 10, 20 ) );
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target, hit, dam_inst ) ) {
+    if( target->dodge_check( z, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
@@ -2723,7 +2723,7 @@ bool mattack::ranged_pull( monster *z )
         }
     }
 
-    if( dodge_check( z, target ) ) {
+    if( target->dodge_check( z ) ) {
         z->moves -= 200;
         game_message_type msg_type = foe && foe->is_avatar() ? m_warning : m_info;
         target->add_msg_player_or_npc( msg_type, _( "The %s's arms fly out at you, but you dodge!" ),
@@ -2842,7 +2842,7 @@ bool mattack::grab( monster *z )
     z->moves -= 80;
 
     const game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
-    if( dodge_check( z, target ) ) {
+    if( target->dodge_check( z ) ) {
         target->add_msg_player_or_npc( msg_type, _( "The %s gropes at you, but you dodge!" ),
                                        _( "The %s gropes at <npcname>, but they dodge!" ),
                                        z->name() );
@@ -4344,7 +4344,7 @@ bool mattack::stretch_bite( monster *z )
     damage_instance dam_inst = damage_instance( damage_stab, rng( 5, 15 ) );
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target, hit, dam_inst ) ) {
+    if( target->dodge_check( z, hit, dam_inst ) ) {
         z->moves -= 150;
         z->add_effect( effect_stunned, 3_turns );
         game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
@@ -4446,7 +4446,7 @@ bool mattack::flesh_golem( monster *z )
     damage_instance dam_inst = damage_instance( damage_bash, rng( 5, 10 ) );
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target, hit, dam_inst ) ) {
+    if( target->dodge_check( z, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
@@ -4568,7 +4568,7 @@ bool mattack::lunge( monster *z )
     damage_instance dam_inst = damage_instance( damage_bash, rng( 3, 7 ) );
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target, hit, dam_inst ) ) {
+    if( target->dodge_check( z, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "The %1$s lunges at you, but you sidestep it!" ),
                                        _( "The %1$s lunges at <npcname>, but they sidestep it!" ), z->name() );
         target->on_dodge( z, z->type->melee_skill );
@@ -4642,7 +4642,7 @@ bool mattack::longswipe( monster *z )
             damage_instance dam_inst = damage_instance( damage_cut, rng( 3, 7 ) );
 
             // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-            if( dodge_check( z, target, hit, dam_inst ) ) {
+            if( target->dodge_check( z, hit, dam_inst ) ) {
                 target->add_msg_player_or_npc( _( "The %s thrusts a claw at you, but you evade it!" ),
                                                _( "The %s thrusts a claw at <npcname>, but they evade it!" ),
                                                z->name() );
@@ -4679,7 +4679,7 @@ bool mattack::longswipe( monster *z )
     damage_instance dam_inst = damage_instance( damage_cut, rng( 6, 10 ) );
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target, hit, dam_inst ) ) {
+    if( target->dodge_check( z, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( _( "The %s slashes at your neck!  You duck!" ),
                                        _( "The %s slashes at <npcname>'s neck!  They duck!" ), z->name() );
         target->on_dodge( z, z->type->melee_skill );
@@ -5078,7 +5078,7 @@ bool mattack::evolve_kill_strike( monster *z )
     damage.add( damage_instance( damage_stab, dice( z->type->melee_dice, z->type->melee_sides ),
                                  rng( 5, 15 ), 1.0, 0.5 ) );
 
-    if( dodge_check( z, target, bodypart_id( "torso" ), damage ) ) {
+    if( target->dodge_check( z, bodypart_id( "torso" ), damage ) ) {
         game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
         target->add_msg_player_or_npc( msg_type, _( "The %s lunges at you, but you dodge!" ),
                                        _( "The %s lunges at <npcname>, but they dodge!" ),
@@ -5344,7 +5344,7 @@ bool mattack::bio_op_takedown( monster *z )
     z->moves -= 100;
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( target->dodge_check( z ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
@@ -5452,7 +5452,7 @@ bool mattack::bio_op_impale( monster *z )
     z->moves -= 100;
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( target->dodge_check( z ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
@@ -5536,7 +5536,7 @@ bool mattack::bio_op_disarm( monster *z )
     z->moves -= 100;
 
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
-    if( dodge_check( z, target ) ) {
+    if( target->dodge_check( z ) ) {
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
         target->on_dodge( z, z->type->melee_skill );
@@ -5906,7 +5906,7 @@ bool mattack::stretch_attack( monster *z )
     bodypart_id hit = target->get_random_body_part();
     damage_instance dam_inst = damage_instance( damage_stab, rng( 5, 10 ) );
 
-    if( dodge_check( z, target, hit, dam_inst ) ) {
+    if( target->dodge_check( z, hit, dam_inst ) ) {
         target->add_msg_player_or_npc( msg_type, _( "You evade the stretched arm and it sails past you!" ),
                                        _( "<npcname> evades the stretched arm!" ) );
         target->on_dodge( z, z->type->melee_skill );
@@ -6003,59 +6003,6 @@ bool mattack::doot( monster *z )
     sounds::sound( z->pos(), 200, sounds::sound_t::music, _( "DOOT." ), false, "music_instrument",
                    "trumpet" );
     return true;
-}
-
-bool mattack::dodge_check( monster *z, Creature *target, bodypart_id bp, damage_instance dam_inst )
-{
-
-    if( target->is_monster() ) {
-        return dodge_check( z, target );
-    }
-
-    Character *guy_target = target->as_character();
-    // If successfully uncanny dodged, no need to calculate dodge chance
-    if( guy_target->uncanny_dodge() ) {
-        return true;
-    }
-
-    float potential_damage = 0.0f;
-    for( damage_unit dmg : dam_inst.damage_units ) {
-        potential_damage += dmg.amount - guy_target->worn.damage_resist( dmg.type, bp );
-
-    }
-    float dmg_ratio = potential_damage / guy_target->get_part_hp_cur( bp );
-
-    //If attack might remove more than half hp of the part dodge no matter the odds
-    if( dmg_ratio >= 0.5f ) {
-        guy_target->on_try_dodge();
-        float attack_roll = z->get_hit() + rng_normal( 0, 5 );
-        const float dodge_ability = guy_target->get_dodge();
-        return dodge_ability > attack_roll;
-    } else if( dmg_ratio > 0.0f ) { // else apply usual rules
-        return dodge_check( z, guy_target );
-    }
-
-    return false;
-}
-
-bool mattack::dodge_check( monster *z, Creature *target )
-{
-    // If successfully uncanny dodged, no need to calculate dodge chance
-    if( target->uncanny_dodge() ) {
-        return true;
-    }
-
-    const float dodge_ability = target->get_dodge();
-    // center is 5 - 0 / 2
-    // stddev is 5 - 0 / 4
-    const float dodge_chance = 1 - normal_roll_chance( 2.5f, 1.25f, dodge_ability - z->get_hit() );
-    if( dodge_chance >= 0.8f ) {
-        target->on_try_dodge();
-        float attack_roll = z->get_hit() + rng_normal( 0, 5 );
-        return dodge_ability > attack_roll;
-    }
-
-    return false;
 }
 
 bool mattack::speaker( monster *z )

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1171,7 +1171,7 @@ bool mattack::smash( monster *z )
         target->add_msg_player_or_npc( _( "The %s takes a powerful swing at you, but you dodge it!" ),
                                        _( "The %s takes a powerful swing at <npcname>, who dodges it!" ),
                                        z->name() );
-        target->on_dodge( z, z->type->melee_skill * 2 );
+        target->on_dodge( z, z->type->melee_skill );
         return true;
     }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -943,7 +943,6 @@ bool mattack::boomer( monster *z )
     }
     target->on_dodge( z, 5 );
 
-
     return true;
 }
 
@@ -990,7 +989,6 @@ bool mattack::boomer_glow( monster *z )
         target->add_msg_player_or_npc( _( "You dodge it!" ),
                                        _( "<npcname> dodges it!" ) );
     }
-
 
     return true;
 }
@@ -1889,7 +1887,6 @@ bool mattack::fungus_inject( monster *z )
         target->on_dodge( z, z->type->melee_skill );
         return true;
     }
-
 
     target->block_hit( z, hit, dam_inst );
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -5999,8 +5999,12 @@ bool mattack::dodge_check( monster *z, Creature *target )
         return true;
     }
 
+    const float dodge_ability = target->get_dodge();
+    if( dodge_ability > 0.0 ) {
+        target->on_try_dodge();
+    }
     ///\EFFECT_DODGE increases chance of dodging, vs their melee skill
-    float dodge = std::max( target->get_dodge() - rng( 0, z->get_hit() ), 0.0f );
+    float dodge = std::max( dodge_ability - rng( 0, z->get_hit() ), 0.0f );
     return dodge > 0.0 && rng( 0, 10000 ) < 10000 / ( 1 + 99 * std::exp( -.6 * dodge ) );
 }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -6029,7 +6029,7 @@ bool mattack::dodge_check( monster *z, Creature *target, bodypart_id bp, damage_
     if( dmg_ratio >= 0.5f ) {
         guy_target->on_try_dodge();
         float attack_roll = z->get_hit() + rng_normal( 0, 5 );
-        const float dodge_ability = target->get_dodge();
+        const float dodge_ability = guy_target->get_dodge();
         return dodge_ability > attack_roll;
     } else if( dmg_ratio > 0.0f ) { // else apply usual rules
         return dodge_check( z, guy_target );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2149,7 +2149,7 @@ bool mattack::impale( monster *z )
                                        _( "The %s lunges at <npcname>, but they dodge!" ),
                                        z->name() );
 
-        target->on_dodge( z, z->type->melee_skill * 2);
+        target->on_dodge( z, z->type->melee_skill * 2 );
         return true;
     }
 
@@ -5999,12 +5999,12 @@ bool mattack::dodge_check( monster *z, Creature *target )
     }
 
     const float dodge_ability = target->get_dodge();
-    if( dodge_ability > 0.0 ) {
+    if( dodge_ability > 0.8f ) {
         target->on_try_dodge();
     }
-    ///\EFFECT_DODGE increases chance of dodging, vs their melee skill
-    float dodge = std::max( dodge_ability - rng( 0, z->get_hit() ), 0.0f );
-    return dodge > 0.0 && rng( 0, 10000 ) < 10000 / ( 1 + 99 * std::exp( -.6 * dodge ) );
+
+    float attack_roll = z->get_hit() + rng_normal( 0, 5 );
+    return dodge_ability > attack_roll;
 }
 
 bool mattack::speaker( monster *z )

--- a/src/monattack.h
+++ b/src/monattack.h
@@ -2,6 +2,8 @@
 #ifndef CATA_SRC_MONATTACK_H
 #define CATA_SRC_MONATTACK_H
 
+#include "bodypart.h"
+
 class monster;
 class Creature;
 
@@ -117,6 +119,7 @@ void frag( monster *z, Creature *target );              // Automated MGL
 void tankgun( monster *z, Creature *target );           // Tankbot primary.
 void flame( monster *z, Creature *target );
 
+bool dodge_check( monster *z, Creature *target, bodypart_id bp, damage_instance dam_inst );
 bool dodge_check( monster *z, Creature *target );
 } //namespace mattack
 

--- a/src/monattack.h
+++ b/src/monattack.h
@@ -119,8 +119,6 @@ void frag( monster *z, Creature *target );              // Automated MGL
 void tankgun( monster *z, Creature *target );           // Tankbot primary.
 void flame( monster *z, Creature *target );
 
-bool dodge_check( monster *z, Creature *target, bodypart_id bp, damage_instance dam_inst );
-bool dodge_check( monster *z, Creature *target );
 } //namespace mattack
 
 #endif // CATA_SRC_MONATTACK_H

--- a/src/monattack.h
+++ b/src/monattack.h
@@ -2,7 +2,6 @@
 #ifndef CATA_SRC_MONATTACK_H
 #define CATA_SRC_MONATTACK_H
 
-
 class monster;
 class Creature;
 

--- a/src/monattack.h
+++ b/src/monattack.h
@@ -2,7 +2,6 @@
 #ifndef CATA_SRC_MONATTACK_H
 #define CATA_SRC_MONATTACK_H
 
-#include "bodypart.h"
 
 class monster;
 class Creature;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1732,7 +1732,8 @@ bool monster::melee_attack( Creature &target, float accuracy )
         return false;
     }
 
-    int hitspread = target.deal_melee_attack( this, melee::melee_hit_range( accuracy ) );
+    const int monster_hit_roll = melee::melee_hit_range( accuracy );
+    int hitspread = target.deal_melee_attack( this, monster_hit_roll );
     if( type->melee_dice == 0 ) {
         // We don't hit, so just return
         return true;
@@ -1766,21 +1767,23 @@ bool monster::melee_attack( Creature &target, float accuracy )
 
     const int total_dealt = dealt_dam.total_damage();
     if( hitspread < 0 ) {
-        bool target_dodging = target.dodge_roll() > 0.0;
+        bool monster_missed = monster_hit_roll < 0.0;
         // Miss
         if( u_see_my_spot && !target.in_sleep_state() ) {
             if( target.is_avatar() ) {
-                if( target_dodging ) {
-                    add_msg( _( "You dodge %s." ), u_see_me ? disp_name() : _( "something" ) );
-                } else {
+                if( monster_missed ) {
                     add_msg( _( "%s misses you." ), u_see_me ? disp_name( false, true ) : _( "Something" ) );
+                } else {
+                    add_msg( _( "You dodge %s." ), u_see_me ? disp_name() : _( "something" ) );
                 }
-            } else if( target.is_npc() && target_dodging ) {
-                add_msg( _( "%1$s dodges %2$s attack." ),
-                         target.disp_name(), u_see_me ? name() : _( "something" ) );
-            } else {
-                add_msg( _( "%1$s misses %2$s!" ),
-                         u_see_me ? disp_name( false, true ) : _( "Something" ), target.disp_name() );
+            } else if( target.is_npc() ) {
+                if( monster_missed ) {
+                    add_msg( _( "%1$s misses %2$s!" ),
+                             u_see_me ? disp_name( false, true ) : _( "Something" ), target.disp_name() );
+                } else {
+                    add_msg( _( "%1$s dodges %2$s attack." ),
+                             target.disp_name(), u_see_me ? name() : _( "something" ) );
+                }
             }
         } else if( target.is_avatar() ) {
             add_msg( _( "You dodge an attack from an unseen source." ) );

--- a/src/monster.h
+++ b/src/monster.h
@@ -414,6 +414,7 @@ class monster : public Creature
         float stability_roll() const override;
         // We just dodged an attack from something
         void on_dodge( Creature *source, float difficulty ) override;
+        void on_try_dodge() override {}
         // Something hit us (possibly null source)
         void on_hit( Creature *source, bodypart_id bp_hit,
                      float difficulty = INT_MIN, dealt_projectile_attack const *proj = nullptr ) override;

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -42,6 +42,39 @@ units::angle random_direction()
     return rng_float( 0_pi_radians, 2_pi_radians );
 }
 
+// Returns the area under a curve with provided standard deviation and center
+// from difficulty to positive infinity. That is, the chance that a normal roll on
+// said curve will return a value of difficulty or greater.
+float normal_roll_chance( float center, float stddev, float difficulty )
+{
+    cata_assert( stddev >= 0.f );
+    // We're going to be using them a lot, so let's name our variables.
+    // M = the given "center" of the curve
+    // S = the given standard deviation of the curve
+    // A = the difficulty
+    // So, the equation of the normal curve is...
+    // y = (1.f/(S*std::sqrt(2 * M_PI))) * exp(-(std::pow(x - M, 2))/(2 * std::pow(S, 2)))
+    // Thanks to wolfram alpha, we know the integral of that from A to B to be
+    // 0.5 * (erf((M-A)/(std::sqrt(2) * S)) - erf((M-B)/(std::sqrt(2) * S)))
+    // And since we know B to be infinity, we can simplify that to
+    // 0.5 * (erfc((A-m)/(std::sqrt(2)* S))+sgn(S)-1) (as long as S != 0)
+    // Wait a second, what are erf, erfc and sgn?
+    // Oh, those are the error function, complementary error function, and sign function
+    // Luckily, erf() is provided to us in math.h, and erfc is just 1 - erf
+    // Sign is pretty obvious x > 0 ? x == 0 ? 0 : 1 : -1;
+    // Since we know S will always be > 0, that term vanishes.
+
+    // With no standard deviation, we will always return center
+    if( stddev == 0.f ) {
+        return ( center > difficulty ) ? 1.f : 0.f;
+    }
+
+    float numerator = difficulty - center;
+    float denominator = std::sqrt( 2 ) * stddev;
+    float compl_erf = 1.f - std::erf( numerator / denominator );
+    return 0.5 * compl_erf;
+}
+
 double normal_roll( double mean, double stddev )
 {
     static std::normal_distribution<double> rng_normal_dist;

--- a/src/rng.h
+++ b/src/rng.h
@@ -70,6 +70,8 @@ inline double rng_normal( double hi )
     return rng_normal( 0.0, hi );
 }
 
+float normal_roll_chance( float center, float stddev, float difficulty );
+
 double normal_roll( double mean, double stddev );
 
 double chi_squared_roll( double trial_num );

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -99,7 +99,7 @@ TEST_CASE( "Character::get_hit_base", "[character][melee][hit][dex]" )
 
     avatar &dummy = get_avatar();
     clear_character( dummy );
-    dummy.dodges_left = 1;
+    dummy.set_dodges_left( 1 );
 
     SECTION( "character get_hit_base increases by 1/4 for each point of DEX" ) {
         CHECK( hit_base_with_dex( dummy, 1 ) == 0.25f );

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -323,7 +323,7 @@ TEST_CASE( "player::get_dodge stamina effects", "[player][melee][dodge][stamina]
 
         SECTION( "30% stamina" ) {
             dummy.set_stamina( .3 * stamina_max );
-            CHECK( dummy.get_dodge() == Approx( 0.4f ).margin( 0.1 ) );
+            CHECK( dummy.get_dodge() == Approx( 0.0f ).margin( 0.1 ) );
         }
 
         SECTION( "20% stamina" ) {

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -308,37 +308,37 @@ TEST_CASE( "player::get_dodge stamina effects", "[player][melee][dodge][stamina]
 
         SECTION( "75% stamina" ) {
             dummy.set_stamina( .75 * stamina_max );
-            CHECK( dummy.get_dodge() == Approx( 4.0f ).margin( 0.001 ) );
+            CHECK( dummy.get_dodge() == Approx( 3.8f ).margin( 0.1 ) );
         }
 
         SECTION( "50% stamina" ) {
             dummy.set_stamina( .5 * stamina_max );
-            CHECK( dummy.get_dodge() == Approx( 4.0f ).margin( 0.001 ) );
+            CHECK( dummy.get_dodge() == Approx( 2.0f ).margin( 0.1 ) );
         }
 
         SECTION( "40% stamina" ) {
             dummy.set_stamina( .4 * stamina_max );
-            CHECK( dummy.get_dodge() == Approx( 3.2f ).margin( 0.001 ) );
+            CHECK( dummy.get_dodge() == Approx( 1.0f ).margin( 0.1 ) );
         }
 
         SECTION( "30% stamina" ) {
             dummy.set_stamina( .3 * stamina_max );
-            CHECK( dummy.get_dodge() == Approx( 2.4f ).margin( 0.001 ) );
+            CHECK( dummy.get_dodge() == Approx( 0.4f ).margin( 0.1 ) );
         }
 
         SECTION( "20% stamina" ) {
             dummy.set_stamina( .2 * stamina_max );
-            CHECK( dummy.get_dodge() == Approx( 1.6f ).margin( 0.001 ) );
+            CHECK( dummy.get_dodge() == Approx( 0.0f ).margin( 0.1 ) );
         }
 
         SECTION( "10% stamina" ) {
             dummy.set_stamina( .1 * stamina_max );
-            CHECK( dummy.get_dodge() == Approx( 0.8f ).margin( 0.001 ) );
+            CHECK( dummy.get_dodge() == Approx( 0.0f ).margin( 0.1 ) );
         }
 
         SECTION( "0% stamina" ) {
             dummy.set_stamina( 0 );
-            CHECK( dummy.get_dodge() == Approx( 0.0f ).margin( 0.001 ) );
+            CHECK( dummy.get_dodge() == Approx( 0.0f ).margin( 0.1 ) );
         }
     }
 }

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -47,7 +47,7 @@ static float brute_special_probability( monster &attacker, Creature &target, con
 {
     size_t hits = 0;
     for( size_t i = 0; i < iters; i++ ) {
-        if( !mattack::dodge_check( &attacker, &target ) ) {
+        if( !target.dodge_check( &attacker ) ) {
             hits++;
         }
     }

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -261,11 +261,11 @@ TEST_CASE( "Charcter can dodge" )
     dude.clear_effects();
     REQUIRE( dude.get_dodge() > 0.0 );
 
-    const int dodges_left = dude.dodges_left;
+    const int dodges_left = dude.get_dodges_left();
     for( int i = 0; i < 10000; ++i ) {
         dude.deal_melee_attack( &zed, 1 );
-        if( dodges_left < dude.dodges_left ) {
-            CHECK( dodges_left < dude.dodges_left );
+        if( dodges_left < dude.get_dodges_left() ) {
+            CHECK( dodges_left < dude.get_dodges_left() );
             break;
         }
     }
@@ -280,10 +280,10 @@ TEST_CASE( "Incapacited character can't dodge" )
     dude.add_effect( effect_sleep, 1_hours );
     REQUIRE( dude.get_dodge() == 0.0 );
 
-    const int dodges_left = dude.dodges_left;
+    const int dodges_left = dude.get_dodges_left();
     for( int i = 0; i < 10000; ++i ) {
         dude.deal_melee_attack( &zed, 1 );
-        CHECK( dodges_left == dude.dodges_left );
+        CHECK( dodges_left == dude.get_dodges_left() );
     }
 }
 

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -204,7 +204,7 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
     // You got a player
     Character &you = get_player_character();
     clear_avatar();
-    you.dodges_left = 1;
+    you.set_dodges_left( 1 ) ;
     REQUIRE( Approx( you.get_dodge() ) == 4.0 );
     you.setpos( target_location );
     const tripoint_abs_ms abs_target_location = you.get_location();
@@ -232,7 +232,7 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
             you.set_all_parts_hp_to_max();
             // Remove stagger/winded effects
             you.clear_effects();
-            you.dodges_left = 1;
+            you.set_dodges_left( 1 );
             int prev_hp = you.get_hp();
             // monster shoots the player
             REQUIRE( attack->call( test_monster ) == true );

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -230,6 +230,7 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
         epsilon_threshold threshold{ expected_damage, 2.5 };
         do {
             you.set_all_parts_hp_to_max();
+            you.set_stamina( you.get_stamina_max() ); // Resets stamina so dummy can keep dodging
             // Remove stagger/winded effects
             you.clear_effects();
             you.set_dodges_left( 1 );


### PR DESCRIPTION
#### Summary
None 

#### Purpose of change
Continuation of #47576

#### Describe the solution

- [x] Check for potential damage before deciding to dodge
- [x] Check for probability of dodge before trying to dodge
- [x] Move check_dodge out of monattack and  into Creature
- [x] Unify all the scattered `get_dodge` to use `dodge_check` every time an actual dodge is supposed to take place
- [x] Make use of `dodge_roll()`
- [x] Move ` dodges_left--` from `on_dodge` to `on_try_dodge`
- [x] Make sure `dodge_check` is called where needed
- [x] doudble check there's no free dodge left-overs
- [x] Make sure tests are still working
- [x] Projectile attacks

Also consume dodge_attempt inside `on_dodge_try` instead of on succesfull dodge which will probably reduce effective chance to dodge since you'll only get one attempt per turn instead of one succes per turn

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Get naked
- Get high dodge
- Get invincible
- Spawn a slime
- Wait and dodge
- See stamina go down
- When stamina get around two bars, the dodges don't happen anymore and the stamina doesn't get lower

Check that dodging projectile cares about stamina
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41293484/f3168ff8-b23c-41f5-a59d-e2e3a0a7cdd7)

Check that you get a message about not trying to doge special attacks
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41293484/e6ef9e86-d461-4233-a1c3-3c721fe83170)


#### Additional context

We still need to unify dodges, this makes two parallele way to doge:
- Special attacks are dodged via `dodge_check` which only tries to dodge if we have 80% or more chance of succes (should make it 50%?) , and only if the attack would do non 0 damage. Alternatively if the attacks were to do more than half the current hp of the target part in damage it tries to doge no matter the chances
- Regular attack go through deal_melee_attack which always calls `on_try_dodge`

I didn't manage to unify everything because deal_melee_attack sometimes use flat hit roll value, and sometimes random value from dice rolls and sometimes random values from rng_normal and I have no idea how to unify those