### PR TITLE
Disallow working on vehicle wheels in water

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -46,6 +46,7 @@
 #include "localized_comparator.h"
 #include "map.h"
 #include "map_selector.h"
+#include "mapdata.h"
 #include "memory_fast.h"
 #include "messages.h"
 #include "monster.h"
@@ -2216,6 +2217,16 @@ std::pair<bool, std::string> veh_interact::calc_lift_requirements( const vpart_i
     avatar &player_character = get_avatar();
 
     if( sel_vpart_info.has_flag( "NEEDS_JACKING" ) ) {
+        if( terrain_here.has_flag( ter_furn_flag::TFLAG_LIQUID ) ) {
+            const auto wrap_badter = foldstring(
+                                         _( "<color_red>Unsuitable terrain</color> for working on part that requires jacking." ),
+                                         getmaxx( w_msg ) - 4 );
+            nmsg += "> " + wrap_badter[0] + "\n";
+            for( size_t i = 1; i < wrap_badter.size(); i++ ) {
+                nmsg += "  " + wrap_badter[i] + "\n";
+            }
+            return std::pair<bool, std::string> ( false, nmsg );
+        }
         qual = qual_JACK;
         lvl = jack_quality( *veh );
         str = veh->lift_strength();
@@ -2333,6 +2344,7 @@ void veh_interact::move_cursor( const point &d, int dstart_at )
     const tripoint vehp = veh->global_pos3() + q;
     const bool has_critter = get_creature_tracker().creature_at( vehp );
     map &here = get_map();
+    terrain_here = here.ter( vehp ).obj();
     bool obstruct = here.impassable_ter_furn( vehp );
     const optional_vpart_position ovp = here.veh_at( vehp );
     if( ovp && &ovp->vehicle() != veh ) {

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -16,6 +16,7 @@
 #include "input.h"
 #include "inventory.h"
 #include "item_location.h"
+#include "mapdata.h"
 #include "memory_fast.h"
 #include "optional.h"
 #include "player_activity.h"
@@ -283,6 +284,10 @@ class veh_interact
          * Can be converted to a vector<vehicle_part>.
          * Updated whenever the cursor moves. */
         std::vector<int> parts_here;
+
+        /* Terrain at current square.
+         * Updated whenever the cursor moves. */
+        ter_t terrain_here;
 
         /* called by exec() */
         void cache_tool_availability();


### PR DESCRIPTION
#### Summary
Bugfixes "Disallow working on vehicle wheels in water"

#### Purpose of change
In [this comment](https://github.com/CleverRaven/Cataclysm-DDA/issues/63957#issuecomment-1458729811) working on vehicle wheels in water was deemed unreasonable as it was considered to be underwater even if the vehicle can float, let alone when it cannot.

#### Describe the solution
Add `veh_interact::terrain_here` which is updated to hold terrain in current square when cursor is moved in the vehicle UI.

Prohibit working on wheels and wheel hubs (detected by checking `NEEDS_JACKING`) when the tile is water (`TFLAG_LIQUID`).

#### Describe alternatives you've considered
Instead of storing terrain in `terrain_here`, an alternative approach could run checks for `TFLAG_LIQUID` in `move_cursor` and store a flag `is_liquid_terrain_here`. However prefer having terrain as implemented for more flexibility since we may want to check for different flags or other aspects in future. In the past it was assumed vehicle modification can be done anywhere, but we now have boats and aircraft, and trains are in the pipeline, so those old assumptions may no longer be valid.

In general one can make the case that other kinds of vehicle modification work should also not be allowed underwater, so we should simply prohibit any work in liquid tiles unless vehicle is a viable watercraft. However, an oversimplistic approach could make boat building from scratch too much of a pain -- it won't float in early stages of the build, so may be forced to start on land. Hence, I want to be careful and take a bit more time to work on that before putting up a PR for it.

#### Testing
![badter](https://user-images.githubusercontent.com/28502722/224784759-e571108c-06c3-4273-8c0e-f0fd9d79b2a3.png)
