### PR TITLE
Set pocket management menu message according to set keybindings

### DIFF
--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2493,44 +2493,8 @@ std::vector<item_pocket *> outfit::grab_drop_pockets()
 void outfit::organize_items_menu()
 {
     std::vector<item *> to_organize;
-    uilist pocket_selector;
     for( item &i : worn ) {
         to_organize.push_back( &i );
     }
-    pocket_favorite_callback cb( to_organize, pocket_selector );
-
-    pocket_selector.title = _( "Inventory Organization" );
-    pocket_selector.text = cb.title;
-    pocket_selector.callback = &cb;
-    pocket_selector.w_x_setup = 0;
-    pocket_selector.w_width_setup = []() {
-        return TERMX;
-    };
-    pocket_selector.pad_right_setup = []() {
-        return std::max( TERMX / 2, TERMX - 50 );
-    };
-    pocket_selector.w_y_setup = 0;
-    pocket_selector.w_height_setup = []() {
-        return TERMY;
-    };
-    pocket_selector.input_category = "INVENTORY";
-    pocket_selector.additional_actions = { { "FAV_PRIORITY", translation() },
-        { "FAV_AUTO_PICKUP", translation() },
-        { "FAV_AUTO_UNLOAD", translation() },
-        { "FAV_ITEM", translation() },
-        { "FAV_CATEGORY", translation() },
-        { "FAV_WHITELIST", translation() },
-        { "FAV_BLACKLIST", translation() },
-        { "FAV_CLEAR", translation() },
-        { "FAV_MOVE_ITEM", translation() },
-        { "FAV_CONTEXT_MENU", translation() },
-        { "FAV_SAVE_PRESET", translation() },
-        { "FAV_APPLY_PRESET", translation() },
-        { "FAV_DEL_PRESET", translation() }
-    };
-    // we override confirm
-    pocket_selector.allow_confirm = false;
-    pocket_selector.allow_additional = true;
-
-    pocket_selector.query();
+    pocket_management_menu( _( "Inventory Organization" ), to_organize );
 }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2441,7 +2441,7 @@ void item_contents::favorite_settings_menu( item *i )
     pocket_management_menu( remove_color_tags( i->display_name() ), to_organize );
 }
 
-void pocket_management_menu( const std::string title, const std::vector<item *> &to_organize )
+void pocket_management_menu( const std::string &title, const std::vector<item *> &to_organize )
 {
     static const std::string input_category = "INVENTORY";
     input_context ctxt( input_category );

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -36,6 +36,34 @@
 
 static const flag_id json_flag_CASING( "CASING" );
 
+class pocket_favorite_callback : public uilist_callback
+{
+    private:
+        std::vector<std::tuple<item_pocket *, int, uilist_entry *>> saved_pockets;
+        // whitelist or blacklist, for interactions
+        bool whitelist = true;
+        std::pair<item *, item_pocket *> item_to_move = { nullptr, nullptr };
+
+        bool needs_to_refresh = false;
+
+        std::string uilist_text;
+
+        // items to create pockets for
+        std::vector<item *> to_organize;
+
+        void move_item( uilist *menu, item_pocket *selected_pocket );
+
+        void refresh_columns( uilist *menu );
+
+        void add_pockets( item &i, uilist &pocket_selector, const std::string &depth );
+    public:
+        explicit pocket_favorite_callback( const std::string &uilist_text,
+                                           const std::vector<item *> &to_organize,
+                                           uilist &pocket_selector );
+        void refresh( uilist *menu ) override;
+        bool key( const input_context &, const input_event &event, int entnum, uilist *menu ) override;
+};
+
 void pocket_favorite_callback::refresh( uilist *menu )
 {
     if( needs_to_refresh ) {
@@ -90,11 +118,10 @@ void pocket_favorite_callback::refresh( uilist *menu )
     wnoutrefresh( menu->window );
 }
 
-pocket_favorite_callback::pocket_favorite_callback( const std::vector<item *> &to_organize,
-        uilist &pocket_selector )
+pocket_favorite_callback::pocket_favorite_callback( const std::string &uilist_text,
+        const std::vector<item *> &to_organize, uilist &pocket_selector )
+    : uilist_text( uilist_text ), to_organize( to_organize )
 {
-    this->to_organize = to_organize;
-
     for( item *i : to_organize ) {
         add_pockets( *i, pocket_selector, "" );
     }
@@ -216,7 +243,7 @@ void pocket_favorite_callback::move_item( uilist *menu, item_pocket *selected_po
         // reset the moved item
         item_to_move = { nullptr, nullptr };
 
-        menu->settext( title );
+        menu->settext( uilist_text );
 
         refresh_columns( menu );
     }
@@ -247,9 +274,9 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         return false;
     }
 
+    const std::string remove_prefix = "<color_light_red>-</color> ";
+    const std::string add_prefix = "<color_green>+</color> ";
     const std::string &action = ctxt.input_to_action( event );
-    //popup( string_format( "%s, %s, %s.", event.long_description(),
-    //                      event.short_description(), action ) );
     if( action == "FAV_WHITELIST" ) {
         whitelist = true;
         return true;
@@ -271,22 +298,15 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
     } else if( action == "FAV_AUTO_UNLOAD" ) {
         selected_pocket->settings.set_unloadable( !selected_pocket->settings.is_unloadable() );
         return true;
-    }
-    uilist selector_menu;
-
-    const std::string remove_prefix = "<color_light_red>-</color> ";
-    const std::string add_prefix = "<color_green>+</color> ";
-    if( action == "FAV_MOVE_ITEM" ) {
+    } else if( action == "FAV_MOVE_ITEM" ) {
         move_item( menu, selected_pocket );
-
         return true;
-    }
-
-    if( action == "FAV_ITEM" ) {
+    } else if( action == "FAV_ITEM" ) {
         const cata::flat_set<itype_id> &listed_itypes = whitelist
                 ? selected_pocket->settings.get_item_whitelist()
                 : selected_pocket->settings.get_item_blacklist();
         cata::flat_set<itype_id> nearby_itypes;
+        uilist selector_menu;
         selector_menu.title = _( "Select an item from nearby" );
         for( const std::list<item> *it_list : get_player_character().crafting_inventory().const_slice() ) {
             nearby_itypes.insert( it_list->front().typeId() );
@@ -368,6 +388,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
             return localized_compare( lhs.name(), rhs.name() );
         } );
 
+        uilist selector_menu;
         for( const item_category &cat : all_cat ) {
             const bool in_list = listed_cat.count( cat.get_id() );
             const std::string &prefix = in_list ? remove_prefix : add_prefix;
@@ -411,6 +432,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         return true;
     } else if( action == "FAV_APPLY_PRESET" ) {
         item_pocket::load_presets();
+        uilist selector_menu;
         selector_menu.title = _( "Select a preset" );
         for( const item_pocket::favorite_settings &preset : item_pocket::pocket_presets ) {
             selector_menu.addentry( preset.get_preset_name().value() );
@@ -423,6 +445,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         return true;
     } else if( action == "FAV_DEL_PRESET" ) {
         item_pocket::load_presets();
+        uilist selector_menu;
         for( const item_pocket::favorite_settings &preset : item_pocket::pocket_presets ) {
             selector_menu.addentry( preset.get_preset_name().value() );
         }
@@ -2413,13 +2436,22 @@ void item_contents::info( std::vector<iteminfo> &info, const iteminfo_query *par
 
 void item_contents::favorite_settings_menu( item *i )
 {
-
     std::vector<item *> to_organize;
-    uilist pocket_selector;
     to_organize.push_back( i );
-    pocket_favorite_callback cb( to_organize, pocket_selector );
-    pocket_selector.title = remove_color_tags( i->display_name() );
-    pocket_selector.text = cb.title;
+    pocket_management_menu( remove_color_tags( i->display_name() ), to_organize );
+}
+
+void pocket_management_menu( const std::string title, const std::vector<item *> &to_organize )
+{
+    static const std::string input_category = "INVENTORY";
+    input_context ctxt( input_category );
+    const std::string uilist_text = string_format(
+                                        _( "Modify pocket settings and move items between pockets.  [<color_yellow>%s</color>] Context menu" ),
+                                        ctxt.get_desc( "FAV_CONTEXT_MENU", 1 ) );
+    uilist pocket_selector;
+    pocket_favorite_callback cb( uilist_text, to_organize, pocket_selector );
+    pocket_selector.title = title;
+    pocket_selector.text = uilist_text;
     pocket_selector.callback = &cb;
     pocket_selector.w_x_setup = 0;
     pocket_selector.w_width_setup = []() {
@@ -2432,8 +2464,9 @@ void item_contents::favorite_settings_menu( item *i )
     pocket_selector.w_height_setup = []() {
         return TERMY;
     };
-    pocket_selector.input_category = "INVENTORY";
-    pocket_selector.additional_actions = { { "FAV_PRIORITY", translation() },
+    pocket_selector.input_category = input_category;
+    pocket_selector.additional_actions = {
+        { "FAV_PRIORITY", translation() },
         { "FAV_AUTO_PICKUP", translation() },
         { "FAV_AUTO_UNLOAD", translation() },
         { "FAV_ITEM", translation() },
@@ -2447,7 +2480,7 @@ void item_contents::favorite_settings_menu( item *i )
         { "FAV_APPLY_PRESET", translation() },
         { "FAV_DEL_PRESET", translation() }
     };
-    // we override confirm
+    // Override CONFIRM with FAV_CONTEXT_MENU
     pocket_selector.allow_confirm = false;
     pocket_selector.allow_additional = true;
 

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -374,6 +374,6 @@ class item_contents
         friend struct item_contents_helper;
 };
 
-void pocket_management_menu( const std::string title, const std::vector<item *> &to_organize );
+void pocket_management_menu( const std::string &title, const std::vector<item *> &to_organize );
 
 #endif // CATA_SRC_ITEM_CONTENTS_H

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -16,7 +16,6 @@
 #include "optional.h"
 #include "ret_val.h"
 #include "type_id.h"
-#include "ui.h"
 #include "units_fwd.h"
 #include "visitable.h"
 
@@ -375,32 +374,6 @@ class item_contents
         friend struct item_contents_helper;
 };
 
-class pocket_favorite_callback : public uilist_callback
-{
-    private:
-        std::vector<std::tuple<item_pocket *, int, uilist_entry *>> saved_pockets;
-        // whitelist or blacklist, for interactions
-        bool whitelist = true;
-        std::pair<item *, item_pocket *> item_to_move = { nullptr, nullptr };
-
-        bool needs_to_refresh = false;
-
-        // items to create pockets for
-        std::vector<item *> to_organize;
-
-        void move_item( uilist *menu, item_pocket *selected_pocket );
-
-        void refresh_columns( uilist *menu );
-
-        void add_pockets( item &i, uilist &pocket_selector, const std::string &depth );
-    public:
-        explicit pocket_favorite_callback( const std::vector<item *> &to_organize,
-                                           uilist &pocket_selector );
-        void refresh( uilist *menu ) override;
-        bool key( const input_context &, const input_event &event, int entnum, uilist *menu ) override;
-
-        const std::string title =
-            _( "Modify pocket settings and move items between pockets.  [<color_yellow>RETURN</color>] Context menu\n" );
-};
+void pocket_management_menu( const std::string title, const std::vector<item *> &to_organize );
 
 #endif // CATA_SRC_ITEM_CONTENTS_H


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Generate the keybinding message according to the currently set hotkeys, reduce code duplication by moving the code into a function, and other code cleanup.

#### Testing
Tested in game and the keybinding message was shown correctly when changing the pocket settings for a single item or the full inventory. Other parts of the UI also worked as expected.

#### Additional context
Currently keybinding messages of uilists are not updated dynamically so this one is not updated either. Perhaps we can change the message members of uilist into callbacks that take the input context and output the dynamic message but that is out of the scope of this PR.
