### PR TITLE
fix #64207

### DIFF
--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -1981,18 +1981,20 @@
         "encumbrance": 30
       },
       {
-        "material": [ { "type": "pseudo_soft_qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
+        "material": [ { "type": "qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 }, { "type": "cotton", "covered_by_mat": 100, "thickness": 0.001 } ],
         "covers": [ "eyes" ],
         "coverage": 95,
         "cover_ranged": 10,
-        "encumbrance": 2
+        "encumbrance": 2,
+        "breathability": "GOOD"
       },
       {
-        "material": [ { "type": "pseudo_soft_qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
+        "material": [ { "type": "qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 }, { "type": "cotton", "covered_by_mat": 100, "thickness": 0.001 } ],
         "covers": [ "mouth" ],
         "coverage": 95,
         "cover_ranged": 10,
-        "encumbrance": 0
+        "encumbrance": 0,
+        "breathability": "GOOD"
       },
       {
         "covers": [ "foot_l", "foot_r" ],

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -1981,7 +1981,10 @@
         "encumbrance": 30
       },
       {
-        "material": [ { "type": "qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 }, { "type": "cotton", "covered_by_mat": 100, "thickness": 0.001 } ],
+        "material": [
+          { "type": "qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 0.001 }
+        ],
         "covers": [ "eyes" ],
         "coverage": 95,
         "cover_ranged": 10,
@@ -1989,7 +1992,10 @@
         "breathability": "GOOD"
       },
       {
-        "material": [ { "type": "qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 }, { "type": "cotton", "covered_by_mat": 100, "thickness": 0.001 } ],
+        "material": [
+          { "type": "qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 0.001 }
+        ],
         "covers": [ "mouth" ],
         "coverage": 95,
         "cover_ranged": 10,

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -1981,13 +1981,13 @@
         "encumbrance": 30
       },
       {
-        "material": [ { "type": "qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
+        "material": [ { "type": "pseudo_soft_qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
         "covers": [ "eyes" ],
         "coverage": 95,
         "encumbrance": 7
       },
       {
-        "material": [ { "type": "qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
+        "material": [ { "type": "pseudo_soft_qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
         "covers": [ "mouth" ],
         "coverage": 95,
         "encumbrance": 1

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -1966,7 +1966,7 @@
     "type": "ARMOR",
     "copy-from": "qt_chainmail_suit",
     "name": { "str": "faraday chainmail suit" },
-    "description": "A fully customized chainmail suit that can be worn over your normal clothing.  The suit is conductively interconnected, protecting against electricity.",
+    "description": "A fully customized chainmail suit that can be worn over your normal clothing.  The suit is conductively interconnected with a cage covering the face, protecting against electricity.",
     "armor": [
       {
         "material": [ { "type": "qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
@@ -1984,13 +1984,15 @@
         "material": [ { "type": "pseudo_soft_qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
         "covers": [ "eyes" ],
         "coverage": 95,
-        "encumbrance": 7
+        "cover_ranged": 10,
+        "encumbrance": 2
       },
       {
         "material": [ { "type": "pseudo_soft_qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
         "covers": [ "mouth" ],
         "coverage": 95,
-        "encumbrance": 1
+        "cover_ranged": 10,
+        "encumbrance": 0
       },
       {
         "covers": [ "foot_l", "foot_r" ],
@@ -2004,7 +2006,7 @@
           "foot_arch_r",
           "foot_arch_l"
         ],
-        "material": [ { "type": "qt_steel", "covered_by_mat": 100, "thickness": 1.2 } ],
+        "material": [ { "type": "qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
         "encumbrance": 10,
         "coverage": 100
       }

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -2124,13 +2124,6 @@
   },
   {
     "type": "material",
-    "id": "pseudo_soft_qt_steel_chain",
-    "//": "Pseudo chain material for not rasping on faces",
-    "copy-from": "qt_steel_chain",
-    "uncomfortable": false
-  },
-  {
-    "type": "material",
     "id": "steel",
     "name": "Steel",
     "density": 8,

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -2123,11 +2123,11 @@
     "burn_products": [ [ "scrap", 1 ] ]
   },
   {
-	  "type": "material",
-	  "id": "pseudo_soft_qt_steel_chain",
-	  "//": "Pseudo chain material for not rasping on faces",
-	  "copy-from": "qt_steel_chain",
-	  "uncomfortable": false
+    "type": "material",
+    "id": "pseudo_soft_qt_steel_chain",
+    "//": "Pseudo chain material for not rasping on faces",
+    "copy-from": "qt_steel_chain",
+    "uncomfortable": false
   },
   {
     "type": "material",

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -2123,6 +2123,13 @@
     "burn_products": [ [ "scrap", 1 ] ]
   },
   {
+	  "type": "material",
+	  "id": "pseudo_soft_qt_steel_chain",
+	  "//": "Pseudo chain material for not rasping on faces",
+	  "copy-from": "qt_steel_chain",
+	  "uncomfortable": false
+  },
+  {
     "type": "material",
     "id": "steel",
     "name": "Steel",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
fixes #64207, ~~in the way provided by @anoobindisguise, then agreed upon by the author~~ well yes, but actually no. it's a functionally identical fix with less materials.json bloat, provided by Drew4484
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
~~creates a copy of qt_steel_chain, except it's comfortable, and applied that to the faraday chainmail suit's eyes and mouth.~~
gives the eyes and mouth of faraday chainmail suit an infinitesimally thin layer of cotton (not actually reflected in the recipe, but I hope we can pretend it doesn't exist because I try to reflect anoobindisguise saying it's a cage), and adjusted breathability to match
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
some convoluted way of telling certain clothing layers to act padded, rather than the whole outfit
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
nakey. faraday suit. uncomfortable, but not for eyes or mouth. the new stats show up in-game
![image](https://user-images.githubusercontent.com/99511880/227272358-71d02637-419e-4992-bd01-2ec53d21b8aa.png)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
the size variants of the faraday chainmail suit has "copy-from" so I am not making a direct edit there
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
picture of one Anouk Wipprecht for reference of the new visualization of face cover (focus on the cage part). also removing the mouth encumbrance completely + lowering eye encumbrance because of this, as well as setting the ranged coverage to 10% on behalf of anoobindisguise. I also cite for the change from qt_steel to qt_steel_chain, as outlined by a comment in the issue
![image](https://user-images.githubusercontent.com/99511880/225139383-ee235581-2b4a-4edd-b344-53909fd70853.png)
even after Drew's fix, it being a modelling of Anouk's work does not change. pretend it's a cage. 
yes, I'll try to keep up to date when future PRs allow us to get rid of this janky fix and set the two layers to comfortable.