### PR TITLE
Cull pets

### DIFF
--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -35,7 +35,7 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "SWARMS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "SWARMS", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_grouse",
@@ -411,7 +411,7 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "SWARMS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "SWARMS", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_grouse_chick",
@@ -648,7 +648,7 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_goose_golden",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -732,7 +732,7 @@
     "biosignature": { "biosig_item": "feces_cow", "biosig_timer": 7 },
     "special_attacks": [ [ "EAT_CROP", 60 ] ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_cow",
@@ -774,7 +774,18 @@
     "biosignature": { "biosig_item": "feces_cow", "biosig_timer": 1 },
     "special_attacks": [ [ "EAT_CROP", 40 ] ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "PET_MOUNTABLE",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "WARM",
+      "PET_WONT_FOLLOW",
+      "MILKABLE",
+      "CAN_BE_CULLED"
+    ]
   },
   {
     "id": "mon_coyote",
@@ -2434,7 +2445,7 @@
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
     "special_attacks": [ [ "EAT_FOOD", 40 ] ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "PET_WONT_FOLLOW", "WARM", "KEENNOSE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "PET_WONT_FOLLOW", "WARM", "KEENNOSE", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_pig",
@@ -2471,7 +2482,7 @@
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "zombify_into": "mon_zombie_pig",
     "special_attacks": [ [ "EAT_FOOD", 20 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_rabbit",
@@ -2657,7 +2668,7 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "special_attacks": [ [ "EAT_CROP", 120 ] ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_goat_kid",
@@ -2964,7 +2975,7 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "special_attacks": [ [ "EAT_CROP", 120 ] ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_ferret",

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -60,6 +60,7 @@ static const flag_id json_flag_TIE_UP( "TIE_UP" );
 static const itype_id itype_cash_card( "cash_card" );
 static const itype_id itype_id_military( "id_military" );
 
+static const quality_id qual_CUT( "CUT" );
 static const quality_id qual_SHEAR( "SHEAR" );
 
 static const skill_id skill_survival( "survival" );
@@ -348,6 +349,16 @@ void play_with( monster &z )
         player_activity( play_with_pet_activity_actor( pet_name, petstr ) ) );
 }
 
+void cull( monster &z )
+{
+    Character &player_character = get_player_character();
+    if( !player_character.has_quality( qual_CUT ) ) {
+        add_msg( _( "You don't have a cutting tool." ) );
+        return;
+    }
+    z.apply_damage( nullptr, bodypart_id( "torso" ), z.get_hp() );
+}
+
 void add_leash( monster &z )
 {
     if( z.has_effect( effect_leashed ) ) {
@@ -565,6 +576,7 @@ bool monexamine::pet_menu( monster &z )
         leash,
         unleash,
         play_with_pet,
+        cull_pet,
         milk,
         shear,
         pay,
@@ -635,6 +647,9 @@ bool monexamine::pet_menu( monster &z )
 
     if( z.has_flag( MF_CANPLAY ) ) {
         amenu.addentry( play_with_pet, true, 'y', _( "Play with %s" ), pet_name );
+    }
+    if( z.has_flag( MF_CAN_BE_CULLED ) ) {
+        amenu.addentry( cull_pet, true, 'y', _( "Cull %s" ), pet_name );
     }
     if( z.has_flag( MF_MILKABLE ) ) {
         amenu.addentry( milk, true, 'm', _( "Milk %s" ), pet_name );
@@ -756,6 +771,11 @@ bool monexamine::pet_menu( monster &z )
         case play_with_pet:
             if( query_yn( _( "Spend a few minutes to play with your %s?" ), pet_name ) ) {
                 play_with( z );
+            }
+            break;
+        case cull_pet:
+            if( query_yn( _( "Really slaughter your %s?" ), pet_name ) ) {
+                cull( z );
             }
             break;
         case leash:

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -176,6 +176,7 @@ std::string enum_to_string<m_flag>( m_flag data )
         case MF_PRIORITIZE_TARGETS: return "PRIORITIZE_TARGETS";
         case MF_NOT_HALLU: return "NOT_HALLUCINATION";
         case MF_CANPLAY: return "CANPLAY";
+        case MF_CAN_BE_CULLED: return "CAN_BE_CULLED";
         case MF_PET_MOUNTABLE: return "PET_MOUNTABLE";
         case MF_PET_HARNESSABLE: return "PET_HARNESSABLE";
         case MF_DOGFOOD: return "DOGFOOD";

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -148,6 +148,7 @@ enum m_flag : int {
     MF_PRIORITIZE_TARGETS,  // This monster will prioritize targets depending on their danger levels
     MF_NOT_HALLU,           // Monsters that will NOT appear when player's producing hallucinations
     MF_CANPLAY,             // This monster can be played with if it's a pet.
+    MF_CAN_BE_CULLED,       // This monster can be culled if it's a pet.
     MF_PET_MOUNTABLE,       // This monster can be mounted and ridden when tamed.
     MF_PET_HARNESSABLE,     // This monster can be harnessed when tamed.
     MF_DOGFOOD,             // This monster will respond to the dog whistle.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Allow player to easily and cleanly kill friendly farm animals"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This PR partially addresses #59708 by allowing the player to easily and cleanly slaughter friendly farm animals. Right now the only solution is to outright attack friendly farm animals in order to harvest them which is very clunky and often results in damaged corpses, even if you use something like a crossbow with small game bolts on friendly chickens. The PR addresses this issue for the player character but does not include a system for NPCs to do this work on behalf of the player.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The feature works by introducing a new flag, CAN_BE_CULLED, that can be applied to monsters. When interacting with a friendly monster via 'e', it introduces a new menu option if this flag is present for that type of monster and the player now has the option to 'cull' their friendly monster which results in a dead pet with an undamaged corpse. The only requirements are that the player has a cutting tool on them when interacting with the friendly monster. This flag is currently only applied to common farm animals that can currently be tamed like chickens, cows, sheep and so on via the respective json files.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I've thought about some of the suggestions mentioned in the respective issue like not requiring a knife for culling chickens or requiring a bigger knife for bigger animals like cows but those ideas seemed a bit extreme to me, somewhat over-engineering the approach. This is a simple QoL improvement that a lot of farmer player will appreciate. At the moment I'm not sure how introducing an activity for NPCs to do this work for the player would work in the codebase so I'm introducing a simple fix for the player in the meantime as I'm tired of chasing fleeing chickens with my crossbow.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
1. In debug mode spawned chicken/cow next to player.
2. Notice I can't interact with them before they are tamed.
3. Once they are tamed and I interact with them, the culling menu option shows up.
4. Culling the animal fails with the appropriate error message if the player does not have a tool with cutting quality on them.
5. Culling the animal works as expected if the player has a cutting tool. The process leaves behind a cleanly killed (undamaged) corpse.
6. Smoked chicken tastes nice.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
