### PR TITLE
remove vestegial symlink

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-../doc/CONTRIBUTING.md


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #61215
It seems this solution for making the contributing doc visible stopped working at some point, but at the same time github now scans the docs folder for it, so we can just remove this.