### PR TITLE
Fixed truncation in monster list ui

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8382,6 +8382,8 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
                     --iCurMon;
                 }
 
+                std::string monNameSelected;
+                std::string sSafemode;
                 const int endY = std::min<int>( iMaxRows - 1, iMenuSize );
                 for( int y = 0; y < endY; ++y ) {
 
@@ -8421,17 +8423,13 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
                     }
 
                     if( selected && !get_safemode().empty() ) {
-                        const std::string monName = is_npc ? get_safemode().npc_type_name() : m->name();
+                        monNameSelected = is_npc ? get_safemode().npc_type_name() : m->name();
 
-                        std::string sSafemode;
-                        if( get_safemode().has_rule( monName, Creature::Attitude::ANY ) ) {
+                        if( get_safemode().has_rule( monNameSelected, Creature::Attitude::ANY ) ) {
                             sSafemode = _( "<R>emove from safe mode blacklist" );
                         } else {
                             sSafemode = _( "<A>dd to safe mode blacklist" );
                         }
-
-                        shortcut_print( w_monsters, point( 2, getmaxy( w_monsters ) - 1 ),
-                                        c_white, c_light_green, sSafemode );
                     }
 
                     nc_color color = c_white;
@@ -8477,7 +8475,7 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
                 }
 
                 mvwprintz( w_monsters_border, point( ( width / 2 ) - numw - 2, 0 ), c_light_green, " %*d", numw,
-                           iActive + 1 );
+                           iActive + 1);
                 wprintz( w_monsters_border, c_white, " / %*d ", numw, static_cast<int>( monster_list.size() ) );
 
                 werase( w_monster_info );
@@ -8499,6 +8497,18 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
                         right_print( w_monster_info_border, 0, 3, c_light_green, press_to_fire_text );
                     }
                     wprintw( w_monster_info_border, " >" );
+                }
+
+                if (!get_safemode().empty()) {
+                    if (get_safemode().has_rule(monNameSelected, Creature::Attitude::ANY)) {
+                        sSafemode = _("<R>emove from safe mode blacklist");
+                    }
+                    else {
+                        sSafemode = _("<A>dd to safe mode blacklist");
+                    }
+
+                    shortcut_print(w_monsters, point(2, getmaxy(w_monsters) - 1),
+                        c_white, c_light_green, sSafemode);
                 }
 
                 draw_scrollbar( w_monsters_border, iActive, iMaxRows, static_cast<int>( monster_list.size() ),

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8475,7 +8475,7 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
                 }
 
                 mvwprintz( w_monsters_border, point( ( width / 2 ) - numw - 2, 0 ), c_light_green, " %*d", numw,
-                           iActive + 1);
+                           iActive + 1 );
                 wprintz( w_monsters_border, c_white, " / %*d ", numw, static_cast<int>( monster_list.size() ) );
 
                 werase( w_monster_info );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8499,16 +8499,15 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
                     wprintw( w_monster_info_border, " >" );
                 }
 
-                if (!get_safemode().empty()) {
-                    if (get_safemode().has_rule(monNameSelected, Creature::Attitude::ANY)) {
-                        sSafemode = _("<R>emove from safe mode blacklist");
-                    }
-                    else {
-                        sSafemode = _("<A>dd to safe mode blacklist");
+                if( !get_safemode().empty() ) {
+                    if( get_safemode().has_rule( monNameSelected, Creature::Attitude::ANY ) ) {
+                        sSafemode = _( "<R>emove from safe mode blacklist" );
+                    } else {
+                        sSafemode = _( "<A>dd to safe mode blacklist" );
                     }
 
-                    shortcut_print(w_monsters, point(2, getmaxy(w_monsters) - 1),
-                        c_white, c_light_green, sSafemode);
+                    shortcut_print( w_monsters, point( 2, getmaxy( w_monsters ) - 1 ),
+                                    c_white, c_light_green, sSafemode );
                 }
 
                 draw_scrollbar( w_monsters_border, iActive, iMaxRows, static_cast<int>( monster_list.size() ),


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixed truncation in monster list ui"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #64230 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The issue stemmed from the fact `shortcut_print` was called too early in the redraw lambda. Moving it to later on fixes this issue.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I tested by making the game window smaller and bigger until the truncation would appear. Following this fix the shortcut text is no longer truncated
To save on making a lot of creature spawns you can make a few then make the window smaller. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
