### PR TITLE
only grab one target at a time

### DIFF
--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2905,8 +2905,8 @@ bool mattack::grab( monster *z )
         return false;
     }
 
-    // Do not attempt to grab while z is already grabbing target. Do something else
-    if( z->has_effect( effect_grabbing ) && target->has_effect( effect_grabbed ) ) {
+    // Do not attempt to grab while z is already grabbing. Do something else
+    if( z->has_effect( effect_grabbing ) ) {
         return false;
     }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
User mentioned in discord:
```im prettys ure ive seen an npc being grabbed, moved close to melee and then gotten additionally grabbed by the same single zombie```
This is not intentional, so changed the check to prevent it.