### PR TITLE
More comparators for `event_transformation` `value_constraints`

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -2172,6 +2172,7 @@ Here are examples of each modification:
     // Each key is the field to which the constraint applies
     // The value specifies the constraint.
     // "equals" can be used to specify a constant cata_variant value the field must take.
+    // "lt", "lteq", "gteq" and "gt" can be used with int type to compare against a constant cata_variant value.
     // "equals_any" can be used to check for a value in a set of values
     // "equals_statistic" specifies that the value must match the value of some statistic (see below)
     "mount" : { "equals": [ "mtype_id", "mon_horse" ] }
@@ -2181,10 +2182,10 @@ Here are examples of each modification:
 "drop_fields" : [ "mount" ]
 ```
 
-The parameter to `"equals"` is normally a length-two array specifying a
-`cata_variant_type` and a value.  As a short cut, you can simply specify an
-`int` or `bool` (e.g. `"equals": 7` or `"equals": true`) for fields which have
-those types.
+The parameter to `"equals"` (and other single-value comparators) is normally a
+length-two array specifying a `cata_variant_type` and a value.  As a short cut,
+you can simply specify an `int` or `bool` (e.g. `"equals": 7` or `"equals": true`)
+for fields which have those types.
 
 The parameter to `"equals_any"` will be a pair where the first element is a
 string `cata_variant_type` and the second is an array of values.  For example:

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -201,7 +201,7 @@ struct value_constraint {
 
     void deserialize( const JsonObject &jo ) {
         cata_variant single_val;
-        const auto check_comp_int = [&]( const std::string &comp ) -> bool {
+        const auto check_comp_int = [&]( const std::string & comp ) -> bool {
             bool ret = single_val.type() == cata_variant_type::int_;
             if( !ret ) {
                 jo.throw_error( string_format( "The value constraint \"%s\" may only be used with int type!",
@@ -258,7 +258,7 @@ struct value_constraint {
             }
         }
 
-        const auto check_one = [&]( const cata_variant &e ) -> void {
+        const auto check_one = [&]( const cata_variant & e ) -> void {
             if( input_type != e.type() ) {
                 debugmsg( "constraint for event_transformation %s matches constant of type %s "
                           "but value compared with it has type %s",

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -201,7 +201,7 @@ struct value_constraint {
 
     void deserialize( const JsonObject &jo ) {
         cata_variant single_val;
-        const auto check_comp_int = [&]( std::string comp ) -> bool {
+        const auto check_comp_int = [&]( const std::string &comp ) -> bool {
             bool ret = single_val.type() == cata_variant_type::int_;
             if( !ret ) {
                 jo.throw_error( string_format( "The value constraint \"%s\" may only be used with int type!",
@@ -258,7 +258,7 @@ struct value_constraint {
             }
         }
 
-        const auto check_one = [&]( const cata_variant e ) -> void {
+        const auto check_one = [&]( const cata_variant &e ) -> void {
             if( input_type != e.type() ) {
                 debugmsg( "constraint for event_transformation %s matches constant of type %s "
                           "but value compared with it has type %s",

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -169,24 +169,56 @@ class event_statistic::impl
 };
 
 struct value_constraint {
+    enum comparator { lt, lteq, gteq, gt };
     std::vector<cata_variant> equals_any_;
     cata::optional<string_id<event_statistic>> equals_statistic_;
+    cata::optional<std::pair<comparator, cata_variant>> val_comp_;
 
     bool permits( const cata_variant &v, stats_tracker &stats ) const {
         if( std::find( equals_any_.begin(), equals_any_.end(), v ) != equals_any_.end() ) {
             return true;
         }
         // NOLINTNEXTLINE(readability-simplify-boolean-expr)
-        if( equals_statistic_ && stats.value_of( *equals_statistic_ ) == v ) {
-            return true;
+        if( equals_statistic_ ) {
+            return stats.value_of( *equals_statistic_ ) == v;
+        }
+        if( val_comp_ ) {
+            int v_int = v.get<int>();
+            int c_int = ( *val_comp_ ).second.get<int>();
+            switch( ( *val_comp_ ).first ) {
+                case comparator::lt:
+                    return v_int < c_int;
+                case comparator::lteq:
+                    return v_int <= c_int;
+                case comparator::gteq:
+                    return v_int >= c_int;
+                case comparator::gt:
+                    return v_int > c_int;
+            }
         }
         return false;
     }
 
     void deserialize( const JsonObject &jo ) {
-        cata_variant equals_variant;
-        if( jo.read( "equals", equals_variant, false ) ) {
-            equals_any_ = { equals_variant };
+        cata_variant single_val;
+        const auto check_comp_int = [&]( std::string comp ) -> bool {
+            bool ret = single_val.type() == cata_variant_type::int_;
+            if( !ret ) {
+                jo.throw_error( string_format( "The value constraint \"%s\" may only be used with int type!",
+                                               comp ) );
+            }
+            return ret;
+        };
+        if( jo.read( "equals", single_val, false ) ) {
+            equals_any_ = { single_val };
+        } else if( jo.read( "lt", single_val, false ) && check_comp_int( "lt" ) ) {
+            val_comp_ = std::pair<comparator, cata_variant>( comparator::lt, single_val );
+        } else if( jo.read( "lteq", single_val, false ) && check_comp_int( "lteq" ) ) {
+            val_comp_ = std::pair<comparator, cata_variant>( comparator::lteq, single_val );
+        } else if( jo.read( "gteq", single_val, false ) && check_comp_int( "gteq" ) ) {
+            val_comp_ = std::pair<comparator, cata_variant>( comparator::gteq, single_val );
+        } else if( jo.read( "gt", single_val, false ) && check_comp_int( "gt" ) ) {
+            val_comp_ = std::pair<comparator, cata_variant>( comparator::gt, single_val );
         }
 
         std::pair<cata_variant_type, std::vector<std::string>> equals_any;
@@ -203,7 +235,7 @@ struct value_constraint {
             equals_statistic_ = stat;
         }
 
-        if( equals_any_.empty() && !equals_statistic_ ) {
+        if( equals_any_.empty() && !equals_statistic_ && !val_comp_ ) {
             jo.throw_error( "No valid value constraint found" );
         }
     }
@@ -226,7 +258,7 @@ struct value_constraint {
             }
         }
 
-        for( const cata_variant &e : equals_any_ ) {
+        const auto check_one = [&]( const cata_variant e ) -> void {
             if( input_type != e.type() ) {
                 debugmsg( "constraint for event_transformation %s matches constant of type %s "
                           "but value compared with it has type %s",
@@ -238,6 +270,14 @@ struct value_constraint {
                           "but that is not a valid value of that type",
                           name, e.get_string(), io::enum_to_string( e.type() ) );
             }
+        };
+
+        for( const cata_variant &e : equals_any_ ) {
+            check_one( e );
+        }
+
+        if( val_comp_ ) {
+            check_one( ( *val_comp_ ).second );
         }
     }
 


### PR DESCRIPTION
#### Summary
Infrastructure "More comparators for `event_transformation` `value_constraints`"

#### Purpose of change
`value_constraints` in `event_transformation` was limited to equality checks.
Adding support for more comparators would facilitate more complex criteria, enabling more interesting achievements, conducts, scores.

#### Describe the solution
Add `lt`, `lteq`, `gteq` and `gt` options for integers, syntactically similar to `equals`.

#### Testing
Apply test cases patch, debug spawn bicycle, ride around at different speeds <, = , > 12mph while keeping an eye on the test scores.

<details>
<summary>test cases</summary>

```diff
diff --git a/data/json/scores.json b/data/json/scores.json
index 3a61a208015..9155e08bd3a 100644
--- a/data/json/scores.json
+++ b/data/json/scores.json
@@ -1,4 +1,29 @@
 [
+  {
+    "id": "test_score_lt",
+    "type": "score",
+    "statistic": "test_stat_lt"
+  },
+  {
+    "id": "test_score_lteq",
+    "type": "score",
+    "statistic": "test_stat_lteq"
+  },
+  {
+    "id": "test_score_eq",
+    "type": "score",
+    "statistic": "test_stat_eq"
+  },
+  {
+    "id": "test_score_gteq",
+    "type": "score",
+    "statistic": "test_stat_gteq"
+  },
+  {
+    "id": "test_score_gt",
+    "type": "score",
+    "statistic": "test_stat_gt"
+  },
   {
     "id": "score_kills",
     "type": "score",
diff --git a/data/json/statistics.json b/data/json/statistics.json
index 6f2fb190a1a..c29b2ca5e7f 100644
--- a/data/json/statistics.json
+++ b/data/json/statistics.json
@@ -1991,5 +1991,70 @@
     "stat_type": "count",
     "event_transformation": "portal_storm_happened",
     "description": { "str_sp": "portal storms seen" }
+  },
+  {
+    "id": "test_transformation_eq",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_ctrl_direct",
+    "value_constraints": { "velocity": { "equals": 1200 } }
+  },
+  {
+    "id": "test_stat_eq",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "test_transformation_eq",
+    "description": { "str_sp": "tiles driven eq 12mph" }
+  },
+  {
+    "id": "test_transformation_lteq",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_ctrl_direct",
+    "value_constraints": { "velocity": { "lteq": 1200 } }
+  },
+  {
+    "id": "test_stat_lteq",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "test_transformation_lteq",
+    "description": { "str_sp": "tiles driven lteq 12mph" }
+  },
+  {
+    "id": "test_transformation_lt",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_ctrl_direct",
+    "value_constraints": { "velocity": { "lt": 1200 } }
+  },
+  {
+    "id": "test_stat_lt",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "test_transformation_lt",
+    "description": { "str_sp": "tiles driven lt 12mph" }
+  },
+  {
+    "id": "test_transformation_gt",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_ctrl_direct",
+    "value_constraints": { "velocity": { "gt": 1200 } }
+  },
+  {
+    "id": "test_stat_gt",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "test_transformation_gt",
+    "description": { "str_sp": "tiles driven gt 12mph" }
+  },
+  {
+    "id": "test_transformation_gteq",
+    "type": "event_transformation",
+    "event_transformation": "moves_veh_ctrl_direct",
+    "value_constraints": { "velocity": { "gteq": 1200 } }
+  },
+  {
+    "id": "test_stat_gteq",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "test_transformation_gteq",
+    "description": { "str_sp": "tiles driven gteq 12mph" }
   }
 ]
```
</details>

#### Screenshots
![comptest](https://user-images.githubusercontent.com/28502722/225062908-51aa366e-c872-4a0d-981f-502df42f3e39.png)

