### PR TITLE
Quick language fixes

### DIFF
--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -572,7 +572,7 @@
     "id": "flask_stamina_eff",
     "name": [ "Constantia" ],
     "desc": [ "You can't get tired." ],
-    "apply_message": "You feel an energy in your muscles, untired and jazzed.",
+    "apply_message": "You feel an energy in your muscles, jazzed up and full of vitality.",
     "remove_message": "The energy in your body fades away.",
     "base_mods": { "stamina_min": [ 50 ] }
   },

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -195,7 +195,6 @@ avians
 aving
 avium
 avy
-awared
 axeman
 axolotl
 azide
@@ -2951,7 +2950,6 @@ unstylish
 untampered
 untargeted
 untilled
-untired
 untrodden
 untyped
 unwield


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Make a couple of quick language fixes that I spotted on the fly.

#### Describe the solution
Reworded sentence to more strongly convey a sense of "lively and energetic".
Remove custom dictionary entries. ("awared" text [had already been amended](https://github.com/CleverRaven/Cataclysm-DDA/pull/62675/files#diff-a2458d6b1f8accd15d8c96785fb1194a112f75d5c6e7b773f812f614bfd8d972L266-R266) in #62675)
