### PR TITLE
Fix typo in minimum gcc version

### DIFF
--- a/doc/COMPILING/COMPILER_SUPPORT.md
+++ b/doc/COMPILING/COMPILER_SUPPORT.md
@@ -72,7 +72,7 @@ ourselves to drop support for 10.11.
 
 ## GCC
 
-We support and test gcc from version 8.1.
+We support and test gcc from version 9.1.
 
 ## Clang
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
When I tried to change the minimum supported gcc version from 8.3 to 9.1 I mistyped and it ended up as 8.1.

#### Describe the solution
Fix that.

#### Describe alternatives you've considered
None.

#### Testing
None.

#### Additional context