### PR TITLE
'vehicle' class cleanup

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1188,7 +1188,7 @@ static int veh_lumi( vehicle &veh )
 {
     float veh_luminance = 0.0f;
     float iteration = 1.0f;
-    auto lights = veh.lights( true );
+    auto lights = veh.lights();
 
     for( const vehicle_part *pt : lights ) {
         const vpart_info &vp = pt->info();

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -510,7 +510,7 @@ void map::generate_lightmap( const int zlev )
     for( wrapped_vehicle &vv : vehs ) {
         vehicle *v = vv.v;
 
-        auto lights = v->lights( true );
+        auto lights = v->lights();
 
         float veh_luminance = 0.0f;
         float iteration = 1.0f;

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -50,7 +50,7 @@ std::vector<vehicle_part *> vehicle::turrets( const tripoint &target )
 {
     std::vector<vehicle_part *> res = turrets();
     // exclude turrets not ready to fire or where target is out of range
-    res.erase( std::remove_if( res.begin(), res.end(), [&]( const vehicle_part * e ) {
+    res.erase( std::remove_if( res.begin(), res.end(), [&]( vehicle_part * e ) {
         return turret_query( *e ).query() != turret_data::status::ready ||
                rl_dist( global_part_pos3( *e ), target ) > e->base.gun_range();
     } ), res.end() );
@@ -65,20 +65,10 @@ turret_data vehicle::turret_query( vehicle_part &pt )
     return turret_data( this, &pt );
 }
 
-turret_data vehicle::turret_query( const vehicle_part &pt ) const
-{
-    return const_cast<vehicle *>( this )->turret_query( const_cast<vehicle_part &>( pt ) );
-}
-
 turret_data vehicle::turret_query( const tripoint &pos )
 {
     auto res = get_parts_at( pos, "TURRET", part_status_flag::any );
     return !res.empty() ? turret_query( *res.front() ) : turret_data();
-}
-
-turret_data vehicle::turret_query( const tripoint &pos ) const
-{
-    return const_cast<vehicle *>( this )->turret_query( pos );
 }
 
 std::string turret_data::name() const

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3505,7 +3505,7 @@ void veh_interact::complete_vehicle( Character &you )
                 you.activity.set_to_null();
             }
 
-            if( veh->part_count( true ) < 2 ) {
+            if( veh->part_count_real() <= 1 ) {
                 you.add_msg_if_player( _( "You completely dismantle the %s." ), veh->name );
                 you.activity.set_to_null();
                 // destroy vehicle clears the cache

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7628,20 +7628,6 @@ int vehicle::num_true_parts() const
     return static_cast<int>( parts.size() - fake_parts.size() );
 }
 
-int vehicle::num_fake_parts() const
-{
-    return static_cast<int>( fake_parts.size() );
-}
-
-int vehicle::num_active_fake_parts() const
-{
-    int ret = 0;
-    for( const int fake_index : fake_parts ) {
-        ret += parts.at( fake_index ).is_active_fake ? 1 : 0;
-    }
-    return ret;
-}
-
 vehicle_part &vehicle::part( int part_num )
 {
     return parts[part_num];

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1936,7 +1936,12 @@ class vehicle
                                  const tripoint &neighbor_precalc ) const;
     public:
         // Number of parts contained in this vehicle
-        int part_count( bool no_fake = false ) const;
+        int part_count() const;
+        // Number of real parts in this vehicle, iterates parts to count
+        int part_count_real() const;
+        // Number of real parts in this vehicle, returns parts.size() - fake_parts.size()
+        int part_count_real_cached() const;
+
         // Returns the vehicle_part with the given part number
         vehicle_part &part( int part_num );
         const vehicle_part &part( int part_num ) const;
@@ -1947,9 +1952,6 @@ class vehicle
         void update_active_fakes();
         // Determines if the given part_num is real or active fake part
         bool real_or_active_fake_part( int part_num ) const;
-        // Number of parts in this vehicle
-        int num_parts() const;
-        int num_true_parts() const;
 
         // Updates the internal precalculated mount offsets after the vehicle has been displaced
         // used in map::displace_vehicle()

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -544,6 +544,9 @@ struct vehicle_part {
         bool has_fake = false; // NOLINT(cata-serialize)
         int fake_part_at = -1; // NOLINT(cata-serialize)
 
+        bool is_real_or_active_fake() const {
+            return !is_fake || is_active_fake;
+        }
 };
 
 class turret_data
@@ -1950,8 +1953,6 @@ class vehicle
         // Updates active state on all fake_mounts based on whether they can fill a gap
         // map.cpp calls this in displace_vehicle
         void update_active_fakes();
-        // Determines if the given part_num is real or active fake part
-        bool real_or_active_fake_part( int part_num ) const;
 
         // Updates the internal precalculated mount offsets after the vehicle has been displaced
         // used in map::displace_vehicle()

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -759,7 +759,6 @@ class vehicle
         // returns damage bypassed
         int damage_direct( map &here, int p, int dmg, damage_type type = damage_type::PURE );
         // Removes the part, breaks it into pieces and possibly removes parts attached to it
-        int break_off( int p, int dmg );
         int break_off( map &here, int p, int dmg );
         // Returns if it did actually explode
         bool explode_fuel( int p, damage_type type );
@@ -795,7 +794,6 @@ class vehicle
         // refresh pivot_cache, clear pivot_dirty
         void refresh_pivot() const;
 
-        void refresh_mass() const;
         void calc_mass_center( bool precalc ) const;
 
         /** empty the contents of a tank, battery or turret spilling liquids randomly on the ground */
@@ -909,9 +907,6 @@ class vehicle
             owner = new_owner;
         }
         void set_owner( const Character &c );
-        void remove_owner() {
-            owner = faction_id::NULL_ID();
-        }
         faction_id get_owner() const {
             return owner;
         }
@@ -1305,11 +1300,8 @@ class vehicle
         * @param e is the index of the engine in the engines array
         */
         units::power engine_fuel_usage( const vehicle_part &vp ) const;
-        /**
-         * Get all vehicle lights (excluding any that are destroyed)
-         * @param active if true return only lights which are enabled
-         */
-        std::vector<vehicle_part *> lights( bool active = false );
+        // Returns all active, available, non-destroyed vehicle lights
+        std::vector<vehicle_part *> lights();
 
         void update_alternator_load();
 
@@ -1697,10 +1689,7 @@ class vehicle
 
         /** Get firing data for a turret */
         turret_data turret_query( vehicle_part &pt );
-        turret_data turret_query( const vehicle_part &pt ) const;
-
         turret_data turret_query( const tripoint &pos );
-        turret_data turret_query( const tripoint &pos ) const;
 
         /** Set targeting mode for specific turrets */
         void turrets_set_targeting();
@@ -1943,7 +1932,6 @@ class vehicle
 
         // Removes fake parts from the parts vector
         void remove_fake_parts( bool cleanup = true );
-        tripoint get_abs_diff( const tripoint &one, const tripoint &two ) const;
         bool should_enable_fake( const tripoint &fake_precalc, const tripoint &parent_precalc,
                                  const tripoint &neighbor_precalc ) const;
     public:
@@ -1952,12 +1940,6 @@ class vehicle
         // Returns the vehicle_part with the given part number
         vehicle_part &part( int part_num );
         const vehicle_part &part( int part_num ) const;
-        // Determines whether the given part_num is valid for this vehicle
-        bool valid_part( int part_num ) const;
-        // Same as vehicle::part() except with const binding
-        const vehicle_part &cpart( int part_num ) const;
-        // Forcibly removes a part from this vehicle. Only exists to support faction_camp.cpp
-        void force_erase_part( int part_num );
         // get the parent part of a fake part or return part_num otherwise
         int get_non_fake_part( int part_num );
         // Updates active state on all fake_mounts based on whether they can fill a gap
@@ -1965,8 +1947,6 @@ class vehicle
         void update_active_fakes();
         // Determines if the given part_num is real or active fake part
         bool real_or_active_fake_part( int part_num ) const;
-        // Determines if this vehicle has any parts
-        bool has_any_parts() const;
         // Number of parts in this vehicle
         int num_parts() const;
         int num_true_parts() const;
@@ -2057,9 +2037,6 @@ class vehicle
         std::shared_ptr<autodrive_controller> active_autodrive_controller; // NOLINT(cata-serialize)
 
     public:
-        // Subtract from parts.size() to get the real part count.
-        int removed_part_count = 0; // NOLINT(cata-serialize)
-
         /**
          * Submap coordinates of the currently loaded submap (see game::m)
          * that contains this vehicle. These values are changed when the map

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1950,8 +1950,6 @@ class vehicle
         // Number of parts in this vehicle
         int num_parts() const;
         int num_true_parts() const;
-        int num_fake_parts() const;
-        int num_active_fake_parts() const;
 
         // Updates the internal precalculated mount offsets after the vehicle has been displaced
         // used in map::displace_vehicle()

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -173,7 +173,7 @@ int vehicle::print_part_list( const catacurses::window &win, int y1, const int m
     int y = y1;
     for( size_t i = 0; i < pl.size(); i++ ) {
         const vehicle_part &vp = parts[ pl [ i ] ];
-        if( vp.is_fake && !vp.is_active_fake ) {
+        if( !vp.is_real_or_active_fake() ) {
             continue;
         }
         if( y >= max_y ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -722,7 +722,7 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
     const int sign_before = sgn( velocity_before );
     bool empty = true;
     map &here = get_map();
-    for( int p = 0; p < num_parts(); p++ ) {
+    for( int p = 0; p < part_count(); p++ ) {
         if( parts.at( p ).removed || ( parts.at( p ).is_fake && !parts.at( p ).is_active_fake ) ) {
             continue;
         }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -723,19 +723,19 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
     bool empty = true;
     map &here = get_map();
     for( int p = 0; p < part_count(); p++ ) {
-        if( parts.at( p ).removed || ( parts.at( p ).is_fake && !parts.at( p ).is_active_fake ) ) {
+        const vehicle_part &vp = parts.at( p );
+        if( vp.removed || !vp.is_real_or_active_fake() ) {
             continue;
         }
 
-        const vpart_info &info = part_info( p );
-        if( !parts.at( p ).is_fake &&
-            info.location != part_location_structure && info.rotor_diameter() == 0 ) {
+        const vpart_info &info = vp.info();
+        if( !vp.is_fake && info.location != part_location_structure && info.rotor_diameter() == 0 ) {
             continue;
         }
         empty = false;
         // Coordinates of where part will go due to movement (dx/dy/dz)
         //  and turning (precalc[1])
-        const tripoint dsp = global_pos3() + dp + parts[p].precalc[1];
+        const tripoint dsp = global_pos3() + dp + vp.precalc[1];
         veh_collision coll = part_collision( p, dsp, just_detect, bash_floor );
         if( coll.type == veh_coll_nothing && info.rotor_diameter() > 0 ) {
             size_t radius = static_cast<size_t>( std::round( info.rotor_diameter() / 2.0f ) );

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2241,8 +2241,8 @@ bool vehicle::should_enable_fake( const tripoint &fake_precalc, const tripoint &
                                   const tripoint &neighbor_precalc ) const
 {
     // if parent's pos is diagonal to neighbor, but fake isn't, fake can fill a gap opened
-    tripoint abs_parent_neighbor_diff = get_abs_diff( parent_precalc, neighbor_precalc );
-    tripoint abs_fake_neighbor_diff = get_abs_diff( fake_precalc, neighbor_precalc );
+    tripoint abs_parent_neighbor_diff = ( parent_precalc - neighbor_precalc ).abs();
+    tripoint abs_fake_neighbor_diff = ( fake_precalc - neighbor_precalc ).abs();
     return ( abs_parent_neighbor_diff.x == 1 && abs_parent_neighbor_diff.y == 1 ) &&
            ( ( abs_fake_neighbor_diff.x == 1 && abs_fake_neighbor_diff.y == 0 ) ||
              ( abs_fake_neighbor_diff.x == 0 && abs_fake_neighbor_diff.y == 1 ) );

--- a/src/vpart_range.h
+++ b/src/vpart_range.h
@@ -113,9 +113,9 @@ class generic_vehicle_part_range
         template<typename T = ::vehicle>
         size_t part_count() const {
             if( with_fake_ ) {
-                return static_cast<const T &>( vehicle_.get() ).num_parts();
+                return static_cast<const T &>( vehicle_.get() ).part_count();
             } else {
-                return static_cast<const T &>( vehicle_.get() ).num_true_parts();
+                return static_cast<const T &>( vehicle_.get() ).part_count_real_cached();
             }
 
         }

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -30,38 +30,36 @@ static void really_clear_map()
     build_test_map( ter_id( "t_pavement" ) );
 }
 
+static int num_fake_parts( const vehicle &veh )
+{
+    return static_cast<int>( veh.fake_parts.size() );
+}
+
+static int num_active_fake_parts( const vehicle &veh )
+{
+    int ret = 0;
+    for( const int fake_index : veh.fake_parts ) {
+        cata_assert( fake_index < veh.part_count() );
+        ret += veh.part( fake_index ).is_active_fake ? 1 : 0;
+    }
+    return ret;
+}
+
 static void validate_part_count( const vehicle &veh, const int target_velocity,
                                  const units::angle &face_dir, const int real_parts,
                                  const int fake_parts, const int active_fakes )
 {
-    if( target_velocity > 0 && veh.velocity <= 200 ) {
-        std::cout << veh.disp_name() << " at dir " << to_degrees( face_dir );
-        std::cout <<  " speed " << veh.velocity << std::endl;
-    }
-    if( to_degrees( veh.face.dir() ) != Approx( to_degrees( face_dir ) ).epsilon( 0.1f ) ) {
-        std::cout << veh.disp_name() << " at dir " << to_degrees( face_dir );
-        std::cout <<  " face " << veh.face.dir() << std::endl;
-    }
-    if( veh.num_true_parts() != real_parts ) {
-        std::cout << veh.disp_name() << " at dir " << to_degrees( face_dir );
-        std::cout <<  " real parts " << veh.num_true_parts() << std::endl;
-    }
-    if( veh.num_fake_parts() != fake_parts ) {
-        std::cout << veh.disp_name() << " at dir " << to_degrees( face_dir );
-        std::cout <<  " fake parts " << veh.num_fake_parts() << std::endl;
-    }
-    if( veh.num_active_fake_parts() != active_fakes ) {
-        std::cout << veh.disp_name() << " at dir " << to_degrees( face_dir );
-        std::cout <<  " active fakes " << veh.num_active_fake_parts() << std::endl;
-    }
-
+    CAPTURE( veh.disp_name() );
+    CAPTURE( veh.velocity );
+    CAPTURE( to_degrees( veh.face.dir() ) );
+    CAPTURE( to_degrees( face_dir ) );
     if( target_velocity > 0 ) {
         REQUIRE( veh.velocity > 200 );
     }
     REQUIRE( to_degrees( veh.face.dir() ) == Approx( to_degrees( face_dir ) ).epsilon( 0.1f ) );
     CHECK( veh.num_true_parts() == real_parts );
-    CHECK( veh.num_fake_parts() == fake_parts );
-    CHECK( veh.num_active_fake_parts() == active_fakes );
+    CHECK( num_fake_parts( veh ) == fake_parts );
+    CHECK( num_active_fake_parts( veh ) == active_fakes );
 }
 
 TEST_CASE( "ensure_fake_parts_enable_on_place", "[vehicle] [vehicle_fake]" )

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -57,7 +57,7 @@ static void validate_part_count( const vehicle &veh, const int target_velocity,
         REQUIRE( veh.velocity > 200 );
     }
     REQUIRE( to_degrees( veh.face.dir() ) == Approx( to_degrees( face_dir ) ).epsilon( 0.1f ) );
-    CHECK( veh.num_true_parts() == real_parts );
+    CHECK( veh.part_count_real() == real_parts );
     CHECK( num_fake_parts( veh ) == fake_parts );
     CHECK( num_active_fake_parts( veh ) == active_fakes );
 }
@@ -310,7 +310,7 @@ TEST_CASE( "ensure_vehicle_with_no_obstacles_has_no_fake_parts", "[vehicle] [veh
         REQUIRE( veh != nullptr );
         WHEN( "The vehicle is placed in the world" ) {
             THEN( "There are no fake parts added" ) {
-                validate_part_count( *veh, 0, 45_degrees, veh->num_parts(), 0, 0 );
+                validate_part_count( *veh, 0, 45_degrees, veh->part_count(), 0, 0 );
             }
         }
     }

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -684,7 +684,7 @@ static void rack_check( const rack_preset &preset )
 }
 
 // Testing vehicle racking and unracking
-TEST_CASE( "Racking and unracking tests", "[vehicle]" )
+TEST_CASE( "Racking and unracking tests", "[vehicle][bikerack]" )
 {
     std::vector<rack_preset> racking_presets {
         // basic test; rack bike on car, unrack it, everything should succeed


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Cleans various unused, rarely used, stubs and duplicate functions from vehicle class

#### Describe the solution

num_parts/num_true_parts/part_count needed special treatment;
* part_count(no_fake = false) - the default overload, returns `parts.size()` and is a duplicate of `num_parts()` except it uses fake_parts.size()
* part_count(no_fake = true) - iterated over 'parts' and counted all parts where is_fake is false
* num_true_parts() - returns `parts.size() - fake_parts.size()`

The problem is num_true_parts is used generic_vehicle_part_range which is in turn used inside vehicle::refresh() **while** fake_parts is being filled. Trying to use the actual real part count in the range class results in bike rack test failures, so to keep status quo and keep tests happy these were refactored to 3 functions:
* `int part_count() const;` - returns parts.size()
* `int part_count_real() const;` - uses std::count_if to iterate and count parts with with is_fake false
* `int part_count_real_cached() const;` - returns `parts.size() - fake_parts.size()` and used in the range class

I'm 90% sure generic_vehicle_part_range shouldn't be using fake_parts as it's being filled and it can cause issues, but it'll require a separate patch to figure out what's getting broken there

Unused:
* `int break_off( int p, int dmg )`
* `void remove_owner()`
* `turret_data turret_query( const vehicle_part &pt ) const;` - used once as a DIY const_cast hack, not actually needed
* `turret_data turret_query( const tripoint &pos ) const;`
* `const vehicle_part &cpart( int part_num ) const;` - no uses, no implementation, part() has const overload
* `void force_erase_part( int part_num );`
* `bool valid_part( int part_num ) const;` - no implementation
* `bool has_any_parts() const;` - unused
* `int removed_part_count = 0; // NOLINT(cata-serialize)` - unused variable, only written to

Useless:
* `tripoint get_abs_diff( const tripoint &one, const tripoint &two ) const;` - same as `(one-two).abs()` with extra steps

Rarely used:
* `int num_fake_parts() const;` - only used in tests, moved to the test
* `int num_active_fake_parts() const;` - only used in tests, moved to the test
* `int num_true_parts() const;` - renamed to `part_count_real()` to match `part_count()`
* `void refresh_mass() const;` - stub immediately calling `calc_mass_center( true );`

Duplicates:
* `int num_parts() const;` - duplicate of `part_count()`, replaced with `part_count` as that one had more users

Removed overloads:
* `int part_count( bool no_fake = false ) const;` only had 1 user with no_fake == true, split to no-parameter `part_count()` and `part_count_real()` (deduplicated and renamed from `num_true_parts()`)
* `std::vector<vehicle_part *> lights( bool active = false );` - all users had set active = true, removed the parameter, only returns enabled lights

Misc:
* `bool real_or_active_fake_part( int part_num ) const;` - was moved to vehicle_part, a few checks that actually checked this but didn't use the function weer made to use the function instead
* A test was also adjusted to use `CAPTURE(...)`s instead of std::cout prints

#### Describe alternatives you've considered

#### Testing

Compiler and tests should hopefully catch me

#### Additional context
