### PR TITLE
Fix pillow cases spawning empty

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1167,7 +1167,11 @@ item item::in_container( const itype_id &cont, const int qty, const bool sealed 
     }
     item container( cont, birthday() );
     if( container.is_container() ) {
-        container.fill_with( *this, qty );
+        if( count_by_charges() ) {
+            container.fill_with( *this, qty );
+        } else {
+            container.put_in( *this, item_pocket::pocket_type::CONTAINER );
+        }
         container.invlet = invlet;
         if( sealed ) {
             container.seal();

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -793,7 +793,7 @@ std::vector<item> json_item_substitution::get_substitution( const item &it,
 
         if( !result.count_by_charges() ) {
             for( int i = 0; i < new_amount; i++ ) {
-                ret.push_back( result.in_its_container( 1 ) );
+                ret.push_back( result.in_its_container() );
             }
         } else {
             while( new_amount > 0 ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #64228

#### Describe the solution

#63704 accidentally contained some code from #60885 it didn't need, so this reverts that. The change should have affected all not stackable items that spawn in containers, not just pillow cases, although I'm not sure if there are even other cases right now.

#### Describe alternatives you've considered

Going all the way with the change so it works properly again and makes #60885 a little bit smaller.

#### Testing

Didn't find the time to test this, yet. Would be great if someone could confirm this works. If not I'll get around to it within 1-2 days.

#### Additional context

