### PR TITLE
Makes tinder easier to craft

### DIFF
--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -895,5 +895,48 @@
         [ "straw_pile", 1 ]
       ]
     ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "tinder",
+    "id_suffix": "softer",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_MATERIALS",
+    "skill_used": "survival",
+    "difficulty": 1,
+    "time": "1 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [
+      [
+        [ "splinter", 2 ],
+        [ "withered", 2 ],
+        [ "cattail_stalk", 1 ]
+      ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "tinder",
+    "id_suffix": "softest",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_MATERIALS",
+    "skill_used": "survival",
+    "difficulty": 1,
+    "time": "1 m",
+    "autolearn": true,
+    "components": [
+      [
+        [ "pine_bough", 1 ],
+        [ "cotton_patchwork", 1 ],
+        [ "paper", 5 ],
+        [ "cardboard", 1 ],
+        [ "rolling_paper", 30 ],
+        [ "wrapper", 5 ],
+        [ "straw_pile", 1 ]
+      ]
+    ]
   }
 ]

--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -908,13 +908,7 @@
     "time": "1 m",
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [
-      [
-        [ "splinter", 2 ],
-        [ "withered", 2 ],
-        [ "cattail_stalk", 1 ]
-      ]
-    ]
+    "components": [ [ [ "splinter", 2 ], [ "withered", 2 ], [ "cattail_stalk", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Makes tinder easier to craft"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#62662 made it so that primitive fire drills requires tinder. By default, tinder requires a tool with cutting 2. In Innawood, you need to create a fire as early as possible, preferably before you spend time making a good cutting tool.
Besides, you probably don't need a good cutting tool to make tinder out of a newspaper.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Split the tinder recipe into 3 parts depending on how good a knife you would need to create it.

The following items can be made into tinder without a knife: pine_bough, cotton_patchwork, paper, cardboard, rolling_paper, wrapper, straw_pile
The following items require cutting 1: splinter, withered, cattail_stalk
The following items still require cutting 2: stick, 2x4, birchbark, willowbark
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered removing the softer ingredients from the cutting 2 recipe, but decided to keep the recipe as-is in order to not have to add the new recipes to the basecamp recipes, while still maintaining the ability to use your basecamp to turn paper into tinder.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I tried the recipes in-game, they seems to work fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
