### PR TITLE
Fix app_microwave lack of microwave tool

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -958,7 +958,7 @@
       },
       "removal": { "time": "1 m" }
     },
-    "pseudo_tools": [ { "id": "pseudo_microwave" } ],
+    "pseudo_tools": [ { "id": "microwave" } ],
     "size": 20,
     "breaks_into": [
       { "item": "plastic_chunk", "count": [ 4, 7 ] },

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -958,7 +958,7 @@
       },
       "removal": { "time": "1 m" }
     },
-    "pseudo_tools": [ { "id": "microwave" } ],
+    "pseudo_tools": [ { "id": "pseudo_microwave" } ],
     "size": 20,
     "breaks_into": [
       { "item": "plastic_chunk", "count": [ 4, 7 ] },

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -397,7 +397,7 @@
     "name": "hotplate abstract"
   },
   {
-    "abstract": "pseudo_microwave_abstract",
+    "id": "pseudo_microwave",
     "copy-from": "microwave",
     "sub": "microwave",
     "type": "TOOL",
@@ -407,7 +407,7 @@
     "volume": "1 ml",
     "symbol": "@",
     "color": "red",
-    "name": "microwave abstract"
+    "name": "microwave"
   },
   {
     "copy-from": "pseudo_hotplate_abstract",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Appliance microwave doesn't work, because uses nonexisted/abstract `pseudo_microwave`
#### Describe the solution
~~Replace `pseudo_tools` `pseudo_microwave` with `microwave`~~ see comments
#### Testing
Before
![image](https://user-images.githubusercontent.com/67688115/225405229-7e2ef2e2-d4fe-438c-83cf-ba6a364d95a1.png)
After
![image](https://user-images.githubusercontent.com/67688115/225405113-618d3f61-cf5a-4edf-8a77-dd39736d7b27.png)
#### Additional context
Maybe also remove `pseudo_microwave_abstract`?  I can't find any usage of it in the files 