### PR TITLE
Aftershock - extend cooking requirements instead of replacing

### DIFF
--- a/data/mods/Aftershock/recipes/requirements.json
+++ b/data/mods/Aftershock/recipes/requirements.json
@@ -2,33 +2,15 @@
   {
     "id": "surface_heat",
     "type": "requirement",
-    "tools": [
-      [
-        [ "hotplate", 1 ],
-        [ "multi_cooker", 1 ],
-        [ "char_smoker", 1 ],
-        [ "toolset", 1 ],
-        [ "afs_atompot", -1 ],
-        [ "fire", -1 ]
-      ]
-    ]
+    "copy-from": "surface_heat",
+    "extend": { "tools": [ [ [ "afs_atompot", -1 ] ] ] }
   },
   {
     "id": "water_boiling_heat",
     "type": "requirement",
     "//": "Tools usable for providing heat usable for boiling water, but not necessarily for anything else.",
-    "tools": [
-      [
-        [ "hotplate", 1 ],
-        [ "multi_cooker", 1 ],
-        [ "char_smoker", 1 ],
-        [ "toolset", 1 ],
-        [ "coffeemaker", 1 ],
-        [ "atomic_coffeepot", -1 ],
-        [ "afs_atompot", -1 ],
-        [ "fire", -1 ]
-      ]
-    ]
+    "copy-from": "water_boiling_heat",
+    "extend": { "tools": [ [ [ "afs_atompot", -1 ] ] ] }
   },
   {
     "id": "electric_probing",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Aftershock overrides cooking / water heating requirements breaking half of https://github.com/CleverRaven/Cataclysm-DDA/pull/62180

#### Describe the solution

The purpose of the override seems to add afs_atompot to the lists, use copy-from and extend instead

#### Describe alternatives you've considered

#### Testing

After patch games with aftershock should receive the updated requirement lists

#### Additional context

Before:
![image](https://user-images.githubusercontent.com/6560075/225457649-e780ffec-9995-4ebe-bfd4-7ab976b0a5ae.png)
After:
![image](https://user-images.githubusercontent.com/6560075/225457743-0121eb3c-bd4d-4c6e-9f1d-ed003d407366.png)
