### PR TITLE
Validate vehicle part's pseudo tools in finalize()

### DIFF
--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -779,6 +779,16 @@ void vpart_info::finalize()
             e.second.z_order = 0;
             e.second.list_order = 5;
         }
+        std::set<std::pair<itype_id, int>> &pt = e.second.pseudo_tools;
+        for( auto it = pt.begin(); it != pt.end(); /* blank */ ) {
+            const itype_id &tool = it->first;
+            if( !tool.is_valid() ) {
+                debugmsg( "invalid pseudo tool itype_id '%s' on '%s'", tool.str(), e.first.str() );
+                pt.erase( it++ );
+            } else {
+                ++it;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Prevent invalid ids in pseudo tools

#### Describe the solution

~~Should only be merged after https://github.com/CleverRaven/Cataclysm-DDA/pull/64279~~

debugmsg and erase any invalid ones in vpart_info::finalize

#### Describe alternatives you've considered

#### Testing

This PR should fail tests (debugmsg on load) on current master, and stop failing after rebasing on the linked PR

#### Additional context
