### PR TITLE
Add and update doxygen docs for skill/stat effects

### DIFF
--- a/doxygen_doc/doxygen_conf.txt
+++ b/doxygen_doc/doxygen_conf.txt
@@ -199,19 +199,19 @@ TAB_SIZE               = 4
 
 ALIASES                =
 
-ALIASES += "EFFECT_STR=\xrefitem Effects_Stat_Strength \"\" \"\" Strength" 
-ALIASES += "EFFECT_DEX=\xrefitem Effects_Stat_Dexterity \"\" \"\" Dexterity" 
-ALIASES += "EFFECT_INT=\xrefitem Effects_Stat_Intelligence \"\" \"\" Intelligence" 
+ALIASES += "EFFECT_STR=\xrefitem Effects_Stat_Strength \"\" \"\" Strength"
+ALIASES += "EFFECT_DEX=\xrefitem Effects_Stat_Dexterity \"\" \"\" Dexterity"
+ALIASES += "EFFECT_INT=\xrefitem Effects_Stat_Intelligence \"\" \"\" Intelligence"
 ALIASES += "EFFECT_PER=\xrefitem Effects_Stat_Perception \"\" \"\" Perception"
 
-ALIASES += "EFFECT_STR_MAX=\xrefitem Effects_Stat_Strength \"\" \"\" Maximum Strength" 
-ALIASES += "EFFECT_DEX_MAX=\xrefitem Effects_Stat_Dexterity \"\" \"\" Maximum Dexterity" 
-ALIASES += "EFFECT_INT_MAX=\xrefitem Effects_Stat_Intelligence \"\" \"\" Maximum Intelligence" 
+ALIASES += "EFFECT_STR_MAX=\xrefitem Effects_Stat_Strength \"\" \"\" Maximum Strength"
+ALIASES += "EFFECT_DEX_MAX=\xrefitem Effects_Stat_Dexterity \"\" \"\" Maximum Dexterity"
+ALIASES += "EFFECT_INT_MAX=\xrefitem Effects_Stat_Intelligence \"\" \"\" Maximum Intelligence"
 ALIASES += "EFFECT_PER_MAX=\xrefitem Effects_Stat_Perception \"\" \"\" Maximum Perception"
 
-ALIASES += "EFFECT_STR_NPC=\xrefitem Effects_Stat_Strength \"\" \"\" NPC Strength" 
-ALIASES += "EFFECT_DEX_NPC=\xrefitem Effects_Stat_Dexterity \"\" \"\" NPC Dexterity" 
-ALIASES += "EFFECT_INT_NPC=\xrefitem Effects_Stat_Intelligence \"\" \"\" NPC Intelligence" 
+ALIASES += "EFFECT_STR_NPC=\xrefitem Effects_Stat_Strength \"\" \"\" NPC Strength"
+ALIASES += "EFFECT_DEX_NPC=\xrefitem Effects_Stat_Dexterity \"\" \"\" NPC Dexterity"
+ALIASES += "EFFECT_INT_NPC=\xrefitem Effects_Stat_Intelligence \"\" \"\" NPC Intelligence"
 ALIASES += "EFFECT_PER_NPC=\xrefitem Effects_Stat_Perception \"\" \"\" NPC Perception"
 
 ALIASES += "EFFECT_BARTER=\xrefitem Effects_Skill_Barter \"\" \"\" Barter"
@@ -245,6 +245,8 @@ ALIASES += "EFFECT_SMG=\xrefitem Effects_Skill_Smg \"\" \"\" Smg"
 ALIASES += "EFFECT_LOCKPICK=\xrefitem Effects_Skill_Lockpick \"\" \"\" Lock Picking"
 ALIASES += "EFFECT_CHEMISTRY=\xrefitem Effects_Skill_Chemistry \"\" \"\" Chemistry"
 
+ALIASES += "EFFECT_SKILLS=\xrefitem Effects_Skill_Multiple \"\" \"\" Multiple skills"
+
 ALIASES += "EFFECT_BARTER_NPC=\xrefitem Effects_Skill_Barter \"\" \"\" NPC Barter"
 ALIASES += "EFFECT_COMPUTER_NPC=\xrefitem Effects_Skill_Computer \"\" \"\" NPC Computer"
 ALIASES += "EFFECT_CARPENTRY_NPC=\xrefitem Effects_Skill_Carpentry \"\" \"\" NPC Carpentry"
@@ -275,6 +277,49 @@ ALIASES += "EFFECT_SHOTGUN_NPC=\xrefitem Effects_Skill_Shotgun \"\" \"\" NPC Sho
 ALIASES += "EFFECT_SMG_NPC=\xrefitem Effects_Skill_Smg \"\" \"\" NPC Smg"
 ALIASES += "EFFECT_LOCKPICK_NPC=\xrefitem Effects_Skill_Lockpick \"\" \"\" NPC Lock Picking"
 ALIASES += "EFFECT_CHEMISTRY_NPC=\xrefitem Effects_Skill_Chemistry \"\" \"\" NPC Chemistry"
+
+ALIASES += "EFFECT_PROF_DISARMING=\xrefitem Effects_Proficiency_Disarming \"\" \"\" Disarming"
+ALIASES += "EFFECT_PROF_LOCKPICKING_EXPERT=\xrefitem Effects_Proficiency_Lockpicking \"\" \"\" Expert Lockpicking"
+ALIASES += "EFFECT_PROF_LOCKPICKING=\xrefitem Effects_Proficiency_Lockpicking \"\" \"\" Lockpicking"
+ALIASES += "EFFECT_PROF_PARKOUR=\xrefitem Effects_Proficiency_Parkour \"\" \"\" Parkour"
+ALIASES += "EFFECT_PROF_SAFECRACKING=\xrefitem Effects_Proficiency_Safecracking \"\" \"\" Safecracking"
+ALIASES += "EFFECT_PROF_SPOTTING=\xrefitem Effects_Proficiency_Spotting \"\" \"\" Trap Spotting"
+ALIASES += "EFFECT_PROF_TRAPS=\xrefitem Effects_Proficiency_Traps \"\" \"\" Traps"
+ALIASES += "EFFECT_PROF_TRAPSETTING=\xrefitem Effects_Proficiency_TrapSetting \"\" \"\" Trap Setting"
+ALIASES += "EFFECT_PROF_WOUND_CARE_EXPERT=\xrefitem Effects_Proficiency_Wound_Care \"\" \"\" Expert Wound Care"
+ALIASES += "EFFECT_PROF_WOUND_CARE=\xrefitem Effects_Proficiency_Wound_Care \"\" \"\" Wound Care"
+
+ALIASES += "EFFECT_TRAIT_BADKNEES=\xrefitem Effects_Trait_Bad_Knees \"\" \"\" Bad Knees"
+ALIASES += "EFFECT_TRAIT_CLUMSY=\xrefitem Effects_Trait_Clumsy \"\" \"\" Clumsy"
+ALIASES += "EFFECT_TRAIT_LIGHTSTEP=\xrefitem Effects_Trait_Light_Step \"\" \"\" Light Step"
+
+ALIASES += "EFFECT_TRAIT_PROF_AUTODOC=\xrefitem Effects_Trait_Profession_Autodoc \"\" \"\" Autodoc Specialist Profession"
+ALIASES += "EFFECT_TRAIT_PROF_CHURL=\xrefitem Effects_Trait_Profession_Churl \"\" \"\" Churl Profession"
+ALIASES += "EFFECT_TRAIT_PROF_MED=\xrefitem Effects_Trait_Profession_Doctor \"\" \"\" Doctor Profession"
+
+ALIASES += "EFFECT_TRAIT_PAWS=\xrefitem Effects_Trait_Paws \"\" \"\" Paws"
+ALIASES += "EFFECT_TRAIT_PAWS_LARGE=\xrefitem Effects_Trait_Paws \"\" \"\" Large Paws"
+ALIASES += "EFFECT_TRAIT_TAIL_CATTLE=\xrefitem Effects_Trait_Tail \"\" \"\" Cattle Tail"
+ALIASES += "EFFECT_TRAIT_BEAK_PECK=\xrefitem Effects_Trait_Beak \"\" \"\" Woodpecker Beak"
+ALIASES += "EFFECT_TRAIT_ARM_TENTACLES=\xrefitem Effects_Trait_Arm \"\" \"\" Tentacle Arms"
+ALIASES += "EFFECT_TRAIT_ARM_TENTACLES_4=\xrefitem Effects_Trait_Arm \"\" \"\" Four Tentacles"
+ALIASES += "EFFECT_TRAIT_ARM_TENTACLES_8=\xrefitem Effects_Trait_Arm \"\" \"\" Eight Tentacles"
+ALIASES += "EFFECT_TRAIT_CLAWS_TENTACLE=\xrefitem Effects_Trait_Claws \"\" \"\" Tentacle Claws"
+ALIASES += "EFFECT_TRAIT_VINES2=\xrefitem Effects_Trait_Vines \"\" \"\" 2 Vines"
+ALIASES += "EFFECT_TRAIT_VINES3=\xrefitem Effects_Trait_Vines \"\" \"\" 3 Vines"
+
+ALIASES += "EFFECT_FATIGUE=\xrefitem Effects_Fatigue \"\" \"\" Fatigue"
+ALIASES += "EFFECT_FOCUS=\xrefitem Effects_Focus \"\" \"\" Focus"
+ALIASES += "EFFECT_SLEEP_DEPRIVATION=\xrefitem Effects_Sleep_Deprivation \"\" \"\" Sleep Deprivation"
+ALIASES += "EFFECT_SPEED_BASE=\xrefitem Effects_Speed \"\" \"\" Base Speed"
+ALIASES += "EFFECT_SPEED=\xrefitem Effects_Speed \"\" \"\" Speed"
+
+ALIASES += "EFFECT_FLAG_FIN=\xrefitem Effects_Flag_Fin \"\" \"\" Fin item"
+ALIASES += "EFFECT_FLAG_FLOATATION=\xrefitem Effects_Flag_Floatation \"\" \"\" Floatation item"
+ALIASES += "EFFECT_FLAG_POWERED=\xrefitem Effects_Flag_Powered \"\" \"\" Powered item"
+
+ALIASES += "EFFECT_FLAG_WEBBED_FEET=\xrefitem Effects_Flag_Webbed_Feet \"\" \"\" Webbed Feet"
+ALIASES += "EFFECT_FLAG_WEBBED_HANDS=\xrefitem Effects_Flag_Webbed_Hands \"\" \"\" Webbed Hands"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding

--- a/doxygen_doc/pages.h
+++ b/doxygen_doc/pages.h
@@ -1,5 +1,5 @@
 /** \page map_management Map Management
- *
+ *  \brief Coordinate systems, overmaps, maps, submaps
  * Cataclysm DDA uses a shifting coordinate system. This means that when the player moves to a new
  * submap, the (0, 0) coordinate moves from one submap to another, and the coordinates of all entities
  * on the map are shifted to accommodate this.
@@ -24,139 +24,187 @@
  * \ref mapbuffer \ref map \ref submap
  */
 
-/*! @page Effects_Stat_Strength
- *  @brief Cross referenced effects of the Strength stat.
- *  @par
+/*! @page Effects_Stat_Strength Stat: Strength
+ *  @brief Effects of the Strength stat.
+ * */
+/*! @page Effects_Stat_Dexterity Stat: Dexterity
+ *  @brief Effects of the Dexterity stat.
+ * */
+/*! @page Effects_Stat_Intelligence Stat: Intelligence
+ *  @brief Effects of the Intelligence stat.
+ * */
+/*! @page Effects_Stat_Perception Stat: Perception
+ *  @brief Effects of the Perception stat.
+ * */
+
+/*! @page Effects_Skill_Barter Skill: Barter
+ *  @brief Effects of the Barter skill.
+ * */
+/*! @page Effects_Skill_Computer Skill: Computer
+ *  @brief Effects of the Computer skill.
+ * */
+/*! @page Effects_Skill_Carpentry Skill: Carpentry
+ *  @brief Effects of the Carpentry skill.
+ * */
+/*! @page Effects_Skill_Cooking Skill: Cooking
+ *  @brief Effects of the Cooking skill.
+ * */
+/*! @page Effects_Skill_Driving Skill: Driving
+ *  @brief Effects of the Driving skill.
+ * */
+/*! @page Effects_Skill_Electronics Skill: Electronics
+ *  @brief Effects of the Electronics skill.
+ * */
+/*! @page Effects_Skill_Fabrication Skill: Fabrication
+ *  @brief Effects of the Fabrication skill.
+ * */
+/*! @page Effects_Skill_Firstaid Skill: Firstaid
+ *  @brief Effects of the Firstaid skill.
+ * */
+/*! @page Effects_Skill_Mechanics Skill: Mechanics
+ *  @brief Effects of the Mechanics skill.
+ * */
+/*! @page Effects_Skill_Speech Skill: Speech
+ *  @brief Effects of the Speech skill.
+ * */
+/*! @page Effects_Skill_Survival Skill: Survival
+ *  @brief Effects of the Survival skill.
+ * */
+/*! @page Effects_Skill_Swimming Skill: Swimming
+ *  @brief Effects of the Swimming skill.
+ * */
+/*! @page Effects_Skill_Tailor Skill: Tailor
+ *  @brief Effects of the Tailor skill.
+ * */
+/*! @page Effects_Skill_Traps Skill: Traps
+ *  @brief Effects of the Traps skill.
+ * */
+/*! @page Effects_Skill_Archery Skill: Archery
+ *  @brief Effects of the Archery skill.
+ * */
+/*! @page Effects_Skill_Bashing Skill: Bashing
+ *  @brief Effects of the Bashing skill.
+ * */
+/*! @page Effects_Skill_Cutting Skill: Cutting
+ *  @brief Effects of the Cutting skill.
+ * */
+/*! @page Effects_Skill_Dodge Skill: Dodge
+ *  @brief Effects of the Dodge skill.
+ * */
+/*! @page Effects_Skill_Gun Skill: Gun
+ *  @brief Effects of the Gun skill.
+ * */
+/*! @page Effects_Skill_Launcher Skill: Launcher
+ *  @brief Effects of the Launcher skill.
+ * */
+/*! @page Effects_Skill_Melee Skill: Melee
+ *  @brief Effects of the Melee skill.
+ * */
+/*! @page Effects_Skill_Stabbing Skill: Stabbing
+ *  @brief Effects of the Stabbing skill.
+ * */
+/*! @page Effects_Skill_Throw Skill: Throw
+ *  @brief Effects of the Throw skill.
+ * */
+/*! @page Effects_Skill_Unarmed Skill: Unarmed
+ *  @brief Effects of the Unarmed skill.
+ * */
+/*! @page Effects_Skill_Pistol Skill: Pistol
+ *  @brief Effects of the Pistol skill.
+ * */
+/*! @page Effects_Skill_Rifle Skill: Rifle
+ *  @brief Effects of the Rifle skill.
+ * */
+/*! @page Effects_Skill_Shotgun Skill: Shotgun
+ *  @brief Effects of the Shotgun skill.
+ * */
+/*! @page Effects_Skill_Smg Skill: Smg
+ *  @brief Effects of the Smg skill.
+ * */
+/*! @page Effects_Skill_Lockpick Skill: Lockpick
+ *  @brief Effects of the Lock picking skill.
+ * */
+/*! @page Effects_Skill_Chemistry Skill: Chemistry
+ *  @brief Effects of the Chemistry skill.
+ * */
+
+/*! @page Effects_Skill_Multiple Skill: Multiple
+ *  @brief Effects that apply to multiple skills.
+ * */
+
+/*! @page Effects_Proficiency_Disarming Proficiency: Disarming
+ *  @brief Effects of the Disarming proficiency
+ * */
+/*! @page Effects_Proficiency_Lockpicking Proficiency: Lockpicking
+ *  @brief Effects of the Lockpicking proficiency
+ * */
+/*! @page Effects_Proficiency_Parkour Proficiency: Parkour
+ *  @brief Effects of the Parkour proficiency
+ * */
+/*! @page Effects_Proficiency_Safecracking Proficiency: Safecracking
+ *  @brief Effects of the Safecracking proficiency
+ * */
+/*! @page Effects_Proficiency_Spotting Proficiency: Spotting
+ *  @brief Effects of the Spotting proficiency
+ * */
+/*! @page Effects_Proficiency_Traps Proficiency: Traps
+ *  @brief Effects of the Traps proficiency
+ * */
+/*! @page Effects_Proficiency_TrapSetting Proficiency: TrapSetting
+ *  @brief Effects of the TrapSetting proficiency
+ * */
+/*! @page Effects_Proficiency_Wound_Care Proficiency: Wound Care
+ *  @brief Effects of the Wound Care proficiency
+ * */
+
+/*! @page Effects_Trait_Bad_Knees Trait: Bad Knees
+ *  @brief Effects of the Bad Knees trait
+ * */
+/*! @page Effects_Trait_Clumsy Trait: Clumsy
+ *  @brief Effects of the Clumsy trait
+ * */
+/*! @page Effects_Trait_Light_Step Trait: Light Step
+ *  @brief Effects of the Light_Step trait
+ * */
+
+/*! @page Effects_Trait_Profession_Autodoc Profession: Autodoc
+ *  @brief Effects of the Autodoc profession
+ * */
+/*! @page Effects_Trait_Profession_Churl Profession: Churl
+ *  @brief Effects of the Churl profession
+ * */
+/*! @page Effects_Trait_Profession_Doctor Profession: Doctor
+ *  @brief Effects of the Doctor profession
+ * */
+
+/*! @page Effects_Trait_Paws Trait: Paws
+ *  @brief Effects of Paws traits
+ * */
+/*! @page Effects_Trait_Tail Trait: Tail
+ *  @brief Effects of Tail traits
+ * */
+/*! @page Effects_Trait_Beak Trait: Beak
+ *  @brief Effects of Beak traits
+ * */
+/*! @page Effects_Trait_Arm Trait: Arm
+ *  @brief Effects of Arm traits
+ * */
+/*! @page Effects_Trait_Claws Trait: Claws
+ *  @brief Effects of Claws traits
+ * */
+/*! @page Effects_Trait_Vines Trait: Vines
+ *  @brief Effects of Vines traits
+ * */
+
+/*! @page Effects_Focus Focus
+ *  @brief Effects of Focus
+ *  @par asdf
  */
-/*! @page Effects_Stat_Dexterity
- *  @brief Cross referenced effects of the Dexterity stat.
+/*! @page Effects_Speed Speed
+ *  @brief Effects of Speed
  *  @par
+ *  Speed affects how fast the character performs most actions. Lower is faster.
  */
-/*! @page Effects_Stat_Intelligence
- *  @brief Cross referenced effects of the Intelligence stat.
- *  @par
- */
-/*! @page Effects_Stat_Perception
- *  @brief Cross referenced effects of the Perception stat.
- *  @par
- */
-/*! @page Effects_Skill_Barter
- *  @brief Cross referenced effects of the Barter skill.
- *  @par
- */
-/*! @page Effects_Skill_Computer
- *  @brief Cross referenced effects of the Computer skill.
- *  @par
- */
-/*! @page Effects_Skill_Carpentry
- *  @brief Cross referenced effects of the Carpentry skill.
- *  @par
- */
-/*! @page Effects_Skill_Cooking
- *  @brief Cross referenced effects of the Cooking skill.
- *  @par
- */
-/*! @page Effects_Skill_Driving
- *  @brief Cross referenced effects of the Driving skill.
- *  @par
- */
-/*! @page Effects_Skill_Electronics
- *  @brief Cross referenced effects of the Electronics skill.
- *  @par
- */
-/*! @page Effects_Skill_Fabrication
- *  @brief Cross referenced effects of the Fabrication skill.
- *  @par
- */
-/*! @page Effects_Skill_Firstaid
- *  @brief Cross referenced effects of the Firstaid skill.
- *  @par
- */
-/*! @page Effects_Skill_Mechanics
- *  @brief Cross referenced effects of the Mechanics skill.
- *  @par
- */
-/*! @page Effects_Skill_Speech
- *  @brief Cross referenced effects of the Speech skill.
- *  @par
- */
-/*! @page Effects_Skill_Survival
- *  @brief Cross referenced effects of the Survival skill.
- *  @par
- */
-/*! @page Effects_Skill_Swimming
- *  @brief Cross referenced effects of the Swimming skill.
- *  @par
- */
-/*! @page Effects_Skill_Tailor
- *  @brief Cross referenced effects of the Tailor skill.
- *  @par
- */
-/*! @page Effects_Skill_Traps
- *  @brief Cross referenced effects of the Traps skill.
- *  @par
- */
-/*! @page Effects_Skill_Archery
- *  @brief Cross referenced effects of the Archery skill.
- *  @par
- */
-/*! @page Effects_Skill_Bashing
- *  @brief Cross referenced effects of the Bashing skill.
- *  @par
- */
-/*! @page Effects_Skill_Cutting
- *  @brief Cross referenced effects of the Cutting skill.
- *  @par
- */
-/*! @page Effects_Skill_Dodge
- *  @brief Cross referenced effects of the Dodge skill.
- *  @par
- */
-/*! @page Effects_Skill_Gun
- *  @brief Cross referenced effects of the Gun skill.
- *  @par
- */
-/*! @page Effects_Skill_Launcher
- *  @brief Cross referenced effects of the Launcher skill.
- *  @par
- */
-/*! @page Effects_Skill_Melee
- *  @brief Cross referenced effects of the Melee skill.
- *  @par
- */
-/*! @page Effects_Skill_Stabbing
- *  @brief Cross referenced effects of the Stabbing skill.
- *  @par
- */
-/*! @page Effects_Skill_Throw
- *  @brief Cross referenced effects of the Throw skill.
- *  @par
- */
-/*! @page Effects_Skill_Unarmed
- *  @brief Cross referenced effects of the Unarmed skill.
- *  @par
- */
-/*! @page Effects_Skill_Pistol
- *  @brief Cross referenced effects of the Pistol skill.
- *  @par
- */
-/*! @page Effects_Skill_Rifle
- *  @brief Cross referenced effects of the Rifle skill.
- *  @par
- */
-/*! @page Effects_Skill_Shotgun
- *  @brief Cross referenced effects of the Shotgun skill.
- *  @par
- */
-/*! @page Effects_Skill_Smg
- *  @brief Cross referenced effects of the Smg skill.
- *  @par
- */
-/*! @page Effects_Skill_Lockpick
- *  @brief Cross referenced effects of the Lock picking skill.
- *  @par
- */
-/*! @page Effects_Skill_Chemistry
- *  @brief Cross referenced effects of the Chemistry skill.
- *  @par
+/*! @page Effects_Fatigue Fatigue
+ *  @brief Effects of Fatigue
  */

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -681,6 +681,7 @@ static int butchery_dissect_skill_level( Character &you, int tool_quality,
     if( htype.is_valid() ) {
         int sk_total = 0;
         int sk_count = 0;
+        /** @EFFECT_SKILLS help with dissection outcomes for tools using that skill */
         for( const skill_id &sk : htype->get_harvest_skills() ) {
             sk_total += you.get_skill_level( sk );
             sk_count++;
@@ -693,9 +694,8 @@ static int butchery_dissect_skill_level( Character &you, int tool_quality,
 static int roll_butchery_dissect( int skill_level, int dex, int tool_quality )
 {
     double skill_shift = 0.0;
-    ///\EFFECT_SURVIVAL randomly increases butcher rolls
     skill_shift += rng_float( 0, skill_level - 3 );
-    ///\EFFECT_DEX >8 randomly increases butcher rolls, slightly, <8 decreases
+    /** @EFFECT_DEX >8 randomly increases butcher rolls, slightly, <8 decreases */
     skill_shift += rng_float( 0, dex - 8 ) / 4.0;
 
     if( tool_quality < 0 ) {
@@ -756,6 +756,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                              qual_BUTCHER, PICKUP_RANGE );
 
     //all BUTCHERY types - FATAL FAILURE
+    /** @EFFECT_SURVIVAL helps avoid fatal failure during non-dissection butchery */
     if( action != butcher_type::DISSECT &&
         roll_butchery_dissect( you.get_skill_level( skill_survival ), you.dex_cur,
                                tool_quality ) <= ( -15 ) && one_in( 2 ) ) {
@@ -1061,6 +1062,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
     if( action != butcher_type::FIELD_DRESS && action != butcher_type::SKIN &&
         action != butcher_type::BLEED ) {
         for( item *content : corpse_item->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+            /** @EFFECT_SURVIVAL increases chance to find hidden items after harvesting */
             if( ( roll_butchery_dissect( you.get_skill_level( skill_survival ), you.dex_cur,
                                          tool_quality ) + 10 ) * 5 > rng( 0, 100 ) ) {
                 //~ %1$s - item name, %2$s - monster name
@@ -1203,6 +1205,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
             }
             break;
         case butcher_type::FIELD_DRESS: {
+            /** @EFFECT_SURVIVAL increases chance to succeed when field dressing */
             bool success = roll_butchery_dissect( you->get_skill_level( skill_survival ), you->dex_cur,
                                                   you->max_quality( qual_BUTCHER, PICKUP_RANGE ) ) > 0;
             add_msg( success ? m_good : m_warning,
@@ -1583,10 +1586,12 @@ void activity_handlers::pulp_do_turn( player_activity *act, Character *you )
     // Stabbing weapons are a lot less effective at pulping
     const int cut_power = std::max( weap_cut, weap_stab / 2 );
 
-    ///\EFFECT_STR increases pulping power, with diminishing returns
+    /** @EFFECT_STR increases pulping power, with diminishing returns */
     float pulp_power = std::sqrt( ( you->get_arm_str() + weap_bash ) * ( cut_power + 1.0f ) );
+    /** @EFFECT_STR increases pulping stamina usage (NEGATIVE) */
     float pulp_effort = you->str_cur + weap_bash;
     // Multiplier to get the chance right + some bonus for survival skill
+    /** @EFFECT_SURVIVAL increases pulping power (+12.5% per skill level) */
     pulp_power *= 40 + you->get_skill_level( skill_survival ) * 5;
 
     int moves = 0;
@@ -3397,7 +3402,7 @@ void activity_handlers::robot_control_finish( player_activity *act, Character *y
 
     you->add_msg_if_player( _( "You unleash your override attack on the %s." ), z->name() );
 
-    /** @EFFECT_INT increases chance of successful robot reprogramming, vs difficulty */
+    /** @EFFECT_INT randomly increases chance of successful robot reprogramming, vs difficulty */
     /** @EFFECT_COMPUTER increases chance of successful robot reprogramming, vs difficulty */
     const int computer_skill = you->get_skill_level( skill_computer );
     const float randomized_skill = rng( 2, you->int_cur ) + computer_skill;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2313,20 +2313,6 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
     you.activity.set_to_null();
 }
 
-static int chop_moves( Character &you, item &it )
-{
-    // quality of tool
-    const int quality = it.get_quality( qual_AXE );
-
-    // attribute; regular tools - based on STR, powered tools - based on DEX
-    const int attr = it.has_flag( flag_POWERED ) ? you.dex_cur : you.get_arm_str();
-
-    int moves = to_moves<int>( time_duration::from_minutes( 60 - attr ) / std::pow( 2, quality - 1 ) );
-    const int helpersize = you.get_num_crafting_helpers( 3 );
-    moves *= ( 1.0f - ( helpersize / 10.0f ) );
-    return moves;
-}
-
 static bool mine_activity( Character &you, const tripoint_bub_ms &src_loc )
 {
     std::vector<item *> mining_inv = you.items_with( [&you]( const item & itm ) {
@@ -2390,7 +2376,7 @@ static bool chop_tree_activity( Character &you, const tripoint_bub_ms &src_loc )
     if( best_qual.is_null() ) {
         return false;
     }
-    int moves = chop_moves( you, best_qual );
+    int moves = iuse::chop_moves( &you, &best_qual );
     if( best_qual.type->can_have_charges() ) {
         you.consume_charges( best_qual, best_qual.type->charges_to_use() );
     }

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -659,6 +659,10 @@ bool avatar::read( item_location &book, item_location ereader )
                  reader->disp_name() );
     }
 
+    /** @EFFECT_INT determines complexity of books that can be read without a speed penalty */
+    /** @EFFECT_INT_NPC determines complexity of books that can be read without a speed penalty */
+    /** @EFFECT_INT determines which NPC or player reads complex books when together */
+    /** @EFFECT_INT_NPC determines which NPC or player reads complex books when together */
     const int intelligence = get_int();
     const bool complex_penalty = type->intel > std::min( intelligence, reader->get_int() ) &&
                                  !reader->has_trait( trait_PROF_DICEMASTER );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2034,6 +2034,10 @@ int Character::bionics_pl_skill( bool autodoc, int skill_level ) const
     skill_id important_skill;
     skill_id least_important_skill;
 
+    /** @EFFECT_FIRSTAID increases effective skill for bionics actions, slightly more with autodoc than without */
+    /** @EFFECT_COMPUTER increases effective skill for bionics actions with autodoc */
+    /** @EFFECT_ELECTRONICS increases effective skill for bionics actions, much more with autodoc than without */
+    /** @EFFECT_MECHANICS slightly increases effective skill for bionics actions without autodoc */
     if( autodoc ) {
         most_important_skill = skill_firstaid;
         important_skill = skill_computer;
@@ -2044,6 +2048,7 @@ int Character::bionics_pl_skill( bool autodoc, int skill_level ) const
         least_important_skill = skill_mechanics;
     }
 
+    /** @EFFECT_STR increases effective skill for bionics actions */
     int pl_skill;
     if( skill_level == -1 ) {
         pl_skill = int_cur                                  * 4 +
@@ -2055,11 +2060,13 @@ int Character::bionics_pl_skill( bool autodoc, int skill_level ) const
         pl_skill = 12 * skill_level;
     }
 
+    /** @EFFECT_TRAIT_PROF_MED increases effective skill for bionics actions */
     // Medical residents have some idea what they're doing
     if( has_trait( trait_PROF_MED ) ) {
         pl_skill += 3;
     }
 
+    /** @EFFECT_TRAIT_PROF_AUTODOC strongly increases effective skill for bionics actions */
     // People trained in bionics gain an additional advantage towards using it
     if( has_trait( trait_PROF_AUTODOC ) ) {
         pl_skill += 7;

--- a/src/character.h
+++ b/src/character.h
@@ -1039,6 +1039,13 @@ class Character : public Creature, public visitable
         bool valid_aoe_technique( Creature &t, const ma_technique &technique );
         bool valid_aoe_technique( Creature &t, const ma_technique &technique,
                                   std::vector<Creature *> &targets );
+
+    protected:
+        /** Used by practice() and new character creation for experience gain calculation*/
+        float get_catchup_modifier() const;
+        /** Used by practice() and new character creation for knowledge gain calculation*/
+        float get_knowledge_modifier() const;
+
     public:
 
         /** This handles giving xp for a skill. Returns true on level-up. */
@@ -2435,7 +2442,7 @@ class Character : public Creature, public visitable
         stomach_contents guts;
         std::list<consumption_event> consumption_history;
 
-        ///\EFFECT_STR increases breath-holding capacity while sinking or suffocating
+        /** @EFFECT_STR increases breath-holding capacity while sinking or suffocating */
         int get_oxygen_max() const;
         // Whether the character can recover their oxygen level
         bool can_recover_oxygen() const;
@@ -2779,12 +2786,13 @@ class Character : public Creature, public visitable
 
         std::map<mutation_category_id, int> mutation_category_level;
 
+        /** Adjusts values related to skill gain based on focus */
         float adjust_for_focus( float amount ) const;
         void update_type_of_scent( bool init = false );
         void update_type_of_scent( const trait_id &mut, bool gain = true );
         void set_type_of_scent( const scenttype_id &id );
         scenttype_id get_type_of_scent() const;
-        /**restore scent after masked_scent effect run out or is removed by water*/
+        /** restore scent after masked_scent effect run out or is removed by water */
         void restore_scent();
         /** Modifies intensity of painkillers  */
         void mod_painkiller( int npkill );
@@ -3643,6 +3651,8 @@ class Character : public Creature, public visitable
         // a cache of all active enchantment values.
         // is recalculated every turn in Character::recalculate_enchantment_cache
         pimpl<enchant_cache> enchantment_cache;
+
+        bool can_see_first_aid_precise_hp() const;
 };
 
 Character &get_player_character();

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -964,6 +964,7 @@ bool outfit::is_barefoot() const
     return true;
 }
 
+/** @EFFECT_SWIMMING reduces swim speed penalty for worn item volume from 1.8% per liter at 0 skill to 0% at 10 skill */
 int outfit::swim_modifier( const int swim_skill ) const
 {
     int ret = 0;

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -31,6 +31,7 @@ static const limb_score_id limb_score_manip( "manip" );
 
 bool Character::can_escape_trap( int difficulty, bool manip = false ) const
 {
+    /** @EFFECT_STR determines base chance to escape trap */
     int chance = get_arm_str();
     chance *= manip ? get_limb_score( limb_score_manip ) : get_limb_score( limb_score_grip );
     return x_in_y( chance, difficulty );
@@ -40,7 +41,7 @@ void Character::try_remove_downed()
 {
 
     /** @EFFECT_DEX increases chance to stand up when knocked down */
-    /** @EFFECT_ARM_STR increases chance to stand up when knocked down, slightly */
+    /** @EFFECT_STR increases chance to stand up when knocked down (half as much as dex) */
     // Downed reduces balance score to 10% unless resisted, multiply to compensate
     int chance = ( get_dex() + get_arm_str() / 2.0 ) * get_limb_score( limb_score_balance ) * 10.0;
     // Always 2,5% chance to stand up
@@ -131,6 +132,7 @@ void Character::try_remove_heavysnare()
             }
         }
     } else {
+        /** @EFFECT_DEX improves chances of escaping a heavy snare (3% per point) */
         if( can_escape_trap( 32 - dex_cur, true ) ) {
             remove_effect( effect_heavysnare );
             add_msg_player_or_npc( m_good, _( "You free yourself from the heavy snare!" ),
@@ -190,8 +192,8 @@ bool Character::try_remove_grab()
             }
         }
 
-        /** @EFFECT_STR increases chance to escape grab */
-        /** @EFFECT_DEX increases chance to escape grab */
+        /** @EFFECT_STR or dexterity, whichever is higher, increases chance to escape grab */
+        /** @EFFECT_DEX or strength, whichever is higher, increases chance to escape grab */
         int defender_check = rng( 0, std::max( get_arm_str(), get_dex() ) );
         int attacker_check = rng( get_effect_int( effect_grabbed, body_part_torso ), 8 );
 
@@ -216,8 +218,6 @@ bool Character::try_remove_grab()
             add_msg_player_or_npc( m_good, _( "You find yourself no longer grabbed." ),
                                    _( "<npcname> finds themselves no longer grabbed." ) );
             remove_effect( effect_grabbed );
-
-            /** @EFFECT_STR increases chance to escape grab */
         } else if( defender_check < attacker_check ) {
             add_msg_player_or_npc( m_bad, _( "You try to break out of the grab, but fail!" ),
                                    _( "<npcname> tries to break out of the grab, but fails!" ) );
@@ -336,7 +336,7 @@ bool Character::move_effects( bool attacking )
     // Currently we only have one thing that forces movement if you succeed, should we get more
     // than this will need to be reworked to only have success effects if /all/ checks succeed
     if( has_effect( effect_in_pit ) ) {
-        /** @EFFECT_DEX increases chance to escape pit, slightly */
+        /** @EFFECT_DEX increases chance to escape a pit (1.25% per point) */
         if( !can_escape_trap( 40 - dex_cur / 2 ) ) {
             add_msg_if_player( m_bad, _( "You try to escape the pit, but slip back in." ) );
             return false;

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -122,9 +122,10 @@ std::pair<int, int> Character::gunmod_installation_odds( const item_location &gu
     }
     // cap success from skill alone to 1 in 5 (~83% chance)
     roll = std::min( static_cast<double>( chances ), 5.0 ) / 6.0 * 100;
-    // focus is either a penalty or bonus of at most +/-10%
+    /** @EFFECT_FOCUS affects gunmod install chance, up to +/-10% */
     roll += ( std::min( std::max( get_focus(), 140 ), 60 ) - 100 ) / 4;
-    // dexterity and intelligence give +/-2% for each point above or below 12
+    /** @EFFECT_DEX affects gunmod install chance, +/-2% for each point above or below 12 */
+    /** @EFFECT_INT affects gunmod install chance, +/-2% for each point above or below 12 */
     roll += ( get_dex() - 12 ) * 2;
     roll += ( get_int() - 12 ) * 2;
     // each level of damage to the base gun reduces success by 10%

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -267,6 +267,7 @@ static float aim_speed_skill_modifier( const Character &c, const skill_id &gun_s
 
 static float aim_speed_dex_modifier( const Character &c, const skill_id & )
 {
+    /** @EFFECT_DEX affects aim speed, +/- 5% per point away from 8 */
     return ( c.get_dex() - 8 ) * 0.5f;
 }
 

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -226,6 +226,7 @@ bool computer_session::hack_attempt( Character &you, int Security ) const
     if( Security == -1 ) {
         Security = comp.security;    // Set to main system security if no value passed
     }
+    /** @EFFECT_COMPUTER increases chance of successful hack attempt, compared to security level */
     const int hack_skill = you.get_skill_level( skill_computer );
 
     // Every time you dig for lab notes, (or, in future, do other suspicious stuff?)
@@ -237,15 +238,13 @@ bool computer_session::hack_attempt( Character &you, int Security ) const
 
     you.moves -= 10 * ( 5 + Security * 2 ) / std::max( 1, hack_skill + 1 );
     int player_roll = hack_skill;
-    ///\EFFECT_INT <8 randomly penalizes hack attempts, 50% of the time
+    /** @EFFECT_INT modifies hack attempts. <8 penalizes 50% of the time, >8 benefits 33% of the time */
     if( you.int_cur < 8 && one_in( 2 ) ) {
         player_roll -= rng( 0, 8 - you.int_cur );
-        ///\EFFECT_INT >8 randomly benefits hack attempts, 33% of the time
     } else if( you.int_cur > 8 && one_in( 3 ) ) {
         player_roll += rng( 0, you.int_cur - 8 );
     }
 
-    ///\EFFECT_COMPUTER increases chance of successful hack attempt, vs Security level
     bool successful_attempt = dice( player_roll, 6 ) >= dice( Security, 6 );
     you.practice( skill_computer, successful_attempt ? ( 15 + Security * 3 ) : 7 );
     return successful_attempt;

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -680,6 +680,7 @@ float Character::metabolic_rate() const
 
     // Penalize fast survivors
     // TODO: Have cold temperature increase, not decrease, metabolism
+    /** @EFFECT_SPEED increases metabolic rate (NEGATIVE) */
     const float effective_hunger = ( get_hunger() + get_starvation() ) * 100.0f / std::max( 50,
                                    get_speed() );
     const float modifier = multi_lerp( thresholds, effective_hunger );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1029,9 +1029,10 @@ float Character::get_recipe_weighted_skill_average( const recipe &making ) const
     // TO DO: Attribute role should also be data-driven either in skills.json or in the recipe itself.
     // For now let's just use Intelligence.  For the average intelligence of 8, give +2.  Inc/dec by 0.25 per stat point.
     // This ensures that at parity, where skill = difficulty, you have a roughly 85% chance of success at average intelligence.
+    /** @EFFECT_INT increases effective skill for crafting (1/4 as much as skill) */
     total_skill_modifiers += int_cur / 4.0f;
     add_msg_debug( debugmode::DF_CRAFTING, "Total skill modifiers: %g (+%g from int)",
-                   total_skill_modifiers, int_cur / 4.f );
+                   total_skill_modifiers, int_cur / 4.0f );
 
     // Missing proficiencies penalize skill level
     for( const recipe_proficiency &recip : making.proficiencies ) {
@@ -1446,7 +1447,8 @@ void Character::complete_craft( item &craft, const std::optional<tripoint> &loc 
             // Worst case is lvl 10, which will typically take
             // 10^4/10 (1,000) minutes, or about 16 hours of crafting it to learn.
             int difficulty = making.difficulty;
-            ///\EFFECT_INT increases chance to learn recipe when crafting from a book
+            /** @EFFECT_SKILLS increases chance to learn recipe when crafting from a book using the skill */
+            /** @EFFECT_INT increases chance to learn recipe when crafting from a book */
             const double learning_speed =
                 std::max( get_skill_level( making.skill_used ), 1 ) *
                 std::max( get_int(), 1 );
@@ -2702,7 +2704,7 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
     int skill_dice = 2 + get_skill_level( dis.skill_used ) * 4;
 
     // Sides on dice is 16 plus your current intelligence
-    ///\EFFECT_INT increases success rate for disassembling items
+    /** @EFFECT_INT increases success rate for disassembling items */
     int skill_sides = 16 + int_cur;
 
     int diff_dice = dis.difficulty;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -359,8 +359,10 @@ bool Creature::sees( const Creature &critter ) const
         return visible( ch );
     } else if( ( wanted_range > 1 && critter.digging() &&
                  here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, critter.pos() ) ) ||
+               /** @EFFECT_PER increases distance at which camouflaged monsters are visible */
                ( critter.has_flag( MF_CAMOUFLAGE ) && wanted_range > this->get_eff_per() ) ||
                ( critter.has_flag( MF_WATER_CAMOUFLAGE ) &&
+                 /** @EFFECT_PER increases distance at which small underwater monsters are visible */
                  wanted_range > this->get_eff_per() &&
                  ( critter.is_likely_underwater() ||
                    here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, critter.pos() ) ||
@@ -1288,6 +1290,7 @@ void Creature::longpull( const std::string &name, const tripoint &p )
     // Pull creature
     const Character *ch = as_character();
     const monster *mon = as_monster();
+    /** @EFFECT_STR increases chance of pulling other creatures at long range */
     const int str = ch != nullptr ? ch->get_str() : mon != nullptr ? mon->get_grab_strength() : 10;
     const int odds = units::to_kilogram( c->get_weight() ) / ( str * 3 );
     if( one_in( clamp<int>( odds * odds, 1, 1000 ) ) ) {

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -108,7 +108,7 @@ bool string_id<effect_type>::is_valid() const
 void weed_msg( Character &p )
 {
     const time_duration howhigh = p.get_effect_dur( effect_weed_high );
-    ///\EFFECT_INT changes messages when smoking weed
+    /** @EFFECT_INT changes messages when smoking weed (INCONSEQUENTIAL) */
     int smarts = p.get_int();
     if( howhigh > 12_minutes && one_in( 7 ) ) {
         int msg = rng( 0, 5 );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3095,7 +3095,7 @@ static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_t
                         plots_cnt += 1;
                         if( comp ) {
                             int skillLevel = comp->get_skill_level( skill_survival );
-                            ///\EFFECT_SURVIVAL increases number of plants harvested from a seed
+                            /** @EFFECT_SURVIVAL increases number of plants harvested from a seed */
                             int plant_count = rng( skillLevel / 2, skillLevel );
                             plant_count *= farm_map.furn( pos )->plant->harvest_multiplier;
                             plant_count = std::min( std::max( plant_count, 1 ), 12 );
@@ -3422,6 +3422,7 @@ bool basecamp::gathering_return( const mission_id &miss_id, time_duration min_ti
     int favor = 2;
     int threat = 10;
     std::string skill_group = "gathering";
+    /** @EFFECT_PER_NPC helps when foraging for plants (1/2 as effective as survival skill) */
     int skill = 2 * comp->get_skill_level( skill_survival ) + comp->per_cur;
     int checks_per_cycle = 6;
     if( miss_id.id == Camp_Foraging ) {
@@ -3433,6 +3434,7 @@ bool basecamp::gathering_return( const mission_id &miss_id, time_duration min_ti
         favor = 1;
         danger = 15;
         skill_group = "trapping";
+        /** @EFFECT_PER_NPC helps when trapping small animals (1/2 as effective as devices skill) */
         skill = 2 * comp->get_skill_level( skill_traps ) + comp->per_cur;
         checks_per_cycle = 4;
     } else if( miss_id.id == Camp_Hunting ) {
@@ -3440,6 +3442,7 @@ bool basecamp::gathering_return( const mission_id &miss_id, time_duration min_ti
         danger = 10;
         favor = 0;
         skill_group = "hunting";
+        /** @EFFECT_PER_NPC helps when hunting for meat (1/3 as effective as gun skill) */
         skill = 1.5 * comp->get_skill_level( skill_gun ) + comp->per_cur / 2.0;
         threat = 12;
         checks_per_cycle = 2;

--- a/src/fungal_effects.cpp
+++ b/src/fungal_effects.cpp
@@ -54,8 +54,8 @@ void fungal_effects::fungalize( const tripoint &p, Creature *origin, double spor
         }
     } else if( player_character.pos() == p ) {
         // TODO: Make this accept NPCs when they understand fungals
-        ///\EFFECT_DEX increases chance of knocking fungal spores away with your TAIL_CATTLE
-        ///\EFFECT_MELEE increases chance of knocking fungal sports away with your TAIL_CATTLE
+        /** @EFFECT_DEX increases chance of knocking fungal spores away with your TAIL_CATTLE (one_in(20-dex-melee)) */
+        /** @EFFECT_MELEE increases chance of knocking fungal sports away with your TAIL_CATTLE (one_in(20-dex-melee)) */
         if( player_character.has_trait( trait_TAIL_CATTLE ) &&
             one_in( 20 - player_character.dex_cur - player_character.get_skill_level( skill_melee ) ) ) {
             add_msg( _( "The spores land on you, but you quickly swat them off with your tail!" ) );

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -1292,7 +1292,7 @@ void draw_caravan_items( const catacurses::window &w, std::vector<itype_id> *ite
 
 int caravan_price( Character &u, int price )
 {
-    ///\EFFECT_BARTER reduces caravan prices, 5% per point, up to 50%
+    /** @EFFECT_BARTER reduces caravan prices, 5% per point, up to 50% */
     if( u.get_skill_level( skill_speech ) > 10 ) {
         return static_cast<int>( static_cast<double>( price ) * .5 );
     }

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -80,7 +80,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
     //vehicle movement: strength check
     int mc = 0;
     int str_req = grabbed_vehicle->total_mass() / 25_kilogram; //strength required to move vehicle.
-    // ARM_STR governs dragging heavy things
+    /** @EFFECT_STR increases weight of vehicle you can drag comfortably or at all */
     int str = u.get_arm_str();
 
     //if vehicle is rollable we modify str_req based on a function of movecost per wheel.
@@ -119,10 +119,9 @@ bool game::grabbed_veh_move( const tripoint &dp )
     }
 
     //final strength check and outcomes
-    ///\ARM_STR determines ability to drag vehicles
     if( str_req <= str ) {
         //calculate exertion factor and movement penalty
-        ///\EFFECT_STR increases speed of dragging vehicles
+        /** @EFFECT_STR increases speed of dragging vehicles */
         u.moves -= 100 * str_req / std::max( 1, str );
         const int ex = dice( 1, 3 ) - 1 + str_req;
         if( ex > str + 1 ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -712,7 +712,7 @@ static void smash()
                           0.8;
     bool mech_smash = false;
     int smashskill;
-    ///\EFFECT_STR increases smashing capability
+    /** @EFFECT_STR increases smashing capability */
     if( player_character.is_mounted() ) {
         auto *mon = player_character.mounted_creature.get();
         smashskill = player_character.get_arm_str() + mon->mech_str_addition() + mon->type->melee_dice *

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1971,7 +1971,7 @@ static constexpr std::array<double, 41> hits_by_accuracy = {
 double item::effective_dps( const Character &guy, Creature &mon ) const
 {
     const float mon_dodge = mon.get_dodge();
-    float base_hit = guy.get_dex() / 4.0f + guy.get_hit_weapon( *this );
+    float base_hit = guy.get_hit_base() + guy.get_hit_weapon( *this );
     base_hit *= std::max( 0.25f, 1.0f - guy.avg_encumb_of_limb_type( body_part_type::type::torso ) /
                           100.0f );
     float mon_defense = mon_dodge + mon.size_melee_penalty() / 5.0f;
@@ -2519,7 +2519,7 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
                            _( "* This food is <bad>tainted</bad> and will poison you." ) );
     }
 
-    ///\EFFECT_SURVIVAL >=3 allows detection of poisonous food
+    /** @EFFECT_SURVIVAL >=3 allows detection of poisonous food */
     if( food_item->has_flag( flag_HIDDEN_POISON ) &&
         player_character.get_skill_level( skill_survival ) >= 3 &&
         parts->test( iteminfo_parts::FOOD_POISON ) ) {
@@ -2528,7 +2528,7 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
                               "<bad>poisonous</bad>." ) );
     }
 
-    ///\EFFECT_SURVIVAL >=5 allows detection of hallucinogenic food
+    /** @EFFECT_SURVIVAL >=5 allows detection of hallucinogenic food */
     if( food_item->has_flag( flag_HIDDEN_HALLU ) &&
         player_character.get_skill_level( skill_survival ) >= 5 &&
         parts->test( iteminfo_parts::FOOD_HALLUCINOGENIC ) ) {
@@ -5304,7 +5304,7 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
         }
     }
 
-    ///\EFFECT_MELEE >2 allows seeing melee damage stats on weapons
+    /** @EFFECT_MELEE >2 allows seeing melee damage stats on weapons */
     if( ( player_character.get_skill_level( skill_melee ) > 2 &&
           ( dmg_bash || dmg_cut || dmg_stab || type->m_to_hit > 0 ) ) || debug_mode ) {
         bodypart_id bp = bodypart_id( "torso" );
@@ -8897,7 +8897,7 @@ bool item::is_two_handed( const Character &guy ) const
     if( has_flag( flag_ALWAYS_TWOHAND ) ) {
         return true;
     }
-    ///\EFFECT_STR determines which weapons can be wielded with one hand
+    /** @EFFECT_STR determines which weapons can be wielded with one hand (452 grams per point) */
     return ( ( weight() / 113_gram ) > guy.get_arm_str() * 4 );
 }
 
@@ -10249,7 +10249,7 @@ int item::gun_recoil( const Character &p, bool bipod ) const
         return 0;
     }
 
-    ///\ARM_STR improves the handling of heavier weapons
+    /** @EFFECT_STR decreases recoil with light weapons */
     // we consider only base weight to avoid exploits
     double wt = std::min( type->weight, p.get_arm_str() * 333_gram ) / 333.0_gram;
 
@@ -10320,8 +10320,9 @@ int item::gun_range( const Character *p ) const
         return 0;
     }
 
-    // Reduce bow range until player has twice minimm required strength
+    // Reduce bow range until player has twice minimum required strength
     if( has_flag( flag_STR_DRAW ) ) {
+        /** @EFFECT_STR increases range with STR_DRAW weapons */
         ret += std::max( 0.0, ( p->get_str() - get_min_str() ) * 0.5 );
     }
 

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -230,6 +230,7 @@ std::optional<int> disassemble( Character *, item *, bool, const tripoint & );
 void cut_log_into_planks( Character & );
 void play_music( Character &p, const tripoint &source, int volume, int max_morale );
 int towel_common( Character *, item *, bool );
+int chop_moves( Character *, item * );
 
 // Helper for validating a potential target of robot control
 bool robotcontrol_can_target( Character *, const monster & );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1107,6 +1107,8 @@ float spell::spell_fail( const Character &guy ) const
     // effective skill of 0 or less is 100% failure
     // effective skill of 8 (8 int, 0 spellcraft, 0 spell level, spell difficulty 0) is ~50% failure
     // effective skill of 30 is 0% failure
+    /** @EFFECT_INT reduces chance of spell failure (equivalent to 1 skill level per point) */
+    /** @EFFECT_SKILLS reduce chances of spell failure using the skill */
     const float effective_skill = 2 * ( get_level() - get_difficulty( guy ) ) + guy.get_int() +
                                   guy.get_skill_level( skill() );
     // add an if statement in here because sufficiently large numbers will definitely overflow because of exponents
@@ -1460,8 +1462,10 @@ std::string spell::exp_progress() const
 
 float spell::exp_modifier( const Character &guy ) const
 {
+    /** @EFFECT_INT affects spell experience, +/- 2.5% per point away from 8 */
     const float int_modifier = ( guy.get_int() - 8.0f ) / 8.0f;
     const float difficulty_modifier = get_difficulty( guy ) / 20.0f;
+    /** @EFFECT_SKILLS affects spell experience, +2% per level of the relevant skill */
     const float spellcraft_modifier = guy.get_skill_level( skill() ) / 10.0f;
 
     return ( int_modifier + difficulty_modifier + spellcraft_modifier ) / 5.0f + 1.0f;
@@ -1911,6 +1915,7 @@ void known_magic::mod_mana( const Character &guy, int add_mana )
 
 int known_magic::max_mana( const Character &guy ) const
 {
+    /** @EFFECT_INT increases max mana */
     const float int_bonus = ( ( 0.2f + guy.get_int() * 0.1f ) - 1.0f ) * mana_base;
     const int bionic_penalty = std::round( std::max( 0.0f,
                                            units::to_kilojoule( guy.get_power_level() ) *
@@ -1974,6 +1979,8 @@ int known_magic::time_to_learn_spell( const Character &guy, const spell_id &sp )
 {
     dialogue d( get_talker_for( guy ), nullptr );
     const int base_time = to_moves<int>( 30_minutes );
+    /** @EFFECT_INT affects time to learn spells */
+    /** @EFFECT_SKILLS affect time to learn spells using the relevant skill */
     const double int_modifier = ( guy.get_int() - 8.0 ) / 8.0;
     const double skill_modifier = guy.get_skill_level( sp->skill ) / 10.0;
     return base_time * ( 1.0 + sp->difficulty.evaluate( d ) / ( 1.0 + int_modifier + skill_modifier ) );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1723,6 +1723,7 @@ void spell_effect::effect_on_condition( const spell &sp, Creature &caster, const
 void spell_effect::slime_split_on_death( const spell &sp, Creature &caster, const tripoint &target )
 {
     sp.make_sound( target, caster );
+    /** @EFFECT_SPEED_BASE determines mass of new slimes spawned when a slime dies */
     int mass = caster.get_speed_base();
     monster *caster_monster = dynamic_cast<monster *>( &caster );
     if( caster_monster && caster_monster->type->id == mon_blob_brain ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1706,7 +1706,7 @@ bool map::can_move_furniture( const tripoint &pos, Character *you ) const
         return false;
     }
 
-    ///\EFFECT_STR determines what furniture the player can move
+    /** @EFFECT_STR determines what furniture the player can move */
     int adjusted_str = you->str_cur;
     if( you->is_mounted() ) {
         auto *mons = you->mounted_creature.get();
@@ -2881,10 +2881,8 @@ int map::bash_rating_internal( const int str, const furn_t &furniture,
 {
     bool furn_smash = false;
     bool ter_smash = false;
-    ///\EFFECT_STR determines what furniture can be smashed
     if( furniture.id && furniture.bash.str_max != -1 ) {
         furn_smash = true;
-        ///\EFFECT_STR determines what terrain can be smashed
     } else if( terrain.bash.str_max != -1 && ( !terrain.bash.bash_below || allow_floor ) ) {
         ter_smash = true;
     }
@@ -2906,7 +2904,7 @@ int map::bash_rating_internal( const int str, const furn_t &furniture,
         return -1;
     }
 
-    ///\EFFECT_STR increases smashing damage
+    /** @EFFECT_STR increases smashing damage */
     if( str < bash_min ) {
         return 0;
     } else if( str >= bash_max ) {

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1384,7 +1384,7 @@ bool character_martial_arts::can_use_attack_vector( const Character &user,
 bool character_martial_arts::can_leg_block( const Character &owner ) const
 {
     const martialart &ma = style_selected.obj();
-    ///\EFFECT_UNARMED increases ability to perform leg block
+    /** @EFFECT_UNARMED increases ability to perform leg block */
     const int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? 5 : owner.get_skill_level(
                                   skill_unarmed );
 
@@ -1419,7 +1419,7 @@ bool character_martial_arts::can_leg_block( const Character &owner ) const
 bool character_martial_arts::can_arm_block( const Character &owner ) const
 {
     const martialart &ma = style_selected.obj();
-    ///\EFFECT_UNARMED increases ability to perform arm block
+    /** @EFFECT_UNARMED increases ability to perform arm block */
     const int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? 5 : owner.get_skill_level(
                                   skill_unarmed );
 

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1443,7 +1443,7 @@ void talk_function::attack_random( const std::vector<npc_ptr> &attacker,
     if( best ) {
         best_score = att->get_skill_level( best );
     }
-    ///\EFFECT_DODGE_NPC increases avoidance of random attacks
+    /** @EFFECT_DODGE_NPC increases avoidance of random attacks */
     if( rng( -1, best_score ) >= rng( 0, def->get_skill_level( skill_dodge ) ) ) {
         def->set_part_hp_cur( bodypart_id( "torso" ), 0 );
         popup( _( "%s is wasted by %s!" ), def->get_name(), att->get_name() );
@@ -1726,14 +1726,14 @@ void talk_function::field_harvest( npc &p, const std::string &place )
 static int scavenging_combat_skill( npc &p, int bonus, bool guns )
 {
     // the following doxygen aliases do not yet exist. this is marked for future reference
-    ///\EFFECT_MELEE_NPC affects scavenging_patrol results
-    ///\EFFECT_SURVIVAL_NPC affects scavenging_patrol results
-    ///\EFFECT_BASHING_NPC affects scavenging_patrol results
-    ///\EFFECT_CUTTING_NPC affects scavenging_patrol results
-    ///\EFFECT_GUN_NPC affects scavenging_patrol results
-    ///\EFFECT_STABBING_NPC affects scavenging_patrol results
-    ///\EFFECT_UNARMED_NPC affects scavenging_patrol results
-    ///\EFFECT_DODGE_NPC affects scavenging_patrol results
+    /** @EFFECT_MELEE_NPC affects scavenging_patrol results */
+    /** @EFFECT_SURVIVAL_NPC affects scavenging_patrol results */
+    /** @EFFECT_BASHING_NPC affects scavenging_patrol results */
+    /** @EFFECT_CUTTING_NPC affects scavenging_patrol results */
+    /** @EFFECT_GUN_NPC affects scavenging_patrol results */
+    /** @EFFECT_STABBING_NPC affects scavenging_patrol results */
+    /** @EFFECT_UNARMED_NPC affects scavenging_patrol results */
+    /** @EFFECT_DODGE_NPC affects scavenging_patrol results */
     return bonus + p.get_skill_level( skill_melee ) + .5 * p.get_skill_level( skill_survival ) +
            p.get_skill_level( skill_bashing ) + p.get_skill_level( skill_cutting ) +
            ( guns ? p.get_skill_level( skill_gun ) : 0 ) + p.get_skill_level( skill_stabbing ) +
@@ -2036,11 +2036,11 @@ bool talk_function::carpenter_return( npc &p )
     if( one_in( 20 ) ) {
         // the following doxygen aliases do not yet exist. this is marked for future reference
 
-        ///\EFFECT_FABRICATION_NPC affects carpenter mission results
+        /** @EFFECT_FABRICATION_NPC affects carpenter mission results */
 
-        ///\EFFECT_DODGE_NPC affects carpenter mission results
+        /** @EFFECT_DODGE_NPC affects carpenter mission results */
 
-        ///\EFFECT_SURVIVAL_NPC affects carpenter mission results
+        /** @EFFECT_SURVIVAL_NPC affects carpenter mission results */
         int skill_1 = comp->get_skill_level( skill_fabrication );
         int skill_2 = comp->get_skill_level( skill_dodge );
         int skill_3 = comp->get_skill_level( skill_survival );
@@ -2092,9 +2092,9 @@ bool talk_function::forage_return( npc &p )
         popup( _( "While foraging, a beast began to stalk %s…" ), comp->get_name() );
         // the following doxygen aliases do not yet exist. this is marked for future reference
 
-        ///\EFFECT_SURVIVAL_NPC affects forage mission results
+        /** @EFFECT_SURVIVAL_NPC affects forage mission results */
 
-        ///\EFFECT_DODGE_NPC affects forage mission results
+        /** @EFFECT_DODGE_NPC affects forage mission results */
         int skill_1 = comp->get_skill_level( skill_survival );
         int skill_2 = comp->get_skill_level( skill_dodge );
         if( skill_1 > rng( -2, 8 ) ) {
@@ -2144,7 +2144,7 @@ bool talk_function::forage_return( npc &p )
     player_character.i_add_or_drop( merch, merch_amount );
     // the following doxygen aliases do not yet exist. this is marked for future reference
 
-    ///\EFFECT_SURVIVAL_NPC affects forage mission results
+    /** @EFFECT_SURVIVAL_NPC affects forage mission results */
     int skill = comp->get_skill_level( skill_survival );
     if( skill > rng_float( -.5, 8 ) ) {
         item_group_id itemlist = Item_spawn_data_farming_seeds;
@@ -2456,28 +2456,48 @@ std::vector<npc_ptr> talk_function::companion_list( const npc &p, const mission_
 
 static int companion_combat_rank( const npc &p )
 {
+    /** @EFFECT_DEX_NPC contributes to base npc combat rank (3*str + 2*dex + 2*per + int) */
+    /** @EFFECT_STR_NPC contributes strongly to base npc combat rank (3*str + 2*dex + 2*per + int) */
+    /** @EFFECT_PER_NPC contributes to base npc combat rank (3*str + 2*dex + 2*per + int) */
+    /** @EFFECT_INT_NPC contributes slightly to base npc combat rank (3*str + 2*dex + 2*per + int) */
     int combat = 2 * p.get_dex() + 3 * p.get_str() + 2 * p.get_per() + p.get_int();
+    /** @EFFECT_SKILLS contribute to base npc combat rank */
     for( const Skill &sk : Skill::skills ) {
         combat += p.get_skill_level( sk.ident() ) * sk.companion_combat_rank_factor();
     }
+    /** @EFFECT_DEX_NPC scales npc combat rank (*N) */
+    /** @EFFECT_STR_NPC scales npc combat rank (*N) */
     return combat * std::min( p.get_dex(), 32 ) * std::min( p.get_str(), 32 ) / 64;
 }
 
 static int companion_survival_rank( const npc &p )
 {
+    /** @EFFECT_DEX_NPC contributes to base npc survival rank (2*dex + 2*per + 1.5*int + str) */
+    /** @EFFECT_STR_NPC contributes slightly to base npc survival rank (2*dex + 2*per + 1.5*int + str) */
+    /** @EFFECT_PER_NPC contributes to base npc survival rank (2*dex + 2*per + 1.5*int + str) */
+    /** @EFFECT_INT_NPC contributes to base npc survival rank (2*dex + 2*per + 1.5*int + str) */
     int survival = 2 * p.get_dex() + p.get_str() + 2 * p.get_per() + 1.5 * p.get_int();
+    /** @EFFECT_SKILLS contribute to base npc survival rank */
     for( const Skill &sk : Skill::skills ) {
         survival += p.get_skill_level( sk.ident() ) * sk.companion_survival_rank_factor();
     }
+    /** @EFFECT_DEX_NPC scales npc survival rank (*N) */
+    /** @EFFECT_PER_NPC scales npc survival rank (*N) */
     return survival * std::min( p.get_dex(), 32 ) * std::min( p.get_per(), 32 ) / 64;
 }
 
 static int companion_industry_rank( const npc &p )
 {
+    /** @EFFECT_DEX_NPC contributes slightly to base npc industry rank (3*int + dex + str + per) */
+    /** @EFFECT_STR_NPC contributes slightly to base npc industry rank (3*int + dex + str + per) */
+    /** @EFFECT_PER_NPC contributes slightly to base npc industry rank (3*int + dex + str + per) */
+    /** @EFFECT_INT_NPC contributes strongly to base npc industry rank (3*int + dex + str + per) */
     int industry = p.get_dex() + p.get_str() + p.get_per() + 3 * p.get_int();
+    /** @EFFECT_SKILLS contribute to base npc industry rank */
     for( const Skill &sk : Skill::skills ) {
         industry += p.get_skill_level( sk.ident() ) * sk.companion_industry_rank_factor();
     }
+    /** @EFFECT_DEX_NPC scales npc industry rank (*N) */
     return industry * std::min( p.get_int(), 32 ) / 8;
 }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -858,13 +858,13 @@ bool mattack::pull_metal_weapon( monster *z )
             // Take the total portion of metal in the item into account
             const float metal_fraction = metal_portion / static_cast<float>( weapon->type->mat_portion_total );
             if( !weapon->has_flag( flag_NO_UNWIELD ) && metal_portion ) {
+                /** @EFFECT_MELEE increases resistance chance vs pull_metal_weapon special attack */
                 const int wp_skill = foe->get_skill_level( skill_melee );
                 // It takes a while
                 z->moves -= att_cost_pull;
                 int success = 100;
-                ///\Grip strength increases resistance to pull_metal_weapon special attack
+                /** @EFFECT_STR >4 allows and increases resistance chance vs pull_metal_weapon special attack */
                 if( foe->str_cur > min_str ) {
-                    ///\EFFECT_MELEE increases resistance to pull_metal_weapon special attack
                     success = std::max( ( 100 * metal_fraction ) - ( 6 * ( foe->str_cur - 6 ) * foe->get_limb_score(
                                             limb_score_grip ) ) - ( 6 * wp_skill ),
                                         0.0f );
@@ -930,7 +930,7 @@ bool mattack::boomer( monster *z )
         }
     }
     if( !target->uncanny_dodge() ) {
-        ///\EFFECT_DODGE increases chance to avoid boomer effect
+        /** @EFFECT_DODGE increases chance to avoid boomer effect */
         if( rng( 0, 10 ) > target->get_dodge() || one_in( target->get_dodge() ) ) {
             target->add_env_effect( effect_boomered, bodypart_id( "eyes" ), 3, 12_turns );
         } else if( u_see ) {
@@ -972,7 +972,7 @@ bool mattack::boomer_glow( monster *z )
         }
     }
     if( !target->uncanny_dodge() ) {
-        ///\EFFECT_DODGE increases chance to avoid glowing boomer effect
+        /** @EFFECT_DODGE increases chance to avoid glowing boomer effect */
         if( rng( 0, 10 ) > target->get_dodge() || one_in( target->get_dodge() ) ) {
             target->add_env_effect( effect_boomered, bodypart_id( "eyes" ), 5, 25_turns );
             target->on_dodge( z, 5 );
@@ -1364,7 +1364,7 @@ bool mattack::science( monster *const z ) // I said SCIENCE again!
             const bool critial_fail = one_in( dodge_skill );
             const bool is_trivial   = dodge_skill > att_rad_dodge_diff;
 
-            ///\EFFECT_DODGE increases chance to avoid science effect
+            /** @EFFECT_DODGE increases chance to avoid science effect */
             if( !critial_fail && ( is_trivial || dodge_skill > rng( 0, att_rad_dodge_diff ) ) ) {
                 target->add_msg_player_or_npc( _( "You dodge the beam!" ),
                                                _( "<npcname> dodges the beam!" ) );
@@ -2211,17 +2211,16 @@ bool mattack::dermatik( monster *z )
 
     // Can we swat the bug away?
     int dodge_roll = z->dodge_roll();
-    ///\EFFECT_MELEE increases chance to deflect dermatik attack
-
-    ///\EFFECT_UNARMED increases chance to deflect dermatik attack
+    /** @EFFECT_MELEE increases chance to deflect dermatik attack */
+    /** @EFFECT_UNARMED increases chance to deflect dermatik attack */
     int swat_skill = ( foe->get_skill_level( skill_melee ) + foe->get_skill_level(
                            skill_unarmed ) * 2 ) / 3;
     int player_swat = dice( swat_skill, 10 );
+    /** @EFFECT_TRAIT_TAIL_CATTLE allows chance to deflect dermatik attack */
     if( foe->has_trait( trait_TAIL_CATTLE ) ) {
         target->add_msg_if_player( _( "You swat at the %s with your tail!" ), z->name() );
-        ///\EFFECT_DEX increases chance of deflecting dermatik attack with TAIL_CATTLE
-
-        ///\EFFECT_UNARMED increases chance of deflecting dermatik attack with TAIL_CATTLE
+        /** @EFFECT_DEX increases chance of deflecting dermatik attack with TAIL_CATTLE */
+        /** @EFFECT_UNARMED increases chance of deflecting dermatik attack with TAIL_CATTLE (1/2 as effective as dex) */
         player_swat += ( ( foe->dex_cur + foe->get_skill_level( skill_unarmed ) ) / 2 );
     }
     Character &player_character = get_player_character();
@@ -2727,8 +2726,8 @@ bool mattack::ranged_pull( monster *z )
 
     if( target->has_grab_break_tec() ) {
         Character *pl = dynamic_cast<Character *>( target );
-        ///\EFFECT_STR increases chance to avoid being grabbed
-        ///\EFFECT_DEX increases chance to avoid being grabbed
+        /** @EFFECT_STR increases chance to avoid being ranged pulled */
+        /** @EFFECT_DEX increases chance to avoid being ranged pulled */
         int defender_check = rng( 0, std::max( pl->get_dex(), pl->get_str() ) );
         int attacker_check = rng( 0, z->type->melee_sides + z->type->melee_dice );
         const ma_technique grab_break = pl->martial_arts_data->get_grab_break( *pl );
@@ -2847,7 +2846,8 @@ bool mattack::grab( monster *z )
         return true;
     }
 
-    ///\EFFECT_DEX increases chance to avoid being grabbed
+    /** @EFFECT_DEX increases chance to avoid being grabbed */
+    /** @EFFECT_STR increases chance to avoid being grabbed */
     int defender_check = rng( 0, std::max( pl->get_dex(), pl->get_str() ) );
     int attacker_check = rng( 0, z->type->melee_sides + z->type->melee_dice );
     const ma_technique grab_break = pl->martial_arts_data->get_grab_break( *pl );
@@ -3073,7 +3073,7 @@ bool mattack::fear_paralyze( monster *z )
     if( player_character.sees( *z ) && !player_character.has_effect( effect_fearparalyze ) ) {
         if( player_character.worn_with_flag( flag_PSYSHIELD_PARTIAL ) && one_in( 4 ) ) {
             add_msg( _( "The %s probes your mind, but is rebuffed!" ), z->name() );
-            ///\EFFECT_INT decreases chance of being paralyzed by fear attack
+            /** @EFFECT_INT decreases chance of being paralyzed by fear attack (95% minus 4.7% per point) */
         } else if( rng( 0, 20 ) > player_character.get_int() ) {
             add_msg( m_bad, _( "The terrifying visage of the %s paralyzes you." ), z->name() );
             player_character.add_effect( effect_fearparalyze, 5_turns );
@@ -4916,7 +4916,7 @@ bool mattack::riotbot( monster *z )
 
         amenu.addentry( ur_arrest, true, 'a', _( "Allow yourself to be arrested." ) );
         amenu.addentry( ur_resist, true, 'r', _( "Resist arrest!" ) );
-        ///\EFFECT_INT >10 allows and increases chance whether you can feign death to avoid riot bot arrest
+        /** @EFFECT_INT >10 may allow feign death attempt to avoid riot bot arrest, >12 always allows */
         if( foe->int_cur > 12 || ( foe->int_cur > 10 && !one_in( foe->int_cur - 8 ) ) ) {
             amenu.addentry( ur_trick, true, 't', _( "Feign death." ) );
         }
@@ -4936,7 +4936,7 @@ bool mattack::riotbot( monster *z )
             const bool is_uncanny = foe->has_active_bionic( bio_uncanny_dodge ) &&
                                     foe->get_power_level() > bio_uncanny_dodge.obj().power_trigger &&
                                     !one_in( 3 );
-            ///\EFFECT_DEX >13 allows and increases chance to slip out of handcuffs
+            /** @EFFECT_DEX >13 allows and increases chance to slip out of handcuffs being applied (13 => 50%, 14 => 67%, 15 => 75%, etc) */
             const bool is_dex = foe->dex_cur > 13 && !one_in( foe->dex_cur - 11 );
 
             if( is_uncanny || is_dex ) {
@@ -4977,7 +4977,7 @@ bool mattack::riotbot( monster *z )
 
         if( choice == ur_trick ) {
 
-            ///\EFFECT_INT >10 allows and increases chance of successful feign death
+            /** @EFFECT_INT >=12 allows successful feign death and increases success rate (12=50%, 13=67%, 14=75%, ...) */
             if( !one_in( foe->int_cur - 10 ) ) {
 
                 add_msg( m_good,
@@ -5370,8 +5370,8 @@ bool mattack::bio_op_takedown( monster *z )
     // At this point, Martial Arts or Tentacle Bracing can make this much less painful
     if( target->has_grab_break_tec() ) {
         Character *pl = dynamic_cast<Character *>( target );
-        ///\EFFECT_STR increases chance to avoid being grabbed
-        ///\EFFECT_DEX increases chance to avoid being grabbed
+        /** @EFFECT_STR increases chance to avoid the bio operator takedown attack */
+        /** @EFFECT_DEX increases chance to avoid the bio operator takedown attack */
         int defender_check = rng( 0, std::max( pl->get_dex(), pl->get_str() ) );
         int attacker_check = rng( 0, z->type->melee_sides + z->type->melee_dice );
         const ma_technique grab_break = pl->martial_arts_data->get_grab_break( *pl );
@@ -5535,9 +5535,9 @@ bool mattack::bio_op_disarm( monster *z )
     int my_roll = dice( 3, 2 * mon_stat );
     my_roll += dice( 3, z->type->melee_skill );
 
-    /** @ARM_STR increases chance to avoid disarm, primary stat */
-    /** @EFFECT_DEX increases chance to avoid disarm, secondary stat */
     /** Grip and reaction scores increase the  chance to avoid/ resist disarm */
+    /** @EFFECT_STR increases chance to avoid disarm */
+    /** @EFFECT_DEX increases chance to avoid disarm */
     /** @EFFECT_MELEE increases chance to avoid disarm */
     int their_roll = dice( 3, foe->get_limb_score( limb_score_grip ) * ( foe->get_arm_str() +
                            foe->get_dex() ) );
@@ -5999,7 +5999,7 @@ bool mattack::dodge_check( monster *z, Creature *target )
         return true;
     }
 
-    ///\EFFECT_DODGE increases chance of dodging, vs their melee skill
+    /** @EFFECT_DODGE increases chance of dodging, vs their melee skill */
     float dodge = std::max( target->get_dodge() - rng( 0, z->get_hit() ), 0.0f );
     return dodge > 0.0 && rng( 0, 10000 ) < 10000 / ( 1 + 99 * std::exp( -.6 * dodge ) );
 }

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -113,8 +113,8 @@ void swap( monster &z )
     Character &player_character = get_player_character();
     player_character.moves -= 150;
 
-    ///\EFFECT_STR increases chance to successfully swap positions with your pet
-    ///\EFFECT_DEX increases chance to successfully swap positions with your pet
+    /** @EFFECT_STR increases chance to successfully swap positions with your pet (str+dex<12 0%, <18 50%, <24 67%, etc) */
+    /** @EFFECT_DEX increases chance to successfully swap positions with your pet (str+dex<12 0%, <18 50%, <24 67%, etc) */
     if( !one_in( ( player_character.str_cur + player_character.dex_cur ) / 6 ) ) {
         bool t = z.has_effect( effect_tied );
         if( t ) {
@@ -138,7 +138,7 @@ void push( monster &z )
     Character &player_character = get_player_character();
     player_character.moves -= 30;
 
-    ///\EFFECT_STR increases chance to successfully push your pet
+    /** @EFFECT_STR >=2 increases chance to successfully push your pet (2 50%, 3 67%, 4 75%, etc) */
     if( one_in( player_character.str_cur ) ) {
         add_msg( _( "You pushed the %s, but it resisted." ), pet_name );
         return;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -794,10 +794,8 @@ bool avatar::create( character_type type, const std::string &tempname )
         mod_skill_level( e.first, e.second );
     }
 
-    // 2 for an average person
-    float catchup_modifier = 1.0f + ( 2.0f * get_int() + get_per() ) / 24.0f;
-    // 1.2 for an average person, always a bit higher than base amount
-    float knowledge_modifier = 1.0f + get_int() / 40.0f;
+    float catchup_modifier = get_catchup_modifier();
+    float knowledge_modifier = get_knowledge_modifier();
     // Grab skills from hobbies and train
     for( const profession *profession : hobbies ) {
         for( const profession::StartingSkill &e : profession->skills() ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1349,6 +1349,7 @@ time_duration npc::time_to_read( const item &book, const Character &reader ) con
     time_duration retval = type->time * reading_speed / 100;
     retval *= std::min( fine_detail_vision_mod(), reader.fine_detail_vision_mod() );
 
+    /** @EFFECT_INT_NPC reduces time to read difficult books */
     if( type->intel > reader.get_int() && !reader.has_trait( trait_PROF_DICEMASTER ) ) {
         retval += type->time * ( time_duration::from_seconds( type->intel - reader.get_int() ) /
                                  1_minutes );
@@ -1576,7 +1577,7 @@ void npc::form_opinion( const Character &you )
         op_of_u.fear += 2;
     }
 
-    ///\EFFECT_STR increases NPC fear of the player
+    /** @EFFECT_STR increases NPC fear of the player */
     if( you.str_max >= 16 ) {
         op_of_u.fear += 2;
     } else if( you.str_max >= 12 ) {
@@ -2648,7 +2649,7 @@ void npc::npc_dismount()
 int npc::smash_ability() const
 {
     if( !is_hallucination() && ( !is_player_ally() || rules.has_flag( ally_rule::allow_bash ) ) ) {
-        ///\EFFECT_STR_NPC increases smash ability
+        /** @EFFECT_STR_NPC increases smash ability */
         int dmg = get_wielded_item() ? get_wielded_item()->damage_melee( damage_type::BASH ) : 0;
         return str_cur + dmg;
     }
@@ -2797,6 +2798,7 @@ int npc::print_info( const catacurses::window &w, int line, int vLines, int colu
     // 3 perception and 3 distance would see all mutations - cap 0
     // 3 perception and 15 distance - cap 5, some mutations visible
     // 3 perception and 20 distance would be barely able to discern huge antlers on a person - cap 10
+    /** @EFFECT_PER determines distance at which NPC mutations can be seen */
     const int per = player_character.get_per();
     const int dist = rl_dist( player_character.pos(), pos() );
     int visibility_cap;
@@ -3422,6 +3424,7 @@ const pathfinding_settings &npc::get_pathfinding_settings( bool no_bashing ) con
         path_settings->bash_strength = 0;
     }
     // TODO: Extract climb skill
+    /** @EFFECT_DEX_NPC determines pathfinding cost for climbing */
     const int climb = std::min( 20, get_dex() );
     if( climb > 1 ) {
         // Success is !one_in(dex), so 0%, 50%, 66%, 75%...

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -363,6 +363,7 @@ std::vector<sphere> npc::find_dangerous_explosives() const
             continue;   // Far enough.
         }
 
+        /** @EFFECT_SPEED determines how close NPCs consider explosives an imminent danger */
         const int turns_to_evacuate = 2 * safe_range / speed_rating();
 
         if( elem->charges > turns_to_evacuate ) {
@@ -552,6 +553,7 @@ void npc::assess_danger()
             continue;
         }
 
+        /** @EFFECT_SPEED for monsters determines how far they are considered a danger */
         float scaled_distance = std::max( 1.0f, dist / critter.speed_rating() );
         float hp_percent = 1.0f - static_cast<float>( critter.get_hp() ) / critter.get_hp_max();
         float critter_danger = std::max( critter_threat * ( hp_percent * 0.5f + 0.5f ),
@@ -601,6 +603,7 @@ void npc::assess_danger()
             warn_about( "monster", 10_minutes, bogey, dist, foe.pos() );
         }
 
+        /** @EFFECT_SPEED for monsters affects how far away they are considered a danger */
         int scaled_distance = std::max( 1, ( 100 * dist ) / foe.get_speed() );
         ai_cache.total_danger += foe_threat / scaled_distance;
         if( must_retreat || no_fighting ) {
@@ -713,6 +716,7 @@ float npc::character_danger( const Character &uc ) const
 
     ret += my_gun ? uc.get_dodge() / 2 : uc.get_dodge();
 
+    /** @EFFECT_SPEED affects how dangerous NPCs seem */
     ret *= std::max( 0.5, uc.get_speed() / 100.0 );
 
     add_msg_debug( debugmode::DF_NPC, "%s danger: %1f", uc.disp_name(), ret );
@@ -2418,8 +2422,8 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
             moves -= 100;
             moved = true;
         }
+        /** @EFFECT_DEX_NPC >1 allows and increases chance to climb CLIMBABLE furniture or terrain (1/N failure) */
     } else if( get_dex() > 1 && here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_CLIMBABLE, p ) ) {
-        ///\EFFECT_DEX_NPC increases chance to climb CLIMBABLE furniture or terrain
         int climb = get_dex();
         if( one_in( climb ) ) {
             add_msg_if_npc( m_neutral, _( "%1$s tries to climb the %2$s but slips." ), get_name(),

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1414,6 +1414,8 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         add_response_done( _( "Bye." ) );
     }
 
+    /** @EFFECT_INT_NPC >=9 may allow friendly churlish conversation */
+    /** @EFFECT_TRAIT_PROF_CHURL may allow friendly churlish conversation */
     if( player_character.has_trait( trait_PROF_CHURL ) && ( actor( true )->get_npc_trust() >= 0 ) &&
         ( actor( true )->get_npc_anger() <= 0 ) && ( actor( true )->int_cur() >= 9 ) &&
         !( the_topic.id == "TALK_CHURL_FRIENDLY" ) ) {

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -135,13 +135,10 @@ double npc_trading::net_price_adjustment( const Character &buyer, const Characte
 {
     // Adjust the prices based on your social skill.
     // cap adjustment so nothing is ever sold below value
-    ///\EFFECT_INT_NPC slightly increases bartering price changes, relative to your INT
-
-    ///\EFFECT_BARTER_NPC increases bartering price changes, relative to your BARTER
-
-    ///\EFFECT_INT slightly increases bartering price changes, relative to NPC INT
-
-    ///\EFFECT_BARTER increases bartering price changes, relative to NPC BARTER
+    /** @EFFECT_INT_NPC slightly increases bartering price changes, relative to your INT */
+    /** @EFFECT_BARTER_NPC increases bartering price changes, relative to your BARTER */
+    /** @EFFECT_INT slightly increases bartering price changes, relative to NPC INT */
+    /** @EFFECT_BARTER increases bartering price changes, relative to NPC BARTER */
     int const int_diff = seller.int_cur - buyer.int_cur;
     double const int_adj = 1 + 0.05 * std::min( 19, std::abs( int_diff ) );
     double const soc_adj = price_adjustment( seller.get_skill_level( skill_speech ) -

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4038,9 +4038,10 @@ void overmap::move_hordes()
             const mtype &type = *this_monster.type;
             if(
                 !type.species.count( species_ZOMBIE ) || // Only add zombies to hordes.
-                this_monster.get_speed() <= 30 || // So are very slow zombies, like crawling zombies.
-                !this_monster.will_join_horde( INT_MAX ) || // So are zombies who won't join a horde of any size.
-                !this_monster.mission_ids.empty() // We mustn't delete monsters that are related to missions.
+                /** @EFFECT_SPEED <=30 for monsters prevents joining hordes */
+                this_monster.get_speed() <= 30 || // Don't add very slow zombies, like crawling zombies.
+                !this_monster.will_join_horde( INT_MAX ) || // Don't add zombies who won't join a horde of any size.
+                !this_monster.mission_ids.empty() // Don't delete monsters that are related to missions.
             ) {
                 // Don't delete the monster, just increment the iterator.
                 monster_map_it++;

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -205,7 +205,7 @@ static void eff_fun_fungus( Character &u, effect &it )
                 u.moves = -200;
                 u.mod_hunger( awfulness );
                 u.mod_thirst( awfulness );
-                ///\EFFECT_STR decreases damage taken by fungus effect
+                /** @EFFECT_STR decreases damage taken by fungus effect (1/str) */
                 u.apply_damage( nullptr, bodypart_id( "torso" ), awfulness / std::max( u.str_cur,
                                 1 ) ); // can't be healthy
             }
@@ -366,9 +366,8 @@ static void eff_fun_hallu( Character &u, effect &it )
                 }
             };
 
-            ///\EFFECT_STR_NPC increases volume of hallucination sounds (NEGATIVE)
-
-            ///\EFFECT_INT_NPC decreases volume of hallucination sounds
+            /** @EFFECT_STR_NPC increases volume of hallucination sounds (NEGATIVE) */
+            /** @EFFECT_INT_NPC decreases volume of hallucination sounds */
             int loudness = 20 + u.str_cur - u.int_cur;
             loudness = ( loudness > 5 ? loudness : 5 );
             loudness = ( loudness < 30 ? loudness : 30 );
@@ -1241,7 +1240,7 @@ void Character::hardcoded_effects( effect &it )
         if( dur > 1_days ) {
             // Spawn some larvae!
             // Choose how many insects; more for large characters
-            ///\EFFECT_STR_MAX increases number of insects hatched from dermatik infection
+            /** @EFFECT_STR_MAX increases number of insects hatched from dermatik infection */
             int num_insects = rng( 1, std::min( 3, str_max / 3 ) );
             apply_damage( nullptr,  bp, rng( 2, 4 ) * num_insects );
             // Figure out where they may be placed
@@ -1269,7 +1268,7 @@ void Character::hardcoded_effects( effect &it )
             it.mod_duration( 1_turns );
         }
     } else if( id == effect_formication ) {
-        ///\EFFECT_INT decreases occurrence of itching from formication effect
+        /** @EFFECT_INT significantly decreases occurrence of itching from formication effect (proportional to one_in(2+int)) */
         if( x_in_y( intense, 600 + 300 * get_int() ) && !has_effect( effect_narcosis ) ) {
             if( !is_npc() ) {
                 //~ %s is bodypart in accusative.
@@ -1682,6 +1681,7 @@ void Character::hardcoded_effects( effect &it )
                         recoil = MAX_RECOIL;
                     } else if( limb == "hand" ) {
                         if( is_armed() && can_drop( *get_wielded_item() ).success() ) {
+                            /** @EFFECT_DEX increases chances of holding on to weapon during toxic arm muscle spasms (4d4<=dex) */
                             if( dice( 4, 4 ) > get_dex() ) {
                                 cancel_activity();  //Prevent segfaults from activities trying to access missing item
                                 put_into_vehicle_or_drop( *this, item_drop_reason::tumbling, { remove_weapon() } );
@@ -1690,6 +1690,7 @@ void Character::hardcoded_effects( effect &it )
                             }
                         }
                     } else if( limb == "leg" ) {
+                        /** @EFFECT_DEX increases chances of avoiding falling down during toxic leg muscle spasms (4d4<=dex) */
                         if( dice( 4, 4 ) > get_dex() && !is_on_ground() ) {
                             schedule_effect( effect_downed, rng( 5_seconds, 10_seconds ) );
                         } else {

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -199,7 +199,7 @@ static void board_up( map &m, const tripoint_range<tripoint> &range )
         }
         // If the furniture is movable and the character can move it, use it to barricade
         //  is workable here as NPCs by definition are not starting the game.  (Let's hope.)
-        ///\EFFECT_STR determines what furniture might be used as a starting area barricade
+        /** @EFFECT_STR determines what furniture might be used as a starting area barricade */
         if( m.furn( p ).obj().is_movable() &&
             m.furn( p ).obj().move_str_req < get_player_character().get_str() ) {
             if( m.furn( p ).obj().movecost == 0 ) {
@@ -369,7 +369,7 @@ void start_location::place_player( avatar &you, const tripoint_abs_omt &omtstart
     here.build_map_cache( here.get_abs_sub().z() );
     const bool must_be_inside = flags().count( "ALLOW_OUTSIDE" ) == 0;
     const bool accommodate_npc = flags().count( "LONE_START" ) == 0;
-    ///\EFFECT_STR allows player to start behind less-bashable furniture and terrain
+    /** @EFFECT_STR allows player to start behind less-bashable furniture and terrain */
     // TODO: Allow using items here
     const int bash = you.get_str();
 

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -189,11 +189,13 @@ std::vector<std::string> talker_npc::get_topics( bool radio_contact )
             add_topics.emplace_back( "TALK_MUTE" );
         }
     }
+    /* @EFFECT_TRAIT_PROF_CHURL required for churlish conversation topics */
     if( player_character.has_trait( trait_PROF_CHURL ) ) {
         if( add_topics.back() == me_npc->chatbin.talk_mug ||
             add_topics.back() == me_npc->chatbin.talk_stranger_aggressive ) {
             me_npc->make_angry();
             add_topics.emplace_back( "TALK_CHURL_ANGRY" );
+            /* @EFFECT_INT_NPC >=9 required for churlish trade */
         } else if( ( me_npc->op_of_u.trust >= 0 ) && ( me_npc->op_of_u.anger <= 0 ) &&
                    ( me_npc->int_cur >= 9 ) ) {
             add_topics.emplace_back( "TALK_CHURL_TRADE" );
@@ -827,9 +829,8 @@ std::string talker_npc::evaluation_by( const talker &alpha ) const
         return _( "&You're blind and can't make anything out." );
     }
 
-    ///\EFFECT_PER affects whether player can size up NPCs
-
-    ///\EFFECT_INT slightly affects whether player can size up NPCs
+    /* @EFFECT_PER affects whether player can size up NPCs (int+per*3>10) */
+    /* @EFFECT_INT slightly affects whether player can size up NPCs (int+per*3>10) */
     int ability = alpha.per_cur() * 3 + alpha.int_cur();
     if( ability <= 10 ) {
         return _( "&You can't make anything out." );

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -372,7 +372,7 @@ bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
             g->update_map( player_character );
         }
         if( !you->is_mounted() ) {
-            ///\EFFECT_DEX decreases chance of taking damage from a tripwire trap
+            /** @EFFECT_DEX >4 increases chance of avoiding all tripwire trap damage (6.7% per point above 4) */
             if( rng( 5, 20 ) > you->dex_cur ) {
                 you->hurtall( rng( 1, 4 ), nullptr );
             }
@@ -394,7 +394,7 @@ bool trapfunc::crossbow( const tripoint &p, Creature *c, item * )
         monster *z = dynamic_cast<monster *>( c );
         Character *you = dynamic_cast<Character *>( c );
         if( you != nullptr ) {
-            ///\EFFECT_DODGE reduces chance of being hit by crossbow trap
+            /** @EFFECT_DODGE reduces chance of being hit by crossbow trap */
             if( !one_in( 4 ) && rng( 8, 20 ) > you->get_dodge() ) {
                 bodypart_id hit( "bp_null" );
                 switch( rng( 1, 10 ) ) {
@@ -495,12 +495,12 @@ bool trapfunc::shotgun( const tripoint &p, Creature *c, item * )
         monster *z = dynamic_cast<monster *>( c );
         Character *you = dynamic_cast<Character *>( c );
         if( you != nullptr ) {
-            ///\EFFECT_STR_MAX increases chance of two shots from shotgun trap
+            /** @EFFECT_STR_MAX increases chance of being hit by two shots from double barrel shotgun trap */
             shots = ( one_in( 8 ) || one_in( 20 - you->str_max ) ? 2 : 1 );
             if( here.tr_at( p ) != tr_shotgun_2 ) {
                 shots = 1;
             }
-            ///\EFFECT_DODGE reduces chance of being hit by shotgun trap
+            /** @EFFECT_DODGE reduces chance of being hit by shotgun trap */
             if( rng( 5, 50 ) > you->get_dodge() ) {
                 bodypart_id hit = bodypart_id( "bp_null" );
                 switch( rng( 1, 10 ) ) {
@@ -745,6 +745,7 @@ bool trapfunc::goo( const tripoint &p, Creature *c, item * )
             //All monsters that aren't blobs or robots transform into a blob
             if( !z->type->in_species( species_ROBOT ) ) {
                 z->poly( mon_blob );
+                /** @EFFECT_SPEED for monsters determines hp when transformed into a blob by a goo trap */
                 z->set_hp( z->get_speed() );
             }
         } else {
@@ -837,7 +838,7 @@ bool trapfunc::pit( const tripoint &p, Creature *c, item * )
                                     _( "You hit the ground hard, but your grav chute handles the impact admirably!" ) );
         } else {
             int dodge = you->get_dodge();
-            ///\EFFECT_DODGE reduces damage taken falling into a pit
+            /** @EFFECT_DODGE reduces damage taken falling into a pit */
             int damage = eff * rng( 10, 20 ) - rng( dodge, dodge * 5 );
             if( damage > 0 ) {
                 you->add_msg_if_player( m_bad, _( "You hurt yourself!" ) );
@@ -887,7 +888,7 @@ bool trapfunc::pit_spikes( const tripoint &p, Creature *c, item * )
         } else if( you->has_active_bionic( bio_shock_absorber ) ) {
             you->add_msg_if_player( m_info,
                                     _( "You hit the ground hard, but your grav chute handles the impact admirably!" ) );
-            ///\EFFECT_DODGE reduces chance of landing on spikes in spiked pit
+            /** @EFFECT_DODGE reduces chance of landing on spikes in spiked pit */
         } else if( 0 == damage || rng( 5, 30 ) < dodge ) {
             you->add_msg_if_player( _( "You avoid the spikes within." ) );
         } else {
@@ -973,7 +974,7 @@ bool trapfunc::pit_glass( const tripoint &p, Creature *c, item * )
         } else if( you->has_active_bionic( bio_shock_absorber ) ) {
             you->add_msg_if_player( m_info,
                                     _( "You hit the ground hard, but your grav chute handles the impact admirably!" ) );
-            ///\EFFECT_DODGE reduces chance of landing on glass in glass pit
+            /** @EFFECT_DODGE reduces chance of landing on glass in glass pit */
         } else if( 0 == damage || rng( 5, 30 ) < dodge ) {
             you->add_msg_if_player( _( "You avoid the glass shards within." ) );
         } else {
@@ -1102,11 +1103,9 @@ static tripoint random_neighbor( tripoint center )
 
 static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, const int diff )
 {
-    ///\EFFECT_STR increases chance to attach grapnel, bullwhip, or rope when falling into a sinkhole
-
-    ///\EFFECT_DEX increases chance to attach grapnel, bullwhip, or rope when falling into a sinkhole
-
-    ///\EFFECT_THROW increases chance to attach grapnel, bullwhip, or rope when falling into a sinkhole
+    /** @EFFECT_THROW increases chance to attach grapnel, bullwhip, or rope when falling into a sinkhole (str + dex + throwing >= difficulty) */
+    /** @EFFECT_STR increases chance to attach grapnel, bullwhip, or rope when falling into a sinkhole (str + dex + throwing >= difficulty) */
+    /** @EFFECT_DEX increases chance to attach grapnel, bullwhip, or rope when falling into a sinkhole (str + dex + throwing >= difficulty) */
     const int throwing_skill_level = you.get_skill_level( skill_throw );
     const int roll = rng( throwing_skill_level, throwing_skill_level + you.str_cur + you.dex_cur );
     map &here = get_map();

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -430,9 +430,9 @@ bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
             }
         }
 
-        ///\EFFECT_INT speeds up aiming of vehicle turrets
+        /** @EFFECT_INT speeds up aiming of vehicle turrets, 5% per point, capped at 80% */
         player_character.moves = std::min( 0,
-                                           player_character.moves - 100 + ( 5 * player_character.int_cur ) );
+                                           player_character.moves - 100 + std::min( 5 * player_character.int_cur, 80 ) );
     }
     return got_target;
 }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1043,6 +1043,7 @@ units::power vehicle::part_vpower_w( const vehicle_part &vp, const bool at_full_
             monster *mon = get_monster( index_of_part( &vp ) );
             if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
                 // An animal that can carry twice as much weight, can pull a cart twice as hard.
+                /** @EFFECT_SPEED for animals determines base power output when pulling a vehicle */
                 pwr = units::from_watt( mon->get_speed() * ( mon->get_size() - 1 ) * 3
                                         * ( mon->get_mountable_weight_ratio() * 5 ) );
             } else {
@@ -1051,7 +1052,7 @@ units::power vehicle::part_vpower_w( const vehicle_part &vp, const bool at_full_
         }
         // Weary multiplier
         const float weary_mult = get_player_character().exertion_adjusted_move_multiplier();
-        ///\EFFECT_STR increases power produced for MUSCLE_* vehicles
+        /** @EFFECT_STR increases power produced for MUSCLE_* vehicles */
         pwr += units::from_watt( get_player_character().str_cur - 8 ) * vpi.engine_muscle_power_factor() *
                weary_mult;
         /// wind-powered vehicles have differing power depending on wind direction

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -598,6 +598,7 @@ void vehicle::thrust( int thd, int z )
         if( vp.info().fuel_type == fuel_type_animal && engines.size() != 1 ) {
             monster *mon = get_monster( e );
             if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
+                ///EFFECT_SPEED for animals limits how fast a vehicle can be moving before it damages the harness and possibly detaches
                 if( velocity > mon->get_speed() * 12 ) {
                     add_msg( m_bad, _( "Your %s is not fast enough to keep up with the %s" ), mon->get_name(), name );
                     int dmg = rng( 0, 10 );
@@ -1325,9 +1326,9 @@ void vehicle::selfdrive( const point &p )
     }
     // TODO: Actually check if we're on land on water (or disable water-skidding)
     if( skidding && valid_wheel_config() ) {
-        ///\EFFECT_DEX increases chance of regaining control of a vehicle
+        /** @EFFECT_DEX increases chance of regaining control of a vehicle */
 
-        ///\EFFECT_DRIVING increases chance of regaining control of a vehicle
+        /** @EFFECT_DRIVING increases chance of regaining control of a vehicle */
         if( handling_diff * rng( 1, 10 ) < 15 ) {
             velocity = static_cast<int>( forward_velocity() );
             skidding = false;
@@ -1444,11 +1445,9 @@ void vehicle::pldrive( Character &driver, const point &p, int z )
         // Let's get rid of that
         driver.moves = std::min( driver.moves, driver.get_speed() );
 
-        ///\EFFECT_DEX reduces chance of losing control of vehicle when turning
-
-        ///\EFFECT_PER reduces chance of losing control of vehicle when turning
-
-        ///\EFFECT_DRIVING reduces chance of losing control of vehicle when turning
+        /** @EFFECT_DEX reduces chance of losing control of vehicle when turning (0.1 driving skill per point) */
+        /** @EFFECT_PER reduces chance of losing control of vehicle when turning (0.1 driving skill per point) */
+        /** @EFFECT_DRIVING reduces chance of losing control of vehicle when turning */
         float skill = std::min( 10.0f, driver.get_skill_level( skill_driving ) +
                                 ( driver.get_dex() + driver.get_per() ) / 10.0f );
         float penalty = rng_float( 0.0f, handling_diff ) - skill;
@@ -1458,6 +1457,7 @@ void vehicle::pldrive( Character &driver, const point &p, int z )
             cost = 100 * ( 1.0f + penalty / 2.5f );
         } else {
             // At 10 skill, with a perfect vehicle, we could turn up to 3 times per turn
+            /** @EFFECT_SPEED determines moves used to steer a vehicle */
             cost = std::max( driver.get_speed(), 100 ) * ( 1.0f - ( -penalty / 10.0f ) * 2 / 3 );
         }
 
@@ -1494,9 +1494,8 @@ void vehicle::pldrive( Character &driver, const point &p, int z )
     // TODO: Actually check if we're on land on water (or disable water-skidding)
     // Only check for recovering from a skid if we did active steering (not cruise control).
     if( skidding && ( p.x != 0 || ( p.y != 0 && !cruise_on ) ) && valid_wheel_config() ) {
-        ///\EFFECT_DEX increases chance of regaining control of a vehicle
-
-        ///\EFFECT_DRIVING increases chance of regaining control of a vehicle
+        /** @EFFECT_DEX increases chance of regaining control of a vehicle (50% as effective as driving skill) */
+        /** @EFFECT_DRIVING increases chance of regaining control of a vehicle */
         if( handling_diff * rng( 1, 10 ) <
             driver.dex_cur + driver.get_skill_level( skill_driving ) * 2 ) {
             driver.add_msg_if_player( _( "You regain control of the %s." ), name );
@@ -2167,7 +2166,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
         int dmg = d_vel * rng_float( 1.0f, 2.0f );
         int move_resist = 1;
         if( psg ) {
-            ///\EFFECT_STR reduces chance of being thrown from your seat when not wearing a seatbelt
+            /** @EFFECT_STR reduces chance of being thrown from your seat when not wearing a seatbelt */
             move_resist = psg->str_cur * 150 + 500;
         } else {
             int pet_resist = 0;
@@ -2177,7 +2176,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
             move_resist = std::max( 100, pet_resist );
         }
         if( veh.part_with_feature( ps, VPFLAG_SEATBELT, true ) == -1 ) {
-            ///\EFFECT_STR reduces chance of being thrown from your seat when not wearing a seatbelt
+            /** @EFFECT_STR reduces chance of being thrown from your seat when not wearing a seatbelt */
             throw_from_seat = d_vel * rng( 80, 120 ) > move_resist;
         } else {
             // Reduce potential damage based on quality of seatbelt
@@ -2199,9 +2198,8 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
 
         if( psg && veh.player_in_control( *psg ) ) {
             const int lose_ctrl_roll = rng( 0, d_vel );
-            ///\EFFECT_DEX reduces chance of losing control of vehicle when shaken
-
-            ///\EFFECT_DRIVING reduces chance of losing control of vehicle when shaken
+            /** @EFFECT_DEX reduces chance of losing control of vehicle when shaken (67% as effective as driving skill) */
+            /** @EFFECT_DRIVING reduces chance of losing control of vehicle when shaken */
             if( lose_ctrl_roll > psg->dex_cur * 2 + psg->get_skill_level( skill_driving ) * 3 ) {
                 psg->add_msg_player_or_npc( m_warning,
                                             _( "You lose control of the %s." ),
@@ -2228,7 +2226,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
                                         _( "The %s is hurled from %s's by the power of the impact!" ),
                                         pet->disp_name(), veh.name );
             }
-            ///\EFFECT_STR reduces distance thrown from seat in a vehicle impact
+            /** @EFFECT_STR reduces distance thrown from seat in a vehicle impact */
             g->fling_creature( rider, direction + rng_float( -30_degrees, 30_degrees ),
                                std::max( 10, d_vel - move_resist / 100 ) );
         }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -409,7 +409,7 @@ void vehicle::smash_security_system()
     }
     const vehicle_part &vp_controls = part( idx_controls );
     const vehicle_part &vp_security = part( idx_security );
-    ///\EFFECT_MECHANICS reduces chance of damaging controls when smashing security system
+    /** @EFFECT_MECHANICS reduces chance of damaging controls when smashing security system (70% / (1+skill) )*/
     const int skill = player_character.get_skill_level( skill_mechanics );
     const int percent_controls = 70 / ( 1 + skill );
     const int percent_alarm = ( skill + 3 ) * 10;
@@ -1753,7 +1753,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         .skip_locked_check()
         .hotkey( "HOTWIRE" )
         .on_submit( [this] {
-            ///\EFFECT_MECHANICS speeds up vehicle hotwiring
+            /** @EFFECT_MECHANICS speeds up vehicle hotwiring */
             const int skill = std::max( 1, get_player_character().get_skill_level( skill_mechanics ) );
             const int moves = to_moves<int>( 6000_seconds / skill );
             const tripoint target = global_square_location().raw() + coord_translate( parts[0].mount );

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -77,6 +77,8 @@ float Character::generic_weakpoint_skill( skill_id skill_1, skill_id skill_2,
         limb_score_id limb_score_1, limb_score_id limb_score_2 ) const
 {
     float skill = ( get_skill_level( skill_1 ) + get_skill_level( skill_2 ) ) / 2.0;
+    /** @EFFECT_DEX increases chance of hitting weak points */
+    /** @EFFECT_PER increases chance of hitting weak points */
     float stat = ( get_dex() - 8 ) / 8.0 + ( get_per() - 8 ) / 8.0;
     float mul = ( get_limb_score( limb_score_1 ) + get_limb_score( limb_score_2 ) ) / 2.0;
     return ( skill + stat ) * mul;
@@ -85,18 +87,24 @@ float Character::generic_weakpoint_skill( skill_id skill_1, skill_id skill_2,
 
 float Character::melee_weakpoint_skill( const item &weapon ) const
 {
+    /** @EFFECT_SKILLS increase chance of hitting weak points with the relevant melee weapons */
+    /** @EFFECT_UNARMED increase chance of hitting weak points when unarmed */
+    /** @EFFECT_MELEE increase chance of hitting weak points in melee */
     return generic_weakpoint_skill( weapon.is_null() ? skill_unarmed : weapon.melee_skill(),
                                     skill_melee, limb_score_vision, limb_score_reaction );
 }
 
 float Character::ranged_weakpoint_skill( const item &weapon ) const
 {
+    /** @EFFECT_SKILLS increase chance of hitting weak points with the relevant ranged weapons */
+    /** @EFFECT_GUN increases chance of hitting weak points with ranged weapons */
     return generic_weakpoint_skill( weapon.gun_skill(), skill_gun, limb_score_vision,
                                     limb_score_vision );
 }
 
 float Character::throw_weakpoint_skill() const
 {
+    /** @EFFECT_THROW increases chance of hitting weak points with thrown weapons */
     return generic_weakpoint_skill( skill_throw, skill_throw, limb_score_vision, limb_score_vision );
 }
 

--- a/tests/enchantments_test.cpp
+++ b/tests/enchantments_test.cpp
@@ -58,7 +58,7 @@ static void test_generic_ench( avatar &p, enchant_test enc_test )
 static enchant_test set_enc_test( avatar &p )
 {
     enchant_test enc_test;
-    enc_test.dex_before = p.get_str();
+    enc_test.dex_before = p.get_dex();
     enc_test.lie_before = get_talker_for( p )->trial_chance_mod( "lie" );
     enc_test.persuade_before = get_talker_for( p )->trial_chance_mod( "persuade" );
     enc_test.intimidate_before = get_talker_for( p )->trial_chance_mod( "intimidate" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Add/update doxygen docs for skill/stat effects"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The relevant docs and info are years out of date. Keeping these docs in sync with the code provides useful auditing of mistakes, intentions, and balace. It can also be useful to players, devs, and content creators.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Updated existing doxygen comments for uses of skills and stats. Added new comments where appropriate. Also started adding comments for the effects of traits, proficiencies, flags, emergent stats (focus / speed / fatigue / etc).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
We could abandon these comments, or move them all to the wiki or other docs.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Very few non-comment changes. Ran tests, played the game a bit.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This PR is mostly comments, but includes a few code changes that jumped out at me while I was working on it. Some typo fixes, some deduplication where I found myself making the same comments on the same code multiple times, a few judgment calls that I can move out to a separate PR if requested. A much bigger audit of the effects and logic called out by the comments is probably in order.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
