### PR TITLE
Fix to pollution by stat modifications in newcharacter.

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1125,6 +1125,7 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
         werase( w_description );
         u.reset_stats();
         u.set_stored_kcal( u.get_healthy_kcal() );
+        u.reset_bonuses(); // Removes pollution of stats by modifications appearing inside reset_stats(). Is reset_stats() even necessary in this context?
         switch( sel ) {
             case 1:
                 mvwprintz( w, point( 2, 5 ), COL_SELECT, _( "Strength:" ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixes the situation where stat mods affect the displayed effects of your base stats."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #64280
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
avatar::reset_stats() is accumulating stat mods each passthrough because character::reset_bonuses() is never called on the object. reset_stats() should never be called without first resetting bonuses as it can reapply additional bonuses without clearing the last ones. Ideally character::reset() should be used in these situations? Regardless, I find that no mod bonuses should affect the displayed effects of your base stats, hence I've placed reset_bonuses() after reset_stats() so it only displays the effect of your base stats, though it could still be polluted by other means as I've not investigated the functions that calculate the bonuses that are affected by the stats.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Calling reset() instead of reset_stats() or extracting the calculations used to determine stat effects and calculate the bonuses in-place instead of relying on the avatar object.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested #64280, while also including the mutation "compound eyes" as that mutation will continually mod perception by 2 while equipped in the same manner as StatsThroughSkills or the BMI rework.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This could likely need some refactoring later. Since this fix is closer to the core issue than #64270 , maybe the fixes from there can be removed safely. If there are other places in code that calls reset_stats() haphazardly it could cause issues in other places.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
