### PR TITLE
[Magiclysm] Adding appropriate Black Dragon mutations

### DIFF
--- a/data/mods/Magiclysm/mutations/mutations.json
+++ b/data/mods/Magiclysm/mutations/mutations.json
@@ -742,5 +742,63 @@
     "category": [ "DRAGON_BLACK" ],
     "threshreq": [ "THRESH_DRAGON_BLACK" ],
     "spells_learned": [ [ "acid_claw", 1 ] ]
+  },
+  {
+    "type": "mutation",
+    "id": "DENSE_BONES",
+    "copy-from": "DENSE_BONES",
+    "extend": { "category": [ "DRAGON_BLACK" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "PRED1",
+    "copy-from": "PRED1",
+    "extend": { "category": [ "DRAGON_BLACK" ], "threshreq": [ "THRESH_DRAGON_BLACK" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "PRED2",
+    "copy-from": "PRED2",
+    "extend": { "category": [ "DRAGON_BLACK" ], "threshreq": [ "THRESH_DRAGON_BLACK" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "PRED3_DRAGON",
+    "name": { "str": "Draconic Predator" },
+    "points": 4,
+    "description": "You have become something more than human. Something better - and far, far worse. Combat skills are easy to learn and maintain, and unlike lesser predators, you mental faculties don'r suffer at all.",
+    "social_modifiers": { "intimidate": 5 },
+    "purifiable": false,
+    "types": [ "PREDATION" ],
+    "prereqs": [ "CARNIVORE" ],
+    "prereqs2": [ "PRED2" ],
+    "leads_to": [ "SAPIOVORE" ],
+    "changes_to": [ "PRED4_DRAGON" ],
+    "threshreq": [ "THRESH_DRAGON_BLACK" ],
+    "cancels": [ "PACIFIST" ],
+    "category": [ "DRAGON_BLACK" ],
+    "flags": [ "PRED3" ]
+  },
+  {
+    "type": "mutation",
+    "id": "PRED4_DRAGON",
+    "name": { "str": "Draconic Apex Predator" },
+    "points": 5,
+    "description": "Your mind and brain have fully adapted to your new place at the top of the magical food chain.  You can effortlessly master and maintain combat skills, and your malevolent intellect only grows.",
+    "social_modifiers": { "intimidate": 6 },
+    "purifiable": false,
+    "types": [ "PREDATION" ],
+    "prereqs": [ "CARNIVORE" ],
+    "prereqs2": [ "PRED3_DRAGON" ],
+    "threshreq": [ "THRESH_DRAGON_BLACK" ],
+    "category": [ "DRAGON_BLACK" ],
+    "passive_mods": { "int_mod": 1 },
+    "flags": [ "PRED4" ]
+  },
+  {
+	"type": "mutation",
+	"id": "SAPIOVORE",
+    "copy-from": "SAPIOVORE",
+    "extend": { "category": [ "DRAGON_BLACK" ], "threshreq": [ "THRESH_DRAGON_BLACK" ], "prereqs2": [ "PRED3_DRAGON", "PRED4_DRAGON" ] }
   }
 ]

--- a/data/mods/Magiclysm/mutations/mutations.json
+++ b/data/mods/Magiclysm/mutations/mutations.json
@@ -796,8 +796,8 @@
     "flags": [ "PRED4" ]
   },
   {
-	"type": "mutation",
-	"id": "SAPIOVORE",
+    "type": "mutation",
+    "id": "SAPIOVORE",
     "copy-from": "SAPIOVORE",
     "extend": { "category": [ "DRAGON_BLACK" ], "threshreq": [ "THRESH_DRAGON_BLACK" ], "prereqs2": [ "PRED3_DRAGON", "PRED4_DRAGON" ] }
   }

--- a/data/mods/Magiclysm/mutations/mutations.json
+++ b/data/mods/Magiclysm/mutations/mutations.json
@@ -799,6 +799,10 @@
     "type": "mutation",
     "id": "SAPIOVORE",
     "copy-from": "SAPIOVORE",
-    "extend": { "category": [ "DRAGON_BLACK" ], "threshreq": [ "THRESH_DRAGON_BLACK" ], "prereqs2": [ "PRED3_DRAGON", "PRED4_DRAGON" ] }
+    "extend": {
+      "category": [ "DRAGON_BLACK" ],
+      "threshreq": [ "THRESH_DRAGON_BLACK" ],
+      "prereqs2": [ "PRED3_DRAGON", "PRED4_DRAGON" ]
+    }
   }
 ]

--- a/data/mods/Magiclysm/mutations/mutations.json
+++ b/data/mods/Magiclysm/mutations/mutations.json
@@ -766,7 +766,7 @@
     "id": "PRED3_DRAGON",
     "name": { "str": "Draconic Predator" },
     "points": 4,
-    "description": "You have become something more than human. Something better - and far, far worse. Combat skills are easy to learn and maintain, and unlike lesser predators, you mental faculties don'r suffer at all.",
+    "description": "You have become something more than human.  Something better - and far, far worse. Combat skills are easy to learn and maintain, and unlike lesser predators, your mental faculties don't suffer at all.",
     "social_modifiers": { "intimidate": 5 },
     "purifiable": false,
     "types": [ "PREDATION" ],

--- a/data/mods/Magiclysm/mutations/mutations.json
+++ b/data/mods/Magiclysm/mutations/mutations.json
@@ -766,7 +766,7 @@
     "id": "PRED3_DRAGON",
     "name": { "str": "Draconic Predator" },
     "points": 4,
-    "description": "You have become something more than human.  Something better - and far, far worse. Combat skills are easy to learn and maintain, and unlike lesser predators, your mental faculties don't suffer at all.",
+    "description": "You have become something more than human.  Something better - and far, far worse.  Combat skills are easy to learn and maintain, and unlike lesser predators, your mental faculties don't suffer at all.",
     "social_modifiers": { "intimidate": 5 },
     "purifiable": false,
     "types": [ "PREDATION" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add (versions of) some appropriate mutation to the Black Dragon category"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The new Dense Bones mutation seemed appropriate for Black Dragons, so I wanted to add it. While poking around in the mutations, I noticed that while black dragons are carnivores, unlike other obligate carnivores they don't get the "Predator" line of mutations, nor do they get "Sapiovore". It seemed very weird to me that dragons of all things wouldn't be able to eat a princess, nor get the psychological benefits of being apex predators, so I decided to give them those traits as well.

However, PRED3 and PRED4 ("Predator" and "Apex Predator") have an associated intelligence debuff, which seemed inappropriate for a category that's all about magic, to the point where it already has several intelligence buffs, so I made alternate versions of those traits just for dragons. PRED3_DRAGON has no intelligence debuff, and PRED4_DRAGON even has a small intelligence buff (+1) because that seemed both funny and in keeping with the theme.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Extended DENSE_BONES, PRED1, PRED2 and SAPIOVORE to include them in the black dragon category. Made alternate version of PRED3 and PRED4 without the int penalty.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Made an invincible character, took a boatload of mutagen and waited until i had every black dragon mutation to make sure the new ones got added.

Just as a point of interest, Black Dragon has so goddamn many mutations that this took two in-game weeks, and I had to reset my instability halfway through because I had like a 70% chance of bad mutations, but there were no more bad mutations to get.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Since black dragons in Magiclysm are described as not merely predatory but actively malevolent, I want to give them Killer Drive as well. Unfortunately, Killer Drive conflicts with Sapiovore, and renders it largely irrelevant anyway. I could've given them Killer Drive instead, but it's a non-threshold mutation, which would conflict with the implication that Sapiovore represents crossing the moral event horizon where you're truly no longer human. I couldn't make a new trait, either, because the Killer Drive functionality is hardcoded. Might come back to it, but this is fine for now.

e: this change will of course also make it possible (and inevitable) for dragon mutants to become carnivores regardless of instability levels. This is intended; not only does it match the behavior of other predator categories, it also makes it a little harder to dodge the downsides of what's supposed to be a very "high highs, low lows" tree
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
