### PR TITLE
Switch a time type to fs::

### DIFF
--- a/src/flexbuffer_cache.cpp
+++ b/src/flexbuffer_cache.cpp
@@ -162,7 +162,7 @@ struct file_flexbuffer : parsed_flexbuffer {
 
         bool is_stale() const override {
             std::error_code ec;
-            std::filesystem::file_time_type mtime = fs::last_write_time( source_file_path_ );
+            fs::file_time_type mtime = fs::last_write_time( source_file_path_ );
             if( ec ) {
                 // Assume yes out of date.
                 return true;
@@ -396,7 +396,7 @@ std::shared_ptr<parsed_flexbuffer> flexbuffer_cache::parse( fs::path json_source
 
     std::error_code ec;
     // If we got this far we can get the mtime.
-    std::filesystem::file_time_type mtime = fs::last_write_time( json_source_path, ec );
+    fs::file_time_type mtime = fs::last_write_time( json_source_path, ec );
 
     return std::make_shared<file_flexbuffer>(
                std::move( storage ),


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
There were build errors on the OS X build.  See for example [this one](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4437676544/jobs/7789080345#step:16:137).  They seemed to only appear on the release build, not the PR CI build.

We were using `std::filesystem::file_time_type` when we should have been using `fs::file_time_type`.  These types are the same on some platforms, but not on others.

#### Describe the solution
Switch to the correct type.

#### Describe alternatives you've considered
None.

#### Testing
I verified it still builds on Linux, but I can't test on OS X.  I'm not sure even CI will test this properly.  We might have to just merge and hope the release builds do better.

#### Additional context