### PR TITLE
Search using charged_quality (such as welding)

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -311,7 +311,7 @@ static std::string craft_success_chance_string( const recipe &recp, const Charac
         color = "cyan";
     }
 
-    return string_format( _( "Minor Failure Chance: <color_%s>%2.2f</color>" ), color, chance );
+    return string_format( _( "Minor Failure Chance: <color_%s>%2.2f%%</color>" ), color, chance );
 }
 
 static std::string cata_fail_chance_string( const recipe &recp, const Character &guy )
@@ -328,7 +328,8 @@ static std::string cata_fail_chance_string( const recipe &recp, const Character 
         color = "light_gray";
     }
 
-    return string_format( _( "Catastrophic Failure Chance: <color_%s>%2.2f</color>" ), color, chance );
+    return string_format( _( "Catastrophic Failure Chance: <color_%s>%2.2f%%</color>" ), color,
+                          chance );
 }
 
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -810,8 +810,8 @@ int item::degradation() const
 void item::rand_degradation()
 {
     degradation_ = damage() <= 0 ? 0 : rng( 0, damage() );
-    degradation_ = degrade_increments() > 0 ? degradation_ * ( 50.f / static_cast<float>
-                   ( degrade_increments() ) ) : 0;
+    degradation_ = type->degrade_increments() > 0 ? degradation_ * ( 50.f / static_cast<float>
+                   ( type->degrade_increments() ) ) : 0;
 }
 
 int item::damage_level( int dmg ) const
@@ -6475,7 +6475,7 @@ std::string item::degradation_symbol() const
             dgr_symbol = colorize( "\u2581", c_red );
             break;
     }
-    return degrade_increments() == 0 ? "" : dgr_symbol;
+    return type->degrade_increments() == 0 ? "" : dgr_symbol;
 }
 
 std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int truncate,
@@ -7134,7 +7134,7 @@ units::length item::length() const
                     stock_length -= 26_cm;
                 }
             } else if( mod->type->gunmod->location.str() == "stock" ) {
-                stock_length = mod->integral_length();
+                stock_length = mod->type->integral_longest_side;
                 if( has_flag( flag_COLLAPSED_STOCK ) || has_flag( flag_FOLDED_STOCK ) ) {
                     // stock is folded so need to reduce length
 
@@ -7143,9 +7143,9 @@ units::length item::length() const
                     stock_length -= 20_cm;
                 }
             } else if( mod->type->gunmod->location.str() == "stock accessory" ) {
-                stock_accessory_length = mod->integral_length();
+                stock_accessory_length = mod->type->integral_longest_side;
             } else {
-                units::length l = mod->integral_length();
+                units::length l = mod->type->integral_longest_side;
                 if( l > max_length ) {
                     max_length = l;
                 }
@@ -7157,11 +7157,6 @@ units::length item::length() const
     units::length max = is_soft() ? 0_mm : type->longest_side;
     max = std::max( contents.item_length_modifier(), max );
     return max;
-}
-
-units::length item::integral_length() const
-{
-    return type->integral_longest_side;
 }
 
 units::volume item::collapsed_volume_delta() const
@@ -8419,11 +8414,6 @@ bool item::is_ebook_storage() const
     return contents.has_pocket_type( item_pocket::pocket_type::EBOOK );
 }
 
-bool item::is_scannable() const
-{
-    return type->book->is_scannable;
-}
-
 bool item::is_maybe_melee_weapon() const
 {
     item_category_id my_cat_id = get_category_shallow().id;
@@ -8706,11 +8696,6 @@ int item::max_damage() const
     return type->damage_max();
 }
 
-int item::degrade_increments() const
-{
-    return type->degrade_increments();
-}
-
 float item::get_relative_health() const
 {
     return ( max_damage() + 1.0f - damage() ) / ( max_damage() + 1.0f );
@@ -8749,7 +8734,7 @@ bool item::mod_damage( int qty, damage_type dt )
 
     if( qty > 0 && !destroy ) {
         int degrade = std::max( get_dmg_lvl_internal( damage_, min_damage(), max_damage() ) - dmg_lvl, 0 );
-        int incr = degrade_increments();
+        int incr = type->degrade_increments();
         if( incr > 0 ) {
             degradation_ += degrade * ( max_damage() - min_damage() ) / incr;
         }
@@ -9035,11 +9020,6 @@ std::vector<const part_material *> item::armor_made_of( const sub_bodypart_id &b
         }
     }
     return matlist;
-}
-
-const std::map<quality_id, int> &item::quality_of() const
-{
-    return type->qualities;
 }
 
 std::vector<const material_type *> item::made_of_types() const

--- a/src/item.h
+++ b/src/item.h
@@ -642,8 +642,6 @@ class item : public visitable
 
         units::length length() const;
 
-        units::length integral_length() const;
-
         /**
          * Simplified, faster volume check for when processing time is important and exact volume is not.
          * NOTE: Result is rounded up to next nearest milliliter when working with stackable (@ref count_by_charges) items that have fractional volume per charge.
@@ -1160,10 +1158,6 @@ class item : public visitable
         std::vector<const part_material *> armor_made_of( const bodypart_id &bp ) const;
         std::vector<const part_material *> armor_made_of( const sub_bodypart_id &bp ) const;
         /**
-        * The ids of all the qualities this contains.
-        */
-        const std::map<quality_id, int> &quality_of() const;
-        /**
          * Same as @ref made_of(), but returns the @ref material_type directly.
          */
         std::vector<const material_type *> made_of_types() const;
@@ -1355,9 +1349,6 @@ class item : public visitable
         /** Maximum amount of damage to an item (state before destroyed) */
         int max_damage() const;
 
-        /** Number of degradation increments before the item is destroyed */
-        int degrade_increments() const;
-
         /**
          * Relative item health.
          * Returns 1 for undamaged ||items, values in the range (0, 1) for damaged items
@@ -1510,7 +1501,6 @@ class item : public visitable
         bool is_salvageable() const;
         bool is_disassemblable() const;
         bool is_craft() const;
-        bool is_scannable() const;
 
         bool is_deployable() const;
         bool is_tool() const;

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -7,6 +7,7 @@
 #include "cata_utility.h"
 #include "item.h"
 #include "item_category.h"
+#include "itype.h"
 #include "material.h"
 #include "requirements.h"
 #include "type_id.h"
@@ -40,10 +41,7 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
         // qualities
         case 'q':
             return [filter]( const item & i ) {
-                return std::any_of( i.quality_of().begin(), i.quality_of().end(),
-                [&filter]( const std::pair<quality_id, int> &e ) {
-                    return lcmatch( e.first->name, filter );
-                } );
+                return i.type->has_any_quality( filter );
             };
         // both
         case 'b':

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <utility>
 
+#include "cata_utility.h"
 #include "character.h"
 #include "debug.h"
 #include "item.h"
@@ -94,6 +95,17 @@ std::string itype::nname( unsigned int quantity ) const
         quantity = 1;
     }
     return name.translated( quantity );
+}
+
+bool itype::has_any_quality( const std::string &quality ) const
+{
+    return std::any_of( qualities.begin(),
+    qualities.end(), [&quality]( const std::pair<quality_id, int> &e ) {
+        return lcmatch( e.first->name, quality );
+    } ) || std::any_of( charged_qualities.begin(),
+    charged_qualities.end(), [&quality]( const std::pair<quality_id, int> &e ) {
+        return lcmatch( e.first->name, quality );
+    } );
 }
 
 int itype::charges_default() const

--- a/src/itype.h
+++ b/src/itype.h
@@ -1352,6 +1352,7 @@ struct itype {
         int damage_max() const {
             return count_by_charges() ? 0 : damage_max_;
         }
+        /** Number of degradation increments before the item is destroyed */
         int degrade_increments() const {
             return count_by_charges() ? 0 : degrade_increments_;
         }

--- a/src/itype.h
+++ b/src/itype.h
@@ -1178,6 +1178,9 @@ struct itype {
         // Tool qualities that work only when the tool has charges_to_use charges remaining
         std::map<quality_id, int> charged_qualities;
 
+        // True if this has given quality or charged_quality (regardless of current charge).
+        bool has_any_quality( const std::string &quality ) const;
+
         // Properties are assigned to the type (belong to the item definition)
         std::map<std::string, std::string> properties;
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9824,7 +9824,7 @@ cata::optional<int> iuse::ebooksave( Character *p, item *it, bool t, const tripo
 
     const item_location book = game_menus::inv::titled_filter_menu(
     [&ebooks]( const item & itm ) {
-        return itm.is_book() && itm.is_scannable() && !ebooks.count( itm.typeId() );
+        return itm.is_book() && itm.type->book->is_scannable && !ebooks.count( itm.typeId() );
     },
     *p->as_avatar(), _( "Scan which book?" ), PICKUP_RANGE );
 

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -205,10 +205,7 @@ std::vector<const recipe *> recipe_subset::search(
                 return search_reqs( r->simple_requirements().get_qualities(), txt );
 
             case search_type::quality_result: {
-                const auto &quals = item::find_type( r->result() )->qualities;
-                return std::any_of( quals.begin(), quals.end(), [&]( const std::pair<quality_id, int> &e ) {
-                    return lcmatch( e.first->name, txt );
-                } );
+                return item::find_type( r->result() )->has_any_quality( txt );
             }
 
             case search_type::description_result: {

--- a/src/string_id.h
+++ b/src/string_id.h
@@ -30,7 +30,7 @@ struct lexicographic;
  * if( critter.type->id == mtype_id("mon_cat") ) { ...
  * \endcode
  * This allows to find all ids that are initialized from static literals (and not
- * through the json loading). The can than easily be checked against the json
+ * through the json loading). That can then easily be checked against the json
  * definition to see whether they are actually defined there (or whether they are
  * defined only in a mod).
  *

--- a/tests/degradation_test.cpp
+++ b/tests/degradation_test.cpp
@@ -110,7 +110,7 @@ TEST_CASE( "Items that get damaged gain degradation", "[item][degradation]" )
     GIVEN( "An item with default degradation rate" ) {
         item it( itype_test_baseball );
         it.mod_damage( -1000 );
-        REQUIRE( it.degrade_increments() == 50 );
+        REQUIRE( it.type->degrade_increments() == 50 );
         REQUIRE( it.degradation() == 0 );
         REQUIRE( it.damage() == -1000 );
         REQUIRE( it.damage_level() == -1 );
@@ -146,7 +146,7 @@ TEST_CASE( "Items that get damaged gain degradation", "[item][degradation]" )
     GIVEN( "An item with half degradation rate" ) {
         item it( itype_test_baseball_half_degradation );
         it.mod_damage( -1000 );
-        REQUIRE( it.degrade_increments() == 100 );
+        REQUIRE( it.type->degrade_increments() == 100 );
         REQUIRE( it.degradation() == 0 );
         REQUIRE( it.damage() == -1000 );
         REQUIRE( it.damage_level() == -1 );
@@ -182,7 +182,7 @@ TEST_CASE( "Items that get damaged gain degradation", "[item][degradation]" )
     GIVEN( "An item with double degradation rate" ) {
         item it( itype_test_baseball_x2_degradation );
         it.mod_damage( -1000 );
-        REQUIRE( it.degrade_increments() == 25 );
+        REQUIRE( it.type->degrade_increments() == 25 );
         REQUIRE( it.degradation() == 0 );
         REQUIRE( it.damage() == -1000 );
         REQUIRE( it.damage_level() == -1 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Charged tools can be searched by quality"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #63094

Also, fix a docs English sentence.

Also added `%` to failure chance. When I saw this number, it was not clear it is meant to be %.
![image](https://user-images.githubusercontent.com/13402666/225793734-2264aed3-93eb-4b18-b2e2-68bd244d4f1b.png)

*Edit:* And light refactoring.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
If filtering by `q:` return true if the quality matches `charged_quality` or `quality`, not just `quality`.

It is using new method defined in `itype.h` ~and `item.h`~:
```cpp
bool has_any_quality( const std::string &quality ) const
```

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Unrelated code refactoring (duplicate code in `clzones.cpp`).
Splitting into ~3~ 4 PRs.
More extensive testing.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
`V`iew menu
1. Spawn welder to visible tile.
2. Go to `V`iew menu.
3. Filter `q:weld`.
4. Observe welder is there.

AIM
1. Spawn welder to adjasent tile.
2. Open AIM (Advanced Inventory Manager).
3. Filter `q:weld`.
4. Observe welder is there.

Crafting Menu
1. Learn welder recipe.
2. Open crafting menu.
3. Search for `q:weld`
4. Observe welder is there.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
*Edit:*
I have removed syntactic sugar of this type:
```
<some_return_type> item::FUNCTION_NAME() const
{
    return type->FUNCTION_THING;  // sometimes call, sometimes value
}
```

for these `FUNCTION_NAME`:

- `integral_length`
- `is_scannable`
- `degrade_increments`
- `quality_of`

I haven't done it for  | the reason
--- | ---
`base_damage_thrown` | it has TODO
`count_by_charges` | too many references
`damage_min` | consistency with `damage()` and `damage_max()`
`damage_max` | consistency with `damage()` and `damage_min()`
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
