### PR TITLE
Make skill help spell learn time instead of hurt

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1936,8 +1936,9 @@ int known_magic::time_to_learn_spell( const Character &guy, const std::string &s
 int known_magic::time_to_learn_spell( const Character &guy, const spell_id &sp ) const
 {
     const int base_time = to_moves<int>( 30_minutes );
-    return base_time * ( 1.0 + sp->difficulty / ( 1.0 + ( guy.get_int() - 8.0 ) / 8.0 ) +
-                         ( guy.get_skill_level( sp->skill ) / 10.0 ) );
+    const double int_modifier = ( guy.get_int() - 8.0 ) / 8.0;
+    const double skill_modifier = guy.get_skill_level( sp->skill ) / 10.0;
+    return base_time * ( 1.0 + sp->difficulty / ( 1.0 + int_modifier + skill_modifier ) );
 }
 
 int known_magic::get_spellname_max_width()


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Higher skill speeds up spell learn time instead of slowing down"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Increased spellcraft (or other specific) skill causes spell learning to slow down. This appears to be an arithmetic/parentheses mistake.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added parentheses to calculation so that skill is added to the divisor instead of to the multiplier.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
With the original code and 10 int, "One spell is all you need" book takes 78 minutes to read at spellcraft 0, 108 minutes at spellcraft 10.
With this patch, it still takes 78m at skill 0, but 58m40s at skill 10.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
It might make sense to allow high skill to reduce the time even further, possibly below the base time, but that would be a more significant change. I attempted here to follow what seems like the most likely intent of the original code, which only requires moving a parenthesis (although I added another pair for clarity as well). 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
