### PR TITLE
Convert anonymous vehicle_part enum to class enum

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1220,13 +1220,13 @@ void map::board_vehicle( const tripoint &pos, Character *p )
         }
         return;
     }
-    if( vp->part().has_flag( vehicle_part::passenger_flag ) ) {
+    if( vp->part().has_flag( vp_flag::passenger_flag ) ) {
         Character *psg = vp->vehicle().get_passenger( vp->part_index() );
         debugmsg( "map::board_vehicle: passenger (%s) is already there",
                   psg ? psg->get_name() : "<null>" );
         unboard_vehicle( pos );
     }
-    vp->part().set_flag( vehicle_part::passenger_flag );
+    vp->part().set_flag( vp_flag::passenger_flag );
     vp->part().passenger_id = p->getID();
     vp->vehicle().invalidate_mass();
 
@@ -1240,7 +1240,7 @@ void map::board_vehicle( const tripoint &pos, Character *p )
 void map::unboard_vehicle( const vpart_reference &vp, Character *passenger, bool dead_passenger )
 {
     // Mark the part as un-occupied regardless of whether there's a live passenger here.
-    vp.part().remove_flag( vehicle_part::passenger_flag );
+    vp.part().remove_flag( vp_flag::passenger_flag );
     vp.vehicle().invalidate_mass();
 
     if( !passenger ) {
@@ -1376,7 +1376,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_
                 debugmsg( "Empty passenger for part #%d at %d,%d,%d player at %d,%d,%d?",
                           prt, part_pos.x, part_pos.y, part_pos.z,
                           player_character.posx(), player_character.posy(), player_character.posz() );
-                veh.part( prt ).remove_flag( vehicle_part::passenger_flag );
+                veh.part( prt ).remove_flag( vp_flag::passenger_flag );
                 r.moved = true;
                 continue;
             }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3237,7 +3237,11 @@ void vehicle_part::deserialize( const JsonObject &data )
     direction = units::from_degrees( direction_int );
     data.read( "blood", blood );
     data.read( "enabled", enabled );
-    data.read( "flags", flags );
+
+    uint32_t flags_int;
+    data.read( "flags", flags_int );
+    flags = static_cast<vp_flag>( flags_int );
+
     data.read( "passenger_id", passenger_id );
     if( data.has_int( "z_offset" ) ) {
         int z_offset = data.get_int( "z_offset" );
@@ -3296,7 +3300,7 @@ void vehicle_part::serialize( JsonOut &json ) const
     json.member( "direction", std::lround( to_degrees( direction ) ) );
     json.member( "blood", blood );
     json.member( "enabled", enabled );
-    json.member( "flags", flags );
+    json.member( "flags", static_cast<uint32_t>( flags ) );
     if( !carried_stack.empty() ) {
         std::stack<vehicle_part::carried_part_data> carried_copy = carried_stack;
         json.member( "carried_stack" );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -766,7 +766,7 @@ bool veh_interact::update_part_requirements()
     }
 
     if( std::any_of( parts_here.begin(), parts_here.end(), [&]( const int e ) {
-    return veh->part( e ).has_flag( vehicle_part::carried_flag );
+    return veh->part( e ).has_flag( vp_flag::carried_flag );
     } ) ) {
         msg = _( "Unracking is required before installing any parts here." );
         return false;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -220,6 +220,15 @@ int cmps_to_vmiph( int cmps );
 int vmiph_to_cmps( int vmiph );
 static constexpr float accel_g = 9.81f;
 
+enum class vp_flag : uint32_t {
+    none = 0,
+    passenger_flag = 1,
+    animal_flag = 2,
+    carried_flag = 4,
+    carrying_flag = 8,
+    tracked_flag = 16 //carried vehicle part with tracking enabled
+};
+
 /**
  * Structure, describing vehicle part (i.e., wheel, seat)
  */
@@ -230,12 +239,6 @@ struct vehicle_part {
         friend item_location;
         friend class turret_data;
 
-        enum : int { passenger_flag = 1,
-                     animal_flag = 2,
-                     carried_flag = 4,
-                     carrying_flag = 8,
-                     tracked_flag = 16 //carried vehicle part with tracking enabled
-                   };
 
         vehicle_part(); /** DefaultConstructible */
 
@@ -245,14 +248,14 @@ struct vehicle_part {
         /** Check this instance is non-null (not default constructed) */
         explicit operator bool() const;
 
-        bool has_flag( const int flag ) const noexcept {
-            return flag & flags;
+        bool has_flag( const vp_flag flag ) const noexcept {
+            return static_cast<uint32_t>( flag ) & static_cast<uint32_t>( flags );
         }
-        int  set_flag( const int flag )       noexcept {
-            return flags |= flag;
+        void set_flag( const vp_flag flag ) noexcept {
+            flags = static_cast<vp_flag>( static_cast<uint32_t>( flags ) | static_cast<uint32_t>( flag ) );
         }
-        int  remove_flag( const int flag )    noexcept {
-            return flags &= ~flag;
+        void remove_flag( const vp_flag flag ) noexcept {
+            flags = static_cast<vp_flag>( static_cast<uint32_t>( flags ) & ~static_cast<uint32_t>( flag ) );
         }
 
         /**
@@ -474,7 +477,7 @@ struct vehicle_part {
          */
         bool removed = false; // NOLINT(cata-serialize)
         bool enabled = true;
-        int flags = 0;
+        vp_flag flags = vp_flag::none;
 
         /** ID of player passenger */
         character_id passenger_id;

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -299,11 +299,11 @@ void vehicle::print_vparts_descs( const catacurses::window &win, int max_y, int 
         const nc_color desc_color = vp.is_broken() ? c_dark_gray : c_light_gray;
         // -4 = -2 for left & right padding + -2 for "> "
         int new_lines = 2 + vp.info().format_description( possible_msg, desc_color, width - 4 );
-        if( vp.has_flag( vehicle_part::carrying_flag ) ) {
+        if( vp.has_flag( vp_flag::carrying_flag ) ) {
             possible_msg += _( "  Carrying a vehicle on a rack.\n" );
             new_lines += 1;
         }
-        if( vp.has_flag( vehicle_part::carried_flag ) ) {
+        if( vp.has_flag( vp_flag::carried_flag ) ) {
             possible_msg += string_format( _( "  Part of a %s carried on a rack.\n" ),
                                            vp.carried_name() );
             new_lines += 1;
@@ -336,7 +336,7 @@ std::vector<itype_id> vehicle::get_printable_fuel_types() const
     std::set<itype_id> opts;
     for( const vpart_reference &vpr : get_all_parts() ) {
         const vehicle_part &pt = vpr.part();
-        if( !pt.has_flag( vehicle_part::carried_flag ) && pt.is_fuel_store() &&
+        if( !pt.has_flag( vp_flag::carried_flag ) && pt.is_fuel_store() &&
             !pt.ammo_current().is_null() ) {
             opts.emplace( pt.ammo_current() );
         }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2156,7 +2156,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
             debugmsg( "throw passenger: passenger at %d,%d,%d, part at %d,%d,%d",
                       rider->posx(), rider->posy(), rider->posz(),
                       part_pos.x, part_pos.y, part_pos.z );
-            veh.part( ps ).remove_flag( vehicle_part::passenger_flag );
+            veh.part( ps ).remove_flag( vp_flag::passenger_flag );
             continue;
         }
 

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -204,7 +204,7 @@ bool vehicle_part::is_cleaner_on() const
 
 bool vehicle_part::is_unavailable( const bool carried ) const
 {
-    return is_broken() || ( has_flag( carried_flag ) && carried );
+    return is_broken() || ( has_flag( vp_flag::carried_flag ) && carried );
 }
 
 bool vehicle_part::is_available( const bool carried ) const

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1478,9 +1478,9 @@ void vehicle::use_monster_capture( int part, const tripoint &pos )
     base.type->invoke( get_avatar(), base, pos );
     parts[part].set_base( base );
     if( base.has_var( "contained_name" ) ) {
-        parts[part].set_flag( vehicle_part::animal_flag );
+        parts[part].set_flag( vp_flag::animal_flag );
     } else {
-        parts[part].remove_flag( vehicle_part::animal_flag );
+        parts[part].remove_flag( vp_flag::animal_flag );
     }
     invalidate_mass();
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

vehicle_part::has_flag() <-> vpart_info::has_flag() and similar flag functions can easily be mixed up as both are contextually similar and use non-class enums

#### Describe the solution

Makes the anonymous enum in vehicle_part an enum class, this blocks using these enum values in vpart_info::has_flag and the other way around at compile time

Fixes 2 instances where a VPFLAG_* flag was fed into vehicle_part::has_flag
https://github.com/CleverRaven/Cataclysm-DDA/blob/363272a960a5e435cf9f4d7fe6629225f4dba51e/src/vehicle.cpp#L7012
https://github.com/CleverRaven/Cataclysm-DDA/blob/363272a960a5e435cf9f4d7fe6629225f4dba51e/src/vehicle.cpp#L344-L358

#### Describe alternatives you've considered

Making vpart_bitflags also an enum class

#### Testing

Hopefully tests catch the runtime stuff, loading a save from earlier commit seemed to work - passengers un/boarded properly, racked vehicles unracked properly.

#### Additional context
