### PR TITLE
☕☢️ Fix atomic coffeepot being unable to use batteries ☢️☕

### DIFF
--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "atomic_coffeepot",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "tools",
     "name": { "str": "atomic coffeemaker" },
     "looks_like": "coffeemaker",


### PR DESCRIPTION
#### Summary

Bugfixes "Fix atomic coffeepot being unable to use batteries"

#### Purpose of change

The atomic coffeepot recently changed to take medium batteries and use charges to perform cooking tasks, however no battery could be inserted.

#### Describe the solution

Changed the item type from `GENERIC` to `TOOL`.

#### Describe alternatives you've considered

None

#### Testing

Loaded a game without patches applied. Tried to insert a medium battery into my atomic coffeepot, and was told it didn't fit.

Loaded a game with this patch applied. Coffeepot takes a medium battery just fine.

#### Additional context

- #64348 