### PR TITLE
Aftershock - Make atomic coffeepot great again!

### DIFF
--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -266,6 +266,27 @@
     "flags": [ "ALLOWS_REMOTE_USE" ]
   },
   {
+    "id": "atomic_coffeepot",
+    "type": "GENERIC",
+    "category": "tools",
+    "name": { "str": "atomic coffeemaker" },
+    "looks_like": "coffeemaker",
+    "description": "A Curie-G coffeemaker, made by CuppaTech.  It famously uses a radioactive generator to heat water for coffee.  Normally the water is heated using energy stored in a capacitor, and makes ordinary coffee.  However, as a special feature, water from the RTG containment area can be used, giving the coffee a very special kick.  The Curie-G is illegal in most countries.",
+    "weight": "6000 g",
+    "volume": "1500 ml",
+    "longest_side": "20 cm",
+    "price": 100000,
+    "price_postapoc": 3000,
+    "to_hit": -2,
+    "bashing": 5,
+    "material": [ "plastic", "aluminum" ],
+    "qualities": [ [ "BOIL", 1 ] ],
+    "symbol": ",",
+    "color": "light_green",
+    "use_action": [ "HOTPLATE_ATOMIC" ],
+    "flags": [ "LEAK_DAM", "RADIOACTIVE", "DURABLE_MELEE" ]
+  },
+  {
     "id": "afs_power_cutter",
     "type": "TOOL",
     "name": { "str": "power cutter (off)", "str_pl": "power cutters (off)" },

--- a/data/mods/Aftershock/recipes/requirements.json
+++ b/data/mods/Aftershock/recipes/requirements.json
@@ -10,7 +10,7 @@
     "type": "requirement",
     "//": "Tools usable for providing heat usable for boiling water, but not necessarily for anything else.",
     "copy-from": "water_boiling_heat",
-    "extend": { "tools": [ [ [ "afs_atompot", -1 ] ] ] }
+    "extend": { "tools": [ [ [ "afs_atompot", -1 ], [ "atomic_coffeepot", -1 ] ] ] }
   },
   {
     "id": "electric_probing",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Make atomic coffeepot great again! (in Aftershock)

Fixes #64348

#### Describe the solution

Reverts atomic coffeemaker to the state it was before https://github.com/CleverRaven/Cataclysm-DDA/pull/62180 for Aftershock mod with minor differences;
Applied the increase in volume from the PR and lowered weight precision

Adds it to the water boiling requirement list

#### Describe alternatives you've considered

Thought of migrating the id to `afs_...` but looks like the id is hardcoded in several places

#### Testing

Start game with aftershock, select clean water or animal cooking oil recipe:
atomic coffeepot should be one of the tools and not require battery charges

#### Additional context
