### PR TITLE
Refactor misleading variable name `vehicle::is_floating`

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -775,8 +775,8 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
     }
 
     // If not enough wheels, mess up the ground a bit.
-    if( !vertical && !veh.valid_wheel_config() && !veh.is_in_water() && !veh.is_flying_in_air() &&
-        dp.z == 0 ) {
+    if( !vertical && !veh.valid_wheel_config() && !( veh.is_watercraft() && veh.can_float() ) &&
+        !veh.is_flying_in_air() && dp.z == 0 ) {
         veh.velocity += veh.velocity < 0 ? 2000 : -2000;
         for( const tripoint &p : veh.get_points() ) {
             const ter_id &pter = ter( p );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3409,7 +3409,10 @@ void vehicle::deserialize( const JsonObject &data )
     data.read( "velocity", velocity );
     data.read( "avg_velocity", avg_velocity );
     data.read( "falling", is_falling );
-    data.read( "floating", in_deep_water );
+    if( !data.read( "in_deep_water", in_deep_water ) ) {
+        // fallback; remove after 0.I
+        data.read( "floating", in_deep_water );
+    }
     data.read( "in_water", in_water );
     data.read( "flying", is_flying );
     data.read( "cruise_velocity", cruise_velocity );
@@ -3585,7 +3588,7 @@ void vehicle::serialize( JsonOut &json ) const
     json.member( "avg_velocity", avg_velocity );
     json.member( "falling", is_falling );
     json.member( "in_water", in_water );
-    json.member( "floating", in_deep_water );
+    json.member( "in_deep_water", in_deep_water );
     json.member( "flying", is_flying );
     json.member( "cruise_velocity", cruise_velocity );
     json.member( "vertical_velocity", vertical_velocity );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3409,7 +3409,7 @@ void vehicle::deserialize( const JsonObject &data )
     data.read( "velocity", velocity );
     data.read( "avg_velocity", avg_velocity );
     data.read( "falling", is_falling );
-    data.read( "floating", is_floating );
+    data.read( "floating", in_deep_water );
     data.read( "in_water", in_water );
     data.read( "flying", is_flying );
     data.read( "cruise_velocity", cruise_velocity );
@@ -3585,7 +3585,7 @@ void vehicle::serialize( JsonOut &json ) const
     json.member( "avg_velocity", avg_velocity );
     json.member( "falling", is_falling );
     json.member( "in_water", in_water );
-    json.member( "floating", is_floating );
+    json.member( "floating", in_deep_water );
     json.member( "flying", is_flying );
     json.member( "cruise_velocity", cruise_velocity );
     json.member( "vertical_velocity", vertical_velocity );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4232,12 +4232,12 @@ void vehicle::set_flying( bool new_flying_value )
 
 bool vehicle::is_watercraft() const
 {
-    return is_floating || ( in_water && wheelcache.empty() );
+    return in_deep_water || ( in_water && wheelcache.empty() );
 }
 
 bool vehicle::is_in_water( bool deep_water ) const
 {
-    return deep_water ? is_floating : in_water;
+    return deep_water ? in_deep_water : in_water;
 }
 
 double vehicle::coeff_water_drag() const
@@ -4292,7 +4292,7 @@ double vehicle::coeff_water_drag() const
 
 float vehicle::k_traction( float wheel_traction_area ) const
 {
-    if( is_floating ) {
+    if( in_deep_water ) {
         return can_float() ? 1.0f : -1.0f;
     }
     if( is_flying ) {
@@ -4501,7 +4501,7 @@ bool vehicle::valid_wheel_config() const
 
 float vehicle::steering_effectiveness() const
 {
-    if( is_floating ) {
+    if( in_deep_water ) {
         // I'M ON A BOAT
         return can_float() ? 1.0f : 0.0f;
     }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2144,9 +2144,11 @@ class vehicle
         // and that's the bit that controls recalculation.  The intent is to only recalculate
         // the coeffs once per turn, even if multiple parts are destroyed in a collision
         mutable bool coeff_air_changed = true; // NOLINT(cata-serialize)
-        // is the vehicle currently mostly in deep water
-        mutable bool is_floating = false;
-        // is the vehicle currently mostly in water
+        // is at least 2/3 of the vehicle on deep water tiles
+        // -- this is the "sink or swim" threshold
+        mutable bool in_deep_water = false;
+        // is at least 1/2 of the vehicle on water tiles
+        // -- fordable for ground vehicles; non-amphibious boats float
         mutable bool in_water = false;
         // is the vehicle currently flying
         mutable bool is_flying = false;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1495,6 +1495,11 @@ class vehicle
          * is the vehicle mostly in water or mostly on fairly dry land?
          */
         bool is_in_water( bool deep_water = false ) const;
+        /**
+         * should vehicle be handled using watercraft logic
+         * as determined by amount of water it is in (and whether it is amphibious)
+         * result being true does not guarantee it is viable boat -- check @ref can_float()
+         */
         bool is_watercraft() const;
         /**
          * is the vehicle flying? is it a rotorcraft?

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -116,7 +116,7 @@ int vehicle::slowdown( int at_velocity ) const
                    "%s at %d vimph, f_drag %3.2f, drag accel %d vmiph - extra drag %d",
                    name, at_velocity, f_total_drag, slowdown, units::to_watt( static_drag() ) );
     // plows slow rolling vehicles, but not falling or floating vehicles
-    if( !( is_falling || in_deep_water || is_flying ) ) {
+    if( !( is_falling || ( is_watercraft() && can_float() ) || is_flying ) ) {
         slowdown -= units::to_watt( static_drag() );
     }
 
@@ -437,7 +437,7 @@ void vehicle::thrust( int thd, int z )
     bool pl_ctrl = player_in_control( get_player_character() );
 
     // No need to change velocity if there are no wheels
-    if( ( in_water && can_float() ) || ( is_rotorcraft() && ( z != 0 || is_flying ) ) ) {
+    if( ( is_watercraft() && can_float() ) || ( is_rotorcraft() && ( z != 0 || is_flying ) ) ) {
         // we're good
     } else if( in_deep_water && !can_float() ) {
         stop();
@@ -1884,8 +1884,8 @@ vehicle *vehicle::act_on_map()
 
         // Eventually send it skidding if no control
         // But not if it's remotely controlled, is in water or can use rails
-        if( !controlled && !pl_ctrl && !in_deep_water && !can_use_rails && !is_flying &&
-            requested_z_change == 0 ) {
+        if( !controlled && !pl_ctrl && !( is_watercraft() && can_float() ) && !can_use_rails &&
+            !is_flying && requested_z_change == 0 ) {
             skidding = true;
         }
     }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -116,7 +116,7 @@ int vehicle::slowdown( int at_velocity ) const
                    "%s at %d vimph, f_drag %3.2f, drag accel %d vmiph - extra drag %d",
                    name, at_velocity, f_total_drag, slowdown, units::to_watt( static_drag() ) );
     // plows slow rolling vehicles, but not falling or floating vehicles
-    if( !( is_falling || is_floating || is_flying ) ) {
+    if( !( is_falling || in_deep_water || is_flying ) ) {
         slowdown -= units::to_watt( static_drag() );
     }
 
@@ -439,7 +439,7 @@ void vehicle::thrust( int thd, int z )
     // No need to change velocity if there are no wheels
     if( ( in_water && can_float() ) || ( is_rotorcraft() && ( z != 0 || is_flying ) ) ) {
         // we're good
-    } else if( is_floating && !can_float() ) {
+    } else if( in_deep_water && !can_float() ) {
         stop();
         if( pl_ctrl ) {
             add_msg( _( "The %s is too leaky!" ), name );
@@ -1790,7 +1790,7 @@ vehicle *vehicle::act_on_map()
     Character &player_character = get_player_character();
     const bool pl_ctrl = player_in_control( player_character );
     // TODO: Remove this hack, have vehicle sink a z-level
-    if( is_floating && !can_float() ) {
+    if( in_deep_water && !can_float() ) {
         add_msg( m_bad, _( "Your %s sank." ), name );
         if( pl_ctrl ) {
             unboard_all();
@@ -1884,7 +1884,7 @@ vehicle *vehicle::act_on_map()
 
         // Eventually send it skidding if no control
         // But not if it's remotely controlled, is in water or can use rails
-        if( !controlled && !pl_ctrl && !is_floating && !can_use_rails && !is_flying &&
+        if( !controlled && !pl_ctrl && !in_deep_water && !can_use_rails && !is_flying &&
             requested_z_change == 0 ) {
             skidding = true;
         }
@@ -2006,7 +2006,7 @@ void vehicle::check_falling_or_floating()
     // If we're flying none of the rest of this matters.
     if( is_flying && is_rotorcraft() ) {
         is_falling = false;
-        is_floating = false;
+        in_deep_water = false;
         in_water = false;
         return;
     }
@@ -2044,7 +2044,7 @@ void vehicle::check_falling_or_floating()
         static_cast<size_t>( supported_wheels ) * 2 >= wheelcache.size() ) {
         is_falling = false;
         in_water = false;
-        is_floating = false;
+        in_deep_water = false;
         return;
     }
     // TODO: Make the vehicle "slide" towards its center of weight
@@ -2053,7 +2053,7 @@ void vehicle::check_falling_or_floating()
     if( pts.empty() ) {
         // Dirty vehicle with no parts
         is_falling = false;
-        is_floating = false;
+        in_deep_water = false;
         in_water = false;
         is_flying = false;
         return;
@@ -2069,8 +2069,8 @@ void vehicle::check_falling_or_floating()
         }
         is_falling = !has_support( position, true );
     }
-    // floating if 2/3rds of the vehicle is in deep water
-    is_floating = 3 * deep_water_tiles >= 2 * pts.size();
+    // in_deep_water if 2/3 of the vehicle is in deep water
+    in_deep_water = 3 * deep_water_tiles >= 2 * pts.size();
     // in_water if 1/2 of the vehicle is in water at all
     in_water =  2 * water_tiles >= pts.size();
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Refactor misleading variable name `vehicle::is_floating`"

#### Purpose of change
`vehicle::is_floating` has an inaccurate and misleading name. It is confusing and frustrating to keep having to double check stuff whenever encountering it.

Unsurprisingly, mistakes have arisen elsewhere due to this misleading name, so also do a general audit of usages of it ( and related `vehicle::in_water` / `vehicle::is_watercraft()` / `vehicle::is_in_water()` )

#### Describe the solution

Rename `vehicle::is_floating` to `vehicle::in_deep_water` to accurately reflect what it actually means and does in practice.

Improve inline comments providing documentation of `in_deep_water`, `in_water` and `is_watercraft()`

In `map::move_vehicle()` there is a check for vehicle with insufficient wheels scraping chassis along the ground and thus losing speed. Refine criteria from simply `!veh.is_in_water()` to `!( veh.is_watercraft() && veh.can_float() )`. This means that only actually viable floating watercraft are excluded. Fixes: ground vehicles (incl. amphibious vehs) that are fording shallow water erroneously being exempted from the penalty.

Migration for old variable name in `vehicle::deserialize()`.

In `vehicle::slowdown()` (additional drag) and `vehicle::act_on_map()` (make veh skid) the misleading name `vehicle::is_floating` was taken at face value; fix by replacing with correct `( is_watercraft() && can_float() )`

In `vehicle::thrust()` refined `( in_water && can_float() )` to `( is_watercraft() && can_float() )` so that for amphibious vehicles fording shallow water, wheels still contribute to thrust and control.

#### Describe alternatives you've considered
Let the problem fester.

#### Testing

Operate a mix of pure boat, pure ground vehicle and amphibious vehicles in water and around shorelines to confirm continued fuction.