### PR TITLE
Fix vehicle cheevos not handling reverse (negative) velocities correctly

### DIFF
--- a/data/json/statistics.json
+++ b/data/json/statistics.json
@@ -391,9 +391,15 @@
     "description": { "str_sp": "minimum z level reached underwater" }
   },
   {
-    "id": "moves_veh_onboard",
+    "id": "vehicle_moves_with_abs_velocity",
     "type": "event_transformation",
     "event_type": "vehicle_moves",
+    "new_fields": { "abs_velocity": { "math_abs": "velocity" } }
+  },
+  {
+    "id": "moves_veh_onboard",
+    "type": "event_transformation",
+    "event_transformation": "vehicle_moves_with_abs_velocity",
     "value_constraints": { "avatar_on_board": { "equals": true } },
     "drop_fields": [ "avatar_on_board" ]
   },
@@ -423,7 +429,7 @@
   {
     "id": "moves_veh_ctrl_direct",
     "type": "event_transformation",
-    "event_type": "vehicle_moves",
+    "event_transformation": "vehicle_moves_with_abs_velocity",
     "value_constraints": { "avatar_is_driving": { "equals": true } },
     "drop_fields": [ "avatar_is_driving" ]
   },
@@ -437,7 +443,7 @@
   {
     "id": "moves_veh_ctrl_remote",
     "type": "event_transformation",
-    "event_type": "vehicle_moves",
+    "event_transformation": "vehicle_moves_with_abs_velocity",
     "value_constraints": { "avatar_remote_control": { "equals": true } },
     "drop_fields": [ "avatar_remote_control" ]
   },
@@ -511,7 +517,7 @@
     "id": "max_velocity_acft",
     "type": "event_statistic",
     "stat_type": "maximum",
-    "field": "velocity",
+    "field": "abs_velocity",
     "event_transformation": "moves_acft_ctrl_direct",
     "description": { "str_sp": "maximum velocity attained while piloting an aircraft" }
   },
@@ -555,7 +561,7 @@
     "id": "max_velocity_boat",
     "type": "event_statistic",
     "stat_type": "maximum",
-    "field": "velocity",
+    "field": "abs_velocity",
     "event_transformation": "moves_boat_ctrl_direct",
     "description": { "str_sp": "maximum velocity attained while sailing a watercraft" }
   },
@@ -591,7 +597,7 @@
     "id": "max_velocity_rail",
     "type": "event_statistic",
     "stat_type": "maximum",
-    "field": "velocity",
+    "field": "abs_velocity",
     "event_transformation": "moves_rail_ctrl_direct",
     "description": { "str_sp": "maximum velocity attained while driving a rail vehicle" }
   },
@@ -635,7 +641,7 @@
     "id": "max_velocity_gndv",
     "type": "event_statistic",
     "stat_type": "maximum",
-    "field": "velocity",
+    "field": "abs_velocity",
     "event_transformation": "moves_gndv_ctrl_direct",
     "description": { "str_sp": "maximum velocity attained while driving a land vehicle" }
   },
@@ -665,7 +671,7 @@
     "id": "max_velocity_skidding",
     "type": "event_statistic",
     "stat_type": "maximum",
-    "field": "velocity",
+    "field": "abs_velocity",
     "event_transformation": "moves_gndv_skidding",
     "description": { "str_sp": "maximum velocity that a driven vehicle skidded at" }
   },

--- a/src/event_field_transformations.cpp
+++ b/src/event_field_transformations.cpp
@@ -48,6 +48,12 @@ static std::vector<cata_variant> is_swimming_terrain( const cata_variant &v )
     return result;
 }
 
+static std::vector<cata_variant> math_abs( const cata_variant &v )
+{
+    std::vector<cata_variant> result = { cata_variant( std::abs( v.get<int>() ) ) };
+    return result;
+}
+
 static std::vector<cata_variant> oter_type_of_oter( const cata_variant &v )
 {
     const oter_id oter = v.get<oter_id>();
@@ -80,11 +86,11 @@ static std::vector<cata_variant> species_of_monster( const cata_variant &v )
 const std::unordered_map<std::string, event_field_transformation> event_field_transformations = {
     {
         "flags_of_itype",
-        {flags_of_itype, cata_variant_type::flag_id, { cata_variant_type::itype_id}}
+        { flags_of_itype, cata_variant_type::flag_id, { cata_variant_type::itype_id } }
     },
     {
         "flags_of_terrain",
-        {flags_of_terrain, cata_variant_type::string, { cata_variant_type::ter_id}}
+        { flags_of_terrain, cata_variant_type::string, { cata_variant_type::ter_id } }
     },
     {
         "is_mounted",
@@ -92,7 +98,11 @@ const std::unordered_map<std::string, event_field_transformation> event_field_tr
     },
     {
         "is_swimming_terrain",
-        {is_swimming_terrain, cata_variant_type::bool_, { cata_variant_type::ter_id } }
+        { is_swimming_terrain, cata_variant_type::bool_, { cata_variant_type::ter_id } }
+    },
+    {
+        "math_abs",
+        { math_abs, cata_variant_type::int_, { cata_variant_type::int_ } }
     },
     {
         "oter_type_of_oter",


### PR DESCRIPTION
#### Summary
Bugfixes "Fix vehicle cheevos not handling reverse (negative) velocities correctly"

#### Purpose of change
In #63474 I forgot to account for negative values of velocity due to vehicles moving in reverse.

Consequently, some stats/cheevos didn't work as intended. As a more visible example: in any recent experimental build, if you take fresh character, debug spawn a vehicle and drive only backwards, the score tab entry for "maximum velocity attained while driving a land vehicle" remains zero.

#### Describe the solution
Add a field transformation that takes in integer `cata_variant` and produces its absolute value.

#### Testing
Take fresh character, debug spawn a vehicle and drive only backwards, the score tab entry for "maximum velocity attained while driving a land vehicle" will correctly reflect highest reverse speed attained.
