### PR TITLE
Set OSX_MIN on CI to match release workflow

### DIFF
--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -62,7 +62,10 @@ then
         ..
     make -j$num_jobs
 else
-    make -j "$num_jobs" RELEASE=1 CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0
+    # The OSX_MIN version here should match that used in release builds so that
+    # CI detects issues that will affect releases.  It doesn't affect builds on
+    # other platforms.
+    make -j "$num_jobs" RELEASE=1 CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 OSX_MIN=10.12
 fi
 
 # vim:tw=0


### PR DESCRIPTION
#### Summary
Infrastructure "Set OSX_MIN on CI to match release workflow"

#### Purpose of change
To avoid bugs appearing in release builds that were not detected on CI.

See for example #64314 which was such an issue.

#### Describe the solution
Update the CI build script to use the same OSX_MIN value as release builds.

#### Describe alternatives you've considered
This is my best guess as to the source of the discrepancy; they both build on version 10.15 build hosts.

#### Testing
Will need to be tested on CI.

#### Additional context