### PR TITLE
Make folding vehicles test less flaky

### DIFF
--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -391,8 +391,8 @@ static void check_folded_item_to_parts_damage_transfer( const folded_item_damage
 TEST_CASE( "Check folded item damage transfers to parts and vice versa", "[item][vehicle]" )
 {
     std::vector<folded_item_damage_preset> presets {
-        { itype_folded_wheelchair_generic, 2111, 2277, 12666, 13666 },
-        { itype_folded_bicycle,            1689, 1961, 18582, 21582 },
+        { itype_folded_wheelchair_generic, 2111, 2411, 12666, 14466 },
+        { itype_folded_bicycle,            1689, 1989, 18582, 21882 },
     };
 
     for( const folded_item_damage_preset &preset : presets ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Make folding vehicles test less flaky for MSVC

Should resolve failures such as https://github.com/CleverRaven/Cataclysm-DDA/issues/62978

#### Describe the solution

Rework the damage roundtripping to use integers

#### Describe alternatives you've considered

#### Testing

MSVC 

#### Additional context

The weird part is that the test was written on VS2019 and passed at the time of writing in both MSVC, gcc and clang, may be something changed in the compiler or crt libraries since (seen the test failure even before 0.G and c++17 move)