### PR TITLE
(Don't merge) Revert "Convert anonymous vehicle_part enum to class enum (#64331)"

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1220,13 +1220,13 @@ void map::board_vehicle( const tripoint &pos, Character *p )
         }
         return;
     }
-    if( vp->part().has_flag( vp_flag::passenger_flag ) ) {
+    if( vp->part().has_flag( vehicle_part::passenger_flag ) ) {
         Character *psg = vp->vehicle().get_passenger( vp->part_index() );
         debugmsg( "map::board_vehicle: passenger (%s) is already there",
                   psg ? psg->get_name() : "<null>" );
         unboard_vehicle( pos );
     }
-    vp->part().set_flag( vp_flag::passenger_flag );
+    vp->part().set_flag( vehicle_part::passenger_flag );
     vp->part().passenger_id = p->getID();
     vp->vehicle().invalidate_mass();
 
@@ -1240,7 +1240,7 @@ void map::board_vehicle( const tripoint &pos, Character *p )
 void map::unboard_vehicle( const vpart_reference &vp, Character *passenger, bool dead_passenger )
 {
     // Mark the part as un-occupied regardless of whether there's a live passenger here.
-    vp.part().remove_flag( vp_flag::passenger_flag );
+    vp.part().remove_flag( vehicle_part::passenger_flag );
     vp.vehicle().invalidate_mass();
 
     if( !passenger ) {
@@ -1376,7 +1376,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_
                 debugmsg( "Empty passenger for part #%d at %d,%d,%d player at %d,%d,%d?",
                           prt, part_pos.x, part_pos.y, part_pos.z,
                           player_character.posx(), player_character.posy(), player_character.posz() );
-                veh.part( prt ).remove_flag( vp_flag::passenger_flag );
+                veh.part( prt ).remove_flag( vehicle_part::passenger_flag );
                 r.moved = true;
                 continue;
             }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3237,11 +3237,7 @@ void vehicle_part::deserialize( const JsonObject &data )
     direction = units::from_degrees( direction_int );
     data.read( "blood", blood );
     data.read( "enabled", enabled );
-
-    uint32_t flags_int;
-    data.read( "flags", flags_int );
-    flags = static_cast<vp_flag>( flags_int );
-
+    data.read( "flags", flags );
     data.read( "passenger_id", passenger_id );
     if( data.has_int( "z_offset" ) ) {
         int z_offset = data.get_int( "z_offset" );
@@ -3300,7 +3296,7 @@ void vehicle_part::serialize( JsonOut &json ) const
     json.member( "direction", std::lround( to_degrees( direction ) ) );
     json.member( "blood", blood );
     json.member( "enabled", enabled );
-    json.member( "flags", static_cast<uint32_t>( flags ) );
+    json.member( "flags", flags );
     if( !carried_stack.empty() ) {
         std::stack<vehicle_part::carried_part_data> carried_copy = carried_stack;
         json.member( "carried_stack" );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -766,7 +766,7 @@ bool veh_interact::update_part_requirements()
     }
 
     if( std::any_of( parts_here.begin(), parts_here.end(), [&]( const int e ) {
-    return veh->part( e ).has_flag( vp_flag::carried_flag );
+    return veh->part( e ).has_flag( vehicle_part::carried_flag );
     } ) ) {
         msg = _( "Unracking is required before installing any parts here." );
         return false;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -340,22 +340,21 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
         bool light_hoverh = one_in( 4 ); // half circle overhead light
         bool light_overh = one_in( 4 );
         bool light_atom  = one_in( 2 );
-        for( vehicle_part &vp : parts ) {
-            const vpart_info vpi = vp.info();
-            if( vpi.has_flag( VPFLAG_CONE_LIGHT ) ) {
-                vp.enabled = light_head;
-            } else if( vpi.has_flag( VPFLAG_WIDE_CONE_LIGHT ) ) {
-                vp.enabled = light_whead;
-            } else if( vpi.has_flag( VPFLAG_DOME_LIGHT ) ) {
-                vp.enabled = light_dome;
-            } else if( vpi.has_flag( VPFLAG_AISLE_LIGHT ) ) {
-                vp.enabled = light_aisle;
-            } else if( vpi.has_flag( VPFLAG_HALF_CIRCLE_LIGHT ) ) {
-                vp.enabled = light_hoverh;
-            } else if( vpi.has_flag( VPFLAG_CIRCLE_LIGHT ) ) {
-                vp.enabled = light_overh;
-            } else if( vpi.has_flag( VPFLAG_ATOMIC_LIGHT ) ) {
-                vp.enabled = light_atom;
+        for( vehicle_part &pt : parts ) {
+            if( pt.has_flag( VPFLAG_CONE_LIGHT ) ) {
+                pt.enabled = light_head;
+            } else if( pt.has_flag( VPFLAG_WIDE_CONE_LIGHT ) ) {
+                pt.enabled = light_whead;
+            } else if( pt.has_flag( VPFLAG_DOME_LIGHT ) ) {
+                pt.enabled = light_dome;
+            } else if( pt.has_flag( VPFLAG_AISLE_LIGHT ) ) {
+                pt.enabled = light_aisle;
+            } else if( pt.has_flag( VPFLAG_HALF_CIRCLE_LIGHT ) ) {
+                pt.enabled = light_hoverh;
+            } else if( pt.has_flag( VPFLAG_CIRCLE_LIGHT ) ) {
+                pt.enabled = light_overh;
+            } else if( pt.has_flag( VPFLAG_ATOMIC_LIGHT ) ) {
+                pt.enabled = light_atom;
             }
         }
 
@@ -438,7 +437,7 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
             }
         }
         if( vp.has_feature( "BOARDABLE" ) ) {   // no passengers
-            pt.remove_flag( vp_flag::passenger_flag );
+            pt.remove_flag( vehicle_part::passenger_flag );
         }
 
         // initial vehicle damage
@@ -1114,7 +1113,7 @@ bool vehicle::has_structural_part( const point &dp ) const
         const vehicle_part &vp = part( elem );
         const vpart_info &vpi = vp.info();
         if( vpi.location == part_location_structure &&
-            !vp.has_flag( vp_flag::carried_flag ) &&
+            !vp.has_flag( vehicle_part::carried_flag ) &&
             !vpi.has_flag( "PROTRUSION" ) ) {
             return true;
         }
@@ -1280,13 +1279,13 @@ bool vehicle::can_unmount( const int p, std::string &reason ) const
         }
     }
 
-    if( vp_to_remove.has_flag( vp_flag::animal_flag ) ) {
+    if( vp_to_remove.has_flag( vehicle_part::animal_flag ) ) {
         reason = _( "Remove carried animal first." );
         return false;
     }
 
-    if( vp_to_remove.has_flag( vp_flag::carrying_flag ) ||
-        vp_to_remove.has_flag( vp_flag::carried_flag ) ) {
+    if( vp_to_remove.has_flag( vehicle_part::carrying_flag ) ||
+        vp_to_remove.has_flag( vehicle_part::carried_flag ) ) {
         reason = _( "Unracking is required before removing this part." );
         return false;
     }
@@ -1397,7 +1396,7 @@ bool vehicle::is_connected( const vehicle_part &to, const vehicle_part &from,
 
             if( vp_next.info().location != part_location_structure || // not a structure part
                 vp_next.info().has_flag( "PROTRUSION" ) ||            // protrusions are not really structure
-                vp_next.has_flag( vp_flag::carried_flag ) ) {    // carried frames are not structure
+                vp_next.has_flag( vehicle_part::carried_flag ) ) {    // carried frames are not structure
                 continue; // can't connect if it's not structure
             }
 
@@ -1506,7 +1505,7 @@ std::vector<vehicle::rackable_vehicle> vehicle::find_vehicles_to_rack( int rack 
         std::vector<int> filtered_rack; // only empty racks
         std::copy_if( maybe_rack.begin(), maybe_rack.end(), std::back_inserter( filtered_rack ),
         [&]( const int &p ) {
-            return !parts[p].has_flag( vp_flag::carrying_flag );
+            return !parts[p].has_flag( vehicle_part::carrying_flag );
         } );
 
         for( const point &offset : four_cardinal_directions ) {
@@ -1586,7 +1585,7 @@ std::vector<vehicle::unrackable_vehicle> vehicle::find_vehicles_to_unrack( int r
 
         for( const int &rack_part : rack_parts ) {
             const vehicle_part &vp_rack = this->part( rack_part );
-            if( !vp_rack.has_flag( vp_flag::carrying_flag ) ) {
+            if( !vp_rack.has_flag( vehicle_part::carrying_flag ) ) {
                 commit_vehicle();
                 continue;
             }
@@ -1596,7 +1595,7 @@ std::vector<vehicle::unrackable_vehicle> vehicle::find_vehicles_to_unrack( int r
                     continue;
                 }
                 const vehicle_part &vp_near = parts[ near_parts[ 0 ] ];
-                if( !vp_near.has_flag( vp_flag::carried_flag ) ) {
+                if( !vp_near.has_flag( vehicle_part::carried_flag ) ) {
                     continue;
                 }
                 // if carried_name is different we have 2 separate vehicles racked on same
@@ -1744,18 +1743,18 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
                     carry_veh->name
                 } );
                 carried_part.enabled = false;
-                carried_part.set_flag( vp_flag::carried_flag );
+                carried_part.set_flag( vehicle_part::carried_flag );
                 //give each carried part a tracked_flag so that we can re-enable overmap tracking on unloading if necessary
                 if( carry_veh->tracking_on ) {
-                    carried_part.set_flag( vp_flag::tracked_flag );
+                    carried_part.set_flag( vehicle_part::tracked_flag );
                 }
 
-                if( carried_part.has_flag( vp_flag::passenger_flag ) ) {
-                    carried_part.remove_flag( vp_flag::passenger_flag );
+                if( carried_part.has_flag( vehicle_part::passenger_flag ) ) {
+                    carried_part.remove_flag( vehicle_part::passenger_flag );
                     carried_part.passenger_id = character_id();
                 }
 
-                parts[ carry_map.rack_part ].set_flag( vp_flag::carrying_flag );
+                parts[ carry_map.rack_part ].set_flag( vehicle_part::carrying_flag );
             }
 
             const std::pair<std::unordered_multimap<point, zone_data>::iterator, std::unordered_multimap<point, zone_data>::iterator>
@@ -1848,7 +1847,7 @@ bool vehicle::remove_part( const int p, RemovePartHandler &handler )
     }
 
     // Unboard any entities standing on removed boardable parts
-    if( part_flag( p, "BOARDABLE" ) && parts[p].has_flag( vp_flag::passenger_flag ) ) {
+    if( part_flag( p, "BOARDABLE" ) && parts[p].has_flag( vehicle_part::passenger_flag ) ) {
         handler.unboard( part_loc );
     }
 
@@ -1882,11 +1881,11 @@ bool vehicle::remove_part( const int p, RemovePartHandler &handler )
     remove_dependent_part( "HANDHELD_BATTERY_MOUNT", "NEEDS_HANDHELD_BATTERY_MOUNT" );
 
     // Release any animal held by the part
-    if( parts[p].has_flag( vp_flag::animal_flag ) ) {
+    if( parts[p].has_flag( vehicle_part::animal_flag ) ) {
         item base = parts[p].get_base();
         handler.spawn_animal_from_part( base, part_loc );
         parts[p].set_base( base );
-        parts[p].remove_flag( vp_flag::animal_flag );
+        parts[p].remove_flag( vehicle_part::animal_flag );
     }
 
     // Update current engine configuration if needed
@@ -2071,27 +2070,27 @@ bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts,
     }
 
     for( const int &rack_part : racks ) {
-        parts[rack_part].remove_flag( vp_flag::carrying_flag );
-        parts[rack_part].remove_flag( vp_flag::tracked_flag );
+        parts[rack_part].remove_flag( vehicle_part::carrying_flag );
+        parts[rack_part].remove_flag( vehicle_part::tracked_flag );
     }
     if( split_vehicles( here, { carried_parts }, { new_vehicle }, { new_mounts } ) ) {
         //~ %s is the vehicle being loaded onto the bicycle rack
         add_msg( _( "You unload the %s from the bike rack." ), new_vehicle->name );
         bool tracked_parts = false; // if any of the unracked vehicle parts carry a tracked_flag
         for( vehicle_part &part : new_vehicle->parts ) {
-            tracked_parts |= part.has_flag( vp_flag::tracked_flag );
+            tracked_parts |= part.has_flag( vehicle_part::tracked_flag );
 
             if( part.carried_stack.empty() ) {
                 // note: we get here if the part was added while the vehicle was carried / mounted.
                 // This is not expected, still try to remove the carried flag, if any.
                 debugmsg( "unracked vehicle part had no carried flag, this is an invalid state" );
-                part.remove_flag( vp_flag::carried_flag );
-                part.remove_flag( vp_flag::tracked_flag );
+                part.remove_flag( vehicle_part::carried_flag );
+                part.remove_flag( vehicle_part::tracked_flag );
             } else {
                 part.carried_stack.pop();
                 if( part.carried_stack.empty() ) {
-                    part.remove_flag( vp_flag::carried_flag );
-                    part.remove_flag( vp_flag::tracked_flag );
+                    part.remove_flag( vehicle_part::carried_flag );
+                    part.remove_flag( vehicle_part::tracked_flag );
                 }
             }
         }
@@ -2110,8 +2109,8 @@ bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts,
         return true;
     } else {
         for( const int &rack_part : racks ) {
-            parts[rack_part].set_flag( vp_flag::carrying_flag );
-            parts[rack_part].set_flag( vp_flag::tracked_flag );
+            parts[rack_part].set_flag( vehicle_part::carrying_flag );
+            parts[rack_part].set_flag( vehicle_part::tracked_flag );
         }
         //~ %s is the vehicle being loaded onto the bicycle rack
         add_msg( m_bad, _( "You can't unload the %s from the bike rack." ), new_vehicle->name );
@@ -2334,7 +2333,7 @@ bool vehicle::split_vehicles( map &here,
 
             // remove the passenger from the old vehicle
             if( passenger ) {
-                parts[ mov_part ].remove_flag( vp_flag::passenger_flag );
+                parts[ mov_part ].remove_flag( vehicle_part::passenger_flag );
                 parts[ mov_part ].passenger_id = character_id();
             }
             // indicate the part needs to be removed from the old vehicle
@@ -3144,7 +3143,7 @@ std::vector<int> vehicle::boarded_parts() const
 {
     std::vector<int> res;
     for( const vpart_reference &vp : get_avail_parts( VPFLAG_BOARDABLE ) ) {
-        if( vp.part().has_flag( vp_flag::passenger_flag ) ) {
+        if( vp.part().has_flag( vehicle_part::passenger_flag ) ) {
             res.push_back( static_cast<int>( vp.part_index() ) );
         }
     }
@@ -3184,7 +3183,7 @@ bool vehicle::is_passenger( Character &c ) const
 Character *vehicle::get_passenger( int you ) const
 {
     you = part_with_feature( you, VPFLAG_BOARDABLE, false );
-    if( you >= 0 && parts[you].has_flag( vp_flag::passenger_flag ) ) {
+    if( you >= 0 && parts[you].has_flag( vehicle_part::passenger_flag ) ) {
         return g->critter_by_id<Character>( parts[you].passenger_id );
     }
     return nullptr;
@@ -7010,7 +7009,7 @@ int vehicle::damage_direct( map &here, int p, int dmg, damage_type type )
     dmg -= std::min<int>( dmg, part_info( p ).damage_reduction[ static_cast<int>( type ) ] );
     int dres = dmg - parts[p].hp();
     if( mod_hp( parts[ p ], 0 - dmg, type ) ) {
-        if( is_flyable() && !rotors.empty() && !parts[p].info().has_flag( VPFLAG_SIMPLE_PART ) ) {
+        if( is_flyable() && !rotors.empty() && !parts[p].has_flag( VPFLAG_SIMPLE_PART ) ) {
             // If we break a part, we can no longer fly the vehicle.
             set_flyable( false );
         }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -220,15 +220,6 @@ int cmps_to_vmiph( int cmps );
 int vmiph_to_cmps( int vmiph );
 static constexpr float accel_g = 9.81f;
 
-enum class vp_flag : uint32_t {
-    none = 0,
-    passenger_flag = 1,
-    animal_flag = 2,
-    carried_flag = 4,
-    carrying_flag = 8,
-    tracked_flag = 16 //carried vehicle part with tracking enabled
-};
-
 /**
  * Structure, describing vehicle part (i.e., wheel, seat)
  */
@@ -239,6 +230,12 @@ struct vehicle_part {
         friend item_location;
         friend class turret_data;
 
+        enum : int { passenger_flag = 1,
+                     animal_flag = 2,
+                     carried_flag = 4,
+                     carrying_flag = 8,
+                     tracked_flag = 16 //carried vehicle part with tracking enabled
+                   };
 
         vehicle_part(); /** DefaultConstructible */
 
@@ -248,14 +245,14 @@ struct vehicle_part {
         /** Check this instance is non-null (not default constructed) */
         explicit operator bool() const;
 
-        bool has_flag( const vp_flag flag ) const noexcept {
-            return static_cast<uint32_t>( flag ) & static_cast<uint32_t>( flags );
+        bool has_flag( const int flag ) const noexcept {
+            return flag & flags;
         }
-        void set_flag( const vp_flag flag ) noexcept {
-            flags = static_cast<vp_flag>( static_cast<uint32_t>( flags ) | static_cast<uint32_t>( flag ) );
+        int  set_flag( const int flag )       noexcept {
+            return flags |= flag;
         }
-        void remove_flag( const vp_flag flag ) noexcept {
-            flags = static_cast<vp_flag>( static_cast<uint32_t>( flags ) & ~static_cast<uint32_t>( flag ) );
+        int  remove_flag( const int flag )    noexcept {
+            return flags &= ~flag;
         }
 
         /**
@@ -477,7 +474,7 @@ struct vehicle_part {
          */
         bool removed = false; // NOLINT(cata-serialize)
         bool enabled = true;
-        vp_flag flags = vp_flag::none;
+        int flags = 0;
 
         /** ID of player passenger */
         character_id passenger_id;

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -299,11 +299,11 @@ void vehicle::print_vparts_descs( const catacurses::window &win, int max_y, int 
         const nc_color desc_color = vp.is_broken() ? c_dark_gray : c_light_gray;
         // -4 = -2 for left & right padding + -2 for "> "
         int new_lines = 2 + vp.info().format_description( possible_msg, desc_color, width - 4 );
-        if( vp.has_flag( vp_flag::carrying_flag ) ) {
+        if( vp.has_flag( vehicle_part::carrying_flag ) ) {
             possible_msg += _( "  Carrying a vehicle on a rack.\n" );
             new_lines += 1;
         }
-        if( vp.has_flag( vp_flag::carried_flag ) ) {
+        if( vp.has_flag( vehicle_part::carried_flag ) ) {
             possible_msg += string_format( _( "  Part of a %s carried on a rack.\n" ),
                                            vp.carried_name() );
             new_lines += 1;
@@ -336,7 +336,7 @@ std::vector<itype_id> vehicle::get_printable_fuel_types() const
     std::set<itype_id> opts;
     for( const vpart_reference &vpr : get_all_parts() ) {
         const vehicle_part &pt = vpr.part();
-        if( !pt.has_flag( vp_flag::carried_flag ) && pt.is_fuel_store() &&
+        if( !pt.has_flag( vehicle_part::carried_flag ) && pt.is_fuel_store() &&
             !pt.ammo_current().is_null() ) {
             opts.emplace( pt.ammo_current() );
         }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2156,7 +2156,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
             debugmsg( "throw passenger: passenger at %d,%d,%d, part at %d,%d,%d",
                       rider->posx(), rider->posy(), rider->posz(),
                       part_pos.x, part_pos.y, part_pos.z );
-            veh.part( ps ).remove_flag( vp_flag::passenger_flag );
+            veh.part( ps ).remove_flag( vehicle_part::passenger_flag );
             continue;
         }
 

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -204,7 +204,7 @@ bool vehicle_part::is_cleaner_on() const
 
 bool vehicle_part::is_unavailable( const bool carried ) const
 {
-    return is_broken() || ( has_flag( vp_flag::carried_flag ) && carried );
+    return is_broken() || ( has_flag( carried_flag ) && carried );
 }
 
 bool vehicle_part::is_available( const bool carried ) const

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1478,9 +1478,9 @@ void vehicle::use_monster_capture( int part, const tripoint &pos )
     base.type->invoke( get_avatar(), base, pos );
     parts[part].set_base( base );
     if( base.has_var( "contained_name" ) ) {
-        parts[part].set_flag( vp_flag::animal_flag );
+        parts[part].set_flag( vehicle_part::animal_flag );
     } else {
-        parts[part].remove_flag( vp_flag::animal_flag );
+        parts[part].remove_flag( vehicle_part::animal_flag );
     }
     invalidate_mass();
 }


### PR DESCRIPTION
#### Summary
Don't merge (and making this comment not fit template so validator step fails)

#### Purpose of change

Trigger CI to probe if commit d31ab2d789559c31f794aa36ba98fd39018038cf is causing the board_vehicle test to fail

#### Describe the solution

Test seems to only fail in the clang12/macos/ubsan config, so I'm trying to test if that commit put in any UBs even though all information found indicates static_cast class enum with fixed underlying type  to it's underlying type and other way around is non-UB

#### Describe alternatives you've considered

#### Testing

And now we wait...

#### Additional context
