### PR TITLE
Use underlying type for vehicle_part::flags enum

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3237,11 +3237,7 @@ void vehicle_part::deserialize( const JsonObject &data )
     direction = units::from_degrees( direction_int );
     data.read( "blood", blood );
     data.read( "enabled", enabled );
-
-    uint32_t flags_int;
-    data.read( "flags", flags_int );
-    flags = static_cast<vp_flag>( flags_int );
-
+    data.read( "flags", flags );
     data.read( "passenger_id", passenger_id );
     if( data.has_int( "z_offset" ) ) {
         int z_offset = data.get_int( "z_offset" );
@@ -3300,7 +3296,7 @@ void vehicle_part::serialize( JsonOut &json ) const
     json.member( "direction", std::lround( to_degrees( direction ) ) );
     json.member( "blood", blood );
     json.member( "enabled", enabled );
-    json.member( "flags", static_cast<uint32_t>( flags ) );
+    json.member( "flags", flags );
     if( !carried_stack.empty() ) {
         std::stack<vehicle_part::carried_part_data> carried_copy = carried_stack;
         json.member( "carried_stack" );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -249,13 +249,14 @@ struct vehicle_part {
         explicit operator bool() const;
 
         bool has_flag( const vp_flag flag ) const noexcept {
-            return static_cast<uint32_t>( flag ) & static_cast<uint32_t>( flags );
+            const uint32_t flag_as_uint32 = static_cast<uint32_t>( flag );
+            return ( flags & flag_as_uint32 ) == flag_as_uint32;
         }
         void set_flag( const vp_flag flag ) noexcept {
-            flags = static_cast<vp_flag>( static_cast<uint32_t>( flags ) | static_cast<uint32_t>( flag ) );
+            flags |= static_cast<uint32_t>( flag );
         }
         void remove_flag( const vp_flag flag ) noexcept {
-            flags = static_cast<vp_flag>( static_cast<uint32_t>( flags ) & ~static_cast<uint32_t>( flag ) );
+            flags &= ~static_cast<uint32_t>( flag );
         }
 
         /**
@@ -477,7 +478,6 @@ struct vehicle_part {
          */
         bool removed = false; // NOLINT(cata-serialize)
         bool enabled = true;
-        vp_flag flags = vp_flag::none;
 
         /** ID of player passenger */
         character_id passenger_id;
@@ -498,6 +498,7 @@ struct vehicle_part {
     private:
         /** What type of part is this? */
         vpart_id id;
+        uint32_t flags = 0;
     public:
         /** If it's a part with variants, which variant it is */
         std::string variant;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes test failure on "Clang 12, macOS 10.15, Tiles, Sound, UBSan" config
Clean up vehicle_part::flags field

#### Describe the solution

Use the underlying type for the flags class member and cast the parameter in accessor methods instead
Hide flags field behind private modifier

#### Describe alternatives you've considered

#### Testing

Tests should work

#### Additional context
