### PR TITLE
New arachnid exclusion mod

### DIFF
--- a/data/mods/No_Spiders/blacklists/location_blacklist.json
+++ b/data/mods/No_Spiders/blacklists/location_blacklist.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "overmap_special",
+    "id": "Spider Pit",
+    "overmaps": [  ],
+    "occurrences": [ 0, 0 ]
+  },
+  {
+    "type": "overmap_special",
+    "id": "demon_spider_lair",
+    "overmaps": [  ],
+    "occurrences": [ 0, 0 ]
+  }
+]

--- a/data/mods/No_Spiders/blacklists/map_extra_blacklist.json
+++ b/data/mods/No_Spiders/blacklists/map_extra_blacklist.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "region_overlay",
+    "regions": [ "all" ],
+    "map_extras": {
+      "forest": { "extras": { "mx_spider": 0 } },
+      "forest_thick": { "extras": { "mx_spider": 0 } },
+      "forest_water": { "extras": { "mx_spider": 0 } },
+      "field": { "extras": { "mx_Trapdoor_spider_den": 0 } },
+      "agricultural": { "extras": { "mx_Trapdoor_spider_den": 0 } },
+      "build": { "extras": { "mx_house_spider": 0 } }
+    }
+  }
+]

--- a/data/mods/No_Spiders/blacklists/monster_blacklist.json
+++ b/data/mods/No_Spiders/blacklists/monster_blacklist.json
@@ -1,0 +1,35 @@
+[
+  {
+    "type": "MONSTER_BLACKLIST",
+    "monsters": [
+      "mon_spider_cellar_small",
+      "mon_spider_cellar_giant",
+      "mon_spider_cellar_mom",
+      "mon_spider_cellar_mega",
+      "mon_spider_cellar_leg",
+      "mon_spider_jumping_small",
+      "mon_spider_jumping_giant",
+      "mon_spider_jumping_mega",
+      "mon_spider_trapdoor_small",
+      "mon_spider_trapdoor_giant",
+      "mon_spider_trapdoor_mega",
+      "mon_spider_web_small",
+      "mon_spider_web",
+      "mon_spider_web_mega",
+      "mon_spider_web_s",
+      "mon_spider_widow_small",
+      "mon_spider_widow_giant",
+      "mon_spider_widow_mega",
+      "mon_spider_widow_giant_s",
+      "mon_spider_wolf_small",
+      "mon_spider_wolf_giant",
+      "mon_spider_wolf_mega",
+      "mon_dermatik_incubator_spider",
+      "mon_spider_fungus",
+      "mon_deer_mutant_spider",
+      "mon_deer_mutant_spider_fawn",
+      "mon_zpider_mass",
+      "mon_mutant_arthropod"
+    ]
+  }
+]

--- a/data/mods/No_Spiders/modinfo.json
+++ b/data/mods/No_Spiders/modinfo.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "No_spiders",
+    "name": "No Arachnid Monsters",
+    "authors": [ "DoctorBoomstick" ],
+    "maintainers": [ "DoctorBoomstick" ],
+    "description": "makes the game arachnophobe-friendly by taking all arachnid monsters and related locations from the base game, and nuking them from orbit.",
+    "category": "monster_exclude",
+    "dependencies": [ "dda" ]
+  }
+]

--- a/data/mods/No_Spiders/modinfo.json
+++ b/data/mods/No_Spiders/modinfo.json
@@ -5,7 +5,7 @@
     "name": "No Arachnid Monsters",
     "authors": [ "DoctorBoomstick" ],
     "maintainers": [ "DoctorBoomstick" ],
-    "description": "makes the game arachnophobe-friendly by taking all arachnid monsters and related locations from the base game, and nuking them from orbit.",
+    "description": "Makes the game arachnophobe-friendly by taking all arachnid monsters and related locations from the base game, and nuking them from orbit.",
     "category": "monster_exclude",
     "dependencies": [ "dda" ]
   }


### PR DESCRIPTION
#### Summary
Mods "Creates a new arachnophobia-friendly mod for CDDA, blacklisting spiders and spider related locations."
#### Purpose of change
If there’s one thing Cataclysm is stuffed with, apart from guns, it's various insects and arachnids. With respect to our spidery friends in particular, I’ve seen quite a few folks with arachnophobia being triggered upon encountering one of the many in-game spiders, with a given tile set’s respective depictions generally dictating the severity. While a simple ASCII S is, in my view, probably not going to trigger most arachnophobes, I figured that playing a game only to be unexpectedly booted by one’s phobia isn’t nice. As such, when somebody suggested that a simple arachnophobia-friendly mod could be created and there was some interest in the thought, I figured that it would be appropriate to pick up the idea.
#### Describe the solution
I’ve put together a very simple mod that blacklists spider enemies from the base game, as well as removing spider-related locations and map extras. The mod also removes the demon spider layer from Magiclysm.
When it came to deciding which enemies deserved the boot, I followed the notion that anything spider-related ought to be axed. Not being an arachnophobe myself, I don’t know if something like the arthropod mutant and spideer would prompt a reaction, but I figured that removal was the better part of thoroughness in this particular case. Plus, if they don’t in fact prompt a trigger, their reintroduction is a simple matter of removing a single line.
#### Describe alternatives you've considered
1.	Possibly removing spider mutagens, however, as pointed out by several people when workshopping the mod, the mutations themselves are versatile and non-intrusive enough to merit their staying. Plus, I don’t suppose that an arachnophobe would inject themselves with something explicitly meant to turn them into a spider.
2.	Also possibly removing some of the spider-like zombie variants and amalgamations, though I’m doubtful of the notion that they would prompt arachnophobia and felt that removing them would possibly effect the monster balance of certain locations.
#### Testing
I loaded up a fresh game with the mod installed and observed that no errors were generated before boarding a Humvee and driving around for a mighty long time and seeing that no spiders manifested themselves.
#### Additional context

