### PR TITLE
only brass recipe ingame now uses proper protective equipment & the proper proficiency

### DIFF
--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -360,7 +360,7 @@
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_UNARMED",
     "skill_used": "fabrication",
-    "skills_required": [ "bashing", 1 ],
+    "skills_required": [ "unarmed", 1 ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_redsmithing" },

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -370,8 +370,8 @@
     "time": "1 h",
     "autolearn": false,
     "book_learn": [ [ "recipe_melee", 2 ] ],
-    "using": [ [ "blacksmithing_standard", 4 ] ],
-    "tools": [ [ [ "drift", -1 ], [ "ppe_gas", 1 ] ] ],
+    "using": [ [ "blacksmithing_standard", 4 ], [ "ppe_gas", 1 ] ],
+    "tools": [ [ [ "drift", -1 ] ] ],
     "components": [ [ [ "copper", 100 ] ], [ [ "chem_zinc_powder", 500 ] ] ]
   },
   {
@@ -379,8 +379,8 @@
     "type": "recipe",
     "copy-from": "knuckle_brass",
     "time": "1 h",
-    "using": [ [ "blacksmithing_standard", 4 ] ],
-    "tools": [ [ [ "drift", -1 ], [ "ppe_gas", 1 ] ] ],
+    "using": [ [ "blacksmithing_standard", 4 ], [ "ppe_gas", 1 ] ],
+    "tools": [ [ [ "drift", -1 ] ] ],
     "components": [ [ [ "copper", 150 ] ], [ [ "chem_zinc_powder", 600 ] ] ]
   },
   {
@@ -388,8 +388,8 @@
     "type": "recipe",
     "copy-from": "knuckle_brass",
     "time": "1 h",
-    "using": [ [ "blacksmithing_standard", 4 ] ],
-    "tools": [ [ [ "drift", -1 ], [ "ppe_gas", 1 ] ] ],
+    "using": [ [ "blacksmithing_standard", 4 ], [ "ppe_gas", 1 ] ],
+    "tools": [ [ [ "drift", -1 ] ] ],
     "components": [ [ [ "copper", 80 ] ], [ [ "chem_zinc_powder", 400 ] ] ]
   },
   {

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -360,7 +360,7 @@
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_UNARMED",
     "skill_used": "fabrication",
-    "skills_required": [ "unarmed", 1 ],
+    "skills_required": [ "bashing", 1 ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_redsmithing" },

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -363,7 +363,7 @@
     "skills_required": [ "bashing", 1 ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_blacksmithing" },
+      { "proficiency": "prof_redsmithing" },
       { "proficiency": "prof_toolsmithing" }
     ],
     "difficulty": 3,
@@ -371,7 +371,7 @@
     "autolearn": false,
     "book_learn": [ [ "recipe_melee", 2 ] ],
     "using": [ [ "blacksmithing_standard", 4 ] ],
-    "tools": [ [ [ "drift", -1 ] ] ],
+    "tools": [ [ [ "drift", -1 ], [ "ppe_gas", 1 ] ] ],
     "components": [ [ [ "copper", 100 ] ], [ [ "chem_zinc_powder", 500 ] ] ]
   },
   {
@@ -380,7 +380,7 @@
     "copy-from": "knuckle_brass",
     "time": "1 h",
     "using": [ [ "blacksmithing_standard", 4 ] ],
-    "tools": [ [ [ "drift", -1 ] ] ],
+    "tools": [ [ [ "drift", -1 ], [ "ppe_gas", 1 ] ] ],
     "components": [ [ [ "copper", 150 ] ], [ [ "chem_zinc_powder", 600 ] ] ]
   },
   {
@@ -389,7 +389,7 @@
     "copy-from": "knuckle_brass",
     "time": "1 h",
     "using": [ [ "blacksmithing_standard", 4 ] ],
-    "tools": [ [ [ "drift", -1 ] ] ],
+    "tools": [ [ [ "drift", -1 ], [ "ppe_gas", 1 ] ] ],
     "components": [ [ [ "copper", 80 ] ], [ [ "chem_zinc_powder", 400 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Making/melting brass without a respirator of some kind is dangerous due to the fumes from the zinc causing health problems. Also, it uses the `Blacksmithing` proficiency despite not having any steel or iron in it's recipe. This pr fixes that.

#### Describe the solution

added the toolset `ppe_gas` from PR #62067 to the recipe as well as changed `prof_blacksmithing` to `prof_redsmithing.`

#### Describe alternatives you've considered

Removing the whole recipe, maybe?
