### PR TITLE
[Magiclysm] Small fix

### DIFF
--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -885,7 +885,7 @@
     "category": "armor",
     "copy-from": "armor_lightplate",
     "name": { "str_sp": "mage armor" },
-    "description": "A summoned magic armor.  It glows shiny and get sturdier with each spell level.",
+    "description": "A summoned magic armor.  It gets shinier and sturdier with each spell level.",
     "material": [ "concentrated_mana" ],
     "warmth": 0,
     "material_thickness": 0,

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -886,6 +886,7 @@
     "copy-from": "armor_lightplate",
     "name": { "str_sp": "mage armor" },
     "description": "A summoned magic armor.  It gets shinier and sturdier with each spell level.",
+    "weight": "1 g",
     "material": [ "concentrated_mana" ],
     "warmth": 0,
     "material_thickness": 0,

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -885,39 +885,41 @@
     "category": "armor",
     "copy-from": "armor_lightplate",
     "name": { "str_sp": "mage armor" },
-    "description": "A summoned magic armor.  It glows shiny and get sturdier with each spell and your intelligence level.",
+    "description": "A summoned magic armor.  It glows shiny and get sturdier with each spell level.",
     "material": [ "concentrated_mana" ],
     "warmth": 0,
     "material_thickness": 0,
     "flags": [ "ONLY_ONE", "OVERSIZE", "PERSONAL", "STURDY", "NO_REPAIR", "NO_SALVAGE", "TRADER_AVOID", "PADDED" ],
-    "passive_effects": [
-      {
-        "has": "WORN",
-        "condition": "ALWAYS",
-        "values": [
-          {
-            "value": "ARMOR_BASH",
-            "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "+", { "u_val": "intelligence" } ] }
-          },
-          {
-            "value": "ARMOR_CUT",
-            "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "+", { "u_val": "intelligence" } ] }
-          },
-          {
-            "value": "ARMOR_STAB",
-            "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "+", { "u_val": "intelligence" } ] }
-          },
-          {
-            "value": "ARMOR_BULLET",
-            "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "+", { "u_val": "intelligence" } ] }
-          },
-          {
-            "value": "LUMINATION",
-            "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "+", { "u_val": "intelligence" } ] }
-          }
-        ]
-      }
-    ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ALWAYS",
+          "values": [
+            {
+              "value": "ARMOR_BASH",
+              "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": -1 } ] }
+            },
+            {
+              "value": "ARMOR_CUT",
+              "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": -1 } ] }
+            },
+            {
+              "value": "ARMOR_STAB",
+              "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": -1 } ] }
+            },
+            {
+              "value": "ARMOR_BULLET",
+              "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": -1 } ] }
+            },
+            {
+              "value": "LUMINATION",
+              "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": 3 } ] }
+            }
+          ]
+        }
+      ]
+    },
     "armor": [
       {
         "encumbrance": 0,


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fixing small bug i found
#### Describe the solution
add relic_data to mage armor, boost the lumination effect, remove the intelligence dependence
#### Additional context
It doesn't fix the #64368 - mage blade, for example, has relic_data already, but test shows it doesn't work still