### PR TITLE
Pre-nerfed technician is in the No Hope mod

### DIFF
--- a/data/mods/No_Hope/monsters.json
+++ b/data/mods/No_Hope/monsters.json
@@ -684,5 +684,13 @@
       "STUN_IMMUNE",
       "MECH_DEFENSIVE"
     ]
+  },
+  {
+    "id": "mon_zombie_technician",
+    "type": "MONSTER",
+    "name": { "str": "zombie technician" },
+    "description": "Still wearing its work clothes and hardhat, this zombie likely used to work on power lines or other electrical equipment.  As it approaches, everything metal you're carrying shifts very slightly in the zombie's direction, as if attracted by a strong magnetic force.",
+    "copy-from": "mon_zombie_technician",
+    "special_attacks": [ [ "PULL_METAL_WEAPON", 25 ], { "type": "bite", "cooldown": 20 }, [ "GRAB", 7 ], [ "scratch", 20 ] ]
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I like the ranged pull mechanics and I don't want it to be removed from the game.

#### Describe the solution
Create a copy-from definition of pre-#64383 zombie technician in the No Hope mod.

#### Describe alternatives you've considered
None.

#### Testing
Created world with the mod, got katana, spawned zombie technician, waited for it to pull away my weapon.

#### Additional context
None.