### PR TITLE
active_items: mark death drops as active items

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -1286,6 +1286,7 @@ class map
          *  @warning function is relatively expensive and meant for user initiated actions, not mapgen
          */
         // TODO: fix point types (remove the first overload)
+        item_location add_item_ret_loc( const tripoint &pos, item obj, bool overflow = true );
         item &add_item_or_charges( const tripoint &pos, item obj, bool overflow = true );
         item &add_item_or_charges( const tripoint_bub_ms &pos, item obj, bool overflow = true );
         item &add_item_or_charges( const point &p, const item &obj, bool overflow = true ) {
@@ -1585,6 +1586,9 @@ class map
         template<typename Map>
         static cata::copy_const<Map, field_entry> *get_field_helper(
             Map &m, const tripoint &p, const field_type_id &type );
+
+        std::pair<item *, tripoint> _add_item_or_charges( const tripoint &pos, item obj,
+                bool overflow = true );
     public:
 
         // Splatters of various kind

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -55,10 +55,10 @@ static const harvest_drop_type_id harvest_drop_flesh( "flesh" );
 
 static const species_id species_ZOMBIE( "ZOMBIE" );
 
-item *mdeath::normal( monster &z )
+item_location mdeath::normal( monster &z )
 {
     if( z.no_corpse_quiet ) {
-        return nullptr;
+        return {};
     }
 
     if( !z.quiet_death ) {
@@ -82,14 +82,10 @@ item *mdeath::normal( monster &z )
             return splatter( z );
         } else {
             const float damage = std::floor( corpse_damage * itype::damage_scale );
-            item *corpse = make_mon_corpse( z, static_cast<int>( damage ) );
-            if( corpse->is_null() ) {
-                return nullptr;
-            }
-            return corpse;
+            return make_mon_corpse( z, static_cast<int>( damage ) );
         }
     }
-    return nullptr;
+    return {};
 }
 
 static void scatter_chunks( const itype_id &chunk_name, int chunk_amt, monster &z, int distance,
@@ -135,7 +131,7 @@ static void scatter_chunks( const itype_id &chunk_name, int chunk_amt, monster &
     }
 }
 
-item *mdeath::splatter( monster &z )
+item_location mdeath::splatter( monster &z )
 {
     const bool gibbable = !z.type->has_flag( MF_NOGIB );
 
@@ -193,7 +189,7 @@ item *mdeath::splatter( monster &z )
         // add corpse with gib flag
         item corpse = item::make_corpse( z.type->id, calendar::turn, z.unique_name, z.get_upgrade_time() );
         if( corpse.is_null() ) {
-            return nullptr;
+            return {};
         }
         // Set corpse to damage that aligns with being pulped
         corpse.set_damage( 4000 );
@@ -201,9 +197,9 @@ item *mdeath::splatter( monster &z )
         if( z.has_effect( effect_no_ammo ) ) {
             corpse.set_var( "no_ammo", "no_ammo" );
         }
-        return &here.add_item_or_charges( z.pos(), corpse );
+        return here.add_item_ret_loc( z.pos(), corpse );
     }
-    return nullptr;
+    return {};
 }
 
 void mdeath::disappear( monster &z )
@@ -275,7 +271,7 @@ void mdeath::broken( monster &z )
     }
 }
 
-item *make_mon_corpse( monster &z, int damageLvl )
+item_location make_mon_corpse( monster &z, int damageLvl )
 {
     item corpse = item::make_corpse( z.type->id, calendar::turn, z.unique_name, z.get_upgrade_time() );
     // All corpses are at 37 C at time of death
@@ -287,5 +283,5 @@ item *make_mon_corpse( monster &z, int damageLvl )
     if( z.has_effect( effect_no_ammo ) ) {
         corpse.set_var( "no_ammo", "no_ammo" );
     }
-    return &get_map().add_item_or_charges( z.pos(), corpse );
+    return get_map().add_item_ret_loc( z.pos(), corpse );
 }

--- a/src/mondeath.h
+++ b/src/mondeath.h
@@ -9,15 +9,15 @@ class monster;
 namespace mdeath
 {
 // Drop a body
-item *normal( monster &z );
+item_location normal( monster &z );
 // Overkill splatter (also part of normal under conditions)
-item *splatter( monster &z );
+item_location splatter( monster &z );
 // Hallucination disappears
 void disappear( monster &z );
 // Broken robot drop
 void broken( monster &z );
 } //namespace mdeath
 
-item *make_mon_corpse( monster &z, int damageLvl );
+item_location make_mon_corpse( monster &z, int damageLvl );
 
 #endif // CATA_SRC_MONDEATH_H

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2692,6 +2692,11 @@ void monster::die( Creature *nkiller )
             }
         }
     }
+    if( corpse ) {
+        corpse->process( get_map(), nullptr, pos() );
+        item_location corpse_loc{ map_cursor{ pos() }, corpse };
+        corpse_loc.make_active();
+    }
 
     // Adjust anger/morale of nearby monsters, if they have the appropriate trigger and are friendly
     // Keep filtering on the dying monsters' triggers to preserve current functionality

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2636,7 +2636,7 @@ void monster::die( Creature *nkiller )
         }
     }
 
-    item *corpse = nullptr;
+    item_location corpse;
     // drop a corpse, or not - this needs to happen after the spell, for e.g. revivification effects
     switch( type->mdeath_effect.corpse_type ) {
         case mdeath_type::NORMAL:
@@ -2670,8 +2670,8 @@ void monster::die( Creature *nkiller )
     }
 
     if( death_drops && !no_extra_death_drops ) {
-        drop_items_on_death( corpse );
-        spawn_dissectables_on_death( corpse );
+        drop_items_on_death( corpse.get_item() );
+        spawn_dissectables_on_death( corpse.get_item() );
     }
     if( death_drops && !is_hallucination() ) {
         for( const item &it : inv ) {
@@ -2693,9 +2693,8 @@ void monster::die( Creature *nkiller )
         }
     }
     if( corpse ) {
-        corpse->process( get_map(), nullptr, pos() );
-        item_location corpse_loc{ map_cursor{ pos() }, corpse };
-        corpse_loc.make_active();
+        corpse->process( get_map(), nullptr, corpse.position() );
+        corpse.make_active();
     }
 
     // Adjust anger/morale of nearby monsters, if they have the appropriate trigger and are friendly

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -265,3 +265,44 @@ TEST_CASE( "milk_rotting", "[active_item][map]" )
     here.check_submap_active_item_consistency();
     CHECK( here.get_submaps_with_active_items().count( test_loc_sm ) == static_cast<size_t>( sealed ) );
 }
+
+TEST_CASE( "active_monster_drops", "[active_item][map]" )
+{
+    clear_map();
+    get_avatar().setpos( tripoint_zero );
+    tripoint start_loc = get_avatar().pos() + tripoint_east;
+    map &here = get_map();
+    restore_on_out_of_scope<std::optional<units::temperature>> restore_temp(
+                get_weather().forced_temperature );
+    get_weather().forced_temperature = units::from_celsius( 21 );
+
+    bool const cookie_rotten_before_death = GENERATE( true, false );
+    CAPTURE( cookie_rotten_before_death );
+
+    item bag_plastic( "bag_plastic" );
+    item cookie( "cookies" );
+    REQUIRE( cookie.needs_processing() );
+    if( cookie_rotten_before_death ) {
+        cookie.set_relative_rot( 10 );
+        REQUIRE( cookie.has_rotten_away() );
+    }
+    REQUIRE( bag_plastic.put_in( cookie, item_pocket::pocket_type::CONTAINER ).success() );
+
+    monster &zombo = spawn_test_monster( "mon_zombie", start_loc, true );
+    zombo.no_extra_death_drops = true;
+    zombo.inv.emplace_back( bag_plastic );
+    calendar::turn += time_duration::from_seconds( cookie.processing_speed() + 1 );
+    zombo.die( nullptr );
+    REQUIRE( here.i_at( start_loc ).size() == 1 );
+    item &dropped_bag = here.i_at( start_loc ).begin()->only_item();
+
+    if( !cookie_rotten_before_death ) {
+        item &dropped_cookie = dropped_bag.only_item();
+        dropped_cookie.set_relative_rot( 10 );
+        REQUIRE( dropped_cookie.has_rotten_away() );
+        calendar::turn += time_duration::from_seconds( cookie.processing_speed() + 1 );
+        here.process_items(); // only corpse is scheduled here
+        here.process_items(); // only cookie is scheduled here
+    }
+    CHECK( dropped_bag.empty() );
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Monster drops aren't processed as active items
* Fixes: #64404
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add monster drops to the active item cache
Process them once to get rid of rotten items

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
New test unit

Advance time by 10 years and kill a bunch of zombies. They should not drop any unsealed perishable food.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This bug was hidden before #63233 due to the order of operations in monster drop logic.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->