### PR TITLE
Make generic guns validator output sane error on bad json

### DIFF
--- a/tools/json_tools/generic_guns_validator.py
+++ b/tools/json_tools/generic_guns_validator.py
@@ -66,6 +66,11 @@ ID_WHITELIST = {
 def items_of_type(data, type):
     result = []
     for i in data:
+        if 'type' not in i:
+            dump = util.CDDAJSONWriter(i).dumps()
+            print("json entry has no 'type' field: " + dump)
+
+            sys.exit(1)
         if i['type'] == type:
             result.append(i)
     return result


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Make generic guns validator output a nice error message if json entry is missing 'type' field

#### Describe the solution

https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4468974784/jobs/7850437991?pr=63520
```python
Importing Generic Guns data from '/home/runner/work/Cataclysm-DDA/Cataclysm-DDA/data/mods/Generic_Guns'
Traceback (most recent call last):
  File "tools/json_tools/generic_guns_validator.py", line 214, in <module>
    sys.exit(main())
  File "tools/json_tools/generic_guns_validator.py", line 134, in main
    core_guns = items_of_type(core_data, 'GUN')
  File "tools/json_tools/generic_guns_validator.py", line 69, in items_of_type
    if i['type'] == type:
KeyError: 'type'
```
Doesn't look too friendly and doesn't specify the item that failed, this patch will make it dump the json object that's missing the type field

#### Describe alternatives you've considered

#### Testing

Running on the same json it should output something like
```python
$ python3 generic_guns_validator.py
Importing Generic Guns data from 'C:\\projects\\Cataclysm-DDA\\data\\mods\\Generic_Guns'
entry has no 'type' field: {
  "id": "EOC_MISSION_GODCO_TROPHY2_done",
  "global": true,
  "condition": {"or": [{"u_has_items": {"item": "egg_spider_cellar", "count": 1}}, {"u_has_items": {"item": "egg_spider_jumping", "count": 1}}, {"u_has_items": {"item": "egg_spider_trapdoor", "count": 1}}, {"u_has_items": {"item": "egg_spider_web", "count": 1}}, {"u_has_items": {"item": "egg_spider_widow", "count": 1}}, {"u_has_items": {"item": "egg_spider_wolf", "count": 1}}]},
  "effect": [{"run_eocs": [{"id": "sell_egg_spider_cellar", "condition": {"u_has_items": {"item": "egg_spider_cellar", "count": 1}}, "effect": {"u_sell_item": "egg_spider_cellar", "count": 1}}, {"id": "sell_egg_spider_jumping", "condition": {"u_has_items": {"item": "egg_spider_jumping", "count": 1}}, "effect": {"u_sell_item": "egg_spider_jumping", "count": 1}}, {"id": "sell_egg_spider_trapdoor", "condition": {"u_has_items": {"item": "egg_spider_trapdoor", "count": 1}}, "effect": {"u_sell_item": "egg_spider_trapdoor", "count": 1}}, {"id": "sell_egg_spider_web", "condition": {"u_has_items": {"item": "egg_spider_web", "count": 1}}, "effect": {"u_sell_item": "egg_spider_web", "count": 1}}, {"id": "sell_egg_spider_widow", "condition": {"u_has_items": {"item": "egg_spider_widow", "count": 1}}, "effect": {"u_sell_item": "egg_spider_widow", "count": 1}}, {"id": "sell_egg_spider_wolf", "condition": {"u_has_items": {"item": "egg_spider_wolf", "count": 1}}, "effect": {"u_sell_item": "egg_spider_wolf", "count": 1}}]}]
}
```

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->