### PR TITLE
Set BACKTRACE in msvc CI builds for better stack traces.

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -36,6 +36,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # Enable pretty backtraces
+  BACKTRACE: 1
   # Compressed size ~1GB based on observations
   CCACHE_LIMIT: 8GB
   CDDA_CCACHE_PATH: ${{ github.workspace }}\ccache\

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,9 @@ jobs:
       - name: Build CDDA (windows msvc)
         if: runner.os == 'Windows'
         env:
+          # Enable pretty backtraces
+          BACKTRACE: 1
+          CDDA_STRIPPED_PDB: 1
           VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\.github\vcpkg_triplets
         run: |
           msbuild -m -p:Configuration=Release -p:Platform=${{ matrix.arch }} "-target:Cataclysm-vcpkg-static;JsonFormatter-vcpkg-static" msvc-full-features\Cataclysm-vcpkg-static.sln

--- a/build-scripts/windist.ps1
+++ b/build-scripts/windist.ps1
@@ -4,6 +4,7 @@ if (Test-path bindist) {
 
 mkdir bindist
 cp cataclysm-tiles.exe bindist/cataclysm-tiles.exe
+cp cataclysm-tiles.stripped.pdb bindist/cataclysm-tiles.pdb
 cp tools/format/json_formatter.exe bindist/json_formatter.exe
 
 mkdir bindist/lang

--- a/msvc-full-features/Cataclysm-common.props
+++ b/msvc-full-features/Cataclysm-common.props
@@ -8,6 +8,12 @@
     <IntDir>$(CDDA_ROOT)objwin\$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
     <OutDir>$(CDDA_ROOT)objwin\$(Configuration)\$(Platform)\$(ProjectName)\</OutDir>
   </PropertyGroup>
+  <PropertyGroup>
+    <_CDDA_BACKTRACE>false</_CDDA_BACKTRACE>
+    <_CDDA_BACKTRACE Condition="'$(BACKTRACE)'!=''">true</_CDDA_BACKTRACE>
+    <_CDDA_STRIPPED_PDB>false</_CDDA_STRIPPED_PDB>
+    <_CDDA_STRIPPED_PDB Condition="'$(CDDA_STRIPPED_PDB)'!=''">true</_CDDA_STRIPPED_PDB>
+  </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgAdditionalInstallOptions>--clean-after-build</VcpkgAdditionalInstallOptions>
   </PropertyGroup>
@@ -35,6 +41,9 @@
     <ClCompile Condition="$(Configuration.StartsWith(Release))">
       <PreprocessorDefinitions>RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Condition="$(_CDDA_BACKTRACE)">
+      <PreprocessorDefinitions>BACKTRACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Condition="$(_CDDA_USE_CCACHE)">
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <ForcedIncludeFiles />
@@ -46,7 +55,10 @@
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
       <LinkStatus>true</LinkStatus>
       <AdditionalOptions>/LTCG:OFF %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>winmm.lib;imm32.lib;version.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;setupapi.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dbghelp.lib;winmm.lib;imm32.lib;version.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;setupapi.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Link Condition="$(_CDDA_STRIPPED_PDB)">
+      <StripPrivateSymbols>$(OutDir)$(TargetName).stripped.pdb</StripPrivateSymbols>
     </Link>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Crash reports are more helpful with symbolicated stack traces. The MSVC builds were not generating these. They should.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Allow setting an env var to enable setting the corresponding preprocessor define in the VS solutions. Set the env var in github CI definitions so builds use the already existing functionality. Also modify the solutions to generate a 'stripped pdb' which contains enough information to attach function names to the stack dump, but is slimmed down compared to a full pdb. Package that pdb in the windist.ps1 script.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Insert a cata_fatal somewhere in the code, hardcoded the define, and got the following output:
```
The program has crashed.
See the log file for a stack trace.
CRASH LOG FILE: ./config/crash.log
VERSION: 0.G-631-g7863db8bd9-dirty
TYPE: Signal
MESSAGE: SIGABRT: Abnormal termination
STACK TRACE:

  #0
    (dbghelp: debug_write_backtrace+0xb5@0,000,7FF,7E3,BBC,875[cataclysm-tiles.exe+0x72c,875]), 
  #1
    (dbghelp: log_crash+0x364@0,000,7FF,7E3,B80,9A4[cataclysm-tiles.exe+0x6f0,9a4]), 
  #2
    (dbghelp: signal_handler+0x57@0,000,7FF,7E3,B80,DD7[cataclysm-tiles.exe+0x6f0,dd7]), 
  #3
    (dbghelp: raise+0x23e@0,000,7FF,7E4,F91,3F6[cataclysm-tiles.exe+0x1,b01,3f6]), 
  #4
    (dbghelp: abort+0x18@0,000,7FF,7E4,F79,79C[cataclysm-tiles.exe+0x1,ae9,79c]), 
  #5
    (dbghelp: flexbuffer_disk_cache::save_to_disk+0xaa5@0,000,7FF,7E3,DC1,AD5[cataclysm-tiles.exe+0x931,ad5]), 
  #6
    (dbghelp: flexbuffer_cache::parse_and_cache+0x3f6@0,000,7FF,7E3,DC0,3B6[cataclysm-tiles.exe+0x930,3b6]), 
  #7
    (dbghelp: `anonymous namespace'::from_path_at_offset_opt_impl+0xb5@0,000,7FF,7E3,DFC,9C5[cataclysm-tiles.exe+0x96c,9c5]), 
  #8
    (dbghelp: json_loader::from_path+0x43@0,000,7FF,7E3,DFC,673[cataclysm-tiles.exe+0x96c,673]), 
  #9
    (dbghelp: read_from_file_json+0x29@0,000,7FF,7E3,DEB,0F9[cataclysm-tiles.exe+0x95b,0f9]), 
  #10
    (dbghelp: read_from_file_optional_json+0x42@0,000,7FF,7E3,DEB,2E2[cataclysm-tiles.exe+0x95b,2e2]), 
  #11
    (dbghelp: options_manager::load+0x47@0,000,7FF,7E3,D05,FB7[cataclysm-tiles.exe+0x875,fb7]), 
  #12
    (dbghelp: catacurses::init_interface+0x2b0@0,000,7FF,7E3,BAE,360[cataclysm-tiles.exe+0x71e,360]), 
  #13
    (dbghelp: WinMain+0x58f@0,000,7FF,7E3,A4C,BEF[cataclysm-tiles.exe+0x5bc,bef]), 
  #14
    (dbghelp: __scrt_common_main_seh+0x106@0,000,7FF,7E4,F69,DD2[cataclysm-tiles.exe+0x1,ad9,dd2]), 
  #15
    (dbghelp: BaseThreadInitThunk+0x14@0,000,7FF,8CE,D07,614[KERNEL32.DLL+0x17,614]), 
  #16
```

Removed the hardcoded define, set the env var, reloaded the solution, and confirmed the define was still set. Removed the env var, the define was no longer set. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
It should be possible to get line numbers instead of offsets as well, but that'll require more thorough changes to code as opposed to just setting a flag and validating it works. That would require shipping a pdb though.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->