### PR TITLE
Palisade Rework

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1478,9 +1478,9 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 4 ], [ "survival", 2 ] ],
     "time": "120 m",
-    "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
+    "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
     "components": [
-      [ [ "log", 3 ] ],
+      [ [ "log", 6 ] ],
       [
         [ "wire", 6 ],
         [ "wire_barbed", 4 ],
@@ -1657,8 +1657,8 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 4 ], [ "survival", 2 ] ],
     "time": "120 m",
-    "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "components": [ [ [ "log", 2 ] ], [ [ "2x4", 3 ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_30", 1 ] ] ],
+    "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "components": [ [ [ "log", 4 ] ], [ [ "2x4", 3 ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_30", 1 ] ] ],
     "pre_note": "Must be between palisade walls to function, and at least one wall must have an adjacent rope & pulley system.",
     "pre_terrain": "t_pit",
     "post_terrain": "t_palisade_gate"
@@ -1940,7 +1940,7 @@
     "time": "120 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
     "components": [
-      [ [ "log", 3 ] ],
+      [ [ "log", 6 ] ],
       [
         [ "wire", 6 ],
         [ "wire_barbed", 4 ],

--- a/data/json/furniture_and_terrain/terrain-embrasures.json
+++ b/data/json/furniture_and_terrain/terrain-embrasures.json
@@ -244,8 +244,8 @@
       "THIN_OBSTACLE"
     ],
     "bash": {
-      "str_min": 28,
-      "str_max": 75,
+      "str_min": 300,
+      "str_max": 400,
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_null",

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -10,8 +10,8 @@
     "coverage": 55,
     "flags": [ "FLAMMABLE", "NOITEM", "DOOR", "WALL", "REDUCE_SCENT", "BLOCK_WIND", "BURROWABLE" ],
     "bash": {
-      "str_min": 24,
-      "str_max": 150,
+      "str_min": 300,
+      "str_max": 400,
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_null",

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -2229,8 +2229,8 @@
     "coverage": 100,
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "REDUCE_SCENT", "CONNECT_WITH_WALL", "WALL", "BLOCK_WIND" ],
     "bash": {
-      "str_min": 35,
-      "str_max": 150,
+      "str_min": 350,
+      "str_max": 500,
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_null",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Palisade Rework"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The purpose of this change is to increase the bash minimum and maximum required to break palisade walls. The current strength of these walls are very low despite this style of fortification being incredibly durable due the timber being buried 5 feet into the ground, offering greater resistance through the earth's resistance.

A real world example of palisade wall strength would be the Battle of Ōhaeawai, where this fortification was used by the Māori defending against British troops. A quote from an article on the battle as British troops took down the walls, "Large fires were made against the stockade in several places, and where the posts were too thick to burn while standing upright, they were pulled down by main force. In some cases it took the whole strength of forty men, with ropes, to pull down one post, although much of the earth at the base had been previously dug away for the purpose of loosening it." Keep in mind, this was after their victory against the Māori and there was still difficulty taking down the walls.
#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
The solution to this was simple, I updated the palisade walls to have a bash minimum of 350 and a maximum of 500. Palisade gates and embrasures were given lower values with 300 minimum and 400 maximum. I also doubled the log requirements for palisade construction as the current log requirement didn't make a lot of sense, alongside giving it a wood sawing requirement to sharpen the timber.
#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Using lower values.
#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Tested in-game and it works as intended.
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
The quoted article that goes over Māori use of palisade walls: 
https://nzetc.victoria.ac.nz/tm/scholarly/tei-BesPaMa-t1-body-d6-d1-d5.html

![Screenshot (965)](https://user-images.githubusercontent.com/81766902/226685906-e3797a89-1088-4334-8df6-51e707a5f96d.png)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->