### PR TITLE
inv_ui: move cell cache to entry and delete redundant calls

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -577,8 +577,11 @@ void inventory_entry::update_cache()
 void inventory_entry::cache_denial( inventory_selector_preset const &preset ) const
 {
     if( !denial ) {
-        denial = { preset.get_denial( *this ) };
+        denial.emplace( preset.get_denial( *this ) );
         enabled = denial->empty();
+    }
+    if( is_collation_header() ) {
+        collation_meta->enabled = denial->empty();
     }
 }
 
@@ -756,7 +759,7 @@ bool inventory_selector_preset::is_stub_cell( const inventory_entry &entry,
     if( !entry.is_item() ) {
         return false;
     }
-    const std::string &text = get_cell_text( entry, cell_index );
+    const std::string &text = entry.get_entry_cell_cache( *this ).text[ cell_index ];
     return text.empty() || text == cells[cell_index].stub;
 }
 
@@ -908,21 +911,10 @@ void inventory_column::move_selection_page( scroll_direction dir )
     highlight( index, dir );
 }
 
-size_t inventory_column::get_entry_cell_width( size_t index, size_t cell_index ) const
-{
-    size_t res = utf8_width( get_entry_cell_cache( index ).text[cell_index], true );
-
-    if( cell_index == 0 ) {
-        res += get_entry_indent( entries[index] );
-    }
-
-    return res;
-}
-
 size_t inventory_column::get_entry_cell_width( const inventory_entry &entry,
         size_t cell_index ) const
 {
-    size_t res = utf8_width( preset.get_cell_text( entry, cell_index ), true );
+    size_t res = utf8_width( entry.get_entry_cell_cache( preset ).text[cell_index], true );
 
     if( cell_index == 0 ) {
         res += get_entry_indent( entry );
@@ -939,11 +931,9 @@ size_t inventory_column::get_cells_width() const
     } );
 }
 
-void inventory_column::set_filter( const std::string &filter )
+void inventory_column::set_filter( const std::string &/* filter */ )
 {
-    entries_cell_cache.clear();
     paging_is_valid = false;
-    prepare_paging( filter );
 }
 
 void selection_column::set_filter( const std::string & )
@@ -952,44 +942,41 @@ void selection_column::set_filter( const std::string & )
     inventory_column::set_filter( std::string() );
 }
 
-inventory_column::entry_cell_cache_t inventory_column::make_entry_cell_cache(
-    const inventory_entry &entry ) const
+void inventory_entry::make_entry_cell_cache(
+    inventory_selector_preset const &preset, bool update_only ) const
 {
-    entry_cell_cache_t result;
-
-    result.assigned = true;
-    result.color = preset.get_color( entry );
-    entry.cache_denial( preset );
-    result.denial = &*entry.denial;
-    result.text.resize( preset.get_cells_count() );
+    if( update_only && !entry_cell_cache ) {
+        return;
+    }
+    entry_cell_cache.emplace( entry_cell_cache_t{
+        preset.get_color( *this ),
+        { preset.get_cells_count(), std::string() } } );
 
     for( size_t i = 0, n = preset.get_cells_count(); i < n; ++i ) {
-        result.text[i] = preset.get_cell_text( entry, i );
+        entry_cell_cache->text[i] = preset.get_cell_text( *this, i );
     }
-
-    return result;
 }
 
-const inventory_column::entry_cell_cache_t &inventory_column::get_entry_cell_cache(
-    size_t index ) const
+void inventory_entry::reset_entry_cell_cache() const
 {
-    cata_assert( index < entries.size() );
-
-    if( entries_cell_cache.size() < entries.size() ) {
-        entries_cell_cache.resize( entries.size() );
-    }
-
-    if( !entries_cell_cache[index].assigned ) {
-        entries_cell_cache[index] = make_entry_cell_cache( entries[index] );
-    }
-
-    return entries_cell_cache[index];
+    entry_cell_cache.reset();
 }
 
-void inventory_column::set_width( const size_t new_width,
-                                  const std::vector<inventory_column *> &all_columns )
+const inventory_entry::entry_cell_cache_t &inventory_entry::get_entry_cell_cache(
+    inventory_selector_preset const &preset ) const
 {
-    reset_width( all_columns );
+
+    if( !entry_cell_cache ) {
+        make_entry_cell_cache( preset, false );
+        cache_denial( preset );
+        cata_assert( entry_cell_cache.has_value() );
+    }
+
+    return *entry_cell_cache;
+}
+
+void inventory_column::set_width( const size_t new_width )
+{
     int width_gap = get_width() - new_width;
     // Now adjust the width if we must
     while( width_gap != 0 ) {
@@ -1042,8 +1029,7 @@ void inventory_column::expand_to_fit( inventory_entry &entry, bool with_denial )
     }
 
     entry.cache_denial( preset );
-
-    // Don't use cell cache here since the entry may not yet be placed into the vector of entries.
+    cata_assert( entry.denial.has_value() );
     const std::string &denial = *entry.denial;
 
     for( size_t i = 0, num = with_denial && denial.empty() ? cells.size() : 1; i < num; ++i ) {
@@ -1093,12 +1079,9 @@ bool inventory_column::has_available_choices() const
     if( !allows_selecting() || !activatable() ) {
         return false;
     }
-    for( size_t i = 0; i < entries.size(); ++i ) {
-        if( entries[i].is_item() && get_entry_cell_cache( i ).denial->empty() ) {
-            return true;
-        }
-    }
-    return false;
+    return std::any_of( entries.begin(), entries.end(), []( inventory_entry const & e ) {
+        return e.is_item() && e.enabled;
+    } );
 }
 
 bool inventory_column::is_selected( const inventory_entry &entry ) const
@@ -1170,12 +1153,13 @@ inventory_column::get_entries_t inventory_column::get_entries( const ffilter_t &
     return res;
 }
 
-void inventory_column::set_stack_favorite( std::vector<item_location> &locations,
+void inventory_column::set_stack_favorite( inventory_entry &entry,
         const bool favorite )
 {
-    for( item_location &loc : locations ) {
+    for( item_location &loc : entry.locations ) {
         loc->set_favorite( favorite );
     }
+    entry.make_entry_cell_cache( preset );
 }
 
 void inventory_column::set_collapsed( inventory_entry &entry, const bool collapse )
@@ -1198,6 +1182,7 @@ void inventory_column::set_collapsed( inventory_entry &entry, const bool collaps
     if( collapsed ) {
         entry.collapsed = collapse;
         paging_is_valid = false;
+        entry.make_entry_cell_cache( preset );
     }
 }
 
@@ -1219,7 +1204,7 @@ void inventory_column::on_input( const inventory_input &input )
             highlight( entries.size() - 1, scroll_direction::BACKWARD );
         } else if( input.action == "TOGGLE_FAVORITE" ) {
             inventory_entry &selected = get_highlighted();
-            set_stack_favorite( selected.locations, !selected.any_item()->is_favorite );
+            set_stack_favorite( selected, !selected.any_item()->is_favorite );
         } else if( input.action == "SHOW_HIDE_CONTENTS" ) {
             inventory_entry &selected = get_highlighted();
             selected.collapsed ? set_collapsed( selected, false ) : set_collapsed( selected, true );
@@ -1246,7 +1231,6 @@ inventory_entry *inventory_column::add_entry( const inventory_entry &entry )
         debugmsg( "Tried to add a duplicate entry." );
         return nullptr;
     }
-    entries_cell_cache.clear();
     paging_is_valid = false;
     if( entry.is_item() ) {
         item_location entry_item = entry.locations.front();
@@ -1392,6 +1376,7 @@ void inventory_column::collate()
 
                     outer->chevron = true;
                     set_collapsed( *outer, true );
+                    outer->reset_entry_cell_cache(); // needed when switching UI modes
                 }
                 e->collation_meta = outer->collation_meta;
                 std::copy( e->locations.begin(), e->locations.end(),
@@ -1443,7 +1428,8 @@ void inventory_column::prepare_paging( const std::string &filter )
                ( filter_fn( it ) &&
                  ( ( !filter.empty() && !it.is_collation_entry() ) || !it.is_hidden( hide_entries_override ) ) );
     };
-    const auto is_not_visible = [&is_visible]( inventory_entry const & it ) {
+    const auto is_not_visible = [&is_visible, this]( inventory_entry const & it ) {
+        it.cache_denial( preset ); // do it here since we're looping over all visible entries anyway
         return !is_visible( it );
     };
 
@@ -1451,13 +1437,6 @@ void inventory_column::prepare_paging( const std::string &filter )
     move_if( entries_hidden, entries, is_visible );
     // remove entries hidden by SHOW_HIDE_CONTENTS
     move_if( entries, entries_hidden, is_not_visible );
-
-    // Recalculate all the widths.
-    // This must go AFTER moving the hidden entries so that
-    // cell widths are calculated with up-to-date visible entries
-    for( inventory_entry *e : get_entries( always_yes ) ) {
-        expand_to_fit( *e );
-    }
 
     // Then sort them with respect to categories
     std::stable_sort( entries.begin(), entries.end(),
@@ -1487,7 +1466,6 @@ void inventory_column::prepare_paging( const std::string &filter )
         }
         current_category = iter->get_category_ptr();
         iter = entries.insert( iter, inventory_entry( current_category ) );
-        expand_to_fit( *iter );
     }
     // Determine the new height.
     entries_per_page = height;
@@ -1507,7 +1485,6 @@ void inventory_column::prepare_paging( const std::string &filter )
             }
         }
     }
-    entries_cell_cache.clear();
     paging_is_valid = true;
     // Select the uppermost possible entry
     const size_t ind = highlighted_index >= entries.size() ? 0 : highlighted_index;
@@ -1518,7 +1495,6 @@ void inventory_column::clear()
 {
     entries.clear();
     entries_hidden.clear();
-    entries_cell_cache.clear();
     paging_is_valid = false;
 }
 
@@ -1596,9 +1572,9 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
     if( !visible() ) {
         return;
     }
-    const auto available_cell_width = [ this ]( size_t index, size_t cell_index ) {
+    const auto available_cell_width = [ this ]( inventory_entry const & entry, size_t cell_index ) {
         const size_t displayed_width = cells[cell_index].current_width;
-        const size_t real_width = get_entry_cell_width( index, cell_index );
+        const size_t real_width = get_entry_cell_width( entry, cell_index );
 
         return displayed_width > real_width ? displayed_width - real_width : 0;
     };
@@ -1611,7 +1587,7 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
         if( !entry ) {
             continue;
         }
-        const inventory_column::entry_cell_cache_t &entry_cell_cache = get_entry_cell_cache( index );
+        const inventory_entry::entry_cell_cache_t &entry_cell_cache = entry.get_entry_cell_cache( preset );
 
         int x1 = p.x + get_entry_indent( entry );
         int x2 = p.x + std::max( static_cast<int>( reserved_width - get_cells_width() ), 0 );
@@ -1631,11 +1607,12 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
             }
         }
 
-        const std::string &denial = *entry_cell_cache.denial;
+        cata_assert( entry.denial.has_value() );
+        const std::string &denial = *entry.denial;
 
         if( !denial.empty() ) {
             const size_t max_denial_width = std::max( static_cast<int>( get_width() - ( min_denial_gap +
-                                            get_entry_cell_width( index, 0 ) ) ), 0 );
+                                            get_entry_cell_width( entry, 0 ) ) ), 0 );
             const size_t denial_width = std::min( max_denial_width, static_cast<size_t>( utf8_width( denial,
                                                   true ) ) );
 
@@ -1667,9 +1644,9 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
             if( text_width > available_width ) {
                 // See if we can steal some of the needed width from an adjacent cell
                 if( cell_index == 0 && count >= 2 ) {
-                    available_width += available_cell_width( index, 1 );
+                    available_width += available_cell_width( entry, 1 );
                 } else if( cell_index > 0 ) {
-                    available_width += available_cell_width( index, cell_index - 1 );
+                    available_width += available_cell_width( entry, cell_index - 1 );
                 }
                 text_width = std::min( text_width, available_width );
             }
@@ -2193,8 +2170,8 @@ void inventory_selector::prepare_layout( size_t client_width, size_t client_heig
     const bool initial = get_active_column().get_highlighted_index() == static_cast<size_t>( -1 );
     for( inventory_column *&elem : columns ) {
         elem->set_height( client_height );
-        elem->reset_width( columns );
         elem->prepare_paging( filter );
+        elem->reset_width( columns );
     }
 
     // Handle screen overflow
@@ -2206,7 +2183,7 @@ void inventory_selector::prepare_layout( size_t client_width, size_t client_heig
     // the available with -> expand it
     auto visible_columns = get_visible_columns();
     if( visible_columns.size() == 1 && are_columns_centered( client_width ) ) {
-        visible_columns.front()->set_width( client_width, columns );
+        visible_columns.front()->set_width( client_width );
     }
 
     reassign_custom_invlets();
@@ -2547,14 +2524,9 @@ int inventory_selector::query_count()
 
 void inventory_selector::set_filter( const std::string &str )
 {
-    prepare_layout();
     filter = str;
     for( inventory_column *const elem : columns ) {
         elem->set_filter( filter );
-    }
-    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
-    if( current_ui ) {
-        current_ui->mark_resize();
     }
 }
 
@@ -2811,8 +2783,10 @@ void inventory_selector::on_input( const inventory_input &input )
         }
     } else if( input.action == "INVENTORY_FILTER" ) {
         query_set_filter();
+        ui.lock()->mark_resize();
     } else if( input.action == "RESET_FILTER" ) {
         set_filter( "" );
+        ui.lock()->mark_resize();
     } else if( input.action == "TOGGLE_SKIP_UNSELECTABLE" ) {
         toggle_skip_unselectable();
     } else {

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -646,7 +646,7 @@ void item_contents::read_mods( const item_contents &read_input )
 }
 
 void item_contents::combine( const item_contents &read_input, const bool convert,
-                             const bool into_bottom )
+                             const bool into_bottom, bool restack_charges )
 {
     std::vector<item> uninserted_items;
     size_t pocket_index = 0;
@@ -692,7 +692,7 @@ void item_contents::combine( const item_contents &read_input, const bool convert
 
             for( const item *it : pocket.all_items_top() ) {
                 const ret_val<item_pocket::contain_code> inserted = current_pocket_iter->insert_item( *it,
-                        into_bottom );
+                        into_bottom, restack_charges );
                 if( !inserted.success() ) {
                     uninserted_items.push_back( *it );
                     debugmsg( "error: item %s cannot fit into pocket while loading: %s",

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -342,7 +342,8 @@ class item_contents
 
         // reads the items in the MOD pocket first
         void read_mods( const item_contents &read_input );
-        void combine( const item_contents &read_input, bool convert = false, bool into_bottom = false );
+        void combine( const item_contents &read_input, bool convert = false, bool into_bottom = false,
+                      bool restack_charges = true );
 
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &data );

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -252,13 +252,16 @@ class item_location::impl::item_on_map : public item_location::impl
                 return 0;
             }
 
-            item obj = *target();
-            obj = obj.split( qty );
-            if( obj.is_null() ) {
-                obj = *target();
+            item *obj = target();
+            item temp;
+            if( target()->count_by_charges() ) {
+                temp = target()->split( qty );
+                if( !temp.is_null() ) {
+                    obj = &temp;
+                }
             }
 
-            int mv = ch.item_handling_cost( obj, true, MAP_HANDLING_PENALTY );
+            int mv = ch.item_handling_cost( *obj, true, MAP_HANDLING_PENALTY );
             mv += 100 * rl_dist( ch.pos(), cur.pos() );
 
             // TODO: handle unpacking costs
@@ -396,18 +399,21 @@ class item_location::impl::item_on_person : public item_location::impl
 
             int mv = 0;
 
-            item obj = *target();
-            obj = obj.split( qty );
-            if( obj.is_null() ) {
-                obj = *target();
+            item *obj = target();
+            item temp;
+            if( target()->count_by_charges() ) {
+                temp = target()->split( qty );
+                if( !temp.is_null() ) {
+                    obj = &temp;
+                }
             }
 
             item &target_ref = *target();
             if( who->is_wielding( target_ref ) ) {
-                mv = who->item_handling_cost( obj, false, 0 );
+                mv = who->item_handling_cost( *obj, false, 0 );
             } else {
                 // then we are wearing it
-                mv = who->item_handling_cost( obj, true, INVENTORY_HANDLING_PENALTY / 2 );
+                mv = who->item_handling_cost( *obj, true, INVENTORY_HANDLING_PENALTY / 2 );
                 mv += 250;
             }
 
@@ -517,13 +523,16 @@ class item_location::impl::item_on_vehicle : public item_location::impl
                 return 0;
             }
 
-            item obj = *target();
-            obj = obj.split( qty );
-            if( obj.is_null() ) {
-                obj = *target();
+            item *obj = target();
+            item temp;
+            if( target()->count_by_charges() ) {
+                temp = target()->split( qty );
+                if( !temp.is_null() ) {
+                    obj = &temp;
+                }
             }
 
-            int mv = ch.item_handling_cost( obj, true, VEHICLE_HANDLING_PENALTY );
+            int mv = ch.item_handling_cost( *obj, true, VEHICLE_HANDLING_PENALTY );
             mv += 100 * rl_dist( ch.pos(), cur.veh.global_part_pos3( cur.part ) );
 
             // TODO: handle unpacking costs
@@ -703,13 +712,7 @@ class item_location::impl::item_in_container : public item_location::impl
                 return 0;
             }
 
-            item obj = *target();
-            obj = obj.split( qty );
-            if( obj.is_null() ) {
-                obj = *target();
-            }
-
-            const int container_mv = container->obtain_cost( *target() );
+            const int container_mv = parent_pocket()->moves();
             if( container_mv == 0 ) {
                 debugmsg( "ERROR: %s does not contain %s", container->tname(), target()->tname() );
                 return 0;

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1982,7 +1982,7 @@ std::list<item> &item_pocket::edit_contents()
 }
 
 ret_val<item_pocket::contain_code> item_pocket::insert_item( const item &it,
-        const bool into_bottom )
+        const bool into_bottom, bool restack_charges )
 {
     ret_val<item_pocket::contain_code> ret = !is_standard_type() ?
             ret_val<item_pocket::contain_code>::make_success() : can_contain( it );
@@ -1993,7 +1993,9 @@ ret_val<item_pocket::contain_code> item_pocket::insert_item( const item &it,
         } else {
             contents.push_back( it );
         }
-        restack();
+        if( restack_charges ) {
+            restack();
+        }
     }
     return ret;
 }

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -318,7 +318,8 @@ class item_pocket
         }
 
         // tries to put an item in the pocket. returns false if failure
-        ret_val<contain_code> insert_item( const item &it, bool into_bottom = false );
+        ret_val<contain_code> insert_item( const item &it, bool into_bottom = false,
+                                           bool restack_charges = true );
         /**
           * adds an item to the pocket with no checks
           * may create a new pocket

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3184,7 +3184,7 @@ void item::deserialize( const JsonObject &data )
 
         contents.read_mods( read_contents );
         update_modified_pockets();
-        contents.combine( read_contents, false, true );
+        contents.combine( read_contents, false, true, false );
 
         if( data.has_object( "contents" ) ) {
             JsonObject tested = data.get_object( "contents" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Address another (~largely academic~) bottleneck in the inventory UI
* See #64406

EDIT: this turned out to have a positive perf impact when collation is enabled so it's no longer just academic
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
for `item_location`: don't copy the target item willy-nilly when calculating obtain cost and also use the pocket shortcut
for `inventory_ui`: move cell cache to entry and remove/reorder redundant calls so that values are only calculated and cached once per execution
for `item`: don't restack charges when deserializing since they had already been stacked before serialization.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Fixing the lower-level things that made the wield UI slow. In this case that means improving `item::weight()` but I don't see a good/robust way without item backlinks. A project for later, maybe.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The inventory/wield/pickup UIs should look and function exactly the same as before. Filtering should still work (including on return in the `E`at menu), reflowing when (un)collapsing should be the same, etc.

Using the save file from #64406 and opening the `w`ield menu:
Before:

![before](https://user-images.githubusercontent.com/68240139/226481868-646d6c4d-6603-4c01-8f08-4dcce7ea0fb2.png)

After:

![after](https://user-images.githubusercontent.com/68240139/226481152-22823e31-75f4-43df-9e4e-707c52a41d2a.png)

It's still slow, but not quite enough for a coffee break anymore.

Load time of that save should be drastically faster with 7adcce0186e97b3104cb7bc73d613f0514bfc98c

In other cases, such as in my yardstick `City of the Dalles` save from other PRs, there should be no perf difference.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->