### PR TITLE
Remove cata::void_t; migrate to std::void_t

### DIFF
--- a/src/cata_type_traits.h
+++ b/src/cata_type_traits.h
@@ -1,15 +1,9 @@
 #ifndef CATA_SRC_CATA_TYPE_TRAITS_H
 #define CATA_SRC_CATA_TYPE_TRAITS_H
 
-// For some template magic in generic_factory.h, it's much easier to use void_t
-// However, C++14 does not have this, so we need our own.
-// It's nothing complex, just strip it out when C++17 comes.
 #include <type_traits>
 namespace cata
 {
-template<typename...>
-using void_t = void;
-
 // Copy constness from the first type to the second.
 // I think something similar is proposed for a future std library version, but
 // I can't find it.

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -634,18 +634,18 @@ inline void mandatory( const JsonObject &jo, const bool was_loaded, const std::s
  * Similarly, if it can use a += operator against it's own type, the non-dummy
  * handle_relative template is constructed.
  */
-template<typename T, typename = cata::void_t<>>
+template<typename T, typename = std::void_t<>>
 struct supports_proportional : std::false_type { };
 
 template<typename T>
-struct supports_proportional<T, cata::void_t<decltype( std::declval<T &>() *= std::declval<float>() )>> :
+struct supports_proportional<T, std::void_t<decltype( std::declval<T &>() *= std::declval<float>() )>> :
 std::true_type {};
 
-template<typename T, typename = cata::void_t<>>
+template<typename T, typename = std::void_t<>>
 struct supports_relative : std::false_type { };
 
 template<typename T>
-struct supports_relative < T, cata::void_t < decltype( std::declval<T &>() += std::declval<T &>() )
+struct supports_relative < T, std::void_t < decltype( std::declval<T &>() += std::declval<T &>() )
 >> : std::true_type {};
 
 // Explicitly specialize these templates for a couple types

--- a/src/mod_tracker.h
+++ b/src/mod_tracker.h
@@ -33,11 +33,11 @@ class mod_error : public std::runtime_error
 
 struct mod_tracker {
     /** Template magic to determine if the conditions above are satisfied */
-    template<typename T, typename = cata::void_t<>>
+    template<typename T, typename = std::void_t<>>
     struct has_src_member : std::false_type {};
 
     template<typename T>
-struct has_src_member<T, cata::void_t<decltype( std::declval<T &>().src.emplace_back( std::declval<T &>().id, mod_id() ) )>> :
+struct has_src_member<T, std::void_t<decltype( std::declval<T &>().src.emplace_back( std::declval<T &>().id, mod_id() ) )>> :
     std::true_type {};
 
     /** Dummy function, for if those conditions are not satisfied */


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Simplifying code and moving to standardized solutions.

Now we're in C++17 we can use `std::void_t` instead of reinventing it.

#### Describe the solution
Remove `cata::void_t`.

Migrate all uses to `std::void_t`.

#### Describe alternatives you've considered
None.

#### Testing
Compiled.

#### Additional context