### PR TITLE
Fixed windows with metal grate converting into wrong window types on sawing down the grate

### DIFF
--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -491,6 +491,87 @@
   },
   {
     "type": "terrain",
+    "id": "t_window_empty_curtains_open",
+    "name": "empty window with curtains",
+    "looks_like": "t_window_open",
+    "roof": "t_flat_roof",
+    "description": "An empty window frame consisting of planks and nails, with open curtains.  You could install a sheet of glass, or even board it up for protection.  You could also convert it into a wall if you took the time to construct it.",
+    "symbol": "0",
+    "color": "yellow",
+    "move_cost": 4,
+    "coverage": 60,
+    "flags": [
+      "TRANSPARENT",
+      "NOITEM",
+      "FLAMMABLE",
+      "SUPPORTS_ROOF",
+      "MOUNTABLE",
+      "CONNECT_WITH_WALL",
+      "PERMEABLE",
+      "SUPPORTS_ROOF"
+    ],
+    "curtain_transform": "t_window_empty",
+    "examine_action": "curtains",
+    "close": "t_window_empty_curtains_closed",
+    "bash": {
+      "str_min": 10,
+      "str_max": 70,
+      "sound": "crunch!",
+      "sound_fail": "whump!",
+      "ter_set": "t_null",
+      "items": [
+        { "item": "2x4", "count": [ 0, 5 ] },
+        { "item": "nail", "charges": [ 0, 5 ] },
+        { "item": "splinter", "count": [ 5, 10 ] },
+        { "item": "sheet", "count": 2 },
+        { "item": "stick", "count": 1 },
+        { "item": "string_36", "count": 1 }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_window_empty_curtains_closed",
+    "name": "empty window with closed curtains",
+    "looks_like": "t_curtains",
+    "roof": "t_flat_roof",
+    "description": "An empty window frame consisting of planks and nails, with closed curtains.  If you examined the curtains more closely, you could peek through the drapes or tear down everything.  You could install a sheet of glass, or even board it up for protection.  You could also convert it into a wall if you took the time to construct it.",
+    "symbol": "0",
+    "color": "yellow",
+    "move_cost": 4,
+    "coverage": 60,
+    "flags": [
+      "NOITEM",
+      "FLAMMABLE",
+      "SUPPORTS_ROOF",
+      "MOUNTABLE",
+      "CONNECT_WITH_WALL",
+      "REDUCE_SCENT",
+      "BLOCK_WIND",
+      "PERMEABLE",
+      "SUPPORTS_ROOF"
+    ],
+    "curtain_transform": "t_window_empty",
+    "open": "t_window_empty_curtains_open",
+    "examine_action": "curtains",
+    "bash": {
+      "str_min": 10,
+      "str_max": 70,
+      "sound": "crunch!",
+      "sound_fail": "whump!",
+      "ter_set": "t_null",
+      "items": [
+        { "item": "2x4", "count": [ 0, 5 ] },
+        { "item": "nail", "charges": [ 0, 5 ] },
+        { "item": "splinter", "count": [ 5, 10 ] },
+        { "item": "sheet", "count": 2 },
+        { "item": "stick", "count": 1 },
+        { "item": "string_36", "count": 1 }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "t_window_frame",
     "name": "window frame",
     "description": "A wooden window frame that has shattered glass around it.  You'll probably get hurt if you crawled through the sharp and jagged shards.  You could smash out the remaining pieces, or take your time and quietly clean them up.",
@@ -997,7 +1078,7 @@
     "type": "terrain",
     "id": "t_metal_grate_window",
     "name": "window with metal grate",
-    "description": "Metal bars made into a grate for a window.  Highly durable and will stand against any foe.",
+    "description": "Metal bars made into a grate for a glass window.  Highly durable and will stand against any foe.",
     "examine_action": "bars",
     "looks_like": "t_window_bars",
     "symbol": "#",
@@ -1005,12 +1086,12 @@
     "move_cost": 0,
     "roof": "t_flat_roof",
     "oxytorch": {
-      "result": "t_window_reinforced",
+      "result": "t_window",
       "duration": "9 seconds",
       "byproducts": [ { "item": "pipe", "count": [ 1, 12 ] }, { "item": "sheet_metal", "count": 4 } ]
     },
     "hacksaw": {
-      "result": "t_window_reinforced",
+      "result": "t_window",
       "duration": "10 minutes",
       "message": "You finish cutting the metal.",
       "byproducts": [ { "item": "pipe", "count": [ 1, 12 ] }, { "item": "sheet_metal", "count": 4 } ]
@@ -1042,20 +1123,20 @@
   {
     "type": "terrain",
     "id": "t_metal_grate_window_with_curtain",
-    "name": "window with metal grate",
-    "description": "Metal bars made into a grate for a window with a closed curtain.  Highly durable and will stand against any foe.",
+    "name": "window with metal grate and curtains",
+    "description": "Metal bars made into a grate for a glass window with a closed curtain.  Highly durable and will stand against any foe.",
     "looks_like": "t_window_bars_curtains",
     "symbol": "#",
     "color": "light_gray",
     "move_cost": 0,
     "roof": "t_flat_roof",
     "oxytorch": {
-      "result": "t_window_reinforced",
+      "result": "t_window_domestic",
       "duration": "9 seconds",
       "byproducts": [ { "item": "pipe", "count": [ 1, 12 ] }, { "item": "sheet_metal", "count": 4 } ]
     },
     "hacksaw": {
-      "result": "t_window_reinforced",
+      "result": "t_window_domestic",
       "duration": "10 minutes",
       "message": "You finish cutting the metal.",
       "byproducts": [ { "item": "pipe", "count": [ 1, 12 ] }, { "item": "sheet_metal", "count": 4 } ]
@@ -1089,8 +1170,8 @@
   {
     "type": "terrain",
     "id": "t_metal_grate_window_with_curtain_open",
-    "name": "window with metal grate",
-    "description": "Metal bars made into a grate for a window with an opened curtain.  Highly durable and will stand against any foe.",
+    "name": "window with metal grate with curtains",
+    "description": "Metal bars made into a grate for a glass window with an opened curtain.  Highly durable and will stand against any foe.",
     "looks_like": "t_window_bars_domestic",
     "symbol": "#",
     "color": "light_gray",
@@ -1108,12 +1189,12 @@
       "SUPPORTS_ROOF"
     ],
     "oxytorch": {
-      "result": "t_window_reinforced",
+      "result": "t_window_domestic",
       "duration": "9 seconds",
       "byproducts": [ { "item": "pipe", "count": [ 1, 12 ] }, { "item": "sheet_metal", "count": 4 } ]
     },
     "hacksaw": {
-      "result": "t_window_reinforced",
+      "result": "t_window_domestic",
       "duration": "10 minutes",
       "message": "You finish cutting the metal.",
       "byproducts": [ { "item": "pipe", "count": [ 1, 12 ] }, { "item": "sheet_metal", "count": 4 } ]
@@ -1139,7 +1220,7 @@
     "type": "terrain",
     "id": "t_metal_grate_window_noglass",
     "name": "window with metal grate",
-    "description": "Metal bars made into a grate for a window.  Highly durable and will stand against any foe",
+    "description": "Metal bars made into a grate for an empty window.  Highly durable and will stand against any foe",
     "examine_action": "bars",
     "looks_like": "t_window_bars",
     "symbol": "#",
@@ -1157,12 +1238,12 @@
       "SUPPORTS_ROOF"
     ],
     "oxytorch": {
-      "result": "t_window_reinforced_noglass",
+      "result": "t_window_empty",
       "duration": "9 seconds",
       "byproducts": [ { "item": "pipe", "count": [ 1, 12 ] }, { "item": "sheet_metal", "count": 4 } ]
     },
     "hacksaw": {
-      "result": "t_window_reinforced_noglass",
+      "result": "t_window_empty",
       "duration": "10 minutes",
       "message": "You finish cutting the metal.",
       "byproducts": [ { "item": "pipe", "count": [ 1, 12 ] }, { "item": "sheet_metal", "count": 4 } ]
@@ -1183,8 +1264,8 @@
   {
     "type": "terrain",
     "id": "t_metal_grate_window_with_curtain_noglass",
-    "name": "window with metal grate",
-    "description": "Metal bars made into a grate for a window with a closed curtain.  Highly durable and will stand against any foe.",
+    "name": "window with metal grate and curtains",
+    "description": "Metal bars made into a grate for an empty window frame with a closed curtain.  Highly durable and will stand against any foe.",
     "looks_like": "t_window_bars_curtains",
     "symbol": "#",
     "color": "light_gray",
@@ -1200,7 +1281,7 @@
       "SUPPORTS_ROOF"
     ],
     "hacksaw": {
-      "result": "t_window_reinforced_noglass",
+      "result": "t_window_empty_curtains_open",
       "duration": "10 minutes",
       "message": "You finish cutting the metal.",
       "byproducts": [ { "item": "pipe", "count": [ 1, 12 ] }, { "item": "sheet_metal", "count": 4 } ]
@@ -1208,7 +1289,7 @@
     "curtain_transform": "t_metal_grate_window_noglass",
     "examine_action": "curtains",
     "oxytorch": {
-      "result": "t_window_reinforced_noglass",
+      "result": "t_window_empty_curtains_open",
       "duration": "9 seconds",
       "byproducts": [ { "item": "pipe", "count": [ 1, 12 ] }, { "item": "sheet_metal", "count": 4 } ]
     },
@@ -1229,8 +1310,8 @@
   {
     "type": "terrain",
     "id": "t_metal_grate_window_with_curtain_open_noglass",
-    "name": "window with metal grate",
-    "description": "Metal bars made into a grate for a window with an opened curtain.  Highly durable and will stand against any foe.",
+    "name": "window with metal grate and curtains",
+    "description": "Metal bars made into a grate for an empty window frame with an opened curtain.  Highly durable and will stand against any foe.",
     "looks_like": "t_window_bars_domestic",
     "symbol": "#",
     "color": "light_gray",
@@ -1247,12 +1328,12 @@
       "THIN_OBSTACLE"
     ],
     "oxytorch": {
-      "result": "t_window_reinforced_noglass",
+      "result": "t_window_empty_curtains_open",
       "duration": "9 seconds",
       "byproducts": [ { "item": "pipe", "count": [ 1, 12 ] }, { "item": "sheet_metal", "count": 4 } ]
     },
     "hacksaw": {
-      "result": "t_window_reinforced_noglass",
+      "result": "t_window_empty_curtains_open",
       "duration": "10 minutes",
       "message": "You finish cutting the metal.",
       "byproducts": [ { "item": "pipe", "count": [ 1, 12 ] }, { "item": "sheet_metal", "count": 4 } ]
@@ -1261,7 +1342,7 @@
     "examine_action": "curtains",
     "close": "t_metal_grate_window_with_curtain_noglass",
     "deconstruct": {
-      "ter_set": "t_window_reinforced_noglass",
+      "ter_set": "t_window_empty",
       "items": [
         { "item": "pipe", "count": [ 10, 12 ] },
         { "item": "sheet_metal_small", "count": [ 30, 40 ] },

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -1170,7 +1170,7 @@
   {
     "type": "terrain",
     "id": "t_metal_grate_window_with_curtain_open",
-    "name": "window with metal grate with curtains",
+    "name": "window with metal grate and curtains",
     "description": "Metal bars made into a grate for a glass window with an opened curtain.  Highly durable and will stand against any foe.",
     "looks_like": "t_window_bars_domestic",
     "symbol": "#",


### PR DESCRIPTION
#### Summary
Bugfixes "Fixed windows with metal grate converting into wrong window types on sawing down the grate"

#### Purpose of change
* Closes #64217.

#### Describe the solution
- Added empty window frame with open and closed curtains. 
- Fixed windows with metal grate converting to wrong window types on sawing down the grate. 
- Updated names and descriptions of windows with metal grates to exclude ambiguity.

#### Describe alternatives you've considered
None.

#### Testing
- Debug spawned all five types of metal grates and saw down the grates from all of them to check what they'll convert into.
- Open and closed curtains on empty frame with curtains. Tore down the curtains.

#### Additional context
None.