### PR TITLE
Raise minimum supported macOS version to 10.13

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -148,7 +148,7 @@ jobs:
             ccache_limit: 4G
 
           - compiler: clang++
-            os: macos-10.15
+            os: macos-12
             release: 0
             cmake: 0
             native: osx
@@ -156,7 +156,7 @@ jobs:
             tiles: 1
             sound: 1
             localize: 1
-            title: Clang 12, macOS 10.15, Tiles, Sound, UBSan
+            title: Clang 14, macOS 12, Tiles, Sound, UBSan
             # ~880MB ccache-compressed in a clean build
             # ~100 compressed
             # observed usage: 3.85GB -> 500MB

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: OSX Curses x64
-            os: macos-10.15
+            os: macos-12
             mxe: none
             tiles: 0
             sound: 0
@@ -151,7 +151,7 @@ jobs:
             ext: dmg
             content: application/x-apple-diskimage
           - name: OSX Tiles x64
-            os: macos-10.15
+            os: macos-12
             mxe: none
             tiles: 1
             sound: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,7 @@ jobs:
       - name: Build CDDA (osx)
         if: runner.os == 'macOS'
         run: |
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 OSX_MIN=10.12 dmgdist
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 OSX_MIN=10.13 dmgdist
           mv Cataclysm.dmg cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Set up JDK 8 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,8 @@
 # Win32 (non-Cygwin)
 #   Run: make NATIVE=win32
 # OS X
-#   Run: make NATIVE=osx OSX_MIN=10.12
-#     It is highly recommended to supply OSX_MIN > 10.11
-#     otherwise optimizations are automatically disabled with -O0
+#   Run: make NATIVE=osx OSX_MIN=10.13
+#     The minimum OSX_MIN version supported is 10.13
 
 # Build types:
 # Debug (no optimizations)

--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -65,7 +65,7 @@ else
     # The OSX_MIN version here should match that used in release builds so that
     # CI detects issues that will affect releases.  It doesn't affect builds on
     # other platforms.
-    make -j "$num_jobs" RELEASE=1 CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 OSX_MIN=10.12
+    make -j "$num_jobs" RELEASE=1 CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 OSX_MIN=10.13
 fi
 
 # vim:tw=0

--- a/doc/COMPILING/COMPILER_SUPPORT.md
+++ b/doc/COMPILING/COMPILER_SUPPORT.md
@@ -9,9 +9,8 @@ and back to those shipping in any supported version of a popular distribution
 or relevant development environment, including Ubuntu, Debian, MSYS, and XCode.
 
 Since macOS can be harder to update we have active developers and users on
-unsupported versions of macOS we would like to support.  Newer macOS cannot
-compile for older macOS, so to support a reasonable number of users we aim to
-support at least 95% of users by macOS market share.
+unsupported versions of macOS we would like to support.  To support a reasonable
+number of users we aim to support at least 95% of users by macOS market share.
 
 At the time of writing:
 * Bionic is about to end general support, so we aim to support the next oldest
@@ -32,7 +31,7 @@ In practice, compiler support is often determined by what is covered in our
 automated testing.
 
 At time of writing, the oldest relevant compiler is XCode 10.1, the latest
-supported on macOS 10.13.
+supported on macOS 10.13, which is based on LLVM 6.
 
 With gcc 9.3, clang 10, and XCode 10.1 we can get all the C++17 language
 features and [most but not all of the C++17 library

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -530,7 +530,7 @@ The Cataclysm source is compiled using `make`.
 ### Make options
 
 * `NATIVE=osx` build for OS X. Required for all Mac builds. This is automatically set if compiling natively on macOS.
-* `OSX_MIN=version` sets `-mmacosx-version-min=` (for OS X > 10.5 set it to 10.6 or higher); omit for 10.5. 10.12 or higher is highly recommended (see ISSUES below). The default value is current system version.
+* `OSX_MIN=version` sets `-mmacosx-version-min=version`, 10.13 or higher is required. The default value is current system version.
 * `TILES=1` build the SDL version with graphical tiles (and graphical ASCII); omit to build with `ncurses`.
 * `SOUND=1` - if you want sound; this requires `TILES=1` and the additional dependencies mentioned above.
 * `FRAMEWORK=1` (tiles only) link to SDL libraries under the OS X Frameworks folders; omit to use SDL shared libraries from Homebrew or Macports.
@@ -591,21 +591,11 @@ sudo pip install dmgbuild pyobjc-framework-Quartz
 
 Once `dmgbuild` is installed, you will be able to use the `dmgdist` target like this. The use of `USE_HOME_DIR=1` is important here because it will allow for an easy upgrade of the game while keeping the user config and his saves in his home directory.
 
-    `make dmgdist NATIVE=osx OSX_MIN=10.12 RELEASE=1 TILES=1 FRAMEWORK=1 LOCALIZE=0 CLANG=1 USE_HOME_DIR=1`
+    `make dmgdist NATIVE=osx OSX_MIN=10.13 RELEASE=1 TILES=1 FRAMEWORK=1 LOCALIZE=0 CLANG=1 USE_HOME_DIR=1`
 
 You should see a `Cataclysm.dmg` file.
 
 ## Mac OS X Troubleshooting
-
-### ISSUE: crash on startup due to libint.8.dylib aborting
-
-If you're compiling on Mountain Lion or above, it won't be possible to run successfully on older OS X versions due to libint.8 / pthreads version issue.
-
-From https://wiki.gnome.org/GTK+/OSX/Building:
-
-> "There's another issue with building on Lion or Mountain Lion using either "native" or the 10.7 SDK: Apple has updated the pthreads implementation to provide recursive locking. This would be good except that Gettext's libintl uses this and if the pthreads implementation doesn't provide it it fabricates its own. Since the Lion pthreads does provide it, libintl links the provided function and then crashes when you try to run it against an older version of the library. The simplest solution is to specify the 10.6 SDK when building on Lion, but that won't work on Mountain Lion, which doesn't include it. See below for how to install and use XCode 3 on Lion and later for building applications compatible with earlier versions of OSX."
-
-Workaround: install XCode 3 like that article describes, or disable localization support in Cataclysm so gettext/libint are not dependencies. Or else simply don't support OS X versions below 10.7.
 
 ### ISSUE: Colors don't show up correctly
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
```
Error: src/vpart_position.h:126:34: error: 'value' is unavailable: introduced in macOS 10.13
            return has_value() ? value().get_label() : std::nullopt;
                                 ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/optional:950:33: note: 'value' has been explicitly marked unavailable here
    constexpr value_type const& value() const&
                                ^
1 error generated.
```
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
* Update documentation to claim macOS >= 10.13 is supported
* Build with latest Xcode on macOS 12

Currently our GitHub Actions workflow runs on macOS 10.15 and uses Xcode 12.4. It claims `std::optional` is available on macOS 10.14 or later. But when I compile locally on macOS 12 with Xcode 14.2, it says `std::optional` is available on macOS 10.13 or later.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->