### PR TITLE
Implement option to display item health bars and item health descriptions at the same time

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6428,10 +6428,12 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     // for portions of string that have <color_ etc in them, this aims to truncate the whole string correctly
     unsigned int truncate_override = 0;
 
+    const std::string item_health_option = get_option<std::string>( "ITEM_HEALTH" );
+    const bool show_bars  = item_health_option == "both" || item_health_option == "bars";
     if( ( damage() != 0 || ( degradation() > 0 && degradation() >= max_damage() / 5 ) ||
-          ( get_option<bool>( "ITEM_HEALTH_BAR" ) && is_armor() ) ) && !is_null() && with_prefix ) {
+          ( show_bars  && is_armor() ) ) && !is_null() && with_prefix ) {
         damtext += durability_indicator();
-        if( get_option<bool>( "ITEM_HEALTH_BAR" ) ) {
+        if( show_bars ) {
             // get the utf8 width of the tags
             truncate_override = utf8_width( damtext, false ) - utf8_width( damtext, true );
         }
@@ -8825,43 +8827,62 @@ std::string item::damage_symbol() const
 
 std::string item::durability_indicator( bool include_intact ) const
 {
-    std::string outputstring;
-
+    const std::string item_health_option = get_option<std::string>( "ITEM_HEALTH" );
+    const bool show_bars_only = item_health_option == "bars";
+    const bool show_description_only = item_health_option == "descriptions";
+    const bool show_both = item_health_option == "both";
+    const bool show_bars = show_both || show_bars_only;
+    const bool show_description = show_both || show_description_only;
+    std::string bars;
+    std::string description;
+    if( show_bars ) {
+        bars = colorize( damage_symbol(), damage_color() ) + degradation_symbol() + "\u00A0";
+    }
     if( damage() < 0 ) {
-        if( get_option<bool>( "ITEM_HEALTH_BAR" ) ) {
-            outputstring = colorize( damage_symbol(), damage_color() ) + degradation_symbol() + "\u00A0";
-        } else if( is_gun() ) {
-            outputstring = pgettext( "damage adjective", "accurized " );
-        } else {
-            outputstring = pgettext( "damage adjective", "reinforced " );
+        if( show_description ) {
+            if( is_gun() ) {
+                description = pgettext( "damage adjective", "accurized " );
+            } else {
+                description = pgettext( "damage adjective", "reinforced " );
+            }
         }
-    } else if( has_flag( flag_CORPSE ) ) {
+        if( show_bars_only ) {
+            return bars;
+        }
+        if( show_description_only ) {
+            return description;
+        }
+        return bars + description;
+    }
+    if( has_flag( flag_CORPSE ) ) {
         if( damage() > 0 ) {
             switch( damage_level() ) {
                 case 1:
-                    outputstring = pgettext( "damage adjective", "bruised " );
-                    break;
+                    return pgettext( "damage adjective", "bruised " );
                 case 2:
-                    outputstring = pgettext( "damage adjective", "damaged " );
-                    break;
+                    return pgettext( "damage adjective", "damaged " );
                 case 3:
-                    outputstring = pgettext( "damage adjective", "mangled " );
-                    break;
+                    return pgettext( "damage adjective", "mangled " );
                 default:
-                    outputstring = pgettext( "damage adjective", "pulped " );
-                    break;
+                    return pgettext( "damage adjective", "pulped " );
             }
         }
-    } else if( get_option<bool>( "ITEM_HEALTH_BAR" ) ) {
-        outputstring = colorize( damage_symbol(), damage_color() ) + degradation_symbol() + "\u00A0";
-    } else {
-        outputstring = string_format( "%s ", get_base_material().dmg_adj( damage_level() ) );
-        if( include_intact && outputstring == " " ) {
-            outputstring = _( "fully intact " );
+    }
+    if( show_bars_only ) {
+        return bars;
+    }
+    description = string_format( "%s ", get_base_material().dmg_adj( damage_level() ) );
+    if( description == " " ) {
+        if( include_intact ) {
+            description = _( "fully intact " );
+        } else {
+            description = "";
         }
     }
-
-    return outputstring;
+    if( show_description_only ) {
+        return description;
+    }
+    return bars + description;
 }
 
 const std::set<itype_id> &item::repaired_with() const

--- a/src/item.h
+++ b/src/item.h
@@ -1406,10 +1406,13 @@ class item : public visitable
         std::string damage_symbol() const;
 
         /**
-         * Provides a prefix for the durability state of the item. with ITEM_HEALTH_BAR enabled,
-         * returns a symbol with color tag already applied. Otherwise, returns an adjective.
+         * Provides a prefix for the durability state of the item.
+         * With ITEM_HEALTH set to:
+         *     "bars": returns a symbol with color tag already applied.
+         *     "descriptions": returns an adjective.
+         *     "both": returns a symbol as well as an adjective.
          * if include_intact is true, this provides a string for the corner case of a player
-         * with ITEM_HEALTH_BAR disabled, but we need still a string for some reason.
+         *     with ITEM_HEALTH set to "descriptions", but we need still a string for some reason.
          */
         std::string durability_indicator( bool include_intact = false ) const;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2008,11 +2008,14 @@ void options_manager::add_options_interface()
     },
     "favorites" );
 
-    add( "ITEM_HEALTH_BAR", "interface", to_translation( "Show item health bars" ),
+    add( "ITEM_HEALTH", "interface", to_translation( "Show item health" ),
          // NOLINTNEXTLINE(cata-text-style): one space after "etc."
-         to_translation( "If true, show item health bars instead of reinforced, scratched etc. text." ),
-         true
-       );
+    to_translation( "Show item health bars, descriptions like reinforced, scratched etc. or both." ), {
+        { "bars", to_translation( "Bars" ) },
+        { "descriptions", to_translation( "Descriptions" ) },
+        { "both", to_translation( "Both" ) }
+    },
+    "bars" );
 
     add( "ITEM_SYMBOLS", "interface", to_translation( "Show item symbols" ),
          to_translation( "If true, show item symbols in inventory and pick up menu." ),

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -308,8 +308,8 @@ TEST_CASE( "item health or damage bar", "[item][tname][health][damage]" )
         REQUIRE( shirt.is_armor() );
         REQUIRE( deg_test.type->category_force == item_category_veh_parts );
 
-        // Ensure the health bar option is enabled
-        override_option opt( "ITEM_HEALTH_BAR", "true" );
+        // Ensure the item health option is set to bars
+        override_option opt( "ITEM_HEALTH", "bars" );
 
         // Damage bar uses a scale of 0 `||` to 4 `XX`, in increments of 25%
         int dam25 = shirt.max_damage() / 4;
@@ -419,17 +419,146 @@ TEST_CASE( "item health or damage bar", "[item][tname][health][damage]" )
         }
     }
 
-    GIVEN( "ITEM_HEALTH_BAR option is disabled" ) {
-        override_option opt( "ITEM_HEALTH_BAR", "false" );
+    GIVEN( "ITEM_HEALTH option set to 'desc'" ) {
+        override_option opt( "ITEM_HEALTH", "descriptions" );
+        item shirt( "longshirt" );
+        item corpse( "corpse" );
+        REQUIRE( shirt.is_armor() );
+        int dam25 = shirt.max_damage() / 4;
 
-        THEN( "clothing health bars are hidden" ) {
-            item shirt( "longshirt" );
-            item deg_test( "test_baseball" );
-            REQUIRE( shirt.is_armor() );
-            REQUIRE( deg_test.type->category_force == item_category_veh_parts );
+        WHEN( "it is undamaged" ) {
+            shirt.set_damage( 0 );
+            REQUIRE( shirt.damage() == 0 );
+            REQUIRE( shirt.damage_level() == 0 );
 
-            CHECK( shirt.tname() == "long-sleeved shirt (poor fit)" );
-            CHECK( deg_test.tname() == "baseball" );
+            corpse.set_damage( 0 );
+            REQUIRE( corpse.damage() == 0 );
+            REQUIRE( corpse.damage_level() == 0 );
+
+            THEN( "it appears undamaged" ) {
+                CHECK( shirt.tname() == "long-sleeved shirt (poor fit)" );
+                CHECK( corpse.tname() == "corpse of a human (fresh)" );
+            }
+        }
+
+        WHEN( "is is one-quarter damaged" ) {
+            shirt.set_damage( dam25 );
+            REQUIRE( shirt.damage() == dam25 );
+            REQUIRE( shirt.damage_level() == 1 );
+
+            corpse.set_damage( dam25 );
+            REQUIRE( corpse.damage() == dam25 );
+            REQUIRE( corpse.damage_level() == 1 );
+
+            THEN( "it appears slightly damaged" ) {
+                CHECK( shirt.tname() == "ripped long-sleeved shirt (poor fit)" );
+                CHECK( corpse.tname() == "bruised corpse of a human (fresh)" );
+            }
+        }
+
+        WHEN( "it is half damaged" ) {
+            shirt.set_damage( dam25 * 2 );
+            REQUIRE( shirt.damage() == dam25 * 2 );
+            REQUIRE( shirt.damage_level() == 2 );
+
+            corpse.set_damage( dam25 * 2 );
+            REQUIRE( corpse.damage() == dam25 * 2 );
+            REQUIRE( corpse.damage_level() == 2 );
+
+
+            THEN( "it appears moderately damaged" ) {
+                CHECK( shirt.tname() == "torn long-sleeved shirt (poor fit)" );
+                CHECK( corpse.tname() == "damaged corpse of a human (fresh)" );
+            }
+        }
+
+        WHEN( "it is three-quarters damaged" ) {
+            shirt.set_damage( dam25 * 3 );
+            REQUIRE( shirt.damage() == dam25 * 3 );
+            REQUIRE( shirt.damage_level() == 3 );
+
+            corpse.set_damage( dam25 * 3 );
+            REQUIRE( corpse.damage() == dam25 * 3 );
+            REQUIRE( corpse.damage_level() == 3 );
+
+            THEN( "it appears heavily damaged" ) {
+                CHECK( shirt.tname() == "shredded long-sleeved shirt (poor fit)" );
+                CHECK( corpse.tname() == "mangled corpse of a human (fresh)" );
+            }
+        }
+
+        WHEN( "it is totally damaged" ) {
+            shirt.set_damage( dam25 * 4 );
+            REQUIRE( shirt.damage() == dam25 * 4 );
+            REQUIRE( shirt.damage_level() == 4 );
+
+            corpse.set_damage( dam25 * 4 );
+            REQUIRE( corpse.damage() == dam25 * 4 );
+            REQUIRE( corpse.damage_level() == 4 );
+
+            THEN( "it appears almost destroyed" ) {
+                CHECK( shirt.tname() == "tattered long-sleeved shirt (poor fit)" );
+                CHECK( corpse.tname() == "pulped corpse of a human (fresh)" );
+            }
+        }
+    }
+
+    GIVEN( "ITEM_HEALTH option set to 'both'" ) {
+        override_option opt( "ITEM_HEALTH", "both" );
+        item shirt( "longshirt" );
+        REQUIRE( shirt.is_armor() );
+        int dam25 = shirt.max_damage() / 4;
+
+        WHEN( "it is undamaged" ) {
+            shirt.set_damage( 0 );
+            REQUIRE( shirt.damage() == 0 );
+            REQUIRE( shirt.damage_level() == 0 );
+
+            THEN( "it appears undamaged" ) {
+                CHECK( shirt.tname() == "<color_c_light_green>||</color>\u00A0long-sleeved shirt (poor fit)" );
+            }
+        }
+
+        WHEN( "is is one-quarter damaged" ) {
+            shirt.set_damage( dam25 );
+            REQUIRE( shirt.damage() == dam25 );
+            REQUIRE( shirt.damage_level() == 1 );
+
+            THEN( "it appears slightly damaged" ) {
+                CHECK( shirt.tname() == "<color_c_yellow>|\\</color>\u00A0ripped long-sleeved shirt (poor fit)" );
+            }
+        }
+
+        WHEN( "it is half damaged" ) {
+            shirt.set_damage( dam25 * 2 );
+            REQUIRE( shirt.damage() == dam25 * 2 );
+            REQUIRE( shirt.damage_level() == 2 );
+
+            THEN( "it appears moderately damaged" ) {
+                CHECK( shirt.tname() == "<color_c_light_red>|.</color>\u00A0torn long-sleeved shirt (poor fit)" );
+            }
+        }
+
+        WHEN( "it is three-quarters damaged" ) {
+            shirt.set_damage( dam25 * 3 );
+            REQUIRE( shirt.damage() == dam25 * 3 );
+            REQUIRE( shirt.damage_level() == 3 );
+
+            THEN( "it appears heavily damaged" ) {
+                CHECK( shirt.tname() ==
+                       "<color_c_magenta>\\.</color>\u00A0shredded long-sleeved shirt (poor fit)" );
+            }
+        }
+
+        WHEN( "it is totally damaged" ) {
+            shirt.set_damage( dam25 * 4 );
+            REQUIRE( shirt.damage() == dam25 * 4 );
+            REQUIRE( shirt.damage_level() == 4 );
+
+            THEN( "it appears almost destroyed" ) {
+                CHECK( shirt.tname() ==
+                       "<color_c_dark_gray>XX</color>\u00A0tattered long-sleeved shirt (poor fit)" );
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Implement option to display item health bars and item health descriptions at the same time"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Fixes #63609

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- Added a new option "ITEM_HEALTH" (string) to replace the existing "ITEM_HEALTH_BAR" (bool) one (let me know if there's a way to migrate the player's existing ITEM_HEALTH_BAR value over to the newly created option).
- Tweaked all uses of the ITEM_HEALTH_BAR option to use the ITEM_HEALTH option instead and change the logic accordingly.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

None.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

- Spawned a bunch of soldier zombies, killed them through the debug menu, looked at the items (clothing, guns) they dropped and confirmed that they appeared as expected when using the three different options.
- Shot some zombies and ensured that the corpses appeared as expected (bruised, etc.) then pulped them and noted that the corpses were described appropriately.
- Accurized a M1911 and noted that it showed up as expected with the three options. 
- Looked at my own inventory of fresh items checked them out
- Wrote some tests and fixed existing ones. 
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

"bars" option selected:
![WindowsTerminal_yd5d3j4pFu](https://user-images.githubusercontent.com/2420411/226689104-b4c7d6ff-7ec4-4561-a6a9-6349cd655e97.png)

"descriptions" option selected:
![WindowsTerminal_9zSeM3WECB](https://user-images.githubusercontent.com/2420411/226689085-fa5fc6f8-d61b-4128-a380-4d443f8e3c55.png)

"both" option selected:
![WindowsTerminal_OzO26aRSKN](https://user-images.githubusercontent.com/2420411/226689148-757943f1-2413-4bb2-909a-ac9ce1f7461d.png)
