### PR TITLE
Timber!

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7785,12 +7785,24 @@
   },
   {
     "type": "construction",
-    "id": "constr_place_lumber",
-    "group": "place_lumber",
+    "id": "constr_gather_timber",
+    "group": "gather_timber",
+    "category": "OTHER",
+    "required_skills": [ [ "survival", 0 ] ],
+    "time": "10 m",
+    "qualities": [ [ { "id": "TREE_CUTTING", "level": 1 } ] ],
+    "byproducts": [ { "item": "timber", "charges": 1 } ],
+    "pre_terrain": "t_trunk",
+    "post_terrain": "t_trunk"
+  },
+  {
+    "type": "construction",
+    "id": "constr_place_timber",
+    "group": "place_timber",
     "category": "OTHER",
     "required_skills": [ [ "fabrication", 0 ] ],
     "time": "15 s",
-    "components": [ [ [ "lumber", 1 ] ] ],
+    "components": [ [ [ "timber", 1 ] ] ],
     "pre_special": "check_empty",
     "dark_craftable": true,
     "post_terrain": "t_trunk",
@@ -7798,13 +7810,13 @@
   },
   {
     "type": "construction",
-    "id": "constr_stack_lumber",
-    "group": "build_stack_lumber",
+    "id": "constr_stack_timber",
+    "group": "build_stack_timber",
     "category": "FURN",
     "required_skills": [ [ "fabrication", 2 ], [ "survival", 1 ] ],
     "time": "10 m",
     "components": [ [ [ "lumber", 4 ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_6", 2 ] ] ],
     "pre_special": "check_empty",
-    "post_terrain": "f_stack_lumber"
+    "post_terrain": "f_stack_timber"
   }
 ]

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7815,7 +7815,7 @@
     "category": "FURN",
     "required_skills": [ [ "fabrication", 2 ], [ "survival", 1 ] ],
     "time": "10 m",
-    "components": [ [ [ "lumber", 4 ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_6", 2 ] ] ],
+    "components": [ [ [ "timber", 4 ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_6", 2 ] ] ],
     "pre_special": "check_empty",
     "post_terrain": "f_stack_timber"
   }

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7792,8 +7792,8 @@
     "time": "10 m",
     "qualities": [ [ { "id": "TREE_CUTTING", "level": 1 } ] ],
     "byproducts": [ { "item": "timber", "charges": 1 } ],
-    "pre_terrain": "t_trunk",
-    "post_terrain": "t_trunk"
+    "pre_terrain": "f_trunk",
+    "post_terrain": "f_null"
   },
   {
     "type": "construction",
@@ -7805,7 +7805,7 @@
     "components": [ [ [ "timber", 1 ] ] ],
     "pre_special": "check_empty",
     "dark_craftable": true,
-    "post_terrain": "t_trunk",
+    "post_terrain": "f_trunk",
     "activity_level": "LIGHT_EXERCISE"
   },
   {

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7790,7 +7790,7 @@
     "category": "OTHER",
     "required_skills": [ [ "survival", 0 ] ],
     "time": "10 m",
-    "qualities": [ [ { "id": "TREE_CUTTING", "level": 1 } ] ],
+    "qualities": [ [ { "id": "AXE", "level": 1 } ] ],
     "byproducts": [ { "item": "timber", "charges": 1 } ],
     "pre_terrain": "f_trunk",
     "post_terrain": "f_null"

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7803,7 +7803,7 @@
     "category": "FURN",
     "required_skills": [ [ "fabrication", 2 ], [ "survival", 1 ] ],
     "time": "10 m",
-    "components": [ [ [ "lumber", 4 ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_30", 1 ] ] ],
+    "components": [ [ [ "lumber", 4 ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_6", 2 ] ] ],
     "pre_note": "Must be between palisade walls to function, and at least one wall must have an adjacent rope & pulley system.",
     "pre_special": "check_empty",
     "post_terrain": "f_stack_lumber"

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7795,5 +7795,17 @@
     "dark_craftable": true,
     "post_terrain": "t_trunk",
     "activity_level": "LIGHT_EXERCISE"
+  },
+  {
+    "type": "construction",
+    "id": "constr_stack_lumber",
+    "group": "build_stack_lumber",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 2 ], [ "survival", 1 ] ],
+    "time": "10 m",
+    "components": [ [ [ "lumber", 4 ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_30", 1 ] ] ],
+    "pre_note": "Must be between palisade walls to function, and at least one wall must have an adjacent rope & pulley system.",
+    "pre_special": "check_empty",
+    "post_terrain": "f_stack_lumber"
   }
 ]

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7788,7 +7788,7 @@
     "id": "constr_place_lumber",
     "group": "place_lumber",
     "category": "OTHER",
-    "required_skills": [  ],
+    "required_skills": [ [ "fabrication", 0 ] ],
     "time": "15 s",
     "components": [ [ [ "lumber", 1 ] ] ],
     "pre_special": "check_empty",

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7804,7 +7804,6 @@
     "required_skills": [ [ "fabrication", 2 ], [ "survival", 1 ] ],
     "time": "10 m",
     "components": [ [ [ "lumber", 4 ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_6", 2 ] ] ],
-    "pre_note": "Must be between palisade walls to function, and at least one wall must have an adjacent rope & pulley system.",
     "pre_special": "check_empty",
     "post_terrain": "f_stack_lumber"
   }

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7782,5 +7782,18 @@
     "pre_special": "check_empty",
     "post_terrain": "f_chair_white",
     "activity_level": "LIGHT_EXERCISE"
+  },
+  {
+    "type": "construction",
+    "id": "constr_place_lumber",
+    "group": "place_lumber",
+    "category": "OTHER",
+    "required_skills": [  ],
+    "time": "15 s",
+    "components": [ [ [ "lumber", 1 ] ] ],
+    "pre_special": "check_empty",
+    "dark_craftable": true,
+    "post_terrain": "t_trunk",
+    "activity_level": "LIGHT_EXERCISE"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1711,12 +1711,17 @@
   },
   {
     "type": "construction_group",
-    "id": "place_lumber",
-    "name": "Place lumber"
+    "id": "gather_timber",
+    "name": "Gather timber"
   },
   {
     "type": "construction_group",
-    "id": "build_stack_lumber",
-    "name": "Build stack of lumber"
+    "id": "place_timber",
+    "name": "Place timber"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_stack_timber",
+    "name": "Build stack of timber"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1713,5 +1713,10 @@
     "type": "construction_group",
     "id": "place_lumber",
     "name": "Place lumber"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_stack_lumber",
+    "name": "Build stack of lumber"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1708,5 +1708,10 @@
     "type": "construction_group",
     "id": "place_chair_wood_white",
     "name": "Place a white wooden chair"
+  },
+  {
+    "type": "construction_group",
+    "id": "place_lumber",
+    "name": "Place lumber"
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-pallet.json
+++ b/data/json/furniture_and_terrain/furniture-pallet.json
@@ -107,10 +107,10 @@
   },
   {
     "type": "furniture",
-    "id": "f_stack_lumber",
-    "name": "stack of lumber",
-    "looks_like": "bundle_lumber",
-    "description": "Four lumber tied together for easier transport.  Deconstruct to untie them.",
+    "id": "f_stack_timber",
+    "name": "stack of timber",
+    "looks_like": "bundle_timber",
+    "description": "Four timber logs tied together for easier transport.  Deconstruct to untie them.",
     "symbol": "#",
     "color": "brown",
     "move_cost_mod": 5,
@@ -123,7 +123,7 @@
       "str_max": 360,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "items": [ { "item": "lumber", "count": [ 2, 3 ] }, { "item": "splinter", "count": [ 60, 144 ] } ]
+      "items": [ { "item": "timber", "count": [ 2, 3 ] }, { "item": "splinter", "count": [ 60, 144 ] } ]
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-pallet.json
+++ b/data/json/furniture_and_terrain/furniture-pallet.json
@@ -117,7 +117,7 @@
     "required_str": -1,
     "coverage": 60,
     "flags": [ "TRANSPARENT", "NOITEM", "MOUNTABLE", "REDUCE_SCENT", "EASY_DECONSTRUCT", "FLAMMABLE_ASH" ],
-    "deconstruct": { "items": [ { "item": "lumber", "count": 4 }, { "item": "rope_makeshift_6", "count": 2 } ] },
+    "deconstruct": { "items": [ { "item": "timber", "count": 4 }, { "item": "rope_makeshift_6", "count": 2 } ] },
     "bash": {
       "str_min": 160,
       "str_max": 360,

--- a/data/json/furniture_and_terrain/furniture-pallet.json
+++ b/data/json/furniture_and_terrain/furniture-pallet.json
@@ -104,5 +104,26 @@
       "sound_fail": "whump!",
       "items": [ { "item": "2x4", "count": [ 16, 24 ] }, { "item": "splinter", "count": [ 20, 48 ] } ]
     }
+  },
+  {
+    "type": "furniture",
+    "id": "f_stack_lumber",
+    "name": "stack of lumber",
+    "looks_like": "bundle_lumber",
+    "description": "Four lumber tied together for easier transport.  Deconstruct to untie them.",
+    "symbol": "#",
+    "color": "brown",
+    "move_cost_mod": 5,
+    "required_str": -1,
+    "coverage": 60,
+    "flags": [ "TRANSPARENT", "NOITEM", "MOUNTABLE", "REDUCE_SCENT", "EASY_DECONSTRUCT", "FLAMMABLE_ASH" ],
+    "deconstruct": { "items": [ { "item": "lumber", "count": 4 }, { "item": "rope_makeshift_6", "count": 2 } ] },
+    "bash": {
+      "str_min": 160,
+      "str_max": 360,
+      "sound": "crunch!",
+      "sound_fail": "whump!",
+      "items": [ { "item": "lumber", "count": [ 2, 3 ] }, { "item": "splinter", "count": [ 60, 144 ] } ]
+    }
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -2373,8 +2373,7 @@
     "color": "brown",
     "move_cost": 4,
     "coverage": 45,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "DIGGABLE", "REDUCE_SCENT", "MOUNTABLE", "SHORT", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "ter_set": "t_dirt", "items": [ { "item": "lumber", "count": 1 } ] },
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "DIGGABLE", "REDUCE_SCENT", "MOUNTABLE", "SHORT" ],
     "bash": {
       "str_min": 80,
       "str_max": 180,

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -2373,7 +2373,8 @@
     "color": "brown",
     "move_cost": 4,
     "coverage": 45,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "DIGGABLE", "REDUCE_SCENT", "MOUNTABLE", "SHORT" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "DIGGABLE", "REDUCE_SCENT", "MOUNTABLE", "SHORT", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "ter_set": "t_dirt", "items": [ { "item": "lumber", "count": 1 } ] },
     "bash": {
       "str_min": 80,
       "str_max": 180,

--- a/data/json/items/resources/wood.json
+++ b/data/json/items/resources/wood.json
@@ -322,10 +322,10 @@
     "flags": [ "FIREWOOD" ]
   },
   {
-    "id": "lumber",
+    "id": "timber",
     "type": "GENERIC",
     "name": { "str": "lumber" },
-    "description": "Large and uncut lumber straight from a tree.",
+    "description": "A large and uncut timber log straight from a tree.",
     "category": "other",
     "weight": "75000 g",
     "volume": "125000 ml",

--- a/data/json/items/resources/wood.json
+++ b/data/json/items/resources/wood.json
@@ -324,7 +324,7 @@
   {
     "id": "timber",
     "type": "GENERIC",
-    "name": { "str": "lumber" },
+    "name": { "str": "timber" },
     "description": "A large and uncut timber log straight from a tree.",
     "category": "other",
     "weight": "75000 g",

--- a/data/json/items/resources/wood.json
+++ b/data/json/items/resources/wood.json
@@ -322,19 +322,19 @@
     "flags": [ "FIREWOOD" ]
   },
   {
-	"id": "lumber",
-	"type": "GENERIC",
-	"name": { "str": "lumber" },
-	"description": "Large and uncut lumber straight from a tree.",
-	"weight": "75000 g",
-	"volume": "125000 ml",
-	"longest_side": "350 cm",
-	"price": 30000,
-	"price_postapoc": 10,
-	"to_hit": -10,
-	"bashing": 10,
-	"material": [ "wood" ],
-	"symbol": "l",
-	"color": "brown"
+    "id": "lumber",
+    "type": "GENERIC",
+    "name": { "str": "lumber" },
+    "description": "Large and uncut lumber straight from a tree.",
+    "weight": "75000 g",
+    "volume": "125000 ml",
+    "longest_side": "350 cm",
+    "price": 30000,
+    "price_postapoc": 10,
+    "to_hit": -10,
+    "bashing": 10,
+    "material": [ "wood" ],
+    "symbol": "l",
+    "color": "brown"
   }
 ]

--- a/data/json/items/resources/wood.json
+++ b/data/json/items/resources/wood.json
@@ -320,5 +320,21 @@
     "price": 30000,
     "price_postapoc": 20,
     "flags": [ "FIREWOOD" ]
+  },
+  {
+	"id": "lumber",
+	"type": "GENERIC",
+	"name": { "str": "lumber" },
+	"description": "Large and uncut lumber straight from a tree.",
+	"weight": "75000 g",
+	"volume": "125000 ml",
+	"longest_side": "350 cm",
+	"price": 30000,
+	"price_postapoc": 10,
+	"to_hit": -10,
+	"bashing": 10,
+	"material": [ "wood" ],
+	"symbol": "l",
+	"color": "brown"
   }
 ]

--- a/data/json/items/resources/wood.json
+++ b/data/json/items/resources/wood.json
@@ -326,6 +326,7 @@
     "type": "GENERIC",
     "name": { "str": "lumber" },
     "description": "Large and uncut lumber straight from a tree.",
+    "category": "other",
     "weight": "75000 g",
     "volume": "125000 ml",
     "longest_side": "350 cm",

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -2786,6 +2786,7 @@ thyreophoran
 tileset
 tillable
 tillage
+timber
 timelapse
 tinamou
 tinning

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -1597,6 +1597,7 @@ ltd
 lucerne
 luddites
 lulo
+lumber
 lumbermill
 lungfish
 lutefisk


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add Timber"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
While the main use of this is for use with palisade walls ( #64422 ), I can see this being useful is a few ways. Firstly, it can make transporting timber much quicker as the player won't be forced to chop every trunk and instead can easily "deconstruct" the trunk, carry the timber to their cargo space (or make a lumber stack and (G)rab four tied together) and transport it for later cutting. Secondly, this could likely be used for other large construction menu items or projects that don't really need cut logs but need timber instead. Lastly, this could be used as a "base" should trees ever get reworked to provide different timber (small, medium, or large).
#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
The solution was to add a new item, "timber", to the game. This is essentially 2.5 logs uncut, which I got the weight, volume, and length from averaging out how many logs you can get per trunk and combining the values. You can get this item through the "Gather timber" construction on tree trunks. If you want to cut it into logs and/or planks later, you can place it back on the ground as a tree trunk and cut it as normal. You can also construct a stack with 4 timber logs and 2 short ropes of any kind and (G)rab it using this method.
#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Altering values used for timber, a different name aside from "timber".
#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Tested in-game, every feature described works as intended.
#### Additional context


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![Screenshot (970)](https://user-images.githubusercontent.com/81766902/226758771-5d37fe8d-cb69-4b24-b412-cd46791fc38c.png)
![Screenshot (978)](https://user-images.githubusercontent.com/81766902/227577865-f5d320ee-dec5-4abe-81c5-95d8aa2b8581.png)
![Screenshot (979)](https://user-images.githubusercontent.com/81766902/227577882-9f224797-65c6-4bc2-a4ef-de19fa15821a.png)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->