### PR TITLE
Erase all before placing Exodii crash buildings

### DIFF
--- a/data/json/mapgen/map_extras/exodii_crashes.json
+++ b/data/json/mapgen/map_extras/exodii_crashes.json
@@ -167,6 +167,7 @@
         "||MM||",
         "||mm||"
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
       "items": { "_": [ { "item": "SUS_exodii_storage_lowvalue", "chance": 100 } ] }
     }
@@ -185,6 +186,7 @@
         "||MM||",
         "||mm||"
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
       "items": { "_": [ { "item": "SUS_exodii_storage_medvalue", "chance": 100 } ] }
     }
@@ -203,6 +205,7 @@
         "||MM||",
         " |mm| "
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
       "items": { "_": [ { "item": "SUS_exodii_storage_medvalue", "chance": 100 } ] }
     }
@@ -221,6 +224,7 @@
         "||||||",
         "||||||"
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
       "items": { "_": [ { "item": "SUS_exodii_storage_medvalue", "chance": 100, "repeat": [ 1, 3 ] } ] }
     }
@@ -238,6 +242,7 @@
         "||M||",
         "||m||"
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
       "items": { "_": [ { "item": "SUS_exodii_storage_highvalue", "chance": 100 } ] }
     }
@@ -255,6 +260,7 @@
         "|||||",
         "|||||"
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
       "items": { "_": [ { "item": "SUS_exodii_storage_highvalue", "chance": 100 } ] }
     }
@@ -272,6 +278,7 @@
         "|||||",
         " ||| "
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
       "items": { "_": [ { "item": "SUS_exodii_storage_highvalue", "chance": 100 } ] }
     }
@@ -287,6 +294,7 @@
         "|_|",
         "|m|"
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
       "items": { "_": [ { "item": "SUS_exodii_storage_lowvalue", "chance": 100 } ] }
     }
@@ -302,6 +310,7 @@
         "|_|",
         "|||"
       ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
       "items": { "_": [ { "item": "SUS_exodii_storage_lowvalue", "chance": 100 } ] }
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I got a [CI failure](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4478152450/jobs/7870568326?pr=64430#step:15:515) due to an Exodii building which was part of `mx_exodii_crash_big_1` being placed atop `f_rubble_rock` furniture on `ranch_camp_77_south`.

#### Describe the solution
These buildings should probably obliterate whatever was previously there, so add the
`ERASE_ALL_BEFORE_PLACING_TERRAIN` flag to all the Exodii crash building nested mapgens.

#### Describe alternatives you've considered
I thought about using `DISMANTLE_ALL_BEFORE_PLACING_TERRAIN`, but the terrain is mostly impassable so the items wouldn't survive anyway.

#### Testing
Unit tests.

#### Additional context