### PR TITLE
Remove default '}' keybind for accessing sidebar options, add a menu item to the main menu for this and remove the associated 'Hint' sidebar widget

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2745,8 +2745,7 @@
     "type": "keybinding",
     "name": "Sidebar options",
     "category": "DEFAULTMODE",
-    "id": "toggle_panel_adm",
-    "bindings": [ { "input_method": "keyboard_char", "key": "}" }, { "input_method": "keyboard_code", "key": "]", "mod": [ "shift" ] } ]
+    "id": "toggle_panel_adm"
   },
   {
     "type": "keybinding",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1052,6 +1052,7 @@ action_id handle_main_menu()
                           ctxt.get_action_name( action_ident( ACTION_KEYBINDINGS ) ) );
 
     REGISTER_ACTION( ACTION_OPTIONS );
+    REGISTER_ACTION( ACTION_TOGGLE_PANEL_ADM );
     REGISTER_ACTION( ACTION_AUTOPICKUP );
     REGISTER_ACTION( ACTION_AUTONOTES );
     REGISTER_ACTION( ACTION_SAFEMODE );

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -333,21 +333,6 @@ bool default_render()
     return true;
 }
 
-// Message on how to use the custom sidebar panel and edit its JSON
-static void draw_custom_hint( const draw_args &args )
-{
-    const catacurses::window &w = args._win;
-
-    werase( w );
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    mvwprintz( w, point( 1, 0 ), c_white, _( "Press } for sidebar options." ) );
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    mvwprintz( w, point( 1, 1 ), c_light_gray,
-               _( "See docs/WIDGETS.md for help." ) );
-
-    wnoutrefresh( w );
-}
-
 // Initialize custom panels from a given "sidebar" style widget
 static std::vector<window_panel> initialize_default_custom_panels( const widget &wgt )
 {
@@ -355,10 +340,6 @@ static std::vector<window_panel> initialize_default_custom_panels( const widget 
 
     // Use defined width, or at least 16
     const int width = std::max( wgt._width, 16 );
-
-    // Show hint on configuration
-    ret.emplace_back( window_panel( draw_custom_hint, "Hint", to_translation( "Hint" ),
-                                    2, width, true ) );
 
     // Add window panel for each child widget
     for( const widget_id &row_wid : wgt._widgets ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Fixes #59684

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- Removed the default setting for the `toggle_panel_adm` keybind.
- Add a menu item for it to the in-game main menu.
- Removed the code related to the obsolete Hint widget.

NB: all keybinds tied to menu items in the in-game main menu are present at the top-level of keybinds, so I've chosen to keep that as-is and not make a special case for the `toggle_panel_adm` keybind as described in the issue.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

None.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

- Accessed in-game main menu, noticed appearance of "Sidebar options" item, used it to access sidebar options, and noticed that it was working as expected.
- Noticed the removal of the Hint sidebar widget.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

sidebar options in main menu:
![WindowsTerminal_BltVkUiSTl](https://user-images.githubusercontent.com/2420411/226789927-0351aa9a-c01b-4ab9-a081-10a54ee0596e.png)

unbound sidebar options:
![WindowsTerminal_I7zWAoiTZb](https://user-images.githubusercontent.com/2420411/226789869-d5de1cb9-a451-4c2d-8ff7-48e29703436a.png)

no hint widget:
![WindowsTerminal_ZRUYjLVc5o](https://user-images.githubusercontent.com/2420411/226789819-ce0b639e-8b8a-46ef-9eea-00e394a0d53c.png)
