### PR TITLE
Add test for spawning items inside a container

### DIFF
--- a/data/mods/TEST_DATA/container_spawn_test.json
+++ b/data/mods/TEST_DATA/container_spawn_test.json
@@ -1,0 +1,254 @@
+[
+  {
+    "type": "test_data",
+    "spawn_data": {
+      "group": [
+        {
+          "given": "group with container-item spawns item with default charges",
+          "group": "test_default_charges_container_item",
+          "expected": 4
+        },
+        {
+          "given": "group with container-item spawns item with custom charges",
+          "group": "test_custom_charges_container_item",
+          "expected": 17
+        },
+        {
+          "given": "group without container-item spawns item with default charges and default container",
+          "group": "test_default_charges_default_container",
+          "expected": 4
+        },
+        {
+          "given": "group without container-item spawns item with custom charges and default container",
+          "group": "test_custom_charges_default_container",
+          "expected": 17
+        },
+        {
+          "given": "group with container-item spawns multiple items without charges",
+          "group": "test_container_item_multiples",
+          "expected": 4
+        },
+        {
+          "given": "group without container-item spawns single item without charges and with default container",
+          "group": "test_default_container_single",
+          "expected": 1
+        }
+      ],
+      "recipe": [
+        { "given": "recipe spawns item with default charges", "recipe": "test_item_with_charges", "expected": 4 },
+        {
+          "given": "recipe spawns item with custom charges",
+          "recipe": "test_item_with_charges_custom",
+          "expected": 17
+        }
+      ],
+      "vehicle": [
+        {
+          "given": "vehicle spawns with item with default charges and default container",
+          "vehicle": "test_vehicle_item_with_default_charges_and_container",
+          "expected": 4
+        },
+        {
+          "given": "vehicle spawns with item without charges and with default container",
+          "vehicle": "test_vehicle_item_with_container_without_charges",
+          "expected": 1
+        }
+      ],
+      "profession": [
+        {
+          "given": "profession item substitution to item with default charges and default container",
+          "profession": "test_profession_substitution_default_charges_default_container",
+          "expected": 4
+        },
+        {
+          "given": "profession item substitution to item with custom charges and default container",
+          "profession": "test_profession_substitution_custom_charges_default_container",
+          "expected": 17
+        },
+        {
+          "given": "profession item substitution to item without charges and with default container",
+          "profession": "test_profession_substitution_without_charges_default_container",
+          "expected": 1
+        }
+      ],
+      "map": [
+        {
+          "given": "map::spawn_item spawns item with default charges and default container",
+          "item": "test_item_with_charges_and_container",
+          "expected": 4
+        },
+        {
+          "given": "map::spawn_item spawns item with custom charges and default container",
+          "item": "test_item_with_charges_and_container",
+          "charges": 17,
+          "expected": 17
+        },
+        {
+          "given": "map::spawn_item spawns item without charges and with default container",
+          "item": "test_item_with_container_without_charges",
+          "expected": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "test_item_with_charges",
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "charges": 4,
+    "name": "test item with charges",
+    "volume": "1ml",
+    "weight": "1g",
+    "description": "nothing",
+    "symbol": "t"
+  },
+  {
+    "id": "test_item_with_charges_and_container",
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "charges": 4,
+    "container": "test_backpack",
+    "name": "test item with charges",
+    "volume": "1ml",
+    "weight": "1g",
+    "description": "nothing",
+    "symbol": "t"
+  },
+  {
+    "id": "test_item_without_charges",
+    "type": "GENERIC",
+    "name": "test item without charges",
+    "volume": "1ml",
+    "weight": "1g",
+    "description": "nothing",
+    "symbol": "t"
+  },
+  {
+    "id": "test_item_with_container_without_charges",
+    "type": "GENERIC",
+    "container": "test_backpack",
+    "name": "test item without charges",
+    "volume": "1ml",
+    "weight": "1g",
+    "description": "nothing",
+    "symbol": "t"
+  },
+  {
+    "id": "test_default_charges_container_item",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "test_backpack",
+    "on_overflow": "discard",
+    "entries": [ { "item": "test_item_with_charges" } ]
+  },
+  {
+    "id": "test_custom_charges_container_item",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "test_backpack",
+    "on_overflow": "discard",
+    "entries": [ { "item": "test_item_with_charges", "charges": 17 } ]
+  },
+  {
+    "id": "test_container_item_multiples",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "test_backpack",
+    "on_overflow": "discard",
+    "entries": [ { "item": "test_item_without_charges", "count": 4 } ]
+  },
+  {
+    "id": "test_default_charges_default_container",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [ { "item": "test_item_with_charges_and_container" } ]
+  },
+  {
+    "id": "test_custom_charges_default_container",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [ { "item": "test_item_with_charges_and_container", "charges": 17 } ]
+  },
+  {
+    "id": "test_default_container_single",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [ { "item": "test_item_with_container_without_charges" } ]
+  },
+  {
+    "type": "recipe",
+    "result": "test_item_with_charges",
+    "container": "test_backpack",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_MATERIALS"
+  },
+  {
+    "type": "recipe",
+    "result": "test_item_with_charges",
+    "id_suffix": "custom",
+    "container": "test_backpack",
+    "charges": 17,
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_MATERIALS"
+  },
+  {
+    "id": "test_vehicle_item_with_default_charges_and_container",
+    "type": "vehicle",
+    "name": "Test Vehicle",
+    "blueprint": [ "#" ],
+    "parts": [ { "x": 0, "y": 0, "parts": [ "folding_frame", "trunk" ] } ],
+    "items": [ { "x": 0, "y": 0, "chance": 100, "items": [ "test_item_with_charges_and_container" ] } ]
+  },
+  {
+    "id": "test_vehicle_item_with_container_without_charges",
+    "type": "vehicle",
+    "name": "Test Vehicle",
+    "blueprint": [ "#" ],
+    "parts": [ { "x": 0, "y": 0, "parts": [ "folding_frame", "trunk" ] } ],
+    "items": [ { "x": 0, "y": 0, "chance": 100, "items": [ "test_item_with_container_without_charges" ] } ]
+  },
+  {
+    "id": "test_trait_substitution",
+    "type": "mutation",
+    "name": "substitution test trait",
+    "description": "substitution test trait",
+    "points": 0
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "test_item_with_charges",
+    "sub": [ { "present": [ "test_trait_substitution" ], "new": [ "test_item_with_charges_and_container" ] } ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "test_item_without_charges",
+    "sub": [ { "present": [ "test_trait_substitution" ], "new": [ "test_item_with_container_without_charges" ] } ]
+  },
+  {
+    "id": "test_profession_substitution_default_charges_default_container",
+    "type": "profession",
+    "traits": [ "test_trait_substitution" ],
+    "items": { "both": { "entries": [ { "item": "test_item_with_charges" } ] } },
+    "name": "substitution test profession",
+    "description": "substitution test profession",
+    "points": 0
+  },
+  {
+    "id": "test_profession_substitution_custom_charges_default_container",
+    "type": "profession",
+    "traits": [ "test_trait_substitution" ],
+    "items": { "both": { "entries": [ { "group": "test_custom_charges_default_container" } ] } },
+    "name": "substitution test profession",
+    "description": "substitution test profession",
+    "points": 0
+  },
+  {
+    "id": "test_profession_substitution_without_charges_default_container",
+    "type": "profession",
+    "traits": [ "test_trait_substitution" ],
+    "items": { "both": { "entries": [ { "item": "test_item_without_charges" } ] } },
+    "name": "substitution test profession",
+    "description": "substitution test profession",
+    "points": 0
+  }
+]

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4769,7 +4769,7 @@ void map::spawn_item( const tripoint &p, const itype_id &type_id, const unsigned
         //let's fail silently if we specify charges for an item that doesn't support it
         new_item.charges = charges;
     }
-    new_item = new_item.in_its_container();
+    new_item = new_item.in_its_container( new_item.count() );
     new_item.set_owner( faction_id( faction ) ); // Set faction to the container as well
     if( ( new_item.made_of( phase_id::LIQUID ) && has_flag( ter_furn_flag::TFLAG_SWIMMABLE, p ) ) ||
         has_flag( ter_furn_flag::TFLAG_DESTROY_ITEM, p ) ) {

--- a/src/test_data.cpp
+++ b/src/test_data.cpp
@@ -6,11 +6,37 @@ std::set<itype_id> test_data::known_bad;
 std::map<vproto_id, std::vector<double>> test_data::drag_data;
 std::map<vproto_id, efficiency_data> test_data::eff_data;
 std::map<itype_id, double> test_data::expected_dps;
+std::map<spawn_type, std::vector<container_spawn_test_data>> test_data::container_spawn_data;
 
 void efficiency_data::deserialize( const JsonObject &jo )
 {
     jo.read( "forward", forward );
     jo.read( "reverse", reverse );
+}
+
+void container_spawn_test_data::deserialize( const JsonObject &jo )
+{
+    jo.read( "given", given );
+    jo.read( "expected", expected_amount );
+
+    if( jo.has_member( "group" ) ) {
+        jo.read( "group", group );
+    }
+    if( jo.has_member( "recipe" ) ) {
+        jo.read( "recipe", recipe );
+    }
+    if( jo.has_member( "vehicle" ) ) {
+        jo.read( "vehicle", vehicle );
+    }
+    if( jo.has_member( "profession" ) ) {
+        jo.read( "profession", profession );
+    }
+    if( jo.has_member( "item" ) ) {
+        jo.read( "item", item );
+    }
+    if( jo.has_member( "charges" ) ) {
+        jo.read( "charges", charges );
+    }
 }
 
 void test_data::load( const JsonObject &jo )
@@ -39,5 +65,40 @@ void test_data::load( const JsonObject &jo )
         std::map<itype_id, double> new_expected_dps;
         jo.read( "expected_dps", new_expected_dps );
         expected_dps.insert( new_expected_dps.begin(), new_expected_dps.end() );
+    }
+
+    if( jo.has_object( "spawn_data" ) )  {
+        JsonObject spawn_jo = jo.get_object( "spawn_data" );
+        if( spawn_jo.has_array( "group" ) ) {
+            std::vector<container_spawn_test_data> test_groups;
+            spawn_jo.read( "group", test_groups );
+            container_spawn_data[spawn_type::item_group].insert(
+                container_spawn_data[spawn_type::item_group].end(), test_groups.begin(), test_groups.end() );
+        }
+        if( spawn_jo.has_array( "recipe" ) ) {
+            std::vector<container_spawn_test_data> test_recipes;
+            spawn_jo.read( "recipe", test_recipes );
+            container_spawn_data[spawn_type::recipe].insert( container_spawn_data[spawn_type::recipe].end(),
+                    test_recipes.begin(), test_recipes.end() );
+        }
+        if( spawn_jo.has_array( "vehicle" ) ) {
+            std::vector<container_spawn_test_data> test_vehicles;
+            spawn_jo.read( "vehicle", test_vehicles );
+            container_spawn_data[spawn_type::vehicle].insert( container_spawn_data[spawn_type::vehicle].end(),
+                    test_vehicles.begin(), test_vehicles.end() );
+        }
+        if( spawn_jo.has_array( "profession" ) ) {
+            std::vector<container_spawn_test_data> test_professions;
+            spawn_jo.read( "profession", test_professions );
+            container_spawn_data[spawn_type::profession].insert(
+                container_spawn_data[spawn_type::profession].end(), test_professions.begin(),
+                test_professions.end() );
+        }
+        if( spawn_jo.has_array( "map" ) ) {
+            std::vector<container_spawn_test_data> test_map;
+            spawn_jo.read( "map", test_map );
+            container_spawn_data[spawn_type::map].insert( container_spawn_data[spawn_type::map].end(),
+                    test_map.begin(), test_map.end() );
+        }
     }
 }

--- a/src/test_data.h
+++ b/src/test_data.h
@@ -17,6 +17,28 @@ struct efficiency_data {
     void deserialize( const JsonObject &jo );
 };
 
+enum class spawn_type : int {
+    none = 0,
+    item_group,
+    recipe,
+    vehicle,
+    profession,
+    map
+};
+
+struct container_spawn_test_data {
+    std::string given;
+    item_group_id group;
+    recipe_id recipe;
+    vproto_id vehicle;
+    profession_id profession;
+    itype_id item;
+    int charges = 0;
+    int expected_amount;
+
+    void deserialize( const JsonObject &jo );
+};
+
 class test_data
 {
     public:
@@ -25,6 +47,7 @@ class test_data
         static std::map<vproto_id, std::vector<double>> drag_data;
         static std::map<vproto_id, efficiency_data> eff_data;
         static std::map<itype_id, double> expected_dps;
+        static std::map<spawn_type, std::vector<container_spawn_test_data>> container_spawn_data;
 
         static void load( const JsonObject &jo );
 };

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5615,12 +5615,14 @@ void vehicle::place_spawn_items()
 
                 for( const itype_id &e : spawn.item_ids ) {
                     if( rng_float( 0, 1 ) < spawn_rate ) {
-                        created.emplace_back( item( e ).in_its_container() );
+                        item spawn( e );
+                        created.emplace_back( spawn.in_its_container( spawn.count() ) );
                     }
                 }
                 for( const std::pair<itype_id, std::string> &e : spawn.variant_ids ) {
                     if( rng_float( 0, 1 ) < spawn_rate ) {
-                        item added = item( e.first ).in_its_container();
+                        item spawn( e.first );
+                        item added = spawn.in_its_container( spawn.count() );
                         added.set_itype_variant( e.second );
                         created.push_back( added );
                     }

--- a/tests/item_spawn_test.cpp
+++ b/tests/item_spawn_test.cpp
@@ -1,0 +1,103 @@
+#include <vector>
+
+#include "cata_catch.h"
+#include "game.h"
+#include "item.h"
+#include "item_group.h"
+#include "map_helpers.h"
+#include "mutation.h"
+#include "profession.h"
+#include "recipe.h"
+#include "test_data.h"
+#include "vehicle.h"
+#include "veh_type.h"
+
+static std::string get_section_name( const spawn_type &type )
+{
+    switch( type ) {
+        case spawn_type::item_group:
+            return "items spawned by itemgroups";
+        case spawn_type::recipe:
+            return "items spawned by recipe";
+        case spawn_type::vehicle:
+            return "items spawned by vehicle";
+        case spawn_type::profession:
+            return "items spawned by profession substitution";
+        case spawn_type::map:
+            return "items spawned by map::spawn_item";
+        default:
+            return "unknown type";
+    }
+
+    return "unknown type";
+}
+
+TEST_CASE( "correct amounts of an item spawn inside a container", "[item_spawn]" )
+{
+    REQUIRE_FALSE( test_data::container_spawn_data.empty() );
+
+    for( std::pair<const spawn_type, std::vector<container_spawn_test_data>> &spawn_category :
+         test_data::container_spawn_data ) {
+        SECTION( get_section_name( spawn_category.first ) ) {
+            REQUIRE_FALSE( spawn_category.second.empty() );
+            for( const container_spawn_test_data &cs_data : spawn_category.second ) {
+                GIVEN( cs_data.given ) {
+                    std::vector<item> items;
+
+                    switch( spawn_category.first ) {
+                        case spawn_type::item_group:
+                            items = item_group::items_from( cs_data.group );
+                            break;
+                        case spawn_type::recipe:
+                            items = cs_data.recipe->create_results();
+                            break;
+                        case spawn_type::vehicle: {
+                            clear_map();
+                            map &here = get_map();
+                            here.add_vehicle( cs_data.vehicle, point_zero, 0_degrees );
+                            REQUIRE( here.get_vehicles().size() == 1 );
+                            vehicle *veh = here.get_vehicles()[0].v;
+                            int part = veh->avail_part_with_feature( point_zero, "CARGO" );
+                            REQUIRE( part >= 0 );
+                            for( item &it : veh->get_items( part ) ) {
+                                items.push_back( it );
+                            }
+                            break;
+                        }
+                        case spawn_type::profession: {
+                            std::vector<trait_id> traits;
+                            for( const trait_and_var &trait : cs_data.profession->get_locked_traits() ) {
+                                traits.push_back( trait.trait );
+                            }
+                            std::list<item> prof_items = cs_data.profession->items( false, traits );
+                            items.insert( items.end(), prof_items.begin(), prof_items.end() );
+                            break;
+                        }
+                        case spawn_type::map: {
+                            clear_map();
+                            map &here = get_map();
+                            here.spawn_item( tripoint_zero, cs_data.item, 1, cs_data.charges );
+                            for( item &it : here.i_at( tripoint_zero ) ) {
+                                items.push_back( it );
+                            }
+                            break;
+                        }
+                        default:
+                            continue;
+                    }
+
+                    REQUIRE( items.size() == 1 );
+                    CAPTURE( items[0].tname() );
+                    REQUIRE_FALSE( items[0].empty() );
+
+                    int count = 0;
+                    for( const item *it : items[0].all_items_top() ) {
+                        count += it->count();
+                    }
+
+                    CHECK( count == cs_data.expected_amount );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

I need to enable spawning multiples of an item inside a container for #60885, but need to ensure I don't break anything while doing so like #64228.

#### Describe the solution

Add a new test for various methods of spawning items inside a container:
- itemgroups
- recipes
- vehicles
- substitutions from trait + profession combos
- `map::spawn_item`

Fixes:
 - vehicle spawns spawn default amount of charges instead of always filling up the default container
 - `map::spawn_item` spawns actual given charges/default charges instead of always filling up the default container

#### Describe alternatives you've considered



#### Testing

Run the test.

#### Additional context

