### PR TITLE
Fix changelog script not preserving leading spaces

### DIFF
--- a/tools/merge_summaries.sh
+++ b/tools/merge_summaries.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Preserve leading spaces
+IFS=''
+
 # Features Content Interface Mods Balance Bugfixes Performance Infrastructure Build I18N
 
 while read -r category description; do


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The `merge_summaries.sh` script discards leading spaces on existing lines, which changes a lot more of the resulting lines than intended. See https://github.com/CleverRaven/Cataclysm-DDA/pull/64454/commits/f0db93c185b881eb60aa298e2d13fc421d9bb604 (commit reversing the unintended changes)

#### Describe the solution
Empty `IFS` before running the script so that `read` doesn't try to format the line as it's reading it
