### PR TITLE
Throwable fire extinguishers can now be placed in grenade-only pockets

### DIFF
--- a/data/json/items/tool/firefighting.json
+++ b/data/json/items/tool/firefighting.json
@@ -155,7 +155,7 @@
       "active": true,
       "type": "transform"
     },
-    "flags": [ "ACT_IN_FIRE", "BOMB" ]
+    "flags": [ "ACT_IN_FIRE", "BOMB", "GRENADE" ]
   },
   {
     "id": "throw_extinguisher_act",


### PR DESCRIPTION
#### Summary

Balance "Throwable fire extinguishers can now be placed in grenade-only pockets"

#### Purpose of change

Throwable fire extinguishers are "A fire extinguisher in grenade form". They're used just like grenades, except for fighting fires instead of zombies. It makes sense they can go in grenade-only pockets.

#### Describe the solution

Add the `GRENADE` flag to the item's JSON.

#### Describe alternatives you've considered

None.

#### Testing

Loaded a game with the changes applied. Added a throwable fire extinguisher to a grenade-only pocket when I couldn't before.

#### Additional context

None