### PR TITLE
Make Rubik restocks more often

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_definitions.json
+++ b/data/json/npcs/exodii/exodii_merchant_definitions.json
@@ -25,10 +25,10 @@
     "shopkeeper_item_group": [
       { "group": "EXODII_basic_trade", "rigid": true },
       { "group": "EXODII_CBM_Store_tier1_extra", "rigid": true, "trust": 1 },
-      { "group": "EXODII_CBM_Store_Tier2", "rigid": true, "trust": 10 },
-      { "group": "EXODII_CBM_Store_Tier3", "rigid": true, "trust": 20, "strict": true },
-      { "group": "EXODII_Store_Salvage_Tech", "rigid": true, "trust": 20 },
-      { "group": "EXODII_CBM_Store_Tier4", "rigid": true, "trust": 40, "strict": true }
+      { "group": "EXODII_CBM_Store_Tier2", "rigid": true, "trust": 5 },
+      { "group": "EXODII_CBM_Store_Tier3", "rigid": true, "trust": 10, "strict": true },
+      { "group": "EXODII_Store_Salvage_Tech", "rigid": true, "trust": 10 },
+      { "group": "EXODII_CBM_Store_Tier4", "rigid": true, "trust": 20, "strict": true }
     ],
     "shopkeeper_consumption_rates": "basic_shop_rates",
     "carry_override": "NC_EXODII_TYPE_1_carried",

--- a/data/json/npcs/exodii/exodii_merchant_itemlist.json
+++ b/data/json/npcs/exodii/exodii_merchant_itemlist.json
@@ -154,7 +154,7 @@
   {
     "type": "item_group",
     "id": "EXODII_CBM_Store_Tier2",
-    "//": "These CBMs should be available in the Exodii store after at least 2 weeks.",
+    "//": "These CBMs should be available in the Exodii store after at least 1 week.",
     "items": [
       [ "bio_tools", 10 ],
       [ "bio_ethanol", 10 ],
@@ -183,7 +183,7 @@
   {
     "type": "item_group",
     "id": "EXODII_CBM_Store_Tier3",
-    "//": "These CBMs should be available in the Exodii store after at least 4 weeks.",
+    "//": "These CBMs should be available in the Exodii store after at least 2 weeks.",
     "items": [
       [ "bio_blood_filter", 10 ],
       [ "bio_purifier", 10 ],
@@ -206,7 +206,7 @@
   {
     "type": "item_group",
     "id": "EXODII_CBM_Store_Tier4",
-    "//": "These CBMs should be available in the Exodii store after at least 8 weeks.",
+    "//": "These CBMs should be available in the Exodii store after at least 3 weeks.",
     "items": [
       [ "bio_surgical_razor", 10 ],
       [ "bio_faraday", 10 ],


### PR DESCRIPTION
#### Summary
Balance "Make Rubik restocks more often"

#### Purpose of change
Currently, Rubik restocks his own CBM supply every two weeks, but for many people (including me), until we get some new missions, waiting to get Alloy Plating CBM is soooooooo boring!

#### Describe the solution
Reduce the restock time to 1 week

#### Describe alternatives you've considered
Not doing this and letting people to get bored more often

#### Testing
~~Should be good~~ Not yet tested!

#### Additional context
~~Hmm, does changing the comments automatically sets restock time?~~
Nvm, comments do nothing