### PR TITLE
Remove achievements/scores/killcount top-level keybinding and move it into the diary menu (bound by default to ')')

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2611,13 +2611,6 @@
   },
   {
     "type": "keybinding",
-    "name": "View achievements, scores, and kills",
-    "category": "DEFAULTMODE",
-    "id": "scores",
-    "bindings": [ { "input_method": "keyboard_char", "key": ")" }, { "input_method": "keyboard_code", "key": "0", "mod": [ "shift" ] } ]
-  },
-  {
-    "type": "keybinding",
     "name": "View morale",
     "category": "DEFAULTMODE",
     "id": "morale",
@@ -2986,7 +2979,8 @@
     "type": "keybinding",
     "id": "diary",
     "name": "Open diary",
-    "category": "DEFAULTMODE"
+    "category": "DEFAULTMODE",
+    "bindings": [ { "input_method": "keyboard_char", "key": ")" }, { "input_method": "keyboard_code", "key": "0", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -4284,6 +4278,13 @@
     "name": "Add new page",
     "category": "DIARY",
     "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "n" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "name": "View achievements, scores, and kills",
+    "category": "DIARY",
+    "id": "VIEW_SCORES",
+    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "v" ] } ]
   },
   {
     "type": "keybinding",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -311,8 +311,6 @@ std::string action_ident( action_id act )
             return "missions";
         case ACTION_FACTIONS:
             return "factions";
-        case ACTION_SCORES:
-            return "scores";
         case ACTION_MEDICAL:
             return "medical";
         case ACTION_BODYSTATUS:
@@ -442,7 +440,6 @@ bool can_action_change_worldstate( const action_id act )
         case ACTION_MAP:
         case ACTION_SKY:
         case ACTION_MISSIONS:
-        case ACTION_SCORES:
         case ACTION_FACTIONS:
         case ACTION_MORALE:
         case ACTION_MEDICAL:
@@ -973,7 +970,6 @@ action_id handle_action_menu()
         } else if( category == _( "Info" ) ) {
             REGISTER_ACTION( ACTION_PL_INFO );
             REGISTER_ACTION( ACTION_MISSIONS );
-            REGISTER_ACTION( ACTION_SCORES );
             REGISTER_ACTION( ACTION_FACTIONS );
             REGISTER_ACTION( ACTION_MORALE );
             REGISTER_ACTION( ACTION_MEDICAL );

--- a/src/action.h
+++ b/src/action.h
@@ -255,8 +255,6 @@ enum action_id : int {
     ACTION_SKY,
     /** Display missions screen */
     ACTION_MISSIONS,
-    /** Display scores screen */
-    ACTION_SCORES,
     /** Display factions screen */
     ACTION_FACTIONS,
     /** Display morale effects screen */

--- a/src/diary_ui.cpp
+++ b/src/diary_ui.cpp
@@ -14,6 +14,7 @@
 #include "options.h"
 #include "output.h"
 #include "popup.h"
+#include "scores_ui.h"
 #include "string_editor_window.h"
 #include "string_formatter.h"
 #include "string_input_popup.h"
@@ -177,6 +178,7 @@ void diary::show_diary_ui( diary *c_diary )
     ctxt.register_action( "NEW_PAGE" );
     ctxt.register_action( "DELETE PAGE" );
     ctxt.register_action( "EXPORT_DIARY" );
+    ctxt.register_action( "VIEW_SCORES" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
 
     ui_adaptor ui_diary;
@@ -245,7 +247,7 @@ void diary::show_diary_ui( diary *c_diary )
         const point &beg = beg_and_max.first;
         const point &max = beg_and_max.second;
 
-        w_desc = catacurses::newwin( 3, max.x * 3 / 10 + max.x + 10, point( beg.x - 5 - max.x * 3 / 10,
+        w_desc = catacurses::newwin( 4, max.x * 3 / 10 + max.x + 10, point( beg.x - 5 - max.x * 3 / 10,
                                      beg.y - 6 ) );
 
         ui.position_from_window( w_desc );
@@ -263,6 +265,8 @@ void diary::show_diary_ui( diary *c_diary )
                                           ctxt.get_desc( "EXPORT_DIARY", _( "Export diary" ), input_context::allow_all_keys )
                                         );
         center_print( w_desc, 1,  c_white, desc );
+        center_print( w_desc, 2,  c_white, ctxt.get_desc( "VIEW_SCORES",
+                      _( "View achievements, scores, and kills" ), input_context::allow_all_keys ) );
 
         wnoutrefresh( w_desc );
     } );
@@ -339,6 +343,8 @@ void diary::show_diary_ui( diary *c_diary )
             c_diary->new_page();
             selected[window_mode::PAGE_WIN] = c_diary->pages.size() - 1;
 
+        } else if( action == "VIEW_SCORES" ) {
+            show_scores_ui( g->achievements(), g->stats(), g->get_kill_tracker() );
         } else if( action == "DELETE PAGE" ) {
             if( !c_diary->pages.empty() ) {
                 if( query_yn( _( "Really delete Page?" ) ) ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2425,7 +2425,6 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "sky" );
     ctxt.register_action( "missions" );
     ctxt.register_action( "factions" );
-    ctxt.register_action( "scores" );
     ctxt.register_action( "morale" );
     ctxt.register_action( "messages" );
     ctxt.register_action( "help" );

--- a/src/game.h
+++ b/src/game.h
@@ -525,6 +525,8 @@ class game
         void reload_npcs();
         void remove_npc( character_id const &id );
         const kill_tracker &get_kill_tracker() const;
+        stats_tracker &stats();
+        achievements_tracker &achievements();
         /** Add follower id to set of followers. */
         void add_npc_follower( const character_id &id );
         /** Remove follower id from follower set. */
@@ -1039,9 +1041,7 @@ class game
         const scenario *scen = nullptr; // NOLINT(cata-serialize)
 
         event_bus &events();
-        stats_tracker &stats();
         timed_event_manager &timed_events; // NOLINT(cata-serialize)
-        achievements_tracker &achievements();
         memorial_logger &memorial();
 
         global_variables global_variables_instance;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2570,10 +2570,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             diary::show_diary_ui( u.get_avatar_diary() );
             break;
 
-        case ACTION_SCORES:
-            show_scores_ui( *achievements_tracker_ptr, stats(), get_kill_tracker() );
-            break;
-
         case ACTION_FACTIONS:
             faction_manager_ptr->display();
             break;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

See issues below for more details.

Fixes #59686
Fixes #59685 

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- Remove global "scores" keybind from code and replace it with a VIEW_SCORES keybind accessible only from the diary menu.
- Re-use "scores" keybind's default use of ')' for the key to access the diary by default.
- Implement VIEW_SCORES keybind and hint at its use from the diary menu.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

None.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

- Checked changed keybinds and ensured that they appeared in the right places and worked as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

diary menu:
![WindowsTerminal_nMG8Yy5khk](https://user-images.githubusercontent.com/2420411/226904133-ec4a40ce-fac9-43ff-8f98-d50db92b08bd.png)

diary keybindings:
![WindowsTerminal_hcPQPGeEah](https://user-images.githubusercontent.com/2420411/226904189-3c892b8a-28ff-4054-a526-c582b9834d31.png)

achievements/scores/killcount menu showing overlaid on top of diary menu:
![WindowsTerminal_VMXz7lZDck](https://user-images.githubusercontent.com/2420411/226904234-374ab4d0-cbd1-4f9c-9625-d2927ce5ff1a.png)
