### PR TITLE
Fix friction drag from insufficient wheels potentially causing direction change in vehicles

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -781,8 +781,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
     // If not enough wheels, mess up the ground a bit.
     if( !vertical && !veh.valid_wheel_config() && !( veh.is_watercraft() && veh.can_float() ) &&
         !veh.is_flying_in_air() && dp.z == 0 ) {
-        veh.velocity -= veh.velocity < 0 ?
-                        std::max( veh.velocity, -2000 ) : std::min( veh.velocity, 2000 );
+        veh.velocity -= std::clamp( veh.velocity, -2000, 2000 ); // extra drag
         for( const tripoint &p : veh.get_points() ) {
             const ter_id &pter = ter( p );
             if( pter == t_dirt || pter == t_grass ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -781,7 +781,8 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
     // If not enough wheels, mess up the ground a bit.
     if( !vertical && !veh.valid_wheel_config() && !( veh.is_watercraft() && veh.can_float() ) &&
         !veh.is_flying_in_air() && dp.z == 0 ) {
-        veh.velocity += veh.velocity < 0 ? 2000 : -2000;
+        veh.velocity -= veh.velocity < 0 ?
+                        std::max( veh.velocity, -2000 ) : std::min( veh.velocity, 2000 );
         for( const tripoint &p : veh.get_points() ) {
             const ter_id &pter = ter( p );
             if( pter == t_dirt || pter == t_grass ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix friction drag from insufficient wheels potentially causing direction change in vehicles"

#### Purpose of change
There's a bit of code that checks for a vehicle having insufficient wheels, and applying additional drag penalty as a flat velocity reduction of 2000 (hundredths of mph). This can inadvertently change direction of travel if initial value is less than 20mph.

#### Describe the solution
Cap the value: apply drag penalty speed reduction as lesser of 2000 and current velocity.

#### Testing
Code inspection