### PR TITLE
JSONized damage verbs for transforming items

### DIFF
--- a/data/json/items/armor/ballistic_armor.json
+++ b/data/json/items/armor/ballistic_armor.json
@@ -112,6 +112,7 @@
     "color": "dark_gray",
     "material_thickness": 25,
     "non_functional": "destroyed_large_ceramic_plate",
+    "damage_verb": "makes a crunch, something has shifted",
     "flags": [ "ABLATIVE_LARGE", "CANT_WEAR" ],
     "armor": [ { "encumbrance": 2, "coverage": 45, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
   },
@@ -260,6 +261,7 @@
     "color": "dark_gray",
     "material_thickness": 25,
     "non_functional": "destroyed_medium_ceramic_plate",
+    "damage_verb": "makes a crunch, something has shifted",
     "flags": [ "ABLATIVE_MEDIUM", "CANT_WEAR" ],
     "armor": [ { "encumbrance": 1, "coverage": 35, "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ] } ]
   },

--- a/data/json/items/armor/exotic.json
+++ b/data/json/items/armor/exotic.json
@@ -14,7 +14,7 @@
     "color": "dark_gray",
     "material_thickness": 10,
     "non_functional": "migo_plate",
-    "damage_verb": "crumbles as blood oozes from it's insides",
+    "damage_verb": "crumbles as blood oozes from its insides",
     "flags": [ "ABLATIVE_LARGE", "CANT_WEAR", "TRADER_AVOID" ],
     "armor": [
       {
@@ -44,7 +44,7 @@
     "color": "dark_gray",
     "material_thickness": 8,
     "non_functional": "migo_plate_undergrown",
-    "damage_verb": "crumbles as blood oozes from it's insides",
+    "damage_verb": "crumbles as blood oozes from its insides",
     "//": "transforms over a day",
     "countdown_interval": 86400,
     "countdown_action": { "type": "transform", "target": "migo_plate_overgrown", "msg": "The iridescent carapace plate expands as it grows." },
@@ -77,7 +77,7 @@
     "color": "dark_gray",
     "material_thickness": 6,
     "non_functional": "migo_plate_naked",
-    "damage_verb": "crumbles as blood oozes from it's insides",
+    "damage_verb": "crumbles as blood oozes from its insides",
     "//": "transforms over a day",
     "countdown_interval": 86400,
     "countdown_action": { "type": "transform", "target": "migo_plate", "msg": "The iridescent carapace plate expands as it grows." },

--- a/data/json/items/armor/exotic.json
+++ b/data/json/items/armor/exotic.json
@@ -14,6 +14,7 @@
     "color": "dark_gray",
     "material_thickness": 10,
     "non_functional": "migo_plate",
+    "damage_verb": "crumbles as blood oozes from it's insides",
     "flags": [ "ABLATIVE_LARGE", "CANT_WEAR", "TRADER_AVOID" ],
     "armor": [
       {
@@ -43,6 +44,7 @@
     "color": "dark_gray",
     "material_thickness": 8,
     "non_functional": "migo_plate_undergrown",
+    "damage_verb": "crumbles as blood oozes from it's insides",
     "//": "transforms over a day",
     "countdown_interval": 86400,
     "countdown_action": { "type": "transform", "target": "migo_plate_overgrown", "msg": "The iridescent carapace plate expands as it grows." },
@@ -75,6 +77,7 @@
     "color": "dark_gray",
     "material_thickness": 6,
     "non_functional": "migo_plate_naked",
+    "damage_verb": "crumbles as blood oozes from it's insides",
     "//": "transforms over a day",
     "countdown_interval": 86400,
     "countdown_action": { "type": "transform", "target": "migo_plate", "msg": "The iridescent carapace plate expands as it grows." },

--- a/doc/ARMOR_BALANCE_AND_DESIGN.md
+++ b/doc/ARMOR_BALANCE_AND_DESIGN.md
@@ -407,6 +407,7 @@ plate definition:
   "color": "dark_gray",
   "material_thickness": 25,
   "non_functional": "destroyed_large_ceramic_plate",
+  "damage_verb": "makes a crunch, something has shifted",
   "flags": [ "ABLATIVE_LARGE", "CANT_WEAR" ],
   "armor": [ { "encumbrance": 2, "coverage": 45, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
 }
@@ -418,6 +419,8 @@ Look at the Plates and Vests and ballistic armor or anything with ABLATIVE_LARGE
 ### Transform vs Durability
 #### Explanation
 Normally armor degrades with use. This degradation is incremental and decreases the armors effectiveness and protection. However not all armor degrades, some instead will become completely compromised. For these items ```"non_functional": "ITEM_ID"``` can be added. Instead of the normal degradation rules, armor with non_functional will have a chance to transform into its non_functional version when struck. Specifically transform items are concerned with how much damage they take before reduction, rather than after reduction and as the damage scales towards their total resistance (and beyond) scales to a 33% chance to transform (and beyond). Example a 50 damage bullet hitting a 50 damage plate has a 33% chance to transform, a 25 damage bullet would only have a 16.5% chance to cause a transform, 100 damage a 66% chance.
+
+Transforming items can also specify a custom destruction message with ```"damage_verb"``` which is what will be said when it is damaged.
 
 #### Example
 ```json
@@ -436,6 +439,7 @@ Normally armor degrades with use. This degradation is incremental and decreases 
   "color": "dark_gray",
   "material_thickness": 25,
   "non_functional": "destroyed_large_ceramic_plate",
+  "damage_verb": "makes a crunch, something has shifted",
   "flags": [ "ABLATIVE_LARGE", "CANT_WEAR" ],
   "armor": [ { "encumbrance": 2, "coverage": 45, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
 }

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3067,6 +3067,7 @@ Armor can be defined like this:
 "material_thickness" : 1,           // Thickness of material, in millimeter units (approximately).  Ordinary clothes range from 0.1 to 0.5. Particularly rugged cloth may reach as high as 1-2mm, and armor or protective equipment can range as high as 10 or rarely more.
 "power_armor" : false,              // If this is a power armor item (those are special).
 "non_functional" : "destroyed",     //this is the itype_id of an item that this turns into when destroyed. Currently only works for ablative armor.
+"damage_verb": "makes a crunch, something has shifted", // if an item uses non-functional this will be the description when it turns into its non functional variant.
 "valid_mods" : ["steel_padded"],    // List of valid clothing mods. Note that if the clothing mod doesn't have "restricted" listed, this isn't needed.
 "armor": [ ... ]
 ```

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -453,6 +453,9 @@ bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_b
                     // TODO: add balistic and shattering verbs for ablative materials instead of hard coded
                     std::string format_string = _( "Your %1$s is %2$s!" );
                     std::string damage_verb = "shattered";
+                    if( !ablative_armor.find_armor_data()->damage_verb.empty() ) {
+                        damage_verb = ablative_armor.find_armor_data()->damage_verb.translated();
+                    }
                     add_msg_if_player( m_bad, format_string, pre_damage_name, damage_verb );
 
                     if( is_avatar() ) {

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -451,8 +451,8 @@ bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_b
                     const std::string pre_damage_name = ablative_armor.tname();
 
                     // TODO: add balistic and shattering verbs for ablative materials instead of hard coded
-                    std::string format_string = _( "Your %1$s is %2$s!" );
-                    std::string damage_verb = "shattered";
+                    std::string format_string = _( "Your %1$s %2$s!" );
+                    std::string damage_verb = "is shattered";
                     if( !ablative_armor.find_armor_data()->damage_verb.empty() ) {
                         damage_verb = ablative_armor.find_armor_data()->damage_verb.translated();
                     }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2882,7 +2882,8 @@ void islot_armor::load( const JsonObject &jo )
     optional( jo, was_loaded, "sided", sided, false );
 
     optional( jo, was_loaded, "warmth", warmth, 0 );
-    optional( jo, false, "non_functional", non_functional, itype_id() );
+    optional( jo, was_loaded, "non_functional", non_functional, itype_id() );
+    optional( jo, was_loaded, "damage_verb", damage_verb );
     optional( jo, was_loaded, "weight_capacity_modifier", weight_capacity_modifier, 1.0 );
     optional( jo, was_loaded, "weight_capacity_bonus", weight_capacity_bonus, mass_reader{}, 0_gram );
     optional( jo, was_loaded, "power_armor", power_armor, false );

--- a/src/itype.h
+++ b/src/itype.h
@@ -374,6 +374,10 @@ struct islot_armor {
          */
         itype_id non_functional;
         /**
+         * The verb for what happens when the item transforms to non-functional
+         */
+        translation damage_verb;
+        /**
          * How much warmth this item provides.
          */
         int warmth = 0;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "JSONized damage verbs for transforming items"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The static damage verbs that were hard coded for transforming items didn't leave a lot of room for explaining what was happening. Making it a JSON value should help with this.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added a new JSON value damage_verb which if it exists items pull from.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested in game with ballistic plates


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Out of date screenshot:
![image](https://user-images.githubusercontent.com/4514073/227053438-268d4080-63a1-4bde-82d0-7870d7503412.png)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->