### PR TITLE
Type fixes for MSVC, use steady_clock for intervals

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2466,7 +2466,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
         if( display_tile.animated ) {
             // idle animations run during the user's turn, and the animation speed
             // needs to be defined by the tileset to look good, so we use system clock:
-            std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+            std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
             auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>( now );
             auto value = now_ms.time_since_epoch();
             // aiming roughly at the standard 60 frames per second:

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2578,24 +2578,24 @@ static void debug_menu_force_temperature()
     } else {
         string_input_popup pop;
 
-        auto ask = [&pop]( const std::string & unit, std::optional<int> current ) {
+        auto ask = [&pop]( const std::string & unit, std::optional<float> current ) {
             int ret = pop.title( string_format( _( "Set temperature to?  [%s]" ), unit ) )
                       .width( 20 )
                       .text( current ? std::to_string( *current ) : "" )
                       .only_digits( true )
                       .query_int();
 
-            return pop.canceled() ? current : std::optional<int>( ret );
+            return pop.canceled() ? current : std::optional<float>( static_cast<float>( ret ) );
         };
 
-        std::optional<int> current;
+        std::optional<float> current;
         std::string option = get_option<std::string>( "USE_CELSIUS" );
 
         if( option == "celsius" ) {
             if( forced_temp ) {
                 current = units::to_celsius( *forced_temp );
             }
-            std::optional<int> ret = ask( "C", current );
+            std::optional<float> ret = ask( "C", current );
             if( ret ) {
                 forced_temp = units::from_celsius( *ret );
             }
@@ -2603,7 +2603,7 @@ static void debug_menu_force_temperature()
             if( forced_temp ) {
                 current = units::to_kelvin( *forced_temp );
             }
-            std::optional<int> ret = ask( "K", current );
+            std::optional<float> ret = ask( "K", current );
             if( ret ) {
                 forced_temp = units::from_kelvin( *ret );
             }
@@ -2611,7 +2611,7 @@ static void debug_menu_force_temperature()
             if( forced_temp ) {
                 current = units::to_fahrenheit( *forced_temp );
             }
-            std::optional<int> ret = ask( "F", current );
+            std::optional<float> ret = ask( "F", current );
             if( ret ) {
                 forced_temp = units::from_fahrenheit( *ret );
             }

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -562,9 +562,9 @@ bool do_turn()
         } else {
             // Rate limit key polling to 10 times a second.
             static auto start = std::chrono::time_point_cast<std::chrono::milliseconds>(
-                                    std::chrono::system_clock::now() );
+                                    std::chrono::steady_clock::now() );
             const auto now = std::chrono::time_point_cast<std::chrono::milliseconds>(
-                                 std::chrono::system_clock::now() );
+                                 std::chrono::steady_clock::now() );
             if( ( now - start ).count() > 100 ) {
                 handle_key_blocking_activity();
                 start = now;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12257,7 +12257,7 @@ void game::debug_hour_timer::print_time()
     if( enabled ) {
         if( calendar::once_every( time_duration::from_hours( 1 ) ) ) {
             const IRLTimeMs now = std::chrono::time_point_cast<std::chrono::milliseconds>(
-                                      std::chrono::system_clock::now() );
+                                      std::chrono::steady_clock::now() );
             if( start_time ) {
                 add_msg( "in-game hour took: %d ms", ( now - *start_time ).count() );
             } else {

--- a/src/game.h
+++ b/src/game.h
@@ -1000,7 +1000,7 @@ class game
         class debug_hour_timer
         {
             public:
-                using IRLTimeMs = std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>;
+                using IRLTimeMs = std::chrono::time_point<std::chrono::steady_clock, std::chrono::milliseconds>;
                 void toggle();
                 void print_time();
             private:

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -67,13 +67,13 @@ static const item_category_id item_category_WEAPON_HELD( "WEAPON_HELD" );
 
 namespace
 {
-using startup_timer = std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>;
+using startup_timer = std::chrono::time_point<std::chrono::steady_clock, std::chrono::milliseconds>;
 startup_timer tp_start;
 
 void debug_print_timer( startup_timer const &tp, std::string const &msg = "inv_ui setup took" )
 {
     startup_timer const tp_now =
-        std::chrono::time_point_cast<std::chrono::milliseconds>( std::chrono::system_clock::now() );
+        std::chrono::time_point_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() );
     add_msg_debug( debugmode::DF_GAME, "%s: %i ms", msg, ( tp_now - tp ).count() );
 }
 
@@ -2227,7 +2227,7 @@ void inventory_selector::reassign_custom_invlets()
 void inventory_selector::prepare_layout()
 {
     startup_timer const tp_prep =
-        std::chrono::time_point_cast<std::chrono::milliseconds>( std::chrono::system_clock::now() );
+        std::chrono::time_point_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() );
 
     const auto snap = []( size_t cur_dim, size_t max_dim ) {
         return cur_dim + 2 * max_win_snap_distance >= max_dim ? max_dim : cur_dim;
@@ -2644,7 +2644,7 @@ inventory_selector::inventory_selector( Character &u, const inventory_selector_p
 {
     item_name_cache_users++;
     tp_start =
-        std::chrono::time_point_cast<std::chrono::milliseconds>( std::chrono::system_clock::now() );
+        std::chrono::time_point_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() );
     ctxt.register_action( "DOWN", to_translation( "Next item" ) );
     ctxt.register_action( "UP", to_translation( "Previous item" ) );
     ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2834,7 +2834,7 @@ static void get_relative( const JsonObject &jo, const std::string &member, std::
                           T default_val )
 {
     if( jo.has_member( member ) ) {
-        value = value.value_or( default_val ) + jo.get_float( member );
+        value = value.value_or( static_cast<T>( default_val ) ) + jo.get_float( member );
     }
 }
 
@@ -2843,7 +2843,7 @@ static void get_proportional( const JsonObject &jo, const std::string &member,
                               std::optional<T> &value, T default_val )
 {
     if( jo.has_member( member ) ) {
-        value = value.value_or( default_val ) * jo.get_float( member );
+        value = value.value_or( static_cast<T>( default_val ) ) * jo.get_float( member );
     }
 }
 

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -435,7 +435,7 @@ void play_music( const std::string &playlist )
         // affects audio, not game logic.
         // NOLINTNEXTLINE(cata-determinism)
         static cata_default_random_engine eng = cata_default_random_engine(
-                std::chrono::system_clock::now().time_since_epoch().count() );
+                std::chrono::steady_clock::now().time_since_epoch().count() );
         std::shuffle( playlist_indexes.begin(), playlist_indexes.end(), eng );
     }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Clear out MSVC warnings, use the correct clock for measuring intervals

#### Describe the solution

Change some types, add some casts

There's still some use of system_clock left in tgz_archiver but that one is for writing file mtime rather than interval

#### Describe alternatives you've considered

#### Testing

#### Additional context
