### PR TITLE
Display keybindings in UI consistently and add options to allow players to customize how the keybindings are displayed

### DIFF
--- a/data/help/texts.json
+++ b/data/help/texts.json
@@ -2,7 +2,7 @@
   {
     "type": "help",
     "order": 0,
-    "name": "<a|A>Introduction",
+    "name": "<a|A> Introduction",
     "messages": [
       "Cataclysm: Dark Days Ahead is a turn-based survival game set in a post-apocalyptic world.  You have survived the original onslaught, but the future looks pretty grim.",
       "You must prepare to face the many hardships to come, including dwindling supplies, hostile creatures, and harmful weather.  Even among fellow survivors you must stay alert, since someone may be plotting behind your back to take your hard-earned loot.",
@@ -13,7 +13,7 @@
   {
     "type": "help",
     "order": 1,
-    "name": "<b|B>Movement",
+    "name": "<b|B> Movement",
     "messages": [
       "Movement is performed using the numpad, the arrow keys, or vikeys.",
       "<HELP_DRAW_DIRECTIONS>",
@@ -26,7 +26,7 @@
   {
     "type": "help",
     "order": 2,
-    "name": "<c|C>Viewing",
+    "name": "<c|C> Viewing",
     "messages": [
       "The player can often see more than can be displayed on the screen at a time.  Pressing <press_look> enters \"Look around\" mode, which allows you to scroll around using the movement keys and view items on the map as well as monsters and their stance toward the character.  Pressing <press_listitems> provides a list of nearby visible items, though items shut away in crates, cupboards, refrigerators and the like won't be displayed until you are close enough.  Pressing Shift+vikeys (h,j,k,l,y,u,b,n) will scroll the view persistently, allowing you to keep an eye on things as you move around.",
       "Places outside of your view but seen previously and still memorized can be visualized, but they will be covered by the \"fog of war.\""
@@ -35,7 +35,7 @@
   {
     "type": "help",
     "order": 3,
-    "name": "<d|D>Hunger, thirst, and sleep",
+    "name": "<d|D> Hunger, thirst, and sleep",
     "messages": [
       "As time passes, you will begin to feel hunger and thirst, and your stomach will remind you of that.  When this happens, status information will appear in the sidebar.  Don't get confused - depending on your condition, it will display both how full your stomach is, as well as hunger intensity in relation to your nutrition status.  Your body nutrition level is distinct from your current hunger: for example, you may feel full after a big meal while still being malnourished, and you will still get hungry while being overweight.  With regular meals, you may even never get hungry and yet become malnourished, if your caloric intake is too low.  In other words, you need to track both your immediate hunger/fullness and the overall nutrition of your whole body.",
       "Food takes some time to digest, and water travels faster through your digestive system than does solid food.  Sudden overeating and overdrinking may make you feel excessively full, so split your meals.  If you had been starved before, it will take some time to recover your body mass by building up stored calories through regular eating.  Overeating for a prolonged period of time leads to obesity.  Both sides of the spectrum are penalized.  When hunger and thirst progress to severe levels, you will also suffer penalties.  Thirst will kill you faster than hunger.",
@@ -48,7 +48,7 @@
   {
     "type": "help",
     "order": 4,
-    "name": "<e|E>Pain and stimulants",
+    "name": "<e|E> Pain and stimulants",
     "messages": [
       "When you take damage from almost any source, you'll start to feel pain.  Pain slows you down and reduces your stats, and finding a way to manage pain is an early imperative.  The most common is drugs: aspirin, codeine, tramadol, oxycodone, and more are all great options.  Be aware that while under the influence of many painkillers, the physiological side effects may slow you down or reduce your stats.",
       "Note that most painkillers take a little while to kick in.  If you take some oxycodone and don't notice the effects right away, don't start taking more -  you may overdose and die!",
@@ -61,7 +61,7 @@
   {
     "type": "help",
     "order": 5,
-    "name": "<f|F>Healing and medication",
+    "name": "<f|F> Healing and medication",
     "messages": [
       "When you take damage, it will change the status of the affected body part, as shown in the sidebar.  Its overall wellness is represented by a series of bars that will deplete and change color the more damage you take.  If the accumulated damage is more than the body part can suffer, it will break.  If that happens to a critical body part (i.e., your torso or head), you will die.  For other body parts, it means broken bones, significant penalties, and a long process of healing - after placing the affected limb in a splint.",
       "Normal damage heals with time.  You heal more during a good sleep, but wounds also heal a bit while you are awake.",
@@ -74,7 +74,7 @@
   {
     "type": "help",
     "order": 6,
-    "name": "<g|G>Addiction",
+    "name": "<g|G> Addiction",
     "messages": [
       "Many drugs (and some consumables) have a potential for addiction.  Each time you consume such a substance, there is a chance that you will grow dependent on it.  Consuming more of that drug will increase your dependence.  Effects vary greatly between addictive substances, but no matter the substance, addiction has only one cure: going cold turkey.  The process may last for days, and will leave you very weak, so try to do it in a safe area.",
       "If you are suffering from withdrawal effects, taking more of the addictive substance will cause the effects to cease immediately, but may deepen your dependence."
@@ -83,7 +83,7 @@
   {
     "type": "help",
     "order": 7,
-    "name": "<h|H>Morale and learning",
+    "name": "<h|H> Morale and learning",
     "messages": [
       "Your character has a morale level, which affects you in many ways.  The depressing post-apocalypse world is tough to deal with, and your mood will naturally decrease very slowly.",
       "There are lots of options for increasing morale: reading an entertaining book, eating delicious food, listening to music, and taking recreational drugs are but a few options.  However, most morale-boosting activities can only elevate your mood to a certain level before they grow boring.",
@@ -98,7 +98,7 @@
   {
     "type": "help",
     "order": 8,
-    "name": "<i|I>Radioactivity and mutation",
+    "name": "<i|I> Radioactivity and mutation",
     "messages": [
       "Though it is relatively rare, certain areas of the world may be contaminated with radiation.  It will gradually accumulate in your body, weakening you more and more.  While in radiation-free areas, your radiation level will slowly decrease; taking Prussian blue tablets will help speed this process.  Get yourself a measuring device, as radiation is invisible, and you may not know that you are under its influence until it results in radiation sickness.",
       "If you become very irradiated, you may develop mutations.  Most of the time, these mutations will be negative; however, many are beneficial, and others have both positive and negative effects.  Your mutations may change your play style considerably.  It is possible to find substances that will remove mutations, though these are extremely rare.",
@@ -108,7 +108,7 @@
   {
     "type": "help",
     "order": 9,
-    "name": "<j|J>Bionics",
+    "name": "<j|J> Bionics",
     "messages": [
       "Bionics are biomechanical upgrades to your body.  While many are simply 'built-in' versions of items you would otherwise have to carry, some bionics have unique effects that are otherwise unobtainable.  Some bionics are constantly working, whereas others need to be toggled on and off as needed.",
       "Most bionics require a source of power, and you will need an internal battery to store energy for them.  Your current amount of energy is displayed in the sidebar right below your health.  Replenishing energy can be done in a variety of ways, but all require the installation of a special bionic just for that purpose.",
@@ -121,7 +121,7 @@
   {
     "type": "help",
     "order": 10,
-    "name": "<k|K>Crafting",
+    "name": "<k|K> Crafting",
     "messages": [
       "Many important items can be very hard to find, or will cost a great deal of money to trade for.  Fortunately, it is possible to craft a wide variety of goods (as best you can) with the proper tools, materials, and training.",
       "Some recipes require a set of tools.  These are not used up when crafting, so you can keep your tool set.  All recipes require one or more ingredients; these ARE used up in crafting.",
@@ -141,7 +141,7 @@
   {
     "type": "help",
     "order": 11,
-    "name": "<l|L>Traps",
+    "name": "<l|L> Traps",
     "messages": [
       "Before sleeping in dangerous territory, it may be wise to set traps to ward off unwanted intrusions - or at least warn you if one is in progress.  There are a few traps to be found in the world, most notably bubble wrap (which will make a loud noise if stepped on, helping to wake you up) and bear traps (which make noise AND damage, and trap anything that steps on them).  Others need to be crafted; this requires the Devices skill, and possibly Mechanics.",
       "To set a trap, simply use the item (press <press_apply>) and choose a direction; the trap will be placed on the chosen tile.  Some traps may require additional tools, like a shovel, to be set.  Once set, a trap will remain in place until stepped on or disarmed.",
@@ -153,7 +153,7 @@
   {
     "type": "help",
     "order": 12,
-    "name": "<m|M>Items overview",
+    "name": "<m|M> Items overview",
     "messages": [
       "There is a wide variety of items available for your use.  You may find them lying on the ground; if so, simply press <press_pickup> to pick up items on the same tile.  Some items are found inside a container, which may be drawn as a { with a blue background.  Pressing <press_examine>, then a direction key, will allow you to examine these containers and loot their contents.",
       "Pressing <press_compare> opens a comparison menu, where you can see two items side-by-side with their attributes color-coded to indicate which is superior.  You can also access the item comparison menu by pressing C after <press_listitems> to open the \"List all items around the player\" menu and selecting an item.",
@@ -171,7 +171,7 @@
   {
     "type": "help",
     "order": 13,
-    "name": "<n|N>Combat",
+    "name": "<n|N> Combat",
     "messages": [
       "Zombies in cities will spawn at the start of the game, but may also wander around.  All monsters are represented by letters (or sprites in the Tiles version) on your screen; a list of monster names, as well as their positions relative to you, is displayed on the right side of the screen.  The 'compass' will display monsters that you see but are currently off the screen.",
       "To attack a monster with a melee weapon, simply move into them.  The time it takes to attack depends on the size and weight of your weapon.  Small, light weapons are the fastest; unarmed attacks increase in speed with your Unarmed Combat skill, and will eventually be VERY fast.  A successful hit with a bashing weapon may stun the monster temporarily.  A miss may make you stumble and lose movement points.  If a monster hits you, your clothing may absorb some of the damage, but you will take what remains.",
@@ -188,7 +188,7 @@
   {
     "type": "help",
     "order": 14,
-    "name": "<o|O>Martial arts styles",
+    "name": "<o|O> Martial arts styles",
     "messages": [
       "A variety of fighting styles are available, particularly for the unarmed fighter.  You can start with your choice of a single, commonly-taught style by starting with the Martial Arts Training trait.  Many, many more can be found in their own traits, trained from manuals or by taking lessons from wandering masters.",
       "To select a fighting style, press <press_pick_style>.  Some styles are relevant only when you are unarmed, others are compatible with (or require) certain weapons.  If your current weapon is compatible with the chosen style, you will start using the selected style immediately.  Otherwise, it will be locked in as your default style.  To start using it, wield a relevant weapon, or empty your hands by pressing <press_wield>, then the key for the item you are currently wielding.  If you wish to prevent yourself from accidentally wielding weapons taken from the ground, enable \"Keep hands free\" found in the styles menu.",
@@ -200,7 +200,7 @@
   {
     "type": "help",
     "order": 15,
-    "name": "<p|P>Survival tips",
+    "name": "<p|P> Survival tips",
     "messages": [
       "The hierarchy of needs for survival in most cases is as follows: shelter, fire, water, food.  The rest is the process of trying to answer a question: What would you do in a survival situation?",
       "The first thing to do, when you are out of immediate danger, is to check your starting location for useful items.  Your initial storage is limited, and a backpack, trenchcoat, or other storage medium will let you carry a lot more.  Finding a weapon is important, but not a first priority; frying pans, butcher knives, and more are common in houses, and hardware stores may have others, as well as useful tools.  Initially, save any guns you find as a last resort: ammo is scarce, while zombies are plenty, and unwanted attention may be more than you can handle.",
@@ -218,7 +218,7 @@
   {
     "type": "help",
     "order": 16,
-    "name": "<r|R>Vehicles and Driving",
+    "name": "<r|R> Vehicles and Driving",
     "messages": [
       "You control vehicles using the numpad, or vikeys.  Note, however, that you control the vehicle's controls, rather than controlling the vehicle directly.",
       "<HELP_DRAW_DIRECTIONS>",
@@ -245,7 +245,7 @@
   {
     "type": "help",
     "order": 17,
-    "name": "<s|S>Skills and proficiencies",
+    "name": "<s|S> Skills and proficiencies",
     "messages": [
       "SKILLS",
       "Each character has a collection of skills they may learn over time.  These are grouped into four categories: Melee, Ranged, Crafting, and Interaction.  Each skill begins at level 0 and increases with study and practice up to a maximum of level 10.  Each level is harder to attain than the one before, but each level also increases the character's ability to do things using that skill, and may unlock crafting recipes or other actions gated by skill level.  Reaching level 10 in any skill represents true mastery, near the limit of human capability.",
@@ -261,7 +261,7 @@
   {
     "type": "help",
     "order": 18,
-    "name": "<1>List of item types and data",
+    "name": "<1> List of item types and data",
     "messages": [
       "~       Liquid\n%%       Food\n!       Medication\nThese are all consumed by using <press_eat>.  They may provide a certain amount of nutrition, may quench your thirst, may be a stimulant or a depressant, and may provide (or reduce!) morale.  There may also be more subtle effects.",
       "/       Large weapon\n;       Small weapon or tool\n,       Tiny item\nThese are all generic items, useful only to be wielded as a weapon.  However, some have special uses; they will show up under the TOOLS section in your inventory.  Press <press_apply> to use these.",
@@ -276,7 +276,7 @@
   {
     "type": "help",
     "order": 19,
-    "name": "<2>Description of map symbols",
+    "name": "<2> Description of map symbols",
     "messages": [
       "MAP SYMBOLS:",
       "<color_brown>.</color>           Field - Empty grassland with occasional wild fruit.",
@@ -304,7 +304,7 @@
   {
     "type": "help",
     "order": 20,
-    "name": "<3>Description of gun types",
+    "name": "<3> Description of gun types",
     "messages": [
       "<color_light_gray>( Handguns</color>\nHandguns are small weapons held in one or both hands.  They are much more difficult to aim and control than larger firearms, and this is reflected in their poor accuracy.  However, their small size makes them appropriate for short-range combat.  They are also relatively quick to reload and use a very wide variety of ammunition.  Their small size and low weight make it possible to carry several loaded handguns, switching from one to the next as their ammo is spent.",
       "<color_green>( Crossbows</color>\nThe best feature of crossbows is low noise they produce.  The bolts they fire are only rarely destroyed; if you pick up the bolts after firing them, your ammunition supply will last much longer.  Crossbows suffer from a short range and a very long reload time (modified by your strength); plus, most only hold a single round.\nFor this reason, it is advisable to carry a few loaded crossbows.  Crossbows can be very difficult to find; however, it is possible to craft one given a high enough Fabrication skill.  Likewise, it is possible to make wooden bolts from any number of wooden objects, though these are much less effective than steel bolts.  Crossbows use the Rifles skill.",
@@ -320,7 +320,7 @@
   {
     "type": "help",
     "order": 21,
-    "name": "<4>FAQ (contains spoilers!)",
+    "name": "<4> FAQ (contains spoilers!)",
     "messages": [
       "Q: What is safe mode, and why does it prevent me from moving?\nA: Safe mode is a way to guarantee that you won't die by holding a movement key down.  When a monster comes into view, your movement will be ignored until safe mode is turned off with the <press_safemode> key.  This ensures that the sudden appearance of a monster won't catch you off guard.",
       "Q: It seems like everything I eat makes me sick!  What's wrong?\nA: Lots of the food found in towns is perishable and will only last a few days after the start of a new game.  The electricity went out several days ago, so fruit, milk, and similar foods are the first to go bad.  After the first couple of days, you should switch to canned food, jerky, and hunting.  Also, you should make sure to cook any food and purify any water you come across, as it may contain parasites or otherwise be unsafe.",

--- a/data/help/texts.json
+++ b/data/help/texts.json
@@ -2,7 +2,7 @@
   {
     "type": "help",
     "order": 0,
-    "name": "<a|A>: Introduction",
+    "name": "<a|A>Introduction",
     "messages": [
       "Cataclysm: Dark Days Ahead is a turn-based survival game set in a post-apocalyptic world.  You have survived the original onslaught, but the future looks pretty grim.",
       "You must prepare to face the many hardships to come, including dwindling supplies, hostile creatures, and harmful weather.  Even among fellow survivors you must stay alert, since someone may be plotting behind your back to take your hard-earned loot.",
@@ -13,7 +13,7 @@
   {
     "type": "help",
     "order": 1,
-    "name": "<b|B>: Movement",
+    "name": "<b|B>Movement",
     "messages": [
       "Movement is performed using the numpad, the arrow keys, or vikeys.",
       "<HELP_DRAW_DIRECTIONS>",
@@ -26,7 +26,7 @@
   {
     "type": "help",
     "order": 2,
-    "name": "<c|C>: Viewing",
+    "name": "<c|C>Viewing",
     "messages": [
       "The player can often see more than can be displayed on the screen at a time.  Pressing <press_look> enters \"Look around\" mode, which allows you to scroll around using the movement keys and view items on the map as well as monsters and their stance toward the character.  Pressing <press_listitems> provides a list of nearby visible items, though items shut away in crates, cupboards, refrigerators and the like won't be displayed until you are close enough.  Pressing Shift+vikeys (h,j,k,l,y,u,b,n) will scroll the view persistently, allowing you to keep an eye on things as you move around.",
       "Places outside of your view but seen previously and still memorized can be visualized, but they will be covered by the \"fog of war.\""
@@ -35,7 +35,7 @@
   {
     "type": "help",
     "order": 3,
-    "name": "<d|D>: Hunger, thirst, and sleep",
+    "name": "<d|D>Hunger, thirst, and sleep",
     "messages": [
       "As time passes, you will begin to feel hunger and thirst, and your stomach will remind you of that.  When this happens, status information will appear in the sidebar.  Don't get confused - depending on your condition, it will display both how full your stomach is, as well as hunger intensity in relation to your nutrition status.  Your body nutrition level is distinct from your current hunger: for example, you may feel full after a big meal while still being malnourished, and you will still get hungry while being overweight.  With regular meals, you may even never get hungry and yet become malnourished, if your caloric intake is too low.  In other words, you need to track both your immediate hunger/fullness and the overall nutrition of your whole body.",
       "Food takes some time to digest, and water travels faster through your digestive system than does solid food.  Sudden overeating and overdrinking may make you feel excessively full, so split your meals.  If you had been starved before, it will take some time to recover your body mass by building up stored calories through regular eating.  Overeating for a prolonged period of time leads to obesity.  Both sides of the spectrum are penalized.  When hunger and thirst progress to severe levels, you will also suffer penalties.  Thirst will kill you faster than hunger.",
@@ -48,7 +48,7 @@
   {
     "type": "help",
     "order": 4,
-    "name": "<e|E>: Pain and stimulants",
+    "name": "<e|E>Pain and stimulants",
     "messages": [
       "When you take damage from almost any source, you'll start to feel pain.  Pain slows you down and reduces your stats, and finding a way to manage pain is an early imperative.  The most common is drugs: aspirin, codeine, tramadol, oxycodone, and more are all great options.  Be aware that while under the influence of many painkillers, the physiological side effects may slow you down or reduce your stats.",
       "Note that most painkillers take a little while to kick in.  If you take some oxycodone and don't notice the effects right away, don't start taking more -  you may overdose and die!",
@@ -61,7 +61,7 @@
   {
     "type": "help",
     "order": 5,
-    "name": "<f|F>: Healing and medication",
+    "name": "<f|F>Healing and medication",
     "messages": [
       "When you take damage, it will change the status of the affected body part, as shown in the sidebar.  Its overall wellness is represented by a series of bars that will deplete and change color the more damage you take.  If the accumulated damage is more than the body part can suffer, it will break.  If that happens to a critical body part (i.e., your torso or head), you will die.  For other body parts, it means broken bones, significant penalties, and a long process of healing - after placing the affected limb in a splint.",
       "Normal damage heals with time.  You heal more during a good sleep, but wounds also heal a bit while you are awake.",
@@ -74,7 +74,7 @@
   {
     "type": "help",
     "order": 6,
-    "name": "<g|G>: Addiction",
+    "name": "<g|G>Addiction",
     "messages": [
       "Many drugs (and some consumables) have a potential for addiction.  Each time you consume such a substance, there is a chance that you will grow dependent on it.  Consuming more of that drug will increase your dependence.  Effects vary greatly between addictive substances, but no matter the substance, addiction has only one cure: going cold turkey.  The process may last for days, and will leave you very weak, so try to do it in a safe area.",
       "If you are suffering from withdrawal effects, taking more of the addictive substance will cause the effects to cease immediately, but may deepen your dependence."
@@ -83,7 +83,7 @@
   {
     "type": "help",
     "order": 7,
-    "name": "<h|H>: Morale and learning",
+    "name": "<h|H>Morale and learning",
     "messages": [
       "Your character has a morale level, which affects you in many ways.  The depressing post-apocalypse world is tough to deal with, and your mood will naturally decrease very slowly.",
       "There are lots of options for increasing morale: reading an entertaining book, eating delicious food, listening to music, and taking recreational drugs are but a few options.  However, most morale-boosting activities can only elevate your mood to a certain level before they grow boring.",
@@ -98,7 +98,7 @@
   {
     "type": "help",
     "order": 8,
-    "name": "<i|I>: Radioactivity and mutation",
+    "name": "<i|I>Radioactivity and mutation",
     "messages": [
       "Though it is relatively rare, certain areas of the world may be contaminated with radiation.  It will gradually accumulate in your body, weakening you more and more.  While in radiation-free areas, your radiation level will slowly decrease; taking Prussian blue tablets will help speed this process.  Get yourself a measuring device, as radiation is invisible, and you may not know that you are under its influence until it results in radiation sickness.",
       "If you become very irradiated, you may develop mutations.  Most of the time, these mutations will be negative; however, many are beneficial, and others have both positive and negative effects.  Your mutations may change your play style considerably.  It is possible to find substances that will remove mutations, though these are extremely rare.",
@@ -108,7 +108,7 @@
   {
     "type": "help",
     "order": 9,
-    "name": "<j|J>: Bionics",
+    "name": "<j|J>Bionics",
     "messages": [
       "Bionics are biomechanical upgrades to your body.  While many are simply 'built-in' versions of items you would otherwise have to carry, some bionics have unique effects that are otherwise unobtainable.  Some bionics are constantly working, whereas others need to be toggled on and off as needed.",
       "Most bionics require a source of power, and you will need an internal battery to store energy for them.  Your current amount of energy is displayed in the sidebar right below your health.  Replenishing energy can be done in a variety of ways, but all require the installation of a special bionic just for that purpose.",
@@ -121,7 +121,7 @@
   {
     "type": "help",
     "order": 10,
-    "name": "<k|K>: Crafting",
+    "name": "<k|K>Crafting",
     "messages": [
       "Many important items can be very hard to find, or will cost a great deal of money to trade for.  Fortunately, it is possible to craft a wide variety of goods (as best you can) with the proper tools, materials, and training.",
       "Some recipes require a set of tools.  These are not used up when crafting, so you can keep your tool set.  All recipes require one or more ingredients; these ARE used up in crafting.",
@@ -141,7 +141,7 @@
   {
     "type": "help",
     "order": 11,
-    "name": "<l|L>: Traps",
+    "name": "<l|L>Traps",
     "messages": [
       "Before sleeping in dangerous territory, it may be wise to set traps to ward off unwanted intrusions - or at least warn you if one is in progress.  There are a few traps to be found in the world, most notably bubble wrap (which will make a loud noise if stepped on, helping to wake you up) and bear traps (which make noise AND damage, and trap anything that steps on them).  Others need to be crafted; this requires the Devices skill, and possibly Mechanics.",
       "To set a trap, simply use the item (press <press_apply>) and choose a direction; the trap will be placed on the chosen tile.  Some traps may require additional tools, like a shovel, to be set.  Once set, a trap will remain in place until stepped on or disarmed.",
@@ -153,7 +153,7 @@
   {
     "type": "help",
     "order": 12,
-    "name": "<m|M>: Items overview",
+    "name": "<m|M>Items overview",
     "messages": [
       "There is a wide variety of items available for your use.  You may find them lying on the ground; if so, simply press <press_pickup> to pick up items on the same tile.  Some items are found inside a container, which may be drawn as a { with a blue background.  Pressing <press_examine>, then a direction key, will allow you to examine these containers and loot their contents.",
       "Pressing <press_compare> opens a comparison menu, where you can see two items side-by-side with their attributes color-coded to indicate which is superior.  You can also access the item comparison menu by pressing C after <press_listitems> to open the \"List all items around the player\" menu and selecting an item.",
@@ -164,14 +164,14 @@
       "For example, on her torso, a character might wear a leather corset (close to skin), a combat shirt (normal), a trenchcoat (outer), and a survivor runner pack (strapped).  Her encumbrance penalty is 0.  If she put on a tank top it would conflict with the leather corset and add the minimum encumbrance penalty of 2.",
       "Items can be damaged through various means, whether intentional or not.  Indicators such as <color_yellow>|\\</color> show the item's current state.  You may be able to repair the item using specific tools, which are listed in the item's information screen.",
       "Items are also subject to degradation, which represents the item's structural integrity over its lifetime.  Items that suffer serious damage can become more degraded, which limits how well the item can be repaired.  The higher the degradation, the less you'll be able to repair it.",
-      "In the View Nearby Items menu (press <press_listitems> to open), you can filter or prioritize items.  You can enter item names, or use various advanced filter strings: {<token>:<search param>}.",
+      "In the View Nearby Items menu (press <press_listitems> to open), you can filter or prioritize items.  You can enter item names, or use various advanced filter strings: {<token><search param>}.",
       "Some available tokens:\n    c = category (books, food, etc)    | {c:books}\n    m = material (cotton, Kevlar, etc) | {m:iron}"
     ]
   },
   {
     "type": "help",
     "order": 13,
-    "name": "<n|N>: Combat",
+    "name": "<n|N>Combat",
     "messages": [
       "Zombies in cities will spawn at the start of the game, but may also wander around.  All monsters are represented by letters (or sprites in the Tiles version) on your screen; a list of monster names, as well as their positions relative to you, is displayed on the right side of the screen.  The 'compass' will display monsters that you see but are currently off the screen.",
       "To attack a monster with a melee weapon, simply move into them.  The time it takes to attack depends on the size and weight of your weapon.  Small, light weapons are the fastest; unarmed attacks increase in speed with your Unarmed Combat skill, and will eventually be VERY fast.  A successful hit with a bashing weapon may stun the monster temporarily.  A miss may make you stumble and lose movement points.  If a monster hits you, your clothing may absorb some of the damage, but you will take what remains.",
@@ -188,7 +188,7 @@
   {
     "type": "help",
     "order": 14,
-    "name": "<o|O>: Martial arts styles",
+    "name": "<o|O>Martial arts styles",
     "messages": [
       "A variety of fighting styles are available, particularly for the unarmed fighter.  You can start with your choice of a single, commonly-taught style by starting with the Martial Arts Training trait.  Many, many more can be found in their own traits, trained from manuals or by taking lessons from wandering masters.",
       "To select a fighting style, press <press_pick_style>.  Some styles are relevant only when you are unarmed, others are compatible with (or require) certain weapons.  If your current weapon is compatible with the chosen style, you will start using the selected style immediately.  Otherwise, it will be locked in as your default style.  To start using it, wield a relevant weapon, or empty your hands by pressing <press_wield>, then the key for the item you are currently wielding.  If you wish to prevent yourself from accidentally wielding weapons taken from the ground, enable \"Keep hands free\" found in the styles menu.",
@@ -200,7 +200,7 @@
   {
     "type": "help",
     "order": 15,
-    "name": "<p|P>: Survival tips",
+    "name": "<p|P>Survival tips",
     "messages": [
       "The hierarchy of needs for survival in most cases is as follows: shelter, fire, water, food.  The rest is the process of trying to answer a question: What would you do in a survival situation?",
       "The first thing to do, when you are out of immediate danger, is to check your starting location for useful items.  Your initial storage is limited, and a backpack, trenchcoat, or other storage medium will let you carry a lot more.  Finding a weapon is important, but not a first priority; frying pans, butcher knives, and more are common in houses, and hardware stores may have others, as well as useful tools.  Initially, save any guns you find as a last resort: ammo is scarce, while zombies are plenty, and unwanted attention may be more than you can handle.",
@@ -218,7 +218,7 @@
   {
     "type": "help",
     "order": 16,
-    "name": "<r|R>: Vehicles and Driving",
+    "name": "<r|R>Vehicles and Driving",
     "messages": [
       "You control vehicles using the numpad, or vikeys.  Note, however, that you control the vehicle's controls, rather than controlling the vehicle directly.",
       "<HELP_DRAW_DIRECTIONS>",
@@ -245,7 +245,7 @@
   {
     "type": "help",
     "order": 17,
-    "name": "<s|S>: Skills and proficiencies",
+    "name": "<s|S>Skills and proficiencies",
     "messages": [
       "SKILLS",
       "Each character has a collection of skills they may learn over time.  These are grouped into four categories: Melee, Ranged, Crafting, and Interaction.  Each skill begins at level 0 and increases with study and practice up to a maximum of level 10.  Each level is harder to attain than the one before, but each level also increases the character's ability to do things using that skill, and may unlock crafting recipes or other actions gated by skill level.  Reaching level 10 in any skill represents true mastery, near the limit of human capability.",
@@ -261,7 +261,7 @@
   {
     "type": "help",
     "order": 18,
-    "name": "<1>: List of item types and data",
+    "name": "<1>List of item types and data",
     "messages": [
       "~       Liquid\n%%       Food\n!       Medication\nThese are all consumed by using <press_eat>.  They may provide a certain amount of nutrition, may quench your thirst, may be a stimulant or a depressant, and may provide (or reduce!) morale.  There may also be more subtle effects.",
       "/       Large weapon\n;       Small weapon or tool\n,       Tiny item\nThese are all generic items, useful only to be wielded as a weapon.  However, some have special uses; they will show up under the TOOLS section in your inventory.  Press <press_apply> to use these.",
@@ -276,7 +276,7 @@
   {
     "type": "help",
     "order": 19,
-    "name": "<2>: Description of map symbols",
+    "name": "<2>Description of map symbols",
     "messages": [
       "MAP SYMBOLS:",
       "<color_brown>.</color>           Field - Empty grassland with occasional wild fruit.",
@@ -304,7 +304,7 @@
   {
     "type": "help",
     "order": 20,
-    "name": "<3>: Description of gun types",
+    "name": "<3>Description of gun types",
     "messages": [
       "<color_light_gray>( Handguns</color>\nHandguns are small weapons held in one or both hands.  They are much more difficult to aim and control than larger firearms, and this is reflected in their poor accuracy.  However, their small size makes them appropriate for short-range combat.  They are also relatively quick to reload and use a very wide variety of ammunition.  Their small size and low weight make it possible to carry several loaded handguns, switching from one to the next as their ammo is spent.",
       "<color_green>( Crossbows</color>\nThe best feature of crossbows is low noise they produce.  The bolts they fire are only rarely destroyed; if you pick up the bolts after firing them, your ammunition supply will last much longer.  Crossbows suffer from a short range and a very long reload time (modified by your strength); plus, most only hold a single round.\nFor this reason, it is advisable to carry a few loaded crossbows.  Crossbows can be very difficult to find; however, it is possible to craft one given a high enough Fabrication skill.  Likewise, it is possible to make wooden bolts from any number of wooden objects, though these are much less effective than steel bolts.  Crossbows use the Rifles skill.",
@@ -320,7 +320,7 @@
   {
     "type": "help",
     "order": 21,
-    "name": "<4>: FAQ (contains spoilers!)",
+    "name": "<4>FAQ (contains spoilers!)",
     "messages": [
       "Q: What is safe mode, and why does it prevent me from moving?\nA: Safe mode is a way to guarantee that you won't die by holding a movement key down.  When a monster comes into view, your movement will be ignored until safe mode is turned off with the <press_safemode> key.  This ensures that the sudden appearance of a monster won't catch you off guard.",
       "Q: It seems like everything I eat makes me sick!  What's wrong?\nA: Lots of the food found in towns is perishable and will only last a few days after the start of a new game.  The electricity went out several days ago, so fruit, milk, and similar foods are the first to go bad.  After the first couple of days, you should switch to canned food, jerky, and hunting.  Also, you should make sure to cook any food and purify any water you come across, as it may contain parasites or otherwise be unsafe.",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4197,6 +4197,7 @@
     "id": "FAV_CONTEXT_MENU",
     "category": "INVENTORY",
     "name": "Open context menu",
+    "short_name": "Context menu",
     "bindings": [
       { "input_method": "keyboard_any", "key": "RETURN" },
       { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -228,6 +228,7 @@
     "id": "ENABLE_MAPEXTRA_NOTE",
     "category": "AUTO_NOTES",
     "name": "Enable auto notes for map extras",
+    "short_name": "Enable",
     "bindings": [
       { "input_method": "keyboard_any", "key": "e" },
       { "input_method": "keyboard_char", "key": "E" },
@@ -239,6 +240,7 @@
     "id": "SWITCH_AUTO_NOTE_OPTION",
     "category": "AUTO_NOTES",
     "name": "Toggle auto notes option",
+    "short_name": "Auto notes",
     "bindings": [
       { "input_method": "keyboard_any", "key": "s" },
       { "input_method": "keyboard_char", "key": "S" },
@@ -250,6 +252,7 @@
     "id": "DISABLE_MAPEXTRA_NOTE",
     "category": "AUTO_NOTES",
     "name": "Disable auto notes for map extras",
+    "short_name": "Disable",
     "bindings": [
       { "input_method": "keyboard_any", "key": "d" },
       { "input_method": "keyboard_char", "key": "D" },
@@ -296,6 +299,7 @@
     "id": "ADD_RULE",
     "category": "AUTO_PICKUP",
     "name": "Add rule",
+    "short_name": "Add",
     "bindings": [
       { "input_method": "keyboard_any", "key": "a" },
       { "input_method": "keyboard_char", "key": "A" },
@@ -307,6 +311,7 @@
     "id": "REMOVE_RULE",
     "category": "AUTO_PICKUP",
     "name": "Remove rule",
+    "short_name": "Remove",
     "bindings": [
       { "input_method": "keyboard_any", "key": "r" },
       { "input_method": "keyboard_char", "key": "R" },
@@ -318,6 +323,7 @@
     "id": "COPY_RULE",
     "category": "AUTO_PICKUP",
     "name": "Copy rule",
+    "short_name": "Copy",
     "bindings": [
       { "input_method": "keyboard_any", "key": "c" },
       { "input_method": "keyboard_char", "key": "C" },
@@ -329,6 +335,7 @@
     "id": "SWAP_RULE_GLOBAL_CHAR",
     "category": "AUTO_PICKUP",
     "name": "Move rule global <-> character",
+    "short_name": "Move",
     "bindings": [
       { "input_method": "keyboard_any", "key": "m" },
       { "input_method": "keyboard_char", "key": "M" },
@@ -340,6 +347,7 @@
     "id": "ENABLE_RULE",
     "category": "AUTO_PICKUP",
     "name": "Enable rule",
+    "short_name": "Enable",
     "bindings": [
       { "input_method": "keyboard_any", "key": "e" },
       { "input_method": "keyboard_char", "key": "E" },
@@ -351,6 +359,7 @@
     "id": "DISABLE_RULE",
     "category": "AUTO_PICKUP",
     "name": "Disable rule",
+    "short_name": "Disable",
     "bindings": [
       { "input_method": "keyboard_any", "key": "d" },
       { "input_method": "keyboard_char", "key": "D" },
@@ -391,6 +400,7 @@
     "id": "SWITCH_AUTO_PICKUP_OPTION",
     "category": "AUTO_PICKUP",
     "name": "Enable auto pickup option",
+    "short_name": "Auto pickup",
     "bindings": [
       { "input_method": "keyboard_any", "key": "s" },
       { "input_method": "keyboard_char", "key": "S" },
@@ -423,6 +433,7 @@
     "id": "ADD_RULE",
     "category": "SAFEMODE",
     "name": "Add rule",
+    "short_name": "Add",
     "bindings": [
       { "input_method": "keyboard_any", "key": "a" },
       { "input_method": "keyboard_char", "key": "A" },
@@ -434,6 +445,7 @@
     "id": "REMOVE_RULE",
     "category": "SAFEMODE",
     "name": "Remove rule",
+    "short_name": "Remove",
     "bindings": [
       { "input_method": "keyboard_any", "key": "r" },
       { "input_method": "keyboard_char", "key": "R" },
@@ -445,6 +457,7 @@
     "id": "COPY_RULE",
     "category": "SAFEMODE",
     "name": "Copy rule",
+    "short_name": "Copy",
     "bindings": [
       { "input_method": "keyboard_any", "key": "c" },
       { "input_method": "keyboard_char", "key": "C" },
@@ -456,6 +469,7 @@
     "id": "SWAP_RULE_GLOBAL_CHAR",
     "category": "SAFEMODE",
     "name": "Move rule global <-> character",
+    "short_name": "Move",
     "bindings": [
       { "input_method": "keyboard_any", "key": "m" },
       { "input_method": "keyboard_char", "key": "M" },
@@ -467,6 +481,7 @@
     "id": "ENABLE_RULE",
     "category": "SAFEMODE",
     "name": "Enable rule",
+    "short_name": "Enable",
     "bindings": [
       { "input_method": "keyboard_any", "key": "e" },
       { "input_method": "keyboard_char", "key": "E" },
@@ -478,6 +493,7 @@
     "id": "DISABLE_RULE",
     "category": "SAFEMODE",
     "name": "Disable rule",
+    "short_name": "Disable",
     "bindings": [
       { "input_method": "keyboard_any", "key": "d" },
       { "input_method": "keyboard_char", "key": "D" },
@@ -507,6 +523,7 @@
     "id": "TEST_RULE",
     "category": "SAFEMODE",
     "name": "Test rule",
+    "short_name": "Test",
     "bindings": [
       { "input_method": "keyboard_any", "key": "t" },
       { "input_method": "keyboard_char", "key": "T" },
@@ -518,6 +535,7 @@
     "id": "SWITCH_SAFEMODE_OPTION",
     "category": "SAFEMODE",
     "name": "Enable safemode option",
+    "short_name": "Safe mode",
     "bindings": [
       { "input_method": "keyboard_any", "key": "s" },
       { "input_method": "keyboard_char", "key": "S" },
@@ -543,6 +561,7 @@
     "id": "USAGE_HELP",
     "category": "SORT_ARMOR",
     "name": "Display usage help",
+    "short_name": "Help",
     "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
   },
   {
@@ -561,6 +580,7 @@
     "id": "MOVE_PANEL",
     "category": "PANEL_MGMT",
     "name": "Select panel for moving",
+    "short_name": "Change display order",
     "bindings": [
       { "input_method": "keyboard_any", "key": "s" },
       { "input_method": "keyboard_any", "key": "RETURN" },
@@ -571,7 +591,7 @@
     "type": "keybinding",
     "id": "TOGGLE_PANEL",
     "category": "PANEL_MGMT",
-    "name": "Toggle panel off",
+    "name": "Toggle panels on/off",
     "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
   },
   {
@@ -579,6 +599,7 @@
     "id": "CHANGE_SIDE",
     "category": "SORT_ARMOR",
     "name": "Change side armor is worn on",
+    "short_name": "Change side",
     "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
   },
   {
@@ -586,6 +607,7 @@
     "id": "TOGGLE_CLOTH",
     "category": "SORT_ARMOR",
     "name": "Toggle armor visibility on character sprite",
+    "short_name": "Hide sprite",
     "bindings": [ { "input_method": "keyboard_any", "key": "H" } ]
   },
   {
@@ -641,6 +663,7 @@
     "type": "keybinding",
     "id": "HELP_KEYBINDINGS",
     "name": "Display keybindings menu",
+    "short_name": "Keybindings",
     "bindings": [ { "input_method": "keyboard_char", "key": "?" }, { "input_method": "keyboard_code", "key": "/", "mod": [ "shift" ] } ]
   },
   {
@@ -927,7 +950,7 @@
     "type": "keybinding",
     "id": "PICK_RANDOM_WORLDNAME",
     "category": "STRING_INPUT",
-    "name": "Pick random world name",
+    "name": "Randomize world name",
     "bindings": [
       { "input_method": "keyboard_char", "key": "*" },
       { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
@@ -964,7 +987,7 @@
     "type": "keybinding",
     "id": "PICK_MODS",
     "category": "WORLDGEN_CONFIRM_DIALOG",
-    "name": "Pick random world name",
+    "name": "Open mod manager",
     "bindings": [
       { "input_method": "keyboard_any", "key": "m" },
       { "input_method": "keyboard_char", "key": "M" },
@@ -1193,6 +1216,7 @@
     "type": "keybinding",
     "id": "QUIT",
     "name": "Exit screen",
+    "short_name": "Quit",
     "bindings": [
       { "input_method": "keyboard_any", "key": "ESC" },
       { "input_method": "keyboard_any", "key": "q" },
@@ -1436,7 +1460,8 @@
   {
     "type": "keybinding",
     "id": "SWITCH_GENDER",
-    "name": "Customize character",
+    "name": "Customize base appearance and name",
+    "short_name": "Customize",
     "bindings": [ { "input_method": "keyboard_any", "key": "y" } ]
   },
   {
@@ -1963,6 +1988,7 @@
     "id": "INVENTORY_FILTER",
     "category": "INVENTORY",
     "name": "Set item filter",
+    "short_name": "Filter",
     "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
   },
   {
@@ -2016,6 +2042,7 @@
     "id": "SHOW_HIDE_CONTENTS",
     "category": "INVENTORY",
     "name": "Show/hide contents",
+    "short_name": "Expand",
     "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
@@ -2023,6 +2050,7 @@
     "id": "SHOW_HIDE_CONTENTS_ALL",
     "category": "INVENTORY",
     "name": "Show/hide all contents",
+    "short_name": "All",
     "bindings": [ { "input_method": "keyboard_char", "key": "E" } ]
   },
   {
@@ -2036,6 +2064,7 @@
     "id": "TOGGLE_EXAMINE",
     "category": "BIONICS",
     "name": "Toggle activate/examine",
+    "short_name": "Toggle",
     "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
   },
   {
@@ -2071,6 +2100,7 @@
     "id": "TOGGLE_EXAMINE",
     "category": "MUTATIONS",
     "name": "Toggle activate/examine",
+    "short_name": "Toggle",
     "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
   },
   {
@@ -2614,6 +2644,7 @@
   {
     "type": "keybinding",
     "name": "View character's morale",
+    "short_name": "Morale",
     "category": "DEFAULTMODE",
     "id": "morale"
   },
@@ -3043,6 +3074,7 @@
     "id": "SORT",
     "category": "LIST_ITEMS",
     "name": "Change sort order",
+    "short_name": "Sort",
     "bindings": [
       { "input_method": "keyboard_any", "key": "s" },
       { "input_method": "keyboard_char", "key": "S" },
@@ -3089,6 +3121,7 @@
     "id": "REASSIGN",
     "category": "BIONICS",
     "name": "Reassign inventory letter",
+    "short_name": "Reassign",
     "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
@@ -3120,13 +3153,14 @@
     "id": "REASSIGN",
     "category": "MUTATIONS",
     "name": "Reassign inventory letter",
+    "short_name": "Reassign",
     "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_SPRITE",
     "category": "MUTATIONS",
-    "name": "Toggle sprite",
+    "name": "Toggle sprite visibility",
     "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
   },
   {
@@ -3212,6 +3246,7 @@
     "id": "ADD_ZONE",
     "category": "ZONES_MANAGER",
     "name": "Add zone",
+    "short_name": "Add",
     "bindings": [
       { "input_method": "keyboard_any", "key": "a" },
       { "input_method": "keyboard_char", "key": "A" },
@@ -3223,6 +3258,7 @@
     "id": "ADD_PERSONAL_ZONE",
     "category": "ZONES_MANAGER",
     "name": "Add personal zone",
+    "short_name": "Personal",
     "bindings": [
       { "input_method": "keyboard_any", "key": "p" },
       { "input_method": "keyboard_char", "key": "P" },
@@ -3234,6 +3270,7 @@
     "id": "REMOVE_ZONE",
     "category": "ZONES_MANAGER",
     "name": "Remove zone",
+    "short_name": "Remove",
     "bindings": [
       { "input_method": "keyboard_any", "key": "r" },
       { "input_method": "keyboard_char", "key": "R" },
@@ -3263,6 +3300,7 @@
     "id": "SHOW_ZONE_ON_MAP",
     "category": "ZONES_MANAGER",
     "name": "Show zone on map",
+    "short_name": "Map",
     "bindings": [
       { "input_method": "keyboard_any", "key": "m" },
       { "input_method": "keyboard_char", "key": "M" },
@@ -3274,6 +3312,7 @@
     "id": "ENABLE_ZONE",
     "category": "ZONES_MANAGER",
     "name": "Enable zone",
+    "short_name": "Enable",
     "bindings": [
       { "input_method": "keyboard_any", "key": "e" },
       { "input_method": "keyboard_char", "key": "E" },
@@ -3285,6 +3324,7 @@
     "id": "DISABLE_ZONE",
     "category": "ZONES_MANAGER",
     "name": "Disable zone",
+    "short_name": "Disable",
     "bindings": [
       { "input_method": "keyboard_any", "key": "d" },
       { "input_method": "keyboard_char", "key": "D" },
@@ -3296,6 +3336,7 @@
     "id": "ENABLE_PERSONAL_ZONES",
     "category": "ZONES_MANAGER",
     "name": "Enable personal zones",
+    "short_name": "Enable personal",
     "bindings": [
       { "input_method": "keyboard_any", "key": "z" },
       { "input_method": "keyboard_char", "key": "Z" },
@@ -3307,6 +3348,7 @@
     "id": "DISABLE_PERSONAL_ZONES",
     "category": "ZONES_MANAGER",
     "name": "Disable personal zones",
+    "short_name": "Disable personal",
     "bindings": [
       { "input_method": "keyboard_any", "key": "x" },
       { "input_method": "keyboard_char", "key": "X" },
@@ -3318,6 +3360,7 @@
     "id": "SHOW_ALL_ZONES",
     "category": "ZONES_MANAGER",
     "name": "Show all zones / hide distant zones",
+    "short_name": "Show all / hide distant",
     "bindings": [
       { "input_method": "keyboard_any", "key": "s" },
       { "input_method": "keyboard_char", "key": "S" },
@@ -3329,6 +3372,7 @@
     "id": "CHANGE_FACTION",
     "category": "ZONES_MANAGER",
     "name": "Change shown faction",
+    "short_name": "Shown faction",
     "bindings": [ { "input_method": "keyboard_any", "key": "F" } ]
   },
   {
@@ -3748,7 +3792,7 @@
     "type": "keybinding",
     "id": "LOAD_BASE_COLORS",
     "category": "COLORS",
-    "name": "Load base colors",
+    "name": "Load color theme",
     "bindings": [
       { "input_method": "keyboard_any", "key": "c" },
       { "input_method": "keyboard_char", "key": "C" },
@@ -4200,6 +4244,7 @@
   {
     "type": "keybinding",
     "name": "View character's morale",
+    "short_name": "Morale",
     "category": "PLAYER_INFO",
     "id": "morale",
     "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
@@ -4209,6 +4254,7 @@
     "category": "WISH_ITEM",
     "id": "CONTAINER",
     "name": "Toggle spawning item with container",
+    "short_name": "Container",
     "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
   },
   {
@@ -4216,6 +4262,7 @@
     "category": "WISH_ITEM",
     "id": "FLAG",
     "name": "Add flags to spawned items",
+    "short_name": "Flag",
     "bindings": [ { "input_method": "keyboard_char", "key": "F" }, { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] } ]
   },
   {
@@ -4223,6 +4270,7 @@
     "category": "WISH_ITEM",
     "id": "EVERYTHING",
     "name": "Toggle spawning everything",
+    "short_name": "Everything",
     "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
   },
   {
@@ -4230,6 +4278,7 @@
     "category": "WISH_ITEM",
     "id": "SNIPPET",
     "name": "Choose snippet",
+    "short_name": "Snippet",
     "bindings": [ { "input_method": "keyboard_any", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
@@ -4422,6 +4471,7 @@
     "type": "keybinding",
     "id": "HELP_KEYBINDINGS",
     "name": "Display keybindings menu",
+    "short_name": "Keybindings",
     "category": "STRING_INPUT",
     "//": "'?' is treated as text input, so a different key is used.",
     "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
@@ -4444,6 +4494,7 @@
     "type": "keybinding",
     "id": "HELP_KEYBINDINGS",
     "name": "Display keybindings menu",
+    "short_name": "Keybindings",
     "category": "STRING_EDITOR",
     "//": "'?' is treated as text input, so a different key is used.",
     "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1779,6 +1779,7 @@
     "id": "FUEL_LIST_UP",
     "category": "VEH_INTERACT",
     "name": "Scroll up through fuel list",
+    "short_name": "For more",
     "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
   },
   {
@@ -1786,6 +1787,7 @@
     "id": "FUEL_LIST_DOWN",
     "category": "VEH_INTERACT",
     "name": "Scroll down through fuel list",
+    "short_name": "For more",
     "bindings": [ { "input_method": "keyboard_any", "key": "]" } ]
   },
   {
@@ -1793,6 +1795,7 @@
     "id": "DESC_LIST_UP",
     "category": "VEH_INTERACT",
     "name": "Scroll up through vehicle part descriptions",
+    "short_name": "For more",
     "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
@@ -1800,6 +1803,7 @@
     "id": "DESC_LIST_DOWN",
     "category": "VEH_INTERACT",
     "name": "Scroll down through vehicle part descriptions",
+    "short_name": "For more",
     "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
@@ -1807,6 +1811,7 @@
     "id": "OVERVIEW_UP",
     "category": "VEH_INTERACT",
     "name": "Scroll up through vehicle overview",
+    "short_name": "For more",
     "bindings": [ { "input_method": "keyboard_char", "key": "{" }, { "input_method": "keyboard_code", "key": "[", "mod": [ "shift" ] } ]
   },
   {
@@ -1814,6 +1819,7 @@
     "id": "OVERVIEW_DOWN",
     "category": "VEH_INTERACT",
     "name": "Scroll down through vehicle overview",
+    "short_name": "For more",
     "bindings": [ { "input_method": "keyboard_char", "key": "}" }, { "input_method": "keyboard_code", "key": "]", "mod": [ "shift" ] } ]
   },
   {

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3561,7 +3561,7 @@
     "type": "keybinding",
     "id": "AUTO_BALANCE",
     "category": "INVENTORY",
-    "name": "Auto balance trade using highlighted item",
+    "name": "Auto balance with highlighted item",
     "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
   },
   {
@@ -4108,7 +4108,7 @@
     "type": "keybinding",
     "id": "SWITCH_LISTS",
     "category": "INVENTORY",
-    "name": "Switch lists",
+    "name": "Switch panes",
     "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
   },
   {

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1248,6 +1248,7 @@
     "id": "FIRE",
     "category": "TARGET",
     "name": "Fire weapon",
+    "short_name": "Fire",
     "bindings": [
       { "input_method": "keyboard_any", "key": "f" },
       { "input_method": "keyboard_any", "key": "RETURN" },
@@ -1365,6 +1366,7 @@
     "type": "keybinding",
     "id": "SELECT",
     "name": "Select with mouse",
+    "short_name": "Select",
     "bindings": [ { "input_method": "mouse", "key": "MOUSE_LEFT" } ]
   },
   {
@@ -1403,6 +1405,7 @@
     "type": "keybinding",
     "id": "NEXT_TAB",
     "name": "Go to next tab",
+    "short_name": "Switch tabs",
     "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
   },
   {
@@ -2071,7 +2074,7 @@
     "type": "keybinding",
     "id": "TOGGLE_SAFE_FUEL",
     "category": "BIONICS",
-    "name": "Toggle safe fuel mod",
+    "name": "Toggle fuel saving mode",
     "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {

--- a/lang/string_extractor/parsers/keybinding.py
+++ b/lang/string_extractor/parsers/keybinding.py
@@ -4,3 +4,5 @@ from ..write_text import write_text
 def parse_keybinding(json, origin):
     if "name" in json:
         write_text(json["name"], origin, comment="Key binding name")
+    if "short_name" in json:
+        write_text(json["short_name"], origin, comment="Key binding name (UI)")

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -536,16 +536,6 @@ std::string press_x( action_id act, const std::string &key_bound_pre,
     input_context ctxt = get_default_mode_input_context();
     return ctxt.press_x( action_ident( act ), key_bound_pre, key_bound_suf, key_unbound );
 }
-std::optional<std::string> press_x_if_bound( action_id act )
-{
-    input_context ctxt = get_default_mode_input_context();
-    std::string description = action_ident( act );
-    if( ctxt.keys_bound_to( description, /*maximum_modifier_count=*/ -1,
-                            /*restrict_to_printable=*/false ).empty() ) {
-        return std::nullopt;
-    }
-    return press_x( act );
-}
 
 action_id get_movement_action_from_delta( const tripoint &d, const iso_rotate rot )
 {

--- a/src/action.h
+++ b/src/action.h
@@ -526,8 +526,6 @@ std::string press_x( action_id act, const std::string &key_bound_pre,
                      const std::string &key_bound_suf, const std::string &key_unbound );
 // ('Z'ing|zing) (X( or Y)))
 std::string press_x( action_id act, const std::string &act_desc );
-// Return "Press X" or nullopt if not bound
-std::optional<std::string> press_x_if_bound( action_id act );
 
 // only has effect in iso mode
 enum class iso_rotate : int {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -841,8 +841,8 @@ void advanced_inventory::redraw_pane( side p )
         wattroff( w, c_white );
     }
     if( !filter_edit && !pane.filter.empty() ) {
-        std::string fsuffix = string_format( " %s", ctxt.get_hint( "RESET_FILTER" ) );
-        print_colored_text( w, point( getmaxx( w ) - utf8_width( fsuffix ) - 2, getmaxy( w ) - 1 ),
+        std::string fsuffix = ctxt.get_hint( "RESET_FILTER" );
+        print_colored_text( w, point( getmaxx( w ) - utf8_width( fsuffix, true ) - 2, getmaxy( w ) - 1 ),
                             fsuffix );
     }
     wnoutrefresh( w );

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -676,8 +676,9 @@ int advanced_inventory::print_header( advanced_inventory_pane &pane, aim_locatio
 
             bcolor = in_vehicle ? c_light_blue :
                      area == data_location || all_brackets ? c_light_gray : c_dark_gray;
-            kcolor = area == data_location ? c_white : sel == data_location ||
-                     container_loc == data_location ? c_light_gray : c_dark_gray;
+            kcolor = area == data_location ? input_context::get_hint_color_for_key() : sel == data_location ||
+                     container_loc == data_location ? input_context::get_hint_color_for_key(
+                         keybinding_hint_state::HIGHLIGHTED ) : input_context::get_hint_color_for_key();
         }
         const std::string key = get_location_key( static_cast<aim_location>( i ) );
         const point p( squares[i].hscreen + point( ofs, 0 ) );
@@ -817,8 +818,8 @@ void advanced_inventory::redraw_pane( side p )
     }
     // draw a darker border around the inactive pane
     draw_border( w, active ? BORDER_COLOR : c_dark_gray );
-    mvwprintw( w, point( 3, 0 ), _( "< [%s] Sort: %s >" ), ctxt.get_desc( "SORT" ),
-               get_sortname( pane.sortby ) );
+    print_colored_text( w, point( 3, 0 ), string_format( _( "< %s: %s >" ), ctxt.get_hint( "SORT" ),
+                        get_sortname( pane.sortby ) ) );
     int max = square.max_size;
     if( max > 0 ) {
         int itemcount = square.get_item_count();
@@ -827,23 +828,22 @@ void advanced_inventory::redraw_pane( side p )
         mvwprintw( w, point( w_width / 2 - fmtw, 0 ), "< %d/%d >", itemcount, max );
     }
 
-    std::string fprefix = string_format( _( "[%s] Filter" ), ctxt.get_desc( "FILTER" ) );
+    std::string fprefix = ctxt.get_hint( "FILTER" );
     if( !filter_edit ) {
         if( !pane.filter.empty() ) {
-            mvwprintw( w, point( 2, getmaxy( w ) - 1 ), "< %s: %s >", fprefix, pane.filter );
+            print_colored_text( w, point( 2, getmaxy( w ) - 1 ), string_format( "< %s: %s >", fprefix,
+                                pane.filter ) );
         } else {
-            mvwprintw( w, point( 2, getmaxy( w ) - 1 ), "< %s >", fprefix );
+            print_colored_text( w, point( 2, getmaxy( w ) - 1 ), string_format( "< %s >", fprefix ) );
         }
     }
     if( active ) {
         wattroff( w, c_white );
     }
     if( !filter_edit && !pane.filter.empty() ) {
-        std::string fsuffix = string_format( _( "[%s] Reset" ), ctxt.get_desc( "RESET_FILTER" ) );
-        mvwprintz( w, point( 6 + utf8_width( fprefix ), getmaxy( w ) - 1 ), c_white,
-                   pane.filter );
-        mvwprintz( w, point( getmaxx( w ) - utf8_width( fsuffix ) - 2, getmaxy( w ) - 1 ), c_white, "%s",
-                   fsuffix );
+        std::string fsuffix = string_format( " %s", ctxt.get_hint( "RESET_FILTER" ) );
+        print_colored_text( w, point( getmaxx( w ) - utf8_width( fsuffix ) - 2, getmaxy( w ) - 1 ),
+                            fsuffix );
     }
     wnoutrefresh( w );
 }
@@ -1165,8 +1165,8 @@ void advanced_inventory::redraw_sidebar()
     Messages::display_messages( head, 2, 1, w_width - 1, head_height - 2 );
     draw_minimap();
     right_print( head, 0, +3, c_white, string_format(
-                     _( "< [<color_yellow>%s</color>] keybindings >" ),
-                     ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
+                     _( "< %s >" ),
+                     ctxt.get_hint( "HELP_KEYBINDINGS" ) ) );
     if( get_player_character().has_watch() ) {
         const std::string time = to_string_time_of_day( calendar::turn );
         mvwprintz( head, point( 2, 0 ), c_white, time );
@@ -1791,7 +1791,9 @@ void query_destination_callback::draw_squares( const uilist *menu )
         // always show storage option for vehicle storage, if applicable
         bool canputitems = menu->entries[i - 1].enabled && square.canputitems();
         nc_color bcolor = canputitems ? sel == loc ? h_white : c_light_gray : c_red;
-        nc_color kcolor = canputitems ? sel == loc ? h_white : c_dark_gray : c_red;
+        nc_color kcolor = canputitems ? sel == loc ? input_context::get_hint_color_for_key(
+                              keybinding_hint_state::HIGHLIGHTED ) : input_context::get_hint_color_for_key() :
+                          input_context::get_hint_color( keybinding_hint_state::TOGGLED_OFF );
         const point p( square.hscreen + point( ofs, 5 ) );
         mvwprintz( menu->window, p, bcolor, "%c", bracket[0] );
         wprintz( menu->window, kcolor, "%s", key );

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -1172,10 +1172,10 @@ void outfit::sort_armor( Character &guy )
             }
         } else if( action == "USAGE_HELP" ) {
             const std::vector<std::string> help_strings = {
-                ctxt.get_hint_pair( "UP", "DOWN", _( "to scroll the left pane (list of items)." ) ),
-                ctxt.get_hint_pair( "SCROLL_ITEM_INFO_UP", "SCROLL_ITEM_INFO_DOWN", _( "to scroll the middle pane (item information)." ) ),
-                ctxt.get_hint_pair( "PREV_TAB", "NEXT_TAB", _( "to scroll the right pane (items grouped by body part)." ) ),
-                ctxt.get_hint_pair( "LEFT", "RIGHT", _( "to limit the left pane to a particular body part." ) ),
+                ctxt.get_hints( { "UP", "DOWN"}, _( "to scroll the left pane (list of items)." ) ),
+                ctxt.get_hints( { "SCROLL_ITEM_INFO_UP", "SCROLL_ITEM_INFO_DOWN"}, _( "to scroll the middle pane (item information)." ) ),
+                ctxt.get_hints( { "PREV_TAB", "NEXT_TAB"}, _( "to scroll the right pane (items grouped by body part)." ) ),
+                ctxt.get_hints( { "LEFT", "RIGHT"}, _( "to limit the left pane to a particular body part." ) ),
                 ctxt.get_hint( "MOVE_ARMOR", _( "to select an item for reordering." ) ),
                 ctxt.get_hint( "ASSIGN_INVLETS", _( "to assign special inventory letters to clothing." ) ),
                 ctxt.get_hint( "CHANGE_SIDE", _( "to change the side on which item is worn." ) ),

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -737,14 +737,11 @@ void outfit::sort_armor( Character &guy )
         std::string temp = bp != bodypart_id( "bp_null" ) ? body_part_name_as_heading( bp, 1 ) : _( "All" );
         wprintz( w_sort_cat, c_yellow, "  << %s >>", temp );
         right_print( w_sort_cat, 0, 0, c_white, string_format(
-                         _( "[<color_yellow>%s</color>] Hide sprite.  "
-                            "[<color_yellow>%s</color>] Change side.  "
-                            "Press [<color_yellow>%s</color>] for help.  "
-                            "Press [<color_yellow>%s</color>] to change keybindings." ),
-                         ctxt.get_desc( "TOGGLE_CLOTH" ),
-                         ctxt.get_desc( "CHANGE_SIDE" ),
-                         ctxt.get_desc( "USAGE_HELP" ),
-                         ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
+                         "%s %s %s %s",
+                         ctxt.get_hint( "TOGGLE_CLOTH" ),
+                         ctxt.get_hint( "CHANGE_SIDE" ),
+                         ctxt.get_hint( "USAGE_HELP" ),
+                         ctxt.get_hint( "HELP_KEYBINDINGS" ) ) );
 
         leftListSize = tmp_worn.size();
         if( leftListLines > leftListSize ) {
@@ -1175,49 +1172,32 @@ void outfit::sort_armor( Character &guy )
             }
         } else if( action == "USAGE_HELP" ) {
             const std::vector<std::string> help_strings = {
-                string_format( _( "[<color_yellow>%s</color>]/[<color_yellow>%s</color>] to scroll the left pane (list of items).\n" ),
-                               ctxt.get_desc( "UP" ), ctxt.get_desc( "DOWN" ) ),
-                string_format( _( "[<color_yellow>%s</color>]/[<color_yellow>%s</color>] to scroll the middle pane (item information).\n" ),
-                               ctxt.get_desc( "SCROLL_ITEM_INFO_UP" ), ctxt.get_desc( "SCROLL_ITEM_INFO_DOWN" ) ),
-                string_format( _( "[<color_yellow>%s</color>]/[<color_yellow>%s</color>] to scroll the right pane (items grouped by body part).\n" ),
-                               ctxt.get_desc( "PREV_TAB" ), ctxt.get_desc( "NEXT_TAB" ) ),
-                string_format( _( "[<color_yellow>%s</color>]/[<color_yellow>%s</color>] to limit the left pane to a particular body part.\n" ),
-                               ctxt.get_desc( "LEFT" ), ctxt.get_desc( "RIGHT" ) ),
-                string_format( _( "[<color_yellow>%s</color>] to select an item for reordering.\n" ),
-                               ctxt.get_desc( "MOVE_ARMOR" ) ),
-                string_format( _( "[<color_yellow>%s</color>] to assign special inventory letters to clothing.\n" ),
-                               ctxt.get_desc( "ASSIGN_INVLETS" ) ),
-                string_format( _( "[<color_yellow>%s</color>] to change the side on which item is worn.\n" ),
-                               ctxt.get_desc( "CHANGE_SIDE" ) ),
-                string_format( _( "[<color_yellow>%s</color>] to toggle item visibility on character sprite.\n" ),
-                               ctxt.get_desc( "TOGGLE_CLOTH" ) ),
-                string_format( _( "[<color_yellow>%s</color>] to sort worn items into natural layer order.\n" ),
-                               ctxt.get_desc( "SORT_ARMOR" ) ),
-                string_format( _( "[<color_yellow>%s</color>] to equip a new item.\n" ),
-                               ctxt.get_desc( "EQUIP_ARMOR" ) ),
-                string_format( _( "[<color_yellow>%s</color>] to equip a new item at the currently selected position.\n" ),
-                               ctxt.get_desc( "EQUIP_ARMOR_HERE" ) ),
-                string_format( _( "[<color_yellow>%s</color>] to remove selected item.\n" ),
-                               ctxt.get_desc( "REMOVE_ARMOR" ) ),
-                "\n",
-                _( "Encumbrance explanation:\n" ),
+                ctxt.get_hint_pair( "UP", "DOWN", _( "to scroll the left pane (list of items)." ) ),
+                ctxt.get_hint_pair( "SCROLL_ITEM_INFO_UP", "SCROLL_ITEM_INFO_DOWN", _( "to scroll the middle pane (item information)." ) ),
+                ctxt.get_hint_pair( "PREV_TAB", "NEXT_TAB", _( "to scroll the right pane (items grouped by body part)." ) ),
+                ctxt.get_hint_pair( "LEFT", "RIGHT", _( "to limit the left pane to a particular body part." ) ),
+                ctxt.get_hint( "MOVE_ARMOR", _( "to select an item for reordering." ) ),
+                ctxt.get_hint( "ASSIGN_INVLETS", _( "to assign special inventory letters to clothing." ) ),
+                ctxt.get_hint( "CHANGE_SIDE", _( "to change the side on which item is worn." ) ),
+                ctxt.get_hint( "TOGGLE_CLOTH", _( "to toggle item visibility on character sprite." ) ),
+                ctxt.get_hint( "SORT_ARMOR", _( "to sort worn items into natural layer order." ) ),
+                ctxt.get_hint( "EQUIP_ARMOR", _( "to equip a new item." ) ),
+                ctxt.get_hint( "EQUIP_ARMOR_HERE", _( "to equip a new item at the currently selected position." ) ),
+                ctxt.get_hint( "REMOVE_ARMOR", _( "to remove selected item." ) ),
+                _( "\nEncumbrance explanation:" ),
                 _( "<color_light_gray>The first number is the summed encumbrance from all clothing on that bodypart."
-                   "The second number is an additional encumbrance penalty caused by wearing either multiple items "
+                   "  The second number is an additional encumbrance penalty caused by wearing either multiple items "
                    "on one of the bodypart's layers or wearing items the wrong way (e.g. a shirt over a backpack)."
-                   "The sum of these values is the effective encumbrance value your character has for that bodypart."
+                   "  The sum of these values is the effective encumbrance value your character has for that bodypart."
                    "</color>" )
             };
-            std::string assembled_string;
-            for( const std::string &current_line : help_strings ) {
-                assembled_string += current_line;
-            }
-
             const auto new_win = []() {
                 return catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
                                            point( std::max( 0, ( TERMX - FULL_SCREEN_WIDTH ) / 2 ),
                                                   std::max( 0, ( TERMY - FULL_SCREEN_HEIGHT ) / 2 ) ) );
             };
-            scrollable_text( new_win, _( "Sort armor help" ), assembled_string );
+            scrollable_text( new_win, _( "Sort armor help" ), enumerate_as_string( help_strings,
+                             enumeration_conjunction::newline ) );
         } else if( action == "QUIT" ) {
             exit = true;
         }

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -364,7 +364,7 @@ void auto_note_manager_gui::show()
         hints.push_back( ctxt.get_hint( "CONFIRM", _( "Toggle" ) ) );
         // TODO: Show info about custom symbols (hotkey, hint, state)
         hints.push_back( ctxt.get_hint( "CHANGE_MAPEXTRA_CHARACTER" ) );
-        hints.push_back( ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB", _( "Switch Page" ) ) );
+        hints.push_back( ctxt.get_hints( { "NEXT_TAB", "PREV_TAB"}, _( "Switch Page" ) ) );
         fold_and_print( w_header, point( 0, 0 ), getmaxx( w_header ) - 1, c_light_gray,
                         enumerate_as_string( hints, enumeration_conjunction::space ) );
 

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -372,10 +372,10 @@ void user_interface::show()
         if( !player_character.name.empty() ) {
             hints.push_back( ctxt.get_hint( "TEST_RULE" ) );
         }
-        hints.push_back( ctxt.get_hint_pair( "MOVE_RULE_UP", "MOVE_RULE_DOWN", _( "Move up/down" ) ) );
+        hints.push_back( ctxt.get_hints( { "MOVE_RULE_UP", "MOVE_RULE_DOWN"}, _( "Move up/down" ) ) );
         hints.push_back( ctxt.get_hint( "CONFIRM", _( "Edit" ) ) );
         if( has_more_than_one_tab ) {
-            hints.push_back( ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB", _( "Switch Page" ) ) );
+            hints.push_back( ctxt.get_hints( { "NEXT_TAB", "PREV_TAB"}, _( "Switch Page" ) ) );
         }
         const int i_hints = fold_and_print( w_header, point( 0, 0 ), getmaxx( w_header ) - 1, c_light_gray,
                                             enumerate_as_string( hints, enumeration_conjunction::space ) );

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1862,9 +1862,9 @@ bool character_martial_arts::pick_style( const avatar &you ) // Style selection 
                                    "\n"
                                    "STR: <color_white>%d</color>, DEX: <color_white>%d</color>, "
                                    "PER: <color_white>%d</color>, INT: <color_white>%d</color>\n"
-                                   "Press [<color_yellow>%s</color>] for more info.\n" ),
+                                   "Press %s for more info.\n" ),
                                 you.get_str(), you.get_dex(), you.get_per(), you.get_int(),
-                                ctxt.get_desc( "SHOW_DESCRIPTION" ) );
+                                ctxt.get_hint_key_only( "SHOW_DESCRIPTION" ) );
     ma_style_callback callback( static_cast<size_t>( STYLE_OFFSET ), selectable_styles );
     kmenu.callback = &callback;
     kmenu.input_category = "MELEE_STYLE_PICKER";

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -270,10 +270,9 @@ static void draw_bionics_titlebar( const catacurses::window &window, avatar *p,
     center_print( window, 0, c_light_red, _( "Bionics" ) );
 
     std::string desc_append = string_format(
-                                  _( "%s Reassign, %s Switch tabs, "
-                                     "%s Toggle fuel saving mode, " ),
-                                  ctxt.get_hint_key_only( "REASSIGN" ), ctxt.get_hint_key_only( "NEXT_TAB" ),
-                                  ctxt.get_hint_key_only( "TOGGLE_SAFE_FUEL" ) );
+                                  _( "%s %s %s" ),
+                                  ctxt.get_hint( "REASSIGN" ), ctxt.get_hint( "NEXT_TAB" ),
+                                  ctxt.get_hint( "TOGGLE_SAFE_FUEL" ) );
     desc_append += string_format( _( " %s Sort: %s" ), ctxt.get_hint_key_only( "SORT" ),
                                   sort_mode_str( uistate.bionic_sort_mode ) );
     std::string desc;
@@ -282,13 +281,11 @@ static void draw_bionics_titlebar( const catacurses::window &window, avatar *p,
                               ctxt.get_hint_key_only( "CONFIRM" ) );
         fuel_string.clear();
     } else if( mode == ACTIVATING ) {
-        desc = string_format( _( "<color_green>Activating</color>  "
-                                 "%s Examine, %s" ),
-                              ctxt.get_hint_key_only( "TOGGLE_EXAMINE" ), desc_append );
+        desc = string_format( _( "<color_green>Activating</color> %s %s" ),
+                              ctxt.get_hint( "TOGGLE_EXAMINE" ), desc_append );
     } else if( mode == EXAMINING ) {
-        desc = string_format( _( "<color_light_blue>Examining</color>  "
-                                 "%s Activate, %s" ),
-                              ctxt.get_hint_key_only( "TOGGLE_EXAMINE" ), desc_append );
+        desc = string_format( _( "<color_light_blue>Examining</color> %s %s" ),
+                              ctxt.get_hint( "TOGGLE_EXAMINE" ), desc_append );
     }
 
     // NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -975,10 +972,10 @@ void avatar::power_bionics()
                     }
                     continue;
                 } else {
-                    popup( _( "You can not activate %s!\n"
-                              "To read a description of %s, press %s, then [%s]." ), bio_data.name,
-                           bio_data.name, ctxt.get_hint_key_only( "TOGGLE_EXAMINE" ), colorize( std::string( 1, tmp->invlet ),
-                                   input_context::get_hint_color_for_key() ) );
+                    popup( _( "You can not activate %s!\n To read a description of %s, press %s, then %s." ),
+                           bio_data.name,
+                           bio_data.name, ctxt.get_hint_key_only( "TOGGLE_EXAMINE" ),
+                           input_context::get_hint_basic( std::string( 1, tmp->invlet ) ) );
                 }
             } else if( menu_mode == EXAMINING ) {
                 // Describing bionics, allow user to jump to description key

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -270,23 +270,25 @@ static void draw_bionics_titlebar( const catacurses::window &window, avatar *p,
     center_print( window, 0, c_light_red, _( "Bionics" ) );
 
     std::string desc_append = string_format(
-                                  _( "[<color_yellow>%s</color>] Reassign, [<color_yellow>%s</color>] Switch tabs, "
-                                     "[<color_yellow>%s</color>] Toggle fuel saving mode, " ),
-                                  ctxt.get_desc( "REASSIGN" ), ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "TOGGLE_SAFE_FUEL" ) );
-    desc_append += string_format( _( " [<color_yellow>%s</color>] Sort: %s" ), ctxt.get_desc( "SORT" ),
+                                  _( "%s Reassign, %s Switch tabs, "
+                                     "%s Toggle fuel saving mode, " ),
+                                  ctxt.get_hint_key_only( "REASSIGN" ), ctxt.get_hint_key_only( "NEXT_TAB" ),
+                                  ctxt.get_hint_key_only( "TOGGLE_SAFE_FUEL" ) );
+    desc_append += string_format( _( " %s Sort: %s" ), ctxt.get_hint_key_only( "SORT" ),
                                   sort_mode_str( uistate.bionic_sort_mode ) );
     std::string desc;
     if( mode == REASSIGNING ) {
-        desc = _( "Reassigning.  Select a bionic to reassign or press [<color_yellow>SPACE</color>] to cancel." );
+        desc = string_format( _( "Reassigning.  Select a bionic to reassign or press %s to cancel." ),
+                              ctxt.get_hint_key_only( "CONFIRM" ) );
         fuel_string.clear();
     } else if( mode == ACTIVATING ) {
         desc = string_format( _( "<color_green>Activating</color>  "
-                                 "[<color_yellow>%s</color>] Examine, %s" ),
-                              ctxt.get_desc( "TOGGLE_EXAMINE" ), desc_append );
+                                 "%s Examine, %s" ),
+                              ctxt.get_hint_key_only( "TOGGLE_EXAMINE" ), desc_append );
     } else if( mode == EXAMINING ) {
         desc = string_format( _( "<color_light_blue>Examining</color>  "
-                                 "[<color_yellow>%s</color>] Activate, %s" ),
-                              ctxt.get_desc( "TOGGLE_EXAMINE" ), desc_append );
+                                 "%s Activate, %s" ),
+                              ctxt.get_hint_key_only( "TOGGLE_EXAMINE" ), desc_append );
     }
 
     // NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -974,8 +976,9 @@ void avatar::power_bionics()
                     continue;
                 } else {
                     popup( _( "You can not activate %s!\n"
-                              "To read a description of %s, press '%s', then '%c'." ), bio_data.name,
-                           bio_data.name, ctxt.get_desc( "TOGGLE_EXAMINE" ), tmp->invlet );
+                              "To read a description of %s, press %s, then [%s]." ), bio_data.name,
+                           bio_data.name, ctxt.get_hint_key_only( "TOGGLE_EXAMINE" ), colorize( std::string( 1, tmp->invlet ),
+                                   input_context::get_hint_color_for_key() ) );
                 }
             } else if( menu_mode == EXAMINING ) {
                 // Describing bionics, allow user to jump to description key

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -796,7 +796,7 @@ static void draw_header( const catacurses::window &w, const input_context &ctxt 
 {
     std::vector<std::string> hints;
     hints.push_back( ctxt.get_hint( "REMOVE_CUSTOM" ) );
-    hints.push_back( ctxt.get_hint_quad( "LEFT", "RIGHT", "UP", "DOWN", _( "To navigate" ) ) );
+    hints.push_back( ctxt.get_hint_directions( _( "To navigate" ) ) );
     hints.push_back( ctxt.get_hint( "CONFIRM", _( "Edit" ) ) );
     hints.push_back( string_format( "\n%s", ctxt.get_hint( "LOAD_BASE_COLORS" ) ) );
     hints.push_back( ctxt.get_hint( "LOAD_TEMPLATE" ) );

--- a/src/color.h
+++ b/src/color.h
@@ -518,6 +518,7 @@ nc_color bgcolor_from_string( const std::string &color );
 color_tag_parse_result get_color_from_tag( const std::string &s,
         report_color_error color_error = report_color_error::yes );
 std::string get_tag_from_color( const nc_color &color );
+std::string scolorize( const std::string &text, const nc_color &color );
 std::string colorize( const std::string &text, const nc_color &color );
 std::string colorize( const translation &text, const nc_color &color );
 

--- a/src/color.h
+++ b/src/color.h
@@ -518,6 +518,11 @@ nc_color bgcolor_from_string( const std::string &color );
 color_tag_parse_result get_color_from_tag( const std::string &s,
         report_color_error color_error = report_color_error::yes );
 std::string get_tag_from_color( const nc_color &color );
+/*
+ * Simple and more efficient version of colorize which doesn't handle any of
+ *   the edge cases.
+ * @return returns the given string surrounded by the proper color tags.
+ */
 std::string scolorize( const std::string &text, const nc_color &color );
 std::string colorize( const std::string &text, const nc_color &color );
 std::string colorize( const translation &text, const nc_color &color );

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -1717,13 +1717,13 @@ computer_session::ynq computer_session::query_ynq( const std::string &text, Args
     ctxt.register_action( "HELP_KEYBINDINGS" );
     print_indented_line( 0, width, force_uc && !is_keycode_mode_supported()
                          //~ 1st: query string, 2nd-4th: keybinding descriptions
-                         ? pgettext( "query_ynq", "%s %s, %s, %s (Case sensitive)" )
+                         ? pgettext( "query_ynq", "%s %s %s %s (Case sensitive)" )
                          //~ 1st: query string, 2nd-4th: keybinding descriptions
-                         : pgettext( "query_ynq", "%s %s, %s, %s" ),
+                         : pgettext( "query_ynq", "%s %s %s %s" ),
                          formatted_text,
-                         ctxt.describe_key_and_name( "YES", allow_key ),
-                         ctxt.describe_key_and_name( "NO", allow_key ),
-                         ctxt.describe_key_and_name( "QUIT", allow_key ) );
+                         ctxt.get_hint( "YES", keybinding_hint_state::ENABLED, allow_key ),
+                         ctxt.get_hint( "NO", keybinding_hint_state::ENABLED, allow_key ),
+                         ctxt.get_hint( "QUIT", keybinding_hint_state::ENABLED, allow_key ) );
 
     do {
         ui_manager::redraw();

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -650,16 +650,16 @@ construction_id construction_menu( const bool blueprint )
             if( current_construct_breakpoint > 0 ) {
                 // Print previous stage indicator if breakpoint is past the beginning
                 trim_and_print( w_con, point( pos_x, 2 ), available_window_width, c_white,
-                                _( "Press [<color_yellow>%s</color>] to show previous stage(s)." ),
-                                ctxt.get_desc( "SCROLL_STAGE_UP" ) );
+                                _( "Press %s to show previous stage(s)." ),
+                                ctxt.get_hint_key_only( "SCROLL_STAGE_UP" ) );
             }
             if( static_cast<size_t>( construct_buffer_breakpoints[current_construct_breakpoint] ) +
                 available_buffer_height < full_construct_buffer.size() ) {
                 // Print next stage indicator if more breakpoints are remaining after screen height
                 trim_and_print( w_con, point( pos_x, w_height - 2 - static_cast<int>( notes.size() ) ),
                                 available_window_width, c_white,
-                                _( "Press [<color_yellow>%s</color>] to show next stage(s)." ),
-                                ctxt.get_desc( "SCROLL_STAGE_DOWN" ) );
+                                _( "Press %s to show next stage(s)." ),
+                                ctxt.get_hint_key_only( "SCROLL_STAGE_DOWN" ) );
             }
             // Leave room for above/below indicators
             int ypos = 3;
@@ -724,26 +724,25 @@ construction_id construction_menu( const bool blueprint )
 
             notes.clear();
             if( tabindex == tabcount - 1 && !filter.empty() ) {
-                notes.push_back( string_format( _( "Press [<color_red>%s</color>] to clear filter." ),
-                                                ctxt.get_desc( "RESET_FILTER" ) ) );
+                notes.push_back( string_format( _( "Press %s to clear filter." ),
+                                                ctxt.get_hint_key_only( "RESET_FILTER" ) ) );
             }
-            notes.push_back( string_format( _( "Press [<color_yellow>%s or %s</color>] to tab." ),
-                                            ctxt.get_desc( "LEFT" ),
-                                            ctxt.get_desc( "RIGHT" ) ) );
-            notes.push_back( string_format( _( "Press [<color_yellow>%s</color>] to search." ),
-                                            ctxt.get_desc( "FILTER" ) ) );
+            notes.push_back( string_format( _( "Press %s to tab." ),
+                                            ctxt.get_hint_pair( "LEFT", "RIGHT" ) ) );
+            notes.push_back( string_format( _( "Press %s to search." ),
+                                            ctxt.get_hint_key_only( "FILTER" ) ) );
             if( !hide_unconstructable ) {
                 notes.push_back( string_format(
-                                     _( "Press [<color_yellow>%s</color>] to hide unavailable constructions." ),
-                                     ctxt.get_desc( "TOGGLE_UNAVAILABLE_CONSTRUCTIONS" ) ) );
+                                     _( "Press %s to hide unavailable constructions." ),
+                                     ctxt.get_hint_key_only( "TOGGLE_UNAVAILABLE_CONSTRUCTIONS" ) ) );
             } else {
                 notes.push_back( string_format(
-                                     _( "Press [<color_red>%s</color>] to show unavailable constructions." ),
-                                     ctxt.get_desc( "TOGGLE_UNAVAILABLE_CONSTRUCTIONS" ) ) );
+                                     _( "Press %s to show unavailable constructions." ),
+                                     ctxt.get_hint_key_only( "TOGGLE_UNAVAILABLE_CONSTRUCTIONS" ) ) );
             }
             notes.push_back( string_format(
-                                 _( "Press [<color_yellow>%s</color>] to view and edit keybindings." ),
-                                 ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
+                                 _( "Press %s to view and edit keybindings." ),
+                                 ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ) ) );
 
             recalc_buffer();
         } // Finished updating

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -728,7 +728,7 @@ construction_id construction_menu( const bool blueprint )
                                                 ctxt.get_hint_key_only( "RESET_FILTER" ) ) );
             }
             notes.push_back( string_format( _( "Press %s to tab." ),
-                                            ctxt.get_hint_pair( "LEFT", "RIGHT" ) ) );
+                                            ctxt.get_hints( { "LEFT", "RIGHT" } ) ) );
             notes.push_back( string_format( _( "Press %s to search." ),
                                             ctxt.get_hint_key_only( "FILTER" ) ) );
             if( !hide_unconstructable ) {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1122,20 +1122,9 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
         const unsigned int header_info_width = std::max( width / 4, width - FULL_SCREEN_WIDTH - 1 );
         const int wStart = ( TERMX - width ) / 2;
 
-        // Keybinding tips
-        static const translation inline_fmt = to_translation(
-                //~ %1$s: action description text before key,
-                //~ %2$s: key description,
-                //~ %3$s: action description text after key.
-                "keybinding", "%1$s[<color_yellow>%2$s</color>]%3$s" );
-        static const translation separate_fmt = to_translation(
-                //~ %1$s: key description,
-                //~ %2$s: action description.
-                "keybinding", "[<color_yellow>%1$s</color>]%2$s" );
         std::vector<std::string> act_descs;
         const auto add_action_desc = [&]( const std::string & act, const std::string & txt ) {
-            act_descs.emplace_back( ctxt.get_desc( act, txt, input_context::allow_all_keys,
-                                                   inline_fmt, separate_fmt ) );
+            act_descs.emplace_back( ctxt.get_hint( act, txt ) );
         };
         add_action_desc( "CONFIRM", pgettext( "crafting gui", "Craft" ) );
         add_action_desc( "HELP_RECIPE", pgettext( "crafting gui", "Describe" ) );
@@ -1153,7 +1142,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
         add_action_desc( "CYCLE_BATCH", pgettext( "crafting gui", "Batch" ) );
         add_action_desc( "HELP_KEYBINDINGS", pgettext( "crafting gui", "Keybindings" ) );
         keybinding_x = isWide ? 5 : 2;
-        keybinding_tips = foldstring( enumerate_as_string( act_descs, enumeration_conjunction::none ),
+        keybinding_tips = foldstring( enumerate_as_string( act_descs, enumeration_conjunction::space ),
                                       width - keybinding_x * 2 );
 
         const int tailHeight = keybinding_tips.size() + 2;
@@ -1891,11 +1880,11 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
             } else if( filterstring.empty() ) {
                 query_str = string_format( _( "Mark recipes in this tab as read?  This cannot be undone.  "
                                               "You can mark all recipes by choosing yes and pressing %s again." ),
-                                           ctxt.get_desc( "MARK_ALL_RECIPES_READ" ) );
+                                           ctxt.get_hint_key_only( "MARK_ALL_RECIPES_READ" ) );
             } else {
                 query_str = string_format( _( "Mark filtered recipes as read?  This cannot be undone.  "
                                               "You can mark all recipes by choosing yes and pressing %s again." ),
-                                           ctxt.get_desc( "MARK_ALL_RECIPES_READ" ) );
+                                           ctxt.get_hint_key_only( "MARK_ALL_RECIPES_READ" ) );
             }
             if( query_yn( query_str ) ) {
                 if( current_list_has_unread ) {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -980,17 +980,14 @@ static void change_spells( Character &character )
         center_print( w_descborder.window, 0, c_magenta, _( "<<color_white>Description</color>>" ) );
 
         nc_color magenta = c_magenta;
-        const std::string help_keybindings = string_format(
-                _( "<<color_white>[<color_yellow>%1$s</color>] Keybindings</color>>" ),
-                ctxt.get_desc( "HELP_KEYBINDINGS" ) );
+        const std::string help_keybindings = ctxt.get_hint( "HELP_KEYBINDINGS" );
         print_colored_text( w_descborder.window,
                             point( w_descborder.width - help_keybindings.length() + 42, TERMY - 1 ),
                             magenta, magenta, help_keybindings );
 
         std::string help_filter;
         if( filterstring.empty() ) {
-            help_filter = string_format( _( "<<color_white>[<color_yellow>%1$s</color>] Filter</color>>" ),
-                                         ctxt.get_desc( "FILTER" ) );
+            help_filter = ctxt.get_hint( "FILTER" );
         } else {
             help_filter = string_format( "<<color_white>%s</color>>", filterstring );
         }

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -83,11 +83,11 @@ void game::extended_description( const tripoint &p )
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         werase( w_head );
-        mvwprintz( w_head, point_zero, c_white,
-                   _( "[%s] describe creatures, [%s] describe furniture, "
-                      "[%s] describe terrain, [%s] describe vehicle/appliance, [%s] close." ),
-                   ctxt.get_desc( "CREATURE" ), ctxt.get_desc( "FURNITURE" ),
-                   ctxt.get_desc( "TERRAIN" ), ctxt.get_desc( "VEHICLE" ), ctxt.get_desc( "QUIT" ) );
+        print_colored_text( w_head, point_zero,
+                            string_format( _( "%s %s %s %s %s " ),
+                                           ctxt.get_hint( "CREATURE" ), ctxt.get_hint( "FURNITURE" ),
+                                           ctxt.get_hint( "TERRAIN" ), ctxt.get_hint( "VEHICLE" ),
+                                           ctxt.get_hint( "QUIT", _( "Close" ) ) ) );
 
         // Set up line drawings
         for( int i = 0; i < TERMX; i++ ) {

--- a/src/dialogue_win.cpp
+++ b/src/dialogue_win.cpp
@@ -19,7 +19,7 @@ multiline_list_entry talk_data::get_entry() const
 {
     multiline_list_entry entry;
     entry.entry_text = colorize( text, color );
-    entry.prefix = formatted_hotkey( hotkey_desc, color );
+    entry.prefix = colorize( hotkey_desc, c_yellow ).append( colorize( ": ", color ) );
     return entry;
 }
 
@@ -58,25 +58,13 @@ void dialogue_window::draw( const std::string &npc_name )
     input_context ctxt( "DIALOGUE_CHOOSE_RESPONSE" );
     if( !is_computer && !is_not_conversation ) {
         const int actions_xoffset = xmid + 2;
-        nc_color cur_color = c_magenta;
-        std::string formatted_text = formatted_hotkey( ctxt.get_desc( "LOOK_AT", 1 ),
-                                     cur_color ).append( _( "Look at" ) );
-        print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
-                            formatted_text );
+        print_colored_text( d_win, point( actions_xoffset, ycurrent ), ctxt.get_hint( "LOOK_AT" ) );
         ++ycurrent;
-        formatted_text = formatted_hotkey( ctxt.get_desc( "SIZE_UP_STATS", 1 ),
-                                           cur_color ).append( _( "Size up stats" ) );
-        print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
-                            formatted_text );
+        print_colored_text( d_win, point( actions_xoffset, ycurrent ), ctxt.get_hint( "SIZE_UP_STATS" ) );
         ++ycurrent;
-        formatted_text = formatted_hotkey( ctxt.get_desc( "YELL", 1 ), cur_color ).append( _( "Yell" ) );
-        print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
-                            formatted_text );
+        print_colored_text( d_win, point( actions_xoffset, ycurrent ), ctxt.get_hint( "YELL" ) );
         ++ycurrent;
-        formatted_text = formatted_hotkey( ctxt.get_desc( "CHECK_OPINION", 1 ),
-                                           cur_color ).append( _( "Check opinion" ) );
-        print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
-                            formatted_text );
+        print_colored_text( d_win, point( actions_xoffset, ycurrent ), ctxt.get_hint( "CHECK_OPINION" ) );
     }
     wnoutrefresh( d_win );
 

--- a/src/dialogue_win.cpp
+++ b/src/dialogue_win.cpp
@@ -19,7 +19,7 @@ multiline_list_entry talk_data::get_entry() const
 {
     multiline_list_entry entry;
     entry.entry_text = colorize( text, color );
-    entry.prefix = colorize( hotkey_desc, c_yellow ).append( colorize( ": ", color ) );
+    entry.prefix = input_context::get_hint_basic( hotkey_desc, keybinding_hint_state::ENABLED );
     return entry;
 }
 

--- a/src/dialogue_win.cpp
+++ b/src/dialogue_win.cpp
@@ -19,7 +19,8 @@ multiline_list_entry talk_data::get_entry() const
 {
     multiline_list_entry entry;
     entry.entry_text = colorize( text, color );
-    entry.prefix = input_context::get_hint_basic( hotkey_desc, keybinding_hint_state::ENABLED );
+    entry.prefix = string_format( "%s\u00A0", input_context::get_hint_basic( hotkey_desc,
+                                  keybinding_hint_state::ENABLED ) );
     return entry;
 }
 

--- a/src/diary_ui.cpp
+++ b/src/diary_ui.cpp
@@ -260,15 +260,14 @@ void diary::show_diary_ui( diary *c_diary )
 
         draw_border( w_desc );
         center_print( w_desc, 0, c_light_gray, string_format( _( "%s´s Diary" ), c_diary->owner ) );
-        std::string desc = string_format( _( "%s, %s, %s, %s" ),
-                                          ctxt.get_desc( "NEW_PAGE", _( "New page" ), input_context::allow_all_keys ),
-                                          ctxt.get_desc( "CONFIRM", _( "Edit text" ), input_context::allow_all_keys ),
-                                          ctxt.get_desc( "DELETE PAGE", _( "Delete page" ), input_context::allow_all_keys ),
-                                          ctxt.get_desc( "EXPORT_DIARY", _( "Export diary" ), input_context::allow_all_keys )
+        std::string desc = string_format( _( "%s %s %s %s" ),
+                                          ctxt.get_hint( "NEW_PAGE" ),
+                                          ctxt.get_hint( "CONFIRM" ),
+                                          ctxt.get_hint( "DELETE PAGE" ),
+                                          ctxt.get_hint( "EXPORT_DIARY" )
                                         );
         center_print( w_desc, 1,  c_white, desc );
-        center_print( w_desc, 2,  c_white, ctxt.get_desc( "VIEW_SCORES",
-                      _( "View achievements, scores, and kills" ), input_context::allow_all_keys ) );
+        center_print( w_desc, 2,  c_white, ctxt.get_hint( "VIEW_SCORES" ) );
 
         wnoutrefresh( w_desc );
     } );

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1261,11 +1261,10 @@ void editmap::edit_fld()
 
         input_context ctxt( fmenu.input_category, keyboard_mode::keycode );
         // \u00A0 is the non-breaking space
-        info_txt_curr = string_format( pgettext( "keybinding descriptions",
-                                       "%s %s %s\u00A0intensity %s %s %s" ),
+        info_txt_curr = string_format( "%s %s %s %s %s %s",
                                        ctxt.get_hint( "EDITMAP_TAB" ),
                                        ctxt.get_hint( "EDITMAP_MOVE" ),
-                                       ctxt.get_hint_pair( "LEFT", "RIGHT" ),
+                                       ctxt.get_hint_pair( "LEFT", "RIGHT", pgettext( "keybinding descriptions", "intensity" ) ),
                                        ctxt.get_hint( "CONFIRM" ),
                                        ctxt.get_hint( "QUIT" ),
                                        ctxt.get_hint( "EDITMAP_SHOW_ALL" ) );
@@ -1909,11 +1908,10 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
             tmpmap_ptr = nullptr;
         }
         input_context ctxt( gpmenu.input_category, keyboard_mode::keycode );
-        // \u00A0 is the non-breaking space
-        info_txt_curr = string_format( pgettext( "keybinding descriptions",
-                                       "%s\u00A0prev/next other type %s\u00A0select %s %s" ),
-                                       ctxt.get_hint_pair( "LEFT", "RIGHT" ),
-                                       ctxt.get_hint_pair( "UP", "DOWN" ),
+        info_txt_curr = string_format( "%s %s %s %s",
+                                       ctxt.get_hint_pair( "LEFT", "RIGHT", pgettext( "keybinding descriptions",
+                                               "prev/next other type" ) ),
+                                       ctxt.get_hint_pair( "UP", "DOWN", pgettext( "keybinding descriptions", "select" ) ),
                                        ctxt.get_hint( "CONFIRM" ),
                                        ctxt.get_hint( "QUIT" ) );
         info_title_curr = string_format( pgettext( "map editor state", "Mapgen: %s" ),

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -394,17 +394,17 @@ std::optional<tripoint> editmap::edit()
 
         // \u00A0 is the non-breaking space
         info_txt_curr = string_format( pgettext( "keybinding descriptions",
-                                       "%s, %s, [%s,%s,%s,%s]\u00A0fast scroll, %s, %s, %s, %s, %s, %s" ),
-                                       ctxt.describe_key_and_name( "EDIT_TRAPS" ),
-                                       ctxt.describe_key_and_name( "EDIT_FIELDS" ),
-                                       ctxt.get_desc( "LEFT_WIDE", 1 ), ctxt.get_desc( "RIGHT_WIDE", 1 ),
-                                       ctxt.get_desc( "UP_WIDE", 1 ), ctxt.get_desc( "DOWN_WIDE", 1 ),
-                                       ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ),
-                                       ctxt.describe_key_and_name( "EDIT_TERRAIN" ),
-                                       ctxt.describe_key_and_name( "EDIT_FURNITURE" ),
-                                       ctxt.describe_key_and_name( "EDIT_OVERMAP" ),
-                                       ctxt.describe_key_and_name( "EDIT_ITEMS" ),
-                                       ctxt.describe_key_and_name( "QUIT" ) );
+                                       "%s %s [%s,%s]\u00A0fast scroll %s %s %s %s %s %s" ),
+                                       ctxt.get_hint( "EDIT_TRAPS" ),
+                                       ctxt.get_hint( "EDIT_FIELDS" ),
+                                       ctxt.get_hint_pair( "LEFT_WIDE", "RIGHT_WIDE" ),
+                                       ctxt.get_hint_pair( "UP_WIDE", "DOWN_WIDE" ),
+                                       ctxt.get_hint( "EDITMAP_SHOW_ALL" ),
+                                       ctxt.get_hint( "EDIT_TERRAIN" ),
+                                       ctxt.get_hint( "EDIT_FURNITURE" ),
+                                       ctxt.get_hint( "EDIT_OVERMAP" ),
+                                       ctxt.get_hint( "EDIT_ITEMS" ),
+                                       ctxt.get_hint( "QUIT" ) );
         info_title_curr = pgettext( "map editor state", "Looking around" );
         do_ui_invalidation();
 
@@ -1144,12 +1144,12 @@ void editmap::edit_feature()
         }
 
         input_context ctxt( emenu.input_category, keyboard_mode::keycode );
-        info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s, %s, %s, %s, %s" ),
-                                       ctxt.describe_key_and_name( "CONFIRM" ),
-                                       ctxt.describe_key_and_name( "CONFIRM_QUIT" ),
-                                       ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ),
-                                       ctxt.describe_key_and_name( "EDITMAP_TAB" ),
-                                       ctxt.describe_key_and_name( "EDITMAP_MOVE" ) );
+        info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s %s %s %s %s" ),
+                                       ctxt.get_hint( "CONFIRM" ),
+                                       ctxt.get_hint( "CONFIRM_QUIT" ),
+                                       ctxt.get_hint( "EDITMAP_SHOW_ALL" ),
+                                       ctxt.get_hint( "EDITMAP_TAB" ),
+                                       ctxt.get_hint( "EDITMAP_MOVE" ) );
         info_title_curr = info_title<T_t>();
         do_ui_invalidation();
 
@@ -1264,13 +1264,13 @@ void editmap::edit_fld()
         input_context ctxt( fmenu.input_category, keyboard_mode::keycode );
         // \u00A0 is the non-breaking space
         info_txt_curr = string_format( pgettext( "keybinding descriptions",
-                                       "%s, %s, [%s,%s]\u00A0intensity, %s, %s, %s" ),
-                                       ctxt.describe_key_and_name( "EDITMAP_TAB" ),
-                                       ctxt.describe_key_and_name( "EDITMAP_MOVE" ),
-                                       ctxt.get_desc( "LEFT", 1 ), ctxt.get_desc( "RIGHT", 1 ),
-                                       ctxt.describe_key_and_name( "CONFIRM" ),
-                                       ctxt.describe_key_and_name( "QUIT" ),
-                                       ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ) );
+                                       "%s %s %s\u00A0intensity %s %s %s" ),
+                                       ctxt.get_hint( "EDITMAP_TAB" ),
+                                       ctxt.get_hint( "EDITMAP_MOVE" ),
+                                       ctxt.get_hint_pair( "LEFT", "RIGHT" ),
+                                       ctxt.get_hint( "CONFIRM" ),
+                                       ctxt.get_hint( "QUIT" ),
+                                       ctxt.get_hint( "EDITMAP_SHOW_ALL" ) );
         info_title_curr = pgettext( "Map editor: Editing field effects", "Field effects" );
         do_ui_invalidation();
 
@@ -1725,23 +1725,23 @@ int editmap::select_shape( shapetype shape, int mode )
 
     do {
         if( moveall ) {
-            info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s, %s, %s, %s, %s" ),
-                                           ctxt.describe_key_and_name( "RESIZE" ),
-                                           ctxt.describe_key_and_name( "SWAP" ),
-                                           ctxt.describe_key_and_name( "CONFIRM" ),
-                                           ctxt.describe_key_and_name( "QUIT" ),
-                                           ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ) );
+            info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s %s %s %s %s" ),
+                                           ctxt.get_hint( "RESIZE" ),
+                                           ctxt.get_hint( "SWAP" ),
+                                           ctxt.get_hint( "CONFIRM" ),
+                                           ctxt.get_hint( "QUIT" ),
+                                           ctxt.get_hint( "EDITMAP_SHOW_ALL" ) );
             info_title_curr = _( "Moving selection" );
         } else {
             info_txt_curr = string_format( pgettext( "keybinding descriptions",
-                                           "%s, %s, %s, %s, %s, %s, %s" ),
-                                           ctxt.describe_key_and_name( "EDITMAP_MOVE" ),
-                                           ctxt.describe_key_and_name( "RESIZE" ),
-                                           ctxt.describe_key_and_name( "SWAP" ),
-                                           ctxt.describe_key_and_name( "START" ),
-                                           ctxt.describe_key_and_name( "CONFIRM" ),
-                                           ctxt.describe_key_and_name( "QUIT" ),
-                                           ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ) );
+                                           "%s %s %s %s %s %s %s" ),
+                                           ctxt.get_hint( "EDITMAP_MOVE" ),
+                                           ctxt.get_hint( "RESIZE" ),
+                                           ctxt.get_hint( "SWAP" ),
+                                           ctxt.get_hint( "START" ),
+                                           ctxt.get_hint( "CONFIRM" ),
+                                           ctxt.get_hint( "QUIT" ),
+                                           ctxt.get_hint( "EDITMAP_SHOW_ALL" ) );
             info_title_curr = _( "Resizing selection" );
         }
         do_ui_invalidation();
@@ -1913,11 +1913,11 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
         input_context ctxt( gpmenu.input_category, keyboard_mode::keycode );
         // \u00A0 is the non-breaking space
         info_txt_curr = string_format( pgettext( "keybinding descriptions",
-                                       "[%s,%s]\u00A0prev/next oter type, [%s,%s]\u00A0select, %s, %s" ),
-                                       ctxt.get_desc( "LEFT", 1 ), ctxt.get_desc( "RIGHT", 1 ),
-                                       ctxt.get_desc( "UP", 1 ), ctxt.get_desc( "DOWN", 1 ),
-                                       ctxt.describe_key_and_name( "CONFIRM" ),
-                                       ctxt.describe_key_and_name( "QUIT" ) );
+                                       "%s\u00A0prev/next other type %s\u00A0select %s %s" ),
+                                       ctxt.get_hint_pair( "LEFT", "RIGHT" ),
+                                       ctxt.get_hint_pair( "UP", "DOWN" ),
+                                       ctxt.get_hint( "CONFIRM" ),
+                                       ctxt.get_hint( "QUIT" ) );
         info_title_curr = string_format( pgettext( "map editor state", "Mapgen: %s" ),
                                          oter_id( gmenu.selected ).id().str() );
         do_ui_invalidation();
@@ -2102,9 +2102,9 @@ void editmap::mapgen_retarget()
 
     blink = true;
     do {
-        info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s, %s" ),
-                                       ctxt.describe_key_and_name( "CONFIRM" ),
-                                       ctxt.describe_key_and_name( "QUIT" ) );
+        info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s %s" ),
+                                       ctxt.get_hint( "CONFIRM" ),
+                                       ctxt.get_hint( "QUIT" ) );
         info_title_curr = pgettext( "map generator", "Mapgen: Moving target" );
         do_ui_invalidation();
 
@@ -2196,10 +2196,10 @@ void editmap::edit_mapgen()
         blink = true;
 
         input_context ctxt( gmenu.input_category, keyboard_mode::keycode );
-        info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s, %s, %s" ),
-                                       ctxt.describe_key_and_name( "EDITMAP_MOVE" ),
-                                       ctxt.describe_key_and_name( "CONFIRM" ),
-                                       ctxt.describe_key_and_name( "QUIT" ) );
+        info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s %s %s" ),
+                                       ctxt.get_hint( "EDITMAP_MOVE" ),
+                                       ctxt.get_hint( "CONFIRM" ),
+                                       ctxt.get_hint( "QUIT" ) );
         info_title_curr = pgettext( "map generator", "Mapgen stamp" );
         do_ui_invalidation();
 

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -393,12 +393,10 @@ std::optional<tripoint> editmap::edit()
         }
 
         // \u00A0 is the non-breaking space
-        info_txt_curr = string_format( pgettext( "keybinding descriptions",
-                                       "%s %s [%s,%s]\u00A0fast scroll %s %s %s %s %s %s" ),
+        info_txt_curr = string_format( "%s %s %s %s %s %s %s %s %s",
                                        ctxt.get_hint( "EDIT_TRAPS" ),
                                        ctxt.get_hint( "EDIT_FIELDS" ),
-                                       ctxt.get_hint_pair( "LEFT_WIDE", "RIGHT_WIDE" ),
-                                       ctxt.get_hint_pair( "UP_WIDE", "DOWN_WIDE" ),
+                                       ctxt.get_hint_quad( "LEFT_WIDE", "RIGHT_WIDE", "UP_WIDE", "DOWN_WIDE", _( "fast scroll" ) ),
                                        ctxt.get_hint( "EDITMAP_SHOW_ALL" ),
                                        ctxt.get_hint( "EDIT_TERRAIN" ),
                                        ctxt.get_hint( "EDIT_FURNITURE" ),

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -395,7 +395,7 @@ std::optional<tripoint> editmap::edit()
         info_txt_curr = string_format( "%s %s %s %s %s %s %s %s %s",
                                        ctxt.get_hint( "EDIT_TRAPS" ),
                                        ctxt.get_hint( "EDIT_FIELDS" ),
-                                       ctxt.get_hint_quad( "LEFT_WIDE", "RIGHT_WIDE", "UP_WIDE", "DOWN_WIDE", _( "fast scroll" ) ),
+                                       ctxt.get_hints( {"LEFT_WIDE", "RIGHT_WIDE", "UP_WIDE", "DOWN_WIDE"}, _( "fast scroll" ) ),
                                        ctxt.get_hint( "EDITMAP_SHOW_ALL" ),
                                        ctxt.get_hint( "EDIT_TERRAIN" ),
                                        ctxt.get_hint( "EDIT_FURNITURE" ),
@@ -1263,7 +1263,7 @@ void editmap::edit_fld()
         info_txt_curr = string_format( "%s %s %s %s %s %s",
                                        ctxt.get_hint( "EDITMAP_TAB" ),
                                        ctxt.get_hint( "EDITMAP_MOVE" ),
-                                       ctxt.get_hint_pair( "LEFT", "RIGHT", pgettext( "keybinding descriptions", "intensity" ) ),
+                                       ctxt.get_hints( {"LEFT", "RIGHT"}, pgettext( "keybinding descriptions", "intensity" ) ),
                                        ctxt.get_hint( "CONFIRM" ),
                                        ctxt.get_hint( "QUIT" ),
                                        ctxt.get_hint( "EDITMAP_SHOW_ALL" ) );
@@ -1908,9 +1908,9 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
         }
         input_context ctxt( gpmenu.input_category, keyboard_mode::keycode );
         info_txt_curr = string_format( "%s %s %s %s",
-                                       ctxt.get_hint_pair( "LEFT", "RIGHT", pgettext( "keybinding descriptions",
+                                       ctxt.get_hints( { "LEFT", "RIGHT"}, pgettext( "keybinding descriptions",
                                                "prev/next other type" ) ),
-                                       ctxt.get_hint_pair( "UP", "DOWN", pgettext( "keybinding descriptions", "select" ) ),
+                                       ctxt.get_hints( { "UP", "DOWN"}, pgettext( "keybinding descriptions", "select" ) ),
                                        ctxt.get_hint( "CONFIRM" ),
                                        ctxt.get_hint( "QUIT" ) );
         info_title_curr = string_format( pgettext( "map editor state", "Mapgen: %s" ),

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -392,7 +392,6 @@ std::optional<tripoint> editmap::edit()
             origin = target;               // 'editmap.origin' only makes sense if we have a list of target points.
         }
 
-        // \u00A0 is the non-breaking space
         info_txt_curr = string_format( "%s %s %s %s %s %s %s %s %s",
                                        ctxt.get_hint( "EDIT_TRAPS" ),
                                        ctxt.get_hint( "EDIT_FIELDS" ),

--- a/src/enums.h
+++ b/src/enums.h
@@ -121,6 +121,17 @@ enum class visibility_type : int {
     BOOMER_DARK
 };
 
+
+enum class keybinding_hint_state : int {
+    ENABLED, // default: yellow key everthing else white
+    DISABLED, // all dark and hard to see
+    TOGGLED_ON, // suffix green
+    TOGGLED_OFF, // suffix red
+    NONE, // no colors (other than keybind) set so that they can be set by parent
+    NONE_AT_ALL, // no colors at all set so that they can be set by parent
+    HIGHLIGHTED, // focused
+};
+
 // Matching rules for comparing a string to an overmap terrain id.
 enum class ot_match_type : int {
     // The provided string must completely match the overmap terrain id, including

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1989,10 +1989,12 @@ void basecamp::worker_assignment_ui()
         } else {
             mvwprintz( w_followers, point( 1, 4 ), c_light_red, no_npcs );
         }
-        mvwprintz( w_followers, point( 1, FULL_SCREEN_HEIGHT - 2 ), c_light_gray,
-                   _( "Press %s to inspect this follower." ), ctxt.get_desc( "INSPECT_NPC" ) );
-        mvwprintz( w_followers, point( 1, FULL_SCREEN_HEIGHT - 1 ), c_light_gray,
-                   _( "Press %s to assign this follower to this camp." ), ctxt.get_desc( "CONFIRM" ) );
+        print_colored_text( w_followers, point( 1, FULL_SCREEN_HEIGHT - 2 ),
+                            string_format( _( "Press %s to inspect this follower." ),
+                                           ctxt.get_hint_key_only( "INSPECT_NPC" ) ) );
+        print_colored_text( w_followers, point( 1, FULL_SCREEN_HEIGHT - 1 ),
+                            string_format( _( "Press %s to assign this follower to this camp." ),
+                                           ctxt.get_hint_key_only( "CONFIRM" ) ) );
         wnoutrefresh( w_followers );
     } );
 
@@ -2099,10 +2101,12 @@ void basecamp::job_assignment_ui()
         } else {
             mvwprintz( w_jobs, point( 46, 4 ), c_light_red, no_npcs );
         }
-        mvwprintz( w_jobs, point( 1, FULL_SCREEN_HEIGHT - 2 ), c_light_gray,
-                   _( "Press %s to inspect this follower." ), ctxt.get_desc( "INSPECT_NPC" ) );
-        mvwprintz( w_jobs, point( 1, FULL_SCREEN_HEIGHT - 1 ), c_light_gray,
-                   _( "Press %s to change this workers job priorities." ), ctxt.get_desc( "CONFIRM" ) );
+        print_colored_text( w_jobs, point( 1, FULL_SCREEN_HEIGHT - 2 ),
+                            string_format( _( "Press %s to inspect this follower." ),
+                                           ctxt.get_hint_key_only( "INSPECT_NPC" ) ) );
+        print_colored_text( w_jobs, point( 1, FULL_SCREEN_HEIGHT - 1 ),
+                            string_format( _( "Press %s to change this workers job priorities." ),
+                                           ctxt.get_hint_key_only( "CONFIRM" ) ) );
         wnoutrefresh( w_jobs );
     } );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6506,7 +6506,7 @@ static void zones_manager_shortcuts( const catacurses::window &w_info, faction_i
     hints.push_back( ctxt.get_hint( "ENABLE_PERSONAL_ZONES" ) );
     hints.push_back( ctxt.get_hint( "DISABLE_PERSONAL_ZONES" ) );
 
-    hints.push_back( ctxt.get_hint_pair( "MOVE_ZONE_UP", "MOVE_ZONE_DOWN", _( "Move up/down" ) ) );
+    hints.push_back( ctxt.get_hints( { "MOVE_ZONE_UP", "MOVE_ZONE_DOWN"}, _( "Move up/down" ) ) );
 
     hints.push_back( ctxt.get_hint( "CONFIRM", _( "Edit" ) ) );
     hints.push_back( ctxt.get_hint( "SHOW_ALL_ZONES" ) );
@@ -7864,7 +7864,7 @@ void game::reset_item_list_state( const catacurses::window &window, int height, 
     mvwputch( window, point( width - 1, TERMY - height - 1 ), c_light_gray,
               LINE_XOXX ); // -|
 
-    print_colored_text( window, point( 2, 0 ), ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB",
+    print_colored_text( window, point( 2, 0 ), ctxt.get_hints( { "NEXT_TAB", "PREV_TAB"},
                         _( "Items" ) ) );
 
     std::string sSort = string_format( "%s %s", ctxt.get_hint( "SORT" ),
@@ -7882,8 +7882,8 @@ void game::reset_item_list_state( const catacurses::window &window, int height, 
     tokens.emplace_back( ctxt.get_hint( "EXAMINE" ) );
     tokens.emplace_back( ctxt.get_hint( "COMPARE" ) );
     tokens.emplace_back( ctxt.get_hint( "FILTER" ) );
-    tokens.emplace_back( ctxt.get_hint_pair( "PRIORITY_INCREASE", "PRIORITY_DECREASE",
-                         _( "Priority" ) ) );
+    tokens.emplace_back( ctxt.get_hints( { "PRIORITY_INCREASE", "PRIORITY_DECREASE"},
+                                         _( "Priority" ) ) );
 
     point pos( 2, TERMY - height - 1 );
     fold_and_print( window, pos, width, c_light_gray, enumerate_as_string( tokens,
@@ -8511,7 +8511,7 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
             draw_custom_border( w_monsters_border, 1, 1, 1, 1, 1, 1, LINE_XOXO, LINE_XOXO );
             draw_custom_border( w_monster_info_border, 1, 1, 1, 1, LINE_XXXO, LINE_XOXX, 1, 1 );
 
-            print_colored_text( w_monsters_border, point( 2, 0 ), ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB",
+            print_colored_text( w_monsters_border, point( 2, 0 ), ctxt.get_hints( { "NEXT_TAB", "PREV_TAB"},
                                 _( "Monsters" ) ) );
 
             if( monster_list.empty() ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7864,7 +7864,8 @@ void game::reset_item_list_state( const catacurses::window &window, int height, 
     mvwputch( window, point( width - 1, TERMY - height - 1 ), c_light_gray,
               LINE_XOXX ); // -|
 
-    print_colored_text( window, point( 2, 0 ), ctxt.get_hint( "NEXT_TAB", _( "Items" ) ) );
+    print_colored_text( window, point( 2, 0 ), ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB",
+                        _( "Items" ) ) );
 
     std::string sSort = string_format( "%s %s", ctxt.get_hint( "SORT" ),
                                        bRadiusSort ? _( "dist" ) : _( "cat" ) );
@@ -7884,17 +7885,7 @@ void game::reset_item_list_state( const catacurses::window &window, int height, 
     tokens.emplace_back( ctxt.get_hint_pair( "PRIORITY_INCREASE", "PRIORITY_DECREASE",
                          _( "Priority" ) ) );
 
-    int gaps = tokens.size() + 1;
-    letters = 0;
-    int n = tokens.size();
-    for( int i = 0; i < n; i++ ) {
-        letters += utf8_width( tokens[i], true ) - 1; //length ignores < >
-    }
-
-    int usedwidth = letters;
-    const int gap_spaces = ( width - usedwidth ) / gaps;
-    usedwidth += gap_spaces * gaps;
-    point pos( gap_spaces + ( width - usedwidth ) / 2, TERMY - height - 1 );
+    point pos( 2, TERMY - height - 1 );
     fold_and_print( window, pos, width, c_light_gray, enumerate_as_string( tokens,
                     enumeration_conjunction::space ) );
 }
@@ -8520,7 +8511,7 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
             draw_custom_border( w_monsters_border, 1, 1, 1, 1, 1, 1, LINE_XOXO, LINE_XOXO );
             draw_custom_border( w_monster_info_border, 1, 1, 1, 1, LINE_XXXO, LINE_XOXX, 1, 1 );
 
-            print_colored_text( w_monsters_border, point( 2, 0 ), ctxt.get_hint( "NEXT_TAB",
+            print_colored_text( w_monsters_border, point( 2, 0 ), ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB",
                                 _( "Monsters" ) ) );
 
             if( monster_list.empty() ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2486,7 +2486,9 @@ input_context get_default_mode_input_context()
 #if !defined(__ANDROID__)
     ctxt.register_action( "toggle_fullscreen" );
 #endif
+#if defined(TILES)
     ctxt.register_action( "toggle_pixel_minimap" );
+#endif
     ctxt.register_action( "toggle_panel_adm" );
     ctxt.register_action( "reload_tileset" );
     ctxt.register_action( "toggle_auto_features" );
@@ -7300,7 +7302,9 @@ look_around_result game::look_around(
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "zoom_out" );
     ctxt.register_action( "zoom_in" );
+#if defined(TILES)
     ctxt.register_action( "toggle_pixel_minimap" );
+#endif
 
     const int old_levz = m.get_abs_sub().z();
     const int min_levz = std::max( old_levz - fov_3d_z_range, -OVERMAP_DEPTH );

--- a/src/game.h
+++ b/src/game.h
@@ -844,7 +844,8 @@ class game
 
         game::vmenu_ret list_items( const std::vector<map_item_stack> &item_list );
         std::vector<map_item_stack> find_nearby_items( int iRadius );
-        void reset_item_list_state( const catacurses::window &window, int height, bool bRadiusSort );
+        void reset_item_list_state( const catacurses::window &window, int height, bool bRadiusSort,
+                                    const input_context &ctxt );
 
         game::vmenu_ret list_monsters( const std::vector<Creature *> &monster_list );
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2091,9 +2091,8 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
     ui.on_redraw( [&]( const ui_adaptor & ) {
         if( !confirm_message.empty() ) {
             draw_border( wnd_message );
-            mvwputch( wnd_message, point( 3, 1 ), c_white, confirm_message
-                      + " " + ctxt.describe_key_and_name( "CONFIRM" )
-                      + " " + ctxt.describe_key_and_name( "QUIT" ) );
+            mvwputch( wnd_message, point( 3, 1 ), c_white, string_format( "%s %s %s", confirm_message,
+                      ctxt.get_hint( "CONFIRM" ), ctxt.get_hint( "QUIT" ) ) );
             wnoutrefresh( wnd_message );
         }
 

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -672,8 +672,8 @@ void defense_game::refresh_setup( const catacurses::window &w, int selection,
     werase( w );
     draw_border( w, c_light_gray, _( "DEFENSE MODE" ), c_light_red );
 
-    print_colored_text( w, point( 2, 1 ), string_format( _( "Press direction keys to cycle %s %s" ),
-                        ctxt.get_hint( "CONFIRM" ), ctxt.get_hint( "START" ) ) );
+    print_colored_text( w, point( 2, 1 ), string_format( _( "Press %s to cycle %s %s" ),
+                        ctxt.get_hint_directions(), ctxt.get_hint( "CONFIRM" ), ctxt.get_hint( "START" ) ) );
     mvwprintz( w, point( 2, 2 ), c_white, _( "Scenario:" ) );
     mvwprintz( w, point( 2, 3 ), SELCOL( 1 ), defense_style_name( style ) );
     mvwprintz( w, point( 28, 3 ), c_light_gray, defense_style_description( style ) );

--- a/src/gamemode_defense.h
+++ b/src/gamemode_defense.h
@@ -8,6 +8,7 @@
 #include "calendar.h"
 #include "coordinates.h"
 #include "enums.h"
+#include "input.h"
 #include "gamemode.h"
 #include "omdata.h"
 #include "type_id.h"
@@ -71,7 +72,7 @@ struct defense_game : public special_game {
         void init_to_style( defense_style new_style );
 
         void setup();
-        void refresh_setup( const catacurses::window &w, int selection );
+        void refresh_setup( const catacurses::window &w, int selection, const input_context &ctxt );
         void init_mtypes();
         void init_constructions();
         void init_map();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2959,8 +2959,9 @@ bool game::handle_action()
                 std::string msg = string_format( _( "Unknown command: \"%s\" (%ld)" ), evt.long_description(), ch );
                 if( !ctxt.keys_bound_to( action_ident( ACTION_KEYBINDINGS ), /*maximum_modifier_count=*/ -1,
                                          /*restrict_to_printable=*/false ).empty() ) {
-                    msg = string_format( "%s\n%s", msg, ctxt.get_hint( action_ident( ACTION_KEYBINDINGS ),
-                                         _( "at any time to see and edit keybindings relevant to the current context." ) ) );
+                    msg = string_format(
+                              _( "Press %s at any time to see and edit keybindings relevant to the current context." ),
+                              ctxt.get_hint_key_only( action_ident( ACTION_KEYBINDINGS ) ) );
                 }
                 add_msg( m_info, msg );
             }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -367,7 +367,7 @@ input_context game::get_player_input( std::string &action )
             if( uquit == QUIT_WATCH ) {
                 deathcam_msg_popup = std::make_unique<static_popup>();
                 deathcam_msg_popup
-                ->wait_message( c_red, _( "Press %s to accept your fate…" ), ctxt.get_desc( "QUIT" ) )
+                ->wait_message( c_red, _( "Press %s to accept your fate…" ), ctxt.get_hint_key_only( "QUIT" ) )
                 .on_top( true );
             }
 
@@ -1752,8 +1752,8 @@ static void handle_debug_mode()
     uilist dbmenu;
     dbmenu.allow_anykey = true;
     dbmenu.title = _( "Debug Mode Filters" );
-    dbmenu.text = string_format( _( "Press [%1$s] to quickly toggle debug mode." ),
-                                 ctxt.get_desc( "debug_mode" ) );
+    dbmenu.text = string_format( _( "Press %s to quickly toggle debug mode." ),
+                                 ctxt.get_hint_key_only( "debug_mode" ) );
 
     dbmenu.entries.reserve( 1 + debugmode::DF_LAST );
 
@@ -2957,12 +2957,10 @@ bool game::handle_action()
             const int ch = evt.get_first_input();
             if( !get_option<bool>( "NO_UNKNOWN_COMMAND_MSG" ) ) {
                 std::string msg = string_format( _( "Unknown command: \"%s\" (%ld)" ), evt.long_description(), ch );
-                if( const std::optional<std::string> hint =
-                        press_x_if_bound( ACTION_KEYBINDINGS ) ) {
-                    msg = string_format( "%s\n%s", msg,
-                                         string_format( _( "%s at any time to see and edit keybindings relevant to "
-                                                           "the current context." ),
-                                                        *hint ) );
+                if( !ctxt.keys_bound_to( action_ident( ACTION_KEYBINDINGS ), /*maximum_modifier_count=*/ -1,
+                                         /*restrict_to_printable=*/false ).empty() ) {
+                    msg = string_format( "%s\n%s", msg, ctxt.get_hint( action_ident( ACTION_KEYBINDINGS ),
+                                         _( "at any time to see and edit keybindings relevant to the current context." ) ) );
                 }
                 add_msg( m_info, msg );
             }

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -107,7 +107,7 @@ std::map<int, inclusive_rectangle<point>> help::draw_menu( const catacurses::win
         const keybinding_hint_state state = selected == text.first ? keybinding_hint_state::HIGHLIGHTED :
                                             keybinding_hint_state::ENABLED ;
         std::string cat_name = text.second.first.translated();
-        std::string shortcut = shortcut_text( cat_name, state, true );
+        std::string shortcut = shortcut_text( cat_name, state );
 
         const int cat_width = utf8_width( shortcut, true );
         if( i < half_size ) {

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -90,7 +90,7 @@ std::string help::get_dir_grid()
 }
 
 std::map<int, inclusive_rectangle<point>> help::draw_menu( const catacurses::window &win,
-                                       int selected ) const
+                                       int selected, const input_context &ctxt ) const
 {
     std::map<int, inclusive_rectangle<point>> opt_map;
 
@@ -106,8 +106,14 @@ std::map<int, inclusive_rectangle<point>> help::draw_menu( const catacurses::win
     for( const auto &text : help_texts ) {
         const keybinding_hint_state state = selected == text.first ? keybinding_hint_state::HIGHLIGHTED :
                                             keybinding_hint_state::ENABLED ;
-        const std::string cat_name = text.second.first.translated();
-        std::string shortcut = shortcut_text( cat_name, state );
+        std::string cat_name = text.second.first.translated();
+        std::string shortcut_only = shortcut_text( cat_name, state, true );
+
+        size_t pos = cat_name.find_first_of( ':' );
+        if( pos != std::string::npos && pos + 2 < cat_name.size() ) {
+            cat_name = cat_name.substr( pos + 2 );
+        }
+        std::string shortcut = ctxt.get_hint_basic( shortcut_only, cat_name, state );
         const int cat_width = utf8_width( shortcut, true );
         if( i < half_size ) {
             second_column = std::max( second_column, cat_width + 4 );
@@ -178,7 +184,7 @@ void help::display_help() const
     ui.on_redraw( [&]( const ui_adaptor & ) {
         draw_border( w_help_border, BORDER_COLOR, _( "Help" ) );
         wnoutrefresh( w_help_border );
-        opt_map = draw_menu( w_help, sel );
+        opt_map = draw_menu( w_help, sel, ctxt );
     } );
 
     std::map<int, std::vector<std::string>> hotkeys;

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -109,7 +109,7 @@ std::map<int, inclusive_rectangle<point>> help::draw_menu( const catacurses::win
         std::string cat_name = text.second.first.translated();
         std::string shortcut_only = shortcut_text( cat_name, state, true );
 
-        size_t pos = cat_name.find_first_of( ':' );
+        size_t pos = cat_name.find_first_of( ' ' );
         if( pos != std::string::npos && pos + 1 < cat_name.size() ) {
             cat_name = cat_name.substr( pos + 1 );
         }

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -104,15 +104,20 @@ std::map<int, inclusive_rectangle<point>> help::draw_menu( const catacurses::win
     int second_column = divide_round_up( getmaxx( win ), 2 );
     size_t i = 0;
     for( const auto &text : help_texts ) {
+        const keybinding_hint_state state = selected == text.first ? keybinding_hint_state::HIGHLIGHTED :
+                                            keybinding_hint_state::ENABLED ;
         const std::string cat_name = text.second.first.translated();
-        const int cat_width = utf8_width( remove_color_tags( shortcut_text( c_white, cat_name ) ) );
+        std::string shortcut = shortcut_text( cat_name, state );
+        const int cat_width = utf8_width( shortcut, true );
         if( i < half_size ) {
             second_column = std::max( second_column, cat_width + 4 );
         }
 
         const point sc_start( i < half_size ? 1 : second_column, y + i % half_size );
-        shortcut_print( win, sc_start, selected == text.first ? hilite( c_white ) : c_white,
-                        selected == text.first ? hilite( c_light_blue ) : c_light_blue, cat_name );
+        wmove( win, sc_start );
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        print_colored_text( win, point( -1, -1 ), shortcut );
+
         ++i;
 
         opt_map.emplace( text.first,

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -110,8 +110,8 @@ std::map<int, inclusive_rectangle<point>> help::draw_menu( const catacurses::win
         std::string shortcut_only = shortcut_text( cat_name, state, true );
 
         size_t pos = cat_name.find_first_of( ':' );
-        if( pos != std::string::npos && pos + 2 < cat_name.size() ) {
-            cat_name = cat_name.substr( pos + 2 );
+        if( pos != std::string::npos && pos + 1 < cat_name.size() ) {
+            cat_name = cat_name.substr( pos + 1 );
         }
         std::string shortcut = ctxt.get_hint_basic( shortcut_only, cat_name, state );
         const int cat_width = utf8_width( shortcut, true );

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -90,7 +90,7 @@ std::string help::get_dir_grid()
 }
 
 std::map<int, inclusive_rectangle<point>> help::draw_menu( const catacurses::window &win,
-                                       int selected, const input_context &ctxt ) const
+                                       int selected ) const
 {
     std::map<int, inclusive_rectangle<point>> opt_map;
 
@@ -107,13 +107,8 @@ std::map<int, inclusive_rectangle<point>> help::draw_menu( const catacurses::win
         const keybinding_hint_state state = selected == text.first ? keybinding_hint_state::HIGHLIGHTED :
                                             keybinding_hint_state::ENABLED ;
         std::string cat_name = text.second.first.translated();
-        std::string shortcut_only = shortcut_text( cat_name, state, true );
+        std::string shortcut = shortcut_text( cat_name, state, true );
 
-        size_t pos = cat_name.find_first_of( ' ' );
-        if( pos != std::string::npos && pos + 1 < cat_name.size() ) {
-            cat_name = cat_name.substr( pos + 1 );
-        }
-        std::string shortcut = ctxt.get_hint_basic( shortcut_only, cat_name, state );
         const int cat_width = utf8_width( shortcut, true );
         if( i < half_size ) {
             second_column = std::max( second_column, cat_width + 4 );
@@ -184,7 +179,7 @@ void help::display_help() const
     ui.on_redraw( [&]( const ui_adaptor & ) {
         draw_border( w_help_border, BORDER_COLOR, _( "Help" ) );
         wnoutrefresh( w_help_border );
-        opt_map = draw_menu( w_help, sel, ctxt );
+        opt_map = draw_menu( w_help, sel );
     } );
 
     std::map<int, std::vector<std::string>> hotkeys;

--- a/src/help.h
+++ b/src/help.h
@@ -27,7 +27,7 @@ class help
     private:
         void deserialize( const JsonArray &ja );
         std::map<int, inclusive_rectangle<point>> draw_menu( const catacurses::window &win,
-                                               int selected, const input_context &ctxt ) const;
+                                               int selected ) const;
         static std::string get_note_colors();
         static std::string get_dir_grid();
 

--- a/src/help.h
+++ b/src/help.h
@@ -10,6 +10,7 @@
 
 #include "cuboid_rectangle.h"
 
+class input_context;
 class JsonArray;
 class translation;
 namespace catacurses
@@ -26,7 +27,7 @@ class help
     private:
         void deserialize( const JsonArray &ja );
         std::map<int, inclusive_rectangle<point>> draw_menu( const catacurses::window &win,
-                                               int selected ) const;
+                                               int selected, const input_context &ctxt ) const;
         static std::string get_note_colors();
         static std::string get_dir_grid();
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1178,6 +1178,11 @@ std::string input_context::colorize_inline_format( const keybinding_hint_state s
     }
     return string_format( fmt, left_text, colored_key, right_text, left_separator, right_separator );
 }
+std::string input_context::get_hint_basic( const std::string &key,
+        const keybinding_hint_state state )
+{
+    return input_context::get_hint_basic( key, "", state );
+}
 
 std::string input_context::get_hint_basic( const std::string &key,
         const std::string &text,
@@ -2087,9 +2092,7 @@ std::string input_context::press_x( const std::string &action_id,
     const std::string separator = _( " or " );
     std::string keyed = key_bound_pre;
     for( size_t j = 0; j < events.size(); j++ ) {
-        keyed += string_format( "%s%s%s", colorize( "[", get_hint_color_for_separator() ),
-                                colorize( events[j].long_description(), get_hint_color_for_key() ), colorize( "]",
-                                        get_hint_color_for_separator() ) );
+        keyed += get_hint_basic( events[j].long_description() );
 
         if( j + 1 < events.size() ) {
             keyed += separator;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1301,6 +1301,23 @@ std::string input_context::get_desc(
             evt_filter ), text, show_separators );
 }
 
+std::string input_context::replace_keybinding_hint_colors( const std::string s,
+        keybinding_hint_state before_state, keybinding_hint_state after_state )
+{
+    // HACK This might break depending on what colours we're switching to/from
+    std::string o = s;
+    nc_color old_key_color = input_context::get_hint_color_for_key( before_state );
+    nc_color new_key_color = input_context::get_hint_color_for_key( after_state );
+    nc_color old_hint_color = input_context::get_hint_color( before_state );
+    nc_color new_hint_color = input_context::get_hint_color( after_state );
+    nc_color old_sep_color = input_context::get_hint_color_for_separator( before_state );
+    nc_color new_sep_color = input_context::get_hint_color_for_separator( after_state );
+    o = string_replace( o, get_tag_from_color( old_key_color ), get_tag_from_color( new_key_color ) );
+    o = string_replace( o, get_tag_from_color( old_hint_color ), get_tag_from_color( new_hint_color ) );
+    o = string_replace( o, get_tag_from_color( old_sep_color ), get_tag_from_color( new_sep_color ) );
+    return o;
+}
+
 const nc_color input_context::get_hint_color( keybinding_hint_state state )
 {
     switch( state ) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1203,7 +1203,7 @@ std::string input_context::get_hint_basic( const std::string &key,
                     text.substr( pos + key.size() ), true );
         }
     }
-    // Fallback to this if key is not present in the text.
+    // Fallback here if we don't want to or can't inline the key within the text.
     return input_context::colorize_separate_format( state, key, text, true );
 }
 
@@ -1658,9 +1658,9 @@ action_id input_context::display_menu( const bool permit_execute_action )
     } ), org_registered_actions.end() );
 
     // colors of the keybindings
-    static const nc_color global_key = c_light_gray;
-    static const nc_color local_key = c_light_green;
-    static const nc_color unbound_key = c_light_red;
+    static const nc_color global_key = get_hint_color( keybinding_hint_state::ENABLED );
+    static const nc_color local_key = get_hint_color( keybinding_hint_state::TOGGLED_ON );
+    static const nc_color unbound_key = get_hint_color( keybinding_hint_state::TOGGLED_OFF );
     // (vertical) scroll offset
     size_t scroll_offset = 0;
     // keybindings help

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1233,9 +1233,9 @@ std::string input_context::get_desc(
     const input_event_filter &evt_filter ) const
 {
     if( action_descriptor == "ANY_INPUT" ) {
-        //~ keybinding description for anykey
-        return input_context::colorize_separate_format( state, pgettext( "keybinding",
-                "any" ), text, show_separators );
+        return input_context::colorize_separate_format( state,
+                //~ keybinding description for anykey
+                pgettext( "keybinding", "any" ), text, show_separators );
     }
 
 
@@ -1318,14 +1318,7 @@ const nc_color input_context::get_hint_color_for_key( keybinding_hint_state stat
 std::string replace_spaces_with_non_breaking( const std::string &s )
 {
     std::string o = s;
-    std::string old( " " );
-    std::string rep( "\u00A0" );
-
-    for( std::size_t pos = 0;
-         ( pos = o.find( old, pos ) ) != std::string::npos;
-         pos += rep.length() ) {
-        o.replace( pos, old.length(), rep );
-    }
+    replace_substring( o, " ", "\u00A0", true );
     return o;
 }
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1292,9 +1292,18 @@ const nc_color input_context::get_hint_color_for_key( keybinding_hint_state stat
     }
 }
 
-std::string replace_spaces_with_non_breaking( std::string s )
+std::string replace_spaces_with_non_breaking( const std::string s )
 {
-    return std::regex_replace( s, std::regex( " " ), "\u00A0" );
+    std::string o = s;
+    std::string old( " " );
+    std::string rep( "\u00A0" );
+
+    for( std::size_t pos = 0;
+         ( pos = o.find( old, pos ) ) != std::string::npos;
+         pos += rep.length() ) {
+        o.replace( pos, old.length(), rep );
+    }
+    return o;
 }
 
 std::string input_context::_get_hint( const std::string &action_descriptor, bool show_suffix,

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1029,7 +1029,7 @@ std::vector<input_event> input_context::keys_bound_to( const std::string &action
     return result;
 }
 
-std::string input_context::get_available_single_char_hotkeys( std::string requested_keys )
+std::string input_context::get_available_single_char_hotkeys( std::string requested_keys ) const
 {
     for( const auto &registered_action : registered_actions ) {
 
@@ -1183,18 +1183,18 @@ std::string input_context::get_hint_basic( const std::string &key,
         const std::string &text,
         const keybinding_hint_state state )
 {
-    // If the given k is the same as the text itself, we'd want to surround
-    //   the key with the proper separators.
     const int pos = ci_find_substr( text, key );
     if( pos >= 0 ) {
-        if( key.size() == text.size() ) {
-            return input_context::colorize_separate_format( state, key, text, true );
+        // If the given k is the same as the text itself, we'd want to surround
+        //   the key with the proper separators.
+        if( get_option<bool>( "KEYBINDINGS_INLINE" ) ) {
+            return input_context::colorize_inline_format( state, key, text.substr( 0, pos ),
+                    text.substr( pos + key.size() ), true );
         }
-        return input_context::colorize_inline_format( state, key, text.substr( 0, pos ),
-                text.substr( pos + key.size() ), true );
+        return input_context::colorize_separate_format( state, key, text, true );
     }
-    // Fallback to this if no string in keys is present in the text.
-    return input_context::colorize_separate_format( state, "", text, false );
+    // Fallback to this if key is not present in the text.
+    return input_context::colorize_separate_format( state, key, text, true );
 }
 std::string input_context::get_desc(
     const std::string &action_descriptor,

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1301,7 +1301,7 @@ std::string input_context::get_desc(
             evt_filter ), text, show_separators );
 }
 
-std::string input_context::replace_keybinding_hint_colors( const std::string s,
+std::string input_context::replace_keybinding_hint_colors( const std::string &s,
         keybinding_hint_state before_state, keybinding_hint_state after_state )
 {
     // HACK This might break depending on what colours we're switching to/from

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1186,8 +1186,8 @@ std::string input_context::get_hint_basic( const std::string &key,
 
 bool should_inline( const int pos, const std::string &text )
 {
-    return pos >= 0 && text.find_first_of( ' ' ) == std::string::npos &&
-           text.find_first_of( "\u00A0" ) == std::string::npos;
+    return pos == 0 || ( pos >> 0 && text.find_first_of( ' ' ) == std::string::npos &&
+                         text.find_first_of( "\u00A0" ) == std::string::npos );
 }
 
 std::string input_context::get_hint_basic( const std::string &key,

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -10,7 +10,6 @@
 #include <memory>
 #include <new>
 #include <optional>
-#include <regex>
 #include <set>
 #include <sstream>
 #include <stdexcept>

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -78,6 +78,24 @@ static std::string int_to_str( int number )
     return buffer.str();
 }
 
+
+static std::string get_padded_suffix( const std::string &s )
+{
+    // \u00A0 is the non-breaking space
+    if( !s.empty() && s.find_first_of( "\u00A0" ) != 0 ) {
+        return string_format( "\u00A0%s", s );
+    }
+    return s;
+}
+
+static std::string replace_spaces_with_non_breaking( const std::string &s )
+{
+    std::string o = s;
+    // \u00A0 is the non-breaking space
+    replace_substring( o, " ", "\u00A0", true );
+    return o;
+}
+
 bool is_mouse_enabled()
 {
 #if defined(_WIN32) && !defined(TILES)
@@ -1140,7 +1158,6 @@ std::string input_context::colorize_separate_format( const keybinding_hint_state
         const bool show_separators, const bool key_not_found )
 {
     const translation fmt = to_translation(
-                                // \u00A0 is the non-breaking space
                                 //~ %1$s: key description,
                                 //~ %2$s: action description.
                                 //~ %3$s: separated left separator
@@ -1263,10 +1280,7 @@ std::string input_context::get_desc(
             }
         }
     }
-    std::string padded_text = text;
-    if( n_text > 0 ) {
-        padded_text = string_format( "\u00A0%s", padded_text );
-    }
+    std::string padded_text = get_padded_suffix( text );
     if( na ) {
         //~ keybinding description for unbound or non-applicable keys
         return input_context::colorize_separate_format( state, pgettext( "keybinding",
@@ -1313,13 +1327,6 @@ const nc_color input_context::get_hint_color_for_key( keybinding_hint_state stat
         default:
             return get_option<bool>( "KEYBINDINGS_ALTERNATE_COLOR_THEME" ) ? c_cyan : c_yellow;
     }
-}
-
-std::string replace_spaces_with_non_breaking( const std::string &s )
-{
-    std::string o = s;
-    replace_substring( o, " ", "\u00A0", true );
-    return o;
 }
 
 std::string input_context::_get_hint( const std::string &action_descriptor, bool show_suffix,
@@ -1388,10 +1395,7 @@ std::string input_context::get_hint_pair( const std::string &left_action_descrip
         keybinding_hint_state state, const input_event_filter &evt_filter ) const
 {
 
-    std::string suffix = replace_spaces_with_non_breaking( suffix_override );
-    if( !suffix.empty() ) {
-        suffix = string_format( "\u00A0%s", suffix );
-    }
+    std::string suffix = get_padded_suffix( replace_spaces_with_non_breaking( suffix_override ) );
     return string_format( "%s%s", get_hint_pair( left_action_descriptor, right_action_descriptor,
                           state, evt_filter ), scolorize( suffix, get_hint_color( state ) ) );
 }
@@ -1440,10 +1444,7 @@ std::string input_context::get_hint_quad( const std::string &first_action_descri
         keybinding_hint_state state,
         const input_event_filter &evt_filter ) const
 {
-    std::string suffix = replace_spaces_with_non_breaking( suffix_override );
-    if( !suffix.empty() ) {
-        suffix = string_format( "\u00A0%s", suffix );
-    }
+    std::string suffix = get_padded_suffix( replace_spaces_with_non_breaking( suffix_override ) );
     return string_format( "%s%s", get_hint_quad( first_action_descriptor,
                           second_action_descriptor, third_action_descriptor, fourth_action_descriptor, state, evt_filter ),
                           scolorize( suffix, get_hint_color( state ) ) );

--- a/src/input.h
+++ b/src/input.h
@@ -78,6 +78,7 @@ inline constexpr int KEY_NUM( const int n )
 {
     return 0x30 + n;     /* Numbers 0, 1, ..., 9 */
 }
+
 constexpr int KEY_NPAGE      = 0x152;    /* page down */
 constexpr int KEY_PPAGE      = 0x153;    /* page up */
 constexpr int KEY_ENTER      = 0x157;    /* enter */
@@ -717,6 +718,8 @@ class input_context
         static std::string colorize_inline_format( keybinding_hint_state state,
                 const std::string &key, const std::string &left_text,
                 const std::string &right_text, bool show_separators );
+        static std::string replace_keybinding_hint_colors( const std::string s,
+                keybinding_hint_state before_state, keybinding_hint_state after_state );
         static const nc_color get_hint_color( keybinding_hint_state state =
                 keybinding_hint_state::ENABLED );
         static const nc_color get_hint_color_for_separator( keybinding_hint_state state =

--- a/src/input.h
+++ b/src/input.h
@@ -718,7 +718,7 @@ class input_context
         static std::string colorize_inline_format( keybinding_hint_state state,
                 const std::string &key, const std::string &left_text,
                 const std::string &right_text, bool show_separators );
-        static std::string replace_keybinding_hint_colors( const std::string s,
+        static std::string replace_keybinding_hint_colors( const std::string &s,
                 keybinding_hint_state before_state, keybinding_hint_state after_state );
         static const nc_color get_hint_color( keybinding_hint_state state =
                 keybinding_hint_state::ENABLED );

--- a/src/input.h
+++ b/src/input.h
@@ -708,6 +708,7 @@ class input_context
         // Helper functions to be used as @ref input_event_filter
         static bool disallow_lower_case_or_non_modified_letters( const input_event &evt );
         static bool allow_all_keys( const input_event &evt );
+        static bool allow_only_mouse( const input_event &evt );
 
         static std::string colorize_separate_format( keybinding_hint_state state,
                 const std::string &key, const std::string &text,
@@ -726,6 +727,11 @@ class input_context
         std::string get_hint_key_only( const std::string &action_descriptor,
                                        keybinding_hint_state state = keybinding_hint_state::ENABLED,
                                        const input_event_filter &evt_filter = allow_all_keys ) const;
+        std::string get_hint_mouse( const std::string &action_descriptor,
+                                    keybinding_hint_state state = keybinding_hint_state::ENABLED ) const;
+        std::string get_hint_mouse( const std::string &action_descriptor,
+                                    const std::string &suffix_override,
+                                    keybinding_hint_state state = keybinding_hint_state::ENABLED ) const;
         std::string get_hint( const std::string &action_descriptor,
                               keybinding_hint_state state = keybinding_hint_state::ENABLED,
                               const input_event_filter &evt_filter = allow_all_keys ) const;
@@ -752,6 +758,13 @@ class input_context
                                    const std::string &fourth_action_descriptor, const std::string &suffix_override,
                                    keybinding_hint_state state = keybinding_hint_state::ENABLED,
                                    const input_event_filter &evt_filter = allow_all_keys ) const;
+        std::string get_hint_directions(
+            keybinding_hint_state state = keybinding_hint_state::ENABLED,
+            const input_event_filter &evt_filter = allow_all_keys ) const;
+        std::string get_hint_directions(
+            const std::string &suffix_override,
+            keybinding_hint_state state = keybinding_hint_state::ENABLED,
+            const input_event_filter &evt_filter = allow_all_keys ) const;
 
         /**
          * Handles input and returns the next action in the queue.

--- a/src/input.h
+++ b/src/input.h
@@ -913,11 +913,9 @@ class input_context
          *
          * @param text The base text for action description
          *
+         * @param state Determines the colour-tagging of the resulting string
+         * @param show_separators Should the key be surrounded by separator chars?
          * @param evt_filter Only keys satisfying this function will be considered
-         * @param inline_fmt Action description format when a key is found in the
-         *                   text (for example "(a)ctive")
-         * @param separate_fmt Action description format when a key is not found
-         *                     in the text (for example "[X] active" or "[N/A] active")
          */
         std::string get_desc( const std::string &action_descriptor,
                               const std::string &text,
@@ -942,6 +940,8 @@ class input_context
                                            const std::string &text,
                                            const keybinding_hint_state state = keybinding_hint_state::ENABLED
                                          );
+        static std::string get_hint_basic( const std::string &key,
+                                           const keybinding_hint_state state = keybinding_hint_state::ENABLED );
         const std::string &input_to_action( const input_event &inp ) const;
         bool is_event_type_enabled( input_event_t type ) const;
         bool is_registered_action( const std::string &action_name ) const;

--- a/src/input.h
+++ b/src/input.h
@@ -708,6 +708,7 @@ class input_context
         // Helper functions to be used as @ref input_event_filter
         static bool disallow_lower_case_or_non_modified_letters( const input_event &evt );
         static bool allow_all_keys( const input_event &evt );
+        static bool allow_only_arrows( const input_event &evt );
         static bool allow_only_mouse( const input_event &evt );
 
         static std::string colorize_separate_format( keybinding_hint_state state,
@@ -738,26 +739,12 @@ class input_context
         std::string get_hint( const std::string &action_descriptor, const std::string &suffix_override,
                               keybinding_hint_state state = keybinding_hint_state::ENABLED,
                               const input_event_filter &evt_filter = allow_all_keys ) const;
-        std::string get_hint_pair( const std::string &left_action_descriptor,
-                                   const std::string &right_action_descriptor,
-                                   keybinding_hint_state state = keybinding_hint_state::ENABLED,
-                                   const input_event_filter &evt_filter = allow_all_keys ) const;
-        std::string get_hint_pair( const std::string &left_action_descriptor,
-                                   const std::string &right_action_descriptor, const std::string &suffix_override,
-                                   keybinding_hint_state state = keybinding_hint_state::ENABLED,
-                                   const input_event_filter &evt_filter = allow_all_keys ) const;
-        std::string get_hint_quad( const std::string &first_action_descriptor,
-                                   const std::string &second_action_descriptor,
-                                   const std::string &third_action_descriptor,
-                                   const std::string &fourth_action_descriptor,
-                                   keybinding_hint_state state = keybinding_hint_state::ENABLED,
-                                   const input_event_filter &evt_filter = allow_all_keys ) const;
-        std::string get_hint_quad( const std::string &first_action_descriptor,
-                                   const std::string &second_action_descriptor,
-                                   const std::string &third_action_descriptor,
-                                   const std::string &fourth_action_descriptor, const std::string &suffix_override,
-                                   keybinding_hint_state state = keybinding_hint_state::ENABLED,
-                                   const input_event_filter &evt_filter = allow_all_keys ) const;
+        std::string get_hints( std::vector<std::string> action_descriptors,
+                               keybinding_hint_state state = keybinding_hint_state::ENABLED,
+                               const input_event_filter &evt_filter  = allow_all_keys ) const;
+        std::string get_hints( std::vector<std::string> action_descriptors,
+                               const std::string &suffix_override, keybinding_hint_state state = keybinding_hint_state::ENABLED,
+                               const input_event_filter &evt_filter  = allow_all_keys ) const;
         std::string get_hint_directions(
             keybinding_hint_state state = keybinding_hint_state::ENABLED,
             const input_event_filter &evt_filter = allow_all_keys ) const;

--- a/src/input.h
+++ b/src/input.h
@@ -700,7 +700,8 @@ class input_context
          */
         std::string get_available_single_char_hotkeys(
             std::string requested_keys =
-                "abcdefghijkpqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-=:;'\",./<>?!@#$%^&*()_+[]\\{}|`~" );
+                "abcdefghijkpqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-=:;'\",./<>?!@#$%^&*()_+[]\\{}|`~" )
+        const;
 
         using input_event_filter = std::function<bool( const input_event & )>;
 
@@ -939,7 +940,8 @@ class input_context
          */
         static std::string get_hint_basic( const std::string &key,
                                            const std::string &text,
-                                           const keybinding_hint_state state = keybinding_hint_state::ENABLED );
+                                           const keybinding_hint_state state = keybinding_hint_state::ENABLED
+                                         );
         const std::string &input_to_action( const input_event &inp ) const;
         bool is_event_type_enabled( input_event_t type ) const;
         bool is_registered_action( const std::string &action_name ) const;

--- a/src/input.h
+++ b/src/input.h
@@ -14,6 +14,8 @@
 #include <list>
 #endif
 
+#include "color.h"
+#include "enums.h"
 #include "point.h"
 #include "translations.h"
 
@@ -297,6 +299,7 @@ struct action_attributes {
     action_attributes() : is_user_created( false ) {}
     bool is_user_created;
     translation name;
+    translation short_name;
     std::vector<input_event> input_events;
 };
 
@@ -584,6 +587,7 @@ class input_context
             }
         };
 
+
         std::vector<manual_key> registered_manual_keys;
 
         // If true, prevent virtual keyboard from dismissing after a key press while this input context is active.
@@ -704,58 +708,49 @@ class input_context
         static bool disallow_lower_case_or_non_modified_letters( const input_event &evt );
         static bool allow_all_keys( const input_event &evt );
 
-        /**
-         * Get a description text for the key/other input method associated
-         * with the given action. If there are multiple bound keys, no more
-         * than max_limit will be described in the result. In addition, only
-         * keys satisfying evt_filter will be described.
-         *
-         * @param action_descriptor The action descriptor for which to return
-         *                          a description of the bound keys.
-         *
-         * @param max_limit No more than max_limit bound keys will be
-         *                  described in the returned description. A value of
-         *                  0 indicates no limit.
-         *
-         * @param evt_filter Only keys satisfying this function will be
-         *                   described.
-         */
-        std::string get_desc( const std::string &action_descriptor,
-                              unsigned int max_limit = 0,
-                              const input_event_filter &evt_filter = allow_all_keys ) const;
+        static std::string colorize_separate_format( const keybinding_hint_state state,
+                const std::string &key, const std::string &text,
+                const bool show_separators, const bool key_not_found = false );
+        static std::string colorize_inline_format( const keybinding_hint_state state,
+                const std::string &key, const std::string &left_text,
+                const std::string &right_text, const bool show_separators );
+        static const nc_color get_hint_color( keybinding_hint_state state =
+                keybinding_hint_state::ENABLED );
+        static const nc_color get_hint_color_for_separator( keybinding_hint_state state =
+                    keybinding_hint_state::ENABLED );
+        static const nc_color get_hint_color_for_key( keybinding_hint_state state =
+                    keybinding_hint_state::ENABLED );
 
-        /**
-         * Get a description based on `text`. If a bound key for `action_descriptor`
-         * satisfying `evt_filter` is contained in `text`, surround the key with
-         * brackets and change the case if necessary (e.g. "(Y)es"). Otherwise
-         * prefix `text` with description of the first bound key satisfying
-         * `evt_filter`, surrounded in square brackets (e.g "[RETURN] Yes").
-         *
-         * @param action_descriptor The action descriptor for which to return
-         *                          a description of the bound keys.
-         *
-         * @param text The base text for action description
-         *
-         * @param evt_filter Only keys satisfying this function will be considered
-         * @param inline_fmt Action description format when a key is found in the
-         *                   text (for example "(a)ctive")
-         * @param separate_fmt Action description format when a key is not found
-         *                     in the text (for example "[X] active" or "[N/A] active")
-         */
-        std::string get_desc( const std::string &action_descriptor,
-                              const std::string &text,
-                              const input_event_filter &evt_filter,
-                              const translation &inline_fmt,
-                              const translation &separate_fmt ) const;
-        std::string get_desc( const std::string &action_descriptor,
-                              const std::string &text,
-                              const input_event_filter &evt_filter = allow_all_keys ) const;
 
-        /**
-         * Equivalent to get_desc( act, get_action_name( act ), filter )
-         **/
-        std::string describe_key_and_name( const std::string &action_descriptor,
-                                           const input_event_filter &evt_filter = allow_all_keys ) const;
+        std::string get_hint_key_only( const std::string &action_descriptor,
+                                       keybinding_hint_state state = keybinding_hint_state::ENABLED,
+                                       const input_event_filter &evt_filter = allow_all_keys ) const;
+        std::string get_hint( const std::string &action_descriptor,
+                              keybinding_hint_state state = keybinding_hint_state::ENABLED,
+                              const input_event_filter &evt_filter = allow_all_keys ) const;
+        std::string get_hint( const std::string &action_descriptor, const std::string &suffix_override,
+                              keybinding_hint_state state = keybinding_hint_state::ENABLED,
+                              const input_event_filter &evt_filter = allow_all_keys ) const;
+        std::string get_hint_pair( const std::string &left_action_descriptor,
+                                   const std::string &right_action_descriptor,
+                                   keybinding_hint_state state = keybinding_hint_state::ENABLED,
+                                   const input_event_filter &evt_filter = allow_all_keys ) const;
+        std::string get_hint_pair( const std::string &left_action_descriptor,
+                                   const std::string &right_action_descriptor, const std::string &suffix_override,
+                                   keybinding_hint_state state = keybinding_hint_state::ENABLED,
+                                   const input_event_filter &evt_filter = allow_all_keys ) const;
+        std::string get_hint_quad( const std::string &first_action_descriptor,
+                                   const std::string &second_action_descriptor,
+                                   const std::string &third_action_descriptor,
+                                   const std::string &fourth_action_descriptor,
+                                   keybinding_hint_state state = keybinding_hint_state::ENABLED,
+                                   const input_event_filter &evt_filter = allow_all_keys ) const;
+        std::string get_hint_quad( const std::string &first_action_descriptor,
+                                   const std::string &second_action_descriptor,
+                                   const std::string &third_action_descriptor,
+                                   const std::string &fourth_action_descriptor, const std::string &suffix_override,
+                                   keybinding_hint_state state = keybinding_hint_state::ENABLED,
+                                   const input_event_filter &evt_filter = allow_all_keys ) const;
 
         /**
          * Handles input and returns the next action in the queue.
@@ -819,6 +814,11 @@ class input_context
          */
         std::string get_action_name( const std::string &action_id ) const;
 
+        /**
+         * Get the human-readable short name for an action.
+         */
+        std::string get_action_short_name( const std::string &action_id ) const;
+
         /* For the future, something like this might be nice:
          * const std::string register_action(const std::string& action_descriptor, x, y, width, height);
          * (x, y, width, height) would describe an area on the visible window that, if clicked, triggers the action.
@@ -872,10 +872,74 @@ class input_context
         input_event first_unassigned_hotkey( const hotkey_queue &queue ) const;
         input_event next_unassigned_hotkey( const hotkey_queue &queue, const input_event &prev ) const;
     private:
+        /**
+         * @return A color-tagged and formatted string (based on the player's options)
+         *  displaying the hotkey, and optionally a "hint" describing the action
+         *  eg. E(x)amine or [x] Examine
+         */
+        std::string _get_hint( const std::string &action_descriptor, bool show_suffix, bool show_separators,
+                               keybinding_hint_state state,
+                               const input_event_filter &evt_filter, const std::string &suffix_override = std::string() ) const;
+        /**
+         * Get a description text for the key/other input method associated
+         * with the given action. If there are multiple bound keys, no more
+         * than max_limit will be described in the result. In addition, only
+         * keys satisfying evt_filter will be described.
+         *
+         * @param action_descriptor The action descriptor for which to return
+         *                          a description of the bound keys.
+         *
+         * @param max_limit No more than max_limit bound keys will be
+         *                  described in the returned description. A value of
+         *                  0 indicates no limit.
+         *
+         * @param evt_filter Only keys satisfying this function will be
+         *                   described.
+         */
+        std::string get_desc( const std::string &action_descriptor,
+                              unsigned int max_limit = 0,
+                              const input_event_filter &evt_filter = allow_all_keys ) const;
+
+        /**
+         * Get a description based on `text`. If a bound key for `action_descriptor`
+         * satisfying `evt_filter` is contained in `text`, surround the key with
+         * brackets and change the case if necessary (e.g. "(Y)es"). Otherwise
+         * prefix `text` with description of the first bound key satisfying
+         * `evt_filter`, surrounded in square brackets (e.g "[RETURN] Yes").
+         *
+         * @param action_descriptor The action descriptor for which to return
+         *                          a description of the bound keys.
+         *
+         * @param text The base text for action description
+         *
+         * @param evt_filter Only keys satisfying this function will be considered
+         * @param inline_fmt Action description format when a key is found in the
+         *                   text (for example "(a)ctive")
+         * @param separate_fmt Action description format when a key is not found
+         *                     in the text (for example "[X] active" or "[N/A] active")
+         */
+        std::string get_desc( const std::string &action_descriptor,
+                              const std::string &text,
+                              const keybinding_hint_state state,
+                              const bool show_separators,
+                              const input_event_filter &evt_filter = allow_all_keys ) const;
+
 
         std::vector<std::string> registered_actions;
         std::string edittext;
     public:
+        /*
+         * Given a key string, text string and a keybinding_hint_state,
+         *   returns a color-tagged string with with the key properly
+         *   inlined into the text if it's present, otherwise fallback
+         *   to presenting the text on its own.
+         *
+         *   eg. get_hint_basic("x", "Examine", keybinding_hint_state::NONE)
+         *          -> "E(<color_yellow>x</color>)amine"
+         */
+        static std::string get_hint_basic( const std::string &key,
+                                           const std::string &text,
+                                           const keybinding_hint_state state = keybinding_hint_state::ENABLED );
         const std::string &input_to_action( const input_event &inp ) const;
         bool is_event_type_enabled( input_event_t type ) const;
         bool is_registered_action( const std::string &action_name ) const;

--- a/src/input.h
+++ b/src/input.h
@@ -709,12 +709,12 @@ class input_context
         static bool disallow_lower_case_or_non_modified_letters( const input_event &evt );
         static bool allow_all_keys( const input_event &evt );
 
-        static std::string colorize_separate_format( const keybinding_hint_state state,
+        static std::string colorize_separate_format( keybinding_hint_state state,
                 const std::string &key, const std::string &text,
-                const bool show_separators, const bool key_not_found = false );
-        static std::string colorize_inline_format( const keybinding_hint_state state,
+                bool show_separators, bool key_not_found = false );
+        static std::string colorize_inline_format( keybinding_hint_state state,
                 const std::string &key, const std::string &left_text,
-                const std::string &right_text, const bool show_separators );
+                const std::string &right_text, bool show_separators );
         static const nc_color get_hint_color( keybinding_hint_state state =
                 keybinding_hint_state::ENABLED );
         static const nc_color get_hint_color_for_separator( keybinding_hint_state state =
@@ -919,8 +919,8 @@ class input_context
          */
         std::string get_desc( const std::string &action_descriptor,
                               const std::string &text,
-                              const keybinding_hint_state state,
-                              const bool show_separators,
+                              keybinding_hint_state state,
+                              bool show_separators,
                               const input_event_filter &evt_filter = allow_all_keys ) const;
 
 
@@ -938,10 +938,10 @@ class input_context
          */
         static std::string get_hint_basic( const std::string &key,
                                            const std::string &text,
-                                           const keybinding_hint_state state = keybinding_hint_state::ENABLED
+                                           keybinding_hint_state state = keybinding_hint_state::ENABLED
                                          );
         static std::string get_hint_basic( const std::string &key,
-                                           const keybinding_hint_state state = keybinding_hint_state::ENABLED );
+                                           keybinding_hint_state state = keybinding_hint_state::ENABLED );
         const std::string &input_to_action( const input_event &inp ) const;
         bool is_event_type_enabled( input_event_t type ) const;
         bool is_registered_action( const std::string &action_name ) const;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3746,17 +3746,14 @@ pickup_selector::pickup_selector( Character &p, const inventory_selector_preset 
 #endif
 
     set_hint( string_format(
-                  _( "%s %s \n%s %s \n%s %s/%s/%s quantity (or type number then %s)" ),
+                  _( "%s %s \n%s %s \n%s %s (or type number then %s)" ),
                   ctxt.get_hint( "WIELD" ),
                   ctxt.get_hint( "WEAR" ),
                   ctxt.get_hint( "SHOW_HIDE_CONTENTS" ),
                   ctxt.get_hint( "SHOW_HIDE_CONTENTS_ALL" ),
                   ctxt.get_hint( "EXAMINE" ),
-                  // todo(strat) replace get_hint_pair and get_hint_quad with a function that takes a list (get_hints)
-                  ctxt.get_hint_key_only( "MARK_WITH_COUNT" ),
-                  ctxt.get_hint_key_only( "INCREASE_COUNT" ),
-                  ctxt.get_hint_key_only( "DECREASE_COUNT" ),
-                  ctxt.get_hint_key_only( "TOGGLE_ENTRY" )));
+                  ctxt.get_hints( {"MARK_WITH_COUNT", "INCREASE_COUNT", "DECREASE_COUNT"}, _( "quantity" ) ),
+                  ctxt.get_hint_key_only( "TOGGLE_ENTRY" ) ) );
 }
 
 void pickup_selector::apply_selection( std::vector<drop_location> selection )

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2638,7 +2638,8 @@ void inventory_selector::draw_footer( const catacurses::window &w ) const
     } else {
         int filter_offset = 0;
         if( has_available_choices() || !filter.empty() ) {
-            std::string text = ctxt.get_hint( "INVENTORY_FILTER" );
+            std::string text = string_format( "%s%s", ctxt.get_hint( "INVENTORY_FILTER" ),
+                                              filter.empty() ? "" : ": " );
             filter_offset = utf8_width( text + filter ) + 6;
 
             mvwprintz( w, point( 2, getmaxy( w ) - border ), c_light_gray, "< " );
@@ -2648,8 +2649,8 @@ void inventory_selector::draw_footer( const catacurses::window &w ) const
         }
 
         right_print( w, getmaxy( w ) - border, border + 1, c_light_gray,
-                     string_format( "< %s %s >", ctxt.get_hint_key_only( "VIEW_CATEGORY_MODE" ),
-                                    io::enum_to_string( _uimode ) ) );
+                     string_format( "< %s >", ctxt.get_hint( "VIEW_CATEGORY_MODE",
+                                    io::enum_to_string( _uimode ) ) ) );
         const auto footer = get_footer( mode );
         if( !footer.first.empty() ) {
             const int string_width = utf8_width( footer.first );

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -370,8 +370,7 @@ void game::item_action_menu( item_location loc )
         num++;
     }
 
-    kmenu.footer_text = string_format( _( "[<color_yellow>%s</color>] keybindings" ),
-                                       ctxt.get_desc( "HELP_KEYBINDINGS" ) );
+    kmenu.footer_text = ctxt.get_hint( "HELP_KEYBINDINGS" );
 
     kmenu.query();
     if( kmenu.ret < 0 || kmenu.ret >= static_cast<int>( iactions.size() ) ) {

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2468,8 +2468,8 @@ void pocket_management_menu( const std::string &title, const std::vector<item *>
     static const std::string input_category = "INVENTORY";
     input_context ctxt( input_category );
     const std::string uilist_text = string_format(
-                                        _( "Modify pocket settings and move items between pockets.  %s Context menu" ),
-                                        ctxt.get_hint_key_only( "FAV_CONTEXT_MENU" ) );
+                                        _( "Modify pocket settings and move items between pockets.  %s" ),
+                                        ctxt.get_hint( "FAV_CONTEXT_MENU" ) );
     uilist pocket_selector;
     pocket_favorite_callback cb( uilist_text, to_organize, pocket_selector );
     pocket_selector.title = title;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2468,8 +2468,8 @@ void pocket_management_menu( const std::string &title, const std::vector<item *>
     static const std::string input_category = "INVENTORY";
     input_context ctxt( input_category );
     const std::string uilist_text = string_format(
-                                        _( "Modify pocket settings and move items between pockets.  [<color_yellow>%s</color>] Context menu" ),
-                                        ctxt.get_desc( "FAV_CONTEXT_MENU", 1 ) );
+                                        _( "Modify pocket settings and move items between pockets.  %s Context menu" ),
+                                        ctxt.get_hint_key_only( "FAV_CONTEXT_MENU" ) );
     uilist pocket_selector;
     pocket_favorite_callback cb( uilist_text, to_organize, pocket_selector );
     pocket_selector.title = title;

--- a/src/iuse_software_kitten.cpp
+++ b/src/iuse_software_kitten.cpp
@@ -157,18 +157,20 @@ void robot_finds_kitten::show() const
                                        _( "Your job is to find kitten.  This task is complicated by the existence of various things "
                                           "which are not kitten.  Robot must touch items to determine if they are kitten or not.  "
                                           "The game ends when robot finds kitten.  Alternatively, you may end the game by hitting %s." ),
-                                       ctxt.get_desc( "QUIT" ) );
+                                       ctxt.get_hint_key_only( "QUIT" ) );
             fold_and_print( w, point( 1, pos ), getmaxx( w ) - 4, c_light_gray,
                             _( "Press any key to start." ) );
             break;
         }
         case ui_state::main:
-            mvwprintz( w, point_zero, c_white, _( "robotfindskitten v22July2008 - press %s to quit." ),
-                       ctxt.get_desc( "QUIT" ) );
+            print_colored_text( w, point_zero,
+                                string_format( _( "robotfindskitten v22July2008 - press %s to quit." ),
+                                               ctxt.get_hint_key_only( "QUIT" ) ) );
             break;
         case ui_state::invalid_input:
-            mvwprintz( w, point_zero, c_white, _( "Invalid command: Use direction keys or press %s to quit." ),
-                       ctxt.get_desc( "QUIT" ) );
+            print_colored_text( w, point_zero,
+                                string_format( _( "Invalid command: Use direction keys or press %s to quit." ),
+                                               ctxt.get_hint_key_only( "QUIT" ) ) );
             break;
         case ui_state::bogus_message: {
             std::vector<std::string> bogusvstr = foldstring( this_bogus_message, rfkCOLS );

--- a/src/iuse_software_kitten.cpp
+++ b/src/iuse_software_kitten.cpp
@@ -169,8 +169,8 @@ void robot_finds_kitten::show() const
             break;
         case ui_state::invalid_input:
             print_colored_text( w, point_zero,
-                                string_format( _( "Invalid command: Use direction keys or press %s to quit." ),
-                                               ctxt.get_hint_key_only( "QUIT" ) ) );
+                                string_format( _( "Invalid command: Use %s or press %s to quit." ),
+                                               ctxt.get_hint_directions(), ctxt.get_hint_key_only( "QUIT" ) ) );
             break;
         case ui_state::bogus_message: {
             std::vector<std::string> bogusvstr = foldstring( this_bogus_message, rfkCOLS );

--- a/src/iuse_software_lightson.cpp
+++ b/src/iuse_software_lightson.cpp
@@ -154,7 +154,7 @@ int lightson_game::start_game()
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         std::vector<std::string> shortcuts;
-        shortcuts.emplace_back( ctxt.get_hint_pair( "TOGGLE_SPACE", "TOGGLE_5", _( "toggle lights" ) ) );
+        shortcuts.emplace_back( ctxt.get_hints( { "TOGGLE_SPACE", "TOGGLE_5"}, _( "toggle lights" ) ) );
         shortcuts.emplace_back( ctxt.get_hint( "RESET" ) );
         shortcuts.emplace_back( ctxt.get_hint( "QUIT" ) );
 

--- a/src/iuse_software_lightson.cpp
+++ b/src/iuse_software_lightson.cpp
@@ -154,24 +154,24 @@ int lightson_game::start_game()
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         std::vector<std::string> shortcuts;
-        shortcuts.emplace_back( _( "<spacebar or 5> toggle lights" ) );
-        shortcuts.emplace_back( _( "<r>eset" ) );
-        shortcuts.emplace_back( _( "<q>uit" ) );
+        shortcuts.emplace_back( ctxt.get_hint_pair( "TOGGLE_SPACE", "TOGGLE_5", _( "toggle lights" ) ) );
+        shortcuts.emplace_back( ctxt.get_hint( "RESET" ) );
+        shortcuts.emplace_back( ctxt.get_hint( "QUIT" ) );
 
         int iWidth = 0;
         for( auto &shortcut : shortcuts ) {
             if( iWidth > 0 ) {
                 iWidth += 1;
             }
-            iWidth += utf8_width( shortcut );
+            iWidth += utf8_width( shortcut, true );
         }
 
         werase( w_border );
         draw_border( w_border );
         int iPos = FULL_SCREEN_WIDTH - iWidth - 1;
         for( auto &shortcut : shortcuts ) {
-            shortcut_print( w_border, point( iPos, 0 ), c_white, c_light_green, shortcut );
-            iPos += utf8_width( shortcut ) + 1;
+            print_colored_text( w_border, point( iPos, 0 ),  shortcut );
+            iPos += utf8_width( shortcut, true ) + 1;
         }
 
         mvwputch( w_border, point( 2, 0 ), hilite( c_white ), _( "Lights on!" ) );

--- a/src/iuse_software_minesweeper.cpp
+++ b/src/iuse_software_minesweeper.cpp
@@ -182,22 +182,22 @@ int minesweeper_game::start_game()
         draw_border( w_minesweeper_border );
 
         std::vector<std::string> shortcuts;
-        shortcuts.emplace_back( _( "<n>ew level" ) );
-        shortcuts.emplace_back( _( "<f>lag" ) );
-        shortcuts.emplace_back( _( "<q>uit" ) );
+        shortcuts.emplace_back( ctxt.get_hint( "NEW" ) );
+        shortcuts.emplace_back( ctxt.get_hint( "FLAG" ) );
+        shortcuts.emplace_back( ctxt.get_hint( "QUIT" ) );
 
         int iWidth = 0;
         for( auto &shortcut : shortcuts ) {
             if( iWidth > 0 ) {
                 iWidth += 1;
             }
-            iWidth += utf8_width( shortcut );
+            iWidth += utf8_width( shortcut, true );
         }
 
         int iPos = FULL_SCREEN_WIDTH - iWidth - 1;
         for( auto &shortcut : shortcuts ) {
-            shortcut_print( w_minesweeper_border, point( iPos, 0 ), c_white, c_light_green, shortcut );
-            iPos += utf8_width( shortcut ) + 1;
+            print_colored_text( w_minesweeper_border, point( iPos, 0 ),  shortcut );
+            iPos += utf8_width( shortcut, true ) + 1;
         }
 
         mvwputch( w_minesweeper_border, point( 2, 0 ), hilite( c_white ), _( "Minesweeper" ) );

--- a/src/iuse_software_snake.cpp
+++ b/src/iuse_software_snake.cpp
@@ -81,7 +81,7 @@ void snake_game::snake_over( const catacurses::window &w_snake, int iScore,
     }
 
     center_print( w_snake, 17, c_yellow, string_format( _( "TOTAL SCORE: %d" ), iScore ) );
-    center_print( w_snake, 21, c_white, ctxt.get_hint( "QUIT", _( "to quit" ) ) );
+    center_print( w_snake, 21, c_white, ctxt.get_hint( "QUIT" ) );
     wnoutrefresh( w_snake );
 }
 

--- a/src/iuse_software_snake.cpp
+++ b/src/iuse_software_snake.cpp
@@ -26,20 +26,22 @@ void snake_game::print_score( const catacurses::window &w_snake, int iScore )
     mvwprintz( w_snake, point( 5, 0 ), c_white, string_format( _( "Score: %d" ), iScore ) );
 }
 
-void snake_game::print_header( const catacurses::window &w_snake, bool show_shortcut )
+void snake_game::print_header( const catacurses::window &w_snake, const input_context &ctxt,
+                               bool show_shortcut )
 {
     draw_border( w_snake, BORDER_COLOR, _( "S N A K E" ), c_white );
     if( show_shortcut ) {
-        std::string shortcut = _( "<q>uit" );
-        shortcut_print( w_snake, point( FULL_SCREEN_WIDTH - utf8_width( shortcut ) - 2, 0 ),
-                        c_white, c_light_green, shortcut );
+        std::string shortcut = ctxt.get_hint( "QUIT" );
+        print_colored_text( w_snake, point( FULL_SCREEN_WIDTH - utf8_width( shortcut, true ) - 2, 0 ),
+                            shortcut );
     }
 }
 
-void snake_game::snake_over( const catacurses::window &w_snake, int iScore )
+void snake_game::snake_over( const catacurses::window &w_snake, int iScore,
+                             const input_context &ctxt )
 {
     werase( w_snake );
-    print_header( w_snake, false );
+    print_header( w_snake, ctxt, false );
 
     // Body of dead snake
     size_t body_length = 3;
@@ -79,8 +81,7 @@ void snake_game::snake_over( const catacurses::window &w_snake, int iScore )
     }
 
     center_print( w_snake, 17, c_yellow, string_format( _( "TOTAL SCORE: %d" ), iScore ) );
-    // TODO: print actual bound keys
-    center_print( w_snake, 21, c_white, _( "Press 'q' or ESC to exit." ) );
+    center_print( w_snake, 21, c_white, ctxt.get_hint( "QUIT", _( "to quit" ) ) );
     wnoutrefresh( w_snake );
 }
 
@@ -129,7 +130,7 @@ int snake_game::start_game()
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         werase( w_snake );
-        print_header( w_snake );
+        print_header( w_snake, ctxt );
         for( auto it = vSnakeBody.begin(); it != vSnakeBody.end(); ++it ) {
             const nc_color col = it + 1 == vSnakeBody.end() ? c_white : c_light_gray;
             mvwputch( w_snake, point( it->second, it->first ), col, '#' );
@@ -235,7 +236,7 @@ int snake_game::start_game()
     } while( true );
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
-        snake_over( w_snake, iScore );
+        snake_over( w_snake, iScore, ctxt );
     } );
     do {
         ui_manager::redraw();

--- a/src/iuse_software_snake.h
+++ b/src/iuse_software_snake.h
@@ -3,7 +3,7 @@
 #define CATA_SRC_IUSE_SOFTWARE_SNAKE_H
 
 
-#include "input.h"
+class input_context;
 
 namespace catacurses
 {

--- a/src/iuse_software_snake.h
+++ b/src/iuse_software_snake.h
@@ -2,6 +2,9 @@
 #ifndef CATA_SRC_IUSE_SOFTWARE_SNAKE_H
 #define CATA_SRC_IUSE_SOFTWARE_SNAKE_H
 
+
+#include "input.h"
+
 namespace catacurses
 {
 class window;
@@ -12,8 +15,9 @@ class snake_game
     public:
         snake_game();
         void print_score( const catacurses::window &w_snake, int iScore );
-        void print_header( const catacurses::window &w_snake, bool show_shortcut = true );
-        void snake_over( const catacurses::window &w_snake, int iScore );
+        void print_header( const catacurses::window &w_snake, const input_context &ctxt,
+                           bool show_shortcut = true );
+        void snake_over( const catacurses::window &w_snake, int iScore, const input_context &ctxt );
         int start_game();
 };
 

--- a/src/iuse_software_sokoban.cpp
+++ b/src/iuse_software_sokoban.cpp
@@ -249,21 +249,20 @@ int sokoban_game::start_game()
         draw_border( w_sokoban, BORDER_COLOR, _( "Sokoban" ), hilite( c_white ) );
 
         std::vector<std::string> shortcuts;
-        shortcuts.emplace_back( _( "<+> next" ) ); // '+': next
-        shortcuts.emplace_back( _( "<-> prev" ) ); // '-': prev
-        shortcuts.emplace_back( _( "<r>eset" ) ); // 'r': reset
-        shortcuts.emplace_back( _( "<q>uit" ) ); // 'q': quit
-        shortcuts.emplace_back( _( "<u>ndo move" ) ); // 'u': undo move
+        shortcuts.emplace_back( ctxt.get_hint( "NEXT" ) );
+        shortcuts.emplace_back( ctxt.get_hint( "PREV" ) );
+        shortcuts.emplace_back( ctxt.get_hint( "RESET" ) );
+        shortcuts.emplace_back( ctxt.get_hint( "QUIT" ) );
+        shortcuts.emplace_back( ctxt.get_hint( "UNDO" ) );
 
         int indent = 10;
         for( auto &shortcut : shortcuts ) {
-            indent = std::max( indent, utf8_width( shortcut ) + 1 );
+            indent = std::max( indent, utf8_width( shortcut, true ) + 1 );
         }
         indent = std::min( indent, 30 );
 
         for( size_t i = 0; i < shortcuts.size(); i++ ) {
-            shortcut_print( w_sokoban, point( FULL_SCREEN_WIDTH - indent, i + 1 ),
-                            c_white, c_light_green, shortcuts[i] );
+            print_colored_text( w_sokoban, point( FULL_SCREEN_WIDTH - indent, i + 1 ),  shortcuts[i] );
         }
 
         print_score( w_sokoban, iScore, iMoves );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2052,19 +2052,22 @@ class spellcasting_callback : public uilist_callback
         }
 
         void refresh( uilist *menu ) override {
+            input_context ctxt = menu->create_main_input_context();
             mvwputch( menu->window, point( menu->w_width - menu->pad_right, 0 ), c_magenta, LINE_OXXX );
             mvwputch( menu->window, point( menu->w_width - menu->pad_right, menu->w_height - 1 ), c_magenta,
                       LINE_XXOX );
             for( int i = 1; i < menu->w_height - 1; i++ ) {
                 mvwputch( menu->window, point( menu->w_width - menu->pad_right, i ), c_magenta, LINE_XOXO );
             }
-            std::string ignore_string = casting_ignore ? _( "Ignore Distractions" ) :
-                                        _( "Popup Distractions" );
-            mvwprintz( menu->window, point( menu->w_width - menu->pad_right + 2, 0 ),
-                       casting_ignore ? c_red : c_light_green, string_format( "%s %s", "[I]", ignore_string ) );
-            const std::string assign_letter = _( "Assign Hotkey [=]" );
-            mvwprintz( menu->window, point( menu->w_width - assign_letter.length() - 1, 0 ), c_yellow,
-                       assign_letter );
+            std::string ignore_string = casting_ignore ? _( "Ignore Distractions" ) : _( "Popup Distractions" );
+            ignore_string = string_format( "%s ", ignore_string );
+
+            print_colored_text( menu->window, point( menu->w_width - menu->pad_right + 2, 0 ),
+                                ctxt.get_hint( "CAST_IGNORE", ignore_string,
+                                               casting_ignore ? keybinding_hint_state::TOGGLED_OFF : keybinding_hint_state::TOGGLED_ON ) );
+            const std::string assign_letter = ctxt.get_hint( "CHOOSE_INVLET", _( "Assign Hotkey" ) );
+            print_colored_text( menu->window, point( menu->w_width - assign_letter.length() - 1, 0 ),
+                                assign_letter );
             if( menu->selected >= 0 && static_cast<size_t>( menu->selected ) < known_spells.size() ) {
                 if( info_txt.empty() || selected_sp != menu->selected ) {
                     info_txt.clear();

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2060,13 +2060,12 @@ class spellcasting_callback : public uilist_callback
                 mvwputch( menu->window, point( menu->w_width - menu->pad_right, i ), c_magenta, LINE_XOXO );
             }
             std::string ignore_string = casting_ignore ? _( "Ignore Distractions" ) : _( "Popup Distractions" );
-            ignore_string = string_format( "%s ", ignore_string );
 
             print_colored_text( menu->window, point( menu->w_width - menu->pad_right + 2, 0 ),
                                 ctxt.get_hint( "CAST_IGNORE", ignore_string,
                                                casting_ignore ? keybinding_hint_state::TOGGLED_OFF : keybinding_hint_state::TOGGLED_ON ) );
             const std::string assign_letter = ctxt.get_hint( "CHOOSE_INVLET", _( "Assign Hotkey" ) );
-            print_colored_text( menu->window, point( menu->w_width - assign_letter.length() - 1, 0 ),
+            print_colored_text( menu->window, point( menu->w_width - assign_letter.length() + 1, 0 ),
                                 assign_letter );
             if( menu->selected >= 0 && static_cast<size_t>( menu->selected ) < known_spells.size() ) {
                 if( info_txt.empty() || selected_sp != menu->selected ) {

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -138,6 +138,7 @@ std::vector<int> main_menu::print_menu_items( const catacurses::window &w_in,
             y_off++;
             continue;
         }
+        // todo(strat) this code adds clickable button to each printed menu item, this code is broken now
         std::vector<std::string> tmp_chars = utf8_display_split( remove_color_tags( txt ) );
         for( int x = 0; static_cast<size_t>( x ) < tmp_chars.size(); x++ ) {
             if( tmp_chars[x] == "[" ) {

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -350,7 +350,7 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
 
     int menu_length = 0;
     for( size_t i = 0; i < vMenuItems.size(); ++i ) {
-        menu_length += utf8_width_notags( vMenuItems[i].c_str() ) + 2;
+        menu_length += utf8_width_notags( vMenuItems[i].c_str() ) + 3;
         if( !vMenuHotkeys[i].empty() ) {
             menu_length += utf8_width( vMenuHotkeys[i][0] );
         }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -119,8 +119,8 @@ std::vector<int> main_menu::print_menu_items( const catacurses::window &w_in,
         }
         ret.push_back( utf8_width_notags( text.c_str() ) );
 
-        std::string temp = shortcut_text( iSel == i ? hilite( c_yellow ) : c_yellow, vItems[i] );
-        text += string_format( "[%s]", colorize( temp, iSel == i ? hilite( c_white ) : c_white ) );
+        text += shortcut_text( vItems[i], iSel == i ?
+                               keybinding_hint_state::HIGHLIGHTED : keybinding_hint_state::ENABLED );
     }
 
     int text_width = utf8_width_notags( text.c_str() );
@@ -174,9 +174,10 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
         case main_menu_opts::SPECIAL:
             for( int i = 1; i < static_cast<int>( special_game_type::NUM_SPECIAL_GAME_TYPES ); i++ ) {
                 std::string spec_name = special_game_name( static_cast<special_game_type>( i ) );
-                nc_color clr = i == sel2 ? hilite( c_yellow ) : c_yellow;
-                sub_opts.push_back( shortcut_text( clr, spec_name ) );
-                int len = utf8_width( shortcut_text( clr, spec_name ), true );
+                std::string menu_option = shortcut_text( spec_name,
+                                          i == sel2 ? keybinding_hint_state::HIGHLIGHTED : keybinding_hint_state::ENABLED );
+                sub_opts.push_back( menu_option );
+                int len = utf8_width( menu_option, true );
                 if( len > xlen ) {
                     xlen = len;
                 }
@@ -184,9 +185,10 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
             break;
         case main_menu_opts::SETTINGS:
             for( int i = 0; static_cast<size_t>( i ) < vSettingsSubItems.size(); ++i ) {
-                nc_color clr = i == sel2 ? hilite( c_yellow ) : c_yellow;
-                sub_opts.push_back( shortcut_text( clr, vSettingsSubItems[i] ) );
-                int len = utf8_width( shortcut_text( clr, vSettingsSubItems[i] ), true );
+                std::string menu_option = shortcut_text( vSettingsSubItems[i],
+                                          i == sel2 ? keybinding_hint_state::HIGHLIGHTED : keybinding_hint_state::ENABLED );
+                sub_opts.push_back( menu_option );
+                int len = utf8_width( menu_option, true );
                 if( len > xlen ) {
                     xlen = len;
                 }
@@ -194,9 +196,10 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
             break;
         case main_menu_opts::NEWCHAR:
             for( int i = 0; static_cast<size_t>( i ) < vNewGameSubItems.size(); i++ ) {
-                nc_color clr = i == sel2 ? hilite( c_yellow ) : c_yellow;
-                sub_opts.push_back( shortcut_text( clr, vNewGameSubItems[i] ) );
-                int len = utf8_width( shortcut_text( clr, vNewGameSubItems[i] ), true );
+                std::string menu_option = shortcut_text( vNewGameSubItems[i],
+                                          i == sel2 ? keybinding_hint_state::HIGHLIGHTED : keybinding_hint_state::ENABLED );
+                sub_opts.push_back( menu_option );
+                int len = utf8_width( menu_option, true );
                 if( len > xlen ) {
                     xlen = len;
                 }
@@ -270,8 +273,7 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
         std::string opt = ( is_selection ? "» " : "  " ) + sub_opts[opt_index];
         int padding = ( xlen + 2 ) - utf8_width( opt, true );
         opt.append( padding, ' ' );
-        nc_color clr = is_selection ? hilite( c_white ) : c_white;
-        trim_and_print( w_sub, point( 1, y + 1 ), xlen + 2, clr, opt );
+        trim_and_print( w_sub, point( 1, y + 1 ), xlen + 2, opt );
         inclusive_rectangle<point> rec( top_left + point( 1, y  + 1 ),
                                         top_left + point( xlen + 2, y + 1 ) );
         main_menu_sub_button_map.emplace_back( rec, std::pair<int, int> { sel, y } );
@@ -1081,7 +1083,7 @@ void main_menu::world_tab( const std::string &worldname )
     std::array<char, 5> hotkeys = { 'd', 'r', 'm', 's', 't' };
     for( const std::string &it : vWorldSubItems ) {
         mmenu.entries.emplace_back( opt_val, true, hotkeys[opt_val],
-                                    remove_color_tags( shortcut_text( c_white, it ) ) );
+                                    remove_color_tags( shortcut_text( it ) ) );
         ++opt_val;
     }
     mmenu.entries.emplace_back( opt_val, true, 'q', _( "<- Back to Main Menu" ), c_yellow, c_yellow );

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -350,14 +350,13 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
 
     int menu_length = 0;
     for( size_t i = 0; i < vMenuItems.size(); ++i ) {
-        menu_length += utf8_width_notags( vMenuItems[i].c_str() ) + 3;
-        if( !vMenuHotkeys[i].empty() ) {
-            menu_length += utf8_width( vMenuHotkeys[i][0] );
-        }
+        const std::string shortcut = remove_color_tags( shortcut_text( vMenuItems[i] ) );
+        const int shortcut_width = utf8_width_notags( shortcut.c_str() ) + 1;
+        menu_length += shortcut_width;
     }
     const int free_space = std::max( 0, window_width - menu_length - offset.x );
-    const int spacing = free_space / ( static_cast<int>( vMenuItems.size() ) + 1 );
-    const int width_of_spacing = spacing * ( vMenuItems.size() + 1 );
+    const int spacing = free_space / static_cast<int>( vMenuItems.size() );
+    const int width_of_spacing = spacing * vMenuItems.size();
     const int adj_offset = std::max( 0, ( free_space - width_of_spacing ) / 2 );
     const int final_offset = offset.x + adj_offset + spacing;
 
@@ -490,7 +489,6 @@ void main_menu::init_strings()
         vNewGameHotkeys.push_back( get_hotkeys( item ) );
     }
 
-    // determine hotkeys from translated menu item text
     vMenuHotkeys.clear();
     for( const std::string &item : vMenuItems ) {
         vMenuHotkeys.push_back( get_hotkeys( item ) );

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -352,12 +352,12 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
     int menu_length = 0;
     for( size_t i = 0; i < vMenuItems.size(); ++i ) {
         const std::string shortcut = remove_color_tags( shortcut_text( vMenuItems[i] ) );
-        const int shortcut_width = utf8_width_notags( shortcut.c_str() ) + 1;
+        const int shortcut_width = utf8_width_notags( shortcut.c_str() );
         menu_length += shortcut_width;
     }
     const int free_space = std::max( 0, window_width - menu_length - offset.x );
-    const int spacing = free_space / static_cast<int>( vMenuItems.size() );
-    const int width_of_spacing = spacing * vMenuItems.size();
+    const int spacing = std::max( 1, free_space / static_cast<int>( vMenuItems.size() + 1 ) );
+    const int width_of_spacing = spacing * ( vMenuItems.size() + 1 );
     const int adj_offset = std::max( 0, ( free_space - width_of_spacing ) / 2 );
     const int final_offset = offset.x + adj_offset + spacing;
 

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -496,16 +496,11 @@ void main_menu::init_strings()
     }
 
     vWorldSubItems.clear();
-    vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "<D|d>elete World" ) );
-    vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "<R|r>eset World" ) );
-    vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "Sh<o|O>w World Mods" ) );
-    vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "Copy World Sett<i|I>ngs" ) );
-    vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "Character to Tem<p|P>late" ) );
-
-    vWorldHotkeys.clear();
-    for( const std::string &item : vWorldSubItems ) {
-        vWorldHotkeys.push_back( get_hotkeys( item ) );
-    }
+    vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "Delete World" ) );
+    vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "Reset World" ) );
+    vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "Show World Mods" ) );
+    vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "Copy World Settings" ) );
+    vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "Character to Template" ) );
 
     vSettingsSubItems.clear();
     vSettingsSubItems.emplace_back( pgettext( "Main Menu|Settings", "<O|o>ptions" ) );
@@ -1081,8 +1076,7 @@ void main_menu::world_tab( const std::string &worldname )
     int opt_val = 0;
     std::array<char, 5> hotkeys = { 'd', 'r', 'm', 's', 't' };
     for( const std::string &it : vWorldSubItems ) {
-        mmenu.entries.emplace_back( opt_val, true, hotkeys[opt_val],
-                                    remove_color_tags( shortcut_text( it ) ) );
+        mmenu.entries.emplace_back( opt_val, true, hotkeys[opt_val], remove_color_tags( it ) );
         ++opt_val;
     }
     mmenu.entries.emplace_back( opt_val, true, 'q', _( "<- Back to Main Menu" ), c_yellow, c_yellow );

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -128,7 +128,7 @@ std::vector<int> main_menu::print_menu_items( const catacurses::window &w_in,
         offset.y -= std::ceil( text_width / getmaxx( w_in ) );
     }
 
-    std::vector<std::string> menu_txt = foldstring( text, getmaxx( w_in ), ']' );
+    std::vector<std::string> menu_txt = foldstring( text, getmaxx( w_in ) );
 
     int y_off = 0;
     int sel_opt = 0;

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -315,10 +315,9 @@ static void draw_medical_titlebar( const catacurses::window &window, avatar *pla
 
     // Hotkey Helper
     std::string desc;
-    desc = string_format( _(
-                              "%s Scroll info %s Use item %s Keybindings" ),
-                          ctxt.get_hint_pair( "SCROLL_INFOBOX_UP", "SCROLL_INFOBOX_DOWN" ),
-                          ctxt.get_hint_key_only( "APPLY" ), ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ) );
+    desc = string_format( "%s %s %s",
+                          ctxt.get_hint_pair( "SCROLL_INFOBOX_UP", "SCROLL_INFOBOX_DOWN", _( "Scroll info" ) ),
+                          ctxt.get_hint( "APPLY" ), ctxt.get_hint( "HELP_KEYBINDINGS" ) );
 
     const int details_width = utf8_width( remove_color_tags( desc ) ) + 3;
     const int max_width = right_indent + TAB_WIDTH;

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -316,7 +316,7 @@ static void draw_medical_titlebar( const catacurses::window &window, avatar *pla
     // Hotkey Helper
     std::string desc;
     desc = string_format( "%s %s %s",
-                          ctxt.get_hint_pair( "SCROLL_INFOBOX_UP", "SCROLL_INFOBOX_DOWN", _( "Scroll info" ) ),
+                          ctxt.get_hints( { "SCROLL_INFOBOX_UP", "SCROLL_INFOBOX_DOWN"}, _( "Scroll info" ) ),
                           ctxt.get_hint( "APPLY" ), ctxt.get_hint( "HELP_KEYBINDINGS" ) );
 
     const int details_width = utf8_width( remove_color_tags( desc ) ) + 3;

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -316,9 +316,9 @@ static void draw_medical_titlebar( const catacurses::window &window, avatar *pla
     // Hotkey Helper
     std::string desc;
     desc = string_format( _(
-                              "[<color_yellow>%s/%s</color>] Scroll info [<color_yellow>%s</color>] Use item [<color_yellow>%s</color>] Keybindings" ),
-                          ctxt.get_desc( "SCROLL_INFOBOX_UP" ), ctxt.get_desc( "SCROLL_INFOBOX_DOWN" ),
-                          ctxt.get_desc( "APPLY" ), ctxt.get_desc( "HELP_KEYBINDINGS" ) );
+                              "%s Scroll info %s Use item %s Keybindings" ),
+                          ctxt.get_hint_pair( "SCROLL_INFOBOX_UP", "SCROLL_INFOBOX_DOWN" ),
+                          ctxt.get_hint_key_only( "APPLY" ), ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ) );
 
     const int details_width = utf8_width( remove_color_tags( desc ) ) + 3;
     const int max_width = right_indent + TAB_WIDTH;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -653,9 +653,8 @@ void Messages::dialog::show()
         filter.query( false, true ); // Draw only
     } else {
         if( filter_str.empty() ) {
-            mvwprintz( w, point( border_width, w_height - 1 ), border_color,
-                       _( "< Press %s to filter, %s to reset >" ),
-                       ctxt.get_desc( "FILTER" ), ctxt.get_desc( "RESET_FILTER" ) );
+            print_colored_text( w, point( border_width, w_height - 1 ), string_format( _( "<%s %s>" ),
+                                ctxt.get_hint( "FILTER" ), ctxt.get_hint( "RESET_FILTER" ) ) );
         } else {
             mvwprintz( w, point( border_width, w_height - 1 ), border_color, "< %s >", filter_str );
             mvwprintz( w, point( border_width + 2, w_height - 1 ), filter_color, "%s", filter_str );

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -42,11 +42,6 @@ static void draw_exam_window( const catacurses::window &win, const int border_y 
     mvwputch( win, point( width - 1, border_y ), BORDER_COLOR, LINE_XOXX );
 }
 
-static const auto shortcut_desc = []( const std::string &comment, const std::string &keys )
-{
-    return string_format( comment, string_format( "[<color_yellow>%s</color>]", keys ) );
-};
-
 // needs extensive improvement
 
 static trait_id GetTrait( const std::vector<trait_id> &active,
@@ -66,32 +61,32 @@ static void show_mutations_titlebar( const catacurses::window &window,
                                      const mutation_menu_mode menu_mode, const input_context &ctxt )
 {
     werase( window );
-    std::string desc;
+    std::vector<std::string> hints;
     if( menu_mode == mutation_menu_mode::reassigning ) {
-        desc += std::string( _( "Reassigning." ) ) + "  " +
-                _( "Select a mutation to reassign or press [<color_yellow>SPACE</color>] to cancel. " );
+        hints.push_back( string_format(
+                             _( "Reassigning. Select a mutation to reassign or press %s to cancel." ),
+                             ctxt.get_hint_key_only( "CONFIRM" ) ) );
     }
     if( menu_mode == mutation_menu_mode::activating ) {
-        desc += colorize( _( "Activating" ),
-                          c_green ) + "  " + shortcut_desc( _( "%s Examine, " ),
-                                  ctxt.get_desc( "TOGGLE_EXAMINE" ) );
+        hints.push_back( colorize( _( "Activating" ), c_green ) );
+        hints.push_back( ctxt.get_hint( "TOGGLE_EXAMINE" ) );
     }
     if( menu_mode == mutation_menu_mode::examining ) {
-        desc += colorize( _( "Examining" ),
-                          c_light_blue ) + "  " + shortcut_desc( _( "%s Activate, " ),
-                                  ctxt.get_desc( "TOGGLE_EXAMINE" ) );
+        hints.push_back( colorize( _( "Examining" ), c_light_blue ) );
+        hints.push_back( ctxt.get_hint( "TOGGLE_EXAMINE", _( "Activate" ) ) );
     }
     if( menu_mode == mutation_menu_mode::hiding ) {
-        desc += colorize( _( "Hidding" ), c_cyan ) + "  " + shortcut_desc( _( "%s Activate, " ),
-                ctxt.get_desc( "TOGGLE_EXAMINE" ) );
+        hints.push_back( colorize( _( "Hiding" ), c_cyan ) );
+        hints.push_back( ctxt.get_hint( "TOGGLE_EXAMINE", _( "Activate" ) ) );
     }
     if( menu_mode != mutation_menu_mode::reassigning ) {
-        desc += shortcut_desc( _( "%s Reassign, " ), ctxt.get_desc( "REASSIGN" ) );
+        hints.push_back( ctxt.get_hint( "REASSIGN" ) );
     }
-    desc += shortcut_desc( _( "%s Toggle sprite visibility, " ), ctxt.get_desc( "TOGGLE_SPRITE" ) );
-    desc += shortcut_desc( _( "%s Change keybindings." ), ctxt.get_desc( "HELP_KEYBINDINGS" ) );
+    hints.push_back( ctxt.get_hint( "TOGGLE_SPRITE" ) );
+    hints.push_back( ctxt.get_hint( "HELP_KEYBINDINGS" ) );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
-    fold_and_print( window, point( 1, 0 ), getmaxx( window ) - 1, c_white, desc );
+    fold_and_print( window, point( 1, 0 ), getmaxx( window ) - 1, c_light_gray,
+                    enumerate_as_string( hints, enumeration_conjunction::space ) );
     wnoutrefresh( window );
 }
 

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -64,7 +64,7 @@ static void show_mutations_titlebar( const catacurses::window &window,
     std::vector<std::string> hints;
     if( menu_mode == mutation_menu_mode::reassigning ) {
         hints.push_back( string_format(
-                             _( "Reassigning. Select a mutation to reassign or press %s to cancel." ),
+                             _( "Reassigning.  Select a mutation to reassign or press %s to cancel." ),
                              ctxt.get_hint_key_only( "CONFIRM" ) ) );
     }
     if( menu_mode == mutation_menu_mode::activating ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1030,7 +1030,7 @@ void set_points( tab_manager &tabs, avatar &u, pool_type &pool )
                                "%s to confirm selection.\n"
                                "Press %s to go to the next tab or "
                                "%s to return to main menu." ),
-                            ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ), ctxt.get_hint_pair( "UP", "DOWN" ),
+                            ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ), ctxt.get_hints( { "UP", "DOWN" } ),
                             ctxt.get_hint_key_only( "CONFIRM" ), ctxt.get_hint_key_only( "NEXT_TAB" ),
                             ctxt.get_hint_key_only( "QUIT" ) );
         } else {
@@ -1091,9 +1091,9 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                            "Press %s to select stat.\n"
                            "Press %s to increase or decrease stat.\n"
                            "Press %s to go to the next tab or return to the previous tab." ),
-                        ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ), ctxt.get_hint_pair( "UP", "DOWN" ),
-                        ctxt.get_hint_pair( "RIGHT", "LEFT" ),
-                        ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB" ) );
+                        ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ), ctxt.get_hints( { "UP", "DOWN" } ),
+                        ctxt.get_hints( { "RIGHT", "LEFT" } ),
+                        ctxt.get_hints( { "NEXT_TAB", "PREV_TAB"} ) );
 
         // This is description line, meaning its length excludes first column and border
         const std::string clear_line( getmaxx( w ) - iSecondColumn - 1, ' ' );
@@ -2589,9 +2589,9 @@ void set_skills( tab_manager &tabs, avatar &u, pool_type pool )
                                              "Press %s to select skill.\n"
                                              "Press %s to increase or decrease skill.\n"
                                              "Press %s to go to the next tab or return to the previous tab." ),
-                                          ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ), ctxt.get_hint_pair( "UP", "DOWN" ),
-                                          ctxt.get_hint_pair( "RIGHT", "LEFT" ),
-                                          ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB" ) ), TERMX - 2 );
+                                          ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ), ctxt.get_hints( { "UP", "DOWN" } ),
+                                          ctxt.get_hints( { "RIGHT", "LEFT" } ),
+                                          ctxt.get_hints( { "NEXT_TAB", "PREV_TAB" } ) ), TERMX - 2 );
         iContentHeight = TERMY - static_cast<int>( keybinding_hint.size() ) - iHeaderHeight - 1;
         w = catacurses::newwin( TERMY, TERMX, point_zero );
         w_list = catacurses::newwin( iContentHeight, 35, point( 1, iHeaderHeight ) );
@@ -3611,11 +3611,11 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
 
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 4 ), TERMX, c_light_gray,
                             _( "Press %s to cycle through editable values." ),
-                            ctxt.get_hint_pair( "UP", "DOWN" ) );
+                            ctxt.get_hints( { "UP", "DOWN"} ) );
 
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 3 ), TERMX, c_light_gray,
                             _( "Press %s to change gender, height, age, and blood type." ),
-                            ctxt.get_hint_pair( "LEFT", "RIGHT" ) );
+                            ctxt.get_hints( { "LEFT", "RIGHT" } ) );
 
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 2 ), TERMX, c_light_gray,
                             _( "Press %s to edit value via popup input." ),
@@ -3623,7 +3623,7 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
 
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 1 ), TERMX, c_light_gray,
                             _( "Press %s to finish character creation or to return to the previous TAB." ),
-                            ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB" ) );
+                            ctxt.get_hints( { "NEXT_TAB", "PREV_TAB" } ) );
         } else {
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 1 ), TERMX, c_light_gray,
                             _( "Press %s to view and alter keybindings." ),

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -393,9 +393,9 @@ static matype_id choose_ma_style( const character_type type, const std::vector<m
                                   "\n"
                                   "STR: <color_white>%d</color>, DEX: <color_white>%d</color>, "
                                   "PER: <color_white>%d</color>, INT: <color_white>%d</color>\n"
-                                  "Press [<color_yellow>%s</color>] for more info.\n" ),
+                                  "Press %s for more info.\n" ),
                                u.get_str(), u.get_dex(), u.get_per(), u.get_int(),
-                               ctxt.get_desc( "SHOW_DESCRIPTION" ) );
+                               ctxt.get_hint_key_only( "SHOW_DESCRIPTION" ) );
     ma_style_callback callback( 0, styles );
     menu.callback = &callback;
     menu.input_category = "MELEE_STYLE_PICKER";
@@ -928,11 +928,11 @@ static void draw_filter_and_sorting_indicators( const catacurses::window &w,
         const input_context &ctxt, const std::string &filterstring, const Compare &sorter )
 {
     const char *const sort_order = sorter.sort_by_points ? _( "points" ) : _( "name" );
-    const std::string sorting_indicator = string_format( "[%1$s] %2$s: %3$s",
-                                          colorize( ctxt.get_desc( "SORT" ), c_green ), _( "sort" ),
+    const std::string sorting_indicator = string_format( "%s: %s",
+                                          ctxt.get_hint( "SORT" ),
                                           sort_order );
-    const std::string filter_indicator = filterstring.empty() ? string_format( _( "[%s] filter" ),
-                                         colorize( ctxt.get_desc( "FILTER" ), c_green ) ) : filterstring;
+    const std::string filter_indicator = filterstring.empty() ? ctxt.get_hint( "FILTER" ) :
+                                         filterstring;
     nc_color current_color = BORDER_COLOR;
     print_colored_text( w, point( 2, getmaxy( w ) - 1 ), current_color, BORDER_COLOR,
                         string_format( "<%1s>-<%2s>", sorting_indicator, filter_indicator ) );
@@ -1025,17 +1025,18 @@ void set_points( tab_manager &tabs, avatar &u, pool_type &pool )
         // Helptext points tab
         if( isWide ) {
             fold_and_print( w, point( 2, TERMY - 4 ), getmaxx( w ) - 4, COL_NOTE_MINOR,
-                            _( "Press <color_light_green>%s</color> to view and alter keybindings.\n"
-                               "Press <color_light_green>%s</color> or <color_light_green>%s</color> to select pool and "
-                               "<color_light_green>%s</color> to confirm selection.\n"
-                               "Press <color_light_green>%s</color> to go to the next tab or "
-                               "<color_light_green>%s</color> to return to main menu." ),
-                            ctxt.get_desc( "HELP_KEYBINDINGS" ), ctxt.get_desc( "UP" ), ctxt.get_desc( "DOWN" ),
-                            ctxt.get_desc( "CONFIRM" ), ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "QUIT" ) );
+                            _( "Press %s to view and alter keybindings.\n"
+                               "Press %s to select pool and "
+                               "%s to confirm selection.\n"
+                               "Press %s to go to the next tab or "
+                               "%s to return to main menu." ),
+                            ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ), ctxt.get_hint_pair( "UP", "DOWN" ),
+                            ctxt.get_hint_key_only( "CONFIRM" ), ctxt.get_hint_key_only( "NEXT_TAB" ),
+                            ctxt.get_hint_key_only( "QUIT" ) );
         } else {
             fold_and_print( w, point( 2, TERMY - 2 ), getmaxx( w ) - 4, COL_NOTE_MINOR,
-                            _( "Press <color_light_green>%s</color> to view and alter keybindings." ),
-                            ctxt.get_desc( "HELP_KEYBINDINGS" ) );
+                            _( "Press %s to view and alter keybindings." ),
+                            ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ) );
         }
         wnoutrefresh( w );
         wnoutrefresh( w_description );
@@ -1086,15 +1087,13 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
         tabs.draw( w );
         // Helptext stats tab
         fold_and_print( w, point( 2, TERMY - 5 ), getmaxx( w ) - 4, COL_NOTE_MINOR,
-                        _( "Press <color_light_green>%s</color> to view and alter keybindings.\n"
-                           "Press <color_light_green>%s</color> / <color_light_green>%s</color> to select stat.\n"
-                           "Press <color_light_green>%s</color> to increase stat or "
-                           "<color_light_green>%s</color> to decrease stat.\n"
-                           "Press <color_light_green>%s</color> to go to the next tab or "
-                           "<color_light_green>%s</color> to return to the previous tab." ),
-                        ctxt.get_desc( "HELP_KEYBINDINGS" ), ctxt.get_desc( "UP" ), ctxt.get_desc( "DOWN" ),
-                        ctxt.get_desc( "RIGHT" ), ctxt.get_desc( "LEFT" ),
-                        ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "PREV_TAB" ) );
+                        _( "Press %s to view and alter keybindings.\n"
+                           "Press %s to select stat.\n"
+                           "Press %s to increase or decrease stat.\n"
+                           "Press %s to go to the next tab or return to the previous tab." ),
+                        ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ), ctxt.get_hint_pair( "UP", "DOWN" ),
+                        ctxt.get_hint_pair( "RIGHT", "LEFT" ),
+                        ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB" ) );
 
         // This is description line, meaning its length excludes first column and border
         const std::string clear_line( getmaxx( w ) - iSecondColumn - 1, ' ' );
@@ -1756,7 +1755,7 @@ static std::string assemble_profession_details( const avatar &u, const input_con
 {
     std::string assembled;
 
-    assembled += string_format( g_switch_msg( u ), ctxt.get_desc( "CHANGE_GENDER" ),
+    assembled += string_format( g_switch_msg( u ), ctxt.get_hint_key_only( "CHANGE_GENDER" ),
                                 sorted_profs[cur_id]->gender_appropriate_name( !u.male ) ) + "\n";
 
     if( sorted_profs[cur_id]->get_requirement().has_value() ) {
@@ -2177,7 +2176,7 @@ static std::string assemble_hobby_details( const avatar &u, const input_context 
 {
     std::string assembled;
 
-    assembled += string_format( g_switch_msg( u ), ctxt.get_desc( "CHANGE_GENDER" ),
+    assembled += string_format( g_switch_msg( u ), ctxt.get_hint_key_only( "CHANGE_GENDER" ),
                                 sorted_hobbies[cur_id]->gender_appropriate_name( !u.male ) ) + "\n";
 
     assembled += "\n" + colorize( _( "Background story:" ), COL_HEADER ) + "\n";
@@ -2586,15 +2585,13 @@ void set_skills( tab_manager &tabs, avatar &u, pool_type pool )
 
     const auto init_windows = [&]( ui_adaptor & ui ) {
         keybinding_hint = foldstring( string_format(
-                                          _( "Press <color_light_green>%s</color> to view and alter keybindings.\n"
-                                             "Press <color_light_green>%s</color> / <color_light_green>%s</color> to select skill.\n"
-                                             "Press <color_light_green>%s</color> to increase skill or "
-                                             "<color_light_green>%s</color> to decrease skill.\n"
-                                             "Press <color_light_green>%s</color> to go to the next tab or "
-                                             "<color_light_green>%s</color> to return to the previous tab." ),
-                                          ctxt.get_desc( "HELP_KEYBINDINGS" ), ctxt.get_desc( "UP" ), ctxt.get_desc( "DOWN" ),
-                                          ctxt.get_desc( "RIGHT" ), ctxt.get_desc( "LEFT" ),
-                                          ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "PREV_TAB" ) ), TERMX - 2 );
+                                          _( "Press %s to view and alter keybindings.\n"
+                                             "Press %s to select skill.\n"
+                                             "Press %s to increase or decrease skill.\n"
+                                             "Press %s to go to the next tab or return to the previous tab." ),
+                                          ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ), ctxt.get_hint_pair( "UP", "DOWN" ),
+                                          ctxt.get_hint_pair( "RIGHT", "LEFT" ),
+                                          ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB" ) ), TERMX - 2 );
         iContentHeight = TERMY - static_cast<int>( keybinding_hint.size() ) - iHeaderHeight - 1;
         w = catacurses::newwin( TERMY, TERMX, point_zero );
         w_list = catacurses::newwin( iContentHeight, 35, point( 1, iHeaderHeight ) );
@@ -2870,7 +2867,7 @@ static std::string assemble_scenario_details( const avatar &u, const input_conte
         const scenario *current_scenario )
 {
     std::string assembled;
-    assembled += string_format( g_switch_msg( u ), ctxt.get_desc( "CHANGE_GENDER" ),
+    assembled += string_format( g_switch_msg( u ), ctxt.get_hint_key_only( "CHANGE_GENDER" ),
                                 current_scenario->gender_appropriate_name( !u.male ) ) + "\n";
 
     assembled += "\n" + colorize( _( "Scenario Story:" ), COL_HEADER ) + "\n";
@@ -3573,69 +3570,64 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
         // Helptext description window
         if( isWide ) {
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 9 ), TERMX, c_light_gray,
-                            _( "Press <color_light_green>%s</color> to view and alter keybindings." ),
-                            ctxt.get_desc( "HELP_KEYBINDINGS" ) );
+                            _( "Press %s to view and alter keybindings." ),
+                            ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ) );
 
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 8 ), TERMX, c_light_gray,
-                            _( "Press <color_light_green>%s</color> to save character template." ),
-                            ctxt.get_desc( "SAVE_TEMPLATE" ) );
+                            _( "Press %s to save character template." ),
+                            ctxt.get_hint_key_only( "SAVE_TEMPLATE" ) );
 
             if( !MAP_SHARING::isSharing() && allow_reroll ) { // no random names when sharing maps
                 fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 7 ), TERMX, c_light_gray,
-                                _( "Press <color_light_green>%s</color> to pick a random name, "
-                                   "<color_light_green>%s</color> to randomize all description values, "
-                                   "<color_light_green>%s</color> to randomize all but scenario, or "
-                                   "<color_light_green>%s</color> to randomize everything." ),
-                                ctxt.get_desc( "RANDOMIZE_CHAR_NAME" ),
-                                ctxt.get_desc( "RANDOMIZE_CHAR_DESCRIPTION" ),
-                                ctxt.get_desc( "REROLL_CHARACTER" ),
-                                ctxt.get_desc( "REROLL_CHARACTER_WITH_SCENARIO" ) );
+                                _( "Press %s to pick a random name, "
+                                   "%s to randomize all description values, "
+                                   "%s to randomize all but scenario, or "
+                                   "%s to randomize everything." ),
+                                ctxt.get_hint_key_only( "RANDOMIZE_CHAR_NAME" ),
+                                ctxt.get_hint_key_only( "RANDOMIZE_CHAR_DESCRIPTION" ),
+                                ctxt.get_hint_key_only( "REROLL_CHARACTER" ),
+                                ctxt.get_hint_key_only( "REROLL_CHARACTER_WITH_SCENARIO" ) );
             } else {
                 fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 7 ), TERMX, c_light_gray,
-                                _( "Press <color_light_green>%s</color> to pick a random name, "
-                                   "<color_light_green>%s</color> to randomize all description values." ),
-                                ctxt.get_desc( "RANDOMIZE_CHAR_NAME" ),
-                                ctxt.get_desc( "RANDOMIZE_CHAR_DESCRIPTION" ) );
+                                _( "Press %s to pick a random name, "
+                                   "%s to randomize all description values." ),
+                                ctxt.get_hint_key_only( "RANDOMIZE_CHAR_NAME" ),
+                                ctxt.get_hint_key_only( "RANDOMIZE_CHAR_DESCRIPTION" ) );
             }
 
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 6 ), TERMX, c_light_gray,
-                            _( "Press <color_light_green>%s</color> to switch gender." ),
-                            ctxt.get_desc( "CHANGE_GENDER" ) );
+                            _( "Press %s to switch gender." ),
+                            ctxt.get_hint_key_only( "CHANGE_GENDER" ) );
 
             if( !get_option<bool>( "SELECT_STARTING_CITY" ) ) {
                 fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 5 ), TERMX, c_light_gray,
-                                _( "Press <color_light_green>%s</color> to select a specific starting location." ),
-                                ctxt.get_desc( "CHOOSE_LOCATION" ) );
+                                _( "Press %s to select a specific starting location." ),
+                                ctxt.get_hint_key_only( "CHOOSE_LOCATION" ) );
             } else {
                 fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 5 ), TERMX, c_light_gray,
-                                _( "Press <color_light_green>%s</color> to select a specific starting city and <color_light_green>%s</color> to select a specific starting location." ),
-                                ctxt.get_desc( "CHOOSE_CITY" ), ctxt.get_desc( "CHOOSE_LOCATION" ) );
+                                _( "Press %s to select a specific starting city and %s to select a specific starting location." ),
+                                ctxt.get_hint_key_only( "CHOOSE_CITY" ), ctxt.get_hint_key_only( "CHOOSE_LOCATION" ) );
             }
 
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 4 ), TERMX, c_light_gray,
-                            _( "Press <color_light_green>%s</color> or <color_light_green>%s</color> "
-                               "to cycle through editable values." ),
-                            ctxt.get_desc( "UP" ),
-                            ctxt.get_desc( "DOWN" ) );
+                            _( "Press %s to cycle through editable values." ),
+                            ctxt.get_hint_pair( "UP", "DOWN" ) );
 
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 3 ), TERMX, c_light_gray,
-                            _( "Press <color_light_green>%s</color> and <color_light_green>%s</color> to change gender, height, age, and blood type." ),
-                            ctxt.get_desc( "LEFT" ),
-                            ctxt.get_desc( "RIGHT" ) );
+                            _( "Press %s to change gender, height, age, and blood type." ),
+                            ctxt.get_hint_pair( "LEFT", "RIGHT" ) );
 
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 2 ), TERMX, c_light_gray,
-                            _( "Press <color_light_green>%s</color> to edit value via popup input." ),
-                            ctxt.get_desc( "CONFIRM" ) );
+                            _( "Press %s to edit value via popup input." ),
+                            ctxt.get_hint_key_only( "CONFIRM" ) );
 
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 1 ), TERMX, c_light_gray,
-                            _( "Press <color_light_green>%s</color> to finish character creation "
-                               "or <color_light_green>%s</color> to return to the previous TAB." ),
-                            ctxt.get_desc( "NEXT_TAB" ),
-                            ctxt.get_desc( "PREV_TAB" ) );
+                            _( "Press %s to finish character creation or to return to the previous TAB." ),
+                            ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB" ) );
         } else {
             fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 1 ), TERMX, c_light_gray,
-                            _( "Press <color_light_green>%s</color> to view and alter keybindings." ),
-                            ctxt.get_desc( "HELP_KEYBINDINGS" ) );
+                            _( "Press %s to view and alter keybindings." ),
+                            ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ) );
 
         }
         wnoutrefresh( w_guide );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1818,7 +1818,7 @@ talk_data talk_response::create_option_line( const dialogue &d, const input_even
     }
     talk_data results;
     results.color = color;
-    results.hotkey_desc = right_justify( hotkey.short_description(), 2 );
+    results.hotkey_desc = hotkey.short_description();
     results.text = ftext;
     return results;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1700,10 +1700,6 @@ void options_manager::add_options_interface()
            );
 
 
-        add( "KEYBINDINGS_INLINE_UP_TO_X", page_id, to_translation( "Limit inlining of keybinding hints" ),
-             to_translation( "Inline keybindings in hints (like 'E(x)amine') if the length of the hint text is smaller than X characters. Disable this limit by setting this to 0." ),
-             0, 999, 20
-           );
         add( "KEYBINDINGS_INLINE_SEPARATOR_LEFT", page_id,
              to_translation( "Inline left separator character" ),
              to_translation( "Character to insert to the left of the inlined key." ),
@@ -1741,7 +1737,6 @@ void options_manager::add_options_interface()
            );
     } );
 
-    get_option( "KEYBINDINGS_INLINE_UP_TO_X" ).setPrerequisite( "KEYBINDINGS_INLINE" );
     get_option( "KEYBINDINGS_INLINE_SEPARATOR_LEFT" ).setPrerequisite( "KEYBINDINGS_INLINE" );
     get_option( "KEYBINDINGS_INLINE_SEPARATOR_RIGHT" ).setPrerequisite( "KEYBINDINGS_INLINE" );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1685,6 +1685,67 @@ void options_manager::add_options_interface()
     add( "USE_LANG", "interface", to_translation( "Language" ),
          to_translation( "Switch language." ), options_manager::get_lang_options(), "" );
 
+    add_option_group( "interface", Group( "keybinding_hints",
+                                          to_translation( "Keybinding hints settings" ),
+                                          to_translation( "Keybinding hints settings.  Customize how keybindings are displayed in the UI." ) ),
+    [&]( const std::string & page_id ) {
+        add( "KEYBINDINGS_ALTERNATE_COLOR_THEME", page_id,
+             to_translation( "Use an alternate keybindings color theme?" ),
+             to_translation( "Use an alternate keybindings color theme? Blue keys instead of yellow keys?" ),
+             false
+           );
+        add( "KEYBINDINGS_INLINE", page_id, to_translation( "Inline keybindings in hints" ),
+             to_translation( "Inline keybindings in hints (like 'E[x]amine') where possible." ),
+             true
+           );
+
+
+        add( "KEYBINDINGS_INLINE_UP_TO_X", page_id, to_translation( "Limit inlining of keybinding hints" ),
+             to_translation( "Inline keybindings in hints (like 'E(x)amine') if the length of the hint text is smaller than X characters. Disable this limit by setting this to 0." ),
+             0, 999, 20
+           );
+        add( "KEYBINDINGS_INLINE_SEPARATOR_LEFT", page_id,
+             to_translation( "Inline left separator character" ),
+             to_translation( "Character to insert to the left of the inlined key." ),
+             "(", 1
+           );
+        add( "KEYBINDINGS_INLINE_SEPARATOR_RIGHT", page_id,
+             to_translation( "Inline right separator character" ),
+             to_translation( "Character to insert to the right of the inlined key." ),
+             ")", 1
+           );
+        add( "KEYBINDINGS_SEPARATE_SEPARATOR_LEFT", page_id,
+             to_translation( "Separate left separator character" ),
+             to_translation( "Character to insert to the left of the separated key." ),
+             "[", 1
+           );
+        add( "KEYBINDINGS_SEPARATE_SEPARATOR_RIGHT", page_id,
+             to_translation( "Separate right separator character" ),
+             to_translation( "Character to insert to the right of the separated key." ),
+             "]", 1
+           );
+        add( "KEYBINDINGS_GROUP_SEPARATOR_LEFT", page_id,
+             to_translation( "Grouped left separator character" ),
+             to_translation( "Character to insert to the left of a group of keys." ),
+             "[", 1
+           );
+        add( "KEYBINDINGS_GROUP_SEPARATOR_RIGHT", page_id,
+             to_translation( "Grouped right separator character" ),
+             to_translation( "Character to insert to the right of a group of keys." ),
+             "]", 1
+           );
+        add( "KEYBINDINGS_GROUP_SEPARATOR_MIDDLE", page_id,
+             to_translation( "Grouped middle separator character" ),
+             to_translation( "Character to insert between each key in a group of keys." ),
+             "/", 1
+           );
+    } );
+
+    get_option( "KEYBINDINGS_INLINE_UP_TO_X" ).setPrerequisite( "KEYBINDINGS_INLINE" );
+    get_option( "KEYBINDINGS_INLINE_SEPARATOR_LEFT" ).setPrerequisite( "KEYBINDINGS_INLINE" );
+    get_option( "KEYBINDINGS_INLINE_SEPARATOR_RIGHT" ).setPrerequisite( "KEYBINDINGS_INLINE" );
+
+
     add_empty_line();
 
     add( "USE_CELSIUS", "interface", to_translation( "Temperature units" ),
@@ -3415,12 +3476,11 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
             mvwprintz( w_options_header, point( 7, 0 ), c_white, "" );
             for( int i = 0; i < static_cast<int>( pages_.size() ); i++ ) {
                 wprintz( w_options_header, c_white, "[" );
+                nc_color color = iCurrentPage == i ? hilite( c_white ) : c_white;
                 if( ingame && i == iWorldOptPage ) {
-                    wprintz( w_options_header, iCurrentPage == i ? hilite( c_light_green ) : c_light_green,
-                             _( "Current world" ) );
+                    wprintz( w_options_header, color, _( "Current world" ) );
                 } else {
-                    wprintz( w_options_header, iCurrentPage == i ? hilite( c_light_green ) : c_light_green,
-                             "%s", pages_[i].name_ );
+                    wprintz( w_options_header, color, "%s", pages_[i].name_ );
                 }
                 wprintz( w_options_header, c_white, "]" );
                 wputch( w_options_header, BORDER_COLOR, LINE_OXOX );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1691,7 +1691,7 @@ void options_manager::add_options_interface()
     [&]( const std::string & page_id ) {
         add( "KEYBINDINGS_ALTERNATE_COLOR_THEME", page_id,
              to_translation( "Use an alternate keybindings color theme?" ),
-             to_translation( "Use an alternate keybindings color theme? Blue keys instead of yellow keys?" ),
+             to_translation( "Use an alternate keybindings color theme?  Blue keys instead of yellow keys?" ),
              false
            );
         add( "KEYBINDINGS_INLINE", page_id, to_translation( "Inline keybindings in hints" ),

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2608,20 +2608,18 @@ void print_global_and_character_mode_headers( const catacurses::window &w, const
 
 //generate colorcoded shortcut text
 std::string shortcut_text( const std::string &fmt, keybinding_hint_state state,
-                           const bool shortcut_only )
+                           const bool remove_shortcut_from_text )
 {
     size_t pos = fmt.find_first_of( '<' );
     size_t pos_end = fmt.find_first_of( '>' );
     if( pos_end != std::string::npos && pos < pos_end ) {
         size_t sep = std::min( fmt.find_first_of( '|', pos ), pos_end );
         std::string shortcut = fmt.substr( pos + 1, sep - pos - 1 );
-        if( shortcut_only ) {
-            return shortcut;
-        }
         std::string prestring = fmt.substr( 0, pos );
         std::string poststring = fmt.substr( pos_end + 1, std::string::npos );
 
-        std::string hint_text = string_format( "%s%s%s", prestring, shortcut,
+        std::string hint_text = string_format( "%s%s%s", prestring,
+                                               remove_shortcut_from_text ? "" : shortcut,
                                                poststring );
         return input_context::get_hint_basic( shortcut, hint_text, state );
     }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2529,16 +2529,15 @@ void replace_keybind_tag( std::string &input )
         std::string keybind_desc;
         std::vector<input_event> keys = ctxt.keys_bound_to( keybind, -1, false, false );
         if( keys.empty() ) { // Display description for unbound keys
-            keybind_desc = string_format( "<%s>", colorize( pgettext( "keybinding", "None applicable" ),
-                                          c_red ) );
+            keybind_desc = colorize( input_context::get_hint_basic( pgettext( "keybinding", "None applicable" ),
+                                     keybinding_hint_state::NONE_AT_ALL ), c_red );
 
             if( !ctxt.is_registered_action( keybind ) ) {
                 debugmsg( "Invalid/Missing <keybind>: '%s'", keybind_full );
             }
         } else {
             keybind_desc = enumerate_as_string( keys.begin(), keys.end(), []( const input_event & k ) {
-                return string_format( "[%s]", colorize( k.long_description(),
-                                                        input_context::get_hint_color_for_key() ) );
+                return input_context::get_hint_basic( k.long_description() );
             }, enumeration_conjunction::or_ );
         }
         std::string to_replace = string_format( "%s%s%s", keybind_tag_start, keybind_full,

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2607,19 +2607,24 @@ void print_global_and_character_mode_headers( const catacurses::window &w, const
 }
 
 //generate colorcoded shortcut text
-std::string shortcut_text( const std::string &fmt, keybinding_hint_state state,
-                           const bool remove_shortcut_from_text )
+std::string shortcut_text( const std::string &fmt, keybinding_hint_state state )
 {
     size_t pos = fmt.find_first_of( '<' );
     size_t pos_end = fmt.find_first_of( '>' );
     if( pos_end != std::string::npos && pos < pos_end ) {
+        // If the hotkey definition is present at the start of the string
+        //   (like "<W|w> Test") and has a space after it, this means that
+        //   we should remove the hotkey from the string and handle any
+        //   inlining (or not) in the code dynamically in a way that works
+        //   and respects the options set by the player.
+        const bool remove_hotkey_from_text  = pos == 0 and fmt[pos_end + 1] == ' ';
         size_t sep = std::min( fmt.find_first_of( '|', pos ), pos_end );
         std::string shortcut = fmt.substr( pos + 1, sep - pos - 1 );
         std::string prestring = fmt.substr( 0, pos );
-        std::string poststring = fmt.substr( pos_end + 1, std::string::npos );
+        std::string poststring = trim( fmt.substr( pos_end + 1, std::string::npos ) );
 
         std::string hint_text = string_format( "%s%s%s", prestring,
-                                               remove_shortcut_from_text ? "" : shortcut,
+                                               remove_hotkey_from_text  ? "" : shortcut,
                                                poststring );
         return input_context::get_hint_basic( shortcut, hint_text, state );
     }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2607,18 +2607,23 @@ void print_global_and_character_mode_headers( const catacurses::window &w, const
 }
 
 //generate colorcoded shortcut text
-std::string shortcut_text( const std::string &fmt, keybinding_hint_state state )
+std::string shortcut_text( const std::string &fmt, keybinding_hint_state state,
+                           const bool shortcut_only )
 {
     size_t pos = fmt.find_first_of( '<' );
     size_t pos_end = fmt.find_first_of( '>' );
     if( pos_end != std::string::npos && pos < pos_end ) {
         size_t sep = std::min( fmt.find_first_of( '|', pos ), pos_end );
+        std::string shortcut = fmt.substr( pos + 1, sep - pos - 1 );
+        if( shortcut_only ) {
+            return shortcut;
+        }
         std::string prestring = fmt.substr( 0, pos );
         std::string poststring = fmt.substr( pos_end + 1, std::string::npos );
-        std::string shortcut = fmt.substr( pos + 1, sep - pos - 1 );
 
-        return input_context::get_hint_basic( shortcut, string_format( "%s%s%s", prestring, shortcut,
-                                              poststring ), state );
+        std::string hint_text = string_format( "%s%s%s", prestring, shortcut,
+                                               poststring );
+        return input_context::get_hint_basic( shortcut, hint_text, state );
     }
 
     // no shortcut?

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -241,14 +241,16 @@ color_tag_parse_result::tag_type update_color_stack(
 void print_colored_text( const catacurses::window &w, const point &p, const std::string &text,
                          report_color_error color_error )
 {
-    print_colored_text( w, p, c_white, c_white, text, color_error );
+    nc_color c = c_white;
+    print_colored_text( w, p, c, c, text, color_error );
 }
 void print_colored_text( const catacurses::window &w, const std::string &text,
                          const report_color_error color_error )
 {
-    print_colored_text( w, c_white, c_white, text, color_error );
+    nc_color c = c_white;
+    print_colored_text( w, c, c, text, color_error );
 }
-void print_colored_text( const catacurses::window &w, const point &p, const nc_color &color,
+void print_colored_text( const catacurses::window &w, const point &p, nc_color &color,
                          const nc_color &base_color, const std::string &text,
                          const report_color_error color_error )
 {
@@ -257,14 +259,13 @@ void print_colored_text( const catacurses::window &w, const point &p, const nc_c
     }
     print_colored_text( w, color, base_color, text, color_error );
 }
-void print_colored_text( const catacurses::window &w, const nc_color &color,
+void print_colored_text( const catacurses::window &w, nc_color &color,
                          const nc_color &base_color, const std::string &text,
                          const report_color_error color_error )
 {
     const auto color_segments = split_by_color( text );
     std::stack<nc_color> color_stack;
-    nc_color c = color;
-    color_stack.push( c );
+    color_stack.push( color );
 
     for( auto seg : color_segments ) {
         if( seg.empty() ) {
@@ -279,8 +280,8 @@ void print_colored_text( const catacurses::window &w, const nc_color &color,
             }
         }
 
-        c = color_stack.empty() ? base_color : color_stack.top();
-        wprintz( w, c, seg );
+        color = color_stack.empty() ? base_color : color_stack.top();
+        wprintz( w, color, seg );
     }
 }
 

--- a/src/output.h
+++ b/src/output.h
@@ -611,7 +611,7 @@ void print_global_and_character_mode_headers( const catacurses::window &w, const
         bool globalSelected, bool show_character = true );
 std::string shortcut_text( const std::string &fmt,
                            keybinding_hint_state state = keybinding_hint_state::ENABLED,
-                           bool shortcut_only = false );
+                           bool remove_shortcut_from_text = false );
 
 /**
  * @return Pair of a string containing the bar, and its color

--- a/src/output.h
+++ b/src/output.h
@@ -97,7 +97,6 @@ std::string string_from_int( catacurses::chtype ch );
 
 // Some consistent colors
 #define BORDER_COLOR c_light_gray
-#define ACTIVE_HOTKEY_COLOR c_yellow
 
 // Display data
 extern int TERMX; // width available for display
@@ -208,8 +207,15 @@ std::vector<std::string> foldstring( const std::string &str, int width, char spl
  * change to a color according to the color tags that are in the text.
  * @param base_color Base color that is used outside of any color tag.
  **/
-void print_colored_text( const catacurses::window &w, const point &p, nc_color &cur_color,
+void print_colored_text( const catacurses::window &w, const point &p, const nc_color &cur_color,
                          const nc_color &base_color, const std::string &text,
+                         report_color_error color_error = report_color_error::yes );
+void print_colored_text( const catacurses::window &w, const nc_color &cur_color,
+                         const nc_color &base_color, const std::string &text,
+                         report_color_error color_error = report_color_error::yes );
+void print_colored_text( const catacurses::window &w, const std::string &text,
+                         report_color_error color_error = report_color_error::yes );
+void print_colored_text( const catacurses::window &w, const point &p, const std::string &text,
                          report_color_error color_error = report_color_error::yes );
 /**
  * Print word wrapped text (with @ref color_tags) into the window.
@@ -297,6 +303,9 @@ inline int fold_and_print_from( const catacurses::window &w, const point &begin,
 void trim_and_print( const catacurses::window &w, const point &begin, int width,
                      const nc_color &base_color, const std::string &text,
                      report_color_error color_error = report_color_error::yes );
+void trim_and_print( const catacurses::window &w, const point &begin, int width,
+                     const std::string &text,
+                     report_color_error color_error = report_color_error::yes );
 std::string trim_by_length( const std::string &text, int width );
 template<typename ...Args>
 inline void trim_and_print( const catacurses::window &w, const point &begin,
@@ -320,6 +329,7 @@ void center_print( const catacurses::window &w, int y, const nc_color &FG,
                    const std::string &text );
 int right_print( const catacurses::window &w, int line, int right_indent,
                  const nc_color &FG, const std::string &text );
+int right_print( const catacurses::window &w, int line, int right_indent, const std::string &text );
 void insert_table( const catacurses::window &w, int pad, int line, int columns,
                    const nc_color &FG, const std::string &divider, bool r_align,
                    const std::vector<std::string> &data );
@@ -597,11 +607,10 @@ std::string string_replace( std::string text, const std::string &before, const s
 std::string replace_colors( std::string text );
 std::string uppercase_first_letter( const std::string &str );
 std::string lowercase_first_letter( const std::string &str );
-size_t shortcut_print( const catacurses::window &w, const point &p, nc_color text_color,
-                       nc_color shortcut_color, const std::string &fmt );
-size_t shortcut_print( const catacurses::window &w, nc_color text_color, nc_color shortcut_color,
-                       const std::string &fmt );
-std::string shortcut_text( nc_color shortcut_color, const std::string &fmt );
+void print_global_and_character_mode_headers( const catacurses::window &w, const point &p,
+        bool globalSelected, bool show_character = true );
+std::string shortcut_text( const std::string &fmt,
+                           const keybinding_hint_state state = keybinding_hint_state::ENABLED );
 
 /**
  * @return Pair of a string containing the bar, and its color
@@ -626,7 +635,9 @@ enum class enumeration_conjunction : int {
     none,
     and_,
     or_,
-    arrow
+    arrow,
+    space,
+    newline
 };
 
 /**
@@ -648,6 +659,10 @@ std::string enumerate_as_string( const Container &values,
                 return values.size() > 2 ? _( ", or " ) : _( " or " );
             case enumeration_conjunction::arrow:
                 return _( " > " );
+            case enumeration_conjunction::space:
+                return " ";
+            case enumeration_conjunction::newline:
+                return "\n";
         }
         debugmsg( "Unexpected conjunction" );
         return _( ", " );
@@ -657,6 +672,10 @@ std::string enumerate_as_string( const Container &values,
         switch( conj ) {
             case enumeration_conjunction::arrow:
                 return _( " > " );
+            case enumeration_conjunction::space:
+                return " ";
+            case enumeration_conjunction::newline:
+                return "\n";
             default:
                 return _( ", " );
         }
@@ -706,13 +725,7 @@ std::string enumerate_as_string( const Container &cont, F &&string_for,
     return enumerate_as_string( cont.begin(), cont.end(), std::forward<F>( string_for ), conj );
 }
 
-/**
- * @return A formatted string including the hotkey, color-tagged to stand out, and standardized
- * surrounding text to highlight that this is a hotkey to anyone using a screen reader
- * @param hotkey The hotkey to be formatted, without any color tags or other formatting
- * @param text_color The color of the surrounding text, so that only the hoteky stands out
- */
-std::string formatted_hotkey( const std::string &hotkey, nc_color text_color );
+
 
 /**
  * @return String containing the bar. Example: "Label [****--...    ]".

--- a/src/output.h
+++ b/src/output.h
@@ -610,8 +610,8 @@ std::string lowercase_first_letter( const std::string &str );
 void print_global_and_character_mode_headers( const catacurses::window &w, const point &p,
         bool globalSelected, bool show_character = true );
 std::string shortcut_text( const std::string &fmt,
-                           const keybinding_hint_state state = keybinding_hint_state::ENABLED,
-                           const bool shortcut_only = false );
+                           keybinding_hint_state state = keybinding_hint_state::ENABLED,
+                           bool shortcut_only = false );
 
 /**
  * @return Pair of a string containing the bar, and its color

--- a/src/output.h
+++ b/src/output.h
@@ -610,8 +610,7 @@ std::string lowercase_first_letter( const std::string &str );
 void print_global_and_character_mode_headers( const catacurses::window &w, const point &p,
         bool globalSelected, bool show_character = true );
 std::string shortcut_text( const std::string &fmt,
-                           keybinding_hint_state state = keybinding_hint_state::ENABLED,
-                           bool remove_shortcut_from_text = false );
+                           keybinding_hint_state state = keybinding_hint_state::ENABLED );
 
 /**
  * @return Pair of a string containing the bar, and its color

--- a/src/output.h
+++ b/src/output.h
@@ -207,10 +207,10 @@ std::vector<std::string> foldstring( const std::string &str, int width, char spl
  * change to a color according to the color tags that are in the text.
  * @param base_color Base color that is used outside of any color tag.
  **/
-void print_colored_text( const catacurses::window &w, const point &p, const nc_color &cur_color,
+void print_colored_text( const catacurses::window &w, const point &p, nc_color &cur_color,
                          const nc_color &base_color, const std::string &text,
                          report_color_error color_error = report_color_error::yes );
-void print_colored_text( const catacurses::window &w, const nc_color &cur_color,
+void print_colored_text( const catacurses::window &w, nc_color &cur_color,
                          const nc_color &base_color, const std::string &text,
                          report_color_error color_error = report_color_error::yes );
 void print_colored_text( const catacurses::window &w, const std::string &text,

--- a/src/output.h
+++ b/src/output.h
@@ -610,7 +610,8 @@ std::string lowercase_first_letter( const std::string &str );
 void print_global_and_character_mode_headers( const catacurses::window &w, const point &p,
         bool globalSelected, bool show_character = true );
 std::string shortcut_text( const std::string &fmt,
-                           const keybinding_hint_state state = keybinding_hint_state::ENABLED );
+                           const keybinding_hint_state state = keybinding_hint_state::ENABLED,
+                           const bool shortcut_only = false );
 
 /**
  * @return Pair of a string containing the bar, and its color

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1158,8 +1158,7 @@ static void draw_om_sidebar(
         }
     }
 
-    mvwprintz( wbar, point( 1, 12 ), input_context::get_hint_color(),
-               _( "Use movement keys to pan." ) );
+    print_colored_text( wbar, point( 1, 12 ), inp_ctxt->get_hint_directions( _( "Pan view" ) ) );
     if( inp_ctxt != nullptr ) {
         print_colored_text( wbar, point( 1, 13 ), inp_ctxt->get_hint( "CHOOSE_DESTINATION",
                             _( "Preview route" ) ) );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1431,8 +1431,8 @@ static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripo
                    direction_name_short( direction_from( orig, tripoint_abs_omt( locations[i], orig.z() ) ) ) );
 
         if( locations.size() > 1 ) {
-            fold_and_print( w_search, point( 1, 6 ), search_width, c_white, ctxt.get_hint_pair( "NEXT_TAB",
-                            "PREV_TAB",  _( "Cycle through search results" ) ) );
+            fold_and_print( w_search, point( 1, 6 ), search_width, c_white, ctxt.get_hints( { "NEXT_TAB",
+                            "PREV_TAB"},  _( "Cycle through search results" ) ) );
         }
         fold_and_print( w_search, point( 1, 10 ), search_width, c_white, ctxt.get_hint( "CONFIRM" ) );
         fold_and_print( w_search, point( 1, 11 ), search_width, c_white, ctxt.get_hint( "QUIT" ) );

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -101,14 +101,6 @@ window_panel::window_panel(
 // panels prettify and helper functions
 // ====================================
 
-static std::string trunc_ellipse( const std::string &input, unsigned int trunc )
-{
-    if( utf8_width( input ) > static_cast<int>( trunc ) ) {
-        return utf8_truncate( input, trunc - 1 ) + "…";
-    }
-    return input;
-}
-
 static int get_wgt_height( const widget_id &wgt )
 {
     if( wgt->_widgets.empty() || wgt->_arrange == "columns" || wgt->_arrange == "minimum_columns" ) {
@@ -641,27 +633,20 @@ static void draw_center_win( catacurses::window &w, int col_width, const input_c
 {
     werase( w );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
-    mvwprintz( w, point( 1, 0 ), c_light_green, trunc_ellipse( ctxt.get_desc( "TOGGLE_PANEL" ),
-               col_width - 1 ) + ":" );
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    mvwprintz( w, point( 1, 1 ), c_white, _( "Toggle panels on/off" ) );
-    mvwprintz( w, point( 1, 2 ), c_light_green, trunc_ellipse( ctxt.get_desc( "MOVE_PANEL" ),
-               col_width - 1 ) + ":" );
-    mvwprintz( w, point( 1, 3 ), c_white, _( "Change display order" ) );
-    mvwprintz( w, point( 1, 4 ), c_light_green, trunc_ellipse( ctxt.get_desc( "QUIT" ),
-               col_width - 1 ) + ":" );
-    mvwprintz( w, point( 1, 5 ), c_white, _( "Exit" ) );
+    print_colored_text( w, point( 1, 0 ), ctxt.get_hint( "TOGGLE_PANEL" ) );
+    print_colored_text( w, point( 1, 1 ), ctxt.get_hint( "MOVE_PANEL" ) );
+    print_colored_text( w, point( 1, 2 ), ctxt.get_hint( "QUIT" ) );
 
     if( left_panel ) {
         const widget_id current_widget = panels[row_indices.at( current_row )].get_widget();
         for( const widget &wgt : widget::get_all() ) {
             if( wgt.getId() == current_widget ) {
-                fold_and_print( w, point( 1, 7 ), col_width - 2, c_white, _( wgt._description ) );
+                fold_and_print( w, point( 1, 3 ), col_width - 2, c_white, _( wgt._description ) );
                 break;
             }
         }
     } else {
-        fold_and_print( w, point( 1, 7 ), col_width - 2, c_white, _( sidebar._description ) );
+        fold_and_print( w, point( 1, 3 ), col_width - 2, c_white, _( sidebar._description ) );
     }
 
     wnoutrefresh( w );

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -316,8 +316,8 @@ static void draw_proficiencies_tab( ui_adaptor &ui, const catacurses::window &wi
     if( focused ) {
         ui.set_cursor( win, point_zero );
     }
-    center_print( win, 0, title_color, string_format( "[<color_yellow>%s</color>] %s",
-                  ctxt.get_desc( "VIEW_PROFICIENCIES" ), _( title_PROFICIENCIES ) ) );
+    center_print( win, 0, title_color, ctxt.get_hint( "VIEW_PROFICIENCIES",
+                  _( title_PROFICIENCIES ) ) );
 
     const int height = getmaxy( win ) - 1;
     const bool do_draw_scrollbar = height < static_cast<int>( profs.size() );
@@ -384,9 +384,7 @@ static void draw_stats_tab( ui_adaptor &ui, const catacurses::window &w_stats, c
     if( is_current_tab ) {
         ui.set_cursor( w_stats, point_zero );
     }
-    center_print( w_stats, 0, title_col,
-                  string_format( "[<color_yellow>%s</color>] %s",
-                                 ctxt.get_desc( "VIEW_BODYSTAT" ), _( title_STATS ) ) );
+    center_print( w_stats, 0, title_col, ctxt.get_hint( "VIEW_BODYSTAT", _( title_STATS ) ) );
 
     const auto highlight_line = [is_current_tab, line]( const unsigned line_to_draw ) {
         return is_current_tab && line == line_to_draw;
@@ -1063,21 +1061,15 @@ static void draw_tip( const catacurses::window &w_tip, const Character &you,
     }
 
 
+    std::vector<std::string>hints;
     if( customize_character ) {
-        right_print( w_tip, 0, 16, c_light_gray, string_format(
-                         _( "[<color_yellow>%s</color>] Customize " ),
-                         ctxt.get_desc( "SWITCH_GENDER" ) ) );
+        hints.push_back( ctxt.get_hint( "SWITCH_GENDER" ) );
     }
+    hints.push_back( ctxt.get_hint( "morale" ) );
+    hints.push_back( ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ) );
+    hints.push_back( string_format( "%s", LINE_XOXO_S ) );
 
-    right_print( w_tip, 0, 6, c_light_gray, string_format(
-                     _( "[<color_yellow>%s</color>] Morale" ),
-                     ctxt.get_desc( "morale" ) ) );
-
-    right_print( w_tip, 0, 1, c_light_gray, string_format(
-                     _( "[<color_yellow>%s</color>]" ),
-                     ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
-
-    right_print( w_tip, 0, 0, c_light_gray, string_format( "%s", LINE_XOXO_S ) );
+    right_print( w_tip, 0, 0, enumerate_as_string( hints, enumeration_conjunction::space ) );
 
     wnoutrefresh( w_tip );
 }

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -103,8 +103,13 @@ std::vector<std::vector<std::string>> query_popup::fold_query(
     int query_cnt = 0;
     int query_width = 0;
     for( const query_popup::query_option &opt : options ) {
-        const std::string &name = ctxt.get_action_name( opt.action );
-        const std::string &desc = ctxt.get_desc( opt.action, name, opt.filter );
+        // TODO: This function is only called once (on init) so we're not able
+        //   to properly color the key (colour tagging it prevents it from
+        //   being highlighted when selected)... This isn't a too much of
+        //   problem with the default settings because the key is separated
+        //   by parens but still...
+        const std::string &desc = ctxt.get_hint( opt.action, keybinding_hint_state::NONE_AT_ALL,
+                                  opt.filter );
         const int this_query_width = utf8_width( desc, true ) + horz_padding;
         ++query_cnt;
         query_width += this_query_width;

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -108,7 +108,7 @@ std::vector<std::vector<std::string>> query_popup::fold_query(
         //   being highlighted when selected)... This isn't a too much of
         //   problem with the default settings because the key is separated
         //   by parens but still...
-        const std::string &desc = ctxt.get_hint( opt.action, keybinding_hint_state::NONE_AT_ALL,
+        const std::string &desc = ctxt.get_hint( opt.action, keybinding_hint_state::ENABLED,
                                   opt.filter );
         const int this_query_width = utf8_width( desc, true ) + horz_padding;
         ++query_cnt;
@@ -242,10 +242,10 @@ void query_popup::show() const
     }
 
     for( size_t ind = 0; ind < buttons.size(); ++ind ) {
-        nc_color col = ind == cur ? hilite( c_white ) : c_white;
         const query_popup::button &btn = buttons[ind];
-        print_colored_text( win, btn.pos + point( border_width, border_width ),
-                            col, col, btn.text );
+        std::string text = ind != cur ? btn.text : input_context::replace_keybinding_hint_colors( btn.text,
+                           keybinding_hint_state::ENABLED, keybinding_hint_state::HIGHLIGHTED );
+        print_colored_text( win, btn.pos + point( border_width, border_width ), text );
     }
 
     wnoutrefresh( win );

--- a/src/proficiency_ui.cpp
+++ b/src/proficiency_ui.cpp
@@ -233,9 +233,9 @@ void prof_window::draw_header()
         fold_and_print( w_header, point( 1, 1 ), w - 2, c_light_gray,
                         cats[current_cat]->_description.translated() );
     }
-    std::string hint_txt = string_format( "[%s] %s   [%s] %s",
-                                          colorize( ctxt.get_desc( "FILTER", 1 ), c_yellow ), _( "filter" ),
-                                          colorize( ctxt.get_desc( "HELP_KEYBINDINGS", 1 ), c_yellow ), _( "help" ) );
+    std::string hint_txt = string_format( "%s %s",
+                                          ctxt.get_hint( "FILTER" ),
+                                          ctxt.get_hint( "HELP_KEYBINDINGS" ) );
     right_print( w_header, 0, 1, c_white, hint_txt );
     wnoutrefresh( w_header );
 }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1778,8 +1778,9 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
         for( const aim_type_prediction &out : sorted ) {
             std::string col_hl = out.is_default ? "light_green" : "light_gray";
             std::string desc =
-                string_format( "<color_white>[</color><color_yellow>%s</color><color_white>]</color> <color_%s>%s %s</color> | %s: <color_light_blue>%3d</color>",
-                               out.hotkey, col_hl, out.name, _( "Aim" ), _( "Moves to fire" ), out.moves );
+                string_format( "%s <color_%s>%s %s</color> | %s: <color_light_blue>%3d</color>",
+                               input_context::get_hint_basic( out.hotkey ), col_hl, out.name, _( "Aim" ), _( "Moves to fire" ),
+                               out.moves );
 
             print_colored_text( w, point( 1, line_number++ ), col, col, desc );
 
@@ -3494,10 +3495,9 @@ void target_ui::draw_help_notice()
 {
     int text_y = getmaxy( w_target ) - 1;
     int width = getmaxx( w_target );
-    const std::string label_help = string_format(
-                                       narrow ? _( "%s show help" ) : _( "%s show all controls" ),
-                                       ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ) );
-    int label_width = std::min( utf8_width( label_help ), width - 6 ); // 6 for borders and "< " + " >"
+    const std::string label_help = ctxt.get_hint( "HELP_KEYBINDINGS" );
+    int label_width = std::min( utf8_width( label_help, true ),
+                                width - 6 ); // 6 for borders and "< " + " >"
     int text_x = width - label_width - 6;
     mvwprintz( w_target, point( text_x + 1, text_y ), c_white, "< " );
     trim_and_print( w_target, point( text_x + 3, text_y ), label_width, c_white, label_help );
@@ -3521,12 +3521,12 @@ void target_ui::draw_controls_list( int text_y )
     // Compile full list
     std::string movement_text = shifting_view ? _( "Shift view" ) : _( "Move cursor" );
     movement_text = colorize( movement_text, input_context::get_hint_color( move_hint_state ) );
-    lines.push_back( {8, string_format( "%s %s", ctxt.get_hint_directions( move_hint_state ), movement_text )} );
+    lines.push_back( {9, string_format( "%s %s", ctxt.get_hint_directions( move_hint_state ), movement_text )} );
     if( is_mouse_enabled() ) {
         std::string move = string_format( _( "%s %s" ), ctxt.get_hint_mouse( "SELECT", _( "Target" ),
                                           move_hint_state ), ctxt.get_hint_mouse( "SCROLL_UP", _( "Cycle" ), move_hint_state ) );
         std::string fire = ctxt.get_hint_mouse( "FIRE", fire_hint_state );
-        lines.push_back( {7, string_format( "%s %s", move, fire )} );
+        lines.push_back( {8, string_format( "%s %s", move, fire )} );
     }
     {
         lines.push_back( {0, string_format( "%s %s", ctxt.get_hint( "NEXT_TARGET", _( "Cycle targets" ), move_hint_state ), ctxt.get_hint( "FIRE", uitext_fire(), fire_hint_state ) )} );
@@ -3544,9 +3544,6 @@ void target_ui::draw_controls_list( int text_y )
                 aim_and_fire.push_back( ctxt.get_hint( e.action, fire_hint_state ) );
             }
         }
-
-
-
         lines.push_back( {2, ctxt.get_hint( "AIM", _( "Steady your aim (10 moves)" ), fire_hint_state )} );
         lines.push_back( {2, ctxt.get_hint( "STOPAIM", _( "Stop aiming" ), fire_hint_state )} );
         lines.push_back( {4, _( "Aim and fire with:" )} );
@@ -3554,9 +3551,9 @@ void target_ui::draw_controls_list( int text_y )
     }
     if( mode == TargetMode::Fire || mode == TargetMode::TurretManual || ( mode == TargetMode::Reach &&
             relevant->is_gun() && you->get_aim_types( *relevant ).size() > 1 ) ) {
-        lines.push_back( {5, ctxt.get_hint( "SWITCH_MODE", _( "Switch firing modes" ) )} );
+        lines.push_back( {6, ctxt.get_hint( "SWITCH_MODE", _( "Switch firing modes" ) )} );
         if( mode == TargetMode::Fire || mode == TargetMode::TurretManual ) {
-            lines.push_back( { 6, ctxt.get_hint( "SWITCH_AMMO", _( "Reload/Switch ammo" ) ) } );
+            lines.push_back( { 7, ctxt.get_hint( "SWITCH_AMMO", _( "Reload/Switch ammo" ) ) } );
         }
     }
     if( mode == TargetMode::Turrets ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3519,15 +3519,14 @@ void target_ui::draw_controls_list( int text_y )
     std::vector<line> lines;
 
     // Compile full list
-    if( shifting_view ) {
-        lines.push_back( {8, colorize( _( "Shift view with directional keys" ), input_context::get_hint_color( move_hint_state ) )} );
-    } else {
-        lines.push_back( {8, colorize( _( "Move cursor with directional keys" ), input_context::get_hint_color( move_hint_state ) ) } );
-    }
+    std::string movement_text = shifting_view ? _( "Shift view" ) : _( "Move cursor" );
+    movement_text = colorize( movement_text, input_context::get_hint_color( move_hint_state ) );
+    lines.push_back( {8, string_format( "%s %s", ctxt.get_hint_directions( move_hint_state ), movement_text )} );
     if( is_mouse_enabled() ) {
-        std::string move = _( "Mouse: LMB: Target, Wheel: Cycle," );
-        std::string fire = _( "RMB: Fire" );
-        lines.push_back( {7, string_format( "%s %s", colorize( move, input_context::get_hint_color( move_hint_state ) ), colorize( fire, input_context::get_hint_color( fire_hint_state ) ) )} );
+        std::string move = string_format( _( "%s %s" ), ctxt.get_hint_mouse( "SELECT", _( "Target" ),
+                                          move_hint_state ), ctxt.get_hint_mouse( "SCROLL_UP", _( "Cycle" ), move_hint_state ) );
+        std::string fire = ctxt.get_hint_mouse( "FIRE", fire_hint_state );
+        lines.push_back( {7, string_format( "%s %s", move, fire )} );
     }
     {
         lines.push_back( {0, string_format( "%s %s", ctxt.get_hint( "NEXT_TARGET", _( "Cycle targets" ), move_hint_state ), ctxt.get_hint( "FIRE", uitext_fire(), fire_hint_state ) )} );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3521,7 +3521,7 @@ void target_ui::draw_controls_list( int text_y )
     // Compile full list
     std::string movement_text = shifting_view ? _( "Shift view" ) : _( "Move cursor" );
     movement_text = colorize( movement_text, input_context::get_hint_color( move_hint_state ) );
-    lines.push_back( {9, string_format( "%s %s", ctxt.get_hint_directions( move_hint_state ), movement_text )} );
+    lines.push_back( {9, ctxt.get_hint_directions( movement_text, move_hint_state )} );
     if( is_mouse_enabled() ) {
         std::string move = string_format( _( "%s %s" ), ctxt.get_hint_mouse( "SELECT", _( "Target" ),
                                           move_hint_state ), ctxt.get_hint_mouse( "SCROLL_UP", _( "Cycle" ), move_hint_state ) );

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -150,9 +150,9 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
         hints.push_back( ctxt.get_hint( "ENABLE_RULE" ) );
         hints.push_back( ctxt.get_hint( "DISABLE_RULE" ) );
         hints.push_back( ctxt.get_hint( "TEST_RULE" ) );
-        hints.push_back( ctxt.get_hint_pair( "MOVE_RULE_UP", "MOVE_RULE_DOWN", _( "Move up/down" ) ) );
+        hints.push_back( ctxt.get_hints( { "MOVE_RULE_UP", "MOVE_RULE_DOWN"}, _( "Move up/down" ) ) );
         hints.push_back( ctxt.get_hint( "CONFIRM", _( "Edit" ) ) );
-        hints.push_back( ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB", _( "Switch page" ) ) );
+        hints.push_back( ctxt.get_hints( { "NEXT_TAB", "PREV_TAB"}, _( "Switch page" ) ) );
 
         const int i_hints = fold_and_print( w_header, point( 0, 0 ), getmaxx( w_header ) - 1, c_light_gray,
                                             enumerate_as_string( hints, enumeration_conjunction::space ) );

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -137,13 +137,6 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
 
         wnoutrefresh( w_border );
 
-        static const std::vector<std::string> hotkeys = {{
-                translate_marker( "<A>dd" ), translate_marker( "<R>emove" ),
-                translate_marker( "<C>opy" ), translate_marker( "<M>ove" ),
-                translate_marker( "<E>nable" ), translate_marker( "<D>isable" ),
-                translate_marker( "<T>est" )
-            }
-        };
         std::vector<std::string> hints;
         hints.push_back( ctxt.get_hint( "SWITCH_SAFEMODE_OPTION",
                                         get_option<bool>( "SAFEMODE" ) ? keybinding_hint_state::TOGGLED_ON :

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -144,51 +144,49 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
                 translate_marker( "<T>est" )
             }
         };
-
-        int tmpx = 0;
-        for( const std::string &hotkey : hotkeys ) {
-            tmpx += shortcut_print( w_header, point( tmpx, 0 ), c_white, c_light_green, _( hotkey ) ) + 2;
+        std::vector<std::string> hints;
+        hints.push_back( ctxt.get_hint( "SWITCH_SAFEMODE_OPTION",
+                                        get_option<bool>( "SAFEMODE" ) ? keybinding_hint_state::TOGGLED_ON :
+                                        keybinding_hint_state::TOGGLED_OFF ) );
+        hints.push_back( ctxt.get_hint( "ADD_RULE" ) );
+        hints.push_back( ctxt.get_hint( "REMOVE_RULE" ) );
+        hints.push_back( ctxt.get_hint( "COPY_RULE" ) );
+        if( is_safemode_in ) {
+            hints.push_back( ctxt.get_hint( "SWAP_RULE_GLOBAL_CHAR" ) );
         }
+        hints.push_back( ctxt.get_hint( "ENABLE_RULE" ) );
+        hints.push_back( ctxt.get_hint( "DISABLE_RULE" ) );
+        hints.push_back( ctxt.get_hint( "TEST_RULE" ) );
+        hints.push_back( ctxt.get_hint_pair( "MOVE_RULE_UP", "MOVE_RULE_DOWN", _( "Move up/down" ) ) );
+        hints.push_back( ctxt.get_hint( "CONFIRM", _( "Edit" ) ) );
+        hints.push_back( ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB", _( "Switch page" ) ) );
 
-        tmpx = 0;
-        tmpx += shortcut_print( w_header, point( tmpx, 1 ), c_white, c_light_green,
-                                _( "<+-> Move up/down" ) ) + 2;
-        tmpx += shortcut_print( w_header, point( tmpx, 1 ), c_white, c_light_green,
-                                _( "<Enter>-Edit" ) ) + 2;
-        shortcut_print( w_header, point( tmpx, 1 ), c_white, c_light_green, _( "<Tab>-Switch Page" ) );
+        const int i_hints = fold_and_print( w_header, point( 0, 0 ), getmaxx( w_header ) - 1, c_light_gray,
+                                            enumerate_as_string( hints, enumeration_conjunction::space ) );
 
         for( int i = 0; i < 78; i++ ) {
-            mvwputch( w_header, point( i, 2 ), c_light_gray, LINE_OXOX ); // Draw line under header
+            mvwputch( w_header, point( i, i_hints ), c_light_gray, LINE_OXOX ); // Draw line under header
         }
 
         for( auto &pos : column_pos ) {
-            mvwputch( w_header, point( pos.second, 2 ), c_light_gray, LINE_OXXX );
-            mvwputch( w_header, point( pos.second, 3 ), c_light_gray, LINE_XOXO );
+            mvwputch( w_header, point( pos.second, i_hints ), c_light_gray, LINE_OXXX );
+            mvwputch( w_header, point( pos.second, i_hints + 1 ), c_light_gray, LINE_XOXO );
         }
 
-        mvwprintz( w_header, point( 1, 3 ), c_white, " #" );
-        mvwprintz( w_header, point( column_pos[COLUMN_RULE] + 4, 3 ), c_white, _( "Rules" ) );
-        mvwprintz( w_header, point( column_pos[COLUMN_ATTITUDE] + 2, 3 ), c_white, _( "Attitude" ) );
-        mvwprintz( w_header, point( column_pos[COLUMN_PROXIMITY] + 2, 3 ), c_white, _( "Dist" ) );
-        mvwprintz( w_header, point( column_pos[COLUMN_WHITE_BLACKLIST] + 2, 3 ), c_white, _( "B/W" ) );
-        mvwprintz( w_header, point( column_pos[COLUMN_CATEGORY] + 2, 3 ), c_white, pgettext( "category",
-                   "Cat" ) );
-        mvwprintz( w_header, point( column_pos[COLUMN_MOVEMENT_MODE] + 2, 3 ), c_white, _( "Mode" ) );
+        mvwprintz( w_header, point( 1, i_hints + 1 ), c_white, " #" );
+        mvwprintz( w_header, point( column_pos[COLUMN_RULE] + 4, i_hints + 1 ), c_white, _( "Rules" ) );
+        mvwprintz( w_header, point( column_pos[COLUMN_ATTITUDE] + 2, i_hints + 1 ), c_white,
+                   _( "Attitude" ) );
+        mvwprintz( w_header, point( column_pos[COLUMN_PROXIMITY] + 2, i_hints + 1 ), c_white, _( "Dist" ) );
+        mvwprintz( w_header, point( column_pos[COLUMN_WHITE_BLACKLIST] + 2, i_hints + 1 ), c_white,
+                   _( "B/W" ) );
+        mvwprintz( w_header, point( column_pos[COLUMN_CATEGORY] + 2, i_hints + 1 ), c_white,
+                   pgettext( "category",
+                             "Cat" ) );
+        mvwprintz( w_header, point( column_pos[COLUMN_MOVEMENT_MODE] + 2, i_hints + 1 ), c_white,
+                   _( "Mode" ) );
 
-        int locx = 17;
-        locx += shortcut_print( w_header, point( locx, 2 ), c_white,
-                                ( tab == GLOBAL_TAB ) ? hilite( c_white ) : c_white, _( "[<Global>]" ) ) + 1;
-        shortcut_print( w_header, point( locx, 2 ), c_white,
-                        ( tab == CHARACTER_TAB ) ? hilite( c_white ) : c_white, _( "[<Character>]" ) );
-
-        locx = 55;
-        mvwprintz( w_header, point( locx, 0 ), c_white, _( "Safe mode enabled:" ) );
-        locx += shortcut_print( w_header, point( locx, 1 ),
-                                ( get_option<bool>( "SAFEMODE" ) ? c_light_green : c_light_red ), c_white,
-                                ( get_option<bool>( "SAFEMODE" ) ? _( "True" ) : _( "False" ) ) );
-        locx += shortcut_print( w_header, point( locx, 1 ), c_white, c_light_green, "  " );
-        locx += shortcut_print( w_header, point( locx, 1 ), c_white, c_light_green, _( "<S>witch" ) );
-        shortcut_print( w_header, point( locx, 1 ), c_white, c_light_green, "  " );
+        print_global_and_character_mode_headers( w_header, point( 17, i_hints ), tab == GLOBAL_TAB );
 
         wnoutrefresh( w_header );
 

--- a/src/smart_controller_ui.cpp
+++ b/src/smart_controller_ui.cpp
@@ -115,10 +115,10 @@ void smart_controller_ui::refresh()
     // key descriptions
     std::string keys_text = string_format(
                                 _( "%s\n%s\n%s\n%s\n%s\n%s" ),
-                                ctxt.get_hint_pair( "UP", "DOWN", _( "Select option" ) ),
+                                ctxt.get_hints( { "UP", "DOWN"}, _( "Select option" ) ),
                                 ctxt.get_hint( "CONFIRM", _( "Change value" ) ),
-                                ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB", _( "Switch between sliders" ) ),
-                                ctxt.get_hint_pair( "LEFT", "RIGHT", _( "Move sliders" ) ),
+                                ctxt.get_hints( { "NEXT_TAB", "PREV_TAB"}, _( "Switch between sliders" ) ),
+                                ctxt.get_hints( { "LEFT", "RIGHT"}, _( "Move sliders" ) ),
                                 ctxt.get_hint( "QUIT", _( "Apply changes and quit" ) ),
                                 ctxt.get_hint( "HELP_KEYBINDINGS" ) );
 

--- a/src/smart_controller_ui.cpp
+++ b/src/smart_controller_ui.cpp
@@ -36,6 +36,7 @@ smart_controller_ui::smart_controller_ui( smart_controller_settings initial_sett
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "NEXT_TAB" );
+    ctxt.register_action( "PREV_TAB" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
 }
 
@@ -116,7 +117,7 @@ void smart_controller_ui::refresh()
                                 _( "%s\n%s\n%s\n%s\n%s\n%s" ),
                                 ctxt.get_hint_pair( "UP", "DOWN", _( "Select option" ) ),
                                 ctxt.get_hint( "CONFIRM", _( "Change value" ) ),
-                                ctxt.get_hint_pair( "NEXT_TAB", "CONFIRM", _( "Switch between sliders" ) ),
+                                ctxt.get_hint_pair( "NEXT_TAB", "PREV_TAB", _( "Switch between sliders" ) ),
                                 ctxt.get_hint_pair( "LEFT", "RIGHT", _( "Move sliders" ) ),
                                 ctxt.get_hint( "QUIT", _( "Apply changes and quit" ) ),
                                 ctxt.get_hint( "HELP_KEYBINDINGS" ) );
@@ -146,14 +147,10 @@ void smart_controller_ui::control()
         ui_manager::redraw();
         action = ctxt.handle_input();
 
-        if( action == "CONFIRM" || ( action == "NEXT_TAB" &&
-                                     selection == smart_controller_ui_selection::lo_and_hi_slider ) ) {
+        if( action == "CONFIRM" ) {
             switch( selection ) {
                 case smart_controller_ui_selection::enabled:
                     settings.enabled = !settings.enabled;
-                    break;
-                case smart_controller_ui_selection::lo_and_hi_slider:
-                    slider = 1 - slider;
                     break;
                 case smart_controller_ui_selection::manual:
                     const translation manual =
@@ -166,6 +163,9 @@ void smart_controller_ui::control()
 
                     break;
             }
+        } else if( selection == smart_controller_ui_selection::lo_and_hi_slider && ( action == "PREV_TAB" ||
+                   action == "NEXT_TAB" ) ) {
+            slider = 1 - slider;
         } else if( action == "UP" || action == "DOWN" ) {
             selection = increment_and_wrap( selection, action == "DOWN", MENU_ITEMS_N );
         } else if( selection == smart_controller_ui_selection::lo_and_hi_slider && ( action == "LEFT" ||

--- a/src/smart_controller_ui.cpp
+++ b/src/smart_controller_ui.cpp
@@ -36,6 +36,7 @@ smart_controller_ui::smart_controller_ui( smart_controller_settings initial_sett
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "NEXT_TAB" );
+    ctxt.register_action( "HELP_KEYBINDINGS" );
 }
 
 void smart_controller_ui::refresh()
@@ -112,19 +113,13 @@ void smart_controller_ui::refresh()
 
     // key descriptions
     std::string keys_text = string_format(
-                                _( "Use [<color_yellow>%s</color> and <color_yellow>%s</color>] to select option.\n"
-                                   "Use [<color_yellow>%s</color>] to change value.\n"
-                                   "Use [<color_yellow>%s</color> or <color_yellow>%s</color>] to switch between sliders.\n"
-                                   "Use [<color_yellow>%s</color> and <color_yellow>%s</color>] to move sliders."
-                                   "Use [<color_yellow>%s</color>] to apply changes and quit." ),
-                                ctxt.get_desc( "UP" ),
-                                ctxt.get_desc( "DOWN" ),
-                                ctxt.get_desc( "CONFIRM" ),
-                                ctxt.get_desc( "NEXT_TAB" ),
-                                ctxt.get_desc( "CONFIRM" ),
-                                ctxt.get_desc( "LEFT" ),
-                                ctxt.get_desc( "RIGHT" ),
-                                ctxt.get_desc( "QUIT" ) );
+                                _( "%s\n%s\n%s\n%s\n%s\n%s" ),
+                                ctxt.get_hint_pair( "UP", "DOWN", _( "Select option" ) ),
+                                ctxt.get_hint( "CONFIRM", _( "Change value" ) ),
+                                ctxt.get_hint_pair( "NEXT_TAB", "CONFIRM", _( "Switch between sliders" ) ),
+                                ctxt.get_hint_pair( "LEFT", "RIGHT", _( "Move sliders" ) ),
+                                ctxt.get_hint( "QUIT", _( "Apply changes and quit" ) ),
+                                ctxt.get_hint( "HELP_KEYBINDINGS" ) );
 
     int keys_text_w =  WIDTH - 2;
     int keys_text_lines_n = foldstring( keys_text, keys_text_w ).size();

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -299,8 +299,7 @@ void trade_ui::_draw_header()
     mvwprintz( _header_w, { 1, 3 }, c_white, _parties[_trader]->get_name() );
     right_print( _header_w, 3, 1, c_white, _( "You" ) );
     center_print( _header_w, header_size - 1, c_white,
-                  _panes[_you]->get_ctxt()->get_hint( trade_selector::ACTION_SWITCH_PANES, _( "to switch panes" ) ) );
+                  _panes[_you]->get_ctxt()->get_hint( trade_selector::ACTION_SWITCH_PANES ) );
     center_print( _header_w, header_size - 2, c_white,
-                  _panes[_you]->get_ctxt()->get_hint( trade_selector::ACTION_AUTOBALANCE,
-                          _( "to auto balance with highlighted item" ) ) );
+                  _panes[_you]->get_ctxt()->get_hint( trade_selector::ACTION_AUTOBALANCE ) );
 }

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -299,13 +299,8 @@ void trade_ui::_draw_header()
     mvwprintz( _header_w, { 1, 3 }, c_white, _parties[_trader]->get_name() );
     right_print( _header_w, 3, 1, c_white, _( "You" ) );
     center_print( _header_w, header_size - 1, c_white,
-                  string_format( _( "%s to switch panes" ),
-                                 colorize( _panes[_you]->get_ctxt()->get_desc(
-                                         trade_selector::ACTION_SWITCH_PANES ),
-                                           c_yellow ) ) );
+                  _panes[_you]->get_ctxt()->get_hint( trade_selector::ACTION_SWITCH_PANES, _( "to switch panes" ) ) );
     center_print( _header_w, header_size - 2, c_white,
-                  string_format( _( "%s to auto balance with highlighted item" ),
-                                 colorize( _panes[_you]->get_ctxt()->get_desc(
-                                         trade_selector::ACTION_AUTOBALANCE ),
-                                           c_yellow ) ) );
+                  _panes[_you]->get_ctxt()->get_hint( trade_selector::ACTION_AUTOBALANCE,
+                          _( "to auto balance with highlighted item" ) ) );
 }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -790,7 +790,7 @@ void uilist::show( ui_adaptor &ui )
                                                      keybinding_hint_state::DISABLED;
                 std::string hint = right_justify( input_context::get_hint_basic(
                                                       entries[ei].hotkey.value().short_description(),
-                                                      hstate ), 2 );
+                                                      hstate ), 4 );
                 print_colored_text( window, point( pad_left + 2, estart + si ), hint );
             }
             if( pad_size > 3 ) {

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -32,7 +32,7 @@
 
 
 // -2 for borders, -4 for padding
-static const int WIDTH_BUFFER = 6;
+static const int OPTION_WIDTH_BUFFER = 6;
 
 
 catacurses::window new_centered_win( int nlines, int ncols )
@@ -432,7 +432,7 @@ void uilist::inputfilter()
     filter_popup = std::make_unique<string_input_popup>();
     filter_popup->context( ctxt ).text( filter )
     .max_length( 256 )
-    .window( window, point( WIDTH_BUFFER, w_height - 1 ), w_width - WIDTH_BUFFER );
+    .window( window, point( 4, w_height - 1 ), w_width - 4 );
     bool loop = true;
     do {
         ui_manager::redraw();
@@ -500,14 +500,14 @@ void uilist::calc_data()
     // Space for a line between text and entries. Only needed if there is actually text.
     const int text_separator_line = text.empty() ? 0 : 1;
     if( w_auto ) {
-        w_width = WIDTH_BUFFER;
+        w_width = 4;
         if( !title.empty() ) {
             w_width = utf8_width( title ) + 5;
         }
     } else {
         w_width = w_width_setup.fun();
     }
-    const int max_desc_width = w_auto ? TERMX - WIDTH_BUFFER : w_width - WIDTH_BUFFER;
+    const int max_desc_width = w_auto ? TERMX - 4 : w_width - 4;
 
     bool h_auto = !w_height_setup.fun;
     if( h_auto ) {
@@ -543,21 +543,21 @@ void uilist::calc_data()
             if( entries[ i ].retval == -1 ) {
                 entries[ i ].retval = i;
             }
-            if( w_auto && w_width < txtwidth + pad + WIDTH_BUFFER + clen ) {
-                w_width = txtwidth + pad + WIDTH_BUFFER + clen;
+            if( w_auto && w_width < txtwidth + pad + OPTION_WIDTH_BUFFER + clen ) {
+                w_width = txtwidth + pad + OPTION_WIDTH_BUFFER + clen;
             }
         } else {
-            if( w_auto && w_width < txtwidth + pad + WIDTH_BUFFER + clen ) {
+            if( w_auto && w_width < txtwidth + pad + OPTION_WIDTH_BUFFER + clen ) {
                 // TODO: or +5 if header
-                w_width = txtwidth + pad + WIDTH_BUFFER + clen;
+                w_width = txtwidth + pad + OPTION_WIDTH_BUFFER + clen;
             }
         }
         if( desc_enabled ) {
             const int min_desc_width = std::min( max_desc_width, std::max( w_width,
-                                                 descwidth_final ) - WIDTH_BUFFER );
+                                                 descwidth_final ) - 4 );
             int descwidth = find_minimum_fold_width( footer_text.empty() ? entries[i].desc : footer_text,
                             desc_lines, min_desc_width, max_desc_width );
-            descwidth += WIDTH_BUFFER; // 2x border + 4x ' ' pad
+            descwidth += 4; // 2x border + 2x ' ' pad
             if( descwidth_final < descwidth ) {
                 descwidth_final = descwidth;
             }
@@ -597,12 +597,12 @@ void uilist::calc_data()
         int realtextwidth = 0;
         if( textwidth == -1 ) {
             if( !w_auto ) {
-                realtextwidth = w_width - WIDTH_BUFFER;
+                realtextwidth = w_width - 4;
             } else {
                 realtextwidth = twidth;
-                if( twidth + WIDTH_BUFFER > w_width ) {
-                    if( realtextwidth + WIDTH_BUFFER > TERMX ) {
-                        realtextwidth = TERMX - WIDTH_BUFFER;
+                if( twidth + 4 > w_width ) {
+                    if( realtextwidth + 4 > TERMX ) {
+                        realtextwidth = TERMX - 4;
                     }
                     textformatted = foldstring( text, realtextwidth );
                     formattxt = false;
@@ -613,15 +613,15 @@ void uilist::calc_data()
                             realtextwidth = w;
                         }
                     }
-                    if( realtextwidth + WIDTH_BUFFER > w_width ) {
-                        w_width = realtextwidth + WIDTH_BUFFER;
+                    if( realtextwidth + 4 > w_width ) {
+                        w_width = realtextwidth + 4;
                     }
                 }
             }
         } else if( textwidth != -1 ) {
             realtextwidth = textwidth;
-            if( realtextwidth + WIDTH_BUFFER > w_width ) {
-                w_width = realtextwidth + WIDTH_BUFFER;
+            if( realtextwidth + 4 > w_width ) {
+                w_width = realtextwidth + 4;
             }
         }
         if( formattxt ) {
@@ -634,7 +634,7 @@ void uilist::calc_data()
         desc_lines = 0;
         for( const uilist_entry &ent : entries ) {
             desc_lines = std::max<int>( desc_lines, foldstring( footer_text.empty() ? ent.desc : footer_text,
-                                        w_width - WIDTH_BUFFER ).size() );
+                                        w_width - 4 ).size() );
         }
         if( desc_lines <= 0 ) {
             desc_enabled = false;
@@ -697,7 +697,7 @@ void uilist::reposition( ui_adaptor &ui )
 {
     setup();
     if( filter_popup ) {
-        filter_popup->window( window, point( WIDTH_BUFFER, w_height - 1 ), w_width - WIDTH_BUFFER );
+        filter_popup->window( window, point( 4, w_height - 1 ), w_width - 4 );
     }
     ui.position_from_window( window );
 }
@@ -747,7 +747,7 @@ void uilist::show( ui_adaptor &ui )
     int estart = 1;
     if( !textformatted.empty() ) {
         for( int i = 0; i < text_lines; i++ ) {
-            trim_and_print( window, point( 2, 1 + i ), getmaxx( window ) - WIDTH_BUFFER,
+            trim_and_print( window, point( 2, 1 + i ), getmaxx( window ) - 4,
                             text_color, _color_error, "%s", textformatted[i] );
         }
 
@@ -796,13 +796,13 @@ void uilist::show( ui_adaptor &ui )
             if( pad_size > 3 ) {
                 // pad_size indicates the maximal width of the entry, it is used above to
                 // activate the highlighting, it is used to override previous text there, but in both
-                // cases printing starts at pad_left+1, here it starts at pad_left+WIDTH_BUFFER, so 3 cells less
+                // cases printing starts at pad_left+1, here it starts at pad_left+4 , so 3 cells less
                 // to be used.
                 const std::string &entry = ei == selected ? remove_color_tags( entries[ ei ].txt ) :
                                            entries[ ei ].txt;
                 point p( pad_left + 6, estart + si );
                 entries[ei].drawn_rect =
-                    inclusive_rectangle<point>( p + point( -WIDTH_BUFFER, 0 ), p + point( -WIDTH_BUFFER + pad_size,
+                    inclusive_rectangle<point>( p + point( -4, 0 ), p + point( -4 + pad_size,
                                                 0 ) );
                 trim_and_print( window, p, entry_space, co, _color_error, "%s", entry );
 
@@ -843,7 +843,7 @@ void uilist::show( ui_adaptor &ui )
         }
 
         if( static_cast<size_t>( selected ) < entries.size() ) {
-            fold_and_print( window, point( 2, w_height - desc_lines - 1 ), w_width - WIDTH_BUFFER, text_color,
+            fold_and_print( window, point( 2, w_height - desc_lines - 1 ), w_width - 4, text_color,
                             footer_text.empty() ? entries[selected].desc : footer_text );
         }
     }
@@ -857,7 +857,7 @@ void uilist::show( ui_adaptor &ui )
     } else {
         if( !filter.empty() ) {
             mvwprintz( window, point( 2, w_height - 1 ), border_color, "< %s >", filter );
-            mvwprintz( window, point( WIDTH_BUFFER, w_height - 1 ), text_color, filter );
+            mvwprintz( window, point( 4, w_height - 1 ), text_color, filter );
         }
     }
     apply_scrollbar();

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -277,7 +277,8 @@ void uilist::init()
     text_color = c_light_gray;  // text color
     title_color = c_white;  // title color
     hilight_color = h_white; // highlight for up/down selection bar
-    hotkey_color = c_yellow; // hotkey text to the right of menu entry's text
+    hotkey_color =
+        input_context::get_hint_color_for_key(); // hotkey text to the right of menu entry's text
     disabled_color = c_dark_gray; // disabled menu entry
     allow_disabled = false;  // disallow selecting disabled options
     allow_anykey = false;    // do not return on unbound keys

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -275,9 +275,9 @@ void uilist::init()
     footer_text.clear();   // takes precedence over per-entry descriptions.
     border_color = c_magenta; // border color
     text_color = c_light_gray;  // text color
-    title_color = c_green;  // title color
+    title_color = c_white;  // title color
     hilight_color = h_white; // highlight for up/down selection bar
-    hotkey_color = c_light_green; // hotkey text to the right of menu entry's text
+    hotkey_color = c_yellow; // hotkey text to the right of menu entry's text
     disabled_color = c_dark_gray; // disabled menu entry
     allow_disabled = false;  // disallow selecting disabled options
     allow_anykey = false;    // do not return on unbound keys
@@ -778,9 +778,15 @@ void uilist::show( ui_adaptor &ui )
 
             mvwprintz( window, point( pad_left + 1, estart + si ), co, padspaces );
             if( entries[ei].hotkey.has_value() && entries[ei].hotkey.value() != input_event() ) {
-                const nc_color hotkey_co = ei == selected ? hilight_color : hotkey_color;
-                mvwprintz( window, point( pad_left + 1, estart + si ), entries[ ei ].enabled ? hotkey_co : co,
-                           "%s", right_justify( entries[ei].hotkey.value().short_description(), 2 ) );
+                const keybinding_hint_state hotkey_co = ei == selected ? keybinding_hint_state::HIGHLIGHTED :
+                                                        keybinding_hint_state::ENABLED;
+                const keybinding_hint_state hstate = entries[ ei ].enabled ? hotkey_co :
+                                                     keybinding_hint_state::DISABLED;
+                print_colored_text( window, point( pad_left + 1, estart + si ), string_format( "%s%s%s",
+                                    colorize( "[", input_context::get_hint_color_for_separator( hstate ) ),
+                                    colorize( right_justify( entries[ei].hotkey.value().short_description(), 1 ),
+                                              input_context::get_hint_color_for_key( hstate ) ), colorize( "]",
+                                                      input_context::get_hint_color_for_separator( hstate ) ) ) );
             }
             if( pad_size > 3 ) {
                 // pad_size indicates the maximal width of the entry, it is used above to
@@ -789,7 +795,7 @@ void uilist::show( ui_adaptor &ui )
                 // to be used.
                 const std::string &entry = ei == selected ? remove_color_tags( entries[ ei ].txt ) :
                                            entries[ ei ].txt;
-                point p( pad_left + 4, estart + si );
+                point p( pad_left + 5, estart + si );
                 entries[ei].drawn_rect =
                     inclusive_rectangle<point>( p + point( -3, 0 ), p + point( -4 + pad_size, 0 ) );
                 trim_and_print( window, p, entry_space, co, _color_error, "%s", entry );

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -782,11 +782,9 @@ void uilist::show( ui_adaptor &ui )
                                                         keybinding_hint_state::ENABLED;
                 const keybinding_hint_state hstate = entries[ ei ].enabled ? hotkey_co :
                                                      keybinding_hint_state::DISABLED;
-                print_colored_text( window, point( pad_left + 1, estart + si ), string_format( "%s%s%s",
-                                    colorize( "[", input_context::get_hint_color_for_separator( hstate ) ),
-                                    colorize( right_justify( entries[ei].hotkey.value().short_description(), 1 ),
-                                              input_context::get_hint_color_for_key( hstate ) ), colorize( "]",
-                                                      input_context::get_hint_color_for_separator( hstate ) ) ) );
+                std::string hint = input_context::get_hint_basic( entries[ei].hotkey.value().short_description(),
+                                   hstate );
+                print_colored_text( window, point( pad_left + 1, estart + si ), hint );
             }
             if( pad_size > 3 ) {
                 // pad_size indicates the maximal width of the entry, it is used above to

--- a/src/ui.h
+++ b/src/ui.h
@@ -462,9 +462,11 @@ class uilist // NOLINT(cata-xy)
         bool allow_additional = false;
         bool hilight_disabled = false;
 
+
+        // HACK this should be private...
+        input_context create_main_input_context() const;
     private:
         report_color_error _color_error = report_color_error::yes;
-        input_context create_main_input_context() const;
         input_context create_filter_input_context() const;
 
     public:

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2809,21 +2809,8 @@ void veh_interact::display_name()
 static std::string veh_act_desc( const input_context &ctxt, const std::string &id,
                                  const std::string &desc, const task_reason reason )
 {
-    static const translation inline_fmt_enabled = to_translation(
-                "keybinding", "<color_light_gray>%1$s<color_light_green>%2$s</color>%3$s</color>" );
-    static const translation inline_fmt_disabled = to_translation(
-                "keybinding", "<color_dark_gray>%1$s<color_green>%2$s</color>%3$s</color>" );
-    static const translation separate_fmt_enabled = to_translation(
-                "keybinding", "<color_light_gray><color_light_green>%1$s</color>-%2$s</color>" );
-    static const translation separate_fmt_disabled = to_translation(
-                "keybinding", "<color_dark_gray><color_green>%1$s</color>-%2$s</color>" );
-    if( reason == task_reason::CAN_DO ) {
-        return ctxt.get_desc( id, desc, input_context::allow_all_keys,
-                              inline_fmt_enabled, separate_fmt_enabled );
-    } else {
-        return ctxt.get_desc( id, desc, input_context::allow_all_keys,
-                              inline_fmt_disabled, separate_fmt_disabled );
-    }
+    return ctxt.get_hint( id, desc,
+                          reason == task_reason::CAN_DO ? keybinding_hint_state::ENABLED : keybinding_hint_state::DISABLED );
 }
 
 /**

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1644,7 +1644,7 @@ void veh_interact::display_overview()
     int y = 0;
     if( overview_offset ) {
         trim_and_print( w_list, point( 1, y ), getmaxx( w_list ) - 1,
-                        c_yellow, _( "'{' to scroll up" ) );
+                        main_context.get_hint( "OVERVIEW_UP" ) );
         y++;
     }
     for( int idx = overview_offset; idx != static_cast<int>( overview_opts.size() ); ++idx ) {
@@ -1681,7 +1681,7 @@ void veh_interact::display_overview()
         } else {
             overview_limit = idx;
             trim_and_print( w_list, point( 1, y ), getmaxx( w_list ) - 1,
-                            c_yellow, _( "'}' to scroll down" ) );
+                            main_context.get_hint( "OVERVIEW_DOWN" ) );
             break;
         }
     }

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -286,9 +286,10 @@ void vehicle::print_vparts_descs( const catacurses::window &win, int max_y, int 
      * important! the calling function needs to track p, start_at, and start_limit, and set
      *    start_limit to 0 if p changes.
      */
+    input_context ctxt = input_context( "VEH_INTERACT", keyboard_mode::keycode );
     start_at = std::max( 0, std::min( start_at, start_limit ) );
     if( start_at ) {
-        msg += std::string( "<color_yellow>" ) + "<  " + _( "More parts here…" ) + "</color>\n";
+        msg += ctxt.get_hint( "DESC_LIST_UP" );
         lines += 1;
     }
     for( size_t i = start_at; i < pl.size(); i++ ) {
@@ -315,7 +316,7 @@ void vehicle::print_vparts_descs( const catacurses::window &win, int max_y, int 
             lines += new_lines;
             start_limit = start_at;
         } else {
-            msg += std::string( "<color_yellow>" ) + _( "More parts here…" ) + "  >" + "</color>\n";
+            msg += ctxt.get_hint( "DESC_LIST_DOWN" );
             start_limit = i;
             break;
         }
@@ -386,6 +387,12 @@ void vehicle::print_fuel_indicators( const catacurses::window &win, const point 
     int max_gauge = ( isHorizontal ? 12 : 5 ) + start_index;
     int max_size = std::min( static_cast<int>( fuels.size() ), max_gauge );
 
+    input_context ctxt = input_context( "VEH_INTERACT", keyboard_mode::keycode );
+    if( start_index > 0 ) {
+        print_colored_text( win, p + point( 0, yofs ), ctxt.get_hint( "FUEL_LIST_UP" ) );
+        yofs++;
+    }
+
     for( int i = start_index; i < max_size; i++ ) {
         const itype_id &f = fuels[i];
         print_fuel_indicator( win, p + point( 0, yofs ), f, fuel_used_last_turn, verbose, desc );
@@ -394,8 +401,7 @@ void vehicle::print_fuel_indicators( const catacurses::window &win, const point 
 
     // check if the current index is less than the max size minus 12 or 5, to indicate that there's more
     if( start_index < static_cast<int>( fuels.size() ) - ( isHorizontal ? 12 : 5 ) ) {
-        mvwprintz( win, p + point( 0, yofs ), c_light_green, ">" );
-        wprintz( win, c_light_gray, " for more" );
+        print_colored_text( win, p + point( 0, yofs ), ctxt.get_hint( "FUEL_LIST_DOWN" ) );
     }
 }
 

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -1002,7 +1002,7 @@ void debug_menu::wishitem( Character *you, const tripoint &pos )
                 if( amount > 0 ) {
                     input_context ctxt( wmenu.input_category, keyboard_mode::keycode );
                     cb.msg = string_format( _( "Wish granted.  Wish for more or hit %s to quit" ),
-                                            ctxt.get_hint( "QUIT" ) );
+                                            ctxt.get_hint_key_only( "QUIT" ) );
                 }
             }
             uistate.wishitem_selected = wmenu.selected;

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -233,17 +233,22 @@ class wish_mutate_callback: public uilist_callback
             mvwprintz( menu->window, point( startx, menu->w_height - 4 ), c_green, msg );
             msg.clear();
             input_context ctxt( menu->input_category, keyboard_mode::keycode );
-            mvwprintw( menu->window, point( startx, menu->w_height - 3 ),
-                       _( "[%s] find, [%s] quit, [t] toggle base trait" ),
-                       ctxt.get_desc( "FILTER" ), ctxt.get_desc( "QUIT" ) );
+            print_colored_text( menu->window, point( startx, menu->w_height - 3 ),
+                                string_format( _( "%s %s %s" ),
+                                               ctxt.get_hint( "UILIST.FILTER" ), ctxt.get_hint( "QUIT" ),
+                                               ctxt.get_hint_basic( "t", _( "toggle base trait" ) ) ) );
 
+            keybinding_hint_state traits_hint_state;
+            std::string traits_hint;
             if( only_active ) {
-                mvwprintz( menu->window, point( startx, menu->w_height - 2 ), c_green,
-                           _( "[a] show active traits (active)" ) );
+                traits_hint_state = keybinding_hint_state::TOGGLED_ON;
+                traits_hint = _( "show active traits (active)" );
             } else {
-                mvwprintz( menu->window, point( startx, menu->w_height - 2 ), c_white,
-                           _( "[a] show active traits" ) );
+                traits_hint_state = keybinding_hint_state::ENABLED;
+                traits_hint = _( "show active traits" );
             }
+            print_colored_text( menu->window, point( startx, menu->w_height - 2 ), ctxt.get_hint_basic( "a",
+                                traits_hint, traits_hint_state ) );
 
             wnoutrefresh( menu->window );
         }
@@ -586,12 +591,17 @@ class wish_monster_callback: public uilist_callback
                 mvwprintz( w_info, point( ( getmaxx( w_info ) - utf8_width( header ) ) / 2, 0 ), c_cyan, header );
             }
 
-            mvwprintz( w_info, point( 0, getmaxy( w_info ) - 3 ), c_green, msg );
+            print_colored_text( w_info, point( 0, getmaxy( w_info ) - 3 ), msg );
             msg.clear();
             input_context ctxt( menu->input_category, keyboard_mode::keycode );
-            mvwprintw( w_info, point( 0, getmaxy( w_info ) - 2 ),
-                       _( "[%s] find, [f]riendly, [h]allucination, [i]ncrease group, [d]ecrease group, [%s] quit" ),
-                       ctxt.get_desc( "FILTER" ), ctxt.get_desc( "QUIT" ) );
+            print_colored_text( w_info, point( 0, getmaxy( w_info ) - 2 ),
+                                string_format( "%s %s %s %s %s %s",
+                                               ctxt.get_hint( "UILIST.FILTER" ),
+                                               ctxt.get_hint_basic( "f", _( "Friendly" ) ),
+                                               ctxt.get_hint_basic( "h", _( "Hallucination" ) ),
+                                               ctxt.get_hint_basic( "i", _( "Increase group" ) ),
+                                               ctxt.get_hint_basic( "d", _( "Decrease group" ) ),
+                                               ctxt.get_hint( "QUIT" ) ) );
 
             wnoutrefresh( w_info );
         }
@@ -646,10 +656,10 @@ void debug_menu::wishmonster( const std::optional<tripoint> &p )
                     ++num_spawned;
                 }
                 input_context ctxt( wmenu.input_category, keyboard_mode::keycode );
-                cb.msg = string_format( _( "Spawned %d monsters, choose another or [%s] to quit." ),
-                                        num_spawned, ctxt.get_desc( "QUIT" ) );
+                cb.msg = string_format( _( "Spawned %d monsters, choose another or %s to quit." ),
+                                        num_spawned, ctxt.get_hint_key_only( "QUIT" ) );
                 if( num_spawned == 0 ) {
-                    cb.msg += _( "\nTarget location is not suitable for placing this kind of monster.  Choose a different target or [i]ncrease the groups size." );
+                    cb.msg += _( "\nTarget location is not suitable for placing this kind of monster.  Choose a different target or increase the groups size." );
                 }
                 uistate.wishmonster_selected = wmenu.selected;
             }
@@ -843,15 +853,17 @@ class wish_item_callback: public uilist_callback
                                 tmp.info( true ) );
             }
 
-            mvwprintz( menu->window, point( startx, menu->w_height - 3 ), c_green, msg );
+            print_colored_text( menu->window, point( startx, menu->w_height - 3 ), msg );
             msg.erase();
             input_context ctxt( menu->input_category, keyboard_mode::keycode );
-            mvwprintw( menu->window, point( startx, menu->w_height - 2 ),
-                       _( "[%s] find, [%s] container, [%s] flag, [%s] everything, [%s] snippet, [%s] quit" ),
-                       ctxt.get_desc( "FILTER" ), ctxt.get_desc( "CONTAINER" ),
-                       ctxt.get_desc( "FLAG" ), ctxt.get_desc( "EVERYTHING" ),
-                       ctxt.get_desc( "SNIPPET" ),
-                       ctxt.get_desc( "QUIT" ) );
+            print_colored_text( menu->window, point( startx, menu->w_height - 2 ),
+                                string_format( "%s %s %s %s %s %s",
+                                               ctxt.get_hint( "UILIST.FILTER" ),
+                                               ctxt.get_hint( "CONTAINER" ),
+                                               ctxt.get_hint( "FLAG" ),
+                                               ctxt.get_hint( "EVERYTHING" ),
+                                               ctxt.get_hint( "SNIPPET" ),
+                                               ctxt.get_hint( "QUIT" ) ) );
             wnoutrefresh( menu->window );
         }
 };
@@ -989,8 +1001,8 @@ void debug_menu::wishitem( Character *you, const tripoint &pos )
                 }
                 if( amount > 0 ) {
                     input_context ctxt( wmenu.input_category, keyboard_mode::keycode );
-                    cb.msg = string_format( _( "Wish granted.  Wish for more or hit [%s] to quit." ),
-                                            ctxt.get_desc( "QUIT" ) );
+                    cb.msg = string_format( _( "Wish granted.  Wish for more or hit %s to quit" ),
+                                            ctxt.get_hint( "QUIT" ) );
                 }
             }
             uistate.wishitem_selected = wmenu.selected;

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1855,9 +1855,9 @@ void worldfactory::draw_modselection_borders( const catacurses::window &win,
     fold_and_print( win, point( 2, TERMY - 10 ), getmaxx( win ) - 4, c_light_gray,
                     _( "%s %s %s %s %s" ),
                     ctxtp.get_hint( "SAVE_DEFAULT_MODS" ),
-                    ctxtp.get_hint_pair( "PREV_TAB", "NEXT_TAB", _( "Switch Main Tab" ) ),
-                    ctxtp.get_hint_pair( "LEFT", "RIGHT", _( "Switch Mod List and Mod Load Order" ) ),
-                    ctxtp.get_hint_pair( "PREV_CATEGORY_TAB", "NEXT_CATEGORY_TAB", _( "Switch Mod List Tab" ) ),
+                    ctxtp.get_hints( { "PREV_TAB", "NEXT_TAB"}, _( "Switch Main Tab" ) ),
+                    ctxtp.get_hints( { "LEFT", "RIGHT"}, _( "Switch Mod List and Mod Load Order" ) ),
+                    ctxtp.get_hints( { "PREV_CATEGORY_TAB", "NEXT_CATEGORY_TAB"}, _( "Switch Mod List Tab" ) ),
                     ctxtp.get_hint( "HELP_KEYBINDINGS" )
                   );
     wnoutrefresh( win );

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1650,10 +1650,11 @@ int worldfactory::show_worldgen_basic( WORLD *world )
         // Hint text
         std::string hint_txt =
             string_format( _( "Press %s to pick a random name for your world.\n"
-                              "Navigate options with directional keys "
+                              "Navigate options with %s "
                               "and confirm with %s.\n"
                               "Press %s to see additional control information." ),
-                           ctxt.get_hint_key_only( "PICK_RANDOM_WORLDNAME" ), ctxt.get_hint_key_only( "CONFIRM" ),
+                           ctxt.get_hint_key_only( "PICK_RANDOM_WORLDNAME" ), ctxt.get_hint_directions(),
+                           ctxt.get_hint_key_only( "CONFIRM" ),
                            ctxt.get_hint_key_only( "HELP_KEYBINDINGS" ) );
         if( !custom_opts && sel_opt > 0 && sel_opt <= static_cast<int>( wg_sliders.size() ) ) {
             hint_txt = wg_sliders[sel_opt - 1]->level_desc( wg_slevels[sel_opt - 1] ).translated();

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1196,7 +1196,7 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
             if( num_lines > window_height ) {
                 // The description didn't fit in the window, so provide a
                 // hint for how to see the whole thing
-                std::string message = std::string( "..." ).append(
+                std::string message = std::string( "…" ).append(
                                           ctxt.get_hint( "VIEW_MOD_DESCRIPTION" ) );
                 print_colored_text( w_description, point( window_width - utf8_width( message, true ),
                                     window_height - 1 ), message );
@@ -1852,11 +1852,11 @@ void worldfactory::draw_modselection_borders( const catacurses::window &win,
     // Add tips & hints
 
     fold_and_print( win, point( 2, TERMY - 10 ), getmaxx( win ) - 4, c_light_gray,
-                    _( "%s | %s | %s | %s | %s" ),
+                    _( "%s %s %s %s %s" ),
                     ctxtp.get_hint( "SAVE_DEFAULT_MODS" ),
-                    ctxtp.get_hint_pair( "PREV_TAB", "NEXT_TAB", _( "switch Main Tab" ) ),
-                    ctxtp.get_hint_pair( "LEFT", "RIGHT", _( "switch Mod List and Mod Load Order" ) ),
-                    ctxtp.get_hint_pair( "PREV_CATEGORY_TAB", "NEXT_CATEGORY_TAB", _( "switch Mod List Tab" ) ),
+                    ctxtp.get_hint_pair( "PREV_TAB", "NEXT_TAB", _( "Switch Main Tab" ) ),
+                    ctxtp.get_hint_pair( "LEFT", "RIGHT", _( "Switch Mod List and Mod Load Order" ) ),
+                    ctxtp.get_hint_pair( "PREV_CATEGORY_TAB", "NEXT_CATEGORY_TAB", _( "Switch Mod List Tab" ) ),
                     ctxtp.get_hint( "HELP_KEYBINDINGS" )
                   );
     wnoutrefresh( win );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Display keybindings in UI consistently and add options to allow players to customize how the keybindings are displayed"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

F*xes most of #58846 but not all...

This PR will:
- Make the code cleaner.
- Improve UX by making it (more) clear which keybindings the player can press at any time in a way that they're more likely to recognize at a glance.
- Ensure that we never display hardcoded keybindings to the player to prevent the situation where the player would rebind some keys but they're hardcoded in the UI so we'll end up displaying wrong keybindings (bad UX).
- Allow players to customize how keybindings are displayed throughout the UI to suit their needs (eg. "[x] Examine", "x: Examine", "(x) Examine", "x - Examine", "E[x]amine").
- Make extensive use of `fold_and_print` for displaying keybindings to allow them to show up well (in theory) no matter what language they're displayed in.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- Create some `input_context::get_hint*` methods built on the existing `get_desc` methods that provide a more complete interface for generating the strings to display.
- Replace all existing uses of `get_desc` outside of the input.cpp with calls to the more complete `get_hint` methods (greatly simplifying UI code in the process).
- Find hardcoded keybindings and replace the vast majority of them with calls to `get_hint*` methods (passing any relevant input_context object around as needed) so that the keybindings are displayed consistently and always display an actual keybinding that the player has set.
- Insert extra bits of code into the existing `shortcut_{print|text}` and `press_x` methods that are harder to refactor to make the keybindings generated by them appear consistently with the keybindings generated through `get_hint*` methods  (This refactoring can be tackled in a subsequent PR to make this one more reasonable to review).
- Add `input_context::get_hint_color*` methods (NB: these should probably be in the `color.h` file) that take a state as a parameter (like ENABLED, DISABLED, TOGGLED_ON, TOGGLED_OFF, HIGHLIGHTED) and try to use them consistently throughout the code as needed such that we have one single place where we can swap all keybindings-related colors around.
- Fix minor UI issues/inconsistencies while I was in the neighborhood.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

None.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to 
make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

- Each changed menu (except the basecamp UI code because I don't know how to trigger it :() was tested at least once after making changes to ensure that nothing was broken.
- WIP I'm doing a second pass now of all the changed screens (most of them) to make sure nothing is broken but any help with testing this would be appreciated.

#### Additional context

To Review:
The majority of the important changes can be found in `input.*`, `options.cpp` and `output.*`. All the other changes stem from there and, for the most part, are relatively simple. I've attached screenshots for each changed UI screen, you can see them by scrolling down!

Here are some screenshots for different keybinding hint settings:

Default settings:
![WindowsTerminal_I837azrnMt](https://user-images.githubusercontent.com/2420411/228027047-f78bd8fb-20d6-4254-8355-81ab8fe66f43.png)
![WindowsTerminal_Wb4qL7nOkJ](https://user-images.githubusercontent.com/2420411/228027069-0ef0da71-32de-4796-985d-e9b077c0d376.png)

settings example \#1:
![WindowsTerminal_y03FKJNmFe](https://user-images.githubusercontent.com/2420411/228027072-e06ef41b-f4d4-4610-9aea-13a7bd49de8c.png)
![WindowsTerminal_w4UwxOrAWj](https://user-images.githubusercontent.com/2420411/228027085-1af64176-6c98-4b30-8013-f5935f8cbb98.png)

settings example \#2:
![WindowsTerminal_4ZpIxUVmye](https://user-images.githubusercontent.com/2420411/228027094-a15bdebd-71ae-4b2f-b503-43516775be83.png)
![WindowsTerminal_PxqIkHzFyK](https://user-images.githubusercontent.com/2420411/228027101-cfa70633-50a1-45d3-8a07-ffae224785f4.png)

settings example \#3:
![WindowsTerminal_TwlGKwnL2A](https://user-images.githubusercontent.com/2420411/228027110-a7a572ab-a05c-4fa0-9201-ed862065b09e.png)
![WindowsTerminal_Udqlq5im11](https://user-images.githubusercontent.com/2420411/228027121-74951037-2902-441c-adcd-aa33cbda820a.png)
