### PR TITLE
Apply Enchantments to Item Info

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1977,6 +1977,8 @@ double item::effective_dps( const Character &guy, Creature &mon ) const
     double num_low_hits = std::max( 0.0, num_all_hits - num_high_hits );
 
     double moves_per_attack = guy.attack_speed( *this );
+    moves_per_attack = guy.calculate_by_enchantment( moves_per_attack, enchant_vals::mod::ATTACK_SPEED,
+                       true );
     // attacks that miss do no damage but take time
     double total_moves = ( hit_trials - num_all_hits ) * moves_per_attack;
     double total_damage = 0.0;
@@ -5230,8 +5232,11 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
         }
 
         if( base_moves ) {
+            int attack_cost = attack_time( player_character );
+            attack_cost = player_character.calculate_by_enchantment( attack_cost,
+                          enchant_vals::mod::ATTACK_SPEED, true );
             info.emplace_back( "BASE", _( "Base moves per attack: " ), "",
-                               iteminfo::lower_is_better, attack_time( player_character ) );
+                               iteminfo::lower_is_better, attack_cost );
         }
 
         if( base_dps ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1614,6 +1614,9 @@ void Character::roll_other_damage( bool /*crit*/, damage_instance &di, bool /*av
             di.add_damage( type_name, other_dam, arpen, armor_mult, other_mul );
         }
     }
+
+    // Apply enchantment damage
+    di = modify_damage_dealt_with_enchantments( di );
 }
 
 matec_id Character::pick_technique( Creature &t, const item_location &weap, bool crit,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Enchantment effects on attack cost and dps now reflected in item info"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Enchantments not reflected in an item's moves per attack and dps as mentioned in #63982. This change reflects these effects the same way a Stat change would affect dps. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
When calculating moves per attack, also apply enchantment impact(s). When calculating dps, also apply enchantment damage. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->