### PR TITLE
Differentiate welding tool names

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -225,7 +225,7 @@
   {
     "type": "vehicle_part",
     "id": "ap_weldkit",
-    "name": { "str": "welding kit rig" },
+    "name": { "str": "high-temperature welding kit rig" },
     "description": "A welding rig complete with a fireproof insulating blanket, allowing for advanced welds and repairs to tempered steels.  It draws power from the vehicle's batteries, but you still need glare protection.  'e'xamine the tile with the rig to use it to repair items in your inventory.  If you attempt to craft an item or perform a repair that requires a welder, you will be given the option of using the welding rig.",
     "item": "welding_kit",
     "flags": [ "CARGO", "OBSTACLE", "APPLIANCE" ],

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1335,7 +1335,7 @@
   {
     "id": "welding_kit",
     "type": "TOOL",
-    "name": { "str": "welding kit" },
+    "name": { "str": "high-temperature welding kit" },
     "description": "A welder combined with a fireproof insulating blanket allows for advanced welds and repairs to tempered steels.",
     "weight": "10500 g",
     "volume": "12500 ml",

--- a/data/json/items/vehicle/rigs.json
+++ b/data/json/items/vehicle/rigs.json
@@ -58,7 +58,7 @@
     "id": "weldkit",
     "copy-from": "vehicle_rig",
     "type": "GENERIC",
-    "name": { "str": "vehicle welding kit" },
+    "name": { "str": "vehicle high-temperature welding kit" },
     "description": "A welder combined with a fireproof insulating blanket, allowing for advanced welds and repairs to tempered steels."
   }
 ]

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -2470,7 +2470,7 @@ TEST_CASE( "repairable and with what tools", "[iteminfo][repair]" )
 
     CHECK( item_info_str( halligan, repaired ) ==
            "--\n"
-           "<color_c_white>Repair</color> using integrated multitool, arc welder, makeshift arc welder, or welding kit.\n"
+           "<color_c_white>Repair</color> using integrated multitool, arc welder, makeshift arc welder, or high-temperature welding kit.\n"
            "<color_c_white>With</color> <color_c_cyan>Steel</color>.\n"
          );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
People have repeatedly, *repeatedly* gotten "welding rig" and "welding kit" mixed up.

#### Describe the solution
Change the display name so it's very obvious which is which, and that that the former 'welding kit' can do more, different things.

#### Describe alternatives you've considered
N/A

#### Testing
Github tests guide my commits!

#### Additional context
@Drew4484 How does this look? This is the difference between the two as far as I'm aware.