### PR TITLE
Fix character received items' charges error

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2302,8 +2302,7 @@ static void receive_item( itype_id &item_name, int count, const std::string &con
     }
     if( container_name.empty() ) {
         if( new_item.count_by_charges() ) {
-            new_item.charges = 1;    // Reset item default charges, prepare to receive specific defined charges
-            new_item.mod_charges( count - 1 );
+            new_item.charges = count;
             d.actor( false )->i_add_or_drop( new_item );
         } else {
             for( int i_cnt = 0; i_cnt < count; i_cnt++ ) {
@@ -2325,8 +2324,7 @@ static void receive_item( itype_id &item_name, int count, const std::string &con
         }
     } else {
         item container( container_name, calendar::turn );
-        new_item.charges = 1;    // Reset item default charges, prepare to receive specific defined charges
-        new_item.mod_charges( count - 1 );
+        new_item.charges = count - 1;
         container.put_in( new_item,
                           item_pocket::pocket_type::CONTAINER );
         d.actor( false )->i_add_or_drop( container );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2324,7 +2324,7 @@ static void receive_item( itype_id &item_name, int count, const std::string &con
         }
     } else {
         item container( container_name, calendar::turn );
-        new_item.charges = count - 1;
+        new_item.charges = count;
         container.put_in( new_item,
                           item_pocket::pocket_type::CONTAINER );
         d.actor( false )->i_add_or_drop( container );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2325,6 +2325,7 @@ static void receive_item( itype_id &item_name, int count, const std::string &con
         }
     } else {
         item container( container_name, calendar::turn );
+        new_item.charges = 1;    // Reset item default charges, prepare to receive specific defined charges
         new_item.mod_charges( count - 1 );
         container.put_in( new_item,
                           item_pocket::pocket_type::CONTAINER );
@@ -4140,7 +4141,7 @@ void talk_effect_t<T>::set_effect( talkfunction_ptr ptr )
     }
     set_effect_consequence( npctalk_setter, response );
 }
-#pragma optimize("", off)
+
 template<class T>
 talk_topic talk_effect_t<T>::apply( const T &d ) const
 {
@@ -4173,7 +4174,7 @@ talk_topic talk_effect_t<T>::apply( const T &d ) const
 
     return next_topic;
 }
-#pragma optimize("", on)
+
 template<class T>
 void talk_effect_t<T>::update_missions( T &d ) const
 {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2302,6 +2302,7 @@ static void receive_item( itype_id &item_name, int count, const std::string &con
     }
     if( container_name.empty() ) {
         if( new_item.count_by_charges() ) {
+            new_item.charges = 1;    // Reset item default charges, prepare to receive specific defined charges
             new_item.mod_charges( count - 1 );
             d.actor( false )->i_add_or_drop( new_item );
         } else {
@@ -4139,7 +4140,7 @@ void talk_effect_t<T>::set_effect( talkfunction_ptr ptr )
     }
     set_effect_consequence( npctalk_setter, response );
 }
-
+#pragma optimize("", off)
 template<class T>
 talk_topic talk_effect_t<T>::apply( const T &d ) const
 {
@@ -4172,7 +4173,7 @@ talk_topic talk_effect_t<T>::apply( const T &d ) const
 
     return next_topic;
 }
-
+#pragma optimize("", on)
 template<class T>
 void talk_effect_t<T>::update_missions( T &d ) const
 {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix mission reward items charges error"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There are numerous scenarios that an item with json-defined charges gets spawned, and the charge that the character receives is wrong. Here's a non-exhaustive list of such scenarios:
1. Ammo conversion with the isolated artisans.
2. Mission with the isolated artisans that gives you 229 instead of 200 `545_ap`.
3. Mission with NPC_Claire_Isherwood that gives you 29 instead of 20 `poppy_pain`.
4. Mission with the old_guard_representative that gives you 36 instead of 17 `44magnum`.
5. ......
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
When spawning the item that is count by charges, reset the charge of that to 1, to be prepared to receive the scenario-defined count. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Wait for #60885 to solve this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Good in game. Tests passed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/64245
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->