### PR TITLE
inv_ui: fix width of merged map column

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2158,6 +2158,7 @@ void inventory_selector::rearrange_columns( size_t client_width )
             own_inv_column.set_indent_entries_override( map_column.indent_entries() );
         }
         map_column.move_entries_to( own_inv_column );
+        own_inv_column.reset_width( {} );
     }
     if( prev_selection ) {
         highlight( prev_selection, false, front_only );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I missed one outdated assumption in #64425 and introduced a bug for small screens

* Fixes: #64490
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Taking a hike
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<details>
<summary>Before #64425, for reference</summary>

![Screenshot from 2023-03-23 10-59-29](https://user-images.githubusercontent.com/68240139/227153219-22159c84-0908-4977-a98b-46ff8540a762.png)

</details>

<details>
<summary>Current bugged version</summary>

![Screenshot from 2023-03-23 11-13-13](https://user-images.githubusercontent.com/68240139/227156586-99d14127-1c0b-49ec-a9ae-d60ce2b0da40.png)

</details>

With this fix:
![Screenshot from 2023-03-23 10-55-55](https://user-images.githubusercontent.com/68240139/227152194-b7a789c5-8288-4d8d-aab7-6afbda028504.png)


There is no perf impact since `reset_width()/expand_to_fit()` are very lightweight since #64425.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->