### PR TITLE
Improve dish: Succotash

### DIFF
--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -1417,5 +1417,25 @@
     "charges": 4,
     "vitamins": [ [ "iron", 2 ] ],
     "fun": 2
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "succotash",
+    "name": { "str_sp": "succotash" },
+    "weight": "197 g",
+    "color": "yellow",
+    "spoils_in": "4 days",
+    "comestible_type": "FOOD",
+    "symbol": "%",
+    "quench": 1,
+    "calories": 300,
+    "description": "Coming from a word meaning \"broken corn kernels\" in the language of the Narragansett, it is a popular dish during hard times in New England.  Cheap and made from common ingredients.",
+    "price": 200,
+    "price_postapoc": 100,
+    "material": [ "veggy" ],
+    "volume": "250 ml",
+    "flags": [ "FREEZERBURN" ],
+    "vitamins": [ [ "vitC", 15 ], [ "iron", 2 ], [ "calcium", 8 ] ],
+    "fun": 1
   }
 ]

--- a/data/json/recipes/food/vegetable_dishes.json
+++ b/data/json/recipes/food/vegetable_dishes.json
@@ -415,5 +415,33 @@
     "tools": [ [ [ "water_boiling_heat", 2, "LIST" ] ] ],
     "//": "No proficiencies required. This is literally just boiling them in a pot of water",
     "components": [ [ [ "groundnut_prepared", 1 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "succotash",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_VEGGI",
+    "skill_used": "cooking",
+    "difficulty": 1,
+    "skills_required": [ "survival", 1 ],
+    "time": "10 m",
+    "batch_time_factors": [ 90, 1 ],
+    "autolearn": true,
+    "qualities": [ { "id": "BOIL", "level": 1 } ],
+    "tools": [ [ [ "surface_heat", 4, "LIST" ] ] ],
+    "components": [
+      [ [ "corn_kernels", 1 ] ],
+      [ [ "raw_beans", 1 ], [ "raw_lentils", 1 ] ],
+      [ [ "water", 1 ], [ "water_clean", 1 ] ],
+      [
+        [ "salt", 1 ],
+        [ "garlic_powder", 1 ],
+        [ "seasoning_italian", 1 ],
+        [ "seasoning_salt", 1 ],
+        [ "wild_herbs", 1 ]
+      ],
+      [ [ "any_butter_or_oil", 1, "LIST" ] ]
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Improve the dish Succotash"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

While I was doing unrelated research, I stumbled upon https://en.wikipedia.org/wiki/Succotash and I saw that the version ingame could have some tweaks.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- Improved description, making it more interesting.
- Made it spoil quicker because it contains much water.
- Because of the above, also add 1 quench.
- Reduced fun from 2 to 1. It is a filling meal and even better if its hot, but it will not make you very happy.
- Adjusted vitamins based on different sites I looked at.
- Moved recipe from recipe_food.json to vegetable_dishes.json
- Instead of beans you can also use lentils as they are also a commonly used legume. Its the apocalypse, its gonna work.
- Seasoning is now required.
- Better batch time savings, but recipe takes slightly longer to make now.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Theres plenty of "deluxe" recipes, too. Involving potatoes, peppers, tomatoes and so on. Some even involve meat.
Maybe I will add one later.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

None yet since it is a quite simple addition.
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->