### PR TITLE
Fix underground emitter drain

### DIFF
--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -68,6 +68,7 @@ void place_appliance( const tripoint &p, const vpart_id &vpart, const std::optio
         veh->install_part( point_zero, vpart );
     }
     veh->name = vpart->name();
+    veh->last_update = calendar::turn;
 
     // Update the vehicle cache immediately,
     // or the appliance will be invisible for the first couple of turns.

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7456,6 +7456,7 @@ void vehicle::update_time( const time_point &update_to )
     }
 
     if( sm_pos.z < 0 ) {
+        last_update = update_to;
         return;
     }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7452,7 +7452,7 @@ void vehicle::update_time( const time_point &update_to )
                 here.emit_field( exhaust_dest( exhaust_part ), e );
             }
         }
-        discharge_battery( power_to_energy_bat( pt.info().epower, update_to - last_update ) );
+        discharge_battery( power_to_energy_bat( -pt.info().epower, update_to - last_update ) );
     }
 
     if( sm_pos.z < 0 ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix battery drain for emitters and underground vehicles

#### Describe the solution

A few bugs clumped together and trigger a sanity check in https://github.com/CleverRaven/Cataclysm-DDA/issues/64287#issuecomment-1480617192 but all of them together sorta cancel each other so they were effectively invisible until the sanity check was added in #64097 to prevent "discharging" negative amounts

This may cause slightly more bug reports as I added debugmsgs when charging or discharging a negative amount, but driving around and crafting didn't seem to trigger these after the fix in this PR

This PR fixes:
* Appliances don't initialize `last_update` to current turn, creating massive time intervals between `calendar::turn` and `vehicle::update_time` on first turn - now new appliances will initialize it
* Vehicles located at zlevel < 0 don't update their `last_update` field, which makes the interval `vehicle::update_time` needs to simulate only grow upwards overflowing the int variables - this is now fixed and last_update will tick forward at any zlevel
* Parts which are both emitter and VPFLAG_ENABLED_DRAINS_EPOWER were being double dipped - batteries discharged once in `vehicle::power_parts()` with the rest of VPFLAG_ENABLED_DRAINS_EPOWER parts and once in `vehicle::update_time` effectively doubling power consumption, but the integer overflow canceled the drain in `vehicle::update_time` so power use was appearing "normal". This PR changes `vehicle::update_time` to only discharge the amount for simualted interval minus 1 turn - so if vehicle is in bubble and power_parts() is running it doesn't discharge anything, if vehicle comes into bubble with larger interval it should simulate discharge up to current turn, and then power_parts will do the last discharge.

Also PR moves time travel protection upwards so emitters are also guarded against going back in time

#### Describe alternatives you've considered

#### Testing

Start some scenario to put you in evac center at summer like normal (or some date, just make sure it's away from turn 0)
Enable debug mode, disable all filters, enable only DF_VEHICLE
Build a battery appliance + small space heater near each other, put some charge in battery via debug
Turn on heater and start looking at the debug message printouts, or put breakpoints in vehicle::update_time and see the intervals simulated and int overflow feeding negative amounts to discharge_batteries

May be automated tests will catch something

#### Additional context
