### PR TITLE
friendly monsters spawn friendly offspring

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -538,6 +538,11 @@
     "//": "This item will spawn active. Not advised for items that drain power when active."
   },
   {
+    "id": "SPAWN_FRIENDLY",
+    "type": "json_flag",
+    "//": "This item will spawn friendly. Used for pets and such."
+  },
+  {
     "id": "STAB",
     "type": "json_flag"
   },

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -303,6 +303,7 @@ const flag_id flag_SOFT( "SOFT" );
 const flag_id flag_SOLARPACK( "SOLARPACK" );
 const flag_id flag_SOLARPACK_ON( "SOLARPACK_ON" );
 const flag_id flag_SPAWN_ACTIVE( "SPAWN_ACTIVE" );
+const flag_id flag_SPAWN_FRIENDLY( "SPAWN_FRIENDLY" );
 const flag_id flag_SPEAR( "SPEAR" );
 const flag_id flag_SPEEDLOADER( "SPEEDLOADER" );
 const flag_id flag_SPEEDLOADER_CLIP( "SPEEDLOADER_CLIP" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -307,6 +307,7 @@ extern const flag_id flag_SMOKED;
 extern const flag_id flag_SOLARPACK;
 extern const flag_id flag_SOLARPACK_ON;
 extern const flag_id flag_SPAWN_ACTIVE;
+extern const flag_id flag_SPAWN_FRIENDLY;
 extern const flag_id flag_SPEAR;
 extern const flag_id flag_SPEEDLOADER;
 extern const flag_id flag_SPEEDLOADER_CLIP;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7747,7 +7747,7 @@ void map::rotten_item_spawn( const item &item, const tripoint &pnt )
     if( rng( 0, 100 ) < comest->rot_spawn_chance ) {
         std::vector<MonsterGroupResult> spawn_details = MonsterGroupManager::GetResultFromGroup( mgroup );
         for( const MonsterGroupResult &mgr : spawn_details ) {
-            add_spawn( mgr, pnt );
+            add_spawn( mgr, pnt, item.has_own_flag( flag_SPAWN_FRIENDLY ) );
         }
         if( get_player_view().sees( pnt ) ) {
             if( item.is_seed() ) {

--- a/src/map.h
+++ b/src/map.h
@@ -1695,7 +1695,7 @@ class map
         void add_spawn( const mtype_id &type, int count, const tripoint &p, bool friendly,
                         int faction_id, int mission_id, const std::string &name,
                         const spawn_data &data );
-        void add_spawn( const MonsterGroupResult &spawn_details, const tripoint &p );
+        void add_spawn( const MonsterGroupResult &spawn_details, const tripoint &p, bool friendly = false );
         void do_vehicle_caching( int z );
         // Note: in 3D mode, will actually build caches on ALL z-levels
         void build_map_cache( int zlev, bool skip_lightmap = false );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6558,9 +6558,9 @@ std::vector<item *> map::put_items_from_loc( const item_group_id &group_id, cons
     return spawn_items( p, items );
 }
 
-void map::add_spawn( const MonsterGroupResult &spawn_details, const tripoint &p )
+void map::add_spawn( const MonsterGroupResult &spawn_details, const tripoint &p, bool friendly )
 {
-    add_spawn( spawn_details.name, spawn_details.pack_size, p, false, -1, -1, "NONE",
+    add_spawn( spawn_details.name, spawn_details.pack_size, p, friendly, -1, -1, "NONE",
                spawn_details.data );
 }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -27,6 +27,7 @@
 #include "explosion.h"
 #include "faction.h"
 #include "field_type.h"
+#include "flag.h"
 #include "game.h"
 #include "game_constants.h"
 #include "harvest.h"
@@ -492,12 +493,17 @@ void monster::try_reproduce()
         }
 
         chance += 2;
+        bool friendly_parent = attitude_to( get_player_character() ) == Creature::Attitude::FRIENDLY;
         if( season_match && female && one_in( chance ) ) {
             int spawn_cnt = rng( 1, type->baby_count );
             if( type->baby_monster ) {
-                here.add_spawn( type->baby_monster, spawn_cnt, pos() );
+                here.add_spawn( type->baby_monster, spawn_cnt, pos(), friendly_parent );
             } else {
-                here.add_item_or_charges( pos(), item( type->baby_egg, *baby_timer, spawn_cnt ), true );
+                item item_to_spawn( type->baby_egg, *baby_timer, spawn_cnt );
+                if( friendly_parent ) {
+                    item_to_spawn.set_flag( flag_SPAWN_FRIENDLY );
+                }
+                here.add_item_or_charges( pos(), item_to_spawn, true );
             }
         }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "friendly animals spawn friendly offspring"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

This change is a QoL improvement for farmer players. The idea is that if the parent animal is friendly to the player, their offspring should be friendly too. Right now players have to be extra careful while going through their pastures to not accidentally 'attack' some of the younger animals because there's a mixture of older/friendly animals and younger, neutral ones. This is especially bad when dealing with a chicken coop that has a grown a bit large. In the long run, this change might also help when dealing with dynamically created pastures of friendly animals.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

PR works by piggybacking on existing interfaces and functionality for the most part. Adding friendly offspring for mammals like cows was straightforward by just overriding the default false 'friendly' parameter of map::add_spawn() with the attitude of the parent towards the player.  Birds that hatch from eggs required an extra flag that is added to the egg item (flag_SPAWN_FRIENDLY) which is then used by map::rotten_item_spawn() to determine if the newly spawned creature should be friendly or not.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Existing behavior seemed super clunky to me as a player so this QoL made sense, to me at least. Code-wise, the solution seems like the most straightforward and least invasive way to go about it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

1. Spawned cows/chickens near player, neutral at first.
2. Locally edited monster::try_reproduction() and item::process_temperature_rot() in order to ensure that the creatures would spawn an egg or baby animal every time the submap would get loaded.
3. Player goes away, comes back, spawned offspring is neutral for cow / chicken.
4. Tried same experiment but starting with friendly parents. Player comes back to submap and offspring is generated friendly.
5. Also locally hacked the evolution code in monster.cpp in order to check whether their evolved variants would also retain the same attitude towards player and that worked as well.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->