### PR TITLE
🌰 Allow blanched/cooked/roasted acorns in soups and stews 🍲

### DIFF
--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -595,7 +595,7 @@
         [ "dandelion_cooked", 1 ],
         [ "burdock_cooked", 1 ],
         [ "bamboo_cooked", 1 ],
-        [ "acorns_cooked", 1 ],
+        [ "acorns_processed_any", 1, "LIST" ],
         [ "dry_lentils", 1 ],
         [ "raw_lentils", 1 ]
       ],
@@ -648,7 +648,7 @@
         [ "dry_mushroom", 1 ],
         [ "mushroom_cooked", 1 ],
         [ "morel_cooked", 1 ],
-        [ "acorns_cooked", 1 ]
+        [ "acorns_processed_any", 1, "LIST" ]
       ],
       [
         [ "fish", 2 ],
@@ -709,7 +709,7 @@
         [ "dry_mushroom", 1 ],
         [ "mushroom_cooked", 1 ],
         [ "morel_cooked", 1 ],
-        [ "acorns_cooked", 1 ]
+        [ "acorns_processed_any", 1, "LIST" ]
       ],
       [ [ "lobster", 2 ], [ "dry_lobster", 2 ], [ "lobster_smoked", 2 ], [ "lobster_canned", 2 ] ]
     ]
@@ -767,7 +767,7 @@
         [ "dry_mushroom", 2 ],
         [ "mushroom_cooked", 2 ],
         [ "morel_cooked", 2 ],
-        [ "acorns_cooked", 2 ]
+        [ "acorns_processed_any", 2, "LIST" ]
       ]
     ]
   },
@@ -799,7 +799,7 @@
         [ "dry_mushroom", 1 ],
         [ "mushroom_cooked", 1 ],
         [ "morel_cooked", 1 ],
-        [ "acorns_cooked", 1 ]
+        [ "acorns_processed_any", 1, "LIST" ]
       ]
     ]
   },
@@ -1132,6 +1132,12 @@
     ]
   },
   {
+    "id": "acorns_processed_any",
+    "type": "requirement",
+    "//": "Any acorns processed to remove tannins and are now palatable, either wet or dry",
+    "components": [ [ [ "acorns_cooked", 1 ], [ "acorn_roasted", 1 ], [ "acorns_blanched", 1 ] ] ]
+  },
+  {
     "id": "mushroom_soup_ingredients",
     "type": "requirement",
     "components": [
@@ -1194,7 +1200,7 @@
         [ "dandelion_cooked", 1 ],
         [ "burdock_cooked", 1 ],
         [ "bamboo_cooked", 1 ],
-        [ "acorns_cooked", 1 ],
+        [ "acorns_processed_any", 1, "LIST" ],
         [ "tofu", 1 ],
         [ "dry_tofu", 1 ],
         [ "raw_edamame", 1 ],


### PR DESCRIPTION
#### Summary

Balance "🌰 More options to use blanched/cooked/roasted acorns in soups and stews 🍲"

#### Purpose of change

Soup recipes were very specific about wanting only cooked acorns, not roasted or blanched. This is odd, because once the tannins are out of the acorns, it doesn't really matter if they're wet, try, or toasted.

#### Describe the solution

JSON edits:

- Create a `acorns_processed_any` ingredient group
- Use that group in soup and stew ingredient lists instead of cooked acorns where appropriate.

#### Describe alternatives you've considered

Doing more [independent research](https://cloudisland.nz/@pjf/110002658515745947) into acorns as food.

#### Testing

Loaded game with changes applied. Finally got to use my blanched acorns (which have been soaking for a week in-game) for something.

#### Additional context

None.