### PR TITLE
Fix print conversion error, fix more type warnings

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2503,11 +2503,10 @@ static void draw_spellbook_info( const spell_type &sp, uilist *menu )
     line += fold_and_print( w, point( start_x, line ), width, gray, "%s", sp.description );
     line++;
 
-    mvwprintz( w, point( start_x, line ), c_light_gray, string_format( "%s: %d", _( "Difficulty" ),
-               sp.difficulty.evaluate( d ) ) );
-    mvwprintz( w, point( start_x + width / 2, line++ ), c_light_gray, string_format( "%s: %d",
-               _( "Max Level" ),
-               sp.max_level.evaluate( d ) ) );
+    mvwprintz( w, point( start_x, line ), c_light_gray,
+               string_format( "%s: %d", _( "Difficulty" ), static_cast<int>( sp.difficulty.evaluate( d ) ) ) );
+    mvwprintz( w, point( start_x + width / 2, line++ ), c_light_gray,
+               string_format( "%s: %d", _( "Max Level" ), static_cast<int>( sp.max_level.evaluate( d ) ) ) );
 
     const std::string fx = sp.effect_name;
     std::string damage_string;
@@ -2546,47 +2545,36 @@ static void draw_spellbook_info( const spell_type &sp, uilist *menu )
                                        left_justify( _( "per lvl" ), 7 ),
                                        //~ translation should not exceed 7 console cells
                                        left_justify( _( "max lvl" ), 7 ) ) );
-    std::vector<std::tuple<std::string, int, float, int>> rows;
 
-    if( sp.max_damage.evaluate( d ) != 0 && sp.min_damage.evaluate( d ) != 0 &&
-        !damage_string.empty() ) {
-        rows.emplace_back( damage_string, sp.min_damage.evaluate( d ), sp.damage_increment.evaluate( d ),
-                           sp.max_damage.evaluate( d ) );
-    }
-
-    if( sp.max_range.evaluate( d ) != 0 && sp.min_range.evaluate( d ) != 0 ) {
-        rows.emplace_back( _( "Range" ), sp.min_range.evaluate( d ), sp.range_increment.evaluate( d ),
-                           sp.max_range.evaluate( d ) );
-    }
-
-    if( sp.min_aoe.evaluate( d ) != 0 && sp.max_aoe.evaluate( d ) != 0 && !aoe_string.empty() ) {
-        rows.emplace_back( aoe_string, sp.min_aoe.evaluate( d ), sp.aoe_increment.evaluate( d ),
-                           sp.max_aoe.evaluate( d ) );
-    }
-
-    if( sp.min_duration.evaluate( d ) != 0 && sp.max_duration.evaluate( d ) != 0 ) {
-        rows.emplace_back( _( "Duration" ), sp.min_duration.evaluate( d ),
-                           static_cast<float>( sp.duration_increment.evaluate( d ) ),
-                           sp.max_duration.evaluate( d ) );
-    }
-
-    rows.emplace_back( _( "Cast Cost" ), sp.base_energy_cost.evaluate( d ),
-                       sp.energy_increment.evaluate( d ),
-                       sp.final_energy_cost.evaluate( d ) );
-    rows.emplace_back( _( "Cast Time" ), sp.base_casting_time.evaluate( d ),
-                       sp.casting_time_increment.evaluate( d ),
-                       sp.final_casting_time.evaluate( d ) );
-
-    for( std::tuple<std::string, int, float, int> &row : rows ) {
-        mvwprintz( w, point( start_x, line ), c_light_gray, std::get<0>( row ) );
-        print_colored_text( w, point( start_x + 11, line ), gray, gray,
-                            color_number( std::get<1>( row ) ) );
-        print_colored_text( w, point( start_x + 19, line ), gray, gray,
-                            color_number( std::get<2>( row ) ) );
-        print_colored_text( w, point( start_x + 27, line ), gray, gray,
-                            color_number( std::get<3>( row ) ) );
+    const auto row = [&]( const std::string & label, const dbl_or_var<dialogue> &min_d,
+    const dbl_or_var<dialogue> &inc_d, const dbl_or_var<dialogue> &max_d, bool check_minmax = false ) {
+        const int min = static_cast<int>( min_d.evaluate( d ) );
+        const float inc = static_cast<float>( inc_d.evaluate( d ) );
+        const int max = static_cast<int>( max_d.evaluate( d ) );
+        if( check_minmax && ( min == 0 || max == 0 ) ) {
+            return;
+        }
+        mvwprintz( w, point( start_x, line ), c_light_gray, label );
+        print_colored_text( w, point( start_x + 11, line ), gray, gray, color_number( min ) );
+        print_colored_text( w, point( start_x + 19, line ), gray, gray, color_number( inc ) );
+        print_colored_text( w, point( start_x + 27, line ), gray, gray, color_number( max ) );
         line++;
+    };
+
+    if( !damage_string.empty() ) {
+        row( damage_string, sp.min_damage, sp.damage_increment, sp.max_damage, true );
     }
+
+    row( _( "Range" ), sp.min_range, sp.range_increment, sp.max_range, true );
+
+    if( !aoe_string.empty() ) {
+        row( aoe_string, sp.min_aoe, sp.aoe_increment, sp.max_aoe, true );
+    }
+
+    row( _( "Duration" ), sp.min_duration, sp.duration_increment, sp.max_duration, true );
+    row( _( "Cast Cost" ), sp.base_energy_cost, sp.energy_increment, sp.final_energy_cost, false );
+    row( _( "Cast Time" ), sp.base_casting_time, sp.casting_time_increment, sp.final_casting_time,
+         false );
 }
 
 void spellbook_callback::refresh( uilist *menu )

--- a/tests/firstaid_test.cpp
+++ b/tests/firstaid_test.cpp
@@ -114,7 +114,7 @@ TEST_CASE( "npc does healing", "[activity][firstaid][npc]" )
         dunsel.apply_damage( nullptr, right_arm, 20 );
         WHEN( "npc bandages self" ) {
             // See npc::heal_self()
-            bandages->type->invoke( dunsel, *bandages, dunsel.pos(), "heal" ).value_or( 0 );
+            bandages->type->invoke( dunsel, *bandages, dunsel.pos(), "heal" );
             process_activity( dunsel );
             THEN( "Check that bandage was consumed and arm is bandaged" ) {
                 CHECK( start_bandage_count - dunsel.items_with( bandages_filter ).size() == 1 );
@@ -126,7 +126,7 @@ TEST_CASE( "npc does healing", "[activity][firstaid][npc]" )
         dunsel.apply_damage( nullptr, right_arm, 20 );
         WHEN( "npc bandages self and is interrupted before finishing" ) {
             // See npc::heal_self()
-            bandages->type->invoke( dunsel, *bandages, dunsel.pos(), "heal" ).value_or( 0 );
+            bandages->type->invoke( dunsel, *bandages, dunsel.pos(), "heal" );
             process_activity_interrupt( dunsel, moves / 2 );
             THEN( "Check that bandage was not consumed and arm is not bandaged" ) {
                 CHECK( start_bandage_count - dunsel.items_with( bandages_filter ).size() == 0 );
@@ -138,7 +138,7 @@ TEST_CASE( "npc does healing", "[activity][firstaid][npc]" )
         dummy.apply_damage( nullptr, right_arm, 20 );
         WHEN( "npc bandages avatar" ) {
             // See npc::heal_player
-            bandages->type->invoke( dunsel, *bandages, dummy.pos(), "heal" ).value_or( 0 );
+            bandages->type->invoke( dunsel, *bandages, dummy.pos(), "heal" );
             process_activity( dunsel );
             THEN( "Check that bandage was consumed and avatar's arm is bandaged" ) {
                 CHECK( start_bandage_count - dunsel.items_with( bandages_filter ).size() == 1 );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #64525

#### Describe the solution

static_cast to correct type, not sure why string_format static asserts didn't shout at the mismatch but it is how it is.

<details>
  <summary>While I'm here fix a couple more discard and type conversion warnings for MSVC</summary>
  
  ### in firstaid_test.cpp
  ```js
  Warning	discarding return value of function with 'nodiscard' attribute	C:\projects\Cataclysm-DDA\tests\firstaid_test.cpp	117
  Warning	discarding return value of function with 'nodiscard' attribute	C:\projects\Cataclysm-DDA\tests\firstaid_test.cpp	129
  Warning	discarding return value of function with 'nodiscard' attribute	C:\projects\Cataclysm-DDA\tests\firstaid_test.cpp	141
  ```
  ### in same function - fix up the evaluations
  ```js
Message	see reference to function template instantiation '_Ty &std::vector<_Ty,std::allocator<_Ty>>::emplace_back<std::string&,double,double,double>(std::string &,double &&,double &&,double &&)' being compiled	C:\projects\Cataclysm-DDA\src\magic.cpp	2554
  ```
</details>

#### Describe alternatives you've considered

#### Testing

Follow steps in linked issue

#### Additional context
![image](https://user-images.githubusercontent.com/6560075/227645676-4bfa24d4-013b-4af8-b288-b591810427f1.png)
