### PR TITLE
Make ASRG not give x1000 intended power

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -937,7 +937,7 @@
     "damage_modifier": 80,
     "durability": 400,
     "description": "A rather heavy brick of metal housing an ASRG, formerly designed by NASA and repurposed for terrestrial use.  Will provide about 130w, basically forever as far as you're concerned.  Even though the alpha radiation these run off of isn't very dangerous in case of a breach, this unit appears to be armored to take a beating and is a good deal heavier owing to its composite plating.",
-    "epower": 130,
+    "epower": "130 W",
     "item": "compact_ASRG_containment",
     "requirements": {
       "repair": {

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1869,7 +1869,7 @@
     "damage_modifier": 80,
     "durability": 400,
     "description": "A military ASRG covered in heavy plating.  Provides constant albeit low power to your car.",
-    "epower": 130,
+    "epower": "130 W",
     "location": "center",
     "item": "compact_ASRG_containment",
     "requirements": {


### PR DESCRIPTION
#### Summary
Bugfixes "ASRG gives 130W, not 130kW"


#### Purpose of change

Fixes #64540

#### Describe the solution

Apply suggested fix.

#### Describe alternatives you've considered

![image](https://user-images.githubusercontent.com/99621099/227692869-d301c955-6fe4-4a8f-b4b8-b15bf96cc819.png)

#### Testing

![image](https://user-images.githubusercontent.com/99621099/227692920-9352b6c2-5d4a-4613-9ec2-42497e5e2193.png)


#### Additional context

``They can then haul them around (very bulky and heavy) and set them up for perpetual power. Per Nasa's design specs these produce 130w continuously. The equivalent of about 8-10 solar panels since these operate continuously irrespective of weather and sun radiance.`` ~ #59479