### PR TITLE
Use dummy definition in clang-tidy lit tests

### DIFF
--- a/tools/clang-tidy-plugin/test/assert.cpp
+++ b/tools/clang-tidy-plugin/test/assert.cpp
@@ -1,14 +1,12 @@
 // RUN: %check_clang_tidy %s cata-assert %t -- -plugins=%cata_plugin --
 
-#include <assert.h>
-#include <stdlib.h>
-
+// check_clang_tidy uses -nostdinc++, so we add dummy declarations of used values here
+#define assert( expr ) static_cast<void>( expr )
 namespace std
 {
-
 void abort();
-
 }
+using std::abort;
 
 #define cata_assert(expression) assert(expression)
 

--- a/tools/clang-tidy-plugin/test/no-long.cpp
+++ b/tools/clang-tidy-plugin/test/no-long.cpp
@@ -1,12 +1,12 @@
 // RUN: %check_clang_tidy %s cata-no-long %t -- -plugins=%cata_plugin --
 
-#include <stdint.h>
-
-// Want these defines without including limits.h.  They're probably not the
-// correct values, but it doesn't matter.
+// check_clang_tidy uses -nostdinc++, so we add dummy declarations of used values here
+// They're probably not the correct values, but it doesn't matter.
 #define LONG_MIN -2147483647
 #define LONG_MAX 2147483647
 #define ULONG_MAX 4294967295
+using int64_t = long long;
+using uint64_t = unsigned long long;
 
 long i1;
 // CHECK-MESSAGES: warning: Variable 'i1' declared as 'long'. Prefer int or int64_t to long. [cata-no-long]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
`check_clang_tidy.py` always passes `-nostdinc++`, so replace standard library declarations with dummy declarations in the lit tests.

#### Describe the solution

#### Describe alternatives you've considered
Figure out why it is always passing `-nostdinc++` and fix it.

#### Testing
The lit tests passes on my local machine.

#### Additional context