### PR TITLE
Fix clang-tidy failures related to xargs

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -51,7 +51,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libncursesw5-dev clang-12 libclang-12-dev llvm-12-dev llvm-12-tools \
             libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev ccache \
-            gettext
+            gettext jq
     - name: prepare
       run: bash ./build-scripts/requirements.sh
     - name: determine changed files

--- a/build-scripts/clang-tidy.sh
+++ b/build-scripts/clang-tidy.sh
@@ -97,9 +97,7 @@ then
     TIDY="all"
 fi
 
-all_cpp_files="$( \
-    grep '"file": "' build/compile_commands.json | \
-    sed "s+.*$PWD/++;s+\"$++")"
+all_cpp_files="$(jq -r '.[].file' build/compile_commands.json)"
 if [ "$TIDY" == "all" ]
 then
     echo "Analyzing all files"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
A `xargs` error emerged in recent `clang-tidy` checks and causes check failures.

https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4519254957/jobs/7959705440#step:7:1381

```
110974 warnings generated.
164119 warnings generated.
xargs: unmatched double quote; by default quotes are special to xargs unless you use the -0 option
110358 warnings generated.
29615 warnings generated.
112733 warnings generated.
Error: Process completed with exit code 1.
```

#### Diagnostics
`$tidyable_cpp_files` should contain a `\n` separated list of  `.cpp` file paths, but there is one ill-formed entry
```
src/chkjson/chkjson.cpp",
```

#### Describe the solution
Use `jq` to extract cpp file paths from `compile_commands.json` instead of the current `grep` + `sed` regex magic that can potentially mess up.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->