### PR TITLE
Fix rounding in vehicle glyph choice

### DIFF
--- a/src/tileray.cpp
+++ b/src/tileray.cpp
@@ -80,31 +80,30 @@ int tileray::quadrant() const
     return static_cast<int>( std::floor( direction / 90_degrees ) ) % 4;
 }
 
+// convert direction to nearest of 0=east, 1=south, 2=west, 3=north
+// ties broken in favor of north/south
 int tileray::dir4() const
 {
-    if( direction >= 45_degrees && direction <= 135_degrees ) {
+    // ensure direction is in range [0,360)
+    const units::angle dir = fmod( fmod( direction, 360_degrees ) + 360_degrees, 360_degrees );
+
+    // adjust and round values near diagonals before comparison to avoid floating point error
+    if( round_to_multiple_of( dir - 45_degrees, 1.5_degrees ) == 0_degrees ||
+        round_to_multiple_of( dir - 135_degrees, 1.5_degrees ) == 0_degrees ) {
         return 1;
-    } else if( direction > 135_degrees && direction < 225_degrees ) {
-        return 2;
-    } else if( direction >= 225_degrees && direction <= 315_degrees ) {
-        return 3;
-    } else {
-        return 0;
     }
+    if( round_to_multiple_of( dir - 225_degrees, 1.5_degrees ) == 0_degrees ||
+        round_to_multiple_of( dir - 315_degrees, 1.5_degrees ) == 0_degrees ) {
+        return 3;
+    }
+
+    return fmod( ( ( direction + 45_degrees ) / 90_degrees ), 4 );
 }
 
+// convert direction to nearest of 0=east, 1=southeast, 2=south, ...., 7=northeast
 int tileray::dir8() const
 {
-    int oct = 0;
-    units::angle dir = direction;
-    if( dir < 23_degrees || dir > 337_degrees ) {
-        return 0;
-    }
-    while( dir > 22_degrees ) {
-        dir -= 45_degrees;
-        oct += 1;
-    }
-    return oct;
+    return fmod( ( ( direction + 22.5_degrees ) / 45_degrees ), 8 );
 }
 
 // This function assumes a vehicle is being drawn.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Diagonal vehicle glyph correction"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
`dir4` did not previously honor our bias toward north/south when rounding diagonal angles.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
New rounding for comparisons in `dir4`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I tried a few different arithmetic and logic approaches, but none were consistent and concise.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Test suite ran. Drove around in-game with a few different vehicles.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This patch also replaces the loop in `dir8` with the same arithmetic logic (sans rounding) as the new `dir4`.
Resolves #49992

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->