### PR TITLE
Correctly silence clang-tidy

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1301,29 +1301,33 @@ template bool navigate_ui_list<defense_location, defense_location>( const std::s
         int page_delta, defense_location size, bool wrap );
 
 // Templating of existing `unsigned int` triggers linter rules against `unsigned long`
-// NOLINTBEGIN(cata-no-long)
+// NOLINTs below are to address
 template<typename V, typename S>
 bool navigate_ui_list( const std::string &action, V &val, int page_delta, S size, bool wrap )
 {
     if( action == "UP" || action == "SCROLL_UP" || action == "DOWN" || action == "SCROLL_DOWN" ) {
         if( wrap ) {
             val = increment_and_wrap( val, action == "DOWN" ||
+                                      // NOLINTNEXTLINE(cata-no-long)
                                       action == "SCROLL_DOWN", static_cast<V>( size ) );
         } else {
             val = increment_and_clamp( val, action == "DOWN" ||
+                                       // NOLINTNEXTLINE(cata-no-long)
                                        action == "SCROLL_DOWN", static_cast<V>( size - 1 ) );
         }
     } else if( ( action == "PAGE_UP" || action == "PAGE_DOWN" ) && page_delta ) {
         // page navigation never wraps
         val = increment_and_clamp( val, action == "PAGE_UP" ? -page_delta : page_delta,
+                                   // NOLINTNEXTLINE(cata-no-long)
                                    static_cast<V>( size - 1 ) );
     } else if( action == "HOME" ) {
+        // NOLINTNEXTLINE(cata-no-long)
         val = static_cast<V>( 0 );
     } else if( action == "END" && size ) {
+        // NOLINTNEXTLINE(cata-no-long)
         val = static_cast<V>( size ? size - 1 : 0 );
     } else {
         return false;
     }
     return true;
 }
-// NOLINTEND(cata-no-long)

--- a/src/ui.h
+++ b/src/ui.h
@@ -579,15 +579,16 @@ inline typename std::enable_if < !std::is_enum<V>::value, V >::type increment_an
         return 0;
     }
     // Templating of existing `unsigned int` triggers linter rules against `unsigned long`
-    // NOLINTBEGIN(cata-no-long)
+    // NOLINTNEXTLINE(cata-no-long)
     if( ( delta < 0 && val < static_cast<V>( -delta ) ) || ( delta > 0 &&
+            // NOLINTNEXTLINE(cata-no-long)
             static_cast<S>( val + delta ) >= size ) ) {
+        // NOLINTNEXTLINE(cata-no-long)
         if( val == 0 || ( val < static_cast<V>( size ) - 1 && delta > 0 ) ) {
             return size - 1;
         } else {
             return 0;
         }
-        // NOLINTEND(cata-no-long)
     } else {
         return val + delta;
     }
@@ -619,13 +620,12 @@ inline typename std::enable_if < !std::is_enum<V>::value, V >::type increment_an
         int delta, S max )
 {
     // Templating of existing `unsigned int` triggers linter rules against `unsigned long`
-    // NOLINTBEGIN(cata-no-long)
     if constexpr( std::is_unsigned_v<V> ) {
+        // NOLINTNEXTLINE(cata-no-long)
         if( delta < 0 && val <= static_cast<V>( -delta ) ) {
             return 0;
         }
     }
-    // NOLINTEND(cata-no-long)
     return std::clamp<V>( val + delta, 0, max );
 }
 


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
See https://github.com/CleverRaven/Cataclysm-DDA/pull/64567
We use clang-tidy 12, which doesn't support this syntax.

#### Describe the solution
 Replace with NOLINTNEXTLINEs.

#### Testing
See CI
