### PR TITLE
Allow displaying unavailable dialogue options

### DIFF
--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -7,6 +7,20 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_TEST_FAIL_RESPONSE",
+    "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
+    "responses": [
+      {
+        "condition": { "and": [ { "compare_num": [ { "const": 0 }, ">", { "const": 1 } ] } ] },
+        "text": "Never See this.",
+        "failure_explanation": "Impossible Test",
+        "failure_topic": "TALK_TEST_START",
+        "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_TEST_SIMPLE_STATS",
     "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
     "responses": [

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -614,6 +614,18 @@ The short format is equivalent to (an unconditional switching of the topic, `eff
 }
 ```
 
+When using a conditional you can specify the response to still appear but be marked as unavaiable. This can be done by adding a `failure_explanation` or `failure_topic` in the bellow example if the condition fails `*Didn't have enough: I, the player, say to you...` will be what appears in the responses, and if selected it will instead go to `TALK_EXPLAIN_FAILURE` and wont trigger the other effects:
+```json
+{
+    "condition": "...something...",
+    "failure_explanation": "Didn't have enough",
+    "failure_topic": "TALK_EXPLAIN_FAILURE",
+    "text": "I, the player, say to you...",
+    "effect": "...",
+    "topic": "TALK_WHATEVER"
+}
+```
+
 #### `text`
 Will be shown to the user, no further meaning.
 

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -330,6 +330,11 @@ class json_talk_response
         bool is_switch = false;
         bool is_default = false;
 
+        // this text appears if the conditions fail explaining why
+        translation failure_explanation;
+        // the topic to move to on failure
+        std::string failure_topic;
+
         void load_condition( const JsonObject &jo );
         bool test_condition( const dialogue &d ) const;
 

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -161,6 +161,26 @@ TEST_CASE( "npc_talk_start", "[npc_talk]" )
     CHECK( d.responses[0].text == "This is a basic test response." );
 }
 
+TEST_CASE( "npc_talk_failures", "[npc_talk]" )
+{
+    dialogue d;
+    prep_test( d );
+
+    d.add_topic( "TALK_TEST_FAIL_RESPONSE" );
+    gen_response_lines( d, 1 );
+    CHECK( d.responses[0].text == "*Impossible Test: Never See this." );
+}
+
+TEST_CASE( "npc_talk_failures_topic", "[npc_talk]" )
+{
+    dialogue d;
+    prep_test( d );
+
+    d.add_topic( "TALK_TEST_FAIL_RESPONSE" );
+    gen_response_lines( d, 1 );
+    CHECK( d.responses[0].success.next_topic.id == "TALK_TEST_START" );
+}
+
 TEST_CASE( "npc_talk_describe_mission", "[npc_talk]" )
 {
     dialogue d;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Allow displaying unavailable dialogue options"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
For certain interactions like the Artisan Crafters and selection menus like in #64285 having the ability to show dialogue options that aren't available would be ideal.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Responses can now include a failure_explanation and/or failure_topic. If either is include when a response condition fails a faux response is added to the list that is displayed in red and goes to TALK_NONE or the failure_topic.

Added relevant documentation

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added unit tests

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
![image](https://user-images.githubusercontent.com/4514073/227751955-9ff92f1e-a07d-4042-9d21-e5429cb47496.png)
![image](https://user-images.githubusercontent.com/4514073/227751957-76d92cc5-c5e0-4c83-b77d-9dc389ea51bf.png)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->