### PR TITLE
Item category spawn rate is now in game options

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -1217,7 +1217,6 @@ When you sort your inventory by category, these are the categories that are disp
 | zone            | The corresponding loot_zone (see loot_zones.json)
 | sort_rank       | Used to sort categories when displaying.  Lower values are shown first
 | priority_zones  | When set, items in this category will be sorted to the priority zone if the conditions are met. If the user does not have the priority zone in the zone manager, the items get sorted into zone set in the 'zone' property. It is a list of objects. Each object has 3 properties: ID: The id of a LOOT_ZONE (see LOOT_ZONES.json), filthy: boolean. setting this means filthy items of this category will be sorted to the priority zone, flags: array of flags
-|spawn_rate       | Sets amount of items from item category that might spawn.  Checks for `spawn_rate` value for item category.  If `spawn_chance` is 0.0, the item will not spawn. If `spawn_chance` is greater than 0.0 and less than 1.0, it will make a random roll (0.0-1.0) to check if the item will have a chance to spawn.  If `spawn_chance` is more than or equal to 1.0, it will add a chance to spawn additional items from the same category.  Items will be taken from item group which original item was located in.  Therefore this parameter won't affect chance to spawn additional items for items set to spawn solitary in mapgen (e.g. through use of `item` or `place_item`).
 
 ```C++
 {
@@ -1225,8 +1224,7 @@ When you sort your inventory by category, these are the categories that are disp
     "name": "ARMOR",
     "zone": "LOOT_ARMOR",
     "sort_rank": -21,
-    "priority_zones": [ { "id": "LOOT_FARMOR", "filthy": true, "flags": [ "RAINPROOF" ] } ],
-    "spawn_rate": 0.5
+    "priority_zones": [ { "id": "LOOT_FARMOR", "filthy": true, "flags": [ "RAINPROOF" ] } ]
 }
 ```
 

--- a/src/item_category.cpp
+++ b/src/item_category.cpp
@@ -57,7 +57,6 @@ void item_category::load( const JsonObject &jo, const std::string & )
     mandatory( jo, was_loaded, "sort_rank", sort_rank_ );
     optional( jo, was_loaded, "priority_zones", zone_priority_ );
     optional( jo, was_loaded, "zone", zone_, std::nullopt );
-    optional( jo, was_loaded, "spawn_rate", spawn_rate, 1.0f );
 }
 
 bool item_category::operator<( const item_category &rhs ) const
@@ -117,9 +116,4 @@ std::optional<zone_type_id> item_category::priority_zone( const item &it ) const
 int item_category::sort_rank() const
 {
     return sort_rank_;
-}
-
-float item_category::get_spawn_rate() const
-{
-    return spawn_rate;
 }

--- a/src/item_category.h
+++ b/src/item_category.h
@@ -38,8 +38,6 @@ class item_category
         translation name_;
         /** Used to sort categories when displaying.  Lower values are shown first. */
         int sort_rank_ = 0;
-        /** Global spawn rate for items from category */
-        float spawn_rate = 1.0f;
 
         std::optional<zone_type_id> zone_;
         std::vector<zone_priority_data> zone_priority_;
@@ -65,7 +63,6 @@ class item_category
         std::optional<zone_type_id> priority_zone( const item &it ) const;
         std::optional<zone_type_id> zone() const;
         int sort_rank() const;
-        float get_spawn_rate() const;
 
         /**
          * Comparison operators

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4933,8 +4933,8 @@ item &map::add_item_or_charges( const tripoint_bub_ms &pos, item obj, bool overf
 
 float map::item_category_spawn_rate( const item &itm )
 {
-    const item_category_id &cat = itm.get_category_of_contents().id;
-    const float spawn_rate = cat.obj().get_spawn_rate();
+    const std::string &cat = itm.get_category_of_contents().id.c_str();
+    const float spawn_rate = get_option<float>( "SPAWN_RATE_" + cat );
 
     return spawn_rate > 1.0f ? roll_remainder( spawn_rate ) : spawn_rate;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2536,11 +2536,6 @@ void options_manager::add_options_world_default()
          0.0, 50.0, 1.0, 0.1
        );
 
-    add( "ITEM_SPAWNRATE", "world_default", to_translation( "Item spawn scaling factor" ),
-         to_translation( "A scaling factor that determines density of item spawns.  A higher number means more items." ),
-         0.01, 10.0, 1.0, 0.01
-       );
-
     add( "NPC_SPAWNTIME", "world_default", to_translation( "Random NPC spawn time" ),
          to_translation( "Baseline average number of days between random NPC spawns.  Average duration goes up with the number of NPCs already spawned.  A higher number means fewer NPCs.  Set to 0 days to disable random NPCs." ),
          0.0, 100.0, 4.0, 0.01
@@ -2551,6 +2546,144 @@ void options_manager::add_options_world_default()
          to_translation( "A scaling factor that determines the time between monster upgrades.  A higher number means slower evolution.  Set to 0.00 to turn off monster upgrades." ),
          0.0, 100, 4.0, 0.01
        );
+
+    add_empty_line();
+
+    add( "ITEM_SPAWNRATE", "world_default", to_translation( "Item spawn scaling factor" ),
+         to_translation( "A scaling factor that determines density of item spawns.  A higher number means more items." ),
+         0.01, 10.0, 1.0, 0.01
+       );
+
+    add_option_group( "world_default", Group( "item_category_spawn_rate",
+                      to_translation( "Item category spawn rate" ),
+                      to_translation( "Spawn rate for item categories.  Values less than or equal to 1.0 represent a chance for items from category in question to spawn at all.  Values more than 1.0 represent amount of additional items from category in question to spawn.  Set to 0.0 to forbid spawning items from category in question." ) ),
+    [&]( const std::string & page_id ) {
+
+        add( "SPAWN_RATE_guns", page_id, to_translation( "Guns" ),
+             to_translation( "Spawn rate for items from GUNS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_magazines", page_id, to_translation( "Magazines" ),
+             to_translation( "Spawn rate for items from MAGAZINES category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_ammo", page_id, to_translation( "Ammo" ),
+             to_translation( "Spawn rate for items from AMMO category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_weapons", page_id, to_translation( "Weapons" ),
+             to_translation( "Spawn rate for items from WEAPONS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_tools", page_id, to_translation( "Tools" ),
+             to_translation( "Spawn rate for items from TOOLS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_clothing", page_id, to_translation( "Clothing" ),
+             to_translation( "Spawn rate for items from CLOTHING category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_armor", page_id, to_translation( "Armor" ),
+             to_translation( "Spawn rate for items from ARMOR category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_food", page_id, to_translation( "Food" ),
+             to_translation( "Spawn rate for items from FOOD category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_drugs", page_id, to_translation( "Drugs" ),
+             to_translation( "Spawn rate for items from DRUGS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_manuals", page_id, to_translation( "Manuals" ),
+             to_translation( "Spawn rate for items from MANUALS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_books", page_id, to_translation( "Books" ),
+             to_translation( "Spawn rate for items from BOOKS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_maps", page_id, to_translation( "Maps" ),
+             to_translation( "Spawn rate for items from MAPS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_mods", page_id, to_translation( "Mods" ),
+             to_translation( "Spawn rate for items from MODS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_mutagen", page_id, to_translation( "Mutagens" ),
+             to_translation( "Spawn rate for items from MUTAGENS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_bionics", page_id, to_translation( "Bionics" ),
+             to_translation( "Spawn rate for items from BIONICS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_currency", page_id, to_translation( "Currency" ),
+             to_translation( "Spawn rate for items from CURRENCY category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_veh_parts", page_id, to_translation( "Vehicle parts" ),
+             to_translation( "Spawn rate for items from VEHICLE PARTS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_fuel", page_id, to_translation( "Fuel" ),
+             to_translation( "Spawn rate for items from FUEL category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_seeds", page_id, to_translation( "Seeds" ),
+             to_translation( "Spawn rate for items from SEEDS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_chems", page_id, to_translation( "Chemicals" ),
+             to_translation( "Spawn rate for items from CHEMICAL STUFF category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_spare_parts", page_id, to_translation( "Spare parts" ),
+             to_translation( "Spawn rate for items from SPARE PARTS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_container", page_id, to_translation( "Containers" ),
+             to_translation( "Spawn rate for items from CONTAINERS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_artifacts", page_id, to_translation( "Artifacts" ),
+             to_translation( "Spawn rate for items from ARTIFACTS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_keys", page_id, to_translation( "Keys" ),
+             to_translation( "Spawn rate for items from KEYS category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+
+        add( "SPAWN_RATE_other", page_id, to_translation( "Other items" ),
+             to_translation( "Spawn rate for items from OTHER category." ),
+             0.0, 10.0, 1.0, 0.01
+           );
+    } );
 
     add_empty_line();
 


### PR DESCRIPTION
#### Summary
Features "Item category spawn rate is now in game options"

#### Purpose of change
Discoverability and ease of use of this feature while it was in json is very low.

#### Describe the solution
Moved this feature from json to game option, under `World options` tab. All options are named as `SPAWN_RATE_FOO`, where `FOO` is an id of item category. `item_category_spawn_rate` function now reads these options rather than json field.

Removed non-unused json field and function, updated docs.

#### Describe alternatives you've considered
None.

#### Testing
Set spawn rate for `FOOD` and `MANUALS` categories to 0.0, `DRUGS` to 2.0 and debug-spawned pharmacy to check than the feature still works.

#### Additional context
![изображение](https://user-images.githubusercontent.com/11132525/227755288-4622ad2f-478d-4a5b-860f-9eab7c11ba01.png)

![изображение](https://user-images.githubusercontent.com/11132525/227755295-d6217602-0402-4dc5-b29e-56d2879b9548.png)
