### PR TITLE
Add all effects to player display speed tab

### DIFF
--- a/data/json/character_modifiers.json
+++ b/data/json/character_modifiers.json
@@ -71,6 +71,13 @@
   },
   {
     "type": "character_mod",
+    "id": "move_mode_move_cost_mod",
+    "description": "Move mode move cost modifier",
+    "mod_type": "x",
+    "value": { "builtin": "move_mode_move_cost_modifier" }
+  },
+  {
+    "type": "character_mod",
     "id": "stamina_move_cost_mod",
     "description": "Stamina move cost modifier",
     "mod_type": "x",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -185,6 +185,8 @@ static const character_modifier_id character_modifier_limb_str_mod( "limb_str_mo
 static const character_modifier_id
 character_modifier_melee_stamina_cost_mod( "melee_stamina_cost_mod" );
 static const character_modifier_id
+character_modifier_move_mode_move_cost_mod( "move_mode_move_cost_mod" );
+static const character_modifier_id
 character_modifier_ranged_dispersion_vision_mod( "ranged_dispersion_vision_mod" );
 static const character_modifier_id
 character_modifier_stamina_move_cost_mod( "stamina_move_cost_mod" );
@@ -6442,7 +6444,8 @@ void Character::burn_move_stamina( int moves )
 
     burn_ratio *= move_mode->stamina_mult();
     mod_stamina( -( ( moves * burn_ratio ) / 100.0 ) * get_modifier(
-                     character_modifier_stamina_move_cost_mod ) );
+                     character_modifier_stamina_move_cost_mod ) * get_modifier(
+                     character_modifier_move_mode_move_cost_mod ) );
     add_msg_debug( debugmode::DF_CHARACTER, "Stamina burn: %d", -( ( moves * burn_ratio ) / 100 ) );
     // Chance to suffer pain if overburden and stamina runs out or has trait BADBACK
     // Starts at 1 in 25, goes down by 5 for every 50% more carried
@@ -9262,117 +9265,179 @@ int Character::run_cost( int base_cost, bool diag ) const
 {
     float movecost = static_cast<float>( base_cost );
     if( diag ) {
-        movecost *= 0.7071f; // because everything here assumes 100 is base
+        movecost /= M_SQRT2; // because effect logic assumes 100 base cost
     }
+    run_cost_effects( movecost );
+    if( diag ) {
+        movecost *= M_SQRT2;
+    }
+    return static_cast<int>( movecost );
+}
+
+std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) const
+{
+    std::vector<run_cost_effect> effects;
+
+    auto run_cost_effect_add = [&movecost, &effects]( float mod, const std::string & desc ) {
+        if( mod != 0 ) {
+            run_cost_effect effect { desc, 1.0, mod };
+            effects.push_back( effect );
+            movecost += mod;
+        }
+    };
+
+    auto run_cost_effect_mul = [&movecost, &effects]( float mod, const std::string & desc ) {
+        if( mod != 1.0 ) {
+            run_cost_effect effect { desc, mod, 0.0 };
+            effects.push_back( effect );
+            movecost *= mod;
+        }
+    };
+
     const bool flatground = movecost < 105;
     map &here = get_map();
     // The "FLAT" tag includes soft surfaces, so not a good fit.
     const bool on_road = flatground && here.has_flag( ter_furn_flag::TFLAG_ROAD, pos() );
     const bool on_fungus = here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FUNGUS, pos() );
 
-    if( !is_mounted() ) {
-        if( movecost > 105 ) {
-            movecost *= mutation_value( "movecost_obstacle_modifier" );
+    if( is_mounted() ) {
+        return effects;
+    }
 
-            if( has_proficiency( proficiency_prof_parkour ) ) {
-                movecost *= .5;
-            }
+    if( movecost > 105 ) {
+        run_cost_effect_mul( mutation_value( "movecost_obstacle_modifier" ),
+                             _( "Obstacle Muts" ) );
 
-            if( movecost < 100 ) {
-                movecost = 100;
-            }
-        }
-        if( has_trait( trait_M_IMMUNE ) && on_fungus ) {
-            if( movecost > 75 ) {
-                // Mycal characters are faster on their home territory, even through things like shrubs
-                movecost = 75;
-            }
+        if( has_proficiency( proficiency_prof_parkour ) ) {
+            run_cost_effect_mul( 0.5, _( "Parkour" ) );
         }
 
-        movecost *= get_modifier( is_prone() ? character_modifier_crawl_speed_movecost_mod :
-                                  character_modifier_limb_run_cost_mod );
-
-        movecost *= mutation_value( "movecost_modifier" );
-        if( flatground ) {
-            movecost *= mutation_value( "movecost_flatground_modifier" );
+        if( movecost < 100 ) {
+            run_cost_effect effect { _( "Bonuses Capped" ) };
+            effects.push_back( effect );
+            movecost = 100;
         }
-        if( has_trait( trait_PADDED_FEET ) && is_barefoot() ) {
-            movecost *= .9f;
-        }
-
-        if( worn_with_flag( flag_SLOWS_MOVEMENT ) ) {
-            movecost *= 1.1f;
-        }
-        if( worn_with_flag( flag_FIN ) ) {
-            movecost *= 1.5f;
-        }
-        if( worn_with_flag( flag_ROLLER_INLINE ) ) {
-            if( on_road ) {
-                if( is_running() ) {
-                    movecost *= 0.5f;
-                } else if( is_walking() ) {
-                    movecost *= 0.85f;
-                }
-            } else {
-                movecost *= 1.5f;
-            }
-        }
-        // Quad skates might be more stable than inlines,
-        // but that also translates into a slower speed when on good surfaces.
-        if( worn_with_flag( flag_ROLLER_QUAD ) ) {
-            if( on_road ) {
-                if( is_running() ) {
-                    movecost *= 0.7f;
-                } else if( is_walking() ) {
-                    movecost *= 0.85f;
-                }
-            } else {
-                movecost *= 1.3f;
-            }
-        }
-        // Skates with only one wheel (roller shoes) are fairly less stable
-        // and fairly slower as well
-        if( worn_with_flag( flag_ROLLER_ONE ) ) {
-            if( on_road ) {
-                if( is_running() ) {
-                    movecost *= 0.85f;
-                } else if( is_walking() ) {
-                    movecost *= 0.9f;
-                }
-            } else {
-                movecost *= 1.1f;
-            }
-        }
-
-        // ROOTS3 does slow you down as your roots are probing around for nutrients,
-        // whether you want them to or not.  ROOTS1 is just too squiggly without shoes
-        // to give you some stability.  Plants are a bit of a slow-mover.  Deal.
-        const bool mutfeet = has_flag( json_flag_TOUGH_FEET ) || worn_with_flag( flag_TOUGH_FEET );
-        if( !is_wearing_shoes( side::LEFT ) && !mutfeet ) {
-            movecost += 8;
-        }
-        if( !is_wearing_shoes( side::RIGHT ) && !mutfeet ) {
-            movecost += 8;
-        }
-
-        if( ( has_trait( trait_ROOTS3 ) || has_trait( trait_CHLOROMORPH ) ) &&
-            here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, pos() ) && is_barefoot() ) {
-            movecost += 10;
-        }
-
-        movecost = calculate_by_enchantment( movecost, enchant_vals::mod::MOVE_COST );
-        movecost /= get_modifier( character_modifier_stamina_move_cost_mod );
-
-        if( !is_mounted() && !is_prone() && has_effect( effect_downed ) ) {
-            movecost *= get_modifier( character_modifier_crawl_speed_movecost_mod ) * 2.5;
+    }
+    if( has_trait( trait_M_IMMUNE ) && on_fungus ) {
+        if( movecost > 75 ) {
+            // Mycal characters are faster on their home territory, even through things like shrubs
+            run_cost_effect_add( 75 - movecost, _( "Mycus on Fungus" ) );
         }
     }
 
-    if( diag ) {
-        movecost *= M_SQRT2;
+    if( is_prone() ) {
+        run_cost_effect_mul( get_modifier( character_modifier_crawl_speed_movecost_mod ),
+                             _( "Crawling" ) );
+    } else {
+        run_cost_effect_mul( get_modifier( character_modifier_limb_run_cost_mod ),
+                             _( "Encum./Wounds" ) );
     }
 
-    return static_cast<int>( movecost );
+    run_cost_effect_mul( mutation_value( "movecost_modifier" ), _( "Mutations" ) );
+
+    if( flatground ) {
+        run_cost_effect_mul( mutation_value( "movecost_flatground_modifier" ),
+                             _( "Flat Ground Mut." ) );
+    }
+
+    if( has_trait( trait_PADDED_FEET ) && is_barefoot() ) {
+        run_cost_effect_mul( 0.9f, _( "Bare Padded Feet" ) );
+    }
+
+    if( worn_with_flag( flag_SLOWS_MOVEMENT ) ) {
+        run_cost_effect_mul( 1.1f, _( "Tight Clothing" ) );
+    }
+
+    if( worn_with_flag( flag_FIN ) ) {
+        run_cost_effect_mul( 1.5f, _( "Swim Fins" ) );
+    }
+
+    if( worn_with_flag( flag_ROLLER_INLINE ) ) {
+        if( on_road ) {
+            if( is_running() ) {
+                run_cost_effect_mul( 0.5f, _( "Inline Skates" ) );
+            } else if( is_walking() ) {
+                run_cost_effect_mul( 0.85f, _( "Inline Skates" ) );
+            }
+        } else {
+            run_cost_effect_mul( 1.5f, _( "Inline Skates" ) );
+        }
+    }
+
+    // Quad skates might be more stable than inlines,
+    // but that also translates into a slower speed when on good surfaces.
+    if( worn_with_flag( flag_ROLLER_QUAD ) ) {
+        if( on_road ) {
+            if( is_running() ) {
+                run_cost_effect_mul( 0.7f, _( "Roller Skates" ) );
+            } else if( is_walking() ) {
+                run_cost_effect_mul( 0.85f, _( "Roller Skates" ) );
+            }
+        } else {
+            run_cost_effect_mul( 1.3f, _( "Roller Skates" ) );
+        }
+    }
+
+    // Skates with only one wheel (roller shoes) are fairly less stable
+    // and fairly slower as well
+    if( worn_with_flag( flag_ROLLER_ONE ) ) {
+        if( on_road ) {
+            if( is_running() ) {
+                run_cost_effect_mul( 0.85f, _( "Heelys" ) );
+            } else if( is_walking() ) {
+                run_cost_effect_mul( 0.9f, _( "Heelys" ) );
+            }
+        } else {
+            run_cost_effect_mul( 1.1f, _( "Heelys" ) );
+        }
+    }
+
+    // ROOTS3 does slow you down as your roots are probing around for nutrients,
+    // whether you want them to or not.  ROOTS1 is just too squiggly without shoes
+    // to give you some stability.  Plants are a bit of a slow-mover.  Deal.
+    const bool mutfeet = has_flag( json_flag_TOUGH_FEET ) || worn_with_flag( flag_TOUGH_FEET );
+    bool no_left_shoe = false;
+    bool no_right_shoe = false;
+    if( !is_wearing_shoes( side::LEFT ) && !mutfeet ) {
+        no_left_shoe = true;
+    }
+    if( !is_wearing_shoes( side::RIGHT ) && !mutfeet ) {
+        no_right_shoe = true;
+    }
+    if( no_left_shoe && no_right_shoe ) {
+        run_cost_effect_add( 16, _( "No Shoes" ) );
+    } else if( no_left_shoe ) {
+        run_cost_effect_add( 8, _( "No Left Shoe" ) );
+    } else if( no_right_shoe ) {
+        run_cost_effect_add( 8, _( "No Right Shoe" ) );
+    }
+
+    if( ( has_trait( trait_ROOTS3 ) || has_trait( trait_CHLOROMORPH ) ) &&
+        here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, pos() ) && is_barefoot() ) {
+        run_cost_effect_add( 10, _( "Roots" ) );
+    }
+
+    run_cost_effect_add( enchantment_cache->get_value_add( enchant_vals::mod::MOVE_COST ),
+                         _( "Enchantments" ) );
+    run_cost_effect_mul( 1.0 + enchantment_cache->get_value_multiply( enchant_vals::mod::MOVE_COST ),
+                         _( "Enchantments" ) );
+
+    run_cost_effect_mul( 1.0 / get_modifier( character_modifier_stamina_move_cost_mod ),
+                         _( "Stamina" ) );
+
+    run_cost_effect_mul( 1.0 / get_modifier( character_modifier_move_mode_move_cost_mod ),
+                         //TODO get these strings from elsewhere
+                         is_running() ? _( "Running" ) :
+                         is_crouching() ? _( "Crouching" ) :
+                         is_prone() ? _( "Prone" ) : _( "Walking" )
+                       );
+
+    if( !is_mounted() && !is_prone() && has_effect( effect_downed ) ) {
+        run_cost_effect_mul( get_modifier( character_modifier_crawl_speed_movecost_mod ) * 2.5,
+                             _( "Downed" ) );
+    }
+
+    return effects;
 }
 
 void Character::place_corpse()
@@ -10883,8 +10948,23 @@ int Character::thirst_speed_penalty( int thirst )
     return static_cast<int>( multi_lerp( thirst_thresholds, thirst ) );
 }
 
+std::vector<speed_bonus_effect> Character::get_speed_bonus_effects() const
+{
+    return speed_bonus_effects;
+}
+
+void Character::mod_speed_bonus( int nspeed, const std::string &desc )
+{
+    if( nspeed != 0 ) {
+        speed_bonus_effect effect { desc, nspeed };
+        speed_bonus_effects.push_back( effect );
+        speed_bonus += nspeed;
+    }
+}
+
 void Character::recalc_speed_bonus()
 {
+    speed_bonus_effects.clear();
     // Minus some for weight...
     int carry_penalty = 0;
     units::mass weight_cap = weight_capacity();
@@ -10894,34 +10974,36 @@ void Character::recalc_speed_bonus()
     if( weight_carried() > weight_cap ) {
         carry_penalty = 25 * ( weight_carried() - weight_cap ) / weight_cap;
     }
-    mod_speed_bonus( -carry_penalty );
+    mod_speed_bonus( -carry_penalty, _( "Weight Carried" ) );
 
-    mod_speed_bonus( +get_speedydex_bonus( get_dex() ) );
+    mod_speed_bonus( +get_speedydex_bonus( get_dex() ), _( "Dexterity" ) );
 
-    mod_speed_bonus( -get_pain_penalty().speed );
+    mod_speed_bonus( -get_pain_penalty().speed, _( "Pain" ) );
 
     if( get_thirst() > 40 ) {
-        mod_speed_bonus( thirst_speed_penalty( get_thirst() ) );
+        mod_speed_bonus( thirst_speed_penalty( get_thirst() ), _( "Thirst" ) );
     }
     // when underweight, you get slower. cumulative with hunger
-    mod_speed_bonus( kcal_speed_penalty() );
+    mod_speed_bonus( kcal_speed_penalty(), _( "Underweight" ) );
 
     for( const auto &maps : *effects ) {
         for( const auto &i : maps.second ) {
             bool reduced = resists_effect( i.second );
-            mod_speed_bonus( i.second.get_mod( "SPEED", reduced ) );
+            //TODO try disp_short_desc() or disp_short_desc(true) if disp_name doesn't work well
+            mod_speed_bonus( i.second.get_mod( "SPEED", reduced ), i.second.disp_name() );
         }
     }
 
     // add martial arts speed bonus
-    mod_speed_bonus( mabuff_speed_bonus() );
+    mod_speed_bonus( mabuff_speed_bonus(), _( "Martial Art" ) );
 
     // Not sure why Sunlight Dependent is here, but OK
     // Ectothermic/COLDBLOOD4 is intended to buff folks in the Summer
     // Threshold-crossing has its charms ;-)
     if( g != nullptr ) {
         if( has_trait( trait_SUNLIGHT_DEPENDENT ) && !g->is_in_sunlight( pos() ) ) {
-            mod_speed_bonus( -( g->light_level( posz() ) >= 12 ? 5 : 10 ) );
+            //FIXME get trait name directly
+            mod_speed_bonus( -( g->light_level( posz() ) >= 12 ? 5 : 10 ), _( "Sunlight Dependent" ) );
         }
         const float temperature_speed_modifier = mutation_value( "temperature_speed_modifier" );
         if( temperature_speed_modifier != 0 ) {
@@ -10930,18 +11012,20 @@ void Character::recalc_speed_bonus()
             if( has_flag( json_flag_ECTOTHERM ) ||
                 player_local_temp < units::from_fahrenheit( 65 - climate_control ) ) {
                 mod_speed_bonus( ( units::to_fahrenheit( player_local_temp ) - 65 + climate_control ) *
-                                 temperature_speed_modifier );
+                                 temperature_speed_modifier, _( "Ectothermic" ) );
             }
         }
     }
     const int prev_speed_bonus = get_speed_bonus();
-    set_speed_bonus( std::round( enchantment_cache->modify_value( enchant_vals::mod::SPEED,
-                                 get_speed() ) - get_speed_base() ) );
-    enchantment_speed_bonus = get_speed_bonus() - prev_speed_bonus;
+    const int speed_bonus_with_enchant = std::round( enchantment_cache->modify_value(
+            enchant_vals::mod::SPEED,
+            get_speed() ) - get_speed_base() );
+    enchantment_speed_bonus = speed_bonus_with_enchant - prev_speed_bonus;
+    mod_speed_bonus( enchantment_speed_bonus, _( "Bio/Mut/Etc Effects" ) );
     // Speed cannot be less than 25% of base speed, so minimal speed bonus is -75% base speed.
     const int min_speed_bonus = static_cast<int>( -0.75 * get_speed_base() );
     if( get_speed_bonus() < min_speed_bonus ) {
-        set_speed_bonus( min_speed_bonus );
+        mod_speed_bonus( min_speed_bonus - get_speed_bonus(), _( "Penalty Cap" ) );
     }
 }
 

--- a/src/character.h
+++ b/src/character.h
@@ -405,6 +405,17 @@ struct pocket_data_with_parent {
     int nested_level;
 };
 
+struct speed_bonus_effect {
+    std::string description;
+    int bonus = 0;
+};
+
+struct run_cost_effect {
+    std::string description;
+    float times = 1.0;
+    float plus = 0;
+};
+
 class Character : public Creature, public visitable
 {
     public:
@@ -504,6 +515,12 @@ class Character : public Creature, public visitable
         int get_per_bonus() const;
         int get_int_bonus() const;
 
+    private:
+        /** Modifiers to character speed, with descriptions */
+        std::vector<speed_bonus_effect> speed_bonus_effects;
+
+    public:
+        std::vector<speed_bonus_effect> get_speed_bonus_effects() const;
         int get_speed() const override;
         int get_enchantment_speed_bonus() const;
         // Strength modified by limb lifting score
@@ -524,6 +541,10 @@ class Character : public Creature, public visitable
         void mod_dex_bonus( int ndex );
         void mod_per_bonus( int nper );
         void mod_int_bonus( int nint );
+
+        /** Setters for stats shared with other creatures */
+        using Creature::mod_speed_bonus;
+        void mod_speed_bonus( int nspeed, const std::string &desc );
 
         // Prints message(s) about current health
         void print_health() const;
@@ -2859,8 +2880,11 @@ class Character : public Creature, public visitable
         // Put corpse+inventory on defined om tile
         void place_corpse( const tripoint_abs_omt &om_target );
 
+        /** Modifies the movement cost and returns a list of effects */
+        std::vector<run_cost_effect> run_cost_effects( float &movecost ) const;
         /** Returns the player's modified base movement cost */
-        int  run_cost( int base_cost, bool diag = false ) const;
+        int run_cost( int base_cost, bool diag = false ) const;
+
         const pathfinding_settings &get_pathfinding_settings() const override;
         std::set<tripoint> get_path_avoid() const override;
         /**

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -270,12 +270,18 @@ static float aim_speed_dex_modifier( const Character &c, const skill_id & )
     return ( c.get_dex() - 8 ) * 0.5f;
 }
 
+static float move_mode_move_cost_modifier( const Character &c, const skill_id & )
+{
+    // Both walk and run speed drop to half their maximums as stamina approaches 0.
+    // Convert stamina to a float first to allow for decimal place carrying
+    return c.move_mode->move_speed_mult();
+}
+
 static float stamina_move_cost_modifier( const Character &c, const skill_id & )
 {
     // Both walk and run speed drop to half their maximums as stamina approaches 0.
     // Convert stamina to a float first to allow for decimal place carrying
-    float stamina_modifier = ( static_cast<float>( c.get_stamina() ) / c.get_stamina_max() + 1 ) / 2;
-    return stamina_modifier * c.move_mode->move_speed_mult();
+    return ( static_cast<float>( c.get_stamina() ) / c.get_stamina_max() + 1 ) / 2;
 }
 
 static float limb_run_cost_modifier( const Character &c, const skill_id & )
@@ -289,6 +295,7 @@ static float call_builtin( const std::string &builtin, const Character &c, const
     static const std::map<std::string, std::function<float( const Character &, const skill_id & )>>
     func_map = {
         { "limb_run_cost_modifier", limb_run_cost_modifier },
+        { "move_mode_move_cost_modifier", move_mode_move_cost_modifier },
         { "stamina_move_cost_modifier", stamina_move_cost_modifier },
         { "aim_speed_dex_modifier", aim_speed_dex_modifier },
         { "aim_speed_skill_modifier", aim_speed_skill_modifier }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -46,8 +46,6 @@
 
 static const bionic_id bio_cqb( "bio_cqb" );
 
-static const json_character_flag json_flag_ECTOTHERM( "ECTOTHERM" );
-
 static const skill_id skill_bashing( "bashing" );
 static const skill_id skill_cutting( "cutting" );
 static const skill_id skill_dodge( "dodge" );
@@ -55,7 +53,6 @@ static const skill_id skill_melee( "melee" );
 static const skill_id skill_stabbing( "stabbing" );
 static const skill_id skill_unarmed( "unarmed" );
 
-static const trait_id trait_SUNLIGHT_DEPENDENT( "SUNLIGHT_DEPENDENT" );
 static const trait_id trait_TROGLO( "TROGLO" );
 static const trait_id trait_TROGLO2( "TROGLO2" );
 static const trait_id trait_TROGLO3( "TROGLO3" );
@@ -64,6 +61,7 @@ static const std::string title_STATS = translate_marker( "STATS" );
 static const std::string title_ENCUMB = translate_marker( "ENCUMBRANCE AND WARMTH" );
 static const std::string title_EFFECTS = translate_marker( "EFFECTS" );
 static const std::string title_SPEED = translate_marker( "SPEED" );
+static const std::string title_MOVE_COST = translate_marker( "MOVE COST" );
 static const std::string title_SKILLS = translate_marker( "SKILLS" );
 static const std::string title_BIONICS = translate_marker( "BIONICS" );
 static const std::string title_TRAITS = translate_marker( "TRAITS" );
@@ -297,6 +295,7 @@ namespace
 enum class player_display_tab : int {
     stats,
     encumbrance,
+    speed,
     skills,
     traits,
     bionics,
@@ -878,6 +877,41 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
     wnoutrefresh( w_skills );
 }
 
+struct speedlist_entry {
+    bool is_speed;
+    std::string description;
+    int val;
+    bool percent;
+};
+
+static void draw_speed_info( const catacurses::window &w_info,
+                             unsigned int line,
+                             const std::vector<speedlist_entry> &speedlist )
+{
+    werase( w_info );
+
+    if( speedlist[line].val != 0 ) {
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        mvwprintz( w_info, point( 1, 0 ), c_light_gray,
+                   //~ One of a list of reasons speed or movecost are being changed
+                   _( "Cause: %s" ), speedlist[line].description );
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        mvwprintz( w_info, point( 1, 1 ), c_light_gray,
+                   //~ speed or movecost reduced by a constant or percentage
+                   speedlist[line].val < 0 ? _( "Effect: %1$s reduced by %2$d%3$c" ) :
+                   //~ speed or movecost increased by a constant or percentage
+                   _( "Effect: %1$s increased by %2$d%3$c" ),
+                   speedlist[line].is_speed ? _( "Speed" ) : _( "Move Cost" ),
+                   std::abs( speedlist[line].val ),
+                   speedlist[line].percent ? '%' : ' ' );
+    } else {
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        mvwprintz( w_info, point( 1, 0 ), c_light_gray, speedlist[line].description );
+    }
+
+    wnoutrefresh( w_info );
+}
+
 static void draw_skills_info( const catacurses::window &w_info, const Character &you,
                               unsigned int line,
                               const std::vector<HeaderSkill> &skillslist )
@@ -889,8 +923,6 @@ static void draw_skills_info( const catacurses::window &w_info, const Character 
         selectedSkill = skillslist[line].skill;
     }
 
-    werase( w_info );
-
     if( selectedSkill ) {
         const SkillLevel &level = you.get_skill_level_object( selectedSkill->ident() );
         std::string info_text = selectedSkill->description();
@@ -901,110 +933,106 @@ static void draw_skills_info( const catacurses::window &w_info, const Character 
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, info_text );
     }
+
     wnoutrefresh( w_info );
 }
 
-static void draw_speed_tab( const catacurses::window &w_speed,
-                            const Character &you,
-                            const std::map<std::string, int> &speed_effects )
+static std::vector<speedlist_entry> get_speedlist_entries( const Character &you, int &move_cost,
+        const std::map<std::string, int> &speed_effects )
 {
-    werase( w_speed );
-    // Finally, draw speed.
-    center_print( w_speed, 0, c_light_gray, _( title_SPEED ) );
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    mvwprintz( w_speed, point( 1, 1 ), c_light_gray, _( "Base Move Cost:" ) );
-    mvwprintz( w_speed, point( 1, 2 ), c_light_gray, _( "Current Speed:" ) );
-    int newmoves = you.get_speed();
-    int pen = 0;
-    unsigned int line = 3;
-    if( you.weight_carried() > you.weight_capacity() ) {
-        pen = 25 * ( you.weight_carried() - you.weight_capacity() ) / you.weight_capacity();
-        mvwprintz( w_speed, point( 1, line ), c_red,
-                   pgettext( "speed penalty", "Overburdened        -%2d%%" ), pen );
-        ++line;
-    }
-    pen = you.get_pain_penalty().speed;
-    if( pen >= 1 ) {
-        mvwprintz( w_speed, point( 1, line ), c_red,
-                   pgettext( "speed penalty", "Pain                -%2d%%" ), pen );
-        ++line;
-    }
-    if( you.get_thirst() > 40 ) {
-        pen = std::abs( Character::thirst_speed_penalty( you.get_thirst() ) );
-        mvwprintz( w_speed, point( 1, line ), c_red,
-                   pgettext( "speed penalty", "Thirst              -%2d%%" ), pen );
-        ++line;
-    }
-    if( you.kcal_speed_penalty() < 0 ) {
-        pen = std::abs( you.kcal_speed_penalty() );
-        const std::string inanition = you.get_bmi_fat() < character_weight_category::underweight ?
-                                      _( "Starving" ) : _( "Underfed" );
-        //~ %s: Starving/Underfed (already left-justified), %2d: speed penalty
-        mvwprintz( w_speed, point( 1, line ), c_red, pgettext( "speed penalty", "%s-%2d%%" ),
-                   left_justify( inanition, 20 ), pen );
-        ++line;
-    }
-    if( you.has_trait( trait_SUNLIGHT_DEPENDENT ) && !g->is_in_sunlight( you.pos() ) ) {
-        pen = ( g->light_level( you.posz() ) >= 12 ? 5 : 10 );
-        mvwprintz( w_speed, point( 1, line ), c_red,
-                   pgettext( "speed penalty", "Out of Sunlight     -%2d%%" ), pen );
-        ++line;
-    }
+    std::vector<speedlist_entry> entries;
 
-    const float temperature_speed_modifier = you.mutation_value( "temperature_speed_modifier" );
-    if( temperature_speed_modifier != 0 ) {
-        const int climate_control = you.enchantment_cache->get_value_add(
-                                        enchant_vals::mod::CLIMATE_CONTROL_HEAT );
-        nc_color pen_color;
-        std::string pen_sign;
-        const units::temperature player_local_temp = get_weather().get_temperature( you.pos() );
-        if( you.has_flag( json_flag_ECTOTHERM ) &&
-            player_local_temp > units::from_fahrenheit( 65 - climate_control ) ) {
-            pen_color = c_green;
-            pen_sign = "+";
-        } else if( player_local_temp < units::from_fahrenheit( 65 - climate_control ) ) {
-            pen_color = c_red;
-            pen_sign = "-";
-        }
-        if( !pen_sign.empty() ) {
-            pen = ( units::to_fahrenheit( player_local_temp ) - 65 + climate_control ) *
-                  temperature_speed_modifier;
-            mvwprintz( w_speed, point( 1, line ), pen_color,
-                       //~ %s: sign of bonus/penalty, %2d: speed bonus/penalty
-                       pgettext( "speed modifier", "Cold-Blooded        %s%2d%%" ), pen_sign, std::abs( pen ) );
-            ++line;
+    for( const speed_bonus_effect &effect : you.get_speed_bonus_effects() ) {
+        if( effect.bonus != 0 ) {
+            const speedlist_entry entry { true, effect.description, effect.bonus, false };
+            entries.push_back( entry );
         }
     }
 
-    const int speed_modifier = you.get_enchantment_speed_bonus();
-
-    if( speed_modifier != 0 ) {
-        mvwprintz( w_speed, point( 1, line ), c_green,
-                   pgettext( "speed bonus", "Bio/Mut/Effects     +%2d" ), speed_modifier );
-        ++line;
-    }
-
+    //FIXME I think these are already included above. Need more testing.
     for( const std::pair<const std::string, int> &speed_effect : speed_effects ) {
-        nc_color col = speed_effect.second > 0 ? c_green : c_red;
-        mvwprintz( w_speed, point( 1, line ), col, "%s", speed_effect.first );
-        mvwprintz( w_speed, point( 21, line ), col, ( speed_effect.second > 0 ? "+" : "-" ) );
-        mvwprintz( w_speed, point( std::abs( speed_effect.second ) >= 10 ? 22 : 23, line ), col, "%d%%",
-                   std::abs( speed_effect.second ) );
-        ++line;
+        if( speed_effect.second != 0 ) {
+            const speedlist_entry entry { true, speed_effect.first, speed_effect.second, false };
+            entries.push_back( entry );
+        }
     }
 
-    int runcost = you.run_cost( 100 );
-    nc_color col = runcost <= 100 ? c_green : c_red;
-    mvwprintz( w_speed, point( 21 + ( runcost >= 100 ? 0 : ( runcost < 10 ? 2 : 1 ) ), 1 ), col,
-               "%d", runcost );
-    col = ( newmoves >= 100 ? c_green : c_red );
-    mvwprintz( w_speed, point( 21 + ( newmoves >= 100 ? 0 : ( newmoves < 10 ? 2 : 1 ) ), 2 ), col,
-               "%d", newmoves );
+    float movecost = 100;
+    for( const run_cost_effect &effect : you.run_cost_effects( movecost ) ) {
+        const int percent = std::trunc( effect.times * 100 - 100 ); // truncate toward 0%
+        const int constant = std::trunc( effect.plus ); // truncate toward 0
+        if( ( effect.times != 1.0 && percent == 0 ) || ( effect.plus != 0 && constant == 0 ) ) {
+            continue; // negligible effect
+        }
+        const speedlist_entry entry { false, effect.description, percent != 0 ? percent : constant, percent != 0 };
+        entries.push_back( entry );
+    }
+    move_cost = static_cast<int>( movecost );
+
+    return entries;
+}
+
+static void draw_speed_tab( ui_adaptor &ui, const catacurses::window &w_speed,
+                            const unsigned line, const player_display_tab curtab,
+                            const Character &you,
+                            const std::vector<speedlist_entry> &speedlist, const int move_cost )
+{
+    //FIXME this tab needs to support scrolling
+    werase( w_speed );
+    const bool is_current_tab = curtab == player_display_tab::speed;
+    if( is_current_tab ) {
+        ui.set_cursor( w_speed, point( 0, 2 ) );
+    }
+
+    const int speed = you.get_speed();
+    center_print( w_speed, 0, c_light_gray, string_format( "%s: <color_%s>%d</color>",
+                  _( title_SPEED ), speed >= 100 ? "light_green" : "red", speed ) );
+    center_print( w_speed, 1, c_light_gray, string_format( "%s: <color_%s>%d</color>",
+                  _( title_MOVE_COST ), move_cost <= 100 ? "light_green" : "red", move_cost ) );
+
+    const int height = getmaxy( w_speed ) - 2;
+    const bool do_draw_scrollbar = height < static_cast<int>( speedlist.size() );
+    const int width = getmaxx( w_speed ) - 1 - ( do_draw_scrollbar ? 1 : 0 );
+    const auto& [i_start, i_end] = subindex_around_cursor( speedlist.size(), height, line,
+                                   is_current_tab );
+
+    for( size_t i = i_start; i < static_cast<size_t>( i_end ); ++i ) {
+        const bool highlight_line = is_current_tab && i == line;
+        const point pos( 1, 2 + i - i_start );
+        if( highlight_line ) {
+            ui.set_cursor( w_speed, pos );
+        }
+        const speedlist_entry entry = speedlist[i];
+
+        // +speed is good, -movecost is good
+        const nc_color col = entry.is_speed == ( entry.val > 0 ) ? c_light_green : c_red;
+        const nc_color hcol = highlight_line ? hilite( col ) : col;
+        mvwprintz( w_speed, pos, hcol, "%s", entry.description );
+        //~ single character abbreviations for Speed and Move Cost
+        mvwprintz( w_speed, pos + point( 18, 0 ), hcol, "%s", entry.is_speed ? _( "S" ) : _( "M" ) );
+        if( entry.val != 0 ) {
+            const char prefix = entry.val < 0 ? '-' : '+';
+            const char suffix = entry.percent ? '%' : ' ';
+            if( entry.val < 1000 ) {
+                mvwprintz( w_speed, pos + point( 19, 0 ), hcol, "%c%3d%c", prefix, std::abs( entry.val ), suffix );
+            } else {
+                // broken limbs can cause this
+                mvwprintz( w_speed, pos + point( 19, 0 ), hcol, "%c!!!%c", prefix, suffix );
+            }
+        }
+    }
+
+    if( do_draw_scrollbar ) {
+        draw_scrollbar( w_speed, i_start, height, speedlist.size(), point( width + 1, 2 ),
+                        c_white, true );
+    }
+
     wnoutrefresh( w_speed );
 }
 
 static void draw_info_window( const catacurses::window &w_info, const Character &you,
                               const unsigned line, const unsigned info_line, const player_display_tab curtab,
+                              const std::vector<speedlist_entry> &speedlist,
                               const std::vector<trait_and_var> &traitslist,
                               const std::vector<bionic_grouping> &bionicslist,
                               const std::vector<std::pair<std::string, std::string>> &effect_name_and_text,
@@ -1016,6 +1044,9 @@ static void draw_info_window( const catacurses::window &w_info, const Character 
             break;
         case player_display_tab::encumbrance:
             draw_encumbrance_info( w_info, you, line, info_line );
+            break;
+        case player_display_tab::speed:
+            draw_speed_info( w_info, line, speedlist );
             break;
         case player_display_tab::skills:
             draw_skills_info( w_info, you, line, skillslist );
@@ -1133,6 +1164,7 @@ static void on_customize_character( Character &you )
 
 static int get_line_count( player_display_tab curtab,
                            Character &you,
+                           const std::vector<speedlist_entry> &speedlist,
                            std::vector<trait_and_var> &traitslist,
                            const std::vector<bionic_grouping> &bionicslist,
                            const std::vector<std::pair<std::string,
@@ -1146,6 +1178,8 @@ static int get_line_count( player_display_tab curtab,
             const std::vector<std::pair<bodypart_id, bool>> bps = list_and_combine_bps( you, nullptr );
             return bps.size();
         }
+        case player_display_tab::speed:
+            return speedlist.size();
         case player_display_tab::traits:
             return traitslist.size();
         case player_display_tab::bionics:
@@ -1166,8 +1200,9 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
         unsigned int &info_line,
         player_display_tab &curtab, input_context &ctxt, const ui_adaptor &ui_tip,
         const ui_adaptor &ui_info, const ui_adaptor &ui_stats, const ui_adaptor &ui_encumb,
-        const ui_adaptor &ui_traits, const ui_adaptor &ui_bionics, const ui_adaptor &ui_effects,
-        const ui_adaptor &ui_skills, const ui_adaptor &ui_proficiencies,
+        const ui_adaptor &ui_speed, const ui_adaptor &ui_traits, const ui_adaptor &ui_bionics,
+        const ui_adaptor &ui_effects, const ui_adaptor &ui_skills, const ui_adaptor &ui_proficiencies,
+        const std::vector<speedlist_entry> &speedlist,
         std::vector<trait_and_var> &traitslist,
         const std::vector<bionic_grouping> &bionicslist,
         const std::vector<std::pair<std::string, std::string>> &effect_name_and_text,
@@ -1182,6 +1217,9 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
                 break;
             case player_display_tab::encumbrance:
                 ui_encumb.invalidate_ui();
+                break;
+            case player_display_tab::speed:
+                ui_speed.invalidate_ui();
                 break;
             case player_display_tab::traits:
                 ui_traits.invalidate_ui();
@@ -1203,7 +1241,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
         }
     };
 
-    unsigned int line_count = get_line_count( curtab, you, traitslist, bionicslist,
+    unsigned int line_count = get_line_count( curtab, you, speedlist, traitslist, bionicslist,
                               effect_name_and_text, skillslist );
 
     if( line_count > 0 ) {
@@ -1241,7 +1279,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
                 invalidate_tab( curtab );
                 curtab = player_display_tab( i );
                 invalidate_tab( curtab );
-                line_count = get_line_count( curtab, you, traitslist, bionicslist, effect_name_and_text,
+                line_count = get_line_count( curtab, you, speedlist, traitslist, bionicslist, effect_name_and_text,
                                              skillslist );
                 line = std::clamp( p.value().y - 1, 0, int( line_count ) );
                 ui_info.invalidate_ui();
@@ -1608,6 +1646,9 @@ void Character::disp_info( bool customize_character )
         }
     }
 
+    int move_cost;
+    std::vector<speedlist_entry> speedlist = get_speedlist_entries( *this, move_cost, speed_effects );
+
     border_helper borders;
 
     player_display_tab curtab = player_display_tab::stats;
@@ -1824,7 +1865,7 @@ void Character::disp_info( bool customize_character )
         wnoutrefresh( w_info_border );
         ui_info.disable_cursor();
         draw_info_window( w_info, *this, line, info_line, curtab,
-                          traitslist, bionicslist, effect_name_and_text, skillslist );
+                          speedlist, traitslist, bionicslist, effect_name_and_text, skillslist );
     } );
 
     // SPEED
@@ -1845,7 +1886,7 @@ void Character::disp_info( bool customize_character )
         borders.draw_border( w_speed_border );
         wnoutrefresh( w_speed_border );
         ui_speed.disable_cursor();
-        draw_speed_tab( w_speed, *this, speed_effects );
+        draw_speed_tab( ui_speed, w_speed, line, curtab, *this, speedlist, move_cost );
     } );
 
     bool done = false;
@@ -1856,8 +1897,8 @@ void Character::disp_info( bool customize_character )
         ui_manager::redraw_invalidated();
 
         done = handle_player_display_action( *this, line, info_line, curtab, ctxt, ui_tip, ui_info,
-                                             ui_stats, ui_encumb, ui_traits, ui_bionics, ui_effects,
-                                             ui_skills, ui_proficiencies, traitslist, bionicslist,
+                                             ui_stats, ui_encumb, ui_speed, ui_traits, ui_bionics, ui_effects,
+                                             ui_skills, ui_proficiencies, speedlist, traitslist, bionicslist,
                                              effect_name_and_text, skillslist, customize_character,
                                              windows, w_tip, tip_btn_highlight );
     } while( !done );

--- a/tests/char_stamina_test.cpp
+++ b/tests/char_stamina_test.cpp
@@ -9,6 +9,8 @@
 #include "units.h"
 
 static const character_modifier_id
+character_modifier_move_mode_move_cost_mod( "move_mode_move_cost_mod" );
+static const character_modifier_id
 character_modifier_stamina_move_cost_mod( "stamina_move_cost_mod" );
 static const character_modifier_id
 character_modifier_stamina_recovery_breathing_mod( "stamina_recovery_breathing_mod" );
@@ -69,7 +71,8 @@ static float move_cost_mod( Character &dummy, const move_mode_id &move_mode,
     REQUIRE( dummy.get_stamina() == new_stamina );
 
     // The point of it all: move cost modifier
-    return dummy.get_modifier( character_modifier_stamina_move_cost_mod );
+    return dummy.get_modifier( character_modifier_stamina_move_cost_mod ) * dummy.get_modifier(
+               character_modifier_move_mode_move_cost_mod );
 }
 
 // Return amount of stamina burned per turn by `burn_move_stamina` in the given movement mode.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Player display speed tab effect list is more comprehensive"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The speed tab shows the player's current base move cost and speed, and some of the reasons those are not the default values. Many common reasons are not shown, leaving the player to guess, or spend time investigating, all the possible causes.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This PR modifies the existing functions that calculate movement cost and speed to also emit a list of each modifier applied along with a description. The `draw_speed_tab` code that partially duplicates that behavior is then replaced with calls to those functions.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I discussed a few different ways to produce and pass the data with folks on Discord, but was encouraged to just get the feature working before doing too much optimization in that direction. It is probably advisable to avoid generating/processing the descriptions when they won't be required, when the functions are called in the normal gameplay loop.
I also considered ways to store *more* info about each modifier, for display in the info tab, but that can also happen later.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I have produced in-game situations triggering about half of the hard coded modifiers touched by this code, and a few dynamic modifiers such as martial arts. I haven't thoroughly tested every modifier to see how it looks in the interface.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
![image](https://user-images.githubusercontent.com/121299/228098459-d9584e08-95f6-4a2f-8430-342ce560f4df.png)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->