### PR TITLE
Crafting GUI filters `m:` (don't show nested) `r:` (added - filter by (by)product)

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -280,19 +280,12 @@ struct availability {
 
         static bool check_can_craft_nested( const recipe &r ) {
             // recursively check if you can craft anything in the nest
-            bool can_craft = false;
             for( const recipe_id &nested_r : r.nested_category_data ) {
-                // if nested recur
-                availability av = availability( &nested_r.obj() );
-                can_craft |= av.can_craft;
-
-                // early return if we can craft anything
-                if( can_craft ) {
-                    break;
+                if( availability( &nested_r.obj() ).can_craft ) {
+                    return true;
                 }
             }
-
-            return can_craft;
+            return false;
         }
 };
 } // namespace
@@ -2013,7 +2006,7 @@ int related_menu_fill( uilist &rmenu,
         }
         recipe_name_prev = recipe_name;
 
-        std::vector<const recipe *> current_part = available.search_result( p.first );
+        std::vector<const recipe *> current_part = available.recipes_that_produce( p.first );
         if( !current_part.empty() ) {
 
             bool different_recipes = false;

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2007,35 +2007,36 @@ int related_menu_fill( uilist &rmenu,
         recipe_name_prev = recipe_name;
 
         std::vector<const recipe *> current_part = available.recipes_that_produce( p.first );
-        if( !current_part.empty() ) {
+        if( current_part.empty() ) {
+            continue;
+        }
 
-            bool different_recipes = false;
+        bool different_recipes = false;
 
-            // 1st pass: check if we need to add group
-            for( size_t recipe_n = 0; recipe_n < current_part.size(); recipe_n++ ) {
-                if( current_part[recipe_n]->result_name( /*decorated=*/true ) != recipe_name ) {
-                    // add group
-                    rmenu.addentry( ++np_last, false, -1, recipe_name );
-                    different_recipes = true;
-                    break;
-                } else if( recipe_n == current_part.size() - 1 ) {
-                    // only one result
-                    rmenu.addentry( ++np_last, true, -1, "─ " + recipe_name );
-                }
+        // 1st pass: check if we need to add group
+        for( size_t recipe_n = 0; recipe_n < current_part.size(); recipe_n++ ) {
+            if( current_part[recipe_n]->result_name( /*decorated=*/true ) != recipe_name ) {
+                // add group
+                rmenu.addentry( ++np_last, false, -1, recipe_name );
+                different_recipes = true;
+                break;
+            } else if( recipe_n == current_part.size() - 1 ) {
+                // only one result
+                rmenu.addentry( ++np_last, true, -1, "─ " + recipe_name );
             }
-
-            if( different_recipes ) {
-                std::string prev_item_name;
-                // 2nd pass: add different recipes
-                for( size_t recipe_n = 0; recipe_n < current_part.size(); recipe_n++ ) {
-                    std::string cur_item_name = current_part[recipe_n]->result_name( /*decorated=*/true );
-                    if( cur_item_name != prev_item_name ) {
-                        std::string sym = recipe_n == current_part.size() - 1 ? "└ " : "├ ";
-                        rmenu.addentry( ++np_last, true, -1, sym + cur_item_name );
-                    }
-                    prev_item_name = cur_item_name;
-                }
+        }
+        if( !different_recipes ) {
+            continue;
+        }
+        std::string prev_item_name;
+        // 2nd pass: add different recipes
+        for( size_t recipe_n = 0; recipe_n < current_part.size(); recipe_n++ ) {
+            std::string cur_item_name = current_part[recipe_n]->result_name( /*decorated=*/true );
+            if( cur_item_name != prev_item_name ) {
+                std::string sym = recipe_n == current_part.size() - 1 ? "└ " : "├ ";
+                rmenu.addentry( ++np_last, true, -1, sym + cur_item_name );
             }
+            prev_item_name = cur_item_name;
         }
     }
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -27,6 +27,7 @@
 #include "input.h"
 #include "inventory.h"
 #include "item.h"
+#include "item_factory.h"
 #include "itype.h"
 #include "json.h"
 #include "localized_comparator.h"
@@ -891,6 +892,19 @@ static recipe_subset filter_recipes( const recipe_subset &available_recipes,
                                        recipe_subset::search_type::difficulty, progress_callback );
                     break;
 
+                case 'r': {
+                    recipe_subset result;
+                    for( const itype *e : item_controller->all() ) {
+                        if( wildcard_match( e->nname( 1 ), qry_filter_str.substr( 2 ) ) ) {
+                            result.include( recipe_subset( available_recipes,
+                                                           available_recipes.recipes_that_produce( e->get_id() ) ) );
+                        }
+                    }
+                    filtered_recipes = result;
+
+                    break;
+                }
+
                 default:
                     break;
             }
@@ -927,6 +941,7 @@ static const std::vector<SearchPrefix> prefixes = {
     { 'm', to_translation( "yes" ), to_translation( "recipes which are <color_cyan>memorized</color> or not (hides nested)" ) },
     { 'P', to_translation( "Blacksmithing" ), to_translation( "<color_cyan>proficiency</color> used to craft" ) },
     { 'l', to_translation( "5" ), to_translation( "<color_cyan>difficulty</color> of the recipe as a number or range" ) },
+    { 'r', to_translation( "buttermilk" ), to_translation( "recipe's (<color_cyan>by</color>)<color_cyan>products</color>; use * as wildcard" ) },
 };
 
 static const translation filter_help_start = to_translation(

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -867,12 +867,15 @@ static recipe_subset filter_recipes( const recipe_subset &available_recipes,
                     break;
 
                 case 'm': {
+                    // get_learned_recipes lists NO nested_recipes
                     const recipe_subset &learned = player_character.get_learned_recipes();
                     recipe_subset temp_subset;
                     if( query_is_yes( qry_filter_str ) ) {
                         temp_subset = available_recipes.intersection( learned );
                     } else {
-                        temp_subset = available_recipes.difference( learned );
+                        // nested_recipes cannot be learned so don't show them
+                        temp_subset = available_recipes.difference( learned )
+                                      .difference( recipe_dict.all_nested() );
                     }
                     filtered_recipes = filtered_recipes.intersection( temp_subset );
                     break;
@@ -921,7 +924,7 @@ static const std::vector<SearchPrefix> prefixes = {
     { 's', to_translation( "food handling" ), to_translation( "<color_cyan>any skill</color> used to craft" ) },
     { 'Q', to_translation( "fine bolt turning" ), to_translation( "<color_cyan>quality</color> required to craft" ) },
     { 't', to_translation( "soldering iron" ), to_translation( "<color_cyan>tool</color> required to craft" ) },
-    { 'm', to_translation( "yes" ), to_translation( "recipes which are <color_cyan>memorized</color> or not" ) },
+    { 'm', to_translation( "yes" ), to_translation( "recipes which are <color_cyan>memorized</color> or not (hides nested)" ) },
     { 'P', to_translation( "Blacksmithing" ), to_translation( "<color_cyan>proficiency</color> used to craft" ) },
     { 'l', to_translation( "5" ), to_translation( "<color_cyan>difficulty</color> of the recipe as a number or range" ) },
 };

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -268,6 +268,7 @@ class recipe
         std::string get_consistency_error() const;
 
         bool is_practice() const;
+        /* Return true if this is NOT a recipe but instead only nested recipe (folder for recipes).*/
         bool is_nested() const;
         bool is_blueprint() const;
         const update_mapgen_id &get_blueprint() const;

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -318,8 +318,12 @@ recipe_subset recipe_subset::intersection( const recipe_subset &subset ) const
 }
 recipe_subset recipe_subset::difference( const recipe_subset &subset ) const
 {
+    return difference( subset.recipes );
+}
+recipe_subset recipe_subset::difference( const std::set<const recipe *> &recipe_set ) const
+{
     std::vector<const recipe *> difference_result;
-    std::set_difference( this->begin(), this->end(), subset.begin(), subset.end(),
+    std::set_difference( this->begin(), this->end(), recipe_set.begin(), recipe_set.end(),
                          std::back_inserter( difference_result ) );
     return recipe_subset( *this, difference_result );
 }

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -265,9 +265,7 @@ std::vector<const recipe *> recipe_subset::search(
                 }
 
                 if( use_range && start > end ) {
-                    int swap = start;
-                    start = end;
-                    end = swap;
+                    std::swap( start, end );
                 }
 
                 if( use_range ) {
@@ -326,15 +324,12 @@ recipe_subset recipe_subset::difference( const recipe_subset &subset ) const
     return recipe_subset( *this, difference_result );
 }
 
-std::vector<const recipe *> recipe_subset::search_result( const itype_id &item ) const
+std::vector<const recipe *> recipe_subset::recipes_that_produce( const itype_id &item ) const
 {
     std::vector<const recipe *> res;
 
     std::copy_if( recipes.begin(), recipes.end(), std::back_inserter( res ), [&]( const recipe * r ) {
-        if( r->obsolete ) {
-            return false;
-        }
-        return item == r->result() || r->in_byproducts( item );
+        return !r->obsolete && ( item == r->result() || r->in_byproducts( item ) );
     } );
 
     return res;

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -176,7 +176,7 @@ class recipe_subset
         /** Set difference between recipe_subsets */
         recipe_subset difference( const recipe_subset &subset ) const;
         /** Find recipes producing the item */
-        std::vector<const recipe *> search_result( const itype_id &item ) const;
+        std::vector<const recipe *> recipes_that_produce( const itype_id &item ) const;
 
         size_t size() const {
             return recipes.size();

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -175,6 +175,7 @@ class recipe_subset
         recipe_subset intersection( const recipe_subset &subset ) const;
         /** Set difference between recipe_subsets */
         recipe_subset difference( const recipe_subset &subset ) const;
+        recipe_subset difference( const std::set<const recipe *> &recipe_set ) const;
         /** Find recipes producing the item */
         std::vector<const recipe *> recipes_that_produce( const itype_id &item ) const;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Crafting GUI: filter by (by)product"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #64259 (Part of #63091)

Add filter for (by)products. With that we can search products and byproducts at the same time.
Example usages:

Searching for "buttermilk" (see Test)

<details>

<summary>Searching "r:cotton patch"</summary>

![image](https://user-images.githubusercontent.com/13402666/228104919-bb5b301a-543f-4bfe-ab3b-e1f953f18593.png)
vs searching "cotton patch"
![image](https://user-images.githubusercontent.com/13402666/228105040-3d70ed87-c18a-4a5d-8a2d-89c04235126a.png)

---
</details>


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change the existing filter for `m:no` to exclude nested recipes. But all individual recipes are still shown,
Add filter `r:QUERY`, where `QUERY` is accepting wildcards (`*`). `r:` filters all recipes (by)producing `QUERY`.

<details>

<summary>before & after</summary>

before
![image](https://user-images.githubusercontent.com/13402666/228106687-ac2c1f7d-f96d-45cc-b2b6-f58bd5710391.png)

after
![image](https://user-images.githubusercontent.com/13402666/228104391-0daf96a9-c864-4a03-a42e-2725dffb9b72.png)

</details>

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
`m:no`
Show only nested categories with non-memorized recipes. And either only the recipes that are not memorized or the entire nest.
This implementation is easier. Sacrificing all nested is better that having all nested all the time. 

`r:`
Have some searching spinning gear like in `d:`.
I didn't get to it, but `r:*` hangs for just 10sec on my PC

Multiple PRs
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
`m:no`

0. Have books with unmemorized recipes.
1. Open crafting GUI
3. `f` for filter
4. `m:no` (`confirm`)
5. See that there are no recipe groups. It still lists unmemorized recipes, as it should.


`r:buttermilk`

0. know recipes for `raw butter` and `heavy cream`
1. Open crafting GUI
2. `f` for filter
3. `r:buttermilk` (no space) (`confirm`)
4. See recipes `raw butter` and `heavy cream`

`r:*` (speed test)

0. Know all recipes
1. Open crafting GUI
2. `f` for filter
3. `r:*` (`confirm`)
4. Game lags for about 10sec - I think that is acceptable

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Introduced #64626

I prefer to call `nested recipes` `folders` or `recipe folders`.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->