### PR TITLE
Fix spell display bug

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -680,7 +680,7 @@ std::string spell::damage_string( const Character &caster ) const
     dialogue d( get_talker_for( caster ), nullptr );
     if( has_flag( spell_flag::RANDOM_DAMAGE ) ) {
         damage_string = string_format( "%d-%d", min_leveled_damage( caster ),
-                                       type->max_damage.evaluate( d ) );
+                                       static_cast<int>( type->max_damage.evaluate( d ) ) );
     } else {
         const int dmg = damage( caster );
         if( dmg >= 0 ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix display bug for spells with RANDOM_DAMAGE flag
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Used this spell, looking at it in the debug menu or spell casting menu causes display error before this fix.
```
{
    "id": "pyrokinetic_eruption",
    "type": "SPELL",
    "name": "[Ψ]Fountain of Flames",
    "description": "Cause a burst of flames at the target location.",
    "message": "You summon flames!",
    "valid_targets": [ "hostile", "ground" ],
    "spell_class": "PYROKINETIC",
      "skill": "metaphysics",
    "flags": [ "CONCENTRATE", "LOUD", "NO_PROJECTILE", "IGNITE_FLAMMABLE", "RANDOM_DAMAGE", "NO_HANDS", "NO_LEGS" ],
    "effect": "attack",
    "shape": "blast",
    "damage_type": "heat",
    "difficulty": 2,
    "max_level": { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": 1.5 } ] },
    "min_damage": 20,
    "max_damage": 150,
    "damage_increment": 1.5,
    "min_range": 4,
    "max_range": 25,
    "range_increment": 1.5,
        "field_id": "fd_fire",
        "min_field_intensity": 1,
        "max_field_intensity": 2,
        "field_chance": 2,
    "energy_source": "STAMINA",
    "base_energy_cost": 1500,
    "final_energy_cost": 300,
    "energy_increment": -125,
    "base_casting_time": 100,
    "final_casting_time": 35,
    "casting_time_increment": -4,
    "sound_type": "combat",
    "sound_description": "a crackle!",
    "learn_spells": { "pyrokinetic_flamethrower": 7, "pyrokinetic_flash": 9, "pyrokinetic_blast": 15, "pyrokinetic_cloak": 17  }
  }
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->