### PR TITLE
Add context to physical activity text json field so that it can be translated properly

### DIFF
--- a/data/json/ui/activity.json
+++ b/data/json/ui/activity.json
@@ -7,37 +7,37 @@
     "clauses": [
       {
         "id": "none",
-        "text": "None",
+        "text": { "str": "None", "ctxt": "activity description" },
         "color": "light_gray",
         "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 0 } ] }
       },
       {
         "id": "light",
-        "text": "Light",
+        "text": { "str": "Light", "ctxt": "activity description" },
         "color": "yellow",
         "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 1 } ] }
       },
       {
         "id": "moderate",
-        "text": "Moderate",
+        "text": { "str": "Moderate", "ctxt": "activity description" },
         "color": "yellow",
         "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 2 } ] }
       },
       {
         "id": "brisk",
-        "text": "Brisk",
+        "text": { "str": "Brisk", "ctxt": "activity description" },
         "color": "light_red",
         "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 3 } ] }
       },
       {
         "id": "active",
-        "text": "Active",
+        "text": { "str": "Active", "ctxt": "activity description" },
         "color": "light_red",
         "condition": { "compare_num": [ { "u_val": "activity_level" }, "==", { "const": 4 } ] }
       },
       {
         "id": "extreme",
-        "text": "Extreme",
+        "text": { "str": "Extreme", "ctxt": "activity description" },
         "color": "red",
         "condition": { "compare_num": [ { "u_val": "activity_level" }, ">=", { "const": 5 } ] }
       }


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Fixes #64023

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Self-explanatory.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

None.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

- 
- Changed the language to French (a language I'm fluent in)
- Went in game, moved around and noticed that non-"None" physical activity levels weren't being displayed in French.
- Made the fix, repeated the steps above and confirmed that physical activity levels were appearing in French.
- Repeated the above steps for Russian as well.


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![FLo9r9NE3f](https://user-images.githubusercontent.com/2420411/228106806-c0040604-c6c9-422b-8a2f-55ced0d0bfd4.png)



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->