### PR TITLE
Properly split changelog lines

### DIFF
--- a/tools/merge_summaries.sh
+++ b/tools/merge_summaries.sh
@@ -5,7 +5,9 @@ IFS=''
 
 # Features Content Interface Mods Balance Bugfixes Performance Infrastructure Build I18N
 
-while read -r category description; do
+while read -r line; do
+    category=$(echo "$line" | head -n1 | cut -d " " -f1)
+    description=$(echo "$line" | head -n1 | cut -d " " -f2-)
     if [ -z "$category" ] || [[ "*" == "$category" ]] || [[ $( expr $category : "2019" ) == 4 ]] ; then
         continue
     fi


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Made a mistake in #64459. Without string splitting on `read`, the whole line gets interpreted as the category.
See https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4527621986/jobs/7997599659#step:4:15

#### Describe the solution
Fix my hubris

#### Testing
Ran the scripts locally and the changes get properly merged into the changelog

```diff
diff --git a/data/changelog.txt b/data/changelog.txt
index 4bf051f5d8..83c50f8155 100644
--- a/data/changelog.txt
+++ b/data/changelog.txt
@@ -3,6 +3,10 @@
 ## Features:
 Tilesets: Automatically prevent occlusions via semi-transparent sprites (similar to retraction)
 Add parametric mapgen to consolidate similar basecamp definitions
+Limbify downed recovery, rework Judo's passive bonus
+EOC on event
+JSONized damage verbs for transforming items
+Allow displaying unavailable dialogue options

...
...
...
```

#### Additional context
