### PR TITLE
Mouse hover support for inventory screens

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3371,8 +3371,8 @@ std::pair<const item *, const item *> inventory_compare_selector::execute()
 
         if( input.entry != nullptr ) {
             highlight( input.entry->any_item() );
-            if ( input.action == "SELECT" ) {
-                toggle_entry(input.entry);
+            if( input.action == "SELECT" ) {
+                toggle_entry( input.entry );
                 just_selected = input.entry;
             }
         } else if( input.action == "TOGGLE_ENTRY" ) {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3972,7 +3972,7 @@ int inventory_examiner::execute()
             if( highlight( input.entry->any_item() ) ) {
                 ui_manager::redraw();
             }
-            if ( input.action == "SELECT" ) {
+            if( input.action == "SELECT" ) {
                 return cleanup();
             }
         }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3529,8 +3529,8 @@ void inventory_multiselector::on_input( const inventory_input &input )
 
     if( input.entry != nullptr ) { // Single Item from mouse
         highlight( input.entry->any_item() );
-        if (input.action == "SELECT") {
-            toggle_entries(count);
+        if( input.action == "SELECT" ) {
+            toggle_entries( count );
         }
     } else if( input.action == "TOGGLE_NON_FAVORITE" ) {
         toggle_entries( count, toggle_mode::NON_FAVORITE_NON_WORN );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3371,8 +3371,10 @@ std::pair<const item *, const item *> inventory_compare_selector::execute()
 
         if( input.entry != nullptr ) {
             highlight( input.entry->any_item() );
-            toggle_entry( input.entry );
-            just_selected = input.entry;
+            if ( input.action == "SELECT" ) {
+                toggle_entry(input.entry);
+                just_selected = input.entry;
+            }
         } else if( input.action == "TOGGLE_ENTRY" ) {
             const auto selection( get_active_column().get_all_selected() );
 
@@ -3970,7 +3972,9 @@ int inventory_examiner::execute()
             if( highlight( input.entry->any_item() ) ) {
                 ui_manager::redraw();
             }
-            return cleanup();
+            if ( input.action == "SELECT" ) {
+                return cleanup();
+            }
         }
 
         if( input.action == "QUIT" || input.action == "CONFIRM" ) {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3534,7 +3534,8 @@ void inventory_multiselector::on_input( const inventory_input &input )
         if( input.action == "SELECT" ) {
             toggle_entries( count );
         }
-    } else if( input.action == "TOGGLE_NON_FAVORITE" ) {
+    }
+    if( input.action == "TOGGLE_NON_FAVORITE" ) {
         toggle_entries( count, toggle_mode::NON_FAVORITE_NON_WORN );
     } else if( input.action ==
                "MARK_WITH_COUNT" ) { // Set count and mark selected with specific key

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2734,7 +2734,7 @@ inventory_input inventory_selector::process_input( const std::string &action, in
 {
     inventory_input res{ action, ch, nullptr };
 
-    if( res.action == "SELECT" || res.action == "COORDINATE" || res.action == "MOUSE_MOVE") {
+    if( res.action == "SELECT" || res.action == "COORDINATE" || res.action == "MOUSE_MOVE" ) {
         std::optional<point> o_p = ctxt.get_coordinates_text( w_inv );
         if( o_p ) {
             point p = o_p.value();

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2662,6 +2662,8 @@ inventory_selector::inventory_selector( Character &u, const inventory_selector_p
     item_name_cache_users++;
     tp_start =
         std::chrono::time_point_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() );
+    ctxt.register_action( "COORDINATE");
+    ctxt.register_action("MOUSE_MOVE");
     ctxt.register_action( "DOWN", to_translation( "Next item" ) );
     ctxt.register_action( "UP", to_translation( "Previous item" ) );
     ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
@@ -2732,7 +2734,7 @@ inventory_input inventory_selector::process_input( const std::string &action, in
 {
     inventory_input res{ action, ch, nullptr };
 
-    if( res.action == "SELECT" ) {
+    if( res.action == "SELECT" || res.action == "COORDINATE" || res.action == "MOUSE_MOVE") {
         std::optional<point> o_p = ctxt.get_coordinates_text( w_inv );
         if( o_p ) {
             point p = o_p.value();
@@ -3067,7 +3069,9 @@ item_location inventory_pick_selector::execute()
             if( highlight( input.entry->any_item() ) ) {
                 ui_manager::redraw();
             }
-            return input.entry->any_item();
+            if (input.action == "SELECT"){
+                return input.entry->any_item();
+            }
         } else if( input.action == "ORGANIZE_MENU" ) {
             u.worn.organize_items_menu();
             return item_location();
@@ -3525,7 +3529,9 @@ void inventory_multiselector::on_input( const inventory_input &input )
 
     if( input.entry != nullptr ) { // Single Item from mouse
         highlight( input.entry->any_item() );
-        toggle_entries( count );
+        if (input.action == "SELECT") {
+            toggle_entries(count);
+        }
     } else if( input.action == "TOGGLE_NON_FAVORITE" ) {
         toggle_entries( count, toggle_mode::NON_FAVORITE_NON_WORN );
     } else if( input.action ==

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2662,8 +2662,8 @@ inventory_selector::inventory_selector( Character &u, const inventory_selector_p
     item_name_cache_users++;
     tp_start =
         std::chrono::time_point_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() );
-    ctxt.register_action( "COORDINATE");
-    ctxt.register_action("MOUSE_MOVE");
+    ctxt.register_action( "COORDINATE" );
+    ctxt.register_action( "MOUSE_MOVE" );
     ctxt.register_action( "DOWN", to_translation( "Next item" ) );
     ctxt.register_action( "UP", to_translation( "Previous item" ) );
     ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3069,7 +3069,7 @@ item_location inventory_pick_selector::execute()
             if( highlight( input.entry->any_item() ) ) {
                 ui_manager::redraw();
             }
-            if (input.action == "SELECT"){
+            if( input.action == "SELECT" ) {
                 return input.entry->any_item();
             }
         } else if( input.action == "ORGANIZE_MENU" ) {


### PR DESCRIPTION
…inventory screen as well as the inventory multi-selector.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Made it so that inventory items highlight when hovered over with the mouse"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
When I first installed the game, I was very confused by how the mouse worked as expected on the main menu, but not anywhere else. On the inventory screen, though I found that clicking items selects them as expected, without seeing the items become highlighted as the mouse is moved over them, it appeared that the dialog did not support the mouse at all. I feel this change adds UI consistency. Relevant to #58106, does not fully fix it.


#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Registered actions for MOUSE_MOVE and COORDINATE on the action handler. COORDINATE turns on mouse hover events, but I found that I needed to register a separate action for MOUSE_MOVE to see the event propagate up to the on_input functions.

#### Describe alternatives you've considered
n/a
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I loaded both the pick-selector and the multi-selector inventory views, by using the 'i' key and 'd' keys, respectively. I am not 100% familiar with all the screens in CDDA yet but it didn't look like this was used in any other places.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
n/a
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->