### PR TITLE
Math expression parser

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -12,5 +12,48 @@
         "success_message": "All at once your body feels like it's beeing pulled in 1000 different directions."
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_math_test_equals_assign",
+    "condition": { "math": [ "u_val('stamina')", "==", "500" ] },
+    "effect": [ { "math": [ "math_test", "=", "-3^2" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_math_test_greater_increment",
+    "condition": { "math": [ "math_test", ">", "0" ] },
+    "effect": [ { "math": [ "math_test", "+=", "1" ] } ],
+    "false_effect": [ { "math": [ "math_test", "--" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_math_switch_math",
+    "effect": {
+      "switch": { "math": [ "math_test" ] },
+      "cases": [
+        { "case": -1, "effect": { "math": [ "math_test_result", "=", "1" ] } },
+        { "case": 9, "effect": { "math": [ "math_test_result", "=", "2" ] } },
+        { "case": 10, "effect": { "math": [ "math_test_result", "=", "3" ] } }
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_math_diag_assign",
+    "effect": [ { "math": [ "u_val('stamina')", "/=", "2" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_math_var",
+    "condition": { "days_since_cataclysm": { "math": [ "math_test_result" ] } },
+    "effect": [ { "u_message": "test var math" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_math_duration",
+    "recurrence": { "math": [ "math_test_result" ] },
+    "global": true,
+    "effect": { "u_message": "test recurrence" }
   }
 ]

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -920,7 +920,7 @@ Effect | Description
 `run_eocs : effect_on_condition_array or single effect_condition_object` | Will run up all members of the `effect_on_condition_array`. Members should either be the id of an effect_on_condition or an inline effect_on_condition.
 `queue_eocs : effect_on_condition_array or single effect_condition_object`, `time_in_future: `duration or [variable object](#variable-object) | Will queue up all members of the `effect_on_condition_array`. Members should either be the id of an effect_on_condition or an inline effect_on_condition. Members will be run `time_in_future` in the future.  If the eoc is global the avatar will be u and npc will be invalid. Otherwise it will be queued for the current alpha if they are a character and not be queued otherwise.
 `u_roll_remainder, npc_roll_remainder : `array of strings and/or [variable objects](#variable-object), `type: `string or [variable object](#variable-object), (*optional* `true_eocs: eocs_array`), (*optional* `false_eocs: eocs_array`), (*optional* `message: ` string or [variable object](#variable-object) ) | Type must be either `bionic`, `mutation`, `spell` or `recipe`.  If the u or npc does not have all of the listed bionics, mutations, spells, or recipes they will be given one randomly and and then all of the effect_on_conditions in `true_eocs` are run, otherwise all the effect_on_conditions in `false_eocs` are run.  If `message` is provided and a result is given then the `message` will be displayed as a message with the first instance of `%s` in it replaced with the name of the result selected.  
-`switch : arithmetic_expression`, `cases: effect_array` | Will calculate value of `switch` and then run member of `cases` with the highest `case` that the `switch` is higher or equal to. `cases` is an array of objects with an int_or_var `case` and an `effect` field which is a dialog effect.
+`switch : arithmetic/math_expression`, `cases: effect_array` | Will calculate value of `switch` and then run member of `cases` with the highest `case` that the `switch` is higher or equal to. `cases` is an array of objects with an int_or_var `case` and an `effect` field which is a dialog effect.
 `u_run_npc_eocs or npc_run_npc_eocs : effect_on_condition_array`, (*optional* `unique_ids: `array of strings and/or [variable objects](#variable-object)), (*optional* `npcs_must_see: npcs_must_see_bool`), (*optional* `npc_range: `int or [variable object](#variable-object)), (*optional* `local: local_bool`) | Will run all members of the `effect_on_condition_array` on npcs. Members should either be the id of an effect_on_condition or an inline effect_on_condition.  If `local`(default: false) is false, then regardless of location all npcs with unique ids in the array `unique_ids` will be affected.  If `local` is true, only unique_ids listed in `unique_ids` will be affected, if it is empty all npcs in range will be effected. If a value is given for `npc_range` the npc must be that close to the source and if `npcs_must_see`(defaults to false) is true the npc must be able to see the source. For `u_run_npc_eocs` u is the source for `npc_run_npc_eocs` it is the npc.
 `weighted_list_eocs: array_array` | Will choose one of a list of eocs to activate based on weight. Members should be an array of first the id of an effect_on_condition or an inline effect_on_condition and second an object that resolves to an integer weight.<br/><br/>Example: This will cause "EOC_SLEEP" 1/10 as often as it makes a test message appear.<pre>    "effect": [<br/>      {<br/>        "weighted_list_eocs": [<br/>          [ "EOC_SLEEP", { "const": 1 } ],<br/>          [ {<br/>              "id": "eoc_test2",<br/>              "effect": [ { "u_message": "A test message appears!", "type": "bad" } ]<br/>            },<br/>            { "const": 10 }<br/>          ]<br/>        ]<br/>      }<br/>    ]</pre>
 
@@ -968,7 +968,7 @@ Condition | Type | Description
 `"u_has_flag"`<br/>`"npc_has_flag"` | string or [variable object](#variable-object) | `true` if the player character or NPC has the specified character flag.  The special trait flag `"MUTATION_THRESHOLD"` checks to see if the player or NPC has crossed a mutation threshold.
 `"u_has_any_trait"`<br/>`"npc_has_any_trait"` | array of strings and/or [variable objects](#variable-object) | `true` if the player character or NPC has any trait or mutation in the array. Used to check multiple specific traits.
 `"u_has_var"`, `"npc_has_var"` | string | `"type": type_str`, `"context": context_str`, and `"value": value_str` are required fields in the same dictionary as `"u_has_var"` or `"npc_has_var"`.<br/>`true` is the player character or NPC has a variable set by `"u_add_var"` or `"npc_add_var"` with the string, `type_str`, `context_str`, and `value_str`.
-`"u_compare_var"`, `"npc_compare_var"` | dictionary | `"type": type_str`, `"context": context_str`, `"op": op_str`, `"value": `int or [variable object](#variable-object) ` are required fields, referencing a var as in `"u_add_var"` or `"npc_add_var"`.<br/>`true` if the player character or NPC has a stored variable that is true for the provided operator `op_str` (one of `==`, `!=`, `<`, `>`, `<=`, `>=`) and value.
+`"u_compare_var"`, `"npc_compare_var"` | dictionary | `"type": type_str`, `"context": context_str`, `"op": op_str`, `"value"`: int or [variable object](#variable-object)  are required fields, referencing a var as in `"u_add_var"` or `"npc_add_var"`.<br/>`true` if the player character or NPC has a stored variable that is true for the provided operator `op_str` (one of `==`, `!=`, `<`, `>`, `<=`, `>=`) and value. <br/><br/>`compare_var` is deprecated, see [Math](#math) for the replacement.
 `"u_compare_time_since_var"`, `"npc_compare_time_since_var_"` | dictionary | `"type": type_str`, `"context": context_str`, `"op": op_str`, `"time": time_string` are required fields, referencing a var as in `"u_add_var"` or `"npc_add_var"`.<br/>`true` if the player character or NPC has a stored variable and the current turn and that value (converted to a time point) plus the time_string is true for the provided operator `op_str` (one of `==`, `!=`, `<`, `>`, `<=`, `>=`).<br/><br/>Example: returns true if the player character has a "test", "test", "var_time_test" variable and the current turn is greater than that value plus 3 days' worth of turns.<pre>{<br/>  "u_compare_time_since_var": "test", "type": "test",<br/>  "context": "var_time_test", "op": ">", "time": "3 days"<br/>}</pre>
 `"compare_string"` | array | The array must contain exactly two entries.  They can be either strings and/or [variable objects](#variable-object).  Returns true if the strings are the same.
 `"u_has_strength"`<br/>`"npc_has_strength"` | int or [variable object](#variable-object) | `true` if the player character's or NPC's strength is at least the value of `u_has_strength` or `npc_has_strength`.
@@ -1210,7 +1210,7 @@ Condition | Type | Description
 ## Utility Structures
 
 ### Variable Object
-`variable_object`: This is either an object, an `arithmetic` [expression](#compare-numbers-and-arithmetics) or array describing a variable name. It can either describe a double, a time duration or a string. If it is an array it must have 2 values the first of which will be a minimum and the second will be a maximum, the value will be randomly between the two. If it is a double `default` is a double which will be the value returned if the variable is not defined. If is it a duration then `default` can be either an int or a string describing a time span. `u_val`, `npc_val`, or `global_val` can be the used for the variable name element.  If `u_val` is used it describes a variable on player u, if `npc_val` is used it describes a variable on player npc, if `global_val` is used it describes a global variable.  If this is a duration `infinite` will be accepted to be a virtually infinite value(it is actually more than a year, if longer is needed a code change to make this a flag or something will be needed).
+`variable_object`: This is either an object, an `arithmetic`/`math` [expression](#compare-numbers-and-arithmetics) or array describing a variable name. It can either describe a double, a time duration or a string. If it is an array it must have 2 values the first of which will be a minimum and the second will be a maximum, the value will be randomly between the two. If it is a double `default` is a double which will be the value returned if the variable is not defined. If is it a duration then `default` can be either an int or a string describing a time span. `u_val`, `npc_val`, or `global_val` can be the used for the variable name element.  If `u_val` is used it describes a variable on player u, if `npc_val` is used it describes a variable on player npc, if `global_val` is used it describes a global variable.  If this is a duration `infinite` will be accepted to be a virtually infinite value(it is actually more than a year, if longer is needed a code change to make this a flag or something will be needed).
 
 example json:
 ```
@@ -1226,6 +1226,8 @@ example json:
 ```
 
 ### Compare Numbers and Arithmetics
+*`arithmetic` and `compare_num` are deprecated in the long term. See [Math](#math) for the replacement.*
+
 `"compare_num"` can be used to compare two values to each other, while `"arithmetic"` can be used to take up to two values, perform arithmetic on them, and then save them in a third value. The syntax is as follows.
 ```
 {
@@ -1307,3 +1309,100 @@ Example | Description
 `"hour"` | Hours since midnight.
 `"moon"` | Phase of the moon.<pre>MOON_NEW =0,<br/>WAXING_CRESCENT =1,<br/>HALF_MOON_WAXING =2,<br/>WAXING_GIBBOUS =3,<br/>FULL =4,<br/>WANING_GIBBOUS =5,<br/>HALF_MOON_WANING =6,<br/>WANING_CRESCENT =7</pre>
 `"arithmetic"` | An arithmetic expression with no result.<br/><br/>Example:<pre>"real_count": { "arithmetic": [<br/>  { "arithmetic": [ { "const":1 }, "+", { "const": 1 } ] },<br/>  "+", { "const": 1 }<br/>] },</pre>
+
+### Math
+A `math` object lets you evaluate math expressions and assign them to dialogue variables or compare them for conditions. It takes the form
+```JSON
+{ "math": [ "2 + 2 - 3", "==", "1" ] }
+```
+or idiomatically
+```JSON
+{ "math": [ "lhs", "operator", "rhs" ] }
+```
+It takes an array as a parameter with 1, 2, or 3 strings:
+
+#### One string = return value
+```JSON
+{ "math": [ "lhs" ] }
+```
+Example:
+```JSON
+{ "value": "LUMINATION", "add": { "math": [ "u_val('morale') * 3 - rng(0, 100)" ] } }
+```
+The expression in `lhs` is evaluated and passed on to the parent object.
+
+#### Two strings = unary operation
+```JSON
+{ "math": [ "lhs", "operator" ] }
+```
+Example:
+```JSON
+"effect": [ { "math": [ "math_test", "++" ] } ]
+```
+`lhs` must be an [assignment target](#assignment-target). `operator` can be `++` or `--` to increment or decrement, respectively.
+
+#### Three strings = assignment or comparison
+```JSON
+{ "math": [ "lhs", "operator", "rhs" ] }
+```
+If `operator` is `=`, `+=`, `-=`, `*=`, `/=`, or `%=` the operation is an assignment:
+```JSON
+"effect": { "math": [ "u_blorg", "=", "rng( 0, 2 ) + u_val('spell_level', 'spell: test_spell_pew') / 2" ] }
+```
+`lhs` must be an [assignment target](#assignment-target). `rhs` is evaluated and stored in the assignment target from `lhs`.
+
+
+If `operator` is `==`, `>=`, `<=`, `>`, or `<`, the operation is a comparison:
+```JSON
+"condition": { "math": [ "u_val('stamina') * 2", ">=", "5000 + rand( 300 )" ] },
+```
+`lhs` and `rhs` are evaluated independently and the result of `operator` is passed on to the parent object.
+
+#### Constants
+The tokens `π` (and `pi` alias ) and `e` are recognized as mathematical constants and get replaced by their nominal values.
+
+#### Math functions
+Common math functions are supported: 
+
+`abs()`, `sqrt()`, `log()`, `sin()`, `cos()`, and `tan()` take one argument, for example `sin( 2 * pi + 1 )`.
+
+`max()` and `min()` take any number of arguments, for example `max( 1, 2, 3 )`.
+
+`rand()` takes one argument `x` and returns a random integer between 0 and x, for example `rand(100)`.
+
+`rng()` takes two arguments `a` and `b` and returns a random floating point value between a and b, for example `rng(1.5, 2)`.
+
+Function composition is also supported, for example `sin( rng(0, max( 0.5, u_sin_var ) ) )`
+
+#### Dialogue functions
+Dialogue functions take single-quoted strings as arguments and can return or manipulate game values. They are scoped just like [variables](#variables).
+
+This section is a work in progress as functions are ported from `arithmetic` to `math`. There is a `val()` shim available that can replace `u_val` and `npc_val`:
+
+```JSON
+{ "math": [ "u_val('stamina')" ] }
+```
+where
+```JSON
+"u_val('stamina')"
+```
+is equivalent to
+```JSON
+{ "u_val": "stamina" }
+```
+Keyword-value pairs are also supported:
+```JSON
+"n_val('spell_level', 'spell: test_spell_pew')"
+```
+is equivalent to
+```JSON
+{ "npc_val": "spell_level", "spell": "test_spell_pew" }
+
+```
+
+
+#### Variables
+Tokens that aren't numbers, [constants](#constants), [functions](#math-functions), or mathematical symbols are treated as dialogue variables. They are scoped by their name so `myvar` is a variable in the global scope, `u_myvar` is scoped on the alpha talker, and `n_myvar` is scoped on the beta talker.
+
+#### Assignment target
+An assignment target can be either a scoped [variable name](#variables) or a scoped [dialogue function](#dialogue-functions).

--- a/src/condition.h
+++ b/src/condition.h
@@ -212,6 +212,7 @@ struct conditional_t {
         void set_can_see( bool is_npc = false );
         void set_compare_string( const JsonObject &jo, const std::string &member );
         void set_compare_num( const JsonObject &jo, const std::string &member );
+        void set_math( const JsonObject &jo, const std::string &member );
         static std::function<double( const T & )> get_get_dbl( const JsonObject &jo );
         static std::function<double( const T & )> get_get_dbl( const std::string &value,
                 const JsonObject &jo );

--- a/src/condition.h
+++ b/src/condition.h
@@ -9,6 +9,7 @@
 
 #include "dialogue.h"
 #include "dialogue_helpers.h"
+#include "math_parser_shim.h"
 #include "mission.h"
 
 class JsonObject;
@@ -213,9 +214,14 @@ struct conditional_t {
         void set_compare_string( const JsonObject &jo, const std::string &member );
         void set_compare_num( const JsonObject &jo, const std::string &member );
         void set_math( const JsonObject &jo, const std::string &member );
-        static std::function<double( const T & )> get_get_dbl( const JsonObject &jo );
+        template<class J>
+        static std::function<double( const T & )> get_get_dbl( J const &jo );
         static std::function<double( const T & )> get_get_dbl( const std::string &value,
                 const JsonObject &jo );
+        template <class J>
+        std::function<void( const T &, double )>
+        static get_set_dbl( const J &jo, const std::optional<dbl_or_var_part<T>> &min,
+                            const std::optional<dbl_or_var_part<T>> &max, bool temp_var );
         bool operator()( const T &d ) const {
             if( !condition ) {
                 return false;
@@ -223,6 +229,21 @@ struct conditional_t {
             return condition( d );
         }
 };
+
+extern template std::function<double( const dialogue & )>
+conditional_t<dialogue>::get_get_dbl<>( kwargs_shim const & );
+extern template std::function<double( const mission_goal_condition_context & )>
+conditional_t<mission_goal_condition_context>::get_get_dbl<>( kwargs_shim const & );
+
+extern template std::function<void( const dialogue &, double )>
+conditional_t<dialogue>::get_set_dbl<>( const kwargs_shim &,
+                                        const std::optional<dbl_or_var_part<dialogue>> &,
+                                        const std::optional<dbl_or_var_part<dialogue>> &, bool );
+extern template std::function<void( const mission_goal_condition_context &, double )>
+conditional_t<mission_goal_condition_context>::get_set_dbl<>( const kwargs_shim &,
+        const std::optional<dbl_or_var_part<mission_goal_condition_context>> &,
+        const std::optional<dbl_or_var_part<mission_goal_condition_context>> &,
+        bool );
 
 #if !defined(MACOSX)
 extern template struct conditional_t<dialogue>;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -3020,28 +3020,26 @@ tripoint_abs_omt Creature::global_omt_location() const
 std::unique_ptr<talker> get_talker_for( Creature &me )
 {
     if( me.is_monster() ) {
-        return std::make_unique<talker_monster>( static_cast<monster *>( &me ) );
+        return std::make_unique<talker_monster>( me.as_monster() );
     } else if( me.is_npc() ) {
-        return std::make_unique<talker_npc>( static_cast<npc *>( &me ) );
+        return std::make_unique<talker_npc>( me.as_npc() );
     } else if( me.is_avatar() ) {
-        return std::make_unique<talker_avatar>( static_cast<avatar *>( &me ) );
+        return std::make_unique<talker_avatar>( me.as_avatar() );
     } else {
         debugmsg( "Invalid creature type %s.", me.get_name() );
-        standard_npc default_npc( "Default" );
-        return get_talker_for( default_npc );
+        return std::make_unique<talker>();
     }
 }
 
 std::unique_ptr<talker> get_talker_for( const Creature &me )
 {
     if( !me.is_monster() ) {
-        return std::make_unique<talker_character_const>( static_cast<const Character *>( &me ) );
+        return std::make_unique<talker_character_const>( me.as_character() );
     } else if( me.is_monster() ) {
-        return std::make_unique<talker_monster_const>( static_cast<const monster *>( &me ) );
+        return std::make_unique<talker_monster_const>( me.as_monster() );
     } else {
         debugmsg( "Invalid creature type %s.", me.get_name() );
-        standard_npc default_npc( "Default" );
-        return get_talker_for( default_npc );
+        return std::make_unique<talker>();
     }
 }
 
@@ -3049,17 +3047,15 @@ std::unique_ptr<talker> get_talker_for( Creature *me )
 {
     if( !me ) {
         debugmsg( "Null creature type." );
-        standard_npc default_npc( "Default" );
-        return get_talker_for( default_npc );
+        return std::make_unique<talker>();
     } else if( me->is_monster() ) {
-        return std::make_unique<talker_monster>( static_cast<monster *>( me ) );
+        return std::make_unique<talker_monster>( me->as_monster() );
     } else if( me->is_npc() ) {
-        return std::make_unique<talker_npc>( static_cast<npc *>( me ) );
+        return std::make_unique<talker_npc>( me->as_npc() );
     } else if( me->is_avatar() ) {
-        return std::make_unique<talker_avatar>( static_cast<avatar *>( me ) );
+        return std::make_unique<talker_avatar>( me->as_avatar() );
     } else {
         debugmsg( "Invalid creature type %s.", me->get_name() );
-        standard_npc default_npc( "Default" );
-        return get_talker_for( default_npc );
+        return std::make_unique<talker>();
     }
 }

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -4,7 +4,9 @@
 
 #include <optional>
 
+#include "calendar.h"
 #include "global_vars.h"
+#include "math_parser.h"
 #include "rng.h"
 #include "type_id.h"
 
@@ -98,6 +100,7 @@ struct talk_effect_fun_t {
         void set_add_faction_trust( const JsonObject &jo, const std::string &member );
         void set_lose_faction_trust( const JsonObject &jo, const std::string &member );
         void set_arithmetic( const JsonObject &jo, const std::string &member, bool no_result );
+        void set_math( const JsonObject &jo, const std::string &member );
         void set_set_string_var( const JsonObject &jo, const std::string &member );
         void set_custom_light_level( const JsonObject &jo, const std::string &member );
         void set_spawn_monster( const JsonObject &jo, const std::string &member, bool is_npc );
@@ -187,12 +190,43 @@ struct str_or_var {
     }
 };
 
+template<typename D>
+struct eoc_math {
+    enum class oper : int {
+        ret = 0,
+        assign,
+
+        // these need mhs
+        plus_assign,
+        minus_assign,
+        mult_assign,
+        div_assign,
+        mod_assign,
+        increase,
+        decrease,
+
+        equal,
+        less,
+        equal_or_less,
+        greater,
+        equal_or_greater,
+    };
+    math_exp<D> lhs;
+    math_exp<D> mhs;
+    math_exp<D> rhs;
+    eoc_math::oper action;
+
+    void from_json( const JsonObject &jo, std::string const &member );
+    double act( D const &d ) const;
+};
+
 template<class T>
 struct dbl_or_var_part {
     std::optional<double> dbl_val;
     std::optional<var_info> var_val;
     std::optional<double> default_val;
     std::optional<talk_effect_fun_t<T>> arithmetic_val;
+    std::optional<eoc_math<T>> math_val;
     double evaluate( const T &d ) const {
         if( dbl_val.has_value() ) {
             return dbl_val.value();
@@ -222,6 +256,8 @@ struct dbl_or_var_part {
                 debugmsg( "No valid arithmetic value for dbl_or_var_part." );
                 return 0;
             }
+        } else if( math_val ) {
+            return math_val->act( d );
         } else {
             debugmsg( "No valid value for dbl_or_var_part." );
             return 0;
@@ -249,6 +285,7 @@ struct duration_or_var_part {
     std::optional<var_info> var_val;
     std::optional<time_duration> default_val;
     std::optional<talk_effect_fun_t<T>> arithmetic_val;
+    std::optional<eoc_math<T>> math_val;
     time_duration evaluate( const T &d ) const {
         if( dur_val.has_value() ) {
             return dur_val.value();
@@ -282,6 +319,8 @@ struct duration_or_var_part {
                 debugmsg( "No valid arithmetic value for duration_or_var_part." );
                 return 0_seconds;
             }
+        } else if( math_val ) {
+            return time_duration::from_turns( math_val->act( d ) );
         } else {
             debugmsg( "No valid value for duration_or_var_part." );
             return 0_seconds;

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -1,0 +1,586 @@
+#include "math_parser.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstddef>
+#include <cstdlib>
+#include <memory>
+#include <optional>
+#include <stack>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "cata_assert.h"
+#include "condition.h"
+#include "debug.h"
+#include "dialogue.h"
+#include "dialogue_helpers.h"
+#include "global_vars.h"
+#include "math_parser_func.h"
+#include "math_parser_impl.h"
+#include "mission.h"
+#include "string_formatter.h"
+
+namespace
+{
+template<typename T, class C>
+constexpr std::optional<T> _get_common( C const &cnt, std::string_view token )
+{
+    auto const it =
+    std::find_if( cnt.cbegin(), cnt.cend(), [&token]( typename C::value_type const & c ) {
+        return c.symbol == token;
+    } );
+    if( it != cnt.end() ) {
+        return { & *it };
+    }
+
+    return std::nullopt;
+}
+
+constexpr std::optional<double> get_constant( std::string_view token )
+{
+    if( std::optional<math_const const *> ret = _get_common<pmath_const>( constants, token ); ret ) {
+        return ( *ret )->val;
+    }
+    return std::nullopt;
+}
+
+std::optional<double> get_number( std::string_view token )
+{
+    char *pEnd = nullptr;
+    double const val = std::strtod( token.data(), &pEnd );
+    if( pEnd == token.data() + token.size() ) {
+        return { val };
+    }
+    errno = 0;
+
+    return get_constant( token );
+}
+
+constexpr std::optional<std::string_view> get_string( std::string_view token )
+{
+    if( token.front() == '\'' && token.back() == '\'' ) {
+        return { token.substr( 1, token.size() - 2 ) };
+    }
+
+    return std::nullopt;
+}
+
+constexpr std::optional<pmath_func> get_function( std::string_view token )
+{
+    return _get_common<pmath_func>( functions, token );
+}
+
+template<class S, typename P, class C>
+std::optional<S> _get_dialogue_func( C const &cnt, std::string_view token )
+{
+    char scope = 'g';
+    std::string_view scoped = token;
+    if( token.size() > 2 && token[1] == '_' ) {
+        scope = token[0];
+        scoped = token.substr( 2, token.size() - 2 );
+    }
+    std::optional<P> df = _get_common<P>( cnt, scoped );
+    if( df ) {
+        if( ( *df )->scopes.find( scope ) == std::string_view::npos ) {
+            throw std::invalid_argument( string_format(
+                                             "Scope %c is not valid for dialogue function %s() (%s)",
+                                             scope, ( *df )->symbol.data(), ( *df )->scopes.data() ) );
+        }
+        return { { *df, scope } };
+    }
+
+    return std::nullopt;
+}
+
+template<class D>
+std::optional<scoped_diag_eval<D>> get_dialogue_eval( std::string_view token )
+{
+    return _get_dialogue_func<scoped_diag_eval<D>, pdiag_func_eval<D>>( dialogue_eval_f<D>, token );
+}
+
+template<class D>
+std::optional<scoped_diag_ass<D>> get_dialogue_ass( std::string_view token )
+{
+    return _get_dialogue_func<scoped_diag_ass<D>, pdiag_func_ass<D>>( dialogue_assign_f<D>, token );
+}
+
+constexpr std::optional<pbin_op> get_binary_op( std::string_view token )
+{
+    return _get_common<pbin_op>( binary_ops, token );
+}
+
+constexpr std::optional<punary_op> get_unary_op( std::string_view token )
+{
+    return _get_common<punary_op>( prefix_unary_ops, token );
+}
+
+struct parse_state {
+    enum class expect : int {
+        oper = 0,
+        operand,
+        lparen,  // operand alias used for functions
+        rparen,
+        eof,     // oper alias used for EOF
+    };
+    static constexpr std::string_view expect_to_string( expect e ) {
+        switch( e ) {
+            // *INDENT-OFF*
+            case expect::oper: return "operator";
+            case expect::operand: return "operand";
+            case expect::lparen: return "left parenthesis";
+            case expect::rparen: return "right parenthesis";
+            case expect::eof: ;
+            // *INDENT-ON*
+        }
+        return "EOF";
+    }
+
+    void validate( expect next ) const {
+        if( previous == expect::lparen && next == expect::rparen ) {
+            return;
+        }
+        expect const alias = next == expect::rparen ? expect::oper : next;
+        if( expected != alias && ( expected != expect::operand || alias != expect::lparen ) &&
+            ( expected != expect::oper || alias != expect::eof ) ) {
+            throw std::invalid_argument( string_format(
+                                             "Expected %s, got %s",
+                                             expect_to_string( expected ).data(),
+                                             expect_to_string( next ).data() ) );
+        }
+    }
+    void set( expect current, bool unary_ok ) {
+        previous = expected;
+        expected = current;
+        allows_prefix_unary = unary_ok;
+    }
+
+    expect expected;
+    expect previous;
+    bool allows_prefix_unary;
+};
+
+template<class D>
+bool is_function( op_t<D> const &op )
+{
+    return std::holds_alternative<pmath_func>( op ) ||
+           std::holds_alternative<scoped_diag_eval<D>>( op ) ||
+           std::holds_alternative<scoped_diag_ass<D>>( op );
+}
+
+template<class D>
+bool is_assign_target( thingie<D> const &thing )
+{
+    return std::holds_alternative<var<D>>( thing.data ) ||
+           std::holds_alternative<func_diag_ass<D>>( thing.data );
+}
+
+} // namespace
+
+template<class D>
+class math_exp<D>::math_exp_impl
+{
+    public:
+        bool parse( std::string_view str, bool assignment ) {
+            if( str.empty() ) {
+                return false;
+            }
+            try {
+                _parse( str, assignment );
+            } catch( std::invalid_argument const &ex ) {
+                std::ptrdiff_t const offset =
+                    str.empty()
+                    ? 0
+                    : std::clamp<std::ptrdiff_t>( last_token.data() - str.data(), 0, 80 );
+                debugmsg( "Expression parsing failed: %s\n\n%.80s\n%*s^\n", ex.what(),
+                          str.data(), offset, " " );
+                ops = {};
+                output = {};
+                arity = {};
+                tree = thingie<D> { 0.0 };
+                return false;
+            }
+            return true;
+        }
+        double eval( D const &d ) const {
+            return tree.eval( d );
+        }
+
+        void assign( D const &d, double val ) const {
+            std::visit( overloaded{
+                [&d, val]( func_diag_ass<D> const & v ) {
+                    v.assign( d, val );
+                },
+                [&d, val]( var<D> const & v ) {
+                    write_var_value( v.varinfo.type, v.varinfo.name,
+                                     d.actor( v.varinfo.type == var_type::npc ),
+                                     std::to_string( val ) );
+                },
+                []( auto &/* v */ ) {
+                    debugmsg( "Assignment called on eval tree" );
+                },
+            },
+            tree.data );
+        }
+
+    private:
+        std::stack<op_t<D>> ops;
+        std::stack<thingie<D>> output;
+        struct arity_t {
+            std::string_view sym;
+            int current{};
+            int expected{};
+            bool stringy = false;
+        };
+        std::stack<arity_t> arity;
+        thingie<D> tree{ 0.0 };
+        std::string_view last_token;
+
+        void _parse( std::string_view str, bool assignment );
+        void parse_string( std::string_view str, parse_state &state );
+        void parse_bin_op( pbin_op const &op, parse_state &state );
+        template<typename T>
+        void parse_diag_f( T const &token, parse_state &state );
+        void parse_comma( parse_state &state );
+        void parse_lparen( parse_state &state );
+        void parse_rparen( parse_state &state );
+        void new_func();
+        void new_oper();
+        void new_var( std::string_view str );
+        void maybe_first_argument();
+        std::vector<std::string> _get_strings( std::vector<thingie<D>> const &params,
+                                               size_t nparams ) const;
+};
+
+template<class D>
+void math_exp<D>::math_exp_impl::maybe_first_argument()
+{
+    if( !arity.empty() && !arity.top().sym.empty() && arity.top().current == 0 ) {
+        arity.top().current++;
+    }
+}
+
+template<class D>
+void math_exp<D>::math_exp_impl::_parse( std::string_view str, bool assignment )
+{
+    constexpr std::string_view expression_separators = "+-*/^,()%";
+    parse_state state{ parse_state::expect::operand, parse_state::expect::eof, true };
+    for( std::string_view const token : tokenize( str, expression_separators ) ) {
+        last_token = token;
+        if( std::optional<std::string_view> str = get_string( token ); str ) {
+            parse_string( *str, state );
+
+        } else if( std::optional<double> val = get_number( token ); val ) {
+            state.validate( parse_state::expect::operand );
+            maybe_first_argument();
+            output.emplace( *val );
+            state.set( parse_state::expect::oper, false );
+
+        } else if( std::optional<pmath_func> ftoken = get_function( token ); ftoken ) {
+            state.validate( parse_state::expect::operand );
+            maybe_first_argument();
+            ops.emplace( *ftoken );
+            arity.emplace( arity_t{ ( *ftoken )->symbol, 0, ( *ftoken )->num_params } );
+            state.set( parse_state::expect::lparen, false );
+
+        } else if( std::optional<scoped_diag_eval<D>> feval = get_dialogue_eval<D>( token ); feval &&
+                   !assignment ) {
+            parse_diag_f( *feval, state );
+
+        } else if( std::optional<scoped_diag_ass<D>> fass = get_dialogue_ass<D>( token ); fass &&
+                   assignment ) {
+            parse_diag_f( *fass, state );
+
+        } else if( std::optional<punary_op> op = get_unary_op( token ); op && state.allows_prefix_unary ) {
+            state.validate( parse_state::expect::operand );
+            ops.emplace( *op );
+            state.set( parse_state::expect::operand, false );
+
+        } else if( std::optional<pbin_op> op = get_binary_op( token ); op ) {
+            parse_bin_op( *op, state );
+
+        } else if( token == "," ) {
+            parse_comma( state );
+
+        } else if( token == "(" ) {
+            parse_lparen( state );
+
+        } else if( token == ")" ) {
+            parse_rparen( state );
+
+        } else {
+            state.validate( parse_state::expect::operand );
+            maybe_first_argument();
+            new_var( token );
+            state.set( parse_state::expect::oper, false );
+        }
+    }
+    state.validate( parse_state::expect::eof );
+    while( !ops.empty() ) {
+        if( std::holds_alternative<paren>( ops.top() ) && std::get<paren>( ops.top() ) == paren::left ) {
+            throw std::invalid_argument( "Unterminated left paranthesis" );
+        }
+        new_oper();
+    }
+
+    if( assignment && !is_assign_target( output.top() ) ) {
+        throw std::invalid_argument( "Assignment tree can only contain one variable name or dialogue assignment function" );
+    }
+
+    if( output.size() != 1 ) {
+        throw std::invalid_argument( "Invalid expression.  That's all we know.  Blame andrei." );
+    }
+    tree = std::move( output.top() );
+    output.pop();
+}
+
+template<class D>
+void math_exp<D>::math_exp_impl::parse_string( std::string_view str, parse_state &state )
+{
+    state.validate( parse_state::expect::operand );
+    maybe_first_argument();
+    if( arity.empty() || !arity.top().stringy ) {
+        throw std::invalid_argument( "String arguments can only be used in dialogue functions" );
+    }
+    output.emplace( std::string{ str } );
+    state.set( parse_state::expect::oper, false );
+}
+
+template<class D>
+void math_exp<D>::math_exp_impl::parse_bin_op( pbin_op const &op, parse_state &state )
+{
+    state.validate( parse_state::expect::oper );
+    while( !ops.empty() && ops.top() > *op ) {
+        new_oper();
+    }
+    ops.emplace( op );
+    state.set( parse_state::expect::operand, true );
+}
+
+template<class D>
+template<typename T>
+void math_exp<D>::math_exp_impl::parse_diag_f( T const &token, parse_state &state )
+{
+    state.validate( parse_state::expect::operand );
+    ops.emplace( token );
+    arity.emplace( arity_t{ token.df->symbol, 0, token.df->num_params, true } );
+    state.set( parse_state::expect::lparen, false );
+}
+
+template<class D>
+void math_exp<D>::math_exp_impl::parse_comma( parse_state &state )
+{
+    state.validate( parse_state::expect::oper );
+    if( arity.empty() || arity.top().sym.empty() ) {
+        throw std::invalid_argument( "Misplaced comma" );
+    }
+    while( ops.top() > paren::left ) {
+        new_oper();
+    }
+    arity.top().current++;
+    if( arity.top().expected > 0 && arity.top().current > arity.top().expected ) {
+        throw std::invalid_argument( string_format(
+                                         "Too many arguments for function %s()",
+                                         arity.top().sym.data() ) );
+    }
+    state.set( parse_state::expect::operand, true );
+}
+
+template<class D>
+void math_exp<D>::math_exp_impl::parse_lparen( parse_state &state )
+{
+    state.validate( parse_state::expect::lparen );
+    if( ops.empty() || !is_function( ops.top() ) ) {
+        arity.emplace( arity_t{ {}, 0, 0 } );
+    }
+    ops.emplace( paren::left );
+    state.set( parse_state::expect::operand, true );
+}
+
+template<class D>
+void math_exp<D>::math_exp_impl::parse_rparen( parse_state &state )
+{
+    state.validate( parse_state::expect::rparen );
+    while( !ops.empty() && ops.top() > paren::left ) {
+        new_oper();
+    }
+    if( ops.empty() || !std::holds_alternative<paren>( ops.top() ) ||
+        std::get<paren>( ops.top() ) != paren::left ) {
+        throw std::invalid_argument( "Misplaced right parenthesis" );
+    }
+    ops.pop();
+    new_func();
+    arity.pop();
+    maybe_first_argument();
+    state.set( parse_state::expect::oper, false );
+}
+
+template<class D>
+void math_exp<D>::math_exp_impl::new_func()
+{
+    if( !ops.empty() && is_function( ops.top() ) ) {
+        typename std::vector<thingie<D>>::size_type const nparams = arity.top().current;
+        if( arity.top().expected > 0 && arity.top().current < arity.top().expected ) {
+            throw std::invalid_argument( string_format(
+                                             "Not enough arguments for function %s()",
+                                             arity.top().sym.data() ) );
+        }
+        std::vector<thingie<D>> params( nparams );
+        for( typename std::vector<thingie<D>>::size_type i = 0; i < nparams; i++ ) {
+            params[i] = std::move( output.top() );
+            output.pop();
+        }
+        std::visit( overloaded{
+            [&params, nparams, this]( scoped_diag_eval<D> const & v )
+            {
+                std::vector<std::string> const strings = _get_strings( params, nparams );
+                output.emplace( std::in_place_type_t<func_diag_eval<D>>(), v.df->f( v.scope, strings ) );
+            },
+            [&params, nparams, this]( scoped_diag_ass<D> const & v )
+            {
+                std::vector<std::string> const strings = _get_strings( params, nparams );
+                output.emplace( std::in_place_type_t<func_diag_ass<D>>(), v.df->f( v.scope, strings ) );
+            },
+            [&params, this]( pmath_func v )
+            {
+                output.emplace( std::in_place_type_t<func<D>>(), std::move( params ), v->f );
+            },
+            []( auto /* v */ )
+            {
+                throw std::invalid_argument( "Internal error.  That's all we know." );
+            },
+        },
+        ops.top() );
+        ops.pop();
+    }
+}
+
+template<class D>
+std::vector<std::string> math_exp<D>::math_exp_impl::_get_strings( std::vector<thingie<D>> const
+        &params, size_t nparams ) const
+{
+    std::vector<std::string> strings( nparams );
+    std::transform( params.begin(), params.end(), strings.begin(), [this]( thingie<D> const & e ) {
+        if( std::holds_alternative<std::string>( e.data ) ) {
+            return std::get<std::string>( e.data );
+        }
+        throw std::invalid_argument( string_format(
+                                         "Parameters for %s() must be strings contained in single quotes",
+                                         arity.top().sym.data() ) );
+        return std::string{};
+    } );
+    return strings;
+}
+
+template<class D>
+void math_exp<D>::math_exp_impl::new_oper()
+{
+    std::visit( overloaded{
+        [this]( pbin_op v )
+        {
+            cata_assert( output.size() >= 2 );
+            thingie rhs = std::move( output.top() );
+            output.pop();
+            thingie lhs = std::move( output.top() );
+            output.pop();
+            output.emplace( std::in_place_type_t<oper<D>>(), lhs, rhs, v->f );
+        },
+        [this]( punary_op v )
+        {
+            cata_assert( !output.empty() );
+            thingie rhs = std::move( output.top() );
+            output.pop();
+            output.emplace( std::in_place_type_t<oper<D>>(), thingie<D> { 0.0 }, rhs, v->f );
+        },
+        []( pmath_func v )
+        {
+            throw std::invalid_argument( string_format(
+                                             "Unterminated math function %s()",
+                                             v->symbol.data() ) );
+        },
+        []( scoped_diag_eval<D> const & v )
+        {
+            throw std::invalid_argument( string_format(
+                                             "Unterminated dialogue function %s()",
+                                             v.df->symbol.data() ) );
+        },
+        []( scoped_diag_ass<D> const & v )
+        {
+            throw std::invalid_argument( string_format(
+                                             "Unterminated dialogue function %s()",
+                                             v.df->symbol.data() ) );
+        },
+        []( paren /* v */ ) {}
+    },
+    ops.top() );
+
+    ops.pop();
+}
+
+template<class D>
+void math_exp<D>::math_exp_impl::new_var( std::string_view str )
+{
+    std::string_view scoped = str;
+    var_type type = var_type::global;
+    if( str.size() > 2 && str[1] == '_' ) {
+        scoped = scoped.substr( 2 );
+        switch( str[0] ) {
+            case 'u':
+                type = var_type::u;
+                break;
+            case 'n':
+                type = var_type::npc;
+                break;
+            default:
+                debugmsg( "Unknown scope %c in variable %.*s", str[0], str.size(), str.data() );
+        }
+    }
+    output.emplace( std::in_place_type_t<var<D>>(), type, "npctalk_var_" + std::string{ scoped } );
+}
+
+template<class D>
+bool math_exp<D>::parse( std::string_view str, bool assignment )
+{
+    impl = std::make_unique<math_exp_impl>();
+    return impl->parse( str, assignment );
+}
+
+template<class D>
+math_exp<D>::math_exp( math_exp<D> const &other ) :
+    impl( other.impl ? std::make_unique<math_exp_impl>( *other.impl ) :
+          std::make_unique<math_exp_impl>() ) {}
+template<class D>
+math_exp<D> &math_exp<D>::operator=( math_exp<D> const &other )
+{
+    impl = other.impl ? std::make_unique<math_exp_impl>( *other.impl ) :
+           std::make_unique<math_exp_impl>();
+    return *this;
+}
+template<class D>
+math_exp<D>::math_exp() = default;
+template<class D>
+math_exp<D>::~math_exp() = default;
+template<class D>
+math_exp<D>::math_exp( math_exp<D> &&/* other */ ) noexcept = default;
+template<class D>
+math_exp<D> &math_exp<D>::operator=( math_exp<D> &&/* other */ )  noexcept = default;
+
+template<class D>
+double math_exp<D>::eval( D const &d ) const
+{
+    return impl->eval( d );
+}
+
+template<class D>
+void math_exp<D>::assign( D const &d, double val ) const
+{
+    return impl->assign( d, val );
+}
+
+template class math_exp<dialogue>;
+template class math_exp<mission_goal_condition_context>;

--- a/src/math_parser.h
+++ b/src/math_parser.h
@@ -1,0 +1,33 @@
+#ifndef CATA_SRC_MATH_PARSER_H
+#define CATA_SRC_MATH_PARSER_H
+
+#include <memory>
+#include <string_view>
+
+struct dialogue;
+struct mission_goal_condition_context;
+
+template<class D>
+class math_exp
+{
+    public:
+        ~math_exp();
+        math_exp();
+        math_exp( math_exp const &other );
+        math_exp( math_exp &&/* other */ ) noexcept;
+        math_exp &operator=( math_exp const &other );
+        math_exp &operator=( math_exp &&/* other */ ) noexcept;
+
+        bool parse( std::string_view str, bool assignment = false );
+        double eval( D const &d ) const;
+        void assign( D const &d, double val ) const;
+
+    private:
+        class math_exp_impl;
+        std::unique_ptr<math_exp_impl> impl;
+};
+
+extern template class math_exp<dialogue>;
+extern template class math_exp<mission_goal_condition_context>;
+
+#endif // CATA_SRC_MATH_PARSER_H

--- a/src/math_parser_func.cpp
+++ b/src/math_parser_func.cpp
@@ -1,7 +1,13 @@
 #include "math_parser_func.h"
+#include "math_parser_shim.h"
 
+#include <exception>
 #include <string_view>
 #include <vector>
+
+#include "condition.h"
+#include "dialogue.h"
+#include "mission.h"
 
 std::vector<std::string_view> tokenize( std::string_view str, std::string_view separators,
                                         bool include_seps )
@@ -28,3 +34,42 @@ std::vector<std::string_view> tokenize( std::string_view str, std::string_view s
     }
     return ret;
 }
+
+template<class D>
+std::function<double( D const & )> u_val( char scope,
+        std::vector<std::string> const &params )
+{
+    kwargs_shim const shim( params, scope );
+    try {
+        return conditional_t<D>::get_get_dbl( shim );
+    } catch( std::exception const &e ) {
+        debugmsg( "shim failed: %s", e.what() );
+        return []( D const & ) {
+            return 0;
+        };
+    }
+}
+
+template<class D>
+std::function<void( D const &, double )> u_val_ass( char scope,
+        std::vector<std::string> const &params )
+{
+    kwargs_shim const shim( params, scope );
+    try {
+        return conditional_t<D>::get_set_dbl( shim, {}, {}, false );
+    } catch( std::exception const &e ) {
+        debugmsg( "shim failed: %s", e.what() );
+        return []( D const &, double ) {};
+    }
+}
+
+template std::function<double( dialogue const & )>
+u_val<dialogue>( char scope,
+                 std::vector<std::string> const &params );
+template std::function<double( mission_goal_condition_context const & )>
+u_val<mission_goal_condition_context>( char scope,
+                                       std::vector<std::string> const &params );
+template std::function<void( dialogue const &, double )>
+u_val_ass( char, std::vector<std::string> const & );
+template std::function<void( mission_goal_condition_context const &, double )>
+u_val_ass( char, std::vector<std::string> const & );

--- a/src/math_parser_func.cpp
+++ b/src/math_parser_func.cpp
@@ -1,0 +1,30 @@
+#include "math_parser_func.h"
+
+#include <string_view>
+#include <vector>
+
+std::vector<std::string_view> tokenize( std::string_view str, std::string_view separators,
+                                        bool include_seps )
+{
+    std::vector<std::string_view> ret;
+    std::string_view::size_type start = 0;
+    std::string_view::size_type pos = 0;
+
+    while( pos != std::string_view::npos ) {
+        pos = str.find_first_of( separators, start );
+        if( pos != start ) {
+            std::string_view const ts = str.substr( start, pos - start );
+            if( std::string_view::size_type const unpad = ts.find_first_not_of( ' ' );
+                unpad != std::string_view::npos ) {
+                std::string_view::size_type const unpad_e = ts.find_last_not_of( ' ' );
+                ret.emplace_back(
+                    ts.substr( unpad, unpad_e - unpad + 1 ) );
+            }
+        }
+        if( pos != std::string_view::npos && include_seps ) {
+            ret.emplace_back( &str[pos], 1 );
+        }
+        start = pos + 1;
+    }
+    return ret;
+}

--- a/src/math_parser_func.h
+++ b/src/math_parser_func.h
@@ -1,0 +1,176 @@
+#ifndef CATA_SRC_MATH_PARSER_FUNC_H
+#define CATA_SRC_MATH_PARSER_FUNC_H
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "rng.h"
+
+struct math_func {
+    std::string_view symbol;
+    int num_params;
+    using f_t = double ( * )( std::vector<double> & );
+    f_t f;
+};
+using pmath_func = math_func const *;
+
+struct math_const {
+    std::string_view symbol;
+    double val;
+};
+using pmath_const = math_const const *;
+
+template<class D>
+struct dialogue_func {
+    dialogue_func<D>( std::string_view s_, std::string_view sc_, int n_ ) : symbol( s_ ),
+        scopes( sc_ ), num_params( n_ ) {}
+    std::string_view symbol;
+    std::string_view scopes;
+    int num_params{};
+};
+
+template <class D>
+struct dialogue_func_eval : dialogue_func<D> {
+    using f_t = std::function<double( D const & )> ( * )( char scope,
+                std::vector<std::string> const & );
+
+    dialogue_func_eval<D>( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
+        : dialogue_func<D>( s_, sc_, n_ ), f( f_ ) {}
+
+    f_t f;
+};
+
+template <class D>
+struct dialogue_func_ass : dialogue_func<D> {
+    using f_t = std::function<void( D const &, double )> ( * )( char scope,
+                std::vector<std::string> const & );
+
+    dialogue_func_ass<D>( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
+        : dialogue_func<D>( s_, sc_, n_ ), f( f_ ) {}
+
+    f_t f;
+};
+
+template<class D>
+using pdiag_func_eval = dialogue_func_eval<D> const *;
+template<class D>
+using pdiag_func_ass = dialogue_func_ass<D> const *;
+
+inline double abs( std::vector<double> &params )
+{
+    return std::abs( params[0] );
+}
+
+inline double max( std::vector<double> &params )
+{
+    if( params.empty() ) {
+        return 0;
+    }
+    return *std::max_element( params.begin(), params.end() );
+}
+
+inline double min( std::vector<double> &params )
+{
+    if( params.empty() ) {
+        return 0;
+    }
+    return *std::min_element( params.begin(), params.end() );
+}
+
+inline double math_rng( std::vector<double> &params )
+{
+    return rng_float( params[0], params[1] );
+}
+
+inline double rand( std::vector<double> &params )
+{
+    return rng( 0, static_cast<int>( std::round( params[0] ) ) );
+}
+
+inline double sqrt( std::vector<double> &params )
+{
+    return std::sqrt( params[0] );
+}
+
+inline double log( std::vector<double> &params )
+{
+    return std::log( params[0] );
+}
+
+inline double sin( std::vector<double> &params )
+{
+    return std::sin( params[0] );
+}
+
+inline double cos( std::vector<double> &params )
+{
+    return std::cos( params[0] );
+}
+
+inline double tan( std::vector<double> &params )
+{
+    return std::tan( params[0] );
+}
+
+constexpr double test_( std::vector<double> &/* params */ )
+{
+    return 42;
+}
+
+template<class D>
+std::function<double( D const & )> u_val( char scope,
+        std::vector<std::string> const &params );
+template<class D>
+std::function<void( D const &, double )> u_val_ass( char scope,
+        std::vector<std::string> const &params );
+
+constexpr std::array<math_func, 11> functions{
+    math_func{ "abs", 1, abs },
+    math_func{ "max", -1, max },
+    math_func{ "min", -1, min },
+    math_func{ "rng", 2, math_rng },
+    math_func{ "rand", 1, rand },
+    math_func{ "sqrt", 1, sqrt },
+    math_func{ "log", 1, log },
+    math_func{ "sin", 1, sin },
+    math_func{ "cos", 1, cos },
+    math_func{ "tan", 1, tan },
+    math_func{ "_test_", 0, test_ },
+};
+
+template<class D>
+inline std::array<dialogue_func_eval<D>, 1> const dialogue_eval_f{
+    dialogue_func_eval{ "val", "un", -1, u_val<D> },
+};
+
+template<class D>
+inline std::array<dialogue_func_ass<D>, 1> const dialogue_assign_f{
+    dialogue_func_ass{ "val", "un", -1, u_val_ass<D> },
+};
+
+namespace math_constants
+{
+# if (defined M_PI && defined M_E)
+constexpr double pi_v = M_PI;
+constexpr double e_v = M_E;
+#else
+constexpr double pi_v = 3.14159265358979323846;
+constexpr double e_v = 2.7182818284590452354;
+#endif
+} // namespace math_constants
+
+constexpr std::array<math_const, 3> constants{
+    math_const{ "π", math_constants::pi_v },
+    math_const{ "pi", math_constants::pi_v },
+    math_const{ "e", math_constants::e_v },
+};
+
+std::vector<std::string_view> tokenize( std::string_view str, std::string_view separators,
+                                        bool include_seps = true );
+
+#endif // CATA_SRC_MATH_PARSER_FUNC_H

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -1,0 +1,259 @@
+#ifndef CATA_SRC_MATH_PARSER_IMPL_H
+#define CATA_SRC_MATH_PARSER_IMPL_H
+
+#include <array>
+#include <cmath>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+#include "debug.h"
+#include "dialogue_helpers.h"
+#include "math_parser_func.h"
+
+struct binary_op {
+    enum class associativity {
+        right = 0,
+        left,
+    };
+    std::string_view symbol;
+    int precedence;
+    associativity assoc;
+    using f_t = double ( * )( double, double );
+    f_t f;
+};
+using pbin_op = binary_op const *;
+struct unary_op {
+    std::string_view symbol;
+    binary_op::f_t f;
+};
+using punary_op = unary_op const *;
+
+constexpr bool operator>( binary_op const &lhs, binary_op const &rhs )
+{
+    return lhs.precedence > rhs.precedence ||
+           ( lhs.precedence == rhs.precedence && lhs.assoc == binary_op::associativity::left );
+}
+enum class paren {
+    left = 0,
+    right,
+};
+
+template<class D>
+struct scoped_diag_eval {
+    pdiag_func_eval<D> df{};
+    char scope = 'g';
+};
+
+template<class D>
+struct scoped_diag_ass {
+    pdiag_func_ass<D> df{};
+    char scope = 'g';
+};
+
+template<class D>
+struct oper;
+template<class D>
+struct func;
+template<class D>
+struct func_diag_eval;
+template<class D>
+struct func_diag_ass;
+template<class D>
+struct var;
+template<class D>
+struct thingie {
+    thingie() = default;
+    template <class U>
+    explicit thingie( U u ) : data( std::in_place_type<U>, std::forward<U>( u ) ) {}
+    template <class T, class... Args>
+    explicit thingie( std::in_place_type_t<T> /*t*/, Args &&...args )
+        : data( std::in_place_type<T>, std::forward<Args>( args )... ) {}
+
+    constexpr double eval( D const &d ) const;
+
+    using impl_t =
+        std::variant<double, std::string, oper<D>, func<D>, func_diag_eval<D>, func_diag_ass<D>, var<D>>;
+    impl_t data;
+};
+
+template<class D>
+struct var {
+    template<class... Args>
+    explicit var( Args &&... args ) : varinfo( std::forward<Args>( args )... ) {}
+
+    double eval( D const &d ) const {
+        std::string const str = read_var_value( varinfo, d );
+        if( str.empty() ) {
+            return 0;
+        }
+        return std::stod( str );
+    }
+
+    var_info varinfo;
+};
+
+template<class D>
+struct func {
+    explicit func( std::vector<thingie<D>> &&params_, math_func::f_t f_ ) : params( params_ ),
+        f( f_ ) {}
+
+    double eval( D const &d ) const {
+        std::vector<double> elems( params.size() );
+        std::transform( params.begin(), params.end(), elems.begin(),
+        [&d]( thingie<D> const & e ) {
+            return e.eval( d );
+        } );
+        return f( elems );
+    }
+
+    std::vector<thingie<D>> params;
+    math_func::f_t f{};
+};
+
+template<class D>
+struct func_diag_eval {
+    using eval_f = std::function<double( D const & )>;
+    explicit func_diag_eval( eval_f &&f_ ) : f( f_ ) {}
+
+    double eval( D const &d ) const {
+        return f( d );
+    }
+
+    eval_f f;
+};
+
+template<class D>
+struct func_diag_ass {
+    using ass_f = std::function<void( D const &, double )>;
+    explicit func_diag_ass( ass_f &&f_ ) : f( f_ ) {}
+
+    double eval( D const &/* d */ ) const {
+        debugmsg( "eval() called on assignment function" );
+        return 0;
+    }
+
+    void assign( D const &d, double val ) const {
+        f( d, val );
+    }
+
+    ass_f f;
+};
+
+template<class D>
+struct oper {
+    oper( thingie<D> l_, thingie<D> r_, binary_op::f_t op_ ) :
+        l( std::make_shared<thingie<D>>( std::move( l_ ) ) ),
+        r( std::make_shared<thingie<D>>( std::move( r_ ) ) ),
+        op( op_ ) {}
+
+    constexpr double eval( D const &d ) const {
+        return ( *op )( l->eval( d ), r->eval( d ) );
+    }
+
+    std::shared_ptr<thingie<D>> l, r;
+    binary_op::f_t op{};
+};
+
+// overload pattern from https://en.cppreference.com/w/cpp/utility/variant/visit
+template <class... Ts>
+struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+template <class... Ts>
+explicit overloaded( Ts... ) -> overloaded<Ts...>;
+template<class D>
+constexpr double thingie<D>::eval( D const &d ) const
+{
+    return std::visit( overloaded{
+        []( double v )
+        {
+            return v;
+        },
+        []( std::string const & v )
+        {
+            debugmsg( "Unexpected string operand %.*s", v.size(), v.data() );
+            return 0.0;
+        },
+        [&d]( auto const & v ) -> double
+        {
+            return v.eval( d );
+        },
+    },
+    data );
+}
+
+template<class D>
+using op_t =
+    std::variant<pbin_op, punary_op, pmath_func, scoped_diag_eval<D>, scoped_diag_ass<D>, paren>;
+
+template<class D>
+constexpr bool operator>( op_t<D> const &lhs, binary_op const &rhs )
+{
+    return ( std::holds_alternative<pbin_op>( lhs ) && *std::get<pbin_op>( lhs ) > rhs ) ||
+           std::holds_alternative<punary_op>( lhs );
+}
+
+template<class D>
+constexpr bool operator>( op_t<D> const &lhs, paren const &rhs )
+{
+    return !std::holds_alternative<paren>( lhs ) || std::less<paren> {}( rhs, std::get<paren>( lhs ) );
+}
+
+constexpr double neg( double /* zero */, double r )
+{
+    return -r;
+}
+
+constexpr double pos( double /* zero */, double r )
+{
+    return r;
+}
+
+constexpr double add( double l, double r )
+{
+    return l + r;
+}
+
+constexpr double sub( double l, double r )
+{
+    return l - r;
+}
+
+constexpr double mul( double l, double r )
+{
+    return l * r;
+}
+
+constexpr double div( double l, double r )
+{
+    return l / r;
+}
+
+inline double mod( double l, double r )
+{
+    return std::fmod( l, r );
+}
+
+inline double math_pow( double l, double r )
+{
+    return std::pow( l, r );
+}
+
+constexpr std::array<binary_op, 6> binary_ops{
+    binary_op{ "+", 2, binary_op::associativity::left, add },
+    binary_op{ "-", 2, binary_op::associativity::left, sub },
+    binary_op{ "*", 3, binary_op::associativity::left, mul },
+    binary_op{ "/", 3, binary_op::associativity::left, div },
+    binary_op{ "%", 3, binary_op::associativity::right, mod },
+    binary_op{ "^", 4, binary_op::associativity::right, math_pow },
+};
+
+constexpr std::array<unary_op, 2> prefix_unary_ops{
+    unary_op{ "+", pos },
+    unary_op{ "-", neg },
+};
+
+
+#endif // CATA_SRC_MATH_PARSER_IMPL_H

--- a/src/math_parser_shim.cpp
+++ b/src/math_parser_shim.cpp
@@ -1,0 +1,86 @@
+#include "math_parser_shim.h"
+#include "math_parser_func.h"
+
+#include <map>
+#include <string_view>
+
+#include "condition.h"
+#include "json_loader.h"
+#include "string_formatter.h"
+
+kwargs_shim::kwargs_shim( std::vector<std::string> const &tokens, char scope )
+{
+    bool positional = false;
+    for( std::string_view const token : tokens ) {
+        std::vector<std::string_view> parts = tokenize( token, ":", false );
+        if( parts.size() == 1 && !positional ) {
+            kwargs.emplace(
+                // NOLINTNEXTLINE(cata-translate-string-literal): not a user-visible string
+                string_format( "%s_val", scope == 'g' ? "global" : scope == 'n' ? "npc" : std::string( 1, scope ) ),
+                parts[0] );
+            positional = true;
+        } else if( parts.size() == 2 ) {
+            kwargs.emplace( parts[0], parts[1] );
+        } else {
+            debugmsg( "Too many parts in token %.*s", token.size(), token.data() );
+        }
+    }
+}
+
+std::string kwargs_shim::str() const
+{
+    std::string ret;
+    for( decltype( kwargs )::value_type const &e : kwargs ) {
+        // NOLINTNEXTLINE(cata-translate-string-literal): not a user-visible string
+        ret += string_format( "'%.*s: %.*s', ", e.first.size(), e.first.data(), e.second.size(),
+                              e.second.data() );
+    }
+    return ret;
+}
+
+JsonValue kwargs_shim::get_member( std::string_view key ) const
+{
+    auto const it = kwargs.find( key );
+    bool const valid = it != kwargs.end();
+    std::string const temp =
+        valid ? string_format( R"("%.*s")", it->second.size(), it->second.data() )
+        : R"("dummy")";
+    return json_loader::from_string( temp );
+}
+
+std::string kwargs_shim::get_string( std::string_view key ) const
+{
+    std::optional<std::string> get = _get_string( key );
+    if( get ) {
+        return *get;
+    }
+    return {};
+}
+
+double kwargs_shim::get_float( std::string_view key ) const
+{
+    std::optional<std::string> get = _get_string( key );
+    if( get && !get->empty() ) {
+        return std::stod( *get );
+    }
+    return 0;
+}
+
+int kwargs_shim::get_int( std::string_view key, int def ) const
+{
+    std::optional<std::string> get = _get_string( key );
+    if( get && !get->empty() ) {
+        return std::stoi( *get );
+    }
+    return def;
+}
+
+std::optional<std::string> kwargs_shim::_get_string( std::string_view key ) const
+{
+    auto itkw = kwargs.find( key );
+    if( itkw != kwargs.end() ) {
+        return { std::string{ itkw->second } };
+    }
+
+    return std::nullopt;
+}

--- a/src/math_parser_shim.h
+++ b/src/math_parser_shim.h
@@ -1,0 +1,57 @@
+#ifndef CATA_SRC_MATH_PARSER_SHIM_H
+#define CATA_SRC_MATH_PARSER_SHIM_H
+
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "json.h"
+
+// temporary shim that pretends to be a JsonObject for the purpose of reusing code between the new
+// "math" and the old "arithmetic"/"compare_num"/"u_val"
+class kwargs_shim
+{
+    public:
+        explicit kwargs_shim( std::vector<std::string> const &tokens, char scope );
+
+        std::string get_string( std::string_view key ) const;
+        double get_float( std::string_view key ) const;
+        int get_int( std::string_view key, int def = 0 ) const;
+
+        bool has_string( std::string_view key ) const {
+            return _get_string( key ).has_value();
+        }
+        bool has_int( std::string_view key ) const {
+            return has_string( key );
+        }
+        bool has_member( std::string_view key ) const {
+            return has_string( key );
+        }
+
+        JsonValue get_member( std::string_view key ) const;
+        static bool has_object( std::string_view /* key */ ) {
+            return false;
+        }
+        static JsonObject get_object( std::string_view /* key */ ) {
+            return {};
+        }
+        static bool has_array( std::string_view /* key */ ) {
+            return false;
+        }
+        static JsonArray get_array( std::string_view /* key */ ) {
+            return {};
+        }
+
+        static void throw_error( std::string_view message ) {
+            debugmsg( message.data() );
+        }
+        std::string str() const;
+        void allow_omitted_members() const {}
+
+    private:
+        std::map<std::string, std::string_view, std::less<>> kwargs;
+        std::optional<std::string> _get_string( std::string_view key ) const;
+};
+
+#endif // CATA_SRC_MATH_PARSER_SHIM_H

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4433,6 +4433,8 @@ void talk_effect_t<T>::parse_sub_effect( const JsonObject &jo )
         subeffect_fun.set_cast_spell( jo, "npc_cast_spell", true, targeted );
     } else if( jo.has_array( "arithmetic" ) ) {
         subeffect_fun.set_arithmetic( jo, "arithmetic", false );
+    } else if( jo.has_array( "math" ) ) {
+        subeffect_fun.set_math( jo, "math" );
     } else if( jo.has_string( "u_spawn_monster" ) ) {
         subeffect_fun.set_spawn_monster( jo, "u_spawn_monster", false );
     } else if( jo.has_string( "npc_spawn_monster" ) ) {

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -30,7 +30,11 @@ double rng_float( double lo, double hi )
     if( lo > hi ) {
         std::swap( lo, hi );
     }
-    return rng_real_dist( rng_get_engine(), std::uniform_real_distribution<>::param_type( lo, hi ) );
+    if( std::isfinite( lo ) && std::isfinite( hi ) ) {
+        return rng_real_dist( rng_get_engine(), std::uniform_real_distribution<>::param_type( lo, hi ) );
+    }
+    debugmsg( "rng_float called with nan/inf" );
+    return 0;
 }
 
 units::angle random_direction()

--- a/src/talker.h
+++ b/src/talker.h
@@ -89,9 +89,15 @@ class talker
         virtual int posz() const {
             return 0;
         }
-        virtual tripoint pos() const = 0;
-        virtual tripoint_abs_ms global_pos() const = 0;
-        virtual tripoint_abs_omt global_omt_location() const = 0;
+        virtual tripoint pos() const {
+            return {};
+        }
+        virtual tripoint_abs_ms global_pos() const {
+            return {};
+        }
+        virtual tripoint_abs_omt global_omt_location() const {
+            return {};
+        }
         virtual void set_pos( tripoint ) {}
         virtual std::string distance_to_goal() const {
             return "";

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -1,0 +1,187 @@
+#include "cata_catch.h"
+
+#include <cmath>
+
+#include "avatar.h"
+#include "dialogue.h"
+#include "global_vars.h"
+#include "math_parser.h"
+#include "math_parser_func.h"
+
+static const spell_id spell_test_spell_pew( "test_spell_pew" );
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity): false positive
+TEST_CASE( "math_parser_parsing", "[math_parser]" )
+{
+    dialogue const d( std::make_unique<talker>(), std::make_unique<talker>() );
+    math_exp<dialogue> testexp;
+
+    CHECK_FALSE( testexp.parse( "" ) );
+    CHECK( testexp.eval( d ) == Approx( 0.0 ) );
+    CHECK( testexp.parse( "50" ) );
+    CHECK( testexp.eval( d ) == Approx( 50 ) );
+
+    // binary
+    CHECK( testexp.parse( "50 + 2" ) );
+    CHECK( testexp.eval( d ) == Approx( 52 ) );
+    CHECK( testexp.parse( "50 + 2 * 3" ) );
+    CHECK( testexp.eval( d ) == Approx( 56 ) );
+    CHECK( testexp.parse( "50 + 2 * 3 ^ 2" ) );
+    CHECK( testexp.eval( d ) == Approx( 68 ) );
+    CHECK( testexp.parse( "50 + ( 2 * 3 ) ^ 2" ) );
+    CHECK( testexp.eval( d ) == Approx( 86 ) );
+    CHECK( testexp.parse( "(((50 + (((((( 2 * 4 ))))) ^ 2))))" ) );
+    CHECK( testexp.eval( d ) == Approx( 114 ) );
+    CHECK( testexp.parse( "50 % 3" ) );
+    CHECK( testexp.eval( d ) == Approx( 2 ) );
+
+    // unary
+    CHECK( testexp.parse( "-50" ) );
+    CHECK( testexp.eval( d ) == Approx( -50 ) );
+    CHECK( testexp.parse( "+50" ) );
+    CHECK( testexp.eval( d ) == Approx( 50 ) );
+    CHECK( testexp.parse( "-3^2" ) );
+    CHECK( testexp.eval( d ) == Approx( 9 ) );
+    CHECK( testexp.parse( "-(3^2)" ) );
+    CHECK( testexp.eval( d ) == Approx( -9 ) );
+    CHECK( testexp.parse( "-3^3" ) );
+    CHECK( testexp.eval( d ) == Approx( -27 ) );
+    CHECK( testexp.parse( "(-3)^2" ) );
+    CHECK( testexp.eval( d ) == Approx( 9 ) );
+    CHECK( testexp.parse( "-3^-2" ) );
+    CHECK( testexp.eval( d ) == Approx( std::pow( -3, -2 ) ) );
+    CHECK( testexp.parse( "2++3" ) ); // equivalent to 2+(+3)
+    CHECK( testexp.eval( d ) == Approx( 5 ) );
+    CHECK( testexp.parse( "2+-3" ) ); // equivalent to 2+(-3)
+    CHECK( testexp.eval( d ) == Approx( -1 ) );
+
+    // functions
+    CHECK( testexp.parse( "_test_()" ) ); // nullary test function
+    CHECK( testexp.parse( "max()" ) ); // variadic called with zero arguments
+    CHECK( testexp.parse( "sin(1)" ) );
+    CHECK( testexp.eval( d ) == Approx( std::sin( 1.0 ) ) );
+    CHECK( testexp.parse( "sin((1))" ) );
+    CHECK( testexp.eval( d ) == Approx( std::sin( 1.0 ) ) );
+    CHECK( testexp.parse( "cos( sin( 1 ) )" ) );
+    CHECK( testexp.eval( d ) == Approx( std::cos( std::sin( 1.0 ) ) ) );
+    CHECK( testexp.parse( "cos( (sin( 1 )) )" ) );
+    CHECK( testexp.eval( d ) == Approx( std::cos( std::sin( 1.0 ) ) ) );
+    CHECK( testexp.parse( "cos( (sin( (1) )) )" ) );
+    CHECK( testexp.eval( d ) == Approx( std::cos( std::sin( 1.0 ) ) ) );
+    CHECK( testexp.parse( "sin(-(-(-(-2))))" ) );
+    CHECK( testexp.eval( d ) == Approx( std::sin( 2 ) ) );
+    CHECK( testexp.parse( "max( 1, 2, 3, 4, 5, 6 )" ) );
+    CHECK( testexp.eval( d ) == Approx( 6 ) );
+    CHECK( testexp.parse( "cos( sin( min( 1 + 2, -50 ) ) )" ) );
+    CHECK( testexp.eval( d ) == Approx( std::cos( std::sin( std::min( 1 + 2, -50 ) ) ) ) );
+
+    // whitespace
+    CHECK( testexp.parse( "       50              +  (  2 *                3 ) ^                2             " ) );
+    CHECK( testexp.eval( d ) == Approx( 86 ) );
+
+    // constants
+    CHECK( testexp.parse( "π" ) );
+    CHECK( testexp.eval( d ) == Approx( math_constants::pi_v ) );
+    CHECK( testexp.parse( "pi" ) );
+    CHECK( testexp.eval( d ) == Approx( math_constants::pi_v ) );
+    CHECK( testexp.parse( "e^2" ) );
+    CHECK( testexp.eval( d ) == Approx( std::pow( math_constants::e_v, 2 ) ) );
+
+    // from https://raw.githubusercontent.com/ArashPartow/math-parser-benchmark-project/master/bench_expr_complete.txt
+    CHECK( testexp.parse( "((((((((5+7)*7.123)-3)-((5+7)-(7.123*3)))-((5*(7-(7.123*3)))/((5*7)+(7.123+3))))-((((5+7)-(7.123*3))+((5/7)+(7.123+3)))+(((5*7)+(7.123+3))*((5/7)/(7.123-3)))))-(((((5/7)-(7.321/3))*((5-7)+(7.321+3)))*(((5-7)-(7.321+3))+((5-7)*(7.321/3))))*((((5-7)+(7.321+3))-((5*7)*(7.321+3)))-(((5-7)*(7.321/3))/(5+((7/7.321)+3)))))))" ) );
+    CHECK( testexp.eval( d ) == Approx( 87139.7243098 ) );
+
+    // nan and inf
+    CHECK( testexp.parse( "1 / 0" ) );
+    CHECK( std::isinf( testexp.eval( d ) ) );
+    CHECK( testexp.parse( "-1 ^ 0.5" ) );
+    CHECK( std::isnan( testexp.eval( d ) ) );
+
+    // failed validation
+    // NOLINTNEXTLINE(readability-function-cognitive-complexity): false positive
+    std::string dmsg = capture_debugmsg_during( [&testexp, &d]() {
+        CHECK_FALSE( testexp.parse( "2+" ) );
+        CHECK_FALSE( testexp.parse( ")" ) );
+        CHECK_FALSE( testexp.parse( "(" ) );
+        CHECK_FALSE( testexp.parse( "()" ) );
+        CHECK_FALSE( testexp.parse( "(2+2))" ) );
+        CHECK_FALSE( testexp.parse( "(2+2^)" ) );
+        CHECK_FALSE( testexp.parse( "((2+2)" ) );
+        CHECK_FALSE( testexp.parse( "(2+2,3)" ) );
+        CHECK_FALSE( testexp.parse( "sin(1,2)" ) ); // too many arguments
+        CHECK_FALSE( testexp.parse( "rng(1)" ) );   // not enough arguments
+        CHECK_FALSE( testexp.parse( "sin((1+2,3))" ) );
+        CHECK_FALSE( testexp.parse( "sin(1" ) );
+        CHECK_FALSE( testexp.parse( "sin" ) );
+        CHECK_FALSE( testexp.parse( "sin('1')" ) );
+        CHECK_FALSE( testexp.parse( "sin(+)" ) );
+        CHECK_FALSE( testexp.parse( "sin(-)" ) );
+        CHECK_FALSE( testexp.parse( "_test_(-)" ) );
+        CHECK_FALSE( testexp.parse( "'string'" ) );
+        CHECK_FALSE( testexp.parse( "('wrong')" ) );
+        CHECK_FALSE( testexp.parse( "2+++2" ) );
+        CHECK( testexp.parse( "2+3" ) );
+        testexp.assign( d, 10 ); // assignment called on eval tree should not crash
+    } );
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity): false positive
+TEST_CASE( "math_parser_dialogue_integration", "[math_parser]" )
+{
+    standard_npc dude;
+    dialogue const d( get_talker_for( get_avatar() ), get_talker_for( &dude ) );
+    math_exp<dialogue> testexp;
+    global_variables &globvars = get_globals();
+
+    // reading scoped variables
+    globvars.set_global_value( "npctalk_var_x", "100" );
+    CHECK( testexp.parse( "x" ) );
+    CHECK( testexp.eval( d ) == Approx( 100 ) );
+    get_avatar().set_value( "npctalk_var_x", "92" );
+    CHECK( testexp.parse( "u_x" ) );
+    CHECK( testexp.eval( d ) == Approx( 92 ) );
+    dude.set_value( "npctalk_var_x", "21" );
+    CHECK( testexp.parse( "n_x" ) );
+    CHECK( testexp.eval( d ) == Approx( 21 ) );
+    CHECK( testexp.parse( "x + u_x + n_x" ) );
+    CHECK( testexp.eval( d ) == Approx( 213 ) );
+
+    // reading scoped values with u_val shim
+    std::string dmsg = capture_debugmsg_during( [&testexp]() {
+        CHECK_FALSE( testexp.parse( "u_val( 3 )" ) ); // only quoted strings accepted as parameters
+        CHECK_FALSE( testexp.parse( "u_val( stamina )" ) );
+        CHECK_FALSE( testexp.parse( "val( 'stamina' )" ) ); // invalid scope for this function
+    } );
+    CHECK( testexp.parse( "u_val('stamina')" ) );
+    CHECK( testexp.eval( d ) == get_avatar().get_stamina() );
+    CHECK( testexp.parse( "u_val('spell_level', 'spell: test_spell_pew')" ) );
+    get_avatar().magic->learn_spell( spell_test_spell_pew, get_avatar(), true );
+    get_avatar().magic->set_spell_level( spell_test_spell_pew, 4, &get_avatar() );
+    REQUIRE( d.actor( false )->get_spell_level( spell_test_spell_pew ) != 0 );
+    CHECK( testexp.eval( d ) == d.actor( false )->get_spell_level( spell_test_spell_pew ) );
+    CHECK( testexp.parse( "u_val('time: 1 m')" ) ); // test get_member() in shim
+    CHECK( testexp.eval( d ) == 60 );
+
+    // assignment to scoped variables
+    CHECK( testexp.parse( "u_testvar", true ) );
+    testexp.assign( d, 159 );
+    CHECK( std::stoi( get_avatar().get_value( "npctalk_var_testvar" ) ) == 159 );
+    CHECK( testexp.parse( "testvar", true ) );
+    testexp.assign( d, 259 );
+    CHECK( std::stoi( globvars.get_global_value( "npctalk_var_testvar" ) ) == 259 );
+    CHECK( testexp.parse( "n_testvar", true ) );
+    testexp.assign( d, 359 );
+    CHECK( std::stoi( dude.get_value( "npctalk_var_testvar" ) ) == 359 );
+
+    // assignment to scoped values with u_val shim
+    CHECK( testexp.parse( "u_val('stamina')", true ) );
+    testexp.assign( d, 459 );
+    CHECK( get_avatar().get_stamina() == 459 );
+    CHECK( testexp.parse( "n_val('stored_kcal')", true ) );
+    testexp.assign( d, 559 );
+    CHECK( dude.get_stored_kcal() == 559 );
+    std::string morelogs = capture_debugmsg_during( [&testexp, &d]() {
+        CHECK( testexp.eval( d ) == Approx( 0 ) ); // eval called on assignment tree should not crash
+        CHECK_FALSE( testexp.parse( "val( 'stamina' ) * 3", true ) ); // eval expression in assignment tree
+    } );
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
`arithmetic` and friends (`compare_num`, `u_val`, and `npc_val`) are too verbose and awkward to use for any real calculation in EOCs. Anything that needs more than one operator gets quickly untenable with curly braces and quotation marks.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Quick example of math in JSON:
```json
  { 
    "type": "effect_on_condition",
    "id": "EOC_math_test",
    "condition": {
        "math": [ "u_val('stamina')", ">=", "500" ] // exactly the same keyword and interface everywhere
    },
    "effect": [
      { "u_message": "math test! "},
      { "math": [ "u_math_test", "=", "u_val('stamina')" ] }, // assign to variable `math_test` in scope `u` (alpha talker)
      { "math": [ "math_test", "=", "u_val('stamina') + 3900" ] }, // assign to variable `math_test` in global scope
      { "math": [ "u_val('pain')", "=", "60 + rng(0,20)" ] }  // assign to special value exposed through stringy function `val` in the `u` scope
    ]
  },
```
Add a validating math expression parser. It can parse any math expression you'd want with simple JSON, can interact with scoped dialogue variables, and run arbitrary functions to calculate or extract data from the game just like EOC functions. 

There's also an `u_val` shim (seen in the snippet above) that lets it reuse some EOC code and can be used to replace almost all instances of `u_val` and `npc_val`.

<details>
<summary>A couple of more examples, taken and from our data:</summary>

<details>
<summary>Instead of this</summary>

```json
{ "compare_num": [ { "u_val": "pos_z" }, ">=", { "const": 0 } ] }
```

</details>

<details>
<summary>You can now write this</summary>

```json
{ "math": [ "u_val('pos_z')", ">=", "0" ]}
```
</details>

<details>
<summary>Instead of this</summary>

```json
{ "value": "LUMINATION", "add": { "arithmetic": [ { "u_val": "morale" } ] } }
```

</details>

<details>
<summary>You can now write this</summary>

```json
{ "value": "LUMINATION", "add": { "math": [ "u_val('morale') * 3 - rng(0, 100)" ] } }
```
and do some math in there at the same time.
</details>

</details>

<details>
<summary>Expressions are validated with helpful messages when something is wrong and there should never be any crashes from bad syntax. Example:</summary>

![Screenshot from 2023-03-28 06-20-49](https://user-images.githubusercontent.com/68240139/228122040-92da1042-1508-4eeb-ad26-38fb11e13e6b.png)

</details>

Internally, this parser is based on shunting-yard with some bells and whistles: validation, unary operators, variadic, and stringy functions. The implementation is hidden from the interface so it could be swapped out theoretically.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

TODO:
- [x] documentation
- [x] another test unit for JSON integration

#### Describe alternatives you've considered
Instead of stringy functions, I was originally accomplishing their goal with scoped variables like `u_spell_level_test_spell_pew` but that was both ambiguous and ugly (it's now `u_val('spell_level', 'spell: test_spell_pew')` through the `u_val` shim but I plan to flatten these kinds of things to `u_spell_level('test_spell_pew')`).

Other parsing algorithms are more efficient and/or more powerful, but their descriptions on Wikipedia weren't written for people like me.

Using a parser generator instead of hand-rolling one: this needs a build-time dependency and is possibly incomprehensible to the average contributor.

Using lua to parse math and/or replace EOC code: I got a mildly negative reaction to this when I proposed it a few months ago so I didn't commit and I don't know what it'd entail.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Test unit that provides 93% coverage for `math_parser`.
EOC test that targets all the integration options.

I've also been fuzzing the parser for a couple of days with libFuzzer and [this fuzz target](https://github.com/andrei8l/Cataclysm-DDA/commit/6334f693e49c4e1522f13bce16c4d10fe4c7efc1) with a seed corpus extracted from the test unit. It's not included in this PR because we're not set up for fuzzing.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I've squashed the commits into logical units so this can be reviewed by commit.

Syntax is validated, but whitespace style is not. I don't have a solution for that.

If this is accepted, I plan to slowly replace and eventually remove `arithmetic`, `compare_num`, `u/npc_val`, and `compare_var`.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->