### PR TITLE
Fix compiler warning for uninitialized limb_type

### DIFF
--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -347,7 +347,7 @@ void body_part_type::load( const JsonObject &jo, const std::string & )
         }
     } else {
         limbtypes.clear();
-        body_part_type::type limb_type;
+        body_part_type::type limb_type = {};
         mandatory( jo, was_loaded, "limb_type", limb_type );
         limbtypes.emplace( limb_type, 1.0f );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When building with cmake and gcc 12.2.1 I encountered an error for `-Wmaybe-uninitialized` related to an object read from json
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
provide a default value for limb_type
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
gcc pragma to disable this warning on the line in question, suggested against by a reviewer of this PR
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled with test suite
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
```
[  9%] Building CXX object src/CMakeFiles/cataclysm-common.dir/bodypart.cpp.o
In file included from /usr/include/c++/12.2.1/set:60,
                 from /home/sparr/src/Cataclysm-DDA/git/src/bodypart.h:10,
                 from /home/sparr/src/Cataclysm-DDA/git/src/bodypart.cpp:1:
In member function ‘std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::iterator std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_lower_bound(_Link_type, _Base_ptr, const _Key&) [with _Key = body_part_type::type; _Val = std::pair<const body_part_type::type, float>; _KeyOfValue = std::_Select1st<std::pair<const body_part_type::type, float> >; _Compare = std::less<body_part_type::type>; _Alloc = std::allocator<std::pair<const body_part_type::type, float> >]’,
    inlined from ‘std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::iterator std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::lower_bound(const key_type&) [with _Key = body_part_type::type; _Val = std::pair<const body_part_type::type, float>; _KeyOfValue = std::_Select1st<std::pair<const body_part_type::type, float> >; _Compare = std::less<body_part_type::type>; _Alloc = std::allocator<std::pair<const body_part_type::type, float> >]’ at /usr/include/c++/12.2.1/bits/stl_tree.h:1270:30,
    inlined from ‘std::map<_Key, _Tp, _Compare, _Alloc>::iterator std::map<_Key, _Tp, _Compare, _Alloc>::lower_bound(const key_type&) [with _Key = body_part_type::type; _Tp = float; _Compare = std::less<body_part_type::type>; _Alloc = std::allocator<std::pair<const body_part_type::type, float> >]’ at /usr/include/c++/12.2.1/bits/stl_map.h:1307:32,
    inlined from ‘std::pair<typename std::_Rb_tree<_Key, std::pair<const _Key, _Tp>, std::_Select1st<std::pair<const _Key, _Tp> >, _Compare, typename __gnu_cxx::__alloc_traits<_Allocator>::rebind<std::pair<const _Key, _Tp> >::other>::iterator, bool> std::map<_Key, _Tp, _Compare, _Alloc>::emplace(_Args&& ...) [with _Args = {body_part_type::type&, float}; _Key = body_part_type::type; _Tp = float; _Compare = std::less<body_part_type::type>; _Alloc = std::allocator<std::pair<const body_part_type::type, float> >]’ at /usr/include/c++/12.2.1/bits/stl_map.h:596:33,
    inlined from ‘void body_part_type::load(const JsonObject&, const std::string&)’ at /home/sparr/src/Cataclysm-DDA/git/src/bodypart.cpp:352:26:
/usr/include/c++/12.2.1/bits/stl_tree.h:1951:9: error: ‘limb_type’ may be used uninitialized [-Werror=maybe-uninitialized]
 1951 |         if (!_M_impl._M_key_compare(_S_key(__x), __k))
      |         ^~
/home/sparr/src/Cataclysm-DDA/git/src/bodypart.cpp: In member function ‘void body_part_type::load(const JsonObject&, const std::string&)’:
/home/sparr/src/Cataclysm-DDA/git/src/bodypart.cpp:350:30: note: ‘limb_type’ was declared here
  350 |         body_part_type::type limb_type;
      |                              ^~~~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-unknown-warning’ may have been intended to silence earlier diagnostics
cc1plus: all warnings being treated as errors
make[2]: *** [src/CMakeFiles/cataclysm-common.dir/build.make:538: src/CMakeFiles/cataclysm-common.dir/bodypart.cpp.o] Error 1
```
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->