### PR TITLE
Fix compiler warning uninitialized anonymous func

### DIFF
--- a/tests/map_iterator_test.cpp
+++ b/tests/map_iterator_test.cpp
@@ -228,12 +228,15 @@ TEST_CASE( "tripoint_range_circle_sizes_correct", "[tripoint_range]" )
     CHECK( points_in_radius_circ( tripoint_zero, 4 ).size() == 69 );
 }
 
+static bool tripoint_range_predicates_radius_test_func( const tripoint &pt )
+{
+    return pt.z < 0;
+}
+
 TEST_CASE( "tripoint_range_predicates_radius", "[tripoint_range]" )
 {
-    tripoint_range<tripoint> tested = points_in_radius_where( tripoint_zero,
-    2, []( const tripoint & pt ) {
-        return pt.z < 0;
-    }, 2 );
+    tripoint_range<tripoint> tested = points_in_radius_where( tripoint_zero, 2,
+                                      tripoint_range_predicates_radius_test_func, 2 );
     std::vector<tripoint> expected = {
         { -2, -2, -2 }, { -1, -2, -2 }, { 0, -2, -2 }, { 1, -2, -2 }, { 2, -2, -2 },
         { -2, -1, -2 }, { -1, -1, -2 }, { 0, -1, -2 }, { 1, -1, -2 }, { 2, -1, -2 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When building with cmake and gcc 12.2.1 I encountered an error for `-Wmaybe-uninitialized` related to an anonymous function
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I converted the function from an anonymous lambda to a named static function
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I tried changing it to a named lambda (`auto test_func = []( const tripoint & pt ) -> bool { return pt.z < 0; };`) but this produced the same error.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled and ran the test.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This is the second maybe-uninitialized warning I've encountered in my first build using cmake+gcc. The first was #64635

```
[ 62%] Building CXX object tests/CMakeFiles/cata_test.dir/map_iterator_test.cpp.o
In file included from /usr/include/c++/12.2.1/functional:59,
                 from /home/sparr/src/Cataclysm-DDA/git/tests/catch/catch.hpp:3480,
                 from /home/sparr/src/Cataclysm-DDA/git/tests/cata_catch.h:11,
                 from /home/sparr/src/Cataclysm-DDA/git/tests/map_iterator_test.cpp:1:
In copy constructor ‘std::function<_Res(_ArgTypes ...)>::function(const std::function<_Res(_ArgTypes ...)>&) [with _Res = bool; _ArgTypes = {const tripoint&}]’,
    inlined from ‘constexpr std::_Optional_payload_base<_Tp>::_Storage<_Up, false>::_Storage(std::in_place_t, _Args&& ...) [with _Args = {const std::function<bool(const tripoint&)>&}; _Up = std::function<bool(const tripoint&)>; _Tp = std::function<bool(const tripoint&)>]’ at /usr/include/c++/12.2.1/optional:244:8,
    inlined from ‘constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(std::in_place_t, _Args&& ...) [with _Args = {const std::function<bool(const tripoint&)>&}; _Tp = std::function<bool(const tripoint&)>]’ at /usr/include/c++/12.2.1/optional:126:4,
    inlined from ‘constexpr std::_Optional_payload<std::function<bool(const tripoint&)>, true, false, false>::_Optional_payload(std::in_place_t, _Args&& ...) [with _Args = {const std::function<bool(const tripoint&)>&}][inherited from std::_Optional_payload_base<std::function<bool(const tripoint&)> >]’ at /usr/include/c++/12.2.1/optional:397:42,
    inlined from ‘constexpr std::_Optional_payload<std::function<bool(const tripoint&)>, false, false, false>::_Optional_payload(std::in_place_t, _Args&& ...) [with _Args = {const std::function<bool(const tripoint&)>&}][inherited from std::_Optional_payload_base<std::function<bool(const tripoint&)> >]’ at /usr/include/c++/12.2.1/optional:431:57,
    inlined from ‘constexpr std::_Optional_base<_Tp, <anonymous>, <anonymous> >::_Optional_base(std::in_place_t, _Args&& ...) [with _Args = {const std::function<bool(const tripoint&)>&}; typename std::enable_if<is_constructible_v<_Tp, _Args ...>, bool>::type <anonymous> = false; _Tp = std::function<bool(const tripoint&)>; bool <anonymous> = false; bool <anonymous> = false]’ at /usr/include/c++/12.2.1/optional:521:4,
    inlined from ‘constexpr std::optional<_Tp>::optional(_Up&&) [with _Up = const std::function<bool(const tripoint&)>&; typename std::enable_if<__and_v<std::__not_<std::is_same<std::optional<_Tp>, typename std::remove_cv<typename std::remove_reference<_Up>::type>::type> >, std::__not_<std::is_same<std::in_place_t, typename std::remove_cv<typename std::remove_reference<_Up>::type>::type> >, std::is_constructible<_T1, _U1>, std::is_convertible<_Iter, _Iterator> >, bool>::type <anonymous> = true; _Tp = std::function<bool(const tripoint&)>]’ at /usr/include/c++/12.2.1/optional:749:47,
    inlined from ‘tripoint_range<Tripoint>::tripoint_range(const Tripoint&, const Tripoint&, const std::function<bool(const T&)>&) [with Tripoint = tripoint]’ at /home/sparr/src/Cataclysm-DDA/git/src/map_iterator.h:99:43,
    inlined from ‘tripoint_range<Tripoint> points_in_radius_where(const Tripoint&, int, const typename tripoint_predicate_fun<std::function<bool(const T&)> >::type&, int) [with Tripoint = tripoint]’ at /home/sparr/src/Cataclysm-DDA/git/src/map_iterator.h:203:77,
    inlined from ‘void ____C_A_T_C_H____T_E_S_T____17()’ at /home/sparr/src/Cataclysm-DDA/git/tests/map_iterator_test.cpp:236:10:
/usr/include/c++/12.2.1/bits/std_function.h:391:17: error: ‘<anonymous>’ may be used uninitialized [-Werror=maybe-uninitialized]
  391 |             __x._M_manager(_M_functor, __x._M_functor, __clone_functor);
      |             ~~~~^~~~~~~~~~
/usr/include/c++/12.2.1/bits/std_function.h: In function ‘void ____C_A_T_C_H____T_E_S_T____17()’:
/usr/include/c++/12.2.1/bits/std_function.h:267:7: note: by argument 2 of type ‘const std::_Any_data&’ to ‘static bool std::_Function_handler<_Res(_ArgTypes ...), _Functor>::_M_manager(std::_Any_data&, const std::_Any_data&, std::_Manager_operation) [with _Res = bool; _Functor = ____C_A_T_C_H____T_E_S_T____17()::<lambda(const tripoint&)>; _ArgTypes = {const tripoint&}]’ declared here
  267 |       _M_manager(_Any_data& __dest, const _Any_data& __source,
      |       ^~~~~~~~~~
/home/sparr/src/Cataclysm-DDA/git/tests/map_iterator_test.cpp:233:61: note: ‘<anonymous>’ declared here
  233 |     tripoint_range<tripoint> tested = points_in_radius_where( tripoint_zero,
      |                                       ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
  234 |     2, []( const tripoint & pt ) {
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                           
  235 |         return pt.z < 0;
      |         ~~~~~~~~~~~~~~~~                                     
  236 |     }, 2 );
      |     ~~~~~~                                                   
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-unknown-warning’ may have been intended to silence earlier diagnostics
cc1plus: all warnings being treated as errors
make[2]: *** [tests/CMakeFiles/cata_test.dir/build.make:1322: tests/CMakeFiles/cata_test.dir/map_iterator_test.cpp.o] Error 1
```
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->