### PR TITLE
Implement unused CLOSE_ADV_INV option

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1584,6 +1584,7 @@ void advanced_inventory::display()
         } );
     }
 
+
     while( !exit ) {
         if( player_character.moves < 0 ) {
             do_return_entry();
@@ -1605,6 +1606,10 @@ void advanced_inventory::display()
         // current item in source pane, might be null
         advanced_inv_listitem *sitem = spane.get_cur_item_ptr();
         aim_location changeSquare = NUM_AIM_LOCATIONS;
+
+        if( !is_processing() && move_all_items_and_waiting_to_quit ) {
+            break;
+        }
 
         const std::string action = is_processing() ? "MOVE_ALL_ITEMS" : ctxt.handle_input();
         if( action == "CATEGORY_SELECTION" ) {
@@ -1643,6 +1648,11 @@ void advanced_inventory::display()
         } else if( action == "MOVE_ALL_ITEMS" ) {
             exit = move_all_items();
             recalc = true;
+            if( exit ) {
+                if( get_option<bool>( "CLOSE_ADV_INV" ) ) {
+                    move_all_items_and_waiting_to_quit = true;
+                }
+            }
         } else if( action == "SORT" ) {
             if( show_sort_menu( spane ) ) {
                 recalc = true;

--- a/src/advanced_inv.h
+++ b/src/advanced_inv.h
@@ -53,6 +53,7 @@ class advanced_inventory
             NUM_PANES = 2
         };
         static constexpr int head_height = 5;
+        bool move_all_items_and_waiting_to_quit = false;
 
         std::unique_ptr<ui_adaptor> ui;
         std::unique_ptr<string_input_popup> spopup;


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Fixes #58249

Implement unused CLOSE_ADV_INV option which closes the AIM menu when the player uses the "move all items" keybind and after they finish moving the items.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

The CLOSE_ADV_INV option wasn't doing anything (it probably worked at some point I'm guessing).

I've implemented the desired behavior for it. 

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Deleting the option.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

- I spawned 1000 glass shards (which are going to take a while to move)
- I set the CLOSE_ADV_INV option to true
- I used the "Move all items" key to move all the glass shards to another tile
- Noticed that the menu didn't close.
- I implemented my fix 
- I repeated these steps and noticed that after after pressing the "Move all items" key, AIM menu stayed up during the processing and when it was done, the menu closed as expected.
- Also, I repeated these steps with the  CLOSE_ADV_INV option to false and noticed that the menu did not close after moving the glass shards (as expected)
