### PR TITLE
Allow bulk cooking of salisfy + dahlia and remove unhealthiness

### DIFF
--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -452,8 +452,6 @@
     "material": [ "veggy" ],
     "volume": "250 ml",
     "fun": -2,
-    "//2": "They contain inulin, which is tough to digest. Nothing fatal but should be avoided if possible.",
-    "healthy": -1,
     "smoking_result": "dry_veggy",
     "flags": [ "RAW" ],
     "vitamins": [ [ "vitC", 18 ], [ "iron", 5 ], [ "calcium", 8 ] ]

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -1892,6 +1892,7 @@
     "skill_used": "cooking",
     "difficulty": 1,
     "time": "12 m",
+    "batch_time_factors": [ 80, 4 ],
     "book_learn": [
       [ "pocket_survival", 1 ],
       [ "survival_book", 1 ],
@@ -1914,6 +1915,7 @@
     "skill_used": "cooking",
     "difficulty": 1,
     "time": "12 m",
+    "batch_time_factors": [ 80, 4 ],
     "autolearn": true,
     "book_learn": [
       [ "pocket_survival", 1 ],


### PR DESCRIPTION
#### Summary

Balance "Salisfy and dahlia can be bulk-cooked. Salsify is now safe to eat in any form."

#### Purpose of change

- Salisfy is a scrape'n'bake recipe. There should be a batch time factor. I've used `[ 80, 4 ]` as most of the prep is in the baking.

- Salsify was listed as -1 health because it contained inulin. That will give most people gas, but is Generally Recognised As Safe. Lots of modern foods have inulin added to boost their fibre content.

- Dahlia roots, as far as I'm aware, are also a scrape'n'bake, so I've added a batch factor there as well.

#### Describe the solution

JSON edits.

#### Describe alternatives you've considered

None.

#### Testing

Added to my current game. Baked a bunch of salsify. Tasty *and* not harmful to one's health.

#### Additional context

- [Salsify on wikipedia](https://en.wikipedia.org/wiki/Tragopogon_porrifolius)
- [Inulin on wikipedia](https://en.wikipedia.org/wiki/Inulin)