### PR TITLE
Monitor time consumption of clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,12 +7,19 @@
 #
 # Comments on the checks we have decided are not worthwhile:
 #
+# * bugprone-throw-keyword-missing
+# This check is too time consuming.  Disable it for now to save CI time.
+#
 # * cert-dcl21-cpp (postfix operator++ and operator-- should return const objects)
 # This is an unconventional code style, and conflicts with
 # readability-const-return-type.
 #
 # * cert-env33-c (calls to system, popen)
 # Unlikely to catch bugs, and using system is convenient for portability.
+#
+# * cert-dcl37-c and cert-dcl-51-cpp (reserved identifiers)
+# These two checks are aliases for bugprone-reserved-identifier.
+# Don't repeatedly run the same check for three times.
 #
 # * cert-err58-cpp (exceptions from static variable declarations)
 # We have lots of memory allocations in static variable declarations, and
@@ -27,6 +34,10 @@
 # * readability-braces-around-statements
 # Covered by astyle and buggy in clang-tidy 8.  Can enable once we have a newer
 # clang-tidy.
+#
+# * readability-identifier-naming
+# We are not enforcing a standard identifier naming scheme in the code base.
+# This check does not bring much value at the moment and consumes a lot of CPU time.
 
 Checks: "\
 bugprone-*,\
@@ -34,6 +45,8 @@ cata-*,\
 cert-*,\
 -cert-dcl21-cpp,\
 -cert-env33-c,\
+-cert-dcl37-c,\
+-cert-dcl51-cpp,\
 -cert-err58-cpp,\
 clang-diagnostic-*,\
 cppcoreguidelines-slicing,\
@@ -47,6 +60,7 @@ performance-*,\
 readability-*,\
 -readability-braces-around-statements,\
 -bugprone-narrowing-conversions,\
+-bugprone-throw-keyword-missing,\
 -misc-no-recursion,\
 -misc-non-private-member-variables-in-classes,\
 -modernize-pass-by-value,\
@@ -56,6 +70,7 @@ readability-*,\
 -readability-convert-member-functions-to-static,\
 -readability-else-after-return,\
 -readability-function-cognitive-complexity,\
+-readability-identifier-naming,\
 -readability-implicit-bool-conversion,\
 -readability-magic-numbers,\
 -readability-named-parameter,\

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -39,6 +39,7 @@ jobs:
         CATA_CLANG_TIDY: plugin
         TILES: 1
         SOUND: 1
+        RELEASE: 1
     steps:
     - name: checkout repository
       uses: actions/checkout@v2
@@ -75,3 +76,7 @@ jobs:
     - uses: ammaraskar/gcc-problem-matcher@master
     - name: run clang-tidy
       run: bash ./build-scripts/clang-tidy.sh
+    - name: show most time consuming checks
+      if: always()
+      run: |
+        jq -n 'reduce(inputs.profile | to_entries[]) as {$key,$value} ({}; .[$key] += $value) | with_entries(select(.key|contains(".wall"))) | to_entries | sort_by(.value) | reverse | .[0:10] | from_entries' clang-tidy-trace/*.json

--- a/build-scripts/clang-tidy-wrapper.sh
+++ b/build-scripts/clang-tidy-wrapper.sh
@@ -7,7 +7,7 @@ plugin=build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
 
 if [ -f "$plugin" ]
 then
-    LD_PRELOAD=$plugin "$CATA_CLANG_TIDY" "$@"
+    LD_PRELOAD=$plugin "$CATA_CLANG_TIDY" --enable-check-profile --store-check-profile=clang-tidy-trace "$@"
 else
     "$CATA_CLANG_TIDY" "$@"
 fi

--- a/src/cata_bitset.h
+++ b/src/cata_bitset.h
@@ -94,6 +94,7 @@ class tiny_bitset
             swap( lhs.storage_, rhs.storage_ );
         }
 
+        // NOLINTNEXTLINE(cata-large-inline-function)
         void set( size_t idx ) {
             cata_assert( idx < size() );
             size_t block_idx = idx / kBitsPerBlock;
@@ -101,6 +102,7 @@ class tiny_bitset
             bits()[block_idx] |= bit_mask;
         }
 
+        // NOLINTNEXTLINE(cata-large-inline-function)
         bool test( size_t idx ) {
             cata_assert( idx < size() );
             size_t block_idx = idx / kBitsPerBlock;
@@ -108,6 +110,7 @@ class tiny_bitset
             return bits()[block_idx] & bit_mask;
         }
 
+        // NOLINTNEXTLINE(cata-large-inline-function)
         void clear( size_t idx ) {
             cata_assert( idx < size() );
             size_t block_idx = idx / kBitsPerBlock;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Re: #64644

A full `clang-tidy` check on CDDA code base exceeds the 6-hour time limit of a GitHub Action workflow.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This pull request first enables time trace profiling in `clang-tidy` so we can know which checks are spending too much time. Next, based on profiling results, I disabled a few checks that are very expensive but add little value.

A full check still times out. This pull request does not completely solve the problem. It's just an improvement.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context



<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->