### PR TITLE
Add harvestable bioluminescent organs to fireflies

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -1298,7 +1298,8 @@
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.015 },
       { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.01 },
-      { "drop": "egg_firefly", "type": "offal", "base_num": [ 0, 3 ] }
+      { "drop": "egg_firefly", "type": "offal", "base_num": [ 0, 3 ] },
+      { "drop": "bioluminescent_sack", "type": "offal", "base_num": [ 0, 3 ] }
     ]
   },
   {

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1476,6 +1476,18 @@
     "ammo_type": "glowstick_juice"
   },
   {
+    "id": "luciferin",
+    "type": "AMMO",
+    "name": { "str_sp": "luciferin" },
+    "symbol": "~",
+    "description": "A chemical used by fireflies to glow in the dark. Reacts with oxygen, producing light.",
+    "volume": "1 ml",
+    "weight": "1 mg",
+    "color": "green",
+    "flags": [ "TRADER_AVOID" ],
+    "ammo_type": "luciferin"
+  },
+  {
     "type": "AMMO",
     "id": "graphite",
     "name": { "str_sp": "graphite" },

--- a/data/json/items/ammo_types.json
+++ b/data/json/items/ammo_types.json
@@ -727,6 +727,12 @@
   },
   {
     "type": "ammunition_type",
+    "id": "luciferin",
+    "name": "luciferin",
+    "default": "luciferin"
+  },
+  {
+    "type": "ammunition_type",
     "id": "cannon",
     "name": "cannon",
     "default": "cannon_shot"

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -1032,6 +1032,19 @@
     "to_hit": -1
   },
   {
+    "id": "bioluminescent_sack_empty",
+    "type": "GENERIC",
+    "category": "other",
+    "name": { "str": "empty bioluminescent sack" },
+    "description": "A small sack from a body of a giant insect. It has no luciferin left.",
+    "weight": "25 g",
+    "volume": "250 ml",
+    "material": [ "iflesh" ],
+    "symbol": "o",
+    "color": "dark_gray",
+    "flags": [ "TRADER_AVOID" ]
+  },
+  {
     "type": "GENERIC",
     "id": "spring",
     "symbol": ",",

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -89,6 +89,44 @@
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "DURABLE_MELEE", "ALLOWS_REMOTE_USE" ]
   },
   {
+    "id": "bioluminescent_sack",
+    "type": "TOOL",
+    "name": { "str": "bioluminescent sack" },
+    "description": "A small sack from a body of a giant insect, containing a bioluminescent substance. Tear it lo let the air in and start the reaction.",
+    "weight": "25 g",
+    "volume": "250 ml",
+    "price": 100,
+    "price_postapoc": 10,
+    "material": [ "iflesh" ],
+    "symbol": "o",
+    "color": "green",
+    "use_action": {
+      "target": "bioluminescent_sack_lit",
+      "target_ammo": "luciferin",
+      "target_charges": 300,
+      "msg": "You tear the sack, letting the air in.",
+      "active": true,
+      "menu_text": "Tear",
+      "type": "transform"
+    }
+  },
+  {
+    "id": "bioluminescent_sack_lit",
+    "type": "TOOL",
+    "name": { "str": "bioluminescent sack" },
+    "description": "A small sack from a body of a giant insect, containing a bioluminescent substance. It glows in the dark.",
+    "weight": "25 g",
+    "volume": "250 ml",
+    "material": [ "iflesh" ],
+    "symbol": "o",
+    "color": "light_green",
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "luciferin": 300 }, "rigid": true } ],
+    "turns_per_charge": 1,
+    "revert_to": "bioluminescent_sack_empty",
+    "revert_msg": "The sack fades out.",
+    "flags": [ "LIGHT_10", "TRADER_AVOID", "SLEEP_IGNORE", "NO_UNLOAD", "NO_RELOAD" ]
+  },
+  {
     "id": "candle",
     "type": "TOOL",
     "name": { "str": "candle" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add harvestable bioluminescent organs to fireflies"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

This PR was inspired by #56237. Fireflies have their own non-electric light sources, so why not make use of them? It may also be useful for innawoods runs.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added a bioluminescent_sack item and its lit and empty stages. Added luciferin ammo for it. Added bioluminescent sack to the firefly harvest.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Luciferin could be harvested like blood, but it would require a separately crafted lamp and would also expose it to oxygen, starting the chemical reaction.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned, killed and butchered a firefly, getting a bioluminescent sack. Activated it and waited for it stop glowing (~ 5 min).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Fireflies emit light by controllably exposing luciferin in their abdomens to oxygen. I'm not sure if they have dedicated organs for this IRL, but even if they don't - it can be a mutation in the game.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->