### PR TITLE
If item has two use actions, show both in Use Item menu

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1134,7 +1134,10 @@ class activatable_inventory_preset : public pickup_inventory_preset
 
             if( uses.size() == 1 ) {
                 return uses.begin()->second.get_name();
-            } else if( uses.size() > 1 ) {
+            } else if( uses.size() == 2 ) {
+                return string_format( _( "%1$s</color> <color_dark_gray>or</color> <color_light_green>%2$s" ),
+                                      uses.begin()->second.get_name(), std::next( uses.begin() )->second.get_name() );
+            } else if( uses.size() > 2 ) {
                 return _( "…" );
             }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "If item has two use actions, show both in Use Item menu"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The Use Item menu shows the item action (if the setting is turned on), but if it has more than one use action it shows an ellipses (…) instead. This works fine, but there's enough space to show two actions for items that only have two. This would become more of an issue if #64334 gets merged, because it would add a plug in action to many devices that previously only had one action, and thus make many items only show an ellipses.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Show both actions in the menu if an item has only two, show an ellipses at three or more.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
At minimum window width it can get fairly crowded for certain items, but since showing item actions is a toggleable option I figured anyone who plays at such a small resolution have them turned off already.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned every item, looked through them to make sure nothing broke. Weapons have the mouthful of "Detach gunmods or Modify attached equipment" but it doesn't block out the item name so it's still legible. Toggling the action display setting still turns them off and on as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
![image](https://user-images.githubusercontent.com/6759778/228452553-76fff4dc-e552-4b98-a6f9-68d802b7ba42.png)

Minimum window width:
![image](https://user-images.githubusercontent.com/6759778/228454885-3a0e6181-ceac-4c06-9765-eef541f52ea0.png)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->