### PR TITLE
inventory_ui: improve pickup header

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1954,6 +1954,12 @@
   },
   {
     "type": "keybinding",
+    "id": "TOGGLE_NUMPAD_NAVIGATION",
+    "name": "Toggle navigation with numpad numbers",
+    "bindings": [ { "input_method": "keyboard_any", "key": "F5" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "INVENTORY_FILTER",
     "category": "INVENTORY",
     "name": "Set item filter",
@@ -1964,11 +1970,7 @@
     "id": "EXAMINE",
     "category": "INVENTORY",
     "name": "Examine",
-    "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
   },
   {
     "type": "keybinding",
@@ -3553,7 +3555,8 @@
     "type": "keybinding",
     "id": "MARK_WITH_COUNT",
     "category": "INVENTORY",
-    "name": "Select a specific amount of highlighted item"
+    "name": "Select a specific amount of highlighted item",
+    "bindings": [ { "input_method": "keyboard_any", "key": "!" } ]
   },
   {
     "type": "keybinding",

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -383,6 +383,7 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "distraction_thirst", distraction_thirst );
     json.member( "distraction_temperature", distraction_temperature );
     json.member( "distraction_mutation", distraction_mutation );
+    json.member( "numpad_navigation", numpad_navigation );
 
     json.member( "input_history" );
     json.start_object();
@@ -450,6 +451,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "distraction_thirst", distraction_thirst );
     jo.read( "distraction_temperature", distraction_temperature );
     jo.read( "distraction_mutation", distraction_mutation );
+    jo.read( "numpad_navigation", numpad_navigation );
 
     if( !jo.read( "vmenu_show_items", vmenu_show_items ) ) {
         // This is an old save: 1 means view items, 2 means view monsters,
@@ -2300,7 +2302,9 @@ size_t inventory_selector::get_layout_height() const
 
 size_t inventory_selector::get_header_height() const
 {
-    return display_stats || !hint.empty() ? 3 : 1;
+    return display_stats || !hint.empty()
+           ? std::max<size_t>( 3, 2 + std::count( hint.begin(), hint.end(), '\n' ) )
+           : 1;
 }
 
 size_t inventory_selector::get_header_min_width() const
@@ -2339,13 +2343,17 @@ void inventory_selector::draw_header( const catacurses::window &w ) const
     fold_and_print( w, point( border + 1, border + 1 ), getmaxx( w ) - 2 * ( border + 1 ), c_dark_gray,
                     hint );
 
-    mvwhline( w, point( border, border + get_header_height() ), LINE_OXOX, getmaxx( w ) - 2 * border );
+    int const bottom = border + get_header_height();
+    mvwhline( w, point( border, bottom ), LINE_OXOX, getmaxx( w ) - 2 * border );
 
     if( display_stats ) {
         size_t y = border;
         for( const std::string &elem : get_stats() ) {
             right_print( w, y++, border + 1, c_dark_gray, elem );
         }
+    }
+    if( uistate.numpad_navigation ) {
+        right_print( w, bottom, border + 1, c_dark_gray, _( "Numpad ON" ) );
     }
 }
 
@@ -2487,11 +2495,20 @@ void inventory_selector::refresh_window()
     wnoutrefresh( w_inv );
 }
 
-std::pair< bool, std::string > inventory_selector::query_string( const std::string &val )
+std::pair< bool, std::string > inventory_selector::query_string( const std::string &val,
+        bool end_with_toggle )
 {
     spopup = std::make_unique<string_input_popup>();
     spopup->max_length( 256 )
     .text( val );
+    if( end_with_toggle ) {
+        for( input_event const &iev : inp_mngr.get_input_for_action( "TOGGLE_ENTRY", "INVENTORY" ) ) {
+            spopup->add_callback( iev.get_first_input(), [this]() {
+                spopup->confirm();
+                return true;
+            } );
+        }
+    };
 
     shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
     if( current_ui ) {
@@ -2521,9 +2538,10 @@ void inventory_selector::query_set_filter()
     }
 }
 
-int inventory_selector::query_count()
+int inventory_selector::query_count( char init, bool end_with_toggle )
 {
-    std::pair< bool, std::string > query = query_string( "" );
+    std::string sinit = init != 0 ? std::string( 1, init ) : std::string();
+    std::pair< bool, std::string > query = query_string( sinit, end_with_toggle );
     int ret = -1;
     if( query.first ) {
         try {
@@ -2677,6 +2695,7 @@ inventory_selector::inventory_selector( Character &u, const inventory_selector_p
     ctxt.register_action( "SELECT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "VIEW_CATEGORY_MODE" );
+    ctxt.register_action( "TOGGLE_NUMPAD_NAVIGATION" );
     ctxt.register_action( "ANY_INPUT" ); // For invlets
     ctxt.register_action( "INVENTORY_FILTER" );
     ctxt.register_action( "RESET_FILTER" );
@@ -2775,6 +2794,8 @@ void inventory_selector::on_input( const inventory_input &input )
         toggle_active_column( scroll_direction::FORWARD );
     } else if( input.action == "VIEW_CATEGORY_MODE" ) {
         toggle_categorize_contained();
+    } else if( input.action == "TOGGLE_NUMPAD_NAVIGATION" ) {
+        uistate.numpad_navigation = !uistate.numpad_navigation;
     } else if( input.action == "EXAMINE_CONTENTS" ) {
         const inventory_entry &selected = get_active_column().get_highlighted();
         if( selected ) {
@@ -3521,23 +3542,21 @@ void inventory_multiselector::toggle_categorize_contained()
 
 void inventory_multiselector::on_input( const inventory_input &input )
 {
-    bool const noMarkCountBound = ctxt.keys_bound_to( "MARK_WITH_COUNT" ).empty();
-
     if( input.entry != nullptr ) { // Single Item from mouse
         highlight( input.entry->any_item() );
         toggle_entries( count );
     } else if( input.action == "TOGGLE_NON_FAVORITE" ) {
         toggle_entries( count, toggle_mode::NON_FAVORITE_NON_WORN );
-    } else if( input.action ==
-               "MARK_WITH_COUNT" ) { // Set count and mark selected with specific key
+    } else if( input.action == "MARK_WITH_COUNT" ) { // Set count and mark selected with specific key
         int query_result = query_count();
         if( query_result >= 0 ) {
             toggle_entries( query_result, toggle_mode::SELECTED );
         }
-    } else if( noMarkCountBound && input.ch >= '0' && input.ch <= '9' ) {
-        count = std::min( count, INT_MAX / 10 - 10 );
-        count *= 10;
-        count += input.ch - '0';
+    } else if( !uistate.numpad_navigation && input.ch >= '0' && input.ch <= '9' ) {
+        int query_result = query_count( input.ch, true );
+        if( query_result >= 0 ) {
+            toggle_entries( query_result, toggle_mode::SELECTED );
+        }
     } else if( input.action == "TOGGLE_ENTRY" ) { // Mark selected
         toggle_entries( count, toggle_mode::SELECTED );
     } else if( input.action == "INCREASE_COUNT" || input.action == "DECREASE_COUNT" ) {
@@ -3725,10 +3744,16 @@ pickup_selector::pickup_selector( Character &p, const inventory_selector_preset 
 #endif
 
     set_hint( string_format(
-                  _( "To pick x items, type a number before selecting.\nPress %s to examine, %s to wield, %s to wear." ),
-                  ctxt.get_desc( "EXAMINE" ),
-                  ctxt.get_desc( "WIELD" ),
-                  ctxt.get_desc( "WEAR" ) ) );
+                  _( "%s wield %s wear\n%s expand %s all\n%s examine %s/%s/%s quantity (or type number then %s)" ),
+                  colorize( ctxt.get_desc( "WIELD" ), c_yellow ),
+                  colorize( ctxt.get_desc( "WEAR" ), c_yellow ),
+                  colorize( ctxt.get_desc( "SHOW_HIDE_CONTENTS" ), c_yellow ),
+                  colorize( ctxt.get_desc( "SHOW_HIDE_CONTENTS_ALL" ), c_yellow ),
+                  colorize( ctxt.get_desc( "EXAMINE" ), c_yellow ),
+                  colorize( ctxt.get_desc( "MARK_WITH_COUNT" ), c_yellow ),
+                  colorize( ctxt.get_desc( "INCREASE_COUNT" ), c_yellow ),
+                  colorize( ctxt.get_desc( "DECREASE_COUNT" ), c_yellow ),
+                  colorize( ctxt.get_desc( "TOGGLE_ENTRY" ), c_yellow ) ) );
 }
 
 void pickup_selector::apply_selection( std::vector<drop_location> selection )

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -715,11 +715,11 @@ class inventory_selector
          * @param val The default value to have set in the query prompt.
          * @return A tuple of a bool and string, bool is true if user confirmed.
          */
-        std::pair< bool, std::string > query_string( const std::string &val );
+        std::pair< bool, std::string > query_string( const std::string &val, bool end_with_toggle = false );
         /** Query the user for a filter and apply it. */
         void query_set_filter();
         /** Query the user for count and return it. */
-        int query_count();
+        int query_count( char init = 0, bool end_with_toggle = false );
 
         /** Tackles screen overflow */
         virtual void rearrange_columns( size_t client_width );

--- a/src/string_input_popup.h
+++ b/src/string_input_popup.h
@@ -261,6 +261,9 @@ class string_input_popup // NOLINT(cata-xy)
         bool confirmed() const {
             return _confirmed;
         }
+        void confirm() {
+            _confirmed = true;
+        }
         /**
          * Returns false if the last input was unhandled. Useful to avoid handling
          * input already handled by the popup itself.

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -148,6 +148,7 @@ class uistatedata
         bool distraction_thirst = true;
         bool distraction_temperature = true;
         bool distraction_mutation = true;
+        bool numpad_navigation = false;
 
         // V Menu Stuff
         int list_item_sort = 0;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The instructions in the pickup header blend in and are too wordy to read so new players don't realize there are helpful keys available. The header also gets garbled on the smallest screens.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
![Screenshot from 2023-03-29 12-44-11](https://user-images.githubusercontent.com/68240139/228495017-f9df6a3b-c658-430e-9af1-b5bc2193afae.png)


<details>
<summary>Before, for reference</summary>

![Screenshot from 2023-03-29 10-49-58](https://user-images.githubusercontent.com/68240139/228464726-cf93425a-fe1c-412d-b14d-640f97690df7.png)


</details>

Also update the default keybindings to make this work. Namely, add a key for `Mark a specific amount of selected items` and remove the double keybindings from `e`xamine as `E` has been repurposed in #62864.

Some internal changes were needed to preserve numpad navigation mode, see https://github.com/CleverRaven/Cataclysm-DDA/pull/64664#issuecomment-1488371822.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Other inventory UIs aren't affected
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->