### PR TITLE
Add fast scrolling support to camp mission UI

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4168,6 +4168,20 @@
   },
   {
     "type": "keybinding",
+    "id": "SCROLL_MISSION_INFO_UP",
+    "category": "FACTIONS",
+    "name": "Scroll camp mission info up",
+    "bindings": [ { "input_method": "keyboard_char", "key": "[" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "SCROLL_MISSION_INFO_DOWN",
+    "category": "FACTIONS",
+    "name": "Scroll camp mission info down",
+    "bindings": [ { "input_method": "keyboard_char", "key": "]" } ]
+  },
+  {
+    "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "VIEW_PROFICIENCIES",
     "name": "View character proficiencies",

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -876,8 +876,10 @@ bool talk_function::display_and_choose_opts(
     ctxt.register_action( "DOWN", to_translation( "Move cursor down" ) );
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "PREV_TAB" );
-    ctxt.register_action( "PAGE_UP" );
-    ctxt.register_action( "PAGE_DOWN" );
+    ctxt.register_action( "PAGE_UP", to_translation( "Fast scroll up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Fast scroll down" ) );
+    ctxt.register_action( "SCROLL_MISSION_INFO_UP" );
+    ctxt.register_action( "SCROLL_MISSION_INFO_DOWN" );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
@@ -1063,15 +1065,30 @@ bool talk_function::display_and_choose_opts(
         mission_key.cur_key = cur_key_list[sel];
         ui_manager::redraw();
         const std::string action = ctxt.handle_input();
+        const int recmax = static_cast<int>( cur_key_list.size() );
+        const int scroll_rate = recmax > 20 ? 10 : 3;
         if( action == "UP" || action == "SCROLL_UP" || action == "DOWN" || action == "SCROLL_DOWN" ) {
             sel = increment_and_wrap( sel, action == "DOWN" || action == "SCROLL_DOWN", cur_key_list.size() );
             info_offset = 0;
-        } else if( action == "PAGE_UP" ) {
+            /*
+            } else if( action == "PAGE_UP" ) {
             if( info_offset > 0 ) {
                 info_offset--;
             }
-        } else if( action == "PAGE_DOWN" ) {
+            } else if( action == "PAGE_DOWN" ) {
             info_offset++;
+            */
+        } else if( action == "SCROLL_MISSION_INFO_UP" ) {
+            if( info_offset > 0 ) {
+                info_offset--;
+            }
+        } else if( action == "SCROLL_MISSION_INFO_DOWN" ) {
+            info_offset++;
+        } else if( action == "PAGE_UP" || action == "PAGE_DOWN" ) {
+            sel = increment_and_wrap( sel, action == "PAGE_UP" ? -scroll_rate : scroll_rate,
+                                      cur_key_list.size() );
+            info_offset = 0;
+
         } else if( action == "NEXT_TAB" && role_id == role_id_faction_camp ) {
             sel = 0;
             info_offset = 0;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Add fast scrolling support to camp mission UI"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Faction camp mission list can be extremely long ( a full-feature workshop, e.g.). I want to add fast scrolling support to camp mission UI, just like in crafting gui.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use PageUp/PageDown to provide fast scrolling. Use [ and ] to scroll the mission info, thus making it consistent with crafting gui.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Use another set of keybindings to provide the feature.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Both the mission list and the mission info scroll properly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->