### PR TITLE
Make elephant gun a double rifle to match reality

### DIFF
--- a/data/json/items/gun/700nx.json
+++ b/data/json/items/gun/700nx.json
@@ -5,7 +5,7 @@
     "looks_like": "ar15",
     "type": "GUN",
     "name": { "str": "Elephant gun" },
-    "description": "A custom-made single shot rifle specially designed for the hunting of huge game.  You could obviously kill everything with this, EVERYTHING.  If you ever find enough ammo of course.",
+    "description": "A ornately engraved, custom-made double rifle specially designed for the hunting of huge game.  You could obviously kill everything with this, EVERYTHING.  If you ever find enough ammo of course.",
     "weight": "8082 g",
     "volume": "4500 ml",
     "longest_side": "110 cm",
@@ -19,8 +19,8 @@
     "dispersion": 90,
     "durability": 8,
     "blackpowder_tolerance": 56,
-    "clip_size": 1,
-    "reload": 600,
+    "clip_size": 2,
+    "reload": 300,
     "barrel_volume": "1000 ml",
     "valid_mod_locations": [
       [ "accessories", 4 ],
@@ -34,7 +34,7 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "flags": [ "NEVER_JAMS", "RELOAD_EJECT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "700nx": 1 } } ]
+    "flags": [ "NEVER_JAMS", "RELOAD_EJECT", "RELOAD_ONE" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "700nx": 2 } } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Make elephant gun a double rifle to match reality"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
After a [recent Reddit post](https://www.reddit.com/r/cataclysmdda/comments/124k5yh/first_time_finding_the_gun_that_holds_the_700_nx/) reminded me that the elephant gun exists (and is kind of an interesting option now that .50 cal is much harder to get), I got curious and looked up what a .700 NX elephant gun actually looks like, and it turned out that every single example I could find was not single-shot like the in-game item, but a two-barreled double rifle.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I'm updating the in-game weapon to be a two-shot double rifle. Curiously, the weight and other stats already seem to match. Note that these all seem to be handmade custom guns so they're all going to be slightly different, but the current stats are in the right range.

References:
[Auction listing at Rock Island Auction Company with some stats and measurements](https://www.rockislandauction.com/detail/72/2345/engraved-b-searcy-co-double-rifle-in-700-nitro-express) 
[Long-winded article with lots of pictures from Revivaler](https://revivaler.com/holland-holland-phillippe-grifnee-signed-600-and-700-nitro-express-double-rifles/) 
[History of the round and rifles from American Rifleman](https://www.americanrifleman.org/content/holland-holland-s-mighty-700-nitro-express/) 
[Short video of someone shooting one](https://www.youtube.com/watch?v=NjIpxOlWTvE) 

In addition to increasing magazine size, I made the reload speed faster. I understand that it's probably a bit slow and awkward to reload just because of the weight, but ~6 seconds seemed a bit steep, especially considering it's a break-action where you can quite quickly load two rounds at once. At 2:52 in [this video](https://www.youtube.com/watch?v=GkX7izHG0xA&t=173s), we can see the guy very unhurriedly reloading one barrel in about 7 seconds. He could certainly do it faster under time pressure, and reloading the other barrel as well wouldn't be that much slower. I don't think there's a good mechanism for making a full reload faster per cartridge than a partial reload, so I've put it at a compromise rate of 300 moves, which probably makes reloading a single barrel slightly faster than it should be, but reloading 2 slightly slower, especially considering rummaging times.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The id trex_gun suggests this was originally intended to be chambered in [.577 Tyrannosaur](https://en.wikipedia.org/wiki/.577_Tyrannosaur), so I could've reverted it to that. But it turns out the only gun that uses that uses that round, the A-Square T-REX, isn't single-shot either (it's a 3+1 internal magazine bolt action), and the changes required would essentially involve making a whole new gun and cartridge from scratch, which seems unnecessary.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned the gun and some ammo, checked that it shoots and reloads and all that.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I hemmed and hawed over whether or not I should give it the double barrel shotgun's ability to fire both barrels simultaneously. While this would technically be possible, considering [what can happen](https://www.youtube.com/watch?v=CZ-yDHL_aYI) when you do that even with significantly less powerful .500 NX, I've deemed it too impractical to include. Even ignoring the fact that it risks knocking the shooter clean off their feet, it's not clear if the gun itelf could handle it without breaking. While it might indeed be doable by a highly trained shooter or sufficiently beefy mutant, we don't have mechanics for breaking the shoulders and buttstocks of anyone else who tries, so I've elected to simply disallow it.  
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->