### PR TITLE
Modular vehicle toolkit part

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4770,6 +4770,30 @@
   },
   {
     "type": "construction",
+    "id": "app_veh_tools_kitchen",
+    "group": "place_veh_tools_kitchen",
+    "category": "APPLIANCE",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "5 m",
+    "components": [ [ [ "veh_tools_kitchen", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_special": "done_appliance",
+    "activity_level": "BRISK_EXERCISE"
+  },
+  {
+    "type": "construction",
+    "id": "app_veh_tools_workshop",
+    "group": "place_veh_tools_workshop",
+    "category": "APPLIANCE",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "5 m",
+    "components": [ [ [ "veh_tools_workshop", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_special": "done_appliance",
+    "activity_level": "BRISK_EXERCISE"
+  },
+  {
+    "type": "construction",
     "id": "app_fridge",
     "group": "place_fridge",
     "category": "APPLIANCE",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1136,6 +1136,16 @@
   },
   {
     "type": "construction_group",
+    "id": "place_veh_tools_kitchen",
+    "name": "Place Kitchen Station"
+  },
+  {
+    "type": "construction_group",
+    "id": "place_veh_tools_workshop",
+    "name": "Place Workshop Station"
+  },
+  {
+    "type": "construction_group",
     "id": "place_fridge",
     "name": "Place Fridge"
   },

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -1,6 +1,20 @@
 [
   {
     "type": "vehicle_part",
+    "id": "ap_veh_tools_kitchen",
+    "name": "kitchen station",
+    "copy-from": "veh_tools_kitchen",
+    "extend": { "flags": [ "APPLIANCE" ] }
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ap_veh_tools_workshop",
+    "name": "workshop station",
+    "copy-from": "veh_tools_workshop",
+    "extend": { "flags": [ "APPLIANCE" ] }
+  },
+  {
+    "type": "vehicle_part",
     "id": "ap_fridge",
     "name": { "str": "refrigerator" },
     "symbol": "H",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -273,16 +273,23 @@
     "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ]
   },
   {
-    "id": "pseudo_battery",
+    "id": "pseudo_magazine",
     "type": "MAGAZINE",
     "category": "spare_parts",
-    "name": { "str": "pseudo battery", "str_pl": "pseudo batteries" },
-    "description": "Pseudo battery for pseudo items such as vehicle tools.  If you see this, then something went wrong",
+    "name": { "str": "pseudo magazine" },
+    "description": "Pseudo magazine for use in dirty vehicle hacks.  If you see this, then something went wrong",
+    "flags": [ "PSEUDO", "ZERO_WEIGHT", "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD" ],
     "ammo_type": [ "battery" ],
     "capacity": 1000000,
-    "//": "TODO: Determine appropriate arbitrary capacity for vehicle batteries",
-    "flags": [ "ZERO_WEIGHT", "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "RECHARGE", "PSEUDO" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "battery": 1000000 } } ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "airtight": true,
+        "watertight": true,
+        "rigid": true,
+        "ammo_restriction": { "battery": 1000000, "propane": 1000000 }
+      }
+    ],
     "symbol": "@",
     "color": "red"
   },

--- a/data/json/items/toolmod.json
+++ b/data/json/items/toolmod.json
@@ -44,15 +44,15 @@
     "magazine_adaptor": [ [ "battery", [ "small_storage_battery", "battery_car", "battery_motorbike" ] ] ]
   },
   {
-    "id": "magazine_battery_pseudo_mod",
+    "id": "pseudo_magazine_mod",
     "copy-from": "mod_battery",
     "type": "TOOLMOD",
     "category": "spare_parts",
-    "name": { "str": "pseudo battery mod" },
+    "name": { "str": "pseudo magazine mod" },
     "description": "If you see this - you see a bug.",
     "color": "light_green",
-    "acceptable_ammo": [ "battery" ],
-    "pocket_mods": [ { "pocket_type": "MAGAZINE_WELL", "default_magazine": "pseudo_battery", "item_restriction": [ "pseudo_battery" ] } ]
+    "flags": [ "PSEUDO" ],
+    "pocket_mods": [ { "pocket_type": "MAGAZINE_WELL", "default_magazine": "pseudo_magazine", "item_restriction": [ "pseudo_magazine" ] } ]
   },
   {
     "id": "magazine_battery_light_mod",

--- a/data/json/vehicleparts/modular_tools.json
+++ b/data/json/vehicleparts/modular_tools.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "modular_tool_station",
+    "breaks_into": [
+      { "count": [ 4, 6 ], "item": "steel_lump" },
+      { "count": [ 4, 6 ], "item": "steel_chunk" },
+      { "count": [ 4, 6 ], "item": "scrap" }
+    ],
+    "broken_color": "light_cyan",
+    "broken_symbol": "x",
+    "categories": [ "utility" ],
+    "color": "light_cyan",
+    "damage_modifier": 10,
+    "damage_reduction": { "all": 30 },
+    "description": "A table rig with a faucet for water tank access, drawers and hooks for storing tools, a few electric connectors and valves for for fuel tank connections.",
+    "durability": 80,
+    "size": "50 L",
+    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "VEH_TOOLS" ],
+    "pseudo_tools": [ { "id": "water_faucet" } ],
+    "veh_tools": { "allowed_tool_types": [ "hotplate", "hotplate_induction", "propane_cooker", "welder" ] },
+    "item": "pipe",
+    "location": "center",
+    "name": { "str": "tool station" },
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
+      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
+      "repair": {
+        "skills": [ [ "mechanics", 4 ] ],
+        "time": "60 m",
+        "using": [ [ "repair_welding_standard", 1 ], [ "soldering_standard", 10 ] ]
+      }
+    },
+    "symbol": "&",
+    "type": "vehicle_part"
+  }
+]

--- a/data/json/vehicleparts/modular_tools.json
+++ b/data/json/vehicleparts/modular_tools.json
@@ -1,6 +1,85 @@
 [
   {
-    "id": "modular_tool_station",
+    "abstract": "veh_tools_abstract",
+    "type": "GENERIC",
+    "name": { "str": "vehicle tool station" },
+    "category": "veh_parts",
+    "weight": "40000 g",
+    "volume": "20 L",
+    "price": 40000,
+    "price_postapoc": 2000,
+    "material": [ "steel" ],
+    "symbol": "&",
+    "color": "light_cyan"
+  },
+  {
+    "type": "GENERIC",
+    "id": "veh_tools_kitchen",
+    "copy-from": "veh_tools_abstract",
+    "name": { "str": "mounted kitchen" },
+    "description": "A table rig with a faucet for water tank access, fume hood, drawers and fixtures for storing tools, low power electric connectors and valves for for fuel tank connections.",
+    "looks_like": "kitchen_unit"
+  },
+  {
+    "type": "GENERIC",
+    "id": "veh_tools_workshop",
+    "copy-from": "veh_tools_abstract",
+    "name": { "str": "mounted workshop" },
+    "description": "A table rig with drawers and fixtures for storing tools, wiring for high power electric connectors and valves for for fuel tank connections.",
+    "looks_like": "welding_rig"
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "veh_tools_kitchen",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_PARTS",
+    "skill_used": "mechanics",
+    "skills_required": [ "electronics", 3 ],
+    "difficulty": 3,
+    "time": "1 h",
+    "autolearn": true,
+    "using": [ [ "welding_standard", 10 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
+    "components": [
+      [ [ "frame", 1 ] ],
+      [ [ "water_faucet", 1 ] ],
+      [ [ "duct_tape", 100 ] ],
+      [ [ "sheet_metal", 4 ] ],
+      [ [ "pipe_fittings", 8 ] ],
+      [ [ "pipe", 16 ] ],
+      [ [ "hose", 2 ] ],
+      [ [ "power_supply", 2 ] ],
+      [ [ "cable", 40 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "veh_tools_workshop",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_PARTS",
+    "skill_used": "mechanics",
+    "skills_required": [ "electronics", 3 ],
+    "difficulty": 3,
+    "time": "1 h",
+    "autolearn": true,
+    "using": [ [ "welding_standard", 10 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
+    "components": [
+      [ [ "frame", 1 ] ],
+      [ [ "duct_tape", 100 ] ],
+      [ [ "sheet_metal", 4 ] ],
+      [ [ "pipe_fittings", 4 ] ],
+      [ [ "pipe", 16 ] ],
+      [ [ "hose", 2 ] ],
+      [ [ "power_supply", 4 ] ],
+      [ [ "cable", 200 ] ]
+    ]
+  },
+  {
+    "abstract": "veh_tools_part_abstract",
+    "type": "vehicle_part",
     "breaks_into": [
       { "count": [ 4, 6 ], "item": "steel_lump" },
       { "count": [ 4, 6 ], "item": "steel_chunk" },
@@ -12,15 +91,28 @@
     "color": "light_cyan",
     "damage_modifier": 10,
     "damage_reduction": { "all": 30 },
-    "description": "A table rig with a faucet for water tank access, drawers and hooks for storing tools, a few electric connectors and valves for for fuel tank connections.",
     "durability": 80,
     "size": "50 L",
     "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "VEH_TOOLS" ],
-    "pseudo_tools": [ { "id": "water_faucet" } ],
-    "veh_tools": { "allowed_tool_types": [ "hotplate", "hotplate_induction", "propane_cooker", "welder" ] },
-    "item": "pipe",
+    "//": "allow tools common for both kitchen unit and workshop; unpowered or low-power and no fume hood required",
+    "allowed_tools": [
+      "pot",
+      "pan",
+      "steel_pan",
+      "copper_pan",
+      "aluminum_pan",
+      "coffeemaker",
+      "atomic_coffeepot",
+      "cordless_drill",
+      "water_purifier",
+      "vac_sealer",
+      "food_processor",
+      "press",
+      "puller",
+      "soldering_iron"
+    ],
+    "item": "veh_tools_abstract",
     "location": "center",
-    "name": { "str": "tool station" },
     "requirements": {
       "install": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
@@ -30,7 +122,40 @@
         "using": [ [ "repair_welding_standard", 1 ], [ "soldering_standard", 10 ] ]
       }
     },
-    "symbol": "&",
-    "type": "vehicle_part"
+    "symbol": "&"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "veh_tools_kitchen",
+    "copy-from": "veh_tools_part_abstract",
+    "description": "A table rig with a faucet for water tank access, fume hood, drawers and fixtures for storing tools, low power electric connectors and valves for for fuel tank connections.",
+    "item": "veh_tools_kitchen",
+    "looks_like": "kitchen_unit",
+    "pseudo_tools": [ { "id": "water_faucet" } ],
+    "//": "allow tools here that require a fume hood but unpowered or low-power",
+    "extend": {
+      "allowed_tools": [
+        "hotplate",
+        "hotplate_induction",
+        "propane_cooker",
+        "oven",
+        "microwave",
+        "chemistry_set",
+        "electrolysis_kit",
+        "electrolyzer_makeshift",
+        "dehydrator",
+        "towel"
+      ]
+    }
+  },
+  {
+    "type": "vehicle_part",
+    "id": "veh_tools_workshop",
+    "copy-from": "veh_tools_part_abstract",
+    "description": "A table rig with drawers and fixtures for storing tools, wiring for high power electric connectors and valves for for fuel tank connections.",
+    "looks_like": "welding_rig",
+    "item": "veh_tools_workshop",
+    "//": "allow tools here that require high power draw but no fume hood",
+    "extend": { "allowed_tools": [ "welding_kit", "welder", "forge", "kiln" ] }
   }
 ]

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -573,6 +573,12 @@
     "type": "json_flag"
   },
   {
+    "id": "VEH_TOOLS",
+    "type": "json_flag",
+    "//": "Modular tool station allowing to 'hook' tools to vehicle batteries/tanks.",
+    "info": "You can 'e'xamine the tile to <color_cyan>connect tools</color> to the vehicle's batteries and tanks."
+  },
+  {
     "id": "VISION",
     "type": "json_flag"
   },

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1912,21 +1912,18 @@ void basecamp::scan_pseudo_items()
 
             if( expansion_map.veh_at( pos ).has_value() &&
                 expansion_map.veh_at( pos )->vehicle().is_appliance() ) {
-                const std::vector<std::pair<itype_id, int>> tools =
-                            expansion_map.veh_at( pos )->part_displayed().value().get_tools();
-
-                for( const auto &tool : tools ) {
-                    if( tool.first.obj().has_flag( flag_PSEUDO ) &&
-                        tool.first.obj().has_flag( flag_ALLOWS_REMOTE_USE ) ) {
+                for( const auto &[tool, discard_] : expansion_map.veh_at( pos )->get_tools() ) {
+                    if( tool.has_flag( flag_PSEUDO ) &&
+                        tool.has_flag( flag_ALLOWS_REMOTE_USE ) ) {
                         bool found = false;
                         for( itype_id &element : expansion.second.available_pseudo_items ) {
-                            if( element == tool.first ) {
+                            if( element == tool.typeId() ) {
                                 found = true;
                                 break;
                             }
                         }
                         if( !found ) {
-                            expansion.second.available_pseudo_items.push_back( tool.first );
+                            expansion.second.available_pseudo_items.push_back( tool.typeId() );
                         }
                     }
                 }

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1751,6 +1751,30 @@ class attach_molle_inventory_preset : public inventory_selector_preset
         const item *vest;
 };
 
+class attach_veh_tool_inventory_preset : public inventory_selector_preset
+{
+    public:
+        explicit attach_veh_tool_inventory_preset( const std::set<itype_id> &allowed_types )
+            : allowed_types( allowed_types ) { }
+
+        bool is_shown( const item_location &loc ) const override {
+            return allowed_types.count( loc->typeId() );
+        }
+
+        std::string get_denial( const item_location &loc ) const override {
+            const item &it = *loc.get_item();
+
+            if( !it.empty() || !it.toolmods().empty() ) {
+                return "item needs to be empty.";
+            }
+
+            return std::string();
+        }
+
+    private:
+        const std::set<itype_id> allowed_types;
+};
+
 class salvage_inventory_preset: public inventory_selector_preset
 {
     public:
@@ -1930,6 +1954,16 @@ item_location game_menus::inv::molle_attach( Character &you, item &tool )
                                                 "There is space for %d small items",
                                                 vacancies ), vacancies )
                                       )
+                       );
+}
+
+item_location game_menus::inv::veh_tool_attach( Character &you, const std::string &vp_name,
+        const std::set<itype_id> &allowed_types )
+{
+    return inv_internal( you, attach_veh_tool_inventory_preset( allowed_types ),
+                         string_format( _( "Attach an item to the %s" ), vp_name ), 1,
+                         string_format( _( "You don't have any items compatible with %s." ), vp_name ),
+                         string_format( _( "Choose a tool to attach to %s" ), vp_name )
                        );
 }
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1962,9 +1962,11 @@ item_location game_menus::inv::veh_tool_attach( Character &you, const std::strin
 {
     return inv_internal( you, attach_veh_tool_inventory_preset( allowed_types ),
                          string_format( _( "Attach an item to the %s" ), vp_name ), 1,
-                         string_format( _( "You don't have any items compatible with %s." ), vp_name ),
-                         string_format( _( "Choose a tool to attach to %s" ), vp_name )
-                       );
+                         string_format( _( "You don't have any items compatible with %s.\n\nAllowed equipment:\n%s" ),
+    vp_name, enumerate_as_string( allowed_types, []( const itype_id & it ) {
+        return it->nname( 1 );
+    } ) ),
+    string_format( _( "Choose a tool to attach to %s" ), vp_name ) );
 }
 
 drop_locations game_menus::inv::multidrop( Character &you )

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -134,6 +134,9 @@ item_location saw_barrel( Character &you, item &tool );
 item_location saw_stock( Character &you, item &tool );
 /** Choosing an item to attach to a load bearing vest. */
 item_location molle_attach( Character &you, item &tool );
+/** Choosing an item to attach to a vehicle tool station. */
+item_location veh_tool_attach( Character &you, const std::string &vp_name,
+                               const std::set<itype_id> &allowed_types );
 /** Choose item to wear. */
 item_location wear( Character &you, const bodypart_id &bp = bodypart_id( "bp_null" ) );
 /** Choose item to take off. */

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <utility>
 
+#include "ammo.h"
 #include "cata_utility.h"
 #include "character.h"
 #include "debug.h"
@@ -414,3 +415,13 @@ std::tuple<encumbrance_modifier_type, int> armor_portion_data::convert_descripto
 }
 
 std::map<itype_id, std::set<itype_id>> islot_magazine::compatible_guns;
+
+const itype_id &itype::tool_slot_first_ammo() const
+{
+    if( tool ) {
+        for( const ammotype &at : tool->ammo_id ) {
+            return at->default_ammotype();
+        }
+    }
+    return itype_id::NULL_ID();
+}

--- a/src/itype.h
+++ b/src/itype.h
@@ -1203,6 +1203,9 @@ struct itype {
         /** Actions an instance can perform (if any) indexed by action type */
         std::map<std::string, use_function> use_methods;
 
+        // @return returns itype_id of first ammo_id or itype_id::NULL_ID if not tool or no ammo defined
+        const itype_id &tool_slot_first_ammo() const;
+
         /** The factor of ammo consumption indexed by action type*/
         std::map<std::string, int> ammo_scale;
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3305,6 +3305,7 @@ void vehicle_part::deserialize( const JsonObject &data )
 
     data.read( "crew_id", crew_id );
     data.read( "items", items );
+    data.read( "tools", tools );
     data.read( "target_first_x", target.first.x );
     data.read( "target_first_y", target.first.y );
     data.read( "target_first_z", target.first.z );
@@ -3360,6 +3361,7 @@ void vehicle_part::serialize( JsonOut &json ) const
         json.member( "z_offset", precalc[0].z );
     }
     json.member( "items", items );
+    json.member( "tools", tools );
     if( target.first != tripoint_min ) {
         json.member( "target_first_x", target.first.x );
         json.member( "target_first_y", target.first.y );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1099,10 +1099,17 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
     }
 
     if( !get_pseudo_tools().empty() ) {
-        append_desc( std::string( "\n" ) + _( "Provides:" ) + " <color_cyan>" +
+        append_desc( string_format( "\n%s<color_cyan>%s</color>", _( "Provides: " ),
         enumerate_as_string( get_pseudo_tools(), []( const std::pair<itype_id, int> &p ) {
             return p.first.obj().nname( 1 );
-        } ) + "</color>" );
+        } ) ) );
+    }
+
+    if( get_toolkit_info() && !get_toolkit_info()->allowed_types.empty() ) {
+        append_desc( string_format( "\n%s<color_cyan>%s</color>", _( "Allows connecting: " ),
+        enumerate_as_string( get_toolkit_info()->allowed_types, []( const itype_id & it ) {
+            return it->nname( 1 );
+        } ) ) );
     }
 
     if( !long_descrip.empty() ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -304,6 +304,17 @@ void vpart_info::load_rotor( std::optional<vpslot_rotor> &roptr, const JsonObjec
     cata_assert( roptr );
 }
 
+void vpart_info::load_toolkit( std::optional<vpslot_toolkit> &tkptr, const JsonObject &jo )
+{
+    vpslot_toolkit toolkit_info{};
+    if( tkptr ) {
+        toolkit_info = *tkptr;
+    }
+    assign( jo, "allowed_tools", toolkit_info.allowed_types );
+    tkptr = toolkit_info;
+    cata_assert( tkptr );
+}
+
 void vpart_info::load_wheel( std::optional<vpslot_wheel> &whptr, const JsonObject &jo )
 {
     vpslot_wheel wh_info{};
@@ -541,6 +552,10 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
 
     if( def.has_flag( "WORKBENCH" ) ) {
         load_workbench( def.workbench_info, jo );
+    }
+
+    if( def.has_flag( "VEH_TOOLS" ) ) {
+        load_toolkit( def.toolkit_info, jo );
     }
 
     if( jo.has_string( "abstract" ) ) {
@@ -787,6 +802,17 @@ void vpart_info::finalize()
                 pt.erase( it++ );
             } else {
                 ++it;
+            }
+        }
+        if( e.second.toolkit_info.has_value() ) {
+            std::set<itype_id> &pt = e.second.toolkit_info->allowed_types;
+            for( auto it = pt.begin(); it != pt.end(); /* blank */ ) {
+                if( !it->is_valid() ) {
+                    debugmsg( "invalid itype_id '%s' on 'allowed_tools' of vpart '%s'", it->str(), e.first.str() );
+                    pt.erase( it++ );
+                } else {
+                    ++it;
+                }
             }
         }
     }
@@ -1072,10 +1098,9 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
                                        base.gun_damage().total_damage() );
     }
 
-    if( !pseudo_tools.empty() ) {
+    if( !get_pseudo_tools().empty() ) {
         append_desc( std::string( "\n" ) + _( "Provides:" ) + " <color_cyan>" +
-                     enumerate_as_string( pseudo_tools.begin(), pseudo_tools.end(),
-        []( const std::pair<itype_id, int> &p ) {
+        enumerate_as_string( get_pseudo_tools(), []( const std::pair<itype_id, int> &p ) {
             return p.first.obj().nname( 1 );
         } ) + "</color>" );
     }
@@ -1245,6 +1270,11 @@ int vpart_info::rotor_diameter() const
 const std::optional<vpslot_workbench> &vpart_info::get_workbench_info() const
 {
     return workbench_info;
+}
+
+const std::optional<vpslot_toolkit> &vpart_info::get_toolkit_info() const
+{
+    return toolkit_info;
 }
 
 std::set<std::pair<itype_id, int>> vpart_info::get_pseudo_tools() const

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -136,6 +136,10 @@ struct vpslot_workbench {
     units::volume allowed_volume = 0_ml;
 };
 
+struct vpslot_toolkit {
+    std::set<itype_id> allowed_types;
+};
+
 struct transform_terrain_data {
     std::set<std::string> pre_flags;
     std::string post_terrain;
@@ -239,6 +243,7 @@ class vpart_info
         static void load_wheel( std::optional<vpslot_wheel> &whptr, const JsonObject &jo );
         static void load_workbench( std::optional<vpslot_workbench> &wbptr, const JsonObject &jo );
         static void load_rotor( std::optional<vpslot_rotor> &roptr, const JsonObject &jo );
+        static void load_toolkit( std::optional<vpslot_toolkit> &tkptr, const JsonObject &jo );
         static void load( const JsonObject &jo, const std::string &src );
         static void finalize();
         static void check();
@@ -263,13 +268,6 @@ class vpart_info
             return bitflags.test( flag );
         }
         void set_flag( const std::string &flag );
-
-        bool has_tool( const itype_id &tool ) const {
-            return std::find_if( pseudo_tools.cbegin(),
-            pseudo_tools.cend(), [&tool]( std::pair<itype_id, int>p ) {
-                return p.first == tool;
-            } ) != pseudo_tools.cend();
-        }
 
         /** Gets all categories of this part */
         const std::set<std::string> &get_categories() const;
@@ -328,6 +326,7 @@ class vpart_info
          * Getter for optional workbench info
          */
         const std::optional<vpslot_workbench> &get_workbench_info() const;
+        const std::optional<vpslot_toolkit> &get_toolkit_info() const;
 
         std::set<std::pair<itype_id, int>> get_pseudo_tools() const;
 
@@ -366,6 +365,7 @@ class vpart_info
         std::optional<vpslot_wheel> wheel_info;
         std::optional<vpslot_rotor> rotor_info;
         std::optional<vpslot_workbench> workbench_info;
+        std::optional<vpslot_toolkit> toolkit_info;
 
         /** Unique identifier for this part */
         vpart_id id;

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -235,19 +235,25 @@ static std::optional<input_event> veh_keybind( const std::optional<std::string> 
 
 veh_menu_item &veh_menu_item::hotkey( const char hotkey_char )
 {
-    if( this->_hotkey_action.has_value() ) {
-        debugmsg( "veh_menu_item::set_hotkey(hotkey_char) called when hotkey action is already set" );
-    }
+    this->_hotkey_action = std::nullopt;
     this->_hotkey_char = hotkey_char;
+    this->_hotkey_event = std::nullopt;
     return *this;
 }
 
 veh_menu_item &veh_menu_item::hotkey( const std::string &action )
 {
-    if( this->_hotkey_char.has_value() ) {
-        debugmsg( "veh_menu_item::set_hotkey(action) called when hotkey char is already set" );
-    }
     this->_hotkey_action = action;
+    this->_hotkey_char = std::nullopt;
+    this->_hotkey_event = std::nullopt;
+    return *this;
+}
+
+veh_menu_item &veh_menu_item::hotkey( const input_event &ev )
+{
+    this->_hotkey_action = std::nullopt;
+    this->_hotkey_char = std::nullopt;
+    this->_hotkey_event = ev;
     return *this;
 }
 
@@ -255,6 +261,7 @@ veh_menu_item &veh_menu_item::hotkey_auto()
 {
     this->_hotkey_char = MENU_AUTOASSIGN;
     this->_hotkey_action = std::nullopt;
+    this->_hotkey_event = std::nullopt;
     return *this;
 }
 

--- a/src/veh_utils.h
+++ b/src/veh_utils.h
@@ -43,6 +43,7 @@ struct veh_menu_item {
     bool _keep_menu_open = false;
     std::optional<char> _hotkey_char = std::nullopt;
     std::optional<std::string> _hotkey_action = std::nullopt;
+    std::optional<input_event> _hotkey_event = std::nullopt;
     std::function<void()> _on_submit;
 
     veh_menu_item &text( const std::string &text );
@@ -52,6 +53,7 @@ struct veh_menu_item {
     veh_menu_item &skip_locked_check( bool skip_locked_check = true );
     veh_menu_item &hotkey( char hotkey_char );
     veh_menu_item &hotkey( const std::string &action );
+    veh_menu_item &hotkey( const input_event &ev );
     veh_menu_item &hotkey_auto();
     veh_menu_item &on_submit( const std::function<void()> &on_submit );
     veh_menu_item &keep_menu_open( bool keep_menu_open = true );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5610,14 +5610,16 @@ std::map<item, input_event> vehicle::prepare_tools( const vehicle_part &vp ) con
 {
     std::map<item, input_event> res;
     for( const std::pair<itype_id, int> &pair : vp.info().get_pseudo_tools() ) {
-        const input_event ev( pair.second, input_event_t::keyboard_char );
         item it( pair.first, calendar::turn );
+        const input_event ev( pair.second, input_event_t::keyboard_char );
         prepare_tool( it );
-        res.emplace( it, ev );
+        res.emplace( it, pair.second > 0 ? ev : input_event( -1, input_event_t::error ) );
     }
     for( const item &it_src : vp.tools ) {
-        const input_event ev( -1, input_event_t::keyboard_char );
         item it( it_src ); // make a copy
+        const input_event ev = it.invlet > 0
+                               ? input_event( it.invlet, input_event_t::keyboard_char )
+                               : input_event();
         prepare_tool( it );
         res.emplace( it, ev );
     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5606,6 +5606,11 @@ std::vector<item> &vehicle::get_tools( vehicle_part &vp )
     return vp.tools;
 }
 
+const std::vector<item> &vehicle::get_tools( const vehicle_part &vp ) const
+{
+    return vp.tools;
+}
+
 std::map<item, input_event> vehicle::prepare_tools( const vehicle_part &vp ) const
 {
     std::map<item, input_event> res;
@@ -7591,6 +7596,9 @@ void vehicle::calc_mass_center( bool use_precalc ) const
         units::mass m_part_items = 0_gram;
         m_part += vp.part().base.weight();
         for( const item &j : get_items( i ) ) {
+            m_part_items += j.weight();
+        }
+        for( const item &j : get_tools( vp.part() ) ) {
             m_part_items += j.weight();
         }
         if( vp.part().info().cargo_weight_modifier != 100 ) {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1652,14 +1652,19 @@ class vehicle
         units::volume stored_volume( int part ) const;
 
         /**
-        * Flags item \p tool with PSEUDO, if it needs battery and has MOD pocket then a
-        * magazine_battery_pseudo_mod is installed and a pseudo battery with high capacity
-        * is inserted into the magazine well pocket with however many battery charges are
-        * available to this vehicle.
+        * Flags item \p tool with PSEUDO, if it has MOD pocket then a `pseudo_magazine_mod` is
+        * installed and a `pseudo_magazine` is inserted into the magazine well pocket with however
+        * many ammo charges of the first ammo type required by the tool are available to this vehicle.
         * @param tool the tool item to modify
-        * @return amount of energy the pseudo battery is set to or 0 joules
+        * @return amount of ammo in the `pseudo_magazine` or 0
         */
-        units::energy prepare_vehicle_tool( item &tool ) const;
+        int64_t tool_prepare( item &tool ) const;
+        /**
+        * if \p tool is not an itype with tool != nullptr this returns { itype::NULL_ID(), 0 } pair
+        * @param tool the item to examine
+        * @return a pair of tool's first ammo type and the amount of it available from tanks / batteries
+        */
+        std::pair<const itype_id &, int> tool_ammo_available( const itype_id &tool_type ) const;
 
         /**
          * Update an item's active status, for example when adding

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -506,6 +506,7 @@ struct vehicle_part {
         mutable const vpart_info *info_cache = nullptr; // NOLINT(cata-serialize)
 
         item base;
+        std::vector<item> tools; // stores tools in VEH_TOOLS drawer
         cata::colony<item> items; // inventory
 
         /** Preferred ammo type when multiple are available */
@@ -1658,13 +1659,19 @@ class vehicle
         * @param tool the tool item to modify
         * @return amount of ammo in the `pseudo_magazine` or 0
         */
-        int64_t tool_prepare( item &tool ) const;
+        int prepare_tool( item &tool ) const;
         /**
         * if \p tool is not an itype with tool != nullptr this returns { itype::NULL_ID(), 0 } pair
         * @param tool the item to examine
         * @return a pair of tool's first ammo type and the amount of it available from tanks / batteries
         */
         std::pair<const itype_id &, int> tool_ammo_available( const itype_id &tool_type ) const;
+        /**
+        * @return pseudo- and attached tools available from this vehicle part,
+        * marked with PSEUDO flags, pseudo_magazine_mod and pseudo_magazine attached, magazines filled
+        * with the first ammo type required by the tool. pseudo tools are mapped to their hotkey if exists.
+        */
+        std::map<item, input_event> prepare_tools( const vehicle_part &vp ) const;
 
         /**
          * Update an item's active status, for example when adding
@@ -1694,6 +1701,7 @@ class vehicle
 
         vehicle_stack get_items( int part ) const;
         vehicle_stack get_items( int part );
+        std::vector<item> &get_tools( vehicle_part &vp );
         void dump_items_from_part( size_t index );
 
         // Generates starting items in the car, should only be called when placed on the map

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1702,6 +1702,7 @@ class vehicle
         vehicle_stack get_items( int part ) const;
         vehicle_stack get_items( int part );
         std::vector<item> &get_tools( vehicle_part &vp );
+        const std::vector<item> &get_tools( const vehicle_part &vp ) const;
         void dump_items_from_part( size_t index );
 
         // Generates starting items in the car, should only be called when placed on the map

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2173,8 +2173,10 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
             you.invalidate_crafting_inventory();
         } );
 
+        const bool detach_ok = !get_tools( part( vp_idx ) ).empty();
         menu.add( string_format( _( "Detach a tool from %s" ), vp_name ) )
-        .enable( !get_tools( part( vp_idx ) ).empty() )
+        .enable( detach_ok )
+        .desc( string_format( detach_ok ? "" : _( "There are no tools attached to %s" ), vp_name ) )
         .skip_locked_check( true )
         .on_submit( [this, vp_idx, vp_name] {
             veh_menu detach_menu( this, string_format( _( "Detach a tool from %s" ), vp_name ) );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1963,6 +1963,9 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         if( !tool_type->has_use() ) {
             continue; // passive tool
         }
+        if( !hotkey_event.sequence.empty() && hotkey_event.sequence.front() == -1 ) {
+            continue; // skip old passive tools
+        }
         const auto &[tool_ammo, ammo_amount] = tool_ammo_available( tool_type );
         menu.add( string_format( _( "Use %s" ), tool_type->nname( 1 ) ) )
         .enable( ammo_amount >= tool_item.typeId()->charges_to_use() )

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -13,6 +13,7 @@
 
 #include "type_id.h"
 
+struct input_event;
 class inventory;
 class Character;
 class vehicle;
@@ -87,7 +88,7 @@ class vpart_position
         // Finds vpart_reference to inner part with specified tool
         std::optional<vpart_reference> part_with_tool( const itype_id &tool_type ) const;
         // Returns a list of all tools provided by vehicle and their hotkey
-        std::vector<std::pair<itype_id, int>> get_tools() const;
+        std::map<item, input_event> get_tools() const;
         // Forms inventory for inventory::form_from_map
         void form_inventory( inventory &inv ) const;
 
@@ -132,7 +133,6 @@ class optional_vpart_position : public std::optional<vpart_position>
         std::optional<vpart_reference> obstacle_at_part() const;
         std::optional<vpart_reference> part_displayed() const;
         std::optional<vpart_reference> part_with_tool( const itype_id &tool_type ) const;
-        std::vector<std::pair<itype_id, int>> get_tools() const;
         std::string extended_description() const;
 };
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Adds modular tool station vehicle parts
2 vehicle part definitions; mounted kitchen, mounted workshop and 2 equivalent appliances
Allows attaching tools to the above, allows draining first "ammo" with tools that have magazine wells.
This in turn allows using propane cookers

#### Describe the solution

Wanted to make propane cooker working with mounted propane tanks, but then realized i'd have to do a combinatorial json of every kitchen unit type with every combo of hotplate/induction/propane/oil/etc cooker instead of the old "hotplate", every welding kit with every welder part etc... So here we are with another refactor to make most tools usable as vehicle sorta-pseudo tool draining vehicle batteries/tanks.

The end goal is replace (or augment, but likely replace would be better) the pre-made kitchen unit / foodco / kitchenmaster / metalmaster etc parts with a workbench part that you "attach" pieces like a propane cooker and it'll hook them up to the vehicle tank or batteries for when requested via `e`xamine or as crafting inventory tools

Reuses looks_like of existing kitchen_unit / welding_rig
Instead of hotkey definitions in vpart json definition it uses the `invlet` from the item for menu hotkeys.

Currently the allowed attachments are mostly what's shared among various kitchen/welder parts.
Divided into 3 "categories";

mounted kitchen - low power stuff requiring fume hood/ventilation: all kinds of heaters/cookers, chemistry set, dehydrator etc
mounted workshop - high power stuff: welder, forge, kiln
common shared by both kitchen and workshop parts: everything low power and not requiring fume hood/ventilation, or passive tools like pans/pots

Not sure what magic prevents from putting a fume hood on the workshop but that's how it currently is.

Stuff that potentially fits the PR but I cut since that'd overstep this PR:
* acetylene_cooker - no tank parts available to mount, but theoretically should be able to drain
* gasoline_cooker - the item type represents on where magazine is integrated into the stove body
* oil_cooker (kerosene cooker) - the item type represents on where magazine is integrated into the stove body
* Various tools possibly fitting on the kitchen or workshop - are left for future PRs

More stuff left for future PRs:
Replacing existing parts with the new modular ones in vehicle definitions, adding migrations for already spawned vehicles - left for future PRs as current migration code doesn't support it, and these modular ones could use testing

#### Describe alternatives you've considered

#### Testing

Vehicle crafting tests should catch the form_from_map changes
Some ui changes have to be tested manually

#### Additional context
![image](https://user-images.githubusercontent.com/6560075/229302121-f4f5d97c-e293-4bbd-8364-c566c2cd6c31.png)
![image](https://user-images.githubusercontent.com/6560075/229302136-6e7b809b-479c-41c2-aef8-6253b81e0c99.png)
