### PR TITLE
Gives sugar beet syrup a batch crafting time

### DIFF
--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -4086,6 +4086,7 @@
     "difficulty": 2,
     "charges": 8,
     "time": "20 m",
+    "batch_time_factors": [ 80, 4 ],
     "autolearn": true,
     "qualities": [ { "id": "COOK", "level": 2 }, { "id": "CUT", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Gives the sugar beet syrup recipe a batch crafting time"

#### Purpose of change

It's annoying that boiling down eight sugar beets into syrup should cost double the amount of time as four (provided you have an adequate heat source or means to contain them)

#### Describe the solution

Give the sugar beet syrup recipe a batch time, like many comparable cooking recipes

#### Describe alternatives you've considered

I considered doing the same thing for tallow and lard.

#### Testing

Shouldn't be needed 

#### Additional context
