### PR TITLE
Fixes for MSVC:  lint build step execution policy and more static_casts

### DIFF
--- a/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
@@ -176,7 +176,7 @@
       <SubSystem>Windows</SubSystem>
     </Link>
     <CustomBuildStep Condition="'$(CDDA_POST_BUILD_JSON_LINT)' != ''">
-      <Command>C:\windows\system32\windowspowershell\v1.0\powershell.exe $(SolutionDir)\style-json.ps1 -FromMSBuild</Command>
+      <Command>C:\windows\system32\windowspowershell\v1.0\powershell.exe -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)\style-json.ps1 -FromMSBuild</Command>
       <Message>Linting JSON</Message>
       <Outputs>non-existent-file-to-always-trigger-custom-step.txt</Outputs>
     </CustomBuildStep>

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2834,7 +2834,7 @@ static void get_relative( const JsonObject &jo, const std::string &member, std::
                           T default_val )
 {
     if( jo.has_member( member ) ) {
-        value = value.value_or( static_cast<T>( default_val ) ) + jo.get_float( member );
+        value = static_cast<T>( value.value_or( default_val ) + jo.get_float( member ) );
     }
 }
 
@@ -2843,7 +2843,7 @@ static void get_proportional( const JsonObject &jo, const std::string &member,
                               std::optional<T> &value, T default_val )
 {
     if( jo.has_member( member ) ) {
-        value = value.value_or( static_cast<T>( default_val ) ) * jo.get_float( member );
+        value = static_cast<T>( value.value_or( default_val ) * jo.get_float( member ) );
     }
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Make lint post build step work with default execution policy
Static cast so msvc stops nagging about types

#### Describe the solution

Windows update ""helpfully"" reset random settings for my OS, again. But this exposed that I had non-default execution policy set for powershell scripts, anyone with the default won't be able to use https://github.com/CleverRaven/Cataclysm-DDA/pull/63716 as it'll error out, this fixes by setting the execution policy in the build step

Also change static_cast place to stop msvc nagging, somehow I placed them wrong in the last PR and still had no warning generated, odd

#### Describe alternatives you've considered

#### Testing

Auto lint step should work without non-default system wide policy
MSVC should compile without warnings/messages

#### Additional context
