### PR TITLE
Upgrade clang-tidy to LLVM 16

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .git,__pycache__,lang/json
+exclude = .git,__pycache__,lang/json,tools/clang-tidy-plugin/test/check_clang_tidy.py
 ignore =
     # E265 forces comments to have a space after the '#'.  We have a bunch of
     # optional debugging code commented out this way, and not having a space is

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,4 +1,4 @@
-name: Clang-tidy (clang-12, tiles)
+name: Clang-tidy 16
 
 on:
   push:
@@ -27,56 +27,109 @@ jobs:
         with:
           cancel_others: 'true'
           paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", ".github/workflows/clang-tidy.yml" ]'
-  build:
+  build-plugin:
     needs: skip-duplicates
     if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
 
-    runs-on: ubuntu-20.04
+    name: "Build clang-tidy plugin"
+    runs-on: ubuntu-22.04
     env:
-        CMAKE: 1
-        CLANG: clang++-12
-        COMPILER: clang++-12
-        CATA_CLANG_TIDY: plugin
-        TILES: 1
-        SOUND: 1
-        RELEASE: 1
+        CC: clang-16
+        CXX: clang++-16
+        CLANG_DIR: '/usr/lib/llvm-16/lib/cmake/clang'
+        LLVM_DIR: '/usr/lib/llvm-16/lib/cmake/llvm'
     steps:
-    - name: checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    - name: install dependencies
+    - name: install LLVM 16
       run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main"
-          sudo apt-get update
-          sudo apt-get install libncursesw5-dev clang-12 libclang-12-dev llvm-12-dev llvm-12-tools \
-            libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev ccache \
-            gettext jq
-    - name: prepare
-      run: bash ./build-scripts/requirements.sh
-    - name: determine changed files
-      if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/github-script@v5
-      with:
-        script: |
-          var fs = require('fs');
-          const response = await github.paginate(github.rest.pulls.listFiles,
-            {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            }
-          );
-          const files = response.map(x => x.filename);
-          for (const path of files) {
-            console.log(path);
-          }
-          fs.writeFileSync("files_changed", files.join('\n'));
-    - uses: ammaraskar/gcc-problem-matcher@master
-    - name: run clang-tidy
-      run: bash ./build-scripts/clang-tidy.sh
-    - name: show most time consuming checks
-      if: always()
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"
+          sudo apt update
+          sudo apt install llvm-16 llvm-16-dev llvm-16-tools clang-16 clang-tidy-16 clang-tools-16 libclang-16-dev
+    - name: install dependencies
       run: |
-        jq -n 'reduce(inputs.profile | to_entries[]) as {$key,$value} ({}; .[$key] += $value) | with_entries(select(.key|contains(".wall"))) | to_entries | sort_by(.value) | reverse | .[0:10] | from_entries' clang-tidy-trace/*.json
+          sudo apt install python3-pip libncursesw5-dev ninja-build cmake gettext
+          pip3 install --user lit
+    - name: ensure clang-tidy and FileCheck commands point to LLVM 16
+      run: |
+          mkdir ~/llvm-command-override
+          ln -s /usr/bin/clang-tidy-16 ~/llvm-command-override/clang-tidy
+          ln -s /usr/bin/FileCheck-16 ~/llvm-command-override/FileCheck
+          echo "$HOME/llvm-command-override" >> $GITHUB_PATH
+    - name: checkout repository
+      uses: actions/checkout@v3
+    - name: build clang-tidy plugin
+      run: |
+          cmake -B build -D CMAKE_BUILD_TYPE=Release \
+                         -D CATA_CLANG_TIDY_PLUGIN=ON \
+                         -D LLVM_DIR="${LLVM_DIR}" \
+                         -D Clang_DIR="${CLANG_DIR}" \
+                         -G Ninja
+          ninja -C build libCataAnalyzerPlugin.so
+    - name: test clang-tidy plugin
+      run: |
+          lit -v build/tools/clang-tidy-plugin/test
+    - name: cache clang-tidy plugin
+      uses: actions/cache@v3
+      with:
+        path: ~/cata-clang-tidy-plugin
+        key: cata-clang-tidy-plugin
+    - name: copy clang-tidy plugin
+      run: |
+        cp build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so ~/cata-clang-tidy-plugin
+
+  check:
+    needs: build-plugin
+    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - title: Check main
+            filter: "/src/"
+          - title: Check tests
+            filter: "/tests/"
+    name: "Run clang-tidy checks"
+    runs-on: ubuntu-22.04
+    env:
+        CC: clang-16
+        CXX: clang++-16
+    steps:
+    - name: install LLVM 16
+      run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"
+          sudo apt update
+          sudo apt install llvm-16 llvm-16-dev llvm-16-tools clang-16 clang-tidy-16 clang-tools-16 libclang-16-dev
+    - name: install dependencies
+      run: |
+          sudo apt update
+          sudo apt install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev gettext \
+                           cmake ninja-build parallel jq
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: configure cmake
+      run: |
+          cmake -B build -D CMAKE_BUILD_TYPE=Release \
+                         -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                         -D TILES=ON \
+                         -D SOUND=ON \
+                         -G Ninja
+    - name: determine scope of files to be checked
+      run: |
+          jq --arg pwd $(pwd) --arg filter "/src/" \
+             '[.[].file] | map(sub($pwd; ".")) | map(select(. | contains($filter))) | join(" ")' \
+             build/compile_commands.json > files
+    - name: cache clang-tidy plugin
+      uses: actions/cache@v3
+      with:
+        path: ~/cata-clang-tidy-plugin
+        key: cata-clang-tidy-plugin
+    - name: ensure clang-tidy plugin exists
+      run: |
+        file ~/cata-clang-tidy-plugin/libCataAnalyzerPlugin.so
+    - name: run clang-tidy in src
+      run: |
+          parallel --linebuffer --keep-order \
+            clang-tidy -p build --checks="-*,cata-*" --use-color --quiet \
+            --load=~/cata-clang-tidy-plugin/libCataAnalyzerPlugin.so \
+             ::: $(cat files)

--- a/Makefile
+++ b/Makefile
@@ -1208,7 +1208,7 @@ astyle-fast: $(ASTYLE_SOURCES)
 	echo $(ASTYLE_SOURCES) | xargs -P 0 -L 1 $(ASTYLE_BINARY) --quiet --options=.astylerc -n
 
 astyle-diff: $(ASTYLE_SOURCES)
-	$(ASTYLE_BINARY) --options=.astylerc -n $$(git diff --name-only src/*.h src/*.cpp tests/*.h tests/*.cpp)
+	$(ASTYLE_BINARY) --options=.astylerc -n $$(git diff --name-only src/*.h src/*.cpp tests/*.h tests/*.cpp tools/*.h tools/*.cpp)
 
 astyle-all: $(ASTYLE_SOURCES)
 	$(ASTYLE_BINARY) --options=.astylerc -n $(ASTYLE_SOURCES)

--- a/tools/clang-tidy-plugin/AlmostNeverAutoCheck.cpp
+++ b/tools/clang-tidy-plugin/AlmostNeverAutoCheck.cpp
@@ -91,6 +91,7 @@ static void CheckDecl( AlmostNeverAutoCheck &Check,
     }
 
     QualType AutoTp = Initializer->getType();
+    QualType DesugaredAutoTp = AutoTp.getDesugaredType( *Result.Context );
     bool WasRRef = VarDeclType.getTypePtr()->isRValueReferenceType();
     bool WasLRef = VarDeclType.getTypePtr()->isLValueReferenceType();
     VarDeclType = VarDeclType.getNonReferenceType();
@@ -107,6 +108,7 @@ static void CheckDecl( AlmostNeverAutoCheck &Check,
     PrintingPolicy Policy( LangOptions{} );
     Policy.adjustForCPlusPlus();
     std::string TypeStr = AutoTp.getAsString( Policy );
+    const std::string DesugaredTypeStr = DesugaredAutoTp.getAsString( Policy );
 
     // In the case of 'const auto' we need to bring the beginning forwards
     // to the start of the 'const'.
@@ -139,10 +141,14 @@ static void CheckDecl( AlmostNeverAutoCheck &Check,
     // details) based on their names.  Skipping the first character of each
     // word to avoid worrying about capitalization.
     for( std::string Fragment : {
-             "terator", "nternal", "__"
+             "terator", "element_type", "mapped_type", "value_type", "nternal", "__"
          } ) {
         if( std::search( TypeStr.begin(), TypeStr.end(), Fragment.begin(), Fragment.end() ) !=
             TypeStr.end() ) {
+            return;
+        }
+        if( std::search( DesugaredTypeStr.begin(), DesugaredTypeStr.end(), Fragment.begin(),
+                         Fragment.end() ) != DesugaredTypeStr.end() ) {
             return;
         }
     }

--- a/tools/clang-tidy-plugin/AlmostNeverAutoCheck.h
+++ b/tools/clang-tidy-plugin/AlmostNeverAutoCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/AssertCheck.h
+++ b/tools/clang-tidy-plugin/AssertCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/AvoidAlternativeTokensCheck.h
+++ b/tools/clang-tidy-plugin/AvoidAlternativeTokensCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/CMakeLists.txt
+++ b/tools/clang-tidy-plugin/CMakeLists.txt
@@ -57,23 +57,7 @@ endif ()
 target_include_directories(${CataAnalyzerName} SYSTEM PRIVATE
         ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
 
-if ("${CATA_CLANG_TIDY_INCLUDE_DIR}" STREQUAL "")
-    set(CTPS_RELEASES https://github.com/jbytheway/clang-tidy-plugin-support/releases/download)
-    set(CTPS_VERSION llvm-12.0.0-r3)
-    set(CTPS_SRC ${CMAKE_CURRENT_BINARY_DIR}/clang-tidy-plugin-support)
-
-    ExternalProject_Add(clang-tidy-plugin-support
-            URL ${CTPS_RELEASES}/${CTPS_VERSION}/clang-tidy-plugin-support-${CTPS_VERSION}.tar.xz
-            URL_HASH SHA256=c84aaf35b4d5bb9130b1cc309a92146ae5c62fd69db30a6254725beac9d60990
-            SOURCE_DIR ${CTPS_SRC}
-            CONFIGURE_COMMAND ""
-            BUILD_COMMAND ""
-            INSTALL_COMMAND ""
-            TEST_COMMAND "")
-
-    add_dependencies(${CataAnalyzerName} clang-tidy-plugin-support)
-    target_include_directories(${CataAnalyzerName} SYSTEM PRIVATE ${CTPS_SRC}/include)
-else ()
+if (NOT "${CATA_CLANG_TIDY_INCLUDE_DIR}" STREQUAL "")
     target_include_directories(${CataAnalyzerName} SYSTEM PRIVATE ${CATA_CLANG_TIDY_INCLUDE_DIR})
 endif ()
 

--- a/tools/clang-tidy-plugin/CataTidyModule.cpp
+++ b/tools/clang-tidy-plugin/CataTidyModule.cpp
@@ -1,11 +1,11 @@
 #include <clang/Basic/Version.h>
+#include <clang-tidy/ClangTidyModule.h>
+#include <clang-tidy/ClangTidyModuleRegistry.h>
 #include <llvm/ADT/StringRef.h>
 
 #include "AlmostNeverAutoCheck.h"
 #include "AssertCheck.h"
 #include "AvoidAlternativeTokensCheck.h"
-#include "ClangTidyModule.h"
-#include "ClangTidyModuleRegistry.h"
 #include "CombineLocalsIntoPointCheck.h"
 #include "DeterminismCheck.h"
 #include "HeaderGuardCheck.h"
@@ -40,7 +40,7 @@
 #include "XYCheck.h"
 
 #if defined( CATA_CLANG_TIDY_EXECUTABLE )
-#include "tool/ClangTidyMain.h"
+#include <clang-tidy/tool/ClangTidyMain.h>
 #endif
 
 namespace clang::tidy

--- a/tools/clang-tidy-plugin/CombineLocalsIntoPointCheck.h
+++ b/tools/clang-tidy-plugin/CombineLocalsIntoPointCheck.h
@@ -6,8 +6,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/DeterminismCheck.h
+++ b/tools/clang-tidy-plugin/DeterminismCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/HeaderGuardCheck.h
+++ b/tools/clang-tidy-plugin/HeaderGuardCheck.h
@@ -1,8 +1,8 @@
 #ifndef CATA_TOOLS_CLANG_TIDY_PLUGIN_HEADERGUARDCHECK_H
 #define CATA_TOOLS_CLANG_TIDY_PLUGIN_HEADERGUARDCHECK_H
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/JsonTranslationInputCheck.h
+++ b/tools/clang-tidy-plugin/JsonTranslationInputCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/LargeInlineFunctionCheck.h
+++ b/tools/clang-tidy-plugin/LargeInlineFunctionCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/LargeStackObjectCheck.h
+++ b/tools/clang-tidy-plugin/LargeStackObjectCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/NoLongCheck.h
+++ b/tools/clang-tidy-plugin/NoLongCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/NoStaticTranslationCheck.h
+++ b/tools/clang-tidy-plugin/NoStaticTranslationCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/OtMatchCheck.h
+++ b/tools/clang-tidy-plugin/OtMatchCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/PointInitializationCheck.h
+++ b/tools/clang-tidy-plugin/PointInitializationCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/RedundantParenthesesCheck.h
+++ b/tools/clang-tidy-plugin/RedundantParenthesesCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/SerializeCheck.cpp
+++ b/tools/clang-tidy-plugin/SerializeCheck.cpp
@@ -1,6 +1,6 @@
 #include "SerializeCheck.h"
 
-#include <ClangTidyDiagnosticConsumer.h>
+#include <clang-tidy/ClangTidyDiagnosticConsumer.h>
 #include <clang/Basic/IdentifierTable.h>
 #include <clang/Basic/SourceLocation.h>
 #include <clang/Basic/SourceManager.h>

--- a/tools/clang-tidy-plugin/SerializeCheck.h
+++ b/tools/clang-tidy-plugin/SerializeCheck.h
@@ -5,8 +5,8 @@
 
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 #include "Utils.h"
 
 namespace clang

--- a/tools/clang-tidy-plugin/SimplifyPointConstructorsCheck.h
+++ b/tools/clang-tidy-plugin/SimplifyPointConstructorsCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/StaticDeclarationsCheck.h
+++ b/tools/clang-tidy-plugin/StaticDeclarationsCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/StaticInitializationOrderCheck.h
+++ b/tools/clang-tidy-plugin/StaticInitializationOrderCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/StaticIntIdConstantsCheck.h
+++ b/tools/clang-tidy-plugin/StaticIntIdConstantsCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/StaticStringIdConstantsCheck.h
+++ b/tools/clang-tidy-plugin/StaticStringIdConstantsCheck.h
@@ -6,8 +6,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/TestFilenameCheck.cpp
+++ b/tools/clang-tidy-plugin/TestFilenameCheck.cpp
@@ -1,6 +1,6 @@
 #include "TestFilenameCheck.h"
 
-#include <ClangTidyDiagnosticConsumer.h>
+#include <clang-tidy/ClangTidyDiagnosticConsumer.h>
 #include <clang/Basic/IdentifierTable.h>
 #include <clang/Basic/SourceLocation.h>
 #include <clang/Basic/SourceManager.h>

--- a/tools/clang-tidy-plugin/TestFilenameCheck.h
+++ b/tools/clang-tidy-plugin/TestFilenameCheck.h
@@ -3,8 +3,8 @@
 
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/TestsMustRestoreGlobalStateCheck.cpp
+++ b/tools/clang-tidy-plugin/TestsMustRestoreGlobalStateCheck.cpp
@@ -1,6 +1,6 @@
 #include "TestsMustRestoreGlobalStateCheck.h"
 
-#include <ClangTidyDiagnosticConsumer.h>
+#include <clang-tidy/ClangTidyDiagnosticConsumer.h>
 #include <clang/Basic/IdentifierTable.h>
 #include <clang/Basic/SourceLocation.h>
 #include <clang/Basic/SourceManager.h>

--- a/tools/clang-tidy-plugin/TestsMustRestoreGlobalStateCheck.h
+++ b/tools/clang-tidy-plugin/TestsMustRestoreGlobalStateCheck.h
@@ -5,8 +5,8 @@
 
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 #include "Utils.h"
 
 namespace clang

--- a/tools/clang-tidy-plugin/TextStyleCheck.cpp
+++ b/tools/clang-tidy-plugin/TextStyleCheck.cpp
@@ -1,6 +1,6 @@
 #include "TextStyleCheck.h"
 
-#include <ClangTidy.h>
+#include <clang-tidy/ClangTidy.h>
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/Expr.h>
 #include <clang/AST/ExprCXX.h>
@@ -93,12 +93,12 @@ void TextStyleCheck::check( const MatchFinder::MatchResult &Result )
     }
 
     // ignore wide/u16/u32 strings
-    if( ( !text.isAscii() && !text.isUTF8() ) || text.getCharByteWidth() != 1 ) {
+    if( ( text.isWide() || text.isUTF16() || text.isUTF32() ) || text.getCharByteWidth() != 1 ) {
         return;
     }
 
     // disable fix-its for utf8 strings to avoid removing the u8 prefix
-    bool fixit = text.isAscii();
+    bool fixit = !text.isUTF8();
     for( size_t i = 0; fixit && i < text.getNumConcatenated(); ++i ) {
         const SourceLocation &loc = text.getStrTokenLoc( i );
         if( !loc.isMacroID() && SrcMgr.getCharacterData( loc )[0] == 'R' ) {

--- a/tools/clang-tidy-plugin/TextStyleCheck.h
+++ b/tools/clang-tidy-plugin/TextStyleCheck.h
@@ -1,12 +1,12 @@
 #ifndef CATA_TOOLS_CLANG_TIDY_PLUGIN_TEXTSTYLECHECK_H
 #define CATA_TOOLS_CLANG_TIDY_PLUGIN_TEXTSTYLECHECK_H
 
-#include <ClangTidyOptions.h>
+#include <clang-tidy/ClangTidyOptions.h>
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/TranslateStringLiteralCheck.h
+++ b/tools/clang-tidy-plugin/TranslateStringLiteralCheck.h
@@ -6,8 +6,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/TranslationsInDebugMessagesCheck.h
+++ b/tools/clang-tidy-plugin/TranslationsInDebugMessagesCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp
+++ b/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp
@@ -1,6 +1,6 @@
 #include "TranslatorCommentsCheck.h"
 
-#include <ClangTidyDiagnosticConsumer.h>
+#include <clang-tidy/ClangTidyDiagnosticConsumer.h>
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/Expr.h>
 #include <clang/ASTMatchers/ASTMatchers.h>

--- a/tools/clang-tidy-plugin/TranslatorCommentsCheck.h
+++ b/tools/clang-tidy-plugin/TranslatorCommentsCheck.h
@@ -1,8 +1,8 @@
 #ifndef CATA_TOOLS_CLANG_TIDY_PLUGIN_TRANSLATORCOMMENTSCHECK_H
 #define CATA_TOOLS_CLANG_TIDY_PLUGIN_TRANSLATORCOMMENTSCHECK_H
 
-#include <ClangTidy.h>
-#include <ClangTidyCheck.h>
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <clang/Basic/SourceLocation.h>
 #include <llvm/ADT/StringRef.h>

--- a/tools/clang-tidy-plugin/UTF8ToLowerUpperCheck.h
+++ b/tools/clang-tidy-plugin/UTF8ToLowerUpperCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/UnsequencedCallsCheck.h
+++ b/tools/clang-tidy-plugin/UnsequencedCallsCheck.h
@@ -5,8 +5,8 @@
 #include <llvm/ADT/StringRef.h>
 #include <unordered_map>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 #include "Utils.h"
 
 namespace clang

--- a/tools/clang-tidy-plugin/UnusedStaticsCheck.h
+++ b/tools/clang-tidy-plugin/UnusedStaticsCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <unordered_set>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/UseLocalizedSortingCheck.h
+++ b/tools/clang-tidy-plugin/UseLocalizedSortingCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/UseMdarrayCheck.h
+++ b/tools/clang-tidy-plugin/UseMdarrayCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/UseNamedPointConstantsCheck.h
+++ b/tools/clang-tidy-plugin/UseNamedPointConstantsCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/UsePointApisCheck.cpp
+++ b/tools/clang-tidy-plugin/UsePointApisCheck.cpp
@@ -78,7 +78,7 @@ static bool doFunctionsMatch( const FunctionDecl *Callee, const FunctionDecl *Ot
 
         if( CalleeParamI == MinArg - SkipArgs ) {
             std::string ShortTypeName = IsTripoint ? "tripoint" : "point";
-            std::string ExpectedTypeName = "const struct " + ShortTypeName + " &";
+            std::string ExpectedTypeName = "const " + ShortTypeName + " &";
             if( OtherCalleeParam->getType().getAsString() != ExpectedTypeName ) {
                 return false;
             }

--- a/tools/clang-tidy-plugin/UsePointApisCheck.h
+++ b/tools/clang-tidy-plugin/UsePointApisCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/UsePointArithmeticCheck.h
+++ b/tools/clang-tidy-plugin/UsePointArithmeticCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/XYCheck.h
+++ b/tools/clang-tidy-plugin/XYCheck.h
@@ -4,8 +4,8 @@
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <llvm/ADT/StringRef.h>
 
-#include "ClangTidy.h"
-#include "ClangTidyCheck.h"
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
 
 namespace clang
 {

--- a/tools/clang-tidy-plugin/test/almost-never-auto.cpp
+++ b/tools/clang-tidy-plugin/test/almost-never-auto.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-almost-never-auto %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-almost-never-auto %t -- --load=%cata_plugin --
 
 using int_alias = int;
 int_alias return_int_alias();

--- a/tools/clang-tidy-plugin/test/assert.cpp
+++ b/tools/clang-tidy-plugin/test/assert.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-assert %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-assert %t -- --load=%cata_plugin --
 
 #include <assert.h>
 #include <stdlib.h>

--- a/tools/clang-tidy-plugin/test/avoid-alternative-tokens.cpp
+++ b/tools/clang-tidy-plugin/test/avoid-alternative-tokens.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-avoid-alternative-tokens %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-avoid-alternative-tokens %t -- --load=%cata_plugin --
 
 void f0()
 {

--- a/tools/clang-tidy-plugin/test/check_clang_tidy.py
+++ b/tools/clang-tidy-plugin/test/check_clang_tidy.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+#
+#===- check_clang_tidy.py - ClangTidy Test Helper ------------*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===------------------------------------------------------------------------===#
+
+r"""
+ClangTidy Test Helper
+=====================
+
+This script runs clang-tidy in fix mode and verify fixes, messages or both.
+
+Usage:
+  check_clang_tidy.py [-resource-dir=<resource-dir>] \
+    [-assume-filename=<file-with-source-extension>] \
+    [-check-suffix=<comma-separated-file-check-suffixes>] \
+    [-check-suffixes=<comma-separated-file-check-suffixes>] \
+    [-std=c++(98|11|14|17|20)[-or-later]] \
+    <source-file> <check-name> <temp-file> \
+    -- [optional clang-tidy arguments]
+
+Example:
+  // RUN: %check_clang_tidy %s llvm-include-order %t -- -- -isystem %S/Inputs
+
+Notes:
+  -std=c++(98|11|14|17|20)-or-later:
+    This flag will cause multiple runs within the same check_clang_tidy
+    execution. Make sure you don't have shared state across these runs.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+def write_file(file_name, text):
+  with open(file_name, 'w', encoding='utf-8') as f:
+    f.write(text)
+    f.truncate()
+
+
+def try_run(args, raise_error=True):
+  try:
+    process_output = \
+      subprocess.check_output(args, stderr=subprocess.STDOUT).decode(errors='ignore')
+  except subprocess.CalledProcessError as e:
+    process_output = e.output.decode(errors='ignore')
+    print('%s failed:\n%s' % (' '.join(args), process_output))
+    if raise_error:
+      raise
+  return process_output
+
+
+# This class represents the appearance of a message prefix in a file.
+class MessagePrefix:
+  def __init__(self, label):
+    self.has_message = False
+    self.prefixes = []
+    self.label = label
+
+  def check(self, file_check_suffix, input_text):
+    self.prefix = self.label + file_check_suffix
+    self.has_message = self.prefix in input_text
+    if self.has_message:
+      self.prefixes.append(self.prefix)
+    return self.has_message
+
+
+class CheckRunner:
+  def __init__(self, args, extra_args):
+    self.resource_dir = args.resource_dir
+    self.assume_file_name = args.assume_filename
+    self.input_file_name = args.input_file_name
+    self.check_name = args.check_name
+    self.temp_file_name = args.temp_file_name
+    self.original_file_name = self.temp_file_name + ".orig"
+    self.expect_clang_tidy_error = args.expect_clang_tidy_error
+    self.std = args.std
+    self.check_suffix = args.check_suffix
+    self.input_text = ''
+    self.has_check_fixes = False
+    self.has_check_messages = False
+    self.has_check_notes = False
+    self.fixes = MessagePrefix('CHECK-FIXES')
+    self.messages = MessagePrefix('CHECK-MESSAGES')
+    self.notes = MessagePrefix('CHECK-NOTES')
+
+    file_name_with_extension = self.assume_file_name or self.input_file_name
+    _, extension = os.path.splitext(file_name_with_extension)
+    if extension not in ['.c', '.hpp', '.m', '.mm']:
+      extension = '.cpp'
+    self.temp_file_name = self.temp_file_name + extension
+
+    self.clang_extra_args = []
+    self.clang_tidy_extra_args = extra_args
+    if '--' in extra_args:
+      i = self.clang_tidy_extra_args.index('--')
+      self.clang_extra_args = self.clang_tidy_extra_args[i + 1:]
+      self.clang_tidy_extra_args = self.clang_tidy_extra_args[:i]
+
+    # If the test does not specify a config style, force an empty one; otherwise
+    # auto-detection logic can discover a ".clang-tidy" file that is not related to
+    # the test.
+    if not any(
+        [arg.startswith('-config=') for arg in self.clang_tidy_extra_args]):
+      self.clang_tidy_extra_args.append('-config={}')
+
+    if extension in ['.m', '.mm']:
+      self.clang_extra_args = ['-fobjc-abi-version=2', '-fobjc-arc', '-fblocks'] + \
+          self.clang_extra_args
+
+    if extension in ['.cpp', '.hpp', '.mm']:
+      self.clang_extra_args.append('-std=' + self.std)
+
+    # Tests should not rely on STL being available, and instead provide mock
+    # implementations of relevant APIs.
+    self.clang_extra_args.append('-nostdinc++')
+
+    if self.resource_dir is not None:
+      self.clang_extra_args.append('-resource-dir=%s' % self.resource_dir)
+
+  def read_input(self):
+    with open(self.input_file_name, 'r', encoding='utf-8') as input_file:
+      self.input_text = input_file.read()
+
+  def get_prefixes(self):
+    for suffix in self.check_suffix:
+      if suffix and not re.match('^[A-Z0-9\\-]+$', suffix):
+        sys.exit('Only A..Z, 0..9 and "-" are allowed in check suffixes list,'
+                 + ' but "%s" was given' % suffix)
+
+      file_check_suffix = ('-' + suffix) if suffix else ''
+
+      has_check_fix = self.fixes.check(file_check_suffix, self.input_text)
+      self.has_check_fixes = self.has_check_fixes or has_check_fix
+
+      has_check_message = self.messages.check(file_check_suffix, self.input_text)
+      self.has_check_messages = self.has_check_messages or has_check_message
+
+      has_check_note = self.notes.check(file_check_suffix, self.input_text)
+      self.has_check_notes = self.has_check_notes or has_check_note
+
+      if has_check_note and has_check_message:
+        sys.exit('Please use either %s or %s but not both' %
+          (self.notes.prefix, self.messages.prefix))
+
+      if not has_check_fix and not has_check_message and not has_check_note:
+        sys.exit('%s, %s or %s not found in the input' %
+          (self.fixes.prefix, self.messages.prefix, self.notes.prefix))
+
+    assert self.has_check_fixes or self.has_check_messages or self.has_check_notes
+
+  def prepare_test_inputs(self):
+    # Remove the contents of the CHECK lines to avoid CHECKs matching on
+    # themselves.  We need to keep the comments to preserve line numbers while
+    # avoiding empty lines which could potentially trigger formatting-related
+    # checks.
+    cleaned_test = re.sub('// *CHECK-[A-Z0-9\\-]*:[^\r\n]*', '//', self.input_text)
+    write_file(self.temp_file_name, cleaned_test)
+    write_file(self.original_file_name, cleaned_test)
+
+  def run_clang_tidy(self):
+    args = ['clang-tidy', self.temp_file_name, '-fix', '--checks=-*,' + self.check_name] + \
+        self.clang_tidy_extra_args + ['--'] + self.clang_extra_args
+    if self.expect_clang_tidy_error:
+      args.insert(0, 'not')
+    print('Running ' + repr(args) + '...')
+    clang_tidy_output = try_run(args)
+    print('------------------------ clang-tidy output -----------------------')
+    print(clang_tidy_output.encode(sys.stdout.encoding, errors="replace").decode(sys.stdout.encoding))
+    print('------------------------------------------------------------------')
+
+    diff_output = try_run(['diff', '-u', self.original_file_name, self.temp_file_name], False)
+    print('------------------------------ Fixes -----------------------------')
+    print(diff_output)
+    print('------------------------------------------------------------------')
+    return clang_tidy_output
+
+  def check_fixes(self):
+    if self.has_check_fixes:
+      try_run(['FileCheck', '-input-file=' + self.temp_file_name, self.input_file_name,
+              '-check-prefixes=' + ','.join(self.fixes.prefixes),
+              '-strict-whitespace'])
+
+  def check_messages(self, clang_tidy_output):
+    if self.has_check_messages:
+      messages_file = self.temp_file_name + '.msg'
+      write_file(messages_file, clang_tidy_output)
+      try_run(['FileCheck', '-input-file=' + messages_file, self.input_file_name,
+             '-check-prefixes=' + ','.join(self.messages.prefixes),
+             '-implicit-check-not={{warning|error}}:'])
+
+  def check_notes(self, clang_tidy_output):
+    if self.has_check_notes:
+      notes_file = self.temp_file_name + '.notes'
+      filtered_output = [line for line in clang_tidy_output.splitlines()
+                         if not ("note: FIX-IT applied" in line)]
+      write_file(notes_file, '\n'.join(filtered_output))
+      try_run(['FileCheck', '-input-file=' + notes_file, self.input_file_name,
+             '-check-prefixes=' + ','.join(self.notes.prefixes),
+             '-implicit-check-not={{note|warning|error}}:'])
+
+  def run(self):
+    self.read_input()
+    self.get_prefixes()
+    self.prepare_test_inputs()
+    clang_tidy_output = self.run_clang_tidy()
+    self.check_fixes()
+    self.check_messages(clang_tidy_output)
+    self.check_notes(clang_tidy_output)
+
+
+def expand_std(std):
+  if std == 'c++98-or-later':
+    return ['c++98', 'c++11', 'c++14', 'c++17', 'c++20']
+  if std == 'c++11-or-later':
+    return ['c++11', 'c++14', 'c++17', 'c++20']
+  if std == 'c++14-or-later':
+    return ['c++14', 'c++17', 'c++20']
+  if std == 'c++17-or-later':
+    return ['c++17', 'c++20']
+  if std == 'c++20-or-later':
+    return ['c++20']
+  return [std]
+
+
+def csv(string):
+  return string.split(',')
+
+
+def parse_arguments():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-expect-clang-tidy-error', action='store_true')
+  parser.add_argument('-resource-dir')
+  parser.add_argument('-assume-filename')
+  parser.add_argument('input_file_name')
+  parser.add_argument('check_name')
+  parser.add_argument('temp_file_name')
+  parser.add_argument(
+    '-check-suffix',
+    '-check-suffixes',
+    default=[''],
+    type=csv,
+    help='comma-separated list of FileCheck suffixes')
+  parser.add_argument('-std', type=csv, default=['c++11-or-later'])
+  return parser.parse_known_args()
+
+
+def main():
+  args, extra_args = parse_arguments()
+
+  abbreviated_stds = args.std
+  for abbreviated_std in abbreviated_stds:
+    for std in expand_std(abbreviated_std):
+      args.std = std
+      CheckRunner(args, extra_args).run()
+
+
+if __name__ == '__main__':
+  main()

--- a/tools/clang-tidy-plugin/test/combine-locals-into-point.cpp
+++ b/tools/clang-tidy-plugin/test/combine-locals-into-point.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-combine-locals-into-point %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-combine-locals-into-point %t -- --load=%cata_plugin -- -isystem %cata_include
 
 #define CATA_NO_STL
 #include "point.h"

--- a/tools/clang-tidy-plugin/test/determinism.cpp
+++ b/tools/clang-tidy-plugin/test/determinism.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-determinism %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-determinism %t -- --load=%cata_plugin --
 
 using size_t = unsigned long;
 

--- a/tools/clang-tidy-plugin/test/header-guard-1.h
+++ b/tools/clang-tidy-plugin/test/header-guard-1.h
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-header-guard %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-header-guard %t -- --load=%cata_plugin --
 
 #ifndef THE_WRONG_HEADER_GUARD
 // CHECK-MESSAGES: warning: Header guard does not follow preferred style. [cata-header-guard]

--- a/tools/clang-tidy-plugin/test/header-guard-2.h
+++ b/tools/clang-tidy-plugin/test/header-guard-2.h
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-header-guard %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-header-guard %t -- --load=%cata_plugin --
 
 #ifndef CATA_TOOLS_CLANG_TIDY_PLUGIN_TEST_OUTPUT_HEADER_GUARD_2_H_TMP_CPP
 #define CATA_TOOLS_CLANG_TIDY_PLUGIN_TEST_OUTPUT_HEADER_GUARD_2_H_TMP_CPP

--- a/tools/clang-tidy-plugin/test/header-guard-3.h
+++ b/tools/clang-tidy-plugin/test/header-guard-3.h
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-header-guard %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-header-guard %t -- --load=%cata_plugin --
 // CHECK-MESSAGES: warning: Header is missing header guard. [cata-header-guard]
 // CHECK-FIXES: #ifndef CATA_TOOLS_CLANG_TIDY_PLUGIN_TEST_OUTPUT_HEADER_GUARD_3_H_TMP_CPP
 // CHECK-FIXES: #define CATA_TOOLS_CLANG_TIDY_PLUGIN_TEST_OUTPUT_HEADER_GUARD_3_H_TMP_CPP

--- a/tools/clang-tidy-plugin/test/header-guard-4.cpp
+++ b/tools/clang-tidy-plugin/test/header-guard-4.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-header-guard,cata-no-long %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-header-guard,cata-no-long %t -- --load=%cata_plugin --
 // Should not need a header guard because it's not a header.
 
 // Include another warning just to avoid the "there were no warnings in your

--- a/tools/clang-tidy-plugin/test/header-guard-5.h
+++ b/tools/clang-tidy-plugin/test/header-guard-5.h
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-header-guard %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-header-guard %t -- --load=%cata_plugin --
 #pragma once
 // CHECK-MESSAGES: [[@LINE]]:1: warning: Header is missing header guard. [cata-header-guard]
 // CHECK-FIXES: #ifndef CATA_TOOLS_CLANG_TIDY_PLUGIN_TEST_OUTPUT_HEADER_GUARD_5_H_TMP_CPP

--- a/tools/clang-tidy-plugin/test/json-translation-input.cpp
+++ b/tools/clang-tidy-plugin/test/json-translation-input.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-json-translation-input %t -- -plugins=%cata_plugin -- -I %test_include
+// RUN: %check_clang_tidy %s cata-json-translation-input %t -- --load=%cata_plugin -- -I %test_include
 
 #include "mock-translation.h"
 

--- a/tools/clang-tidy-plugin/test/large-inline-functions.cpp
+++ b/tools/clang-tidy-plugin/test/large-inline-functions.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-large-inline-function %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-large-inline-function %t -- --load=%cata_plugin --
 
 inline void f0()
 // CHECK-MESSAGES: warning: Function 'f0' declared inline in a cpp file. 'inline' should only be used in header files. [cata-large-inline-function]

--- a/tools/clang-tidy-plugin/test/large-inline-functions.h
+++ b/tools/clang-tidy-plugin/test/large-inline-functions.h
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-large-inline-function %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-large-inline-function %t -- --load=%cata_plugin --
 
 inline void f0()
 // CHECK-MESSAGES: warning: Function 'f0' declared inline but contains more than 2 statements. Consider moving the definition to a cpp file. [cata-large-inline-function]

--- a/tools/clang-tidy-plugin/test/large-stack-object.cpp
+++ b/tools/clang-tidy-plugin/test/large-stack-object.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-large-stack-object %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-large-stack-object %t -- --load=%cata_plugin --
 
 void f0()
 {

--- a/tools/clang-tidy-plugin/test/lit.cfg
+++ b/tools/clang-tidy-plugin/test/lit.cfg
@@ -14,8 +14,7 @@ if config.cata_check_clang_tidy:
     check_clang_tidy = config.cata_check_clang_tidy
 else:
     check_clang_tidy = os.path.join(
-            config.plugin_build_root, 'clang-tidy-plugin-support', 'bin',
-            'check_clang_tidy.py')
+            config.cata_source_dir, "./tools/clang-tidy-plugin/test/check_clang_tidy.py" )
 
 check_clang_tidy += ' -std=c++17'
 

--- a/tools/clang-tidy-plugin/test/no-long.cpp
+++ b/tools/clang-tidy-plugin/test/no-long.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-no-long %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-no-long %t -- --load=%cata_plugin --
 
 #include <stdint.h>
 

--- a/tools/clang-tidy-plugin/test/no-static-translation.cpp
+++ b/tools/clang-tidy-plugin/test/no-static-translation.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-no-static-translation %t -- -plugins=%cata_plugin -- -I %test_include
+// RUN: %check_clang_tidy %s cata-no-static-translation %t -- --load=%cata_plugin -- -I %test_include
 
 #include "mock-translation.h"
 

--- a/tools/clang-tidy-plugin/test/ot-match.cpp
+++ b/tools/clang-tidy-plugin/test/ot-match.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-ot-match %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-ot-match %t -- --load=%cata_plugin -- -isystem %cata_include
 
 struct oter_id;
 

--- a/tools/clang-tidy-plugin/test/point-initialization.cpp
+++ b/tools/clang-tidy-plugin/test/point-initialization.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-point-initialization %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-point-initialization %t -- --load=%cata_plugin -- -isystem %cata_include
 
 #define CATA_NO_STL
 #include "point.h"

--- a/tools/clang-tidy-plugin/test/redundant-parentheses.cpp
+++ b/tools/clang-tidy-plugin/test/redundant-parentheses.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-redundant-parentheses %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-redundant-parentheses %t -- --load=%cata_plugin -- -isystem %cata_include
 
 #define MACRO(a, b) ( g1( ( a ), ( b ) ) )
 

--- a/tools/clang-tidy-plugin/test/serialize.cpp
+++ b/tools/clang-tidy-plugin/test/serialize.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-serialize %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-serialize %t -- --load=%cata_plugin --
 
 struct JsonIn {
     bool read( int & );

--- a/tools/clang-tidy-plugin/test/simplify-point-constructors.cpp
+++ b/tools/clang-tidy-plugin/test/simplify-point-constructors.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-simplify-point-constructors %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-simplify-point-constructors %t -- --load=%cata_plugin -- -isystem %cata_include
 
 #define CATA_NO_STL
 #include "point.h"

--- a/tools/clang-tidy-plugin/test/static-declarations.cpp
+++ b/tools/clang-tidy-plugin/test/static-declarations.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-static-declarations %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-static-declarations %t -- --load=%cata_plugin --
 
 const int i0 = 0;
 // CHECK-MESSAGES: warning: Global declaration of 'i0' in a cpp file should be static or have a previous declaration in a header. [cata-static-declarations]

--- a/tools/clang-tidy-plugin/test/static-declarations.h
+++ b/tools/clang-tidy-plugin/test/static-declarations.h
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-static-declarations %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-static-declarations %t -- --load=%cata_plugin --
 
 static void f0()
 // CHECK-MESSAGES: warning: Declaration 'f0' should not be declared static in a header.  Either move the definition to a cpp file or declare it inline instead. [cata-static-declarations]

--- a/tools/clang-tidy-plugin/test/static-initialization-order.cpp
+++ b/tools/clang-tidy-plugin/test/static-initialization-order.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-static-initialization-order %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-static-initialization-order %t -- --load=%cata_plugin --
 
 extern const int i0;
 extern const int i0b;

--- a/tools/clang-tidy-plugin/test/static-int_id-constants.cpp
+++ b/tools/clang-tidy-plugin/test/static-int_id-constants.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-static-int_id-constants %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-static-int_id-constants %t -- --load=%cata_plugin -- -isystem %cata_include
 
 template<typename T>
 class int_id

--- a/tools/clang-tidy-plugin/test/static-string_id-constants-2.cpp
+++ b/tools/clang-tidy-plugin/test/static-string_id-constants-2.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-static-string_id-constants %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-static-string_id-constants %t -- --load=%cata_plugin -- -isystem %cata_include
 
 template<typename T>
 class string_id

--- a/tools/clang-tidy-plugin/test/static-string_id-constants-3.cpp
+++ b/tools/clang-tidy-plugin/test/static-string_id-constants-3.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-static-string_id-constants %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-static-string_id-constants %t -- --load=%cata_plugin -- -isystem %cata_include
 
 template<typename T>
 class string_id

--- a/tools/clang-tidy-plugin/test/static-string_id-constants-4.cpp
+++ b/tools/clang-tidy-plugin/test/static-string_id-constants-4.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-static-string_id-constants %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-static-string_id-constants %t -- --load=%cata_plugin -- -isystem %cata_include
 
 template<typename T>
 class string_id

--- a/tools/clang-tidy-plugin/test/static-string_id-constants.cpp
+++ b/tools/clang-tidy-plugin/test/static-string_id-constants.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-static-string_id-constants %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-static-string_id-constants %t -- --load=%cata_plugin -- -isystem %cata_include
 
 template<typename T>
 class string_id

--- a/tools/clang-tidy-plugin/test/test-filename.cpp
+++ b/tools/clang-tidy-plugin/test/test-filename.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-test-filename %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-test-filename %t -- --load=%cata_plugin -- -isystem %cata_include
 
 #define TEST_CASE(name)
 

--- a/tools/clang-tidy-plugin/test/tests-must-restore-global-state.cpp
+++ b/tools/clang-tidy-plugin/test/tests-must-restore-global-state.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-tests-must-restore-global-state %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-tests-must-restore-global-state %t -- --load=%cata_plugin -- -isystem %cata_include
 
 bool fov_3d;
 int fov_3d_z_range;

--- a/tools/clang-tidy-plugin/test/text-style.cpp
+++ b/tools/clang-tidy-plugin/test/text-style.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-text-style %t -- -plugins=%cata_plugin -config="{CheckOptions: [{key: cata-text-style.EscapeUnicode, value: 1}]}" --
+// RUN: %check_clang_tidy %s cata-text-style %t -- --load=%cata_plugin -config="{CheckOptions: [{key: cata-text-style.EscapeUnicode, value: 1}]}" --
 
 // check_clang_tidy uses -nostdinc++, so we add dummy declaration of std::string here
 namespace std

--- a/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
+++ b/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-translations-in-debug-messages %t -- -plugins=%cata_plugin -- -I %test_include
+// RUN: %check_clang_tidy %s cata-translations-in-debug-messages %t -- --load=%cata_plugin -- -I %test_include
 
 #include "mock-translation.h"
 

--- a/tools/clang-tidy-plugin/test/translator-comments.cpp
+++ b/tools/clang-tidy-plugin/test/translator-comments.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-translator-comments %t -- -plugins=%cata_plugin -- -I %test_include
+// RUN: %check_clang_tidy %s cata-translator-comments %t -- --load=%cata_plugin -- -I %test_include
 
 #include "mock-translation.h"
 

--- a/tools/clang-tidy-plugin/test/unsequenced-calls.cpp
+++ b/tools/clang-tidy-plugin/test/unsequenced-calls.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-unsequenced-calls %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-unsequenced-calls %t -- --load=%cata_plugin --
 
 struct A {
     // Define a const and a non-const member function

--- a/tools/clang-tidy-plugin/test/unused-statics.cpp
+++ b/tools/clang-tidy-plugin/test/unused-statics.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-unused-statics %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-unused-statics %t -- --load=%cata_plugin --
 
 class A0 {};
 

--- a/tools/clang-tidy-plugin/test/use-localized-sorting.cpp
+++ b/tools/clang-tidy-plugin/test/use-localized-sorting.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-use-localized-sorting %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-use-localized-sorting %t -- --load=%cata_plugin -- -isystem %cata_include
 
 namespace std
 {

--- a/tools/clang-tidy-plugin/test/use-mdarray.cpp
+++ b/tools/clang-tidy-plugin/test/use-mdarray.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-use-mdarray %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-use-mdarray %t -- --load=%cata_plugin -- -isystem %cata_include
 
 int a0[24][24];
 // CHECK-MESSAGES: warning: Consider using cata::mdarray rather than a raw 2D C array in declaration of 'a0'. [cata-use-mdarray]

--- a/tools/clang-tidy-plugin/test/use-named-point-constants.cpp
+++ b/tools/clang-tidy-plugin/test/use-named-point-constants.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-use-named-point-constants %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-use-named-point-constants %t -- --load=%cata_plugin -- -isystem %cata_include
 
 #define CATA_NO_STL
 #include "point.h"

--- a/tools/clang-tidy-plugin/test/use-point-apis.cpp
+++ b/tools/clang-tidy-plugin/test/use-point-apis.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-use-point-apis %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-use-point-apis %t -- --load=%cata_plugin -- -isystem %cata_include
 
 #define CATA_NO_STL
 #include "point.h"
@@ -129,7 +129,7 @@ int f11( int, const point &p, Args &&... );
 int g11()
 {
     return f11( 7, 0, 1, "foo", 3.5f );
-    // CHECK-MESSAGES: warning: Call to 'f11<char const (&)[4], float>' could instead call overload using a point parameter. [cata-use-point-apis]
+    // CHECK-MESSAGES: warning: Call to 'f11<const char (&)[4], float>' could instead call overload using a point parameter. [cata-use-point-apis]
     // CHECK-FIXES: return f11( 7, point( 0, 1 ), "foo", 3.5f );
 }
 

--- a/tools/clang-tidy-plugin/test/use-point-arithmetic.cpp
+++ b/tools/clang-tidy-plugin/test/use-point-arithmetic.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-use-point-arithmetic %t -- -plugins=%cata_plugin -- -isystem %cata_include
+// RUN: %check_clang_tidy %s cata-use-point-arithmetic %t -- --load=%cata_plugin -- -isystem %cata_include
 
 #define CATA_NO_STL
 #include "point.h"

--- a/tools/clang-tidy-plugin/test/xy-fields.cpp
+++ b/tools/clang-tidy-plugin/test/xy-fields.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-xy %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-xy %t -- --load=%cata_plugin --
 
 struct A0 {
     // CHECK-MESSAGES: warning: 'A0' defines fields 'x' and 'y'.  Consider combining into a single point field. [cata-xy]

--- a/tools/clang-tidy-plugin/test/xy-params.cpp
+++ b/tools/clang-tidy-plugin/test/xy-params.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cata-xy %t -- -plugins=%cata_plugin --
+// RUN: %check_clang_tidy %s cata-xy %t -- --load=%cata_plugin --
 
 void f0( int x, int y );
 // CHECK-MESSAGES: warning: 'f0' has parameters 'x' and 'y'.  Consider combining into a single point parameter. [cata-xy]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
We have custom `clang-tidy` checks, but the `clang-tidy` version we are using does not support plugins out-of-the-box. So we have to use a patched version of `clang-tidy` to run our custom checks: https://github.com/jbytheway/clang-tidy-plugin-support. This makes setting up `clang-tidy` checks in local development environments a little bit involved, especially for non-Debian/Ubuntu distro users.

Fortunately, plugin support landed in a later LLVM release: https://reviews.llvm.org/D111100. This simplifies `clang-tidy` workflow a lot. After building our custom checks as a shared library, we can just run the checks with a vanilla version of  `clang-tidy`.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- [x] Make custom `clang-tidy` checks compile with LLVM 16 API
- [x] Ensure `lit` test suite of custom `clang-tidy` checks pass
- [ ] Run `clang-tidy` 16 on CDDA code base

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->