### PR TITLE
Enable -g1 in CMake release build to produce source and line number in stack trace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,11 +255,11 @@ if (NOT MSVC)
     if (NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
         set(CATA_WARNINGS "${CATA_WARNINGS} -Wredundant-decls")
     endif ()
-    set(CATA_OTHER_FLAGS "${CATA_OTHER_FLAGS} -fsigned-char")
+    set(CATA_OTHER_FLAGS "${CATA_OTHER_FLAGS} -fsigned-char -g1")
     # Compact the whitespace in the warning string
     string(REGEX REPLACE "[\t ]+" " " CATA_WARNINGS "${CATA_WARNINGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CATA_WARNINGS} ${CATA_OTHER_FLAGS}")
-    set(CMAKE_CXX_FLAGS_DEBUG "-Og -g")
+    set(CMAKE_CXX_FLAGS_DEBUG "-Og -g2")
 endif ()
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
#### Summary
Build "Enable -g1 in CMake release build to produce source and line number in stack trace"

#### Purpose of change
So that crash logs generated by self-compiled versions of the game using CMake contain more accurate debug information. It  slightly increases the target binary size but it's still way smaller than the size of the actual build directory so I think it's fine to enable it by default.

#### Describe the solution
Add "-g1" to the default c++ flags. Chang "-g" to "-g2" in the debug c++ flags to restore the default behavior.

#### Describe alternatives you've considered
Add this as a suggestion to the compile docs for people to not read.

#### Testing
Tested locally with the debug menu's test crash option and the game generated a crash log with source and line number information:

<details>
<summary>Example crash log</summary>

```
The program has crashed.
See the log file for a stack trace.
CRASH LOG FILE: ./config/crash.log
VERSION: 0.G-853-g2d8003b284
TYPE: Signal
MESSAGE: SIGSEGV: Segmentation fault
STACK TRACE:

  #0
    (dbghelp: @0x7ff6b123043f[cataclysm-tiles.exe+0x24043f]), 
    (libbacktrace: debug_write_backtrace(std::ostream&)+0xa1@0x14024043f),
    0x14024043f    …/src/debug.cpp:1121    debug_write_backtrace(std::ostream&)
  #1
    (dbghelp: @0x7ff6b1218eb3[cataclysm-tiles.exe+0x228eb3]), 
    (libbacktrace: log_crash+0x1de@0x140228eb3),
    0x140228eb3    D:/Softwares/MinGW-w64-12.2.0/lib/gcc/x86_64-w64-mingw32/12.2.0/include/c++/sstream:918    std::__cxx11::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >::str() const
    0x140228eb3    …/src/crash.cpp:85    log_crash
  #2
    (dbghelp: @0x7ff6b12190db[cataclysm-tiles.exe+0x2290db]), 
    (libbacktrace: signal_handler+0x52@0x1402290db),
    0x1402290db    …/src/crash.cpp:137    signal_handler
  #3
    (dbghelp: raise+0x21b@0x7ffcd5b7adfb[msvcrt.dll+0x2adfb]), 
    (backtrace_syminfo failed: errno = -1, msg = no symbol table in PE/COFF executable),
    (backtrace_pcinfo failed: errno = -1, msg = no debug info in PE/COFF executable),
  #4
    (dbghelp: @0x7ff6b1255831[cataclysm-tiles.exe+0x265831]), 
    (libbacktrace: debug_menu::debug()+0x286a@0x140265831),
    0x140265831    …/src/debug_menu.cpp:3142    debug_menu::debug()
  #5
    (dbghelp: @0x7ff6b138ba9c[cataclysm-tiles.exe+0x39ba9c]), 
    (libbacktrace: game::do_regular_action(action_id&, avatar&, std::optional<tripoint> const&)+0x2940@0x14039ba9c),
    0x14039ba9c    …/src/handle_action.cpp:2630    game::do_regular_action(action_id&, avatar&, std::optional<tripoint> const&)
  #6
    (dbghelp: @0x7ff6b138d73f[cataclysm-tiles.exe+0x39d73f]), 
    (libbacktrace: game::handle_action()+0xb99@0x14039d73f),
    0x14039d73f    …/src/handle_action.cpp:2985    game::handle_action()
  #7
    (dbghelp: @0x7ff6b1280d7e[cataclysm-tiles.exe+0x290d7e]), 
    (libbacktrace: do_turn()+0x608@0x140290d7e),
    0x140290d7e    …/src/do_turn.cpp:543    do_turn()
  #8
    (dbghelp: @0x7ff6b0ff4966[cataclysm-tiles.exe+0x4966]), 
    (libbacktrace: WinMain+0x1f7f@0x140004966),
    0x140004966    …/src/main.cpp:816    WinMain
  #9
    (dbghelp: @0x7ff6b0ff12ef[cataclysm-tiles.exe+0x12ef]), 
    (libbacktrace: __tmainCRTStartup+0x16f@0x1400012ef),
    0x1400012ef    [unknown src]:0    [unknown func]
  #10
    (dbghelp: @0x7ff6b0ff13e6[cataclysm-tiles.exe+0x13e6]), 
    (libbacktrace: WinMainCRTStartup+0x16@0x1400013e6),
    0x1400013e6    [unknown src]:0    [unknown func]
  #11
    (dbghelp: BaseThreadInitThunk+0x14@0x7ffcd5c87614[KERNEL32.DLL+0x17614]), 
    (backtrace_syminfo failed: errno = -1, msg = no symbol table in PE/COFF executable),
    (backtrace_pcinfo failed: errno = -1, msg = no debug info in PE/COFF executable),
  #12
    (dbghelp: RtlUserThreadStart+0x21@0x7ffcd68a26a1[ntdll.dll+0x526a1]), 
    (backtrace_syminfo failed: errno = -1, msg = no symbol table in PE/COFF executable),
    (backtrace_pcinfo failed: errno = -1, msg = no debug info in PE/COFF executable),
```
</details>

#### Additional context

I haven't tested with other compilers but Clang seems to provide the "-g1" and "-g2" options according to its docs.

I didn't test the debug build but according to CMake docs, `CMAKE_CXX_FLAGS_DEBUG` is added after `CATA_OTHER_FLAGS` and according to gcc docs, `"-g<level>"` that comes last in the command line options takes effect, so I think debug build is unaffected.