### PR TITLE
[CR] Force tools to check all pockets for crafting components, including non-magazine ones

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11786,7 +11786,7 @@ bool item::use_charges( const itype_id &what, int &qty, std::list<item> &used,
                     item temp( *e );
                     used.push_back( temp );
                     qty -= n;
-					return VisitResponse::SKIP;
+                    return VisitResponse::SKIP;
                 }
             }
             return VisitResponse::NEXT;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11786,9 +11786,10 @@ bool item::use_charges( const itype_id &what, int &qty, std::list<item> &used,
                     item temp( *e );
                     used.push_back( temp );
                     qty -= n;
+					return VisitResponse::SKIP;
                 }
             }
-            return VisitResponse::SKIP;
+            return VisitResponse::NEXT;
 
         } else if( e->count_by_charges() ) {
             if( e->typeId() == what ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #64287
* Fixes #61866


`item::use_charges` always returns a visit response of `SKIP` for tools, but there's an entire code block to handle consuming ammo for those. However it's possible for tools to have non-magazine pockets, and we need to grab components out of there in cases like crafting, without double-counting or accidentally consuming *ammo* for a tool in use.

#### Describe the solution
Very carefully adjust the logic so that we check children(pockets) for tools *and only tools* .

#### Describe alternatives you've considered
-Forcing tools to have only magazine pockets
-@mqrause suggested changing the visitable check in `requirement_data::continue_requirements` as a safer approach but this was a dead-end.

#### Testing
Repeated the fixed issues locally and found it resolved those issues. Ran the test suite locally and got only failures related to translation content.

Needs some local testing before I mark this as ready to go.

#### Additional context
`TOOL`s with multiple pockets of differing types (i.e. a `MAGAZINE` *and* a `CONTAINER` pocket) already have some broken behavior. https://discord.com/channels/598523535169945603/598529174302490644/1091095803235418153

Such items do not exist in vanilla/in-repo mods so this doesn't attempt to address them.

#56622 for some historical context.