### PR TITLE
Additional Location Achievements

### DIFF
--- a/data/json/achievements.json
+++ b/data/json/achievements.json
@@ -1591,23 +1591,9 @@
     "requirements": [  ]
   },
   {
-    "id": "achievement_reach_fema_camp",
-    "type": "achievement",
-    "name": "Federal Emergency",
-    "requirements": [
-      {
-        "event_statistic": "last_overmap_special_avatar_entered",
-        "is": "==",
-        "target": [ "overmap_special_id", "FEMA Camp" ],
-        "visible": "when_achievement_completed",
-        "description": "Reach a FEMA camp"
-      }
-    ]
-  },
-  {
     "id": "achievement_reach_exodii_base",
     "type": "achievement",
-    "name": "Strange Fortress",
+    "name": "Strange Neighbors",
     "requirements": [
       {
         "event_statistic": "last_overmap_special_avatar_entered",
@@ -1633,34 +1619,6 @@
     ]
   },
   {
-    "id": "achievement_reach_prison",
-    "type": "achievement",
-    "name": "Concrete Hell",
-    "requirements": [
-      {
-        "event_statistic": "last_overmap_special_avatar_entered",
-        "is": "==",
-        "target": [ "overmap_special_id", "Prison" ],
-        "visible": "when_achievement_completed",
-        "description": "Reach a Prison"
-      }
-    ]
-  },
-  {
-    "id": "achievement_reach_alcatraz",
-    "type": "achievement",
-    "name": "The Rock",
-    "requirements": [
-      {
-        "event_statistic": "last_overmap_special_avatar_entered",
-        "is": "==",
-        "target": [ "overmap_special_id", "Alcatraz Prison" ],
-        "visible": "when_achievement_completed",
-        "description": "Reach the Toughest prison on earth"
-      }
-    ]
-  },
-  {
     "id": "achievement_reach_new_england_church_retreat",
     "type": "achievement",
     "name": "Bible Study",
@@ -1671,20 +1629,6 @@
         "target": [ "overmap_special_id", "New England Church Retreat" ],
         "visible": "when_achievement_completed",
         "description": "Do you have a few minutes to talk about our lord and saviour Jesus Christ?"
-      }
-    ]
-  },
-  {
-    "id": "achievement_reach_regional_airport",
-    "type": "achievement",
-    "name": "Connecting Flight",
-    "requirements": [
-      {
-        "event_statistic": "last_overmap_special_avatar_entered",
-        "is": "==",
-        "target": [ "overmap_special_id", "regional_airport" ],
-        "visible": "when_achievement_completed",
-        "description": "All flights have been delayed due to the apocalypse."
       }
     ]
   },

--- a/data/json/achievements.json
+++ b/data/json/achievements.json
@@ -1645,5 +1645,5 @@
         "description": "Reach Isherwood Farms"
       }
     ]
-  }  
+  }
 ]

--- a/data/json/achievements.json
+++ b/data/json/achievements.json
@@ -1589,5 +1589,117 @@
     "//": "this is the achievement that lets you forever have meta progression disabled",
     "description": "STOP HAND-HOLDING ME!!!",
     "requirements": [  ]
-  }
+  },
+  {
+    "id": "achievement_reach_fema_camp",
+    "type": "achievement",
+    "name": "Federal Emergency",
+    "requirements": [
+      {
+        "event_statistic": "last_overmap_special_avatar_entered",
+        "is": "==",
+        "target": [ "overmap_special_id", "FEMA Camp" ],
+        "visible": "when_achievement_completed",
+        "description": "Reach a FEMA camp"
+      }
+    ]
+  },
+  {
+    "id": "achievement_reach_exodii_base",
+    "type": "achievement",
+    "name": "Strange Fortress",
+    "requirements": [
+      {
+        "event_statistic": "last_overmap_special_avatar_entered",
+        "is": "==",
+        "target": [ "overmap_special_id", "exodii_base" ],
+        "visible": "when_achievement_completed",
+        "description": "Reach the strange fortress"
+      }
+    ]
+  },
+  {
+    "id": "achievement_reach_hub01",
+    "type": "achievement",
+    "name": "Is this thing on?",
+    "requirements": [
+      {
+        "event_statistic": "last_overmap_special_avatar_entered",
+        "is": "==",
+        "target": [ "overmap_special_id", "hub_01" ],
+        "visible": "when_achievement_completed",
+        "description": "Reach Hub-01"
+      }
+    ]
+  },
+  {
+    "id": "achievement_reach_prison",
+    "type": "achievement",
+    "name": "Concrete Hell",
+    "requirements": [
+      {
+        "event_statistic": "last_overmap_special_avatar_entered",
+        "is": "==",
+        "target": [ "overmap_special_id", "Prison" ],
+        "visible": "when_achievement_completed",
+        "description": "Reach a Prison"
+      }
+    ]
+  },
+  {
+    "id": "achievement_reach_alcatraz",
+    "type": "achievement",
+    "name": "The Rock",
+    "requirements": [
+      {
+        "event_statistic": "last_overmap_special_avatar_entered",
+        "is": "==",
+        "target": [ "overmap_special_id", "Alcatraz Prison" ],
+        "visible": "when_achievement_completed",
+        "description": "Reach the Toughest prison on earth"
+      }
+    ]
+  },
+  {
+    "id": "achievement_reach_new_england_church_retreat",
+    "type": "achievement",
+    "name": "Bible Study",
+    "requirements": [
+      {
+        "event_statistic": "last_overmap_special_avatar_entered",
+        "is": "==",
+        "target": [ "overmap_special_id", "New England Church Retreat" ],
+        "visible": "when_achievement_completed",
+        "description": "Do you have a few minutes to talk about our lord and saviour Jesus Christ?"
+      }
+    ]
+  },
+  {
+    "id": "achievement_reach_regional_airport",
+    "type": "achievement",
+    "name": "Connecting Flight",
+    "requirements": [
+      {
+        "event_statistic": "last_overmap_special_avatar_entered",
+        "is": "==",
+        "target": [ "overmap_special_id", "regional_airport" ],
+        "visible": "when_achievement_completed",
+        "description": "All flights have been delayed due to the apocalypse."
+      }
+    ]
+  },
+  {
+    "id": "achievement_reach_isherwood_farms",
+    "type": "achievement",
+    "name": "Open Fields",
+    "requirements": [
+      {
+        "event_statistic": "last_overmap_special_avatar_entered",
+        "is": "==",
+        "target": [ "overmap_special_id", "Isherwood Farms" ],
+        "visible": "when_achievement_completed",
+        "description": "Reach Isherwood Farms"
+      }
+    ]
+  }  
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Addition of Achievements for major locations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Create additional Achievements for a handful of Important locations. Hub 01 / Exodii Base / Church Retreat etc

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Took framework of Refugee center achievement and created additional versions for several other locations. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Used Debug menu to teleport to Exodii base, Hub 01 and Church retreat. Confirmed achievement activation. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->