### PR TITLE
Tutorial spilled paint fix

### DIFF
--- a/data/json/mapgen/tutorial.json
+++ b/data/json/mapgen/tutorial.json
@@ -6,10 +6,10 @@
   },
   {
     "type": "item_group",
-	"id": "paint_tutorial",
-	"subtype": "collection",
-    "items": [ 
-	  { "item": "paint_red", "prob": 100, "container-group": "paintcans" },
+    "id": "paint_tutorial",
+    "subtype": "collection",
+    "items": [
+      { "item": "paint_red", "prob": 100, "container-group": "paintcans" },
       { "item": "paint_blue", "prob": 100, "container-group": "paintcans" },
       { "item": "paint_yellow", "prob": 100, "container-group": "paintcans" },
       { "item": "paint_green", "prob": 100, "container-group": "paintcans" },

--- a/data/json/mapgen/tutorial.json
+++ b/data/json/mapgen/tutorial.json
@@ -4,7 +4,6 @@
     "id": "fully_loaded_lighter",
     "items": [ { "item": "lighter", "prob": 100, "charges": 100 } ]
   },
-  
   {
     "type": "item_group",
 	"id": "paint_tutorial",

--- a/data/json/mapgen/tutorial.json
+++ b/data/json/mapgen/tutorial.json
@@ -97,9 +97,7 @@
         "_": { "item": "codeine", "chance": 100 },
         "C": [ { "item": "peanutbutter", "chance": 100 }, { "item": "crackers", "chance": 100 } ]
       },
-	  "items": {
-		  "(": { "item": "paint_tutorial", "chance": 100 }
-	  },
+      "items": { "(": { "item": "paint_tutorial", "chance": 100 } },
       "monster": { "d": { "monster": "mon_dummy_tutorial" } },
       "traps": {
         "1": "tr_tutorial_1",

--- a/data/json/mapgen/tutorial.json
+++ b/data/json/mapgen/tutorial.json
@@ -4,6 +4,26 @@
     "id": "fully_loaded_lighter",
     "items": [ { "item": "lighter", "prob": 100, "charges": 100 } ]
   },
+  
+  {
+    "type": "item_group",
+	"id": "paint_tutorial",
+	"subtype": "collection",
+    "items": [ 
+	  { "item": "paint_red", "prob": 100, "container-group": "paintcans" },
+      { "item": "paint_blue", "prob": 100, "container-group": "paintcans" },
+      { "item": "paint_yellow", "prob": 100, "container-group": "paintcans" },
+      { "item": "paint_green", "prob": 100, "container-group": "paintcans" },
+      { "item": "paint_purple", "prob": 100, "container-group": "paintcans" },
+      { "item": "paint_orange", "prob": 100, "container-group": "paintcans" },
+      { "item": "paint_pink", "prob": 100, "container-group": "paintcans" },
+      { "item": "paint_cyan", "prob": 100, "container-group": "paintcans" },
+      { "item": "paint_brown", "prob": 100, "container-group": "paintcans" },
+      { "item": "paint_white", "prob": 100, "container-group": "paintcans" },
+      { "item": "paint_black", "prob": 100, "container-group": "paintcans" },
+      { "item": "paint_gray", "prob": 100, "container-group": "paintcans" }
+    ]
+  },
   {
     "type": "mapgen",
     "method": "json",
@@ -74,18 +94,13 @@
         "%": { "item": "helmet_ball", "chance": 100 },
         "^": { "item": "mask_dust", "chance": 100 },
         "*": { "item": "paint_brush", "chance": 100 },
-        "(": [
-          { "item": "paint_red", "chance": 100 },
-          { "item": "paint_blue", "chance": 100 },
-          { "item": "paint_white", "chance": 100 },
-          { "item": "paint_green", "chance": 100 },
-          { "item": "paint_purple", "chance": 100 },
-          { "item": "paint_yellow", "chance": 100 }
-        ],
         ")": { "item": "baseball", "chance": 100, "amount": 10 },
         "_": { "item": "codeine", "chance": 100 },
         "C": [ { "item": "peanutbutter", "chance": 100 }, { "item": "crackers", "chance": 100 } ]
       },
+	  "items": {
+		  "(": { "item": "paint_tutorial", "chance": 100 }
+	  },
       "monster": { "d": { "monster": "mon_dummy_tutorial" } },
       "traps": {
         "1": "tr_tutorial_1",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Adds a new itemgroup to spawn the paint in the tutorial in cans instead of spilled"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The paint that spawns at the end of the tutorial spawns without any containers since the changes in #62957.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a new itemgroup for the paint that puts them in containers.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Letting newbs cry over spilt paint.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Played the tutorial and were wowed by the presence of paint in containers.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
![image](https://user-images.githubusercontent.com/45432782/229008793-cc33e4e6-584e-4ff9-b0ad-55e04f3e3964.png)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->