### PR TITLE
[CR] NPC spawn with reasonable stored_kcal

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -838,6 +838,8 @@ void npc::randomize( const npc_class_id &type )
 
     set_body();
     recalc_hp();
+    randomize_height();
+    set_stored_kcal( get_healthy_kcal() );
 
     starting_weapon( myclass );
     starting_clothes( *this, myclass, male );
@@ -882,8 +884,6 @@ void npc::randomize( const npc_class_id &type )
     }
 
     set_base_age( rng( 18, 55 ) );
-    randomize_height();
-    set_stored_kcal( get_healthy_kcal() );
 
     // Add eocs
     effect_on_conditions::load_new_character( *this );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -745,7 +745,7 @@ void npc::load_npc_template( const string_id<npc_template> &ident )
 }
 
 npc::~npc() = default;
-#pragma optimize ("",off)
+
 void npc::randomize( const npc_class_id &type )
 {
     if( !getID().is_valid() ) {
@@ -891,7 +891,7 @@ void npc::randomize( const npc_class_id &type )
     // Add eocs
     effect_on_conditions::load_new_character( *this );
 }
-#pragma optimize ("",on)
+
 void npc::learn_ma_styles_from_traits()
 {
     for( const trait_id &iter : get_mutations() ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -883,6 +883,7 @@ void npc::randomize( const npc_class_id &type )
 
     set_base_age( rng( 18, 55 ) );
     randomize_height();
+    set_stored_kcal( get_healthy_kcal() );
 
     // Add eocs
     effect_on_conditions::load_new_character( *this );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -745,7 +745,7 @@ void npc::load_npc_template( const string_id<npc_template> &ident )
 }
 
 npc::~npc() = default;
-
+#pragma optimize ("",off)
 void npc::randomize( const npc_class_id &type )
 {
     if( !getID().is_valid() ) {
@@ -839,8 +839,11 @@ void npc::randomize( const npc_class_id &type )
     set_body();
     recalc_hp();
     randomize_height();
-    set_stored_kcal( get_healthy_kcal() );
-
+    int days_since_cata = to_days<int>( calendar::turn - calendar::start_of_cataclysm );
+    double time_influence = days_since_cata >= 180 ? 3.0 : 6.0 - 3.0 * days_since_cata / 180.0;
+    double weight_percent = std::clamp<double>( chi_squared_roll( time_influence ) / 5.0,
+                            0.2, 5.0 );
+    set_stored_kcal( weight_percent * get_healthy_kcal() );
     starting_weapon( myclass );
     starting_clothes( *this, myclass, male );
     starting_inv( *this, myclass );
@@ -888,7 +891,7 @@ void npc::randomize( const npc_class_id &type )
     // Add eocs
     effect_on_conditions::load_new_character( *this );
 }
-
+#pragma optimize ("",on)
 void npc::learn_ma_styles_from_traits()
 {
     for( const trait_id &iter : get_mutations() ) {

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -51,6 +51,13 @@ double exponential_roll( double lambda )
                                  std::exponential_distribution<>::param_type( lambda ) );
 }
 
+double chi_squared_roll( double trial_num )
+{
+    static std::chi_squared_distribution<double> rng_chi_squared_dist;
+    return rng_chi_squared_dist( rng_get_engine(),
+                                 std::chi_squared_distribution<>::param_type( trial_num ) );
+}
+
 double rng_exponential( double min, double mean )
 {
     const double adjusted_mean = mean - min;

--- a/src/rng.h
+++ b/src/rng.h
@@ -73,6 +73,8 @@ inline double rng_normal( double hi )
 
 double normal_roll( double mean, double stddev );
 
+double chi_squared_roll( double trial_num );
+
 double rng_exponential( double min, double mean );
 
 inline double rng_exponential( double mean )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "NPC spawn with reasonable stored_kcal"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When spawned, NPC's stored calories are hard set to 54'000'000 cal. With the new BMI system, this means that a majority of them are underweight.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
When randomizing npcs, set their stored_kcal to a time-related level. I also moved this part of code to before they mutate, so it wouldn't neutralize body-size mutation ( if there's any).

The details are:

I introduced a chi_squared_distribution roll to `rng.cpp` and `rng.h`. The distribution gradually transit from χ^2(6) to χ^2(3), in the period of 180 days.

`weight_percent` is the relative percentage against BMI 5.0 (healthy). So `weight_percent = 1.5` means that you have a BMI of 7.5.

At day 0, with the distribution of χ^2(6), 81% of NPCs have BMI more than 3.0 (aka "Normal") , 54% of them have BMI more than 5.0 (aka "Overweight"), and 12% of them have BMI more than 10.0 ( aka "Obese" ).

After day 180, with the distribution of χ^2(3), 57% of them have BMI more than 2.0 (aka "Underweight"), 39% of NPCs have BMI more than 3.0 (aka "Normal"), 17% of them have BMI more than 5.0 (aka "Overweight").

I also clamped the weight_percent from 0.2 to 5.0, making it fall between XS and XXXL size.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Use an alternative distribution.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned many npcs at different time_points, confirmed that their stored_kcal fall in the right ballpark.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->