### PR TITLE
inv_ui: never hide entries in the selection column

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1234,9 +1234,9 @@ void inventory_column::on_change( const inventory_entry &/* entry */ )
 inventory_entry *inventory_column::add_entry( const inventory_entry &entry )
 {
     entries_t &dest = entry.is_hidden( hide_entries_override ) ? entries_hidden : entries;
-    if( std::find( dest.begin(), dest.end(), entry ) != dest.end() ) {
+    if( auto it = std::find( dest.begin(), dest.end(), entry ); it != dest.end() ) {
         debugmsg( "Tried to add a duplicate entry." );
-        return nullptr;
+        return &*it;
     }
     paging_is_valid = false;
     if( entry.is_item() ) {
@@ -1738,7 +1738,10 @@ size_t inventory_column::visible_cells() const
 
 selection_column::selection_column( const std::string &id, const std::string &name ) :
     inventory_column( selection_preset ),
-    selected_cat( id, no_translation( name ), 0 ) {}
+    selected_cat( id, no_translation( name ), 0 )
+{
+    hide_entries_override = { false };
+}
 
 selection_column::~selection_column() = default;
 
@@ -2782,6 +2785,11 @@ void inventory_column::cycle_hide_override()
     } else {
         hide_entries_override = false;
     }
+}
+
+void selection_column::cycle_hide_override()
+{
+    // never hide entries
 }
 
 void inventory_selector::on_input( const inventory_input &input )

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -496,7 +496,7 @@ class inventory_column
         void toggle_skip_unselectable( bool skip );
         void collate();
         void uncollate();
-        void cycle_hide_override();
+        virtual void cycle_hide_override();
 
     protected:
         /**
@@ -545,6 +545,7 @@ class inventory_column
         size_t entries_per_page = std::numeric_limits<size_t>::max();
         size_t height = std::numeric_limits<size_t>::max();
         size_t reserved_width = 0;
+        std::optional<bool> hide_entries_override = std::nullopt;
 
     private:
         struct cell_t {
@@ -563,7 +564,6 @@ class inventory_column
         std::vector<cell_t> cells;
 
         std::optional<bool> indent_entries_override = std::nullopt;
-        std::optional<bool> hide_entries_override = std::nullopt;
         /** @return Number of visible cells */
         size_t visible_cells() const;
         void _get_entries( get_entries_t *res, entries_t const &ent,
@@ -599,6 +599,7 @@ class selection_column : public inventory_column
         }
 
         void set_filter( const std::string &filter ) override;
+        void cycle_hide_override() override;
 
     private:
         const pimpl<item_category> selected_cat;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The selection column in inventory UIs sometimes hides entries but it shouldn't.

* Fixes: #64719
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Set the override so the selection column never hides entries. Also slightly change the debugmsg path to make sure it doesn't crash the game if it ever happens again.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Before: hidden item from collapsed container, revealed by filter, was selected but didn't show up in the selection column. Toggling it again leads to a debug message and crash.

![before](https://user-images.githubusercontent.com/68240139/229037340-3ae5d2b6-8c2c-46f4-86b3-ff5d5505ebd8.png)

After: the selection column sees all

![after](https://user-images.githubusercontent.com/68240139/229037468-a7cbc59f-be5d-4fff-8ba3-90c366bc0334.png)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->