### PR TITLE
Update COMPILING.md C++14 reference to C++17

### DIFF
--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -36,9 +36,9 @@ You have three major choices here: GCC, Clang and MXE.
 
 (Note that your distro may have separate packages e.g. `gcc` only includes the C compiler and for C++ you'll need to install `g++`.)
 
-Cataclysm is targeting the C++14 standard and that means you'll need a compiler that supports it. You can easily check if your version of `g++` supports C++14 by running:
+Cataclysm is targeting the C++17 standard and that means you'll need a compiler that supports it. You can easily check if your version of `g++` supports C++14 by running:
 
-    $ `g++ --std=c++14`
+    $ `g++ --std=c++17`
     g++: fatal error: no input files
     compilation terminated.
 

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -36,7 +36,7 @@ You have three major choices here: GCC, Clang and MXE.
 
 (Note that your distro may have separate packages e.g. `gcc` only includes the C compiler and for C++ you'll need to install `g++`.)
 
-Cataclysm is targeting the C++17 standard and that means you'll need a compiler that supports it. You can easily check if your version of `g++` supports C++14 by running:
+Cataclysm is targeting the C++17 standard and that means you'll need a compiler that supports it. You can easily check if your version of `g++` supports C++17 by running:
 
     $ `g++ --std=c++17`
     g++: fatal error: no input files

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -632,7 +632,7 @@ There are reports of CDDA building fine on recent OpenBSD and FreeBSD machines (
 
 ### Building on FreeBSD/amd64 13.0 with the system compiler
 
-FreeBSD provides C++17 support out of the box since 12.0, and uses clang as the default compiler.
+FreeBSD uses clang as the default compiler, which provides C++17 support out of the box since 12.0.
 
 Install the following with pkg (or from Ports):
 

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -632,7 +632,7 @@ There are reports of CDDA building fine on recent OpenBSD and FreeBSD machines (
 
 ### Building on FreeBSD/amd64 13.0 with the system compiler
 
-FreeBSD uses clang as the default compiler, which provides C++17 support out of the box since 12.0.
+FreeBSD uses clang as the default compiler, which provides C++17 support out of the box since FreeBSD 12.0.
 
 Install the following with pkg (or from Ports):
 

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -36,17 +36,7 @@ You have three major choices here: GCC, Clang and MXE.
 
 (Note that your distro may have separate packages e.g. `gcc` only includes the C compiler and for C++ you'll need to install `g++`.)
 
-Cataclysm is targeting the C++17 standard and that means you'll need a compiler that supports it. You can easily check if your version of `g++` supports C++17 by running:
-
-    $ `g++ --std=c++17`
-    g++: fatal error: no input files
-    compilation terminated.
-
-If you get a line like:
-
-    g++: error: unrecognized command line option ‘--std=c++17’
-
-This means you'll need a newer version of GCC (`g++`).
+Cataclysm is targeting the C++17 standard and that means you'll need a compiler that supports it. You can check if your C++ compiler supports the standard by reading [COMPILER_SUPPORT.md](./COMPILER_SUPPORT.md)
 
 The general rule is the newer the compiler the better.
 

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -632,7 +632,7 @@ There are reports of CDDA building fine on recent OpenBSD and FreeBSD machines (
 
 ### Building on FreeBSD/amd64 13.0 with the system compiler
 
-FreeBSD uses clang as the default compiler as of 10.0, and combines it with libc++ to provide C++17 support out of the box.
+FreeBSD provides C++17 support out of the box since 12.0, and uses clang as the default compiler.
 
 Install the following with pkg (or from Ports):
 

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -44,7 +44,7 @@ Cataclysm is targeting the C++17 standard and that means you'll need a compiler 
 
 If you get a line like:
 
-    g++: error: unrecognized command line option ‘--std=c++14’
+    g++: error: unrecognized command line option ‘--std=c++17’
 
 This means you'll need a newer version of GCC (`g++`).
 
@@ -632,7 +632,7 @@ There are reports of CDDA building fine on recent OpenBSD and FreeBSD machines (
 
 ### Building on FreeBSD/amd64 13.0 with the system compiler
 
-FreeBSD uses clang as the default compiler as of 10.0, and combines it with libc++ to provide C++14 support out of the box.
+FreeBSD uses clang as the default compiler as of 10.0, and combines it with libc++ to provide C++17 support out of the box.
 
 Install the following with pkg (or from Ports):
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
DDA now uses C++17, not C++14 anymore!

#### Describe the solution
Replace the text, simple as that

#### Describe alternatives you've considered
NONE

#### Testing
See my branch

#### Additional context
