### PR TITLE
New bar enconters for the Ancilla Bar

### DIFF
--- a/data/json/mapgen/robofaq_locs/robofac_hq_chunks.json
+++ b/data/json/mapgen/robofaq_locs/robofac_hq_chunks.json
@@ -258,10 +258,10 @@
         "                        "
       ],
       "nested": {
-        "1": { "chunks": [ [ "BEM_hireable", 20 ], [ "null", 20 ] ] },
+        "1": { "chunks": [ [ "BEM_hireable", 40 ], [ "BEM_jabberwock", 20 ], [ "null", 20 ] ] },
         "2": { "chunks": [ [ "BEM_human_sample", 20 ], [ "BEM_anchor_seller", 20 ], [ "null", 20 ] ] },
         "3": { "chunks": [ [ "BEM_keycard_seller", 20 ], [ "BEM_template_seller", 20 ], [ "null", 20 ] ] },
-        "4": { "chunks": [ [ "BEM_gunrunner", 20 ], [ "null", 20 ] ] }
+        "4": { "chunks": [ [ "BEM_gunrunner", 20 ], [ "BEM_drugrunner", 20 ], [ "null", 20 ] ] }
       }
     }
   },
@@ -328,6 +328,26 @@
   {
     "type": "mapgen",
     "method": "json",
+    "nested_mapgen_id": "BEM_drugrunner",
+    "object": {
+      "faction_owner": [ { "id": "robofac_auxiliaries", "x": [ 0, 0 ], "y": [ 0, 0 ] } ],
+      "mapgensize": [ 1, 1 ],
+      "place_npcs": [ { "class": "BEM_drugrunner", "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "BEM_jabberwock",
+    "object": {
+      "faction_owner": [ { "id": "robofac_auxiliaries", "x": [ 0, 0 ], "y": [ 0, 0 ] } ],
+      "mapgensize": [ 1, 1 ],
+      "place_npcs": [ { "class": "BEM_jabberwock", "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "update_mapgen_id": "nest_ancilla_bar_remove_BEMs",
     "object": {
       "remove_npcs": [
@@ -335,6 +355,7 @@
         { "class": "BEM_anchor_seller", "x": 0, "y": 0 },
         { "class": "BEM_human_sample", "x": 0, "y": 0 },
         { "class": "BEM_gunrunner", "x": 0, "y": 0 },
+        { "class": "BEM_drugrunner", "x": 0, "y": 0 },
         { "class": "BEM_template_seller", "x": 0, "y": 0 },
         { "class": "BEM_keycard_seller", "x": 0, "y": 0 }
       ]

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_drugs.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_drugs.json
@@ -1,0 +1,62 @@
+[
+  {
+    "type": "npc_class",
+    "id": "NC_BEM_DRUGRUNNER",
+    "name": { "str": "Mercenary" },
+    "job_description": "Drugrunning for the name of Hub 01 and money, mostly money.",
+    "common": false,
+    "traits": [ { "group": "BG_survival_story_POLICE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_str": { "rng": [ -1, 1 ] },
+    "bonus_dex": { "rng": [ 0, 2 ] },
+    "bonus_int": { "rng": [ 2, 1 ] },
+    "bonus_per": { "rng": [ 1, 2 ] },
+    "worn_override": "BEM_DRUGRUNNER_worn",
+    "carry_override": "BEM_DRUGRUNNER_stock",
+    "weapon_override": "NC_ANCILLA_GRUNT_wield",
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
+      { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "firstaid", "bonus": { "rng": [ 4, 6 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 2, 4 ] } }
+    ],
+    "shopkeeper_price_rules": [ { "group": "BEM_DRUGRUNNER_STOCK", "markup": 4.5 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "BEM_DRUGRUNNER_worn",
+    "subtype": "collection",
+    "items": [
+      { "group": "military_ballistic_vest_pristine" },
+      { "group": "NC_BOUNTY_HUNTER_pants" },
+      { "item": "pants_army" },
+      { "group": "NC_BOUNTY_HUNTER_coat" },
+      { "item": "boots_combat" },
+      { "item": "molle_pack" },
+      { "item": "under_armor" },
+      { "item": "under_armor_shorts" },
+      { "item": "holster" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "BEM_DRUGRUNNER_stock",
+    "subtype": "collection",
+    "entries": [
+      { "item": "glock17_22", "charges": 22, "ammo-item": "9mmP", "count": [ 1, 2 ] },
+      { "item": "coke", "prob": 30, "charges": [ 1, 8 ] },
+      { "item": "pure_meth", "prob": 30, "charges": [ 1, 6 ] },
+      { "item": "heroin", "prob": 100, "charges": [ 1, 4 ] },
+      { "item": "oxycodone", "prob": 100, "charges": [ 1, 10 ] },
+      { "group": "harddrugs", "prob": 100, "count": [ 6, 12 ] }
+    ]
+  },
+  {
+    "id": [ "BEM_DRUGRUNNER_1" ],
+    "type": "talk_topic",
+    "dynamic_line": "&This visitor seems way more watchful than normal.  You can notice zip bags peeking out from <mypossesivepronoun> overcoat, they are clearly pushing something.  It takes not much longer for them to notice you in kind.\n\"You want something?  Or just gawking?\"",
+    "responses": [
+      { "text": "Sure, let see what you offer", "topic": "TALK_DONE", "effect": "start_trade" },
+      { "text": "Not interested.", "topic": "TALK_DONE" }
+    ]
+  }
+]

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_jabberwock.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_jabberwock.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "BEM_jabberwock_mission",
+    "type": "mission_definition",
+    "name": { "str": "\"God\"-Slayer" },
+    "goal": "MGOAL_KILL_MONSTER",
+    "difficulty": 5,
+    "value": 200000,
+    "urgent": true,
+    "description": "A traumatized mercenary has claimed to have seen what you assume to be powerful monster.  Maybe you should investigate this for the benefit of everyone.",
+    "start": {
+      "assign_mission_target": {
+        "om_terrain": "forest_thick",
+        "om_terrain_replace": "forest",
+        "reveal_radius": 1,
+        "random": true,
+        "search_range": 60,
+        "min_distance": 15,
+        "z": 0
+      },
+      "update_mapgen": { "place_monster": [ { "monster": "mon_jabberwock", "x": 11, "y": 11, "target": true } ] }
+    },
+    "end": { "effect": { "u_add_var": "completed_bem_jabberwock", "type": "dialogue", "context": "bem", "value": "yes" } },
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "dialogue": {
+      "//": "All dialogue about this mission is handled through talk_topics, so we don't use any of these strings.",
+      "describe": "…",
+      "offer": "…",
+      "accepted": "…",
+      "rejected": "…",
+      "advice": "…",
+      "inquire": "…",
+      "success": "…",
+      "success_lie": "…",
+      "failure": "…"
+    }
+  },
+  {
+    "id": "BEM_JABBERWOCK_1",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_has_mission": "BEM_jabberwock_mission",
+      "yes": "&You see one more traumatized face, all too many and too frequent for any help to be worthwhile.",
+      "no": {
+        "u_has_var": "completed_bem_jabberwock",
+        "type": "dialogue",
+        "context": "bem",
+        "value": "yes",
+        "yes": "&You see one more traumatized face, all too many and too frequent for any help to be worthwhile.",
+        "no": "&The mercenary stares intently at stain in the ceiling, firmly clutching a now cold cup of soup.  No one else seems to be very concerned about this."
+      }
+    },
+    "responses": [
+      {
+        "text": "Attempt a friendly approach",
+        "topic": "BEM_JABBERWOCK_2",
+        "condition": {
+          "not": {
+            "or": [
+              { "u_has_mission": "BEM_jabberwock_mission" },
+              { "u_has_var": "completed_bem_jabberwock", "type": "dialogue", "context": "bem", "value": "yes" }
+            ]
+          }
+        }
+      },
+      { "text": "Leave the traveler to their trauma.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "BEM_JABBERWOCK_2",
+    "type": "talk_topic",
+    "dynamic_line": "&<mypronoun> seems completely lost to the present, but you can't help but notice their gear is caked with mud and broken twigs.  It doesnt look like you'll be getting much conversation from this one.",
+    "responses": [
+      { "text": "Press on in search of a reaction", "topic": "BEM_JABBERWOCK_3" },
+      { "text": "Try to find someone more interested in conversation.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "BEM_JABBERWOCK_3",
+    "type": "talk_topic",
+    "dynamic_line": "&Continued prodding manages to extract a baffling response from your interlocutor \"I- I-ve seen it, the god of our new world, a god of flesh and bone.  <mypronoun> says with a maddened glare, as if this where some sort of shocking revelation.\"",
+    "responses": [
+      {
+        "text": "Show your map to the mercenary, and have them mark where they saw this \"god\".",
+        "topic": "BEM_JABBERWOCK_4"
+      },
+      { "text": "Yeah I'm sure I have seen that one too.  Try to stay safe.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "BEM_JABBERWOCK_4",
+    "type": "talk_topic",
+    "dynamic_line": "&<mypronoun> silently points a in your maps with a trembling hand.",
+    "speaker_effect": { "effect": { "assign_mission": "BEM_jabberwock_mission" } },
+    "responses": [ { "text": "Thank you.", "topic": "TALK_DONE", "effect": "end_conversation" } ]
+  }
+]

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_jabberwock.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_jabberwock.json
@@ -90,7 +90,7 @@
   {
     "id": "BEM_JABBERWOCK_4",
     "type": "talk_topic",
-    "dynamic_line": "&<mypronoun> silently points a in your maps with a trembling hand.",
+    "dynamic_line": "&<mypronoun> silently points at your maps with a trembling hand.",
     "speaker_effect": { "effect": { "assign_mission": "BEM_jabberwock_mission" } },
     "responses": [ { "text": "Thank you.", "topic": "TALK_DONE", "effect": "end_conversation" } ]
   }

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/NPC_BEMS.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/NPC_BEMS.json
@@ -12,6 +12,26 @@
   },
   {
     "type": "npc",
+    "id": "BEM_drugrunner",
+    "name_unique": "the pill pusher",
+    "class": "NC_BEM_DRUGRUNNER",
+    "attitude": 0,
+    "mission": 7,
+    "chat": "BEM_DRUGRUNNER_1",
+    "faction": "robofac_auxiliaries"
+  },
+  {
+    "type": "npc",
+    "id": "BEM_jabberwock",
+    "name_unique": "the traumatized traveler",
+    "class": "NC_ANCILLA_GRUNT",
+    "attitude": 0,
+    "mission": 7,
+    "chat": "BEM_JABBERWOCK_1",
+    "faction": "robofac_auxiliaries"
+  },
+  {
+    "type": "npc",
     "id": "BEM_human_sample",
     "name_unique": "the shady mercenary",
     "class": "NC_ANCILLA_GRUNT",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "New bar encounters for the Ancilla Bar"

#### Purpose of change
The bar needs more random visitors to actually feel like a lived on space. And this PR adds two extra generic mercs to the rotation.

#### Describe the solution
The two mercs are:

- The pill pusher: Who sells mostly medical drugs and some recreational ones.

- The traumatized traveler: Who can be interacted with to get a single quest to kill a Jabberwock.  The jabberwock is meant to be temporary, once we have a framework for scarier zombie evolutions, we can put one of these here.


#### Testing

Loaded into the bar, saw both mercenaries spawn and interacted with them.

#### Additional context

I'll probably add Makayla as a visitor next time I revisit the Ancilla Bar.