### PR TITLE
Enhanced mouse support for inventory screens

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -223,6 +223,7 @@ void game_menus::inv::common( avatar &you )
     std::string filter;
     do {
         you.inv->restack( you );
+        inv_s.drag_enabled = true;
         inv_s.clear_items();
         inv_s.add_character_items( you );
         inv_s.set_filter( filter );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3513,7 +3513,7 @@ std::pair<const item *, const item *> inventory_compare_selector::execute()
 
         if( input.entry != nullptr ) {
             highlight( input.entry->any_item() );
-            if( input.action == "SELECT" ) {
+            if( input.action == "SELECT" || input.action == "ANY_INPUT" ) {
                 toggle_entry( input.entry );
                 just_selected = input.entry;
             } else if( input.action != "MOUSE_MOVE" ) {
@@ -3673,7 +3673,7 @@ void inventory_multiselector::on_input( const inventory_input &input )
 {
     if( input.entry != nullptr ) { // Single Item from mouse
         highlight( input.entry->any_item() );
-        if( input.action == "SELECT" ) {
+        if( input.action == "SELECT" || input.action == "ANY_INPUT" ) {
             toggle_entries( count );
         }
     }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -595,8 +595,7 @@ const item_category *inventory_entry::get_category_ptr() const
     if( !is_item() ) {
         return nullptr;
     }
-    custom_category = &any_item()->get_category_of_contents();
-    return custom_category;
+    return &any_item()->get_category_of_contents();
 }
 
 bool inventory_column::activatable() const
@@ -919,6 +918,20 @@ void inventory_column::move_selection_page( scroll_direction dir )
     highlight( index, dir );
 }
 
+void inventory_column::scroll_selection_page( scroll_direction dir )
+{
+    size_t index = highlighted_index;
+
+    while( page_of( index = next_highlightable_index( index, dir ) ) == page_index() ) {
+
+        if( index == highlighted_index && page_of( index ) == page_index() ) {
+            break; // If flipped and still on the same page - no need to flip
+        }
+    }
+
+    highlight( index, dir );
+}
+
 size_t inventory_column::get_entry_cell_width( const inventory_entry &entry,
         size_t cell_index ) const
 {
@@ -1196,7 +1209,6 @@ void inventory_column::set_collapsed( inventory_entry &entry, const bool collaps
 
 void inventory_column::on_input( const inventory_input &input )
 {
-
     if( !empty() && active ) {
         if( input.action == "DOWN" ) {
             move_selection( scroll_direction::FORWARD );
@@ -1206,6 +1218,10 @@ void inventory_column::on_input( const inventory_input &input )
             move_selection_page( scroll_direction::FORWARD );
         } else if( input.action == "PAGE_UP" ) {
             move_selection_page( scroll_direction::BACKWARD );
+        } else if( input.action == "SCROLL_DOWN" ) {
+            scroll_selection_page( scroll_direction::FORWARD );
+        } else if( input.action == "SCROLL_UP" ) {
+            scroll_selection_page( scroll_direction::BACKWARD );
         } else if( input.action == "HOME" ) {
             highlight( 0, scroll_direction::FORWARD );
         } else if( input.action == "END" ) {
@@ -1894,6 +1910,60 @@ bool inventory_selector::add_entry_rec( inventory_column &entry_column,
 
     return vis_contents;
 }
+
+bool inventory_selector::drag_drop_item( item *sourceItem, item *destItem )
+{
+    if( sourceItem == destItem ) {
+        return false;
+    }
+    auto pockets = destItem->get_all_contained_pockets();
+    if( pockets.empty() ) {
+        popup( _( "Destination has no pockets." ) );
+        return false;
+    }
+    int base_move_cost = 0;
+    auto parentContainers = u.parents( *sourceItem );
+    for( item *parent : parentContainers ) {
+        base_move_cost += parent->obtain_cost( *sourceItem );
+    }
+    std::vector<item_pocket *> containable_pockets;
+    uilist action_menu;
+    action_menu.text = _( "Select pocket" );
+    int index = 0;
+    bool any_containable = false;
+    for( item_pocket *pocket : pockets ) {
+        std::string pocket_text = string_format( _( "%s - %s/%s | %d moves" ),
+                                  pocket->get_description().translated(), vol_to_info( "", "", pocket->contains_volume() ).sValue,
+                                  vol_to_info( "", "", pocket->max_contains_volume() ).sValue, pocket->moves() + base_move_cost );
+        action_menu.addentry( index++, true, std::optional<input_event>(), pocket_text );
+        ret_val<item_pocket::contain_code> contain = pocket->can_contain( *sourceItem );
+        if( contain.success() ) {
+            any_containable = true;
+        } else {
+            action_menu.entries.back().enabled = false;
+        }
+    }
+    if( !any_containable ) {
+        popup( string_format( _( "%s contains no pockets that can contain item." ),
+                              destItem->tname( 1, false, 0, false, false, false ) ) );
+        return false;
+    }
+    action_menu.query();
+    if( action_menu.ret >= 0 && static_cast<size_t>( action_menu.ret ) < pockets.size() ) {
+        ret_val<item_pocket::contain_code> contain = pockets[action_menu.ret]->can_contain( *sourceItem );
+        if( contain.success() ) {
+            // storage should mimick character inserting
+            u.store( pockets[action_menu.ret], *sourceItem, true, base_move_cost );
+            return true;
+        } else {
+            popup( _( "Cannot put item in pocket: %s" ), contain.str() );
+            return false;
+        }
+    }
+
+    return false;
+}
+
 
 bool inventory_selector::add_contained_items( item_location &container )
 {
@@ -2688,6 +2758,8 @@ inventory_selector::inventory_selector( Character &u, const inventory_selector_p
     ctxt.register_action( "MOUSE_MOVE" );
     ctxt.register_action( "DOWN", to_translation( "Next item" ) );
     ctxt.register_action( "UP", to_translation( "Previous item" ) );
+    ctxt.register_action( "SCROLL_UP", to_translation( "Move cursor up" ) );
+    ctxt.register_action( "SCROLL_DOWN", to_translation( "Move cursor down" ) );
     ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
     ctxt.register_action( "NEXT_COLUMN", to_translation( "Next column" ) );
@@ -2698,6 +2770,7 @@ inventory_selector::inventory_selector( Character &u, const inventory_selector_p
     ctxt.register_action( "TOGGLE_FAVORITE", to_translation( "Toggle favorite" ) );
     ctxt.register_action( "HOME", to_translation( "Home" ) );
     ctxt.register_action( "END", to_translation( "End" ) );
+    ctxt.register_action( "CLICK_AND_DRAG" );
     ctxt.register_action( "SELECT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "VIEW_CATEGORY_MODE" );
@@ -2757,7 +2830,8 @@ inventory_input inventory_selector::process_input( const std::string &action, in
 {
     inventory_input res{ action, ch, nullptr };
 
-    if( res.action == "SELECT" || res.action == "COORDINATE" || res.action == "MOUSE_MOVE" ) {
+    if( res.action == "SELECT" || res.action == "COORDINATE" || res.action == "MOUSE_MOVE" ||
+        res.action == "CLICK_AND_DRAG" ) {
         std::optional<point> o_p = ctxt.get_coordinates_text( w_inv );
         if( o_p ) {
             point p = o_p.value();
@@ -2765,6 +2839,15 @@ inventory_input inventory_selector::process_input( const std::string &action, in
                 res.entry = find_entry_by_coordinate( p );
                 if( res.entry != nullptr && res.entry->is_selectable() ) {
                     return res;
+                }
+                if( res.entry == nullptr && res.action == "SELECT" ) {
+                    p.x++;
+                    res.entry = find_entry_by_coordinate( p );
+                    // if the user has clicked the coordinate just to the left of a pocket, they are clicking the pocket's expander icon
+                    if( res.entry != nullptr && res.entry->is_selectable() && res.entry->chevron ) {
+                        res.action = "SHOW_HIDE_CONTENTS";
+                        return res;
+                    }
                 }
             }
         }
@@ -3091,16 +3174,45 @@ item_location inventory_pick_selector::execute()
 {
     shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
     debug_print_timer( tp_start );
+    item_location startDragItem;
+    bool dragActive = false;
     while( true ) {
         ui_manager::redraw();
         const inventory_input input = get_input();
 
         if( input.entry != nullptr ) {
-            if( highlight( input.entry->any_item() ) ) {
-                ui_manager::redraw();
-            }
-            if( input.action == "SELECT" || input.action == "ANY_INPUT" ) {
+            if( drag_enabled && input.action == "CLICK_AND_DRAG" ) {
+                if( input.entry->is_item() ) {
+                    dragActive = true;
+                    startDragItem = input.entry->locations.front();
+                }
+            } else if( input.action == "MOUSE_MOVE" ) {
+                if( !dragActive && highlight( input.entry->any_item() ) ) {
+                    ui_manager::redraw();
+                }
+            } else if( input.action == "SELECT" ) {
+                dragActive = false;
+                item_location startDragItemCpy = startDragItem;
+                startDragItem = item_location();
+                item_location endDragItem;
+                if( input.entry->is_item() ) {
+                    endDragItem = input.entry->locations.front();
+                    if( startDragItemCpy && endDragItem && startDragItemCpy != endDragItem ) {
+                        if( drag_drop_item( startDragItemCpy.get_item(), endDragItem.get_item() ) ) {
+                            clear_items();
+                            add_character_items( u );
+                        }
+                    } else {
+                        return input.entry->any_item();
+                    }
+                }
+            } else if( input.action == "ANY_INPUT" ) {
                 return input.entry->any_item();
+            } else {
+                if( !dragActive && highlight( input.entry->any_item() ) ) {
+                    ui_manager::redraw();
+                }
+                on_input( input );
             }
         } else if( input.action == "ORGANIZE_MENU" ) {
             u.worn.organize_items_menu();
@@ -3401,9 +3513,11 @@ std::pair<const item *, const item *> inventory_compare_selector::execute()
 
         if( input.entry != nullptr ) {
             highlight( input.entry->any_item() );
-            if( input.action == "SELECT" || input.action == "ANY_INPUT" ) {
+            if( input.action == "SELECT" ) {
                 toggle_entry( input.entry );
                 just_selected = input.entry;
+            } else if( input.action != "MOUSE_MOVE" ) {
+                inventory_selector::on_input( input );
             }
         } else if( input.action == "TOGGLE_ENTRY" ) {
             const auto selection( get_active_column().get_all_selected() );
@@ -3559,7 +3673,7 @@ void inventory_multiselector::on_input( const inventory_input &input )
 {
     if( input.entry != nullptr ) { // Single Item from mouse
         highlight( input.entry->any_item() );
-        if( input.action == "SELECT" || input.action == "ANY_INPUT" ) {
+        if( input.action == "SELECT" ) {
             toggle_entries( count );
         }
     }
@@ -4007,16 +4121,16 @@ int inventory_examiner::execute()
             if( highlight( input.entry->any_item() ) ) {
                 ui_manager::redraw();
             }
-            if( input.action == "SELECT" || input.action == "ANY_INPUT" ) {
+            if( input.action == "SELECT" ) {
                 return cleanup();
             }
         }
 
         if( input.action == "QUIT" || input.action == "CONFIRM" ) {
             return cleanup();
-        } else if( input.action == "PAGE_UP" ) {
+        } else if( input.action == "PAGE_UP" || input.action == "SCROLL_UP" ) {
             examine_window_scroll -= scroll_item_info_lines;
-        } else if( input.action == "PAGE_DOWN" ) {
+        } else if( input.action == "PAGE_DOWN" || input.action == "SCROLL_DOWN" ) {
             examine_window_scroll += scroll_item_info_lines;
         } else {
             ui->invalidate_ui(); //The player is probably doing something that requires updating the base window

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -504,6 +504,7 @@ class inventory_column
          */
         void move_selection( scroll_direction dir );
         void move_selection_page( scroll_direction dir );
+        void scroll_selection_page( scroll_direction dir );
 
         size_t next_highlightable_index( size_t index, scroll_direction dir ) const;
 
@@ -696,6 +697,8 @@ class inventory_selector
                             item_location &loc, item_category const *entry_category = nullptr,
                             item_category const *children_category = nullptr,
                             item_location const &topmost_parent = {}, int indent = 0 );
+
+        bool drag_drop_item( item *sourceItem, item *destItem );
 
         inventory_input get_input();
         inventory_input process_input( const std::string &action, int ch );
@@ -921,8 +924,10 @@ class inventory_pick_selector : public inventory_selector
     public:
         explicit inventory_pick_selector( Character &p,
                                           const inventory_selector_preset &preset = default_preset ) :
-            inventory_selector( p, preset ) {}
-
+            inventory_selector( p, preset ) {
+            drag_enabled = false;
+        }
+        bool drag_enabled;
         item_location execute();
 };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Added sorting, showing&hiding pocket contents, and scrolling via mouse in inventory screens"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Per #58106 I am adding full mouse support to the inventory screens. My other PR adds mouse-hover support, this one adds using the expander button next to pockets to show/hide contents, as well as scrolling the screens using the scroll wheel. I also saw a suggestion for adding drag-drop support to the screen (inventory_pick_selector only) and felt it was a worthy addition.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

For clicking the expander, the GUI simply checks if the user has clicked the character just left of a selectable item, and if they have, the flow continues as if the user had pressed the '>' key.
For drag-drop, I registered a handler for CLICK_AND_DRAG for when the user presses left mouse down, and it marks what object was selected when left-click is pressed, and what item is selected when it released. If they are not the same item, and the destination is a pocket, the code attempts to place the object inside the pocket, throwing the same errors that the sorting view shows when it is not possible.
For mouse scrolling, I registered SCROLL_UP and SCROLL_DOWN actions and added a new function for handling scrolling which always goes to the next page in the inventory if there is one. This works in tandem with drag-drop when the user clicks an item on one page and drags it to a pocket on another.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
I opened the inventory drop dialog, as well as the inventory list ('i') and the inventory compare view ('I') to verify that they are working as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->