### PR TITLE
Standarized Makaylas

### DIFF
--- a/data/json/effect_on_condition.json
+++ b/data/json/effect_on_condition.json
@@ -385,6 +385,39 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "MAKAYLA_MUTATOR_portal_storm",
+    "recurrence": "15 minutes",
+    "//": "The assumption is that Makayla controls this normally, so the effects are only active when she's the avatar.  Thus global:true.",
+    "global": true,
+    "condition": {
+      "and": [
+        { "is_weather": "portal_storm" },
+        { "u_has_trait": "MAKAYLA_MUTATOR" },
+        { "not": { "u_has_worn_with_flag": "PORTAL_PROOF" } },
+        "u_is_outside"
+      ]
+    },
+    "deactivate_condition": { "not": { "is_weather": "portal_storm" } },
+    "effect": [
+      { "u_message": "Everything feels fuzzy.", "type": "info" },
+      { "arithmetic": [ { "u_val": "vitamin", "name": "mutagen_feline" }, "=", { "const": 450 } ] },
+      { "arithmetic": [ { "u_val": "vitamin", "name": "mutagen" }, "=", { "const": 750 } ] },
+      {
+        "run_eocs": [
+          {
+            "id": "cat_ears_portal_storm",
+            "condition": { "not": { "u_has_trait": "FELINE_EARS" } },
+            "effect": [
+              { "u_message": "It didn't take very long for the ears to be back.", "type": "info" },
+              { "u_add_trait": "FELINE_EARS" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "record_portal_storm_data",
     "recurrence": "5 minutes",
     "global": true,

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6407,6 +6407,17 @@
   },
   {
     "type": "mutation",
+    "id": "MAKAYLA_MUTATOR",
+    "name": { "str": "Catastrophic mutation" },
+    "points": -2,
+    "mixed_effect": true,
+    "description": "Exposure to portal storms and related phenomena causes you to mutate in a mostly predictable fashion.",
+    "purifiable": false,
+    "valid": false,
+    "cancels": [ "CHAOTIC", "UNSTABLE" ]
+  },
+  {
+    "type": "mutation",
     "id": "CHAOTIC",
     "name": { "str": "Genetic Chaos" },
     "points": -4,

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -15,6 +15,8 @@
     "class": "NC_ARSONIST",
     "attitude": 0,
     "mission": 3,
+    "age": 24,
+    "height": 165,
     "chat": "TALK_ARSONIST",
     "faction": "no_faction",
     "mission_offered": "MISSION_ARSONIST_1_AMMONIUM_NITRATE"
@@ -27,21 +29,78 @@
     "common": false,
     "traits": [
       { "group": "BG_survival_story_CRIMINAL" },
-      { "group": "NPC_starting_traits" },
-      { "group": "Appearance_demographics" },
-      [ "FELINE_EARS", 100 ]
+      { "trait": "long_over_eye", "variant": "brown" },
+      { "trait": "eye_color", "variant": "blue" },
+      { "trait": "SKIN_LIGHT" },
+      { "trait": "QUICK" },
+      { "trait": "FASTHEALER" },
+      { "trait": "OPTIMISTIC" },
+      { "trait": "FELINE_EARS" },
+      { "trait": "MAKAYLA_MUTATOR" }
     ],
-    "bonus_dex": { "rng": [ -2, 0 ] },
-    "bonus_int": { "rng": [ -2, 0 ] },
-    "bonus_per": { "rng": [ 0, 2 ] },
+    "bonus_dex": { "rng": [ 2, 2 ] },
+    "bonus_int": { "rng": [ 1, 1 ] },
+    "bonus_per": { "rng": [ 2, 2 ] },
     "shopkeeper_item_group": "NC_ARSONIST_STOCK",
     "carry_override": "NC_ARSONIST_STOCK",
+    "worn_override": "NC_ARSONIST_worn",
     "skills": [
-      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "rng": [ 0, -4 ] } ] } },
-      { "skill": "gun", "bonus": { "rng": [ 1, 3 ] } },
-      { "skill": "pistol", "bonus": { "rng": [ 1, 3 ] } },
-      { "skill": "throw", "bonus": { "rng": [ 0, 2 ] } },
-      { "skill": "speech", "bonus": { "rng": [ 2, 4 ] } }
+      { "skill": "firstaid", "bonus": 3 },
+      { "skill": "cooking", "bonus": 5 },
+      { "skill": "fabrication", "bonus2": 5 },
+      { "skill": "survival", "bonus": 2 },
+      { "skill": "melee", "bonus": 5 },
+      { "skill": "bashing", "bonus": 4 },
+      { "skill": "gun", "bonus": 4 },
+      { "skill": "pistol", "bonus": 4 },
+      { "skill": "throw", "bonus": 6 },
+      { "skill": "swimming", "bonus": 3 },
+      { "skill": "driving", "bonus": 3 },
+      { "skill": "speech", "bonus": 3 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_ARSONIST_worn",
+    "subtype": "collection",
+    "items": [
+      { "item": "backpack_leather" },
+      { "item": "legrig", "contents-group": "makayla_ammo" },
+      { "item": "bunker_pants" },
+      { "group": "clothing_watch" },
+      { "item": "bunker_coat" },
+      { "item": "socks" },
+      { "item": "boots_combat" },
+      { "item": "slingpack" },
+      { "item": "bra" },
+      { "item": "tank_top" },
+      { "item": "panties" },
+      { "item": "model_10_revolver", "ammo-item": "38_special", "charges": 6, "container-item": "holster" },
+      { "item": "webbing_belt", "contents-group": "makayla_belt" },
+      { "item": "gloves_fingerless_mod" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "makayla_ammo",
+    "subtype": "collection",
+    "items": [
+      { "item": "38_speedloader6", "ammo-item": "38_special", "charges": 6 },
+      { "item": "38_speedloader6", "ammo-item": "38_special", "charges": 6 },
+      { "item": "38_speedloader6", "ammo-item": "38_special", "charges": 6 },
+      { "item": "38_special" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "makayla_belt",
+    "subtype": "collection",
+    "items": [
+      { "item": "gadget_pouch" },
+      { "item": "bandages", "count": 5 },
+      { "item": "pockknife" },
+      { "item": "lighter", "charges": 100 },
+      { "item": "hatchet" }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Content "Standarize Makayla's gear, skills and traits"

#### Purpose of change

I want to make Makayla spawn in different locations using EOCs, this doesn't really work very well if she's completely different every time you meet her.  Also making  NPCs  have better defined personalities usually works for the better, and this is harder if they are random.

#### Describe the solution
Gave Makayla a definite Inventory, skills and trait lists. Took the time to explain mechanically why she has mutated ears from day one too.

Unfortunately some things cannot still be set definitively, namely stats. And it doesn't seem like the game actually respects the Age and height settings included here.

At least these are relatively minor differences most players aren't likely to notice.

#### Testing
Spawned the center to no errors, swapped into Makayla to check the trait worked.

#### Additional context

I'll make a bug report for the Age and height settings being ignored with this PR as an example.