### PR TITLE
Make makeshift bandages not require tailoring

### DIFF
--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -28,10 +28,10 @@
     "activity_level": "NO_EXERCISE",
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "time": "9 s",
+    "time": "1 s",
     "autolearn": true,
     "flags": [ "BLIND_EASY" ],
+    "//": "Too simple to learn any tailoring or healthcare.",
     "components": [ [ [ "sheet_cotton", 1 ], [ "sheet_cotton_patchwork", 1 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary
Balance "Make makeshift bandages not require tailoring, making them easier to craft at 0 tailoring"

#### Purpose of change
Makeshift bandages trained tailoring, which made no sense as it's basically looking at a cotton sheet and saying "this is a bandage". This also made them really hard to craft without skill which makes no sense. It doesn't even require cutting or anything.

#### Describe the solution
Remove the skill requirement, also reduce time to 1 second.

#### Describe alternatives you've considered
Somehow making this and some other crafts (like soap flakes) impossible to fail, IDK how though.

#### Testing
![изображение](https://user-images.githubusercontent.com/52408044/229332297-0e136250-2704-49e7-99ed-cc74ddb5af3e.png)

#### Additional context
N/A.