### PR TITLE
Store limb_scores as map instead of vector

### DIFF
--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -415,10 +415,10 @@ void body_part_type::load( const JsonObject &jo, const std::string & )
         const JsonArray &jarr = jo.get_array( "limb_scores" );
         for( const JsonValue jval : jarr ) {
             bp_limb_score bpls;
-            bpls.id = limb_score_id( jval.get_array().get_string( 0 ) );
+            const limb_score_id id = limb_score_id( jval.get_array().get_string( 0 ) );
             bpls.score = jval.get_array().get_float( 1 );
             bpls.max = jval.get_array().size() > 2 ? jval.get_array().get_float( 2 ) : bpls.score;
-            limb_scores.emplace_back( bpls );
+            limb_scores[id] = bpls;
         }
     }
 
@@ -536,12 +536,12 @@ void body_part_type::check() const
         debugmsg( "Bodypart %s has inconsistent opposite part!", id.str() );
     }
 
-    for( const bp_limb_score &bpls : limb_scores ) {
-        if( !bpls.id.is_valid() ) {
-            debugmsg( "Body part %s has invalid limb score %s.", id.str(), bpls.id.str() );
+    for( const std::pair<const limb_score_id, bp_limb_score> &bpls : limb_scores ) {
+        if( !bpls.first.is_valid() ) {
+            debugmsg( "Body part %s has invalid limb score %s.", id.str(), bpls.first.str() );
         }
-        if( bpls.score > bpls.max ) {
-            debugmsg( "Body part %s has higher %s score than max.", id.str(), bpls.id.str() );
+        if( bpls.second.score > bpls.second.max ) {
+            debugmsg( "Body part %s has higher %s score than max.", id.str(), bpls.first.str() );
         }
     }
 
@@ -561,32 +561,19 @@ void body_part_type::check() const
 
 float body_part_type::get_limb_score( const limb_score_id &id ) const
 {
-    for( const bp_limb_score &bpls : limb_scores ) {
-        if( bpls.id == id ) {
-            return bpls.score;
-        }
-    }
-    return 0.0f;
+    const auto it = limb_scores.find( id );
+    return it == limb_scores.end() ? 0.0f : it->second.score;
 }
 
 float body_part_type::get_limb_score_max( const limb_score_id &id ) const
 {
-    for( const bp_limb_score &bpls : limb_scores ) {
-        if( bpls.id == id ) {
-            return bpls.max;
-        }
-    }
-    return 0.0f;
+    const auto it = limb_scores.find( id );
+    return it == limb_scores.end() ? 0.0f : it->second.max;
 }
 
 bool body_part_type::has_limb_score( const limb_score_id &id ) const
 {
-    for( const bp_limb_score &bpls : limb_scores ) {
-        if( bpls.id == id ) {
-            return true;
-        }
-    }
-    return false;
+    return limb_scores.count( id );
 }
 
 float body_part_type::unarmed_damage( const damage_type &dt ) const

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -136,7 +136,6 @@ struct limb_score {
 };
 
 struct bp_limb_score {
-    limb_score_id id = limb_score_id::NULL_ID();
     float score = 0.0f;
     float max = 0.0f;
 };
@@ -217,7 +216,7 @@ struct body_part_type {
 
     private:
         // limb score values
-        std::vector<bp_limb_score> limb_scores;
+        std::map<limb_score_id, bp_limb_score> limb_scores;
         damage_instance damage;
 
     public:


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Checking for the presence of a limb_score currently requires a linear search of the limb scores for the body part in question, which is slightly wasteful, especially if the body part doesn't have that limb score.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change the vector of ids and scores to a map from id to scores.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Ran test suite. Broke an arm in the game and confirmed some lifting tasks still degrade as before.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This is another small effort toward resolving #64765 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->