### PR TITLE
[Bombastic Perks] Mo' Perks & Thick Skull adjustments

### DIFF
--- a/data/mods/BombasticPerks/perkdata/closedfist.json
+++ b/data/mods/BombasticPerks/perkdata/closedfist.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "integrated_hand_closedfist",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "callused hands" },
+    "description": "You've dealt so many blows your hands are rough with calluses.  The bottoms of your hand can deal blows hard enough to hammer or finely crush objects.",
+    "copy-from": "integrated_hand_openpalm",
+    "bashing": 4,
+    "cutting": 0,
+    "qualities": [ [ "HAMMER", 2 ], [ "HAMMER_FINE", 1 ], [ "FINE_GRIND", 1 ] ]
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/openpalm.json
+++ b/data/mods/BombasticPerks/perkdata/openpalm.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "integrated_hand_openpalm",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "callused hands" },
+    "description": "You've dealt so many blows your hands are rough with calluses.  The edge of your hand is sharp enough to cut paper.",
+    "price": 0,
+    "price_postapoc": 0,
+    "material": [ "flesh" ],
+    "material_thickness": 2,
+    "symbol": "x",
+    "color": "magenta",
+    "cutting": 4,
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "ZERO_WEIGHT" ],
+    "armor": [ { "encumbrance": 1, "coverage": 100, "covers": [ "hand_l", "hand_r" ] } ],
+    "qualities": [ [ "BUTCHER", 5 ], [ "CUT", 1 ] ]
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/pinchedfingers.json
+++ b/data/mods/BombasticPerks/perkdata/pinchedfingers.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "integrated_hand_pinchedfingers",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "callused hands" },
+    "description": "You've dealt so many blows your hands are rough with calluses.  The tips of your fingers can pinch firmly enough to pry nails or turn small bolts.",
+    "copy-from": "integrated_hand_openpalm",
+    "extend": { "flags": [ "STAB" ] },
+    "qualities": [ [ "PRY", 1 ], [ "PRYING_NAIL", 1 ], [ "WRENCH", 1 ], [ "WRENCH_FINE", 1 ] ]
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/thick_skull.json
+++ b/data/mods/BombasticPerks/perkdata/thick_skull.json
@@ -4,14 +4,14 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str_sp": "thick skull" },
-    "description": "You've taken so many hits to the head your skull's gotten thicker.",
+    "description": "You've taken so many hits to the head that your skull's gotten thicker.",
     "price": 0,
     "price_postapoc": 0,
     "material": [ "bone" ],
     "material_thickness": 3,
     "symbol": "x",
     "color": "magenta",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "SKINTIGHT", "ZERO_WEIGHT", "NO_SALVAGE" ],
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "ZERO_WEIGHT", "NO_SALVAGE", "SOFT" ],
     "armor": [
       {
         "covers": [ "head" ],

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -107,9 +107,14 @@
         "topic": "TALK_PERK_MENU_PINCHEDFINGERS"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_bloody_mess" } },
+        "condition": { "not": { "or": [ { "u_has_trait": "perk_bloody_mess" }, { "u_has_trait": "perk_gentle_death" } ] } }
         "text": "Gain [<trait_name:perk_bloody_mess>]",
         "topic": "TALK_PERK_MENU_BLOODY_MESS"
+      },
+      {
+        "condition": { "not": { "or": [ { "u_has_trait": "perk_bloody_mess" }, { "u_has_trait": "perk_gentle_death" } ] } },
+        "text": "Gain [<trait_name:perk_gentle_death>]",
+        "topic": "TALK_PERK_MENU_GENTLE_DEATH"
       },
       {
         "condition": { "not": { "u_has_trait": "perk_tuck_and_roll" } },
@@ -125,6 +130,11 @@
         "condition": { "not": { "u_has_trait": "perk_jumpy" } },
         "text": "Gain [<trait_name:perk_jumpy>]",
         "topic": "TALK_PERK_MENU_JUMPY"
+      },
+      {
+        "condition": { "and": [ { "u_has_skill": { "skill": "pistol", "level": 3 } }, { "not": { "u_has_trait": "perk_quickdraw" } } ] },
+        "text": "Gain [<trait_name:perk_quickdraw>]",
+        "topic": "TALK_PERK_MENU_QUICKDRAW"
       },
       {
         "condition": { "not": { "u_has_trait": "perk_hobbyist" } },
@@ -400,7 +410,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_PERK_MENU_BLOODY_MESS",
-    "dynamic_line": "<trait_name:perk_bloody_mess>: \"<trait_description:perk_bloody_mess>\"",
+    "dynamic_line": "<trait_name:perk_bloody_mess>: \"<trait_description:perk_bloody_mess>\"\n\nMutually exclusive with Gentle Death.",
     "responses": [
       {
         "text": "Select Perk.",
@@ -409,6 +419,27 @@
         "failure_topic": "TALK_PERK_MENU_FAIL",
         "effect": [
           { "u_add_trait": "perk_bloody_mess" },
+          {
+            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
+          }
+        ]
+      },
+      { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_PERK_MENU_GENTLE_DEATH",
+    "dynamic_line": "<trait_name:perk_gentle_death>: \"<trait_description:perk_gentle_death>\"\n\n\Mutually exclusive with Bloody Mess.",
+    "responses": [
+      {
+        "text": "Select Perk.",
+        "topic": "TALK_PERK_MENU_MAIN",
+        "condition": { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] },
+        "failure_topic": "TALK_PERK_MENU_FAIL",
+        "effect": [
+          { "u_add_trait": "perk_gentle_death" },
           {
             "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
           }
@@ -472,6 +503,27 @@
         "failure_topic": "TALK_PERK_MENU_FAIL",
         "effect": [
           { "u_add_trait": "perk_jumpy" },
+          {
+            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
+          }
+        ]
+      },
+      { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_PERK_MENU_QUICKDRAW",
+    "dynamic_line": "<trait_name:perk_quickdraw>: \"<trait_description:perk_quickdraw>\"\n\nRequires handguns 3.",
+    "responses": [
+      {
+        "text": "Select Perk.",
+        "topic": "TALK_PERK_MENU_MAIN",
+        "condition": { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] },
+        "failure_topic": "TALK_PERK_MENU_FAIL",
+        "effect": [
+          { "u_add_trait": "perk_quickdraw" },
           {
             "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
           }

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -50,6 +50,63 @@
         "topic": "TALK_PERK_MENU_THICK_SKULL"
       },
       {
+        "condition": {
+          "and": [
+            {
+              "not": {
+                "or": [
+                  { "u_has_trait": "perk_way_openpalm" },
+                  { "u_has_trait": "perk_way_closedfist" },
+                  { "u_has_trait": "perk_way_pinchedfingers" }
+                ]
+              }
+            },
+            { "u_has_skill": { "skill": "unarmed", "level": 2 } },
+            { "u_has_skill": { "skill": "cutting", "level": 1 } }
+          ]
+        },
+        "text": "Gain [<trait_name:perk_way_openpalm>]",
+        "topic": "TALK_PERK_MENU_OPENPALM"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "not": {
+                "or": [
+                  { "u_has_trait": "perk_way_openpalm" },
+                  { "u_has_trait": "perk_way_closedfist" },
+                  { "u_has_trait": "perk_way_pinchedfingers" }
+                ]
+              }
+            },
+            { "u_has_skill": { "skill": "unarmed", "level": 2 } },
+            { "u_has_skill": { "skill": "bashing", "level": 1 } }
+          ]
+        },
+        "text": "Gain [<trait_name:perk_way_closedfist>]",
+        "topic": "TALK_PERK_MENU_CLOSEDFIST"
+      },
+      {
+        "condition": {
+          "and": [
+            {
+              "not": {
+                "or": [
+                  { "u_has_trait": "perk_way_openpalm" },
+                  { "u_has_trait": "perk_way_closedfist" },
+                  { "u_has_trait": "perk_way_pinchedfingers" }
+                ]
+              }
+            },
+            { "u_has_skill": { "skill": "unarmed", "level": 2 } },
+            { "u_has_skill": { "skill": "stabbing", "level": 1 } }
+          ]
+        },
+        "text": "Gain [<trait_name:perk_way_pinchedfingers>]",
+        "topic": "TALK_PERK_MENU_PINCHEDFINGERS"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_bloody_mess" } },
         "text": "Gain [<trait_name:perk_bloody_mess>]",
         "topic": "TALK_PERK_MENU_BLOODY_MESS"
@@ -268,6 +325,69 @@
         "failure_topic": "TALK_PERK_MENU_FAIL",
         "effect": [
           { "u_add_trait": "perk_thick_skull" },
+          {
+            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
+          }
+        ]
+      },
+      { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_PERK_MENU_OPENPALM",
+    "dynamic_line": "<trait_name:perk_way_openpalm>: \"<trait_description:perk_way_openpalm>\"\n\nRequires unarmed 2 and cutting 1, mutually exclusive with Way of the Closed Fist or Pinched Fingers.",
+    "responses": [
+      {
+        "text": "Select Perk.",
+        "topic": "TALK_PERK_MENU_MAIN",
+        "condition": { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] },
+        "failure_topic": "TALK_PERK_MENU_FAIL",
+        "effect": [
+          { "u_add_trait": "perk_way_openpalm" },
+          {
+            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
+          }
+        ]
+      },
+      { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_PERK_MENU_CLOSEDFIST",
+    "dynamic_line": "\"<trait_name:perk_way_closedfist>: \"<trait_description:perk_way_closedfist>\"\n\nRequires unarmed 2 and bashing 1, mutually exclusive with Way of the Open Palm or Pinched Fingers.",
+    "responses": [
+      {
+        "text": "Select Perk.",
+        "topic": "TALK_PERK_MENU_MAIN",
+        "condition": { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] },
+        "failure_topic": "TALK_PERK_MENU_FAIL",
+        "effect": [
+          { "u_add_trait": "perk_way_closedfist" },
+          {
+            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
+          }
+        ]
+      },
+      { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_PERK_MENU_PINCHEDFINGERS",
+    "dynamic_line": "\"<trait_name:perk_way_pinchedfingers>: \"<trait_description:perk_way_pinchedfingers>\"\n\nRequires unarmed 2 and piercing 1, mutually exclusive with Way of the Open Palm or Closed Fist.",
+    "responses": [
+      {
+        "text": "Select Perk.",
+        "topic": "TALK_PERK_MENU_MAIN",
+        "condition": { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] },
+        "failure_topic": "TALK_PERK_MENU_FAIL",
+        "effect": [
+          { "u_add_trait": "perk_way_pinchedfingers" },
           {
             "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
           }

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -107,14 +107,9 @@
         "topic": "TALK_PERK_MENU_PINCHEDFINGERS"
       },
       {
-        "condition": { "not": { "or": [ { "u_has_trait": "perk_bloody_mess" }, { "u_has_trait": "perk_gentle_death" } ] } }
+        "condition": { "not": { "u_has_trait": "perk_bloody_mess" } },
         "text": "Gain [<trait_name:perk_bloody_mess>]",
         "topic": "TALK_PERK_MENU_BLOODY_MESS"
-      },
-      {
-        "condition": { "not": { "or": [ { "u_has_trait": "perk_bloody_mess" }, { "u_has_trait": "perk_gentle_death" } ] } },
-        "text": "Gain [<trait_name:perk_gentle_death>]",
-        "topic": "TALK_PERK_MENU_GENTLE_DEATH"
       },
       {
         "condition": { "not": { "u_has_trait": "perk_tuck_and_roll" } },
@@ -130,11 +125,6 @@
         "condition": { "not": { "u_has_trait": "perk_jumpy" } },
         "text": "Gain [<trait_name:perk_jumpy>]",
         "topic": "TALK_PERK_MENU_JUMPY"
-      },
-      {
-        "condition": { "and": [ { "u_has_skill": { "skill": "pistol", "level": 3 } }, { "not": { "u_has_trait": "perk_quickdraw" } } ] },
-        "text": "Gain [<trait_name:perk_quickdraw>]",
-        "topic": "TALK_PERK_MENU_QUICKDRAW"
       },
       {
         "condition": { "not": { "u_has_trait": "perk_hobbyist" } },
@@ -410,7 +400,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_PERK_MENU_BLOODY_MESS",
-    "dynamic_line": "<trait_name:perk_bloody_mess>: \"<trait_description:perk_bloody_mess>\"\n\nMutually exclusive with Gentle Death.",
+    "dynamic_line": "<trait_name:perk_bloody_mess>: \"<trait_description:perk_bloody_mess>\"",
     "responses": [
       {
         "text": "Select Perk.",
@@ -419,27 +409,6 @@
         "failure_topic": "TALK_PERK_MENU_FAIL",
         "effect": [
           { "u_add_trait": "perk_bloody_mess" },
-          {
-            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
-          }
-        ]
-      },
-      { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" },
-      { "text": "Quit.", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_PERK_MENU_GENTLE_DEATH",
-    "dynamic_line": "<trait_name:perk_gentle_death>: \"<trait_description:perk_gentle_death>\"\n\n\Mutually exclusive with Bloody Mess.",
-    "responses": [
-      {
-        "text": "Select Perk.",
-        "topic": "TALK_PERK_MENU_MAIN",
-        "condition": { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] },
-        "failure_topic": "TALK_PERK_MENU_FAIL",
-        "effect": [
-          { "u_add_trait": "perk_gentle_death" },
           {
             "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
           }
@@ -503,27 +472,6 @@
         "failure_topic": "TALK_PERK_MENU_FAIL",
         "effect": [
           { "u_add_trait": "perk_jumpy" },
-          {
-            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
-          }
-        ]
-      },
-      { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" },
-      { "text": "Quit.", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_PERK_MENU_QUICKDRAW",
-    "dynamic_line": "<trait_name:perk_quickdraw>: \"<trait_description:perk_quickdraw>\"\n\nRequires handguns 3.",
-    "responses": [
-      {
-        "text": "Select Perk.",
-        "topic": "TALK_PERK_MENU_MAIN",
-        "condition": { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] },
-        "failure_topic": "TALK_PERK_MENU_FAIL",
-        "effect": [
-          { "u_add_trait": "perk_quickdraw" },
           {
             "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
           }

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -116,6 +116,33 @@
   },
   {
     "type": "mutation",
+    "id": "perk_way_openpalm",
+    "name": { "str": "Way of the Open Palm" },
+    "points": 0,
+    "description": "You've dealt enough blows that your hands have callused, and your knifehand strikes are sharp enough to draw blood.",
+    "category": [ "perk" ],
+    "integrated_armor": [ "integrated_hand_openpalm" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_way_closedfist",
+    "name": { "str": "Way of the Closed Fist" },
+    "points": 0,
+    "description": "You've dealt enough blows that your hands have callused, and your hammerfist strikes are as strong as a real hammer.",
+    "category": [ "perk" ],
+    "integrated_armor": [ "integrated_hand_closedfist" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_way_pinchedfingers",
+    "name": { "str": "Way of the Pinched Fingers" },
+    "points": 0,
+    "description": "You've dealt enough blows that your hands have callused, your spearhand strikes can pierce armor, and your grip can turn bolts barehanded.",
+    "category": [ "perk" ],
+    "integrated_armor": [ "integrated_hand_pinchedfingers" ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_tuck_and_roll",
     "name": { "str": "Tuck and Roll" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -161,6 +161,15 @@
   },
   {
     "type": "mutation",
+    "id": "perk_gentle_death",
+    "name": { "str": "Gentle Death" },
+    "points": 0,
+    "description": "You won't be hunting rabbits with bazookas, but a little overkill won't spoil the meat.  Enemies you kill tend to stay intact.",
+    "category": [ "perk" ],
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "OVERKILL_DAMAGE", "add": 30.0 } ] } ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_tingly",
     "name": { "str": "Tingly" },
     "points": 0,
@@ -176,6 +185,15 @@
     "description": "You've not been the same since the apocalypse, almost everything makes you jump.  You are just a bit quicker to act though.",
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SPEED", "multiply": 0.03 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_quickdraw",
+    "name": { "str": "Quickdraw" },
+    "points": 0,
+    "description": "You're the fastest gun in the West!  You can access items in containers 30% faster.",
+    "obtain_cost_multiplier": 0.7,
+    "category": [ "perk" ]
   },
   {
     "type": "mutation",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -161,15 +161,6 @@
   },
   {
     "type": "mutation",
-    "id": "perk_gentle_death",
-    "name": { "str": "Gentle Death" },
-    "points": 0,
-    "description": "You won't be hunting rabbits with bazookas, but a little overkill won't spoil the meat.  Enemies you kill tend to stay intact.",
-    "category": [ "perk" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "OVERKILL_DAMAGE", "add": 30.0 } ] } ]
-  },
-  {
-    "type": "mutation",
     "id": "perk_tingly",
     "name": { "str": "Tingly" },
     "points": 0,
@@ -185,15 +176,6 @@
     "description": "You've not been the same since the apocalypse, almost everything makes you jump.  You are just a bit quicker to act though.",
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SPEED", "multiply": 0.03 } ] } ]
-  },
-  {
-    "type": "mutation",
-    "id": "perk_quickdraw",
-    "name": { "str": "Quickdraw" },
-    "points": 0,
-    "description": "You're the fastest gun in the West!  You can access items in containers 30% faster.",
-    "obtain_cost_multiplier": 0.7,
-    "category": [ "perk" ]
   },
   {
     "type": "mutation",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -180,7 +180,7 @@
   {
     "type": "mutation",
     "id": "perk_hobbyist",
-    "name": { "str": "Hobyist" },
+    "name": { "str": "Hobbyist" },
     "points": 0,
     "description": "No work, no social obligations, lots of time to focus on your hobbies.  You feel like you've been picking up skills faster recently.",
     "category": [ "perk" ],


### PR DESCRIPTION
#### Summary
Mods "More Bombastic Perks"

#### Purpose of change

Fresh mod needs more content + Thick Skull perk:
-Conflicts with skintight layer clothing when your skull's in your head. 😛
-Blocks rigid headgear such as army helmets.

#### Describe the solution
Existing Perks:
     -Hobbyist typo fixed
     -Thick Skull moved to personal layer & given SOFT flag so headgear cannot conflict with it.
New Perks:
     Way of the Closed Fist/Pinched Fingers/Open Palm:
           -All provide hand armor
           -Serve as bash/pierce/cut damage when punching w/o gloves.
           -Give (ballpeen? no claw end) hammer, small wrench, or knife qualities
           -Required unarmed 2 & their damage type 1
           -Mutually exclusive
           -Reference to Jade Empire :D

#### Describe alternatives you've considered

Move locked out perks to their own line instead of being combined with prereq skills' line.

#### Testing

Get a skill point with 0 in skills, see I cannot take Way of the X perks.
Get a skill point with prereq skills, see I can take Way of X perk. The other options disappear after I do.

#### Additional context
![image](https://user-images.githubusercontent.com/99621099/229337066-03a1d88e-a836-48a4-a028-ec64ae19edd1.png)

First usage of mutually exclusive & skill-gated perks :D