### PR TITLE
Disabled Rigid Containers Display Correctly In UI

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8053,21 +8053,21 @@ bool Character::is_waterproof( const body_part_set &parts ) const
     return covered_with_flag( flag_WATERPROOF, parts );
 }
 
-units::volume Character::free_space() const
+units::volume Character::free_space( bool for_display ) const
 {
     units::volume volume_capacity = 0_ml;
     volume_capacity += weapon.get_total_capacity();
     for( const item_pocket *pocket : weapon.get_all_contained_pockets() ) {
         if( pocket->contains_phase( phase_id::SOLID ) ) {
             for( const item *it : pocket->all_items_top() ) {
-                volume_capacity -= it->volume();
+                volume_capacity -= it->volume( false, false, -1, for_display );
             }
         } else if( !pocket->empty() ) {
             volume_capacity -= pocket->volume_capacity();
         }
     }
     volume_capacity += weapon.check_for_free_space();
-    volume_capacity += worn.free_space();
+    volume_capacity += worn.free_space( for_display );
     return volume_capacity;
 }
 
@@ -8167,9 +8167,9 @@ units::volume Character::volume_capacity_with_tweaks( const item_tweaks &tweaks 
     return volume_capacity;
 }
 
-units::volume Character::volume_carried() const
+units::volume Character::volume_carried( bool for_display ) const
 {
-    return volume_capacity() - free_space();
+    return volume_capacity() - free_space( for_display );
 }
 
 void Character::start_hauling()

--- a/src/character.h
+++ b/src/character.h
@@ -1971,7 +1971,7 @@ class Character : public Creature, public visitable
         std::vector<item *> inv_dump();
         std::vector<const item *> inv_dump() const;
         units::mass weight_carried() const;
-        units::volume volume_carried() const;
+        units::volume volume_carried( bool for_display = false ) const;
 
         units::length max_single_item_length() const;
         units::volume max_single_item_volume() const;
@@ -2002,7 +2002,7 @@ class Character : public Creature, public visitable
         units::volume volume_capacity_with_tweaks( const item_tweaks &tweaks ) const;
         units::volume volume_capacity_with_tweaks( const std::vector<std::pair<item_location, int>>
                 &locations ) const;
-        units::volume free_space() const;
+        units::volume free_space( bool for_display = false ) const;
         /**
          * Returns the total volume of all worn holsters.
         */

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1454,7 +1454,7 @@ bool outfit::covered_with_flag( const flag_id &f, const body_part_set &parts ) c
     return to_cover.none();
 }
 
-units::volume outfit::free_space() const
+units::volume outfit::free_space( bool for_display ) const
 {
     units::volume volume_capacity = 0_ml;
     for( const item &w : worn ) {
@@ -1462,7 +1462,7 @@ units::volume outfit::free_space() const
         for( const item_pocket *pocket : w.get_all_contained_pockets() ) {
             if( pocket->contains_phase( phase_id::SOLID ) ) {
                 for( const item *it : pocket->all_items_top() ) {
-                    volume_capacity -= it->volume();
+                    volume_capacity -= it->volume( false, false, -1, for_display );
                 }
             } else if( !pocket->empty() ) {
                 volume_capacity -= pocket->volume_capacity();

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -109,7 +109,7 @@ class outfit
         units::volume free_holster_volume() const;
         units::volume contents_volume_with_tweaks( const std::map<const item *, int> &without ) const;
         units::volume volume_capacity_with_tweaks( const std::map<const item *, int> &without ) const;
-        units::volume free_space() const;
+        units::volume free_space( bool for_display = false ) const;
         units::volume max_single_item_volume() const;
         units::length max_single_item_length() const;
         // total volume

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2426,7 +2426,7 @@ inventory_selector::stats inventory_selector::get_weight_and_volume_and_holster_
 inventory_selector::stats inventory_selector::get_raw_stats() const
 {
     return get_weight_and_volume_and_holster_stats( u.weight_carried(), u.weight_capacity(),
-            u.volume_carried(), u.volume_capacity(),
+            u.volume_carried( true ), u.volume_capacity(),
             u.max_single_item_length(), u.max_single_item_volume(),
             u.free_holster_volume(), u.used_holsters(), u.total_holsters() );
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7179,7 +7179,8 @@ units::volume item::base_volume() const
     return type->volume;
 }
 
-units::volume item::volume( bool integral, bool ignore_contents, int charges_in_vol ) const
+units::volume item::volume( bool integral, bool ignore_contents, int charges_in_vol,
+                            bool for_display ) const
 {
     charges_in_vol = charges_in_vol < 0 || charges_in_vol > charges ? charges : charges_in_vol;
     if( is_null() ) {
@@ -7229,7 +7230,7 @@ units::volume item::volume( bool integral, bool ignore_contents, int charges_in_
     }
 
     if( !ignore_contents ) {
-        ret += contents.item_size_modifier();
+        ret += contents.item_size_modifier( for_display );
     }
 
     // if it has additional pockets include the volume of those

--- a/src/item.h
+++ b/src/item.h
@@ -638,7 +638,7 @@ class item : public visitable
          * @param charges_in_vol if specified, get the volume for this many charges instead of current charges
          */
         units::volume volume( bool integral = false, bool ignore_contents = false,
-                              int charges_in_vol = -1 ) const;
+                              int charges_in_vol = -1, bool for_display = false ) const;
 
         units::length length() const;
 

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2336,10 +2336,14 @@ bool item_contents::all_pockets_rigid() const
     return true;
 }
 
-units::volume item_contents::item_size_modifier() const
+units::volume item_contents::item_size_modifier( bool for_display ) const
 {
     units::volume total_vol = 0_ml;
     for( const item_pocket &pocket : contents ) {
+        // if a pocket is disabled, rigid and for display then show it as full
+        if( for_display && pocket.settings.is_disabled() && pocket.rigid() ) {
+            total_vol += pocket.volume_capacity() - pocket.contains_volume();
+        }
         total_vol += pocket.item_size_modifier();
     }
     return total_vol;

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -143,7 +143,7 @@ class item_contents
         item &legacy_front();
         const item &legacy_front() const;
 
-        units::volume item_size_modifier() const;
+        units::volume item_size_modifier( bool for_display = false ) const;
         units::mass item_weight_modifier() const;
         units::length item_length_modifier() const;
 

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2088,11 +2088,11 @@ units::length item_pocket::min_containable_length() const
     return 0_mm;
 }
 
-units::volume item_pocket::contains_volume() const
+units::volume item_pocket::contains_volume( bool for_display ) const
 {
     units::volume vol = 0_ml;
     for( const item &it : contents ) {
-        vol += it.volume();
+        vol += it.volume( for_display );
     }
     return vol;
 }

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -208,7 +208,7 @@ class item_pocket
         units::length min_containable_length() const;
 
         // combined volume of contained items
-        units::volume contains_volume() const;
+        units::volume contains_volume( bool for_display = false ) const;
         units::volume remaining_volume() const;
         // how many more of @it can this pocket hold?
         int remaining_capacity_for_item( const item &it ) const;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
For some other plans I have for pockets I want to work on cleaning up the UI. First step is making rigid disabled pockets display correctly.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Rigid containers that are disabled show their volume, not volume - pocket size + volume contained.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Still WIP just marking it for now
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->