### PR TITLE
Fix blackpowder .30-06 fmj having doubled stat reduction

### DIFF
--- a/data/json/items/ammo/3006.json
+++ b/data/json/items/ammo/3006.json
@@ -70,7 +70,7 @@
   },
   {
     "id": "bp_3006fmj",
-    "copy-from": "bp_3006",
+    "copy-from": "3006fmj",
     "type": "AMMO",
     "name": { "str_sp": ".30-06 Springfield M2 AP, black powder" },
     "description": "Armor piercing .30-06 M2 ammunition with a 168gr FMJ bullet.  It is an extremely powerful and accurate cartridge, but pays for its armor penetration abilities with lowered damage.  Someone was down on their luck when they hand-reloaded this one - it's filled with black powder instead of smokeless powder.  Expect lower velocity, muzzle smoke, and a dirtier barrel if you shoot it.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix blackpowder .30-06 fmj having doubled stat reduction"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
".30-06 Springfield M2 AP, black powder" has worse stats than it should due to inheriting the blackpowder associated reductions twice. It also has duplicated RECYCLED, BLACKPOWDER, and MUZZLE_SMOKE effects.

To see what I mean, compare
https://cdda-guide.nornagon.net/item/bp_3006fmj?v=cdda-experimental-2023-04-01-1744
and
https://cdda-guide.nornagon.net/item/bp_3006?v=cdda-experimental-2023-04-01-1744
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
bp_3006fmj needs to inherit from 3006fmj, not bp_3006. That's the only change I made.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
none
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Made change, loaded game, verified that the blackpowder .30-06 M2 AP had correct stats.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I also checked all of the other files in /data/json/items/ammo and verified that every instance where an ammo type inherits from a blackpowder ammo type is correct in doing so. I didn't find any other instances of this bug. Specifically, I ctrl-f'd for "copy-from": "bp
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->