### PR TITLE
Expose world_generator.all_worlds getter

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3290,6 +3290,9 @@ bool game::save()
             debugmsg( "game not saved" );
             return false;
         } else {
+            world_generator->last_world_name = world_generator->active_world->world_name;
+            world_generator->last_character_name = u.name;
+            world_generator->save_last_world_info();
             world_generator->active_world->add_save( save_t::from_save_id( u.get_save_id() ) );
             return true;
         }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -209,19 +209,20 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
                 sub_opts.emplace_back( colorize( _( "Create World" ), sel2 == 0 ? hilite( c_yellow ) : c_yellow ) );
                 xlen = utf8_width( sub_opts.back(), true );
             }
-            std::vector<std::string> all_worldnames = world_generator->all_worldnames();
-            for( int i = 0; static_cast<size_t>( i ) < all_worldnames.size(); i++ ) {
-                int savegames_count = world_generator->get_world( all_worldnames[i] )->world_saves.size();
+            int i = 0;
+            for( const auto& [name, world] : world_generator->get_all_worlds() ) {
+                int savegames_count = world->world_saves.size();
                 nc_color clr = c_white;
-                if( all_worldnames[i] == "TUTORIAL" || all_worldnames[i] == "DEFENSE" ) {
+                if( name == "TUTORIAL" || name == "DEFENSE" ) {
                     clr = c_light_cyan;
                 }
-                sub_opts.push_back( colorize( string_format( "%s (%d)", all_worldnames[i], savegames_count ),
+                sub_opts.push_back( colorize( string_format( "%s (%d)", name, savegames_count ),
                                               ( sel2 == i + ( extra_opt ? 1 : 0 ) ) ? hilite( clr ) : clr ) );
                 int len = utf8_width( sub_opts.back(), true );
                 if( len > xlen ) {
                     xlen = len;
                 }
+                i++;
             }
         }
         break;
@@ -611,10 +612,9 @@ bool main_menu::opening_screen()
     size_t last_world_pos = 0;
 
     // Make [Load Game] the default cursor position if there's game save available
-    if( !world_generator->all_worldnames().empty() ) {
+    if( !world_generator->get_all_worlds().empty() ) {
         std::vector<std::string> worlds = world_generator->all_worldnames();
-        last_world_pos = std::find( worlds.begin(), worlds.end(),
-                                    world_generator->last_world_name ) - worlds.begin();
+        last_world_pos = world_generator->get_world_index( world_generator->last_world_name );
         if( last_world_pos >= worlds.size() ) {
             last_world_pos = 0;
         }
@@ -755,11 +755,11 @@ bool main_menu::opening_screen()
                     }
                     break;
                 case main_menu_opts::LOADCHAR:
-                    max_item_count = world_generator->all_worldnames().size();
+                    max_item_count = world_generator->get_all_worlds().size();
                     break;
                 case main_menu_opts::WORLD:
                     // extra 1 = "Create New World"
-                    max_item_count = world_generator->all_worldnames().size() + 1;
+                    max_item_count = world_generator->get_all_worlds().size() + 1;
                     break;
                 case main_menu_opts::NEWCHAR:
                     max_item_count = vNewGameSubItems.size();
@@ -846,12 +846,12 @@ bool main_menu::opening_screen()
                     }
                     break;
                 case main_menu_opts::WORLD:
-                    sel2 = std::min<int>( sel2, world_generator->all_worldnames().size() );
-                    world_tab( sel2 > 0 ? world_generator->all_worldnames().at( sel2 - 1 ) : "" );
+                    sel2 = std::min<int>( sel2, world_generator->get_all_worlds().size() );
+                    world_tab( sel2 > 0 ? world_generator->get_world_name( sel2 - 1 ) : "" );
                     break;
                 case main_menu_opts::LOADCHAR:
-                    if( static_cast<std::size_t>( sel2 ) < world_generator->all_worldnames().size() ) {
-                        start = load_character_tab( world_generator->all_worldnames().at( sel2 ) );
+                    if( static_cast<std::size_t>( sel2 ) < world_generator->get_all_worlds().size() ) {
+                        start = load_character_tab( world_generator->get_world_name( sel2 ) );
                         if( start ) {
                             load_game = true;
                         }

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -427,6 +427,11 @@ bool worldfactory::has_world( const std::string &name ) const
     return all_worlds.count( name ) > 0;
 }
 
+const std::map<std::string, std::unique_ptr<WORLD>> &worldfactory::get_all_worlds() const
+{
+    return all_worlds;
+}
+
 std::vector<std::string> worldfactory::all_worldnames() const
 {
     std::vector<std::string> result;
@@ -2038,6 +2043,30 @@ WORLD *worldfactory::get_world( const std::string &name )
         return nullptr;
     }
     return iter->second.get();
+}
+
+std::string worldfactory::get_world_name( const size_t index )
+{
+    size_t i = 0;
+    for( const auto &elem : all_worlds ) {
+        if( i == index ) {
+            return elem.first;
+        }
+        i++;
+    }
+    return "";
+}
+
+size_t worldfactory::get_world_index( const std::string &name )
+{
+    size_t i = 0;
+    for( const auto &elem : all_worlds ) {
+        if( elem.first == name ) {
+            return i;
+        }
+        i++;
+    }
+    return 0;
 }
 
 // Helper predicate to exclude files from deletion when resetting a world directory.

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -99,6 +99,10 @@ class worldfactory
         WORLD *make_new_world( const std::vector<mod_id> &mods );
         /// Returns the *existing* world of given name.
         WORLD *get_world( const std::string &name );
+        /// Returns the *existing* world's name from its index in the world list.
+        std::string get_world_name( size_t index );
+        /// Returns the *existing* world's index in the world list from its name.
+        size_t get_world_index( const std::string &name );
         bool has_world( const std::string &name ) const;
 
         void set_active_world( WORLD *world );
@@ -131,6 +135,8 @@ class worldfactory
         static std::map<size_t, inclusive_rectangle<point>> draw_worldgen_tabs( const catacurses::window &w,
                 size_t current );
         void show_active_world_mods( const std::vector<mod_id> &world_mods );
+
+        const std::map<std::string, std::unique_ptr<WORLD>> &get_all_worlds() const;
 
     private:
         std::map<std::string, std::unique_ptr<WORLD>> all_worlds;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Generating the full list of world names just to iterate over them or search within them is wasteful.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Expose all_worlds via a public getter, along with two other lookup functions, then use those in places all_worldnames was previously used.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
A custom container/iterator type for exposing just the keys of a map for iteration and indexing, but that seemed overkill and difficult.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Various interactions with the load and world menus.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Also included a small bug fix discovered during testing. The "last world" was previously only updated on loading, which leaves the load cursor in the "wrong" place after creating a new character and saving.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->