### PR TITLE
Add ability to remove plants from planters without destroying planter

### DIFF
--- a/data/json/furniture_and_terrain/furniture-domestic_plants.json
+++ b/data/json/furniture_and_terrain/furniture-domestic_plants.json
@@ -183,14 +183,15 @@
     },
     "bash": {
       "str_min": 6,
-      "str_max": 14,
-      "sound": "crunch.",
-      "sound_fail": "whish.",
+      "str_max": 10,
+      "sound": "rrrrip!",
+      "sound_fail": "brush.",
+      "sound_vol": 8,
+      "furn_set": "f_planter",
       "items": [
-        { "item": "2x4", "count": [ 4, 10 ] },
-        { "item": "nail", "charges": [ 15, 30 ] },
-        { "item": "pebble", "charges": [ 150, 200 ] },
-        { "item": "material_soil", "count": [ 60, 75 ] }
+        { "item": "withered", "count": [ 2, 8 ] },
+        { "item": "leaves", "count": [ 4, 16 ] },
+        { "item": "twig", "count": [ 1, 5 ] }
       ]
     },
     "plant_data": { "transform": "f_planter", "base": "f_planter" }
@@ -217,14 +218,15 @@
     },
     "bash": {
       "str_min": 6,
-      "str_max": 14,
-      "sound": "crunch.",
-      "sound_fail": "whish.",
+      "str_max": 10,
+      "sound": "rrrrip!",
+      "sound_fail": "brush.",
+      "sound_vol": 8,
+      "furn_set": "f_planter",
       "items": [
-        { "item": "2x4", "count": [ 4, 10 ] },
-        { "item": "nail", "charges": [ 15, 30 ] },
-        { "item": "pebble", "charges": [ 150, 200 ] },
-        { "item": "material_soil", "count": [ 60, 75 ] }
+        { "item": "withered", "count": [ 2, 8 ] },
+        { "item": "leaves", "count": [ 4, 16 ] },
+        { "item": "twig", "count": [ 1, 5 ] }
       ]
     },
     "plant_data": { "transform": "f_planter_harvest", "base": "f_planter" }
@@ -250,16 +252,16 @@
       ]
     },
     "bash": {
-      "str_min": 6,
-      "str_max": 14,
-      "sound": "crunch.",
-      "sound_fail": "whish.",
-      "items": [
-        { "item": "2x4", "count": [ 4, 10 ] },
-        { "item": "nail", "charges": [ 15, 30 ] },
-        { "item": "pebble", "charges": [ 150, 200 ] },
-        { "item": "material_soil", "count": [ 60, 75 ] }
-      ]
+        "str_min": 2,
+        "str_max": 6,
+        "sound": "rrrrip!",
+        "sound_fail": "brush.",
+        "sound_vol": 4,
+        "furn_set": "f_planter",
+        "items": [
+          { "item": "withered", "count": [ 1, 2 ] },
+          { "item": "leaves", "count": [ 1, 2 ] }
+        ]
     },
     "plant_data": { "transform": "f_planter_seedling", "base": "f_planter" }
   },
@@ -284,15 +286,16 @@
       ]
     },
     "bash": {
-      "str_min": 6,
-      "str_max": 14,
-      "sound": "crunch.",
-      "sound_fail": "whish.",
+      "str_min": 4,
+      "str_max": 8,
+      "sound": "rrrrip!",
+      "sound_fail": "brush.",
+      "sound_vol": 6,
+      "furn_set": "f_planter",
       "items": [
-        { "item": "2x4", "count": [ 4, 10 ] },
-        { "item": "nail", "charges": [ 15, 30 ] },
-        { "item": "pebble", "charges": [ 150, 200 ] },
-        { "item": "material_soil", "count": [ 60, 75 ] }
+        { "item": "withered", "count": [ 1, 2 ] },
+        { "item": "leaves", "count": [ 2, 6 ] },
+        { "item": "twig", "count": [ 0, 1 ] }
       ]
     },
     "plant_data": { "transform": "f_planter_mature", "base": "f_planter" }

--- a/data/json/furniture_and_terrain/furniture-domestic_plants.json
+++ b/data/json/furniture_and_terrain/furniture-domestic_plants.json
@@ -252,16 +252,13 @@
       ]
     },
     "bash": {
-        "str_min": 2,
-        "str_max": 6,
-        "sound": "rrrrip!",
-        "sound_fail": "brush.",
-        "sound_vol": 4,
-        "furn_set": "f_planter",
-        "items": [
-          { "item": "withered", "count": [ 1, 2 ] },
-          { "item": "leaves", "count": [ 1, 2 ] }
-        ]
+      "str_min": 2,
+      "str_max": 6,
+      "sound": "rrrrip!",
+      "sound_fail": "brush.",
+      "sound_vol": 4,
+      "furn_set": "f_planter",
+      "items": [ { "item": "withered", "count": [ 1, 2 ] }, { "item": "leaves", "count": [ 1, 2 ] } ]
     },
     "plant_data": { "transform": "f_planter_seedling", "base": "f_planter" }
   },

--- a/data/json/furniture_and_terrain/furniture-domestic_plants.json
+++ b/data/json/furniture_and_terrain/furniture-domestic_plants.json
@@ -1,4 +1,4 @@
-[ 
+[
   {
     "type": "furniture",
     "id": "f_indoor_plant",

--- a/data/json/furniture_and_terrain/furniture-domestic_plants.json
+++ b/data/json/furniture_and_terrain/furniture-domestic_plants.json
@@ -1,4 +1,4 @@
-[
+[ 
   {
     "type": "furniture",
     "id": "f_indoor_plant",


### PR DESCRIPTION
#### Summary
Bugfixes "Add ability to remove plants from planters without destroying planter"

#### Purpose of change

The only way to change the use of a planter or to use the planters that the game pre-generates such as the farmhouse greenhouse planters is to... destroy them.

This was silly, so this change adds the ability to smash a planter with a plant in it - which will destroy the plant, and revert the planter to a plain planter furniture - allowing you to either plant something in it, or to smash it again which will smash the planter as normal.

#### Describe the solution

For each of the the 4 tiers of planter with plant furniture items, bash will furn_set convert to an empty planter, instead of setting them to a destroyed planter.  It will drop assorted leaves, withered plants and twigs depending on how far along the plant had grown.

#### Describe alternatives you've considered

Editing c++ to add ability to overturn earth directly to planters.  Jsonizing the bash function is much easier.

#### Testing

Converted a glasshouse planter array from roses to empty planters.

#### Additional context

Preview of what it looks like ingame after I smashed a planter with a rose in it.

![image](https://user-images.githubusercontent.com/34361592/229502619-b091c8ab-3222-43b6-95ed-82547ff4053b.png)

