### PR TITLE
Deduplicate failure msg for action attempted mounted or underwater

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2354,8 +2354,7 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
 
 std::optional<tripoint> lockpick_activity_actor::select_location( avatar &you )
 {
-    if( you.is_mounted() ) {
-        you.add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
+    if( you.cant_do_mounted() ) {
         return std::nullopt;
     }
 
@@ -6641,12 +6640,10 @@ std::unique_ptr<activity_actor> vehicle_folding_activity_actor::deserialize( Jso
 
 bool vehicle_unfolding_activity_actor::unfold_vehicle( Character &p, bool check_only ) const
 {
-    if( p.is_underwater() ) {
-        p.add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p.cant_do_underwater() ) {
         return false;
     }
-    if( p.is_mounted() ) {
-        p.add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p.cant_do_mounted() ) {
         return false;
     }
     map &here = get_map();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1519,6 +1519,18 @@ bool Character::check_mount_is_spooked()
     return false;
 }
 
+bool Character::cant_do_mounted( bool msg ) const
+{
+    if( is_mounted() ) {
+        if( msg ) {
+            add_msg_player_or_npc( m_info, _( "You can't do that while mounted." ),
+                                   _( "<npcname> can't do that while mounted." ) );
+        }
+        return true;
+    }
+    return false;
+}
+
 bool Character::is_mounted() const
 {
     return has_effect( effect_riding ) && mounted_creature;

--- a/src/character.h
+++ b/src/character.h
@@ -1240,6 +1240,7 @@ class Character : public Creature, public visitable
 
         bool can_mount( const monster &critter ) const;
         void mount_creature( monster &z );
+        bool cant_do_mounted( bool msg = true ) const;
         bool is_mounted() const;
         bool check_mount_will_move( const tripoint &dest_loc );
         bool check_mount_is_spooked();

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1748,8 +1748,7 @@ trinary Character::consume( item &target, bool force )
         add_msg_if_player( m_info, _( "You do not have that item." ) );
         return trinary::NONE;
     }
-    if( is_underwater() && !has_trait( trait_WATERSLEEP ) ) {
-        add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( !has_trait( trait_WATERSLEEP ) && cant_do_underwater() ) {
         return trinary::NONE;
     }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -252,6 +252,18 @@ void Creature::process_turn()
     }
 }
 
+bool Creature::cant_do_underwater( bool msg ) const
+{
+    if( is_underwater() ) {
+        if( msg ) {
+            add_msg_player_or_npc( m_info, _( "You can't do that while underwater." ),
+                                   _( "<npcname> can't do that while underwater." ) );
+        }
+        return true;
+    }
+    return false;
+}
+
 bool Creature::is_underwater() const
 {
     return underwater;

--- a/src/creature.h
+++ b/src/creature.h
@@ -506,6 +506,7 @@ class Creature : public viewer
 
         virtual bool digging() const;
         virtual bool is_on_ground() const = 0;
+        bool cant_do_underwater( bool msg = true ) const;
         virtual bool is_underwater() const;
         bool is_likely_underwater() const; // Should eventually be virtual, although not pure
         virtual bool is_warm() const; // is this creature warm, for IR vision, heat drain, etc

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5846,16 +5846,14 @@ void game::examine( const tripoint &examp, bool with_pickup )
                     return;
                 }
             }
-        } else if( u.is_mounted() ) {
-            add_msg( m_warning, _( "You cannot do that while mounted." ) );
+        } else {
+            u.cant_do_mounted();
         }
         npc *np = dynamic_cast<npc *>( c );
-        if( np != nullptr && !u.is_mounted() ) {
+        if( np != nullptr && !u.cant_do_mounted() ) {
             if( npc_menu( *np ) ) {
                 return;
             }
-        } else if( np != nullptr && u.is_mounted() ) {
-            add_msg( m_warning, _( "You cannot do that while mounted." ) );
         }
     }
 
@@ -5889,15 +5887,11 @@ void game::examine( const tripoint &examp, bool with_pickup )
     const tripoint player_pos = u.pos();
 
     if( m.has_furn( examp ) ) {
-        if( u.is_mounted() ) {
-            add_msg( m_warning, _( "You cannot do that while mounted." ) );
-        } else {
+        if( !u.cant_do_mounted() ) {
             xfurn_t.examine( u, examp );
         }
     } else {
-        if( u.is_mounted() && xter_t.can_examine( examp ) ) {
-            add_msg( m_warning, _( "You cannot do that while mounted." ) );
-        } else {
+        if( xter_t.can_examine( examp ) && !u.is_mounted() ) {
             xter_t.examine( u, examp );
         }
     }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4032,8 +4032,7 @@ void trap::examine( const tripoint &examp ) const
         return;
     }
 
-    if( player_character.is_mounted() ) {
-        add_msg( m_warning, _( "You cannot do that while mounted." ) );
+    if( player_character.cant_do_mounted() ) {
         return;
     }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -665,8 +665,7 @@ std::optional<int> iuse::antibiotic( Character *p, item *, bool, const tripoint 
 
 std::optional<int> iuse::eyedrops( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
     if( !it->ammo_sufficient( p ) ) {
@@ -684,8 +683,7 @@ std::optional<int> iuse::eyedrops( Character *p, item *it, bool, const tripoint 
 
 std::optional<int> iuse::fungicide( Character *p, item *, bool, const tripoint & )
 {
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
 
@@ -742,8 +740,7 @@ std::optional<int> iuse::fungicide( Character *p, item *, bool, const tripoint &
 
 std::optional<int> iuse::antifungal( Character *p, item *, bool, const tripoint & )
 {
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
     p->add_effect( effect_antifungal, 4_hours );
@@ -761,8 +758,7 @@ std::optional<int> iuse::antifungal( Character *p, item *, bool, const tripoint 
 
 std::optional<int> iuse::antiparasitic( Character *p, item *, bool, const tripoint & )
 {
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
     p->add_msg_if_player( _( "You take some antiparasitic medication." ) );
@@ -954,8 +950,7 @@ std::optional<int> iuse::meditate( Character *p, item *it, bool t, const tripoin
     if( !p || t ) {
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     if( p->has_trait( trait_SPIRITUAL ) ) {
@@ -1767,8 +1762,7 @@ std::optional<int> iuse::fishing_rod( Character *p, item *it, bool, const tripoi
         // Long actions - NPCs don't like those yet.
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     map &here = get_map();
@@ -1800,12 +1794,10 @@ std::optional<int> iuse::fish_trap( Character *p, item *it, bool t, const tripoi
             return 0;
         }
 
-        if( p->is_mounted() ) {
-            p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+        if( p->cant_do_mounted() ) {
             return std::nullopt;
         }
-        if( p->is_underwater() ) {
-            p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+        if( p->cant_do_underwater() ) {
             return std::nullopt;
         }
 
@@ -2356,8 +2348,7 @@ std::optional<int> iuse::rm13armor_on( Character *p, item *it, bool t, const tri
 
 std::optional<int> iuse::unpack_item( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
     std::string oname = it->typeId().str() + "_on";
@@ -2402,8 +2393,7 @@ std::optional<int> iuse::pack_cbm( Character *p, item *it, bool, const tripoint 
 
 std::optional<int> iuse::pack_item( Character *p, item *it, bool t, const tripoint & )
 {
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
     if( t ) { // Normal use
@@ -2428,8 +2418,7 @@ std::optional<int> iuse::pack_item( Character *p, item *it, bool t, const tripoi
 
 std::optional<int> iuse::water_purifier( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     item_location obj = g->inv_map_splice( []( const item & e ) {
@@ -2777,8 +2766,7 @@ std::optional<int> iuse::crowbar_weak( Character *p, item *it, bool, const tripo
 
 std::optional<int> iuse::crowbar( Character *p, item *it, bool, const tripoint &pos )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
 
@@ -2859,8 +2847,7 @@ std::optional<int> iuse::makemound( Character *p, item *it, bool t, const tripoi
     if( !p || t ) {
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     const std::optional<tripoint> pnt_ = choose_adjacent( _( "Till soil where?" ) );
@@ -2893,8 +2880,7 @@ std::optional<int> iuse::dig( Character *p, item * /* it */, bool t, const tripo
     if( !p || t ) {
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
 
@@ -2916,8 +2902,7 @@ std::optional<int> iuse::dig_channel( Character *p, item */* it */, bool t, cons
     if( !p || t ) {
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
 
@@ -2935,8 +2920,7 @@ std::optional<int> iuse::fill_pit( Character *p, item */* it */, bool t, const t
     if( !p || t ) {
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
 
@@ -2958,8 +2942,7 @@ std::optional<int> iuse::fill_pit( Character *p, item */* it */, bool t, const t
 
 std::optional<int> iuse::clear_rubble( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     const std::function<bool( const tripoint & )> f = []( const tripoint & pnt ) {
@@ -2991,8 +2974,7 @@ std::optional<int> iuse::clear_rubble( Character *p, item *it, bool, const tripo
 
 std::optional<int> iuse::siphon( Character *p, item *, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     map &here = get_map();
@@ -3227,12 +3209,10 @@ std::optional<int> iuse::jackhammer( Character *p, item *it, bool, const tripoin
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
 
@@ -3343,12 +3323,10 @@ std::optional<int> iuse::pickaxe( Character *p, item *it, bool, const tripoint &
         // Long action
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
 
@@ -3498,8 +3476,7 @@ std::optional<int> iuse::teleport( Character *p, item *it, bool, const tripoint 
         // That would be evil
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     if( !it->ammo_sufficient( p ) ) {
@@ -3807,8 +3784,7 @@ std::optional<int> iuse::molotov_lit( Character *p, item *it, bool t, const trip
 
 std::optional<int> iuse::firecracker_pack( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
     if( !p->has_charges( itype_fire, 1 ) ) {
@@ -3848,8 +3824,7 @@ std::optional<int> iuse::firecracker_pack_act( Character *, item *it, bool, cons
 
 std::optional<int> iuse::firecracker( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
     if( !p->use_charges_if_avail( itype_fire, 1 ) ) {
@@ -3902,8 +3877,7 @@ std::optional<int> iuse::portal( Character *p, item *it, bool, const tripoint & 
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     tripoint t( p->posx() + rng( -2, 2 ), p->posy() + rng( -2, 2 ), p->posz() );
@@ -4173,8 +4147,7 @@ std::optional<int> iuse::mp3_on( Character *p, item *it, bool t, const tripoint 
 
 std::optional<int> iuse::rpgdie( Character *you, item *die, bool, const tripoint & )
 {
-    if( you->is_mounted() ) {
-        you->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( you->cant_do_mounted() ) {
         return std::nullopt;
     }
     int num_sides = die->get_var( "die_num_sides", 0 );
@@ -4333,12 +4306,10 @@ std::optional<int> iuse::portable_game( Character *p, item *it, bool active, con
         // Long action
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
     if( p->has_trait( trait_ILLITERATE ) ) {
@@ -4628,8 +4599,7 @@ std::optional<int> iuse::dog_whistle( Character *p, item *, bool, const tripoint
     if( !p->is_avatar() ) {
         return std::nullopt;
     }
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
     p->add_msg_if_player( _( "You blow your dog whistle." ) );
@@ -4701,8 +4671,7 @@ std::optional<int> iuse::blood_draw( Character *p, item *it, bool, const tripoin
     if( p->is_npc() ) {
         return std::nullopt;    // No NPCs for now!
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     if( !it->empty() ) {
@@ -4782,8 +4751,7 @@ std::optional<int> iuse::blood_draw( Character *p, item *it, bool, const tripoin
 
 void iuse::cut_log_into_planks( Character &p )
 {
-    if( p.is_mounted() ) {
-        p.add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p.cant_do_mounted() ) {
         return;
     }
     const int moves = to_moves<int>( 20_minutes );
@@ -4798,8 +4766,7 @@ std::optional<int> iuse::lumber( Character *p, item *, bool t, const tripoint & 
     if( t ) {
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     map &here = get_map();
@@ -4850,8 +4817,7 @@ std::optional<int> iuse::chop_tree( Character *p, item *it, bool t, const tripoi
     if( !p || t ) {
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     map &here = get_map();
@@ -4892,8 +4858,7 @@ std::optional<int> iuse::chop_logs( Character *p, item *it, bool t, const tripoi
     if( !p || t ) {
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
 
@@ -4936,8 +4901,7 @@ std::optional<int> iuse::oxytorch( Character *p, item *it, bool, const tripoint 
         // Long action
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     if( !p->has_quality( qual_GLARE, 1 ) ) {
@@ -4984,8 +4948,7 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, bool t, const tripoint
     if( !p || t ) {
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
 
@@ -5026,8 +4989,7 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, bool t, const tripoint
 
 std::optional<int> iuse::boltcutters( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
 
@@ -5066,8 +5028,7 @@ std::optional<int> iuse::boltcutters( Character *p, item *it, bool, const tripoi
 
 std::optional<int> iuse::mop( Character *p, item *, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     map &here = get_map();
@@ -5222,8 +5183,7 @@ std::optional<int> iuse::heat_food( Character *p, item *it, bool, const tripoint
 
 std::optional<int> iuse::hotplate( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     if( !it->ammo_sufficient( p ) ) {
@@ -5239,8 +5199,7 @@ std::optional<int> iuse::hotplate( Character *p, item *it, bool, const tripoint 
 
 std::optional<int> iuse::hotplate_atomic( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     if( it->typeId() == itype_atomic_coffeepot ) {
@@ -5428,8 +5387,7 @@ std::optional<int> iuse::radglove( Character *p, item *it, bool, const tripoint 
 
 std::optional<int> iuse::contacts( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
     const time_duration duration = rng( 6_days, 8_days );
@@ -5476,12 +5434,10 @@ std::optional<int> iuse::gun_repair( Character *p, item *it, bool, const tripoin
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
-    if( p->is_underwater() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     /** @EFFECT_MECHANICS >1 allows gun repair */
@@ -6041,8 +5997,7 @@ std::optional<int> iuse::einktabletpc( Character *p, item *it, bool t, const tri
             play_music( *p, pos, 8, std::min( 25, songs ) );
         }
         return std::nullopt;
-    } else if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    } else if( p->cant_do_mounted() ) {
         return std::nullopt;
     } else if( !p->is_npc() ) {
 
@@ -6050,8 +6005,7 @@ std::optional<int> iuse::einktabletpc( Character *p, item *it, bool t, const tri
             ei_invalid, ei_photo, ei_music, ei_recipe, ei_uploaded_photos, ei_monsters, ei_download, ei_decrypt
         };
 
-        if( p->is_underwater() ) {
-            p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+        if( p->cant_do_underwater() ) {
             return std::nullopt;
         }
         if( p->has_trait( trait_ILLITERATE ) ) {
@@ -8119,8 +8073,7 @@ std::optional<int> iuse::multicooker( Character *p, item *it, bool t, const trip
             mc_start, mc_stop, mc_take, mc_upgrade, mc_empty
         };
 
-        if( p->is_underwater() ) {
-            p->add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+        if( p->cant_do_underwater() ) {
             return std::nullopt;
         }
 
@@ -8932,8 +8885,7 @@ std::optional<int> iuse::cord_attach( Character *p, item *it, bool, const tripoi
 
 std::optional<int> iuse::shavekit( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     if( !it->ammo_sufficient( p ) ) {
@@ -8946,8 +8898,7 @@ std::optional<int> iuse::shavekit( Character *p, item *it, bool, const tripoint 
 
 std::optional<int> iuse::hairkit( Character *p, item *, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     p->assign_activity( player_activity( haircut_activity_actor() ) );
@@ -9116,8 +9067,7 @@ std::optional<int> iuse::directional_hologram( Character *p, item *it, bool, con
 
 std::optional<int> iuse::capture_monster_veh( Character *p, item *it, bool, const tripoint &pos )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     if( !it->has_flag( flag_VEHICLE ) ) {
@@ -9271,8 +9221,7 @@ std::optional<int> iuse::wash_soft_items( Character *p, item *, bool, const trip
         p->add_msg_if_player( _( "You can't see to do that!" ) );
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     // Check that player isn't over volume limit as this might cause it to break... this is a hack.
@@ -9292,8 +9241,7 @@ std::optional<int> iuse::wash_hard_items( Character *p, item *, bool, const trip
         p->add_msg_if_player( _( "You can't see to do that!" ) );
         return std::nullopt;
     }
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     // Check that player isn't over volume limit as this might cause it to break... this is a hack.
@@ -9327,8 +9275,7 @@ std::optional<int> iuse::wash_all_items( Character *p, item *, bool, const tripo
 
 std::optional<int> iuse::wash_items( Character *p, bool soft_items, bool hard_items )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     p->inv->restack( *p );
@@ -9499,8 +9446,7 @@ static item *wield_before_use( Character *const p, item *const it, const std::st
 
 std::optional<int> iuse::craft( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     it = wield_before_use( p, it, _( "Wield the %s and start working?" ) );
@@ -9538,8 +9484,7 @@ std::optional<int> iuse::craft( Character *p, item *it, bool, const tripoint & )
 
 std::optional<int> iuse::disassemble( Character *p, item *it, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
     it = wield_before_use( p, it, _( "Wield the %s and start working?" ) );
@@ -9868,8 +9813,7 @@ std::optional<int> iuse::ebookread( Character *p, item *it, bool t, const tripoi
 
 std::optional<int> iuse::binder_add_recipe( Character *p, item *binder, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
+    if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -267,8 +267,7 @@ std::optional<int> iuse_transform::use( Character &p, item &it, bool t, const tr
             p.add_msg_if_player( m_info, need_fire_msg, it.tname() );
             return std::nullopt;
         }
-        if( p.is_underwater() ) {
-            p.add_msg_if_player( m_info, _( "You can't do that while underwater" ) );
+        if( p.cant_do_underwater() ) {
             return std::nullopt;
         }
     }
@@ -1047,8 +1046,7 @@ void deploy_furn_actor::load( const JsonObject &obj )
 std::optional<int> deploy_furn_actor::use( Character &p, item &it, bool,
         const tripoint &pos ) const
 {
-    if( p.is_mounted() ) {
-        p.add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
+    if( p.cant_do_mounted() ) {
         return std::nullopt;
     }
     tripoint pnt = pos;
@@ -2606,17 +2604,10 @@ bool repair_item_actor::can_use_tool( const Character &p, const item &tool, bool
         }
         return false;
     }
-    if( p.is_underwater() ) {
-        if( print_msg ) {
-            p.add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
-        }
+    if( p.cant_do_underwater( print_msg ) ) {
         return false;
     }
-    if( p.is_mounted() ) {
-        if( print_msg ) {
-            p.add_msg_player_or_npc( m_bad, _( "You can't do that while mounted." ),
-                                     _( "<npcname> can't do that while mounted." ) );
-        }
+    if( p.cant_do_mounted( print_msg ) ) {
         return false;
     }
     if( p.fine_detail_vision_mod() > 4 ) {
@@ -3311,12 +3302,10 @@ static Character &get_patient( Character &healer, const tripoint &pos )
 
 std::optional<int> heal_actor::use( Character &p, item &it, bool, const tripoint &pos ) const
 {
-    if( p.is_underwater() ) {
-        p.add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p.cant_do_underwater() ) {
         return std::nullopt;
     }
-    if( p.is_mounted() ) {
-        p.add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p.cant_do_mounted() ) {
         return std::nullopt;
     }
     if( it.is_filthy() ) {
@@ -3845,12 +3834,10 @@ static void place_and_add_as_known( Character &p, const tripoint &pos, const tra
 std::optional<int> place_trap_actor::use( Character &p, item &it, bool, const tripoint & ) const
 {
     const bool could_bury = !bury_question.empty();
-    if( !allow_underwater && p.is_underwater() ) {
-        p.add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( !allow_underwater && p.cant_do_underwater() ) {
         return std::nullopt;
     }
-    if( p.is_mounted() ) {
-        p.add_msg_if_player( m_info, _( "You can't do that while mounted." ) );
+    if( p.cant_do_mounted() ) {
         return std::nullopt;
     }
     const std::optional<tripoint> pos_ = choose_adjacent( string_format( _( "Place %s where?" ),
@@ -4409,8 +4396,7 @@ void deploy_tent_actor::load( const JsonObject &obj )
 std::optional<int> deploy_tent_actor::use( Character &p, item &it, bool, const tripoint & ) const
 {
     int diam = 2 * radius + 1;
-    if( p.is_mounted() ) {
-        p.add_msg_if_player( _( "You cannot do that while mounted." ) );
+    if( p.cant_do_mounted() ) {
         return std::nullopt;
     }
     const std::optional<tripoint> dir = choose_direction( string_format(
@@ -4534,12 +4520,10 @@ std::optional<int> sew_advanced_actor::use( Character &p, item &it, bool, const 
     if( p.is_npc() ) {
         return std::nullopt;
     }
-    if( p.is_mounted() ) {
-        p.add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
+    if( p.cant_do_mounted() ) {
         return std::nullopt;
     }
-    if( p.is_underwater() ) {
-        p.add_msg_if_player( m_info, _( "You can't do that while underwater." ) );
+    if( p.cant_do_underwater() ) {
         return std::nullopt;
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The code to tell the player they can't perform an action while underwater/mounted is repeated 14/34 times. Some instances have subtle probably-not-intentional differences in spelling or message level.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Move the message to dedicated check functions.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Ran test suite, which includes a few tests for underwater eating. Performed a few actions in game with the relevant checks.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->