### PR TITLE
Add `looks_like` to `22_casing_new`

### DIFF
--- a/data/json/items/generic/casing.json
+++ b/data/json/items/generic/casing.json
@@ -31,6 +31,7 @@
   },
   {
     "id": "22_casing_new",
+    "looks_like": "9mm_casing",
     "type": "GENERIC",
     "category": "spare_parts",
     "price": 100,


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Unfired .22 casing didn't have a `looks_like`, so it looked out of place in some tilesets.

#### Describe the solution

JSON edit.

#### Describe alternatives you've considered

None.

#### Testing

Loaded game with patch applied. Unfired .22 casing gets a graphical tile.

#### Additional context

None