### PR TITLE
Enable custom sprite for swivel chairs

### DIFF
--- a/data/json/vehicleparts/seats.json
+++ b/data/json/vehicleparts/seats.json
@@ -236,6 +236,12 @@
   },
   {
     "copy-from": "seat_abstract",
+    "id": "seat_swivel_chair",
+    "symbol": "#",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "seat_abstract",
     "id": "seat_windshield",
     "symbol": "#",
     "type": "vehicle_part"

--- a/data/json/vehicles/carts.json
+++ b/data/json/vehicles/carts.json
@@ -151,7 +151,7 @@
     "type": "vehicle",
     "name": "Swivel Chair",
     "blueprint": [ "#" ],
-    "parts": [ { "x": 0, "y": 0, "parts": [ "xlframe_vertical_2", "wheel_caster", "seat" ] } ]
+    "parts": [ { "x": 0, "y": 0, "parts": [ "xlframe_vertical_2", "wheel_caster", "seat_swivel_chair" ] } ]
   },
   {
     "id": "water_cart",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

#### Purpose of change

Enable custom sprite for swivel chairs

#### Describe the solution

Add seat_swivel_chair as a part and put it on swivel chair

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![image](https://user-images.githubusercontent.com/41293484/229872866-73355863-9ce0-46c8-9404-d50620a83571.png)

#### Additional context

I was not able to change the shape of existing seats to this one, same with saddles. It seems that changing shapes works for winshields, quarterpanel and frames but not for seats

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->