### PR TITLE
Cache values of statistics in value constraints

### DIFF
--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -174,31 +174,6 @@ struct value_constraint {
     std::optional<string_id<event_statistic>> equals_statistic_;
     std::optional<std::pair<comparator, cata_variant>> val_comp_;
 
-    bool permits( const cata_variant &v, stats_tracker &stats ) const {
-        if( std::find( equals_any_.begin(), equals_any_.end(), v ) != equals_any_.end() ) {
-            return true;
-        }
-        // NOLINTNEXTLINE(readability-simplify-boolean-expr)
-        if( equals_statistic_ ) {
-            return stats.value_of( *equals_statistic_ ) == v;
-        }
-        if( val_comp_ ) {
-            int v_int = v.get<int>();
-            int c_int = ( *val_comp_ ).second.get<int>();
-            switch( ( *val_comp_ ).first ) {
-                case comparator::lt:
-                    return v_int < c_int;
-                case comparator::lteq:
-                    return v_int <= c_int;
-                case comparator::gteq:
-                    return v_int >= c_int;
-                case comparator::gt:
-                    return v_int > c_int;
-            }
-        }
-        return false;
-    }
-
     void deserialize( const JsonObject &jo ) {
         cata_variant single_val;
         const auto check_comp_int = [&]( const std::string & comp ) -> bool {
@@ -475,10 +450,112 @@ struct event_transformation_impl : public event_transformation::impl {
     std::vector<std::pair<std::string, value_constraint>> constraints_;
     std::vector<std::string> drop_fields_;
 
+    struct updatable_value_constraint;
+
+    struct state : stats_tracker_multiset_state, event_multiset_watcher {
+        state( const event_transformation_impl *trans, stats_tracker &stats ) :
+            transformation_( trans ),
+            data_( trans->initialize( stats ) ),
+            cached_value_constraints_( trans->make_cached_value_constraints( this, stats ) ) {
+            cata_assert( cached_value_constraints_.size() == trans->constraints_.size() );
+            trans->source_->add_watcher( stats, this );
+        }
+
+        void value_constraint_changed( stats_tracker &stats ) {
+            data_ = transformation_->initialize( cached_value_constraints_, stats );
+            stats.transformed_set_changed( transformation_->id_, data_ );
+        }
+
+        void event_added( const cata::event &e, stats_tracker &stats ) override {
+            EventVector transformed =
+                transformation_->match_and_transform( e.data(), cached_value_constraints_ );
+            for( cata::event::data_type &d : transformed ) {
+                cata::event new_event( e.type(), e.time(), std::move( d ) );
+                data_.add( new_event );
+                stats.transformed_set_changed( transformation_->id_, new_event );
+            }
+        }
+
+        void events_reset( const event_multiset &new_value, stats_tracker &stats ) override {
+            data_ = transformation_->initialize(
+                        new_value.counts(), cached_value_constraints_, stats );
+            stats.transformed_set_changed( transformation_->id_, data_ );
+        }
+
+        const event_transformation_impl *transformation_;
+        event_multiset data_;
+        std::list<updatable_value_constraint> cached_value_constraints_;
+    };
+
+    // This is a helper class that wraps a value_constraint but caches the
+    // value of any target statistic and is notified whenever that statistic
+    // value changes.  This allows us to avoid recomputing the value of that
+    // target statistic.
+    struct updatable_value_constraint : stat_watcher {
+        updatable_value_constraint(
+            const std::pair<std::string, value_constraint> &p,
+            state *st,
+            stats_tracker &stats
+        )
+            : parent_constraint_( &p.second )
+            , parent_state_( st )
+            , field_name_( p.first ) {
+            const value_constraint &val = p.second;
+            if( val.equals_statistic_ ) {
+                cached_value_ = stats.value_of( *val.equals_statistic_ );
+                stats.add_watcher( *val.equals_statistic_, this );
+            }
+        }
+
+        const std::string &field_name() const {
+            return field_name_;
+        }
+
+        void new_value( const cata_variant &new_val, stats_tracker &stats ) override {
+            cached_value_ = new_val;
+            parent_state_->value_constraint_changed( stats );
+        }
+
+        bool permits( const cata_variant &v ) const {
+            const value_constraint &p = *parent_constraint_;
+            if( std::find( p.equals_any_.begin(), p.equals_any_.end(), v ) != p.equals_any_.end() ) {
+                return true;
+            }
+            // NOLINTNEXTLINE(readability-simplify-boolean-expr)
+            if( cached_value_ ) {
+                return *cached_value_ == v;
+            }
+            if( p.val_comp_ ) {
+                const int v_int = v.get<int>();
+                const int c_int = p.val_comp_->second.get<int>();
+                using comparator = value_constraint::comparator;
+                switch( p.val_comp_->first ) {
+                    case comparator::lt:
+                        return v_int < c_int;
+                    case comparator::lteq:
+                        return v_int <= c_int;
+                    case comparator::gteq:
+                        return v_int >= c_int;
+                    case comparator::gt:
+                        return v_int > c_int;
+                }
+            }
+            return false;
+        }
+
+        std::optional<cata_variant> cached_value_;
+        const value_constraint *parent_constraint_;
+        state *parent_state_;
+        std::string field_name_;
+    };
+
     using EventVector = std::vector<cata::event::data_type>;
 
-    EventVector match_and_transform( const cata::event::data_type &input_data,
-                                     stats_tracker &stats ) const {
+    EventVector match_and_transform(
+        const cata::event::data_type &input_data,
+        const std::list<updatable_value_constraint> &cached_value_constraints ) const {
+        cata_assert( cached_value_constraints.size() == constraints_.size() );
+
         EventVector result = { input_data };
         for( const std::pair<std::string, new_field> &p : new_fields_ ) {
             EventVector before_this_pass = std::move( result );
@@ -490,11 +567,10 @@ struct event_transformation_impl : public event_transformation::impl {
         }
 
         auto violates_constraints = [&]( const cata::event::data_type & data ) {
-            for( const std::pair<std::string, value_constraint> &p : constraints_ ) {
-                const std::string &field = p.first;
-                const value_constraint &constraint = p.second;
+            for( const updatable_value_constraint &constraint : cached_value_constraints ) {
+                const std::string &field = constraint.field_name();
                 const auto it = data.find( field );
-                if( it == data.end() || !constraint.permits( it->second, stats ) ) {
+                if( it == data.end() || !constraint.permits( it->second ) ) {
                     return true;
                 }
             }
@@ -513,13 +589,26 @@ struct event_transformation_impl : public event_transformation::impl {
         return result;
     }
 
-    event_multiset initialize( const event_multiset::summaries_type &input,
-                               stats_tracker &stats ) const {
+    std::list<updatable_value_constraint> make_cached_value_constraints(
+        state *st, stats_tracker &stats ) const {
+        // Need to use list here rather than vector because
+        // updatable_value_constraint is not movable.
+        std::list<updatable_value_constraint> result;
+        for( const auto &p : constraints_ ) {
+            result.emplace_back( p, st, stats );
+        }
+        return result;
+    }
+
+    event_multiset initialize(
+        const event_multiset::summaries_type &input,
+        const std::list<updatable_value_constraint> &cached_value_constraints,
+        stats_tracker & ) const {
         event_multiset result;
 
         for( const std::pair<const cata::event::data_type, event_summary> &p : input ) {
             cata::event::data_type event_data = p.first;
-            EventVector transformed = match_and_transform( event_data, stats );
+            EventVector transformed = match_and_transform( event_data, cached_value_constraints );
             for( cata::event::data_type &d : transformed ) {
                 result.add( { d, p.second } );
             }
@@ -527,8 +616,14 @@ struct event_transformation_impl : public event_transformation::impl {
         return result;
     }
 
+    event_multiset initialize(
+        const std::list<updatable_value_constraint> &cached_value_constraints,
+        stats_tracker &stats ) const {
+        return initialize( source_->get( stats ).counts(), cached_value_constraints, stats );
+    }
+
     event_multiset initialize( stats_tracker &stats ) const override {
-        return initialize( source_->get( stats ).counts(), stats );
+        return initialize( make_cached_value_constraints( nullptr, stats ), stats );
     }
 
     void check( const std::string &name ) const override {
@@ -559,44 +654,6 @@ struct event_transformation_impl : public event_transformation::impl {
             }
         }
     }
-
-    struct state : stats_tracker_multiset_state, event_multiset_watcher, stat_watcher {
-        state( const event_transformation_impl *trans, stats_tracker &stats ) :
-            transformation_( trans ),
-            data_( trans->initialize( stats ) ) {
-            trans->source_->add_watcher( stats, this );
-            for( const auto &p : trans->constraints_ ) {
-                if( p.second.equals_statistic_ ) {
-                    // TODO: we need a version of value_constraint that is
-                    // itself a watcher so that it can cache the statistic
-                    // value it cares about and not constantly recompute it.
-                    stats.add_watcher( *p.second.equals_statistic_, this );
-                }
-            }
-        }
-
-        void new_value( const cata_variant &, stats_tracker &stats ) override {
-            data_ = transformation_->initialize( stats );
-            stats.transformed_set_changed( transformation_->id_, data_ );
-        }
-
-        void event_added( const cata::event &e, stats_tracker &stats ) override {
-            EventVector transformed = transformation_->match_and_transform( e.data(), stats );
-            for( cata::event::data_type &d : transformed ) {
-                cata::event new_event( e.type(), e.time(), std::move( d ) );
-                data_.add( new_event );
-                stats.transformed_set_changed( transformation_->id_, new_event );
-            }
-        }
-
-        void events_reset( const event_multiset &new_value, stats_tracker &stats ) override {
-            data_ = transformation_->initialize( new_value.counts(), stats );
-            stats.transformed_set_changed( transformation_->id_, data_ );
-        }
-
-        const event_transformation_impl *transformation_;
-        event_multiset data_;
-    };
 
     std::unique_ptr<stats_tracker_state> watch( stats_tracker &stats ) const override {
         return std::make_unique<state>( this, stats );


### PR DESCRIPTION
#### Summary
Performance "Cache values of statistics in value constraints"

#### Purpose of change
Fixes #63903.

Previously, every time a value was compared to the value of some statistic in a value constraint, that statistic was recomputed from scratch.

This led to O(n^2) runtime, and potentially very slow load times for games (in particular, the achievement for revisiting your starting OMT was problematic).

#### Describe the solution
Instead, use the existing stats tracker infrastructure to cache the statistic value and automatically update the cached value whenever it changes, but not otherwise.

#### Describe alternatives you've considered
I did consider a different fix that would have made loads faster but not helped in-game performance.  This is better.

#### Testing
Now the example savegame from #63903 loads in a matter of seconds, rather than many minutes.

Unit tests still pass, and I verified that it's still possible to get the achievement for returning to the origin OMT.

#### Additional context
I noticed this bug long ago (hence the TODO in the code which I'm finally resolving).  Thanks to @Terrorforge for reminding me to actually fix it.