### PR TITLE
Change fur and faux fur tailoring to require Fabric Cutting 1 

### DIFF
--- a/data/json/requirements/tailoring.json
+++ b/data/json/requirements/tailoring.json
@@ -342,21 +342,21 @@
     "id": "tailoring_faux_fur",
     "type": "requirement",
     "//": "350g per unit. Crafting faux fur items, per 371 g of faux fur with rework; 21 g + excessive weight of material is wasted, producing faux fur patches and scraps.  Time needed is usually 40 minutes per unit if hand-stitching.",
-    "qualities": [ { "id": "SEW", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 }, { "id": "CUT_FINE", "level": 1 } ],
+    "qualities": [ { "id": "SEW", "level": 1 }, { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "sheet_faux_fur", 1 ] ], [ [ "filament", 7, "LIST" ] ] ]
   },
   {
     "id": "tailoring_faux_fur_patchwork",
     "type": "requirement",
     "//": "350g per unit. Crafting possibly-patchwork faux fur items, per 371 g of faux fur; 21 g + excessive weight of material is wasted, producing faux fur patches and scraps.  Time needed is usually 40 minutes per unit if hand-stitching (most of the time actually needed goes into making a patchwork sheet).",
-    "qualities": [ { "id": "SEW", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 }, { "id": "CUT_FINE", "level": 1 } ],
+    "qualities": [ { "id": "SEW", "level": 1 }, { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "sheet_faux_fur", 1 ], [ "sheet_faux_fur_patchwork", 1 ] ], [ [ "filament", 7, "LIST" ] ] ]
   },
   {
     "id": "tailoring_faux_fur_small",
     "type": "requirement",
     "//": "40g per unit. Crafting possibly-patchwork faux fur items, per 46 g of faux fur; 6 g + excessive weight of material is wasted, producing faux fur scraps.  Time needed is usually 25 minutes per unit if hand-stitching (most of the time actually needed goes into making a patchwork sheet).",
-    "qualities": [ { "id": "SEW", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 }, { "id": "CUT_FINE", "level": 1 } ],
+    "qualities": [ { "id": "SEW", "level": 1 }, { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "faux_fur", 1 ] ], [ [ "filament", 4, "LIST" ] ] ]
   },
   {
@@ -393,7 +393,7 @@
     "//": "250g per unit. Crafting fur items, per 372 g of fur; 122 g + excessive weight of material is wasted, producing fur patches as byproducts.  Time needed is usually 60 minutes per unit if hand-stitching for extra material processing time.",
     "qualities": [
       { "id": "SEW", "level": 1 },
-      { "id": "FABRIC_CUT", "level": 2 },
+      { "id": "FABRIC_CUT", "level": 1 },
       { "id": "LEATHER_AWL", "level": 1 },
       { "id": "CUT_FINE", "level": 1 }
     ],
@@ -405,7 +405,7 @@
     "//": "250g per unit. Crafting fur items, per 372 g of fur; 122 g + excessive weight of material is wasted, producing fur patches as byproducts.  Time needed is usually 60 minutes per unit if hand-stitching for extra material processing time.",
     "qualities": [
       { "id": "SEW", "level": 1 },
-      { "id": "FABRIC_CUT", "level": 2 },
+      { "id": "FABRIC_CUT", "level": 1 },
       { "id": "LEATHER_AWL", "level": 1 },
       { "id": "CUT_FINE", "level": 1 }
     ],
@@ -424,7 +424,7 @@
     "//": "35g per unit. Crafting either small or patchwork fur items, per 46 g of fur; 11 g + excessive weight of material is wasted, producing fur patches as byproducts.  Time needed is usually 15 minutes per unit if hand-stitching.",
     "qualities": [
       { "id": "SEW", "level": 1 },
-      { "id": "FABRIC_CUT", "level": 2 },
+      { "id": "FABRIC_CUT", "level": 1 },
       { "id": "LEATHER_AWL", "level": 1 },
       { "id": "CUT_FINE", "level": 1 }
     ],


### PR DESCRIPTION
Change fur tailoring requirements to require Fabric Cutting 1

#### Summary
Balance "Changes fur and faux fur tailoring to require Fabric Cutting 1 instead of 2"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently tailored fur clothing is locked behind Kevlar Shears, which prevents Innawoods or other non-technological characters from making fur clothing until they are well into an Iron-Age level of technology. This change allows characters who do not have access to Iron-Age technology to make tailored fur clothing. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change the tailoring requirements for fur (and faux fur) to only need Fabric Cutting 1.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Change the Bronze Shears (and Forged Shears and Shears) to have Fabric Cutting 2.

Add an additional level of Fabric Cutting (1 for cotton, synthetic cloth, Lycra, 2 for leather, fur, neoprene, 3 for Kevlar, Nomex). Scissors, X-Acto Knives, etc would have Level 1, Shears, Forged Shears, and Bronze Shears would have Level 2, and Kevlar Shears would have Level 3. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Change requirements in /requirements/tailoring.json so fur and faux fur requires Fabric Cutting 1. 

Spawn a character with pelts, tailoring supplies, and the requisite skills. 

Observe that all fur items now only require Fabric Cutting 1. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This change mostly impacts Innawoods characters who choose an Autumn or Winter start - for these characters freezing to death before being able to make decently warm clothing beyond a Fur Cloak is a major concern. 

Historically, tailored fur clothing appeared long before the advent of iron tools. See the clothing of Otzi the iceman, circa 3500 BCE. https://en.wikipedia.org/wiki/%C3%96tzi#/media/File:Archeoparc_-_Museum_%C3%96tzi_Kleidung.jpg

Fur-bearing pelts aren't appreciably harder to cut than leather. I hunt and had a piece of furred deerskin on hand, which I cut with a pair of regular Fiskars scissors. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->