### PR TITLE
Mouse hover hotkey regression

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3098,7 +3098,7 @@ item_location inventory_pick_selector::execute()
             if( highlight( input.entry->any_item() ) ) {
                 ui_manager::redraw();
             }
-            if( input.action == "SELECT" ) {
+            if( input.action == "SELECT" || input.action == "ANY_INPUT" ) {
                 return input.entry->any_item();
             }
         } else if( input.action == "ORGANIZE_MENU" ) {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3400,7 +3400,7 @@ std::pair<const item *, const item *> inventory_compare_selector::execute()
 
         if( input.entry != nullptr ) {
             highlight( input.entry->any_item() );
-            if( input.action == "SELECT" ) {
+            if( input.action == "SELECT" || input.action == "ANY_INPUT" ) {
                 toggle_entry( input.entry );
                 just_selected = input.entry;
             }
@@ -4006,7 +4006,7 @@ int inventory_examiner::execute()
             if( highlight( input.entry->any_item() ) ) {
                 ui_manager::redraw();
             }
-            if( input.action == "SELECT" ) {
+            if( input.action == "SELECT" || input.action == "ANY_INPUT" ) {
                 return cleanup();
             }
         }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3558,7 +3558,7 @@ void inventory_multiselector::on_input( const inventory_input &input )
 {
     if( input.entry != nullptr ) { // Single Item from mouse
         highlight( input.entry->any_item() );
-        if( input.action == "SELECT" ) {
+        if( input.action == "SELECT" || input.action == "ANY_INPUT" ) {
             toggle_entries( count );
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixed regression in inventory screens where pressing an item's hotkey does not work as expected"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixing #64857 , regression caused by #64632 , pressing an item's hotkey currently only highlights the item.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Screens now look for "ANY_INPUT" action when determining whether item passed in by input.entry should be selected.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded the game and tested each screen with an item assigned with a hotkey.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->