### PR TITLE
Add trap avoid json flag

### DIFF
--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -1453,7 +1453,8 @@
     "delete": {
       "reproduction": { "baby_egg": "egg_spider_web", "baby_count": 3, "baby_timer": 15 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
-    }
+    },
+    "trap_avoids": [ "tr_sinkhole" ]
   },
   {
     "id": "mon_spider_web",
@@ -1496,6 +1497,7 @@
     "anger_triggers": [ "PLAYER_WEAK", "PLAYER_CLOSE" ],
     "upgrades": { "half_life": 42, "into": "mon_spider_web_mega" },
     "zombify_into": "mon_meat_cocoon_small",
+    "trap_avoids": [ "tr_sinkhole" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "WEBWALK", "CLIMBS", "PATH_AVOID_FIRE", "PATH_AVOID_FALL" ]
   },
   {

--- a/doc/MONSTERS.md
+++ b/doc/MONSTERS.md
@@ -72,6 +72,7 @@ Property                 | Description
 `vision_day`             | (integer) Vision range in full daylight, with `50` being the typical maximum
 `vision_night`           | (integer) Vision range in total darkness, ex. coyote `5`, bear `10`, sewer rat `30`, flaming eye `40`
 `tracking_distance`      | (integer) Amount of tiles the monster will keep between itself and its current tracked enemy or followed leader. Defaults to `3`.
+`trap_avoids`            | (array of strings) trap_id of traps that are not triggered by this monster. Default behaviour is to trigger all traps.
 `luminance`              | (integer) Amount of light passively emitted by the monster, from `0-10`
 `death_drops`            | (string or item group) Item group to spawn when the monster dies
 `death_function`         | (array of strings) How the monster behaves on death. See JSON_FLAGS

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1045,7 +1045,7 @@ bool monster::avoid_trap( const tripoint & /* pos */, const trap &tr ) const
         return true;
     }
 
-    if( get_trap_avoids().count( tr.id ) > 0 ) {
+    if( type->trap_avoids.count( tr.id ) > 0 ) {
         return true;
     }
 
@@ -3594,9 +3594,4 @@ const pathfinding_settings &monster::get_pathfinding_settings() const
 std::set<tripoint> monster::get_path_avoid() const
 {
     return std::set<tripoint>();
-}
-
-const std::set<trap_str_id> &monster::get_trap_avoids() const
-{
-    return type->trap_avoids;
 }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -62,6 +62,7 @@
 #include "text_snippets.h"
 #include "translations.h"
 #include "trap.h"
+#include "type_id.h"
 #include "units.h"
 #include "viewer.h"
 #include "weakpoint.h"
@@ -1044,8 +1045,7 @@ bool monster::avoid_trap( const tripoint & /* pos */, const trap &tr ) const
         return true;
     }
 
-    std::vector<std::string> tavoids = get_trap_avoids();
-    if (std::find(tavoids.begin(), tavoids.end(), tr.id.str()) != tavoids.end()) {
+    if( get_trap_avoids().count( tr.id ) > 0 ) {
         return true;
     }
 
@@ -3596,7 +3596,7 @@ std::set<tripoint> monster::get_path_avoid() const
     return std::set<tripoint>();
 }
 
-std::vector<std::string> monster::get_trap_avoids() const
+const std::set<trap_str_id> &monster::get_trap_avoids() const
 {
     return type->trap_avoids;
 }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1043,6 +1043,12 @@ bool monster::avoid_trap( const tripoint & /* pos */, const trap &tr ) const
     if( digging() || flies() ) {
         return true;
     }
+
+    std::vector<std::string> tavoids = get_trap_avoids();
+    if (std::find(tavoids.begin(), tavoids.end(), tr.id.str()) != tavoids.end()) {
+        return true;
+    }
+
     return dice( 3, type->sk_dodge + 1 ) >= dice( 3, tr.get_avoidance() );
 }
 
@@ -3588,4 +3594,9 @@ const pathfinding_settings &monster::get_pathfinding_settings() const
 std::set<tripoint> monster::get_path_avoid() const
 {
     return std::set<tripoint>();
+}
+
+std::vector<std::string> monster::get_trap_avoids() const
+{
+    return type->trap_avoids;
 }

--- a/src/monster.h
+++ b/src/monster.h
@@ -575,7 +575,6 @@ class monster : public Creature
         void on_load();
 
         const pathfinding_settings &get_pathfinding_settings() const override;
-        const std::set<trap_str_id> &get_trap_avoids() const;
         std::set<tripoint> get_path_avoid() const override;
         // summoned monsters via spells
         void set_summon_time( const time_duration &length );

--- a/src/monster.h
+++ b/src/monster.h
@@ -575,7 +575,7 @@ class monster : public Creature
         void on_load();
 
         const pathfinding_settings &get_pathfinding_settings() const override;
-        std::vector<std::string> get_trap_avoids() const;
+        const std::set<trap_str_id> &get_trap_avoids() const;
         std::set<tripoint> get_path_avoid() const override;
         // summoned monsters via spells
         void set_summon_time( const time_duration &length );

--- a/src/monster.h
+++ b/src/monster.h
@@ -575,6 +575,7 @@ class monster : public Creature
         void on_load();
 
         const pathfinding_settings &get_pathfinding_settings() const override;
+        std::vector<std::string> get_trap_avoids() const;
         std::set<tripoint> get_path_avoid() const override;
         // summoned monsters via spells
         void set_summon_time( const time_duration &length );

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -33,6 +33,7 @@
 #include "pathfinding.h"
 #include "rng.h"
 #include "translations.h"
+#include "type_id.h"
 #include "units.h"
 #include "weakpoint.h"
 
@@ -438,6 +439,13 @@ void MonsterGenerator::finalize_mtypes()
         }
         if( mon.status_chance_multiplier < 0 ) {
             mon.status_chance_multiplier = 0;
+        }
+
+        // Check if trap_ids are valid
+        for( trap_str_id trap_avoid_id : mon.trap_avoids ) {
+            if( !trap_avoid_id.is_valid() ) {
+                debugmsg( "Invalid trap '%s'", trap_avoid_id.str() );
+            }
         }
 
         // Lower bound for hp scaling

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -778,7 +778,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     assign( jo, "armor_pure", armor_pure, strict, 0 );
     assign( jo, "armor_biological", armor_biological, strict, 0 );
 
-    optional( jo, was_loaded, "trap_avoids", trap_avoids, string_id_reader<trap> {} );
+    optional( jo, was_loaded, "trap_avoids", trap_avoids );
 
     if( !was_loaded ) {
         weakpoints_deferred.clear();

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -770,6 +770,16 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     assign( jo, "armor_pure", armor_pure, strict, 0 );
     assign( jo, "armor_biological", armor_biological, strict, 0 );
 
+    if ( jo.has_array("trap_avoids") ) {
+        for( const JsonValue entry : jo.get_array( "trap_avoids" ) ) {
+            if( entry.test_string() ) {
+                trap_avoids.push_back( entry.get_string() );
+            } else {
+                entry.throw_error( "array element is not a string." );
+            }
+        }
+    }
+
     if( !was_loaded ) {
         weakpoints_deferred.clear();
         weakpoints_deferred_inline.clear();

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -770,15 +770,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     assign( jo, "armor_pure", armor_pure, strict, 0 );
     assign( jo, "armor_biological", armor_biological, strict, 0 );
 
-    if ( jo.has_array("trap_avoids") ) {
-        for( const JsonValue entry : jo.get_array( "trap_avoids" ) ) {
-            if( entry.test_string() ) {
-                trap_avoids.push_back( entry.get_string() );
-            } else {
-                entry.throw_error( "array element is not a string." );
-            }
-        }
-    }
+    optional( jo, was_loaded, "trap_avoids", trap_avoids, string_id_reader<trap>{} );
 
     if( !was_loaded ) {
         weakpoints_deferred.clear();

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -778,7 +778,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     assign( jo, "armor_pure", armor_pure, strict, 0 );
     assign( jo, "armor_biological", armor_biological, strict, 0 );
 
-    optional( jo, was_loaded, "trap_avoids", trap_avoids, string_id_reader<trap>{} );
+    optional( jo, was_loaded, "trap_avoids", trap_avoids, string_id_reader<trap> {} );
 
     if( !was_loaded ) {
         weakpoints_deferred.clear();

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -347,7 +347,7 @@ struct mtype {
         weakpoint_families families;
 
         // Traps avoided by this monster
-        std::vector<std::string> trap_avoids;
+        std::set<trap_str_id> trap_avoids;
 
     private:
         std::vector<weakpoints_id> weakpoints_deferred;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -346,6 +346,9 @@ struct mtype {
         ::weakpoints weakpoints;
         weakpoint_families families;
 
+        // Traps avoided by this monster
+        std::vector<std::string> trap_avoids;
+
     private:
         std::vector<weakpoints_id> weakpoints_deferred;
         ::weakpoints weakpoints_deferred_inline;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add trap_avoids Json property to Monsters to control trap trigger"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Some monsters set up traps which can be triggered by themselves(e.g Web spinning spiders and sinkholes Fixes #54849) and sometimes it doesn't make sense for certain traps to be triggered by monsters(e.g ferals and cot trap haven't added that to this PR can be a separate change)
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Create a new mtype attribute(trap_avoids) which is a vector of strings(trap_ids). These are populated from the json files during world creation.

Check for trap_id in monster::avoid_trap method if exists trap not triggered(Normally this function avoids trap only for fliers and diggers)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Hardcode monsters to individual traps however this seems a more generic approach and with more possibilities.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added flags to monsters and made them walk through traps to see if they triggered them or not
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->