### PR TITLE
Corrects military shootout casing itemgroup

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -745,7 +745,7 @@
   },
   {
     "id": "ammo_casings_milspec",
-    "//": "Casings for setpieces implying military shootouts",
+    "//": "Casings for setpieces implying military shootouts by CQB folks.  Weirdness thrown in to account for trying to kill XEDRA/Extradimensionals.  No vehicular only stuff.",
     "type": "item_group",
     "subtype": "distribution",
     "entries": [

--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -750,12 +750,13 @@
     "subtype": "distribution",
     "entries": [
       { "item": "9mm_casing", "prob": 50, "count": [ 1, 8 ] },
-      { "item": "46mm_casing", "prob": 10, "count": [ 1, 8 ] },
+      { "item": "46mm_casing", "prob": 10, "count": [ 1, 50 ] },
+      { "item": "40x46mm_m118_casing", "prob": 5, "count": [ 1, 2 ] },
       { "item": "223_casing", "prob": 300, "count": [ 1, 30 ] },
-      { "item": "3006_casing", "prob": 50, "count": [ 1, 3 ] },
+      { "group": "nested_casing_223", "prob": 75, "count": [ 1, 100 ] },
       { "item": "762_51_casing", "prob": 25, "count": [ 1, 30 ] },
-      { "item": "762_casing", "prob": 25, "count": [ 1, 30 ] },
-      { "item": "50_casing", "prob": 25, "count": [ 1, 3 ] },
+      { "group": "nested_casing_308", "prob": 15, "count": [ 1, 50 ] },
+      { "item": "50_casing", "prob": 5, "count": [ 1, 3 ] },
       { "item": "shot_hull", "prob": 50, "count": [ 1, 3 ] }
     ]
   },
@@ -786,6 +787,20 @@
       [ "32_casing", 70 ],
       [ "30carbine_casing", 40 ]
     ]
+  },
+  {
+    "id": "nested_casing_223",
+    "type": "item_group",
+    "//": "SAW casing and linkage.",
+    "subtype": "collection",
+    "entries": [ { "item": "ammolink223" }, { "item": "223_casing" } ]
+  },
+  {
+    "id": "nested_casing_308",
+    "type": "item_group",
+    "//": "GPMG casings and linkage.",
+    "subtype": "collection",
+    "entries": [ { "item": "ammolink308" }, { "item": "762_51_casing" } ]
   },
   {
     "id": "ammo_casings_bulk",


### PR DESCRIPTION

#### Summary
Content "Adjusts Military Shootout Casings"

#### Purpose of change

The `ammo_casings_milspec` group is being used inside Labs, I think to employ military squads coming in and assaulting XEDRA locations. In this group were 30-06 and 7.62x39 casings, which would be incorrect for any military squad today. 

#### Describe the solution

Remove these two items from the group. Fluff the group a bit too while I'm at it - I added sub groups for belted machineguns, and  a few 40x46 grenade casings. No HMG's - can't shoulder fire those.

#### Describe alternatives you've considered

Only remove.

#### Testing

Loaded game. Tested itemgroup via debug.

#### Additional context

None.