### PR TITLE
Remove SMG type from repeating crossbow

### DIFF
--- a/data/json/items/ranged/crossbows.json
+++ b/data/json/items/ranged/crossbows.json
@@ -534,7 +534,7 @@
     "price": 324000,
     "material": [ "steel", "wood" ],
     "flags": [ "FIRE_TWOHAND", "PRIMITIVE_RANGED_WEAPON", "TRADER_AVOID" ],
-    "skill": "smg",
+    "skill": "rifle",
     "ammo": [ "bolt" ],
     "weight": "3628 g",
     "volume": "2500 ml",


### PR DESCRIPTION
#### Summary
Content "Makes Repeating Crossbow not a SMG"

#### Purpose of change
A repeating crossbow is not capable of the hundreds of RPM that the SMG skills is intended to help you mitigate, and is more in line with the RPM that are achievable from some rifles.

#### Describe the solution

Bring the Repeating Crossbow in line with most other crossbows in type by switching it to the rifle type, which is a more reasonable approximation of skillset.
#### Describe alternatives you've considered

A whole new skill...
a new fantastic skill for you
With me to tell you "no"
you'll cho ko know
that the SMG isn't 
the right skill

#### Testing

Loaded game, Loaded the crossbow. 

#### Additional context
None.