### PR TITLE
Update vcpkg configuration, again

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -71,21 +71,15 @@ jobs:
         echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
       shell: cmd
 
-    - name: Restore artifacts, or run vcpkg, build and cache artifacts
-      uses: lukka/run-vcpkg@v10
+    - name: Install stable CMake
+      uses: lukka/get-cmake@latest
+
+    - name: Install vcpkg
+      uses: lukka/run-vcpkg@v11
       id: runvcpkg
       with:
-        # run-vcpkg tries to hash vcpkg.json but complans if it finds more than one.
-        # That said, we also have our custom vcpkg_triplets to hash, so we keep everything the same.
-        appendedCacheKey: ${{ hashFiles( 'msvc-full-features/vcpkg.json', 'msvc-object_creator/vcpkg.json', '.github/vcpkg_triplets/**', '.github/vckg_ports/**' ) }}
-        # Rev this value to drop cache without changing vcpkg commit
-        prependedCacheKey: v1-x64-full
         vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-        # We have to use at least this version of vcpkg to include fixes for yasm-tool's
-        # availability only as an x86 host tool. Keep it in sync with the builtin-baseline
-        # field in vcpkg.json. Caching happens as a post-action which runs at the end of
-        # the whole workflow, after vcpkg install happens during msbuild run.
-        vcpkgGitCommitId: 'd08e708c2111893da3cc7e49b597ee4654c8076e'
+        vcpkgGitCommitId: '5b1214315250939257ef5d62ecdcbca18cf4fb1c'
 
     - name: Integrate vcpkg
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,23 +190,19 @@ jobs:
         run: |
           git clone --depth=1 --shallow-submodules --recurse-submodules https://github.com/Fris0uman/CDDA-Soundpacks '${{ github.workspace }}/CDDA-Soundpacks'
           mv '${{ github.workspace }}/CDDA-Soundpacks/sound/CC-Sounds' '${{ github.workspace }}/data/sound'
+      - name: Install dependencies (windows msvc) (0/3)
+        if: runner.os == 'Windows'
+        uses: lukka/get-cmake@latest
       - name: Install dependencies (windows msvc) (1/3)
         if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Install dependencies (windows msvc) (2/3)
         if: runner.os == 'Windows'
-        uses: lukka/run-vcpkg@v10
+        uses: lukka/run-vcpkg@v11
         id: runvcpkg
         with:
-          appendedCacheKey: ${{ hashFiles( 'msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/**', '.github/vckg_ports/**' ) }}
-          # Rev this value to drop cache without changing vcpkg commit
-          prependedCacheKey: v1-${{ matrix.arch }}
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          # We have to use at least this version of vcpkg to include fixes for yasm-tool's
-          # availability only as an x86 host tool. Keep it in sync with the builtin-baseline
-          # field in vcpkg.json. Caching happens as a post-action which runs at the end of
-          # the whole workflow, after vcpkg install happens during msbuild run.
-          vcpkgGitCommitId: 'd08e708c2111893da3cc7e49b597ee4654c8076e'
+          vcpkgGitCommitId: '5b1214315250939257ef5d62ecdcbca18cf4fb1c'
       - name: Install dependencies (windows msvc) (3/3)
         if: runner.os == 'Windows'
         run: |

--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -23,7 +23,7 @@ Steps from current guide were tested on Windows 10 (64 bit), Visual Studio 2019 
 
 2. Install `Git for Windows` (installer can be downloaded from [Git homepage](https://git-scm.com/)).
 
-3. Install and configure `vcpkg`. If you already have `vcpkg` installed, you should update it to at least commit `d08e708c2111893da3cc7e49b597ee4654c8076e` (the most recent tested good revision) and rerun `.\bootstrap-vcpkg.bat` as described:
+3. Install and configure `vcpkg`. If you already have `vcpkg` installed, you should update it to at least commit `5b1214315250939257ef5d62ecdcbca18cf4fb1c` (the most recent tested good revision) and rerun `.\bootstrap-vcpkg.bat` as described:
 
 ***WARNING: It is important that, wherever you decide to clone this repo, the path does not include whitespace. That is, `C:/dev/vcpkg` is acceptable, but `C:/dev test/vcpkg` is not.***
 

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -9,7 +9,7 @@
         },
         {
           "name": "sdl2-mixer",
-          "features": [ "libflac", "mpg123", "libmodplug", "libvorbis" ]
+          "features": [ "libflac", "mpg123", "libmodplug" ]
         },
         "sdl2-ttf"
     ],

--- a/msvc-object_creator/vcpkg.json
+++ b/msvc-object_creator/vcpkg.json
@@ -6,7 +6,7 @@
         "sdl2-image",
         {
           "name": "sdl2-mixer",
-          "features": [ "libflac", "mpg123", "libmodplug", "libvorbis" ]
+          "features": [ "libflac", "mpg123", "libmodplug" ]
         },
         "sdl2-ttf",
         "qt5-base"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Another package has evaporated from the internet, prompting us to need to update vcpkg again. Coincidentally, the `run-vcpkg` action recently updated and now uses built-in vcpkg caching machinery for build caching instead of its ad-hoc mechanism. We should use that because it'll be more granular and let us share packages across all three Windows builds we do (cdda, object creator and cdda release). To successfully maintain a consistent cachekey, though, we need to install a consistent version of cmake (as the cmake version feeds into the cachekey for many packages).
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use `lukka/get-cmake` for a consistent cmake in the builds. Update `lukka/run-vcpkg` to v11 (implicitly .1 now that it is setup to automatically enable vcpkg's builtin caching). Update the vcpkg commit hash to the minimum version v11 needs.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Pushed to my repo, got successful builds.
Pushed again to my repo, got some cache hits but not enough. Investigation showed it was due to a differing cmake version.
Pushed to my repo with get-cmake, cache keys were consistent again.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Example inconsistent cache key output:
Workflow 1:
```
         [DEBUG] <abientries for vcpkg-cmake-config:x64-windows-static>
         [DEBUG]   cmake|3.26.2
         [DEBUG]   copyright|04b60f99a43bfd7fefdc8364b24aac704a2160cef969b75ba6a38b62dc4c4b70
         [DEBUG]   features|core
         [DEBUG]   portfile.cmake|832b34e63f5af41ad1b2e4aa79c5bfa507a005b120b51548e674accc706837d7
         [DEBUG]   ports.cmake|47a3510fcec56fae26f4fb082afd972a70a04e26efa73e2de69123139500f02d
         [DEBUG]   post_build_checks|2
         [DEBUG]   powershell|7.2.10
         [DEBUG]   triplet|x64-windows-static
         [DEBUG]   triplet_abi|970059e5d3062703dfb6c76d85edd3e4e131a15053dda64e3c633f1dc770c322-2b9f5a18de013332e7068fafe850651fd91434ba2a08aae552b8565a2236f81b-d8af9437be18a355155567aff5acd748ca04f5ff
         [DEBUG]   vcpkg-port-config.cmake|72bc3093337e633bdd19fe5d4dd1f38ca1918def49608d676a9c98c686d38b1e
         [DEBUG]   vcpkg.json|4ffbabc2feab69abd21267f57669ef5e404bcbfa5ab6d93234374d98f5ff1864
         [DEBUG]   vcpkg_cmake_config_fixup.cmake|f92905382d90e37fa2addd96becce31f5075175196b117de6dd997a4ac1d6d06
         [DEBUG]   vcpkg_list|f5de3ebcbc40a4db90622ade9aca918e2cf404dc0d91342fcde457d730e6fa29
         [DEBUG] </abientries>
         [DEBUG] Trying to hash D:\a\Cataclysm-DDA\b\vcpkg\buildtrees\vcpkg-cmake-config\x64-windows-static.vcpkg_abi_info.txt
         [DEBUG] D:\a\Cataclysm-DDA\b\vcpkg\buildtrees\vcpkg-cmake-config\x64-windows-static.vcpkg_abi_info.txt has hash 4322594241aaee227c8b37b054dabc2b7e72226f698a6cff360dfd1739b99539
```
Workflow 2:
```
         [DEBUG] <abientries for vcpkg-cmake-config:x64-windows-static>
         [DEBUG]   cmake|3.26.1
         [DEBUG]   copyright|04b60f99a43bfd7fefdc8364b24aac704a2160cef969b75ba6a38b62dc4c4b70
         [DEBUG]   features|core
         [DEBUG]   portfile.cmake|832b34e63f5af41ad1b2e4aa79c5bfa507a005b120b51548e674accc706837d7
         [DEBUG]   ports.cmake|47a3510fcec56fae26f4fb082afd972a70a04e26efa73e2de69123139500f02d
         [DEBUG]   post_build_checks|2
         [DEBUG]   powershell|7.2.10
         [DEBUG]   triplet|x64-windows-static
         [DEBUG]   triplet_abi|970059e5d3062703dfb6c76d85edd3e4e131a15053dda64e3c633f1dc770c322-2b9f5a18de013332e7068fafe850651fd91434ba2a08aae552b8565a2236f81b-d8af9437be18a355155567aff5acd748ca04f5ff
         [DEBUG]   vcpkg-port-config.cmake|72bc3093337e633bdd19fe5d4dd1f38ca1918def49608d676a9c98c686d38b1e
         [DEBUG]   vcpkg.json|4ffbabc2feab69abd21267f57669ef5e404bcbfa5ab6d93234374d98f5ff1864
         [DEBUG]   vcpkg_cmake_config_fixup.cmake|f92905382d90e37fa2addd96becce31f5075175196b117de6dd997a4ac1d6d06
         [DEBUG]   vcpkg_list|f5de3ebcbc40a4db90622ade9aca918e2cf404dc0d91342fcde457d730e6fa29
         [DEBUG] </abientries>
         [DEBUG] Trying to hash D:\a\Cataclysm-DDA\b\vcpkg\buildtrees\vcpkg-cmake-config\x64-windows-static.vcpkg_abi_info.txt
         [DEBUG] D:\a\Cataclysm-DDA\b\vcpkg\buildtrees\vcpkg-cmake-config\x64-windows-static.vcpkg_abi_info.txt has hash 36facd654b73ffd6ae67d9f5cfee5dddd61f93509a61a31d499a734e643a3d29
```
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->