### PR TITLE
Validate main_tool to prevent some CTD

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2179,7 +2179,6 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
     if( !act->targets.empty() ) {
         ploc = act->targets.data();
     }
-        
     item &main_tool = !w_hack.init( *act ) ?
                       ploc ?
                       **ploc : you->i_at( act->index ) : w_hack.get_item();

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2179,8 +2179,7 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
     if( !act->targets.empty() ) {
         ploc = act->targets.data();
     }
-    item *main_tool = &( !w_hack.init( *act ) ?
-                         ploc ?
+    item *main_tool = &( !w_hack.init( *act ) ? ploc ?
                          **ploc : you->i_at( act->index ) : w_hack.get_item() );
     if( main_tool == nullptr ) {
         debugmsg( "Empty main tool for repair" );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2179,11 +2179,15 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
     if( !act->targets.empty() ) {
         ploc = act->targets.data();
     }
-
+        
     item &main_tool = !w_hack.init( *act ) ?
                       ploc ?
                       **ploc : you->i_at( act->index ) : w_hack.get_item();
-
+    if( &main_tool == nullptr ) {
+        debugmsg( "Empty main tool for repair" );
+        act->set_to_null();
+        return;
+    }
     item *used_tool = main_tool.get_usable_item( iuse_name_string );
     if( used_tool == nullptr ) {
         debugmsg( "Lost tool used for long repair" );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2179,16 +2179,16 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
     if( !act->targets.empty() ) {
         ploc = act->targets.data();
     }
-        
-    item &main_tool = !w_hack.init( *act ) ?
-                      ploc ?
-                      **ploc : you->i_at( act->index ) : w_hack.get_item();
-    if( &main_tool == nullptr ) {
+
+    item *main_tool = &( !w_hack.init( *act ) ?
+                         ploc ?
+                         **ploc : you->i_at( act->index ) : w_hack.get_item() );
+    if( main_tool == nullptr ) {
         debugmsg( "Empty main tool for repair" );
         act->set_to_null();
         return;
     }
-    item *used_tool = main_tool.get_usable_item( iuse_name_string );
+    item *used_tool = main_tool->get_usable_item( iuse_name_string );
     if( used_tool == nullptr ) {
         debugmsg( "Lost tool used for long repair" );
         act->set_to_null();
@@ -2279,7 +2279,7 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
 
     // target selection and validation.
     while( act->targets.size() < 2 ) {
-        item_location item_loc = game_menus::inv::repair( *you, actor, &main_tool );
+        item_location item_loc = game_menus::inv::repair( *you, actor, main_tool );
 
         if( item_loc == item_location::nowhere ) {
             you->add_msg_if_player( m_info, _( "Never mind." ) );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2179,7 +2179,8 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
     if( !act->targets.empty() ) {
         ploc = act->targets.data();
     }
-    item *main_tool = &( !w_hack.init( *act ) ? ploc ?
+    item *main_tool = &( !w_hack.init( *act ) ?
+                         ploc ?
                          **ploc : you->i_at( act->index ) : w_hack.get_item() );
     if( main_tool == nullptr ) {
         debugmsg( "Empty main tool for repair" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Less crash is better.

When the tool used for repair gets `item_location lost its target item during a save/load cycle` error, it can lead to CTD when loading the save. This is non-ideal, because this doesn't provide a valid reason for the crash, and players will be unable to get into their saves.

 Example: load the save file provided by #64447, in current experimental.

Also in #63740 when the repair activity's tool is not found, game will also crash.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

In repair_item_finish(), validate main_tool before continuing.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This is a mitigation for #63740 and for **loading**  #64447. It won't address the real problems, just to make them less severe, mentally and physically.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->