### PR TITLE
Renders the lighthouse truly safe and removes the lake cabin from the safe place scenario.

### DIFF
--- a/data/json/mapgen/lake_buildings/cabin_lake.json
+++ b/data/json/mapgen/lake_buildings/cabin_lake.json
@@ -95,7 +95,7 @@
           { "item": "dishes_dining", "chance": 10, "repeat": [ 1, 2 ] }
         ]
       },
-      "place_monsters": [ { "monster": "GROUP_BEACH", "x": [ 1, 22 ], "y": [ 1, 22 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 1, 22 ], "y": [ 1, 22 ], "density": 0.1 } ]
     }
   },
   {
@@ -205,7 +205,7 @@
         "d": { "item": "fishing_items", "chance": 5, "repeat": [ 1, 2 ] },
         "M": { "item": "stash_wood", "chance": 100, "repeat": [ 6, 10 ] }
       },
-      "place_monsters": [ { "monster": "GROUP_BEACH", "x": [ 10, 22 ], "y": [ 15, 22 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 10, 22 ], "y": [ 15, 22 ], "density": 0.1 } ]
     }
   },
   {

--- a/data/json/mapgen/lake_buildings/lighthouse.json
+++ b/data/json/mapgen/lake_buildings/lighthouse.json
@@ -87,8 +87,7 @@
           { "item": "dry_goods", "chance": 30, "repeat": [ 1, 2 ] },
           { "item": "preserved_food", "chance": 30, "repeat": [ 1, 2 ] }
         ]
-      },
-      "place_monsters": [ { "monster": "GROUP_BEACH", "x": [ 1, 22 ], "y": [ 1, 22 ], "density": 0.1 } ]
+      }
     }
   },
   {

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -106,7 +106,6 @@
       "sloc_lmoe",
       "sloc_horse_ranch",
       "sloc_lighthouse_ground",
-      "sloc_cabin_lake",
       "sloc_lodge_ground",
       "sloc_freshwater_research_station",
       "sloc_light_industry_scen"


### PR DESCRIPTION
#### Summary
Bugfixes "fixes #64758 by removing enemy spawns from the lighthouse, and removing the lake cabin from the safe place scenario."
#### Purpose of change
Issue #64758 pointed out that zombies were spawning at the lighthouse and lake cabin locations, despite them being starting locations for the safe place scenario.
#### Describe the solution
As recommended in the PR itself, I removed zombie spawns from the lighthouse locations, rendering them completely devoid of enemies. Apart from this, I removed the lake cabin from the starting list of possible locations for the safe place scenario, as I felt that zombie spawns within the property made sense and did not deserve removal. In addition, I changed the zombie groups within the latter area to pull from the standard zombie group rather than the beach group, as a bunch of randos tromping about somebody’s private home in their swimming gear didn’t make the greatest amount of sense in the world.
#### Describe alternatives you've considered
1.	Using EOCs to remove enemies from the scenario location upon game start would be a far more elegant solution; however, I am not aware of how one would go about implementing such an EOC nor if removing enemies is even possible in the first place.
2.	It was suggested to me that a boarded-up or safe variant of these two locations could be created for use by the scenario, which is a solution that might merit further thought.
#### Testing
The PR is a simple line removal, so no issues should be forthcoming.
#### Additional context
consult issue #64758 for the original issue.
