### PR TITLE
Item Use EOC Adjustments - Alternate snippet spam fix

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -394,6 +394,13 @@
       "ELECTRICSTORAGE",
       "PORTABLE_GAME",
       {
+        "type": "effect_on_conditions",
+        "menu_text": "Dig into local files and logs",
+        "description": "You can take a look at the local files stored on this laptop.",
+        "need_charges_msg": "The laptop's batteries need more charge.",
+        "effect_on_conditions": [ "EOC_READ_LOCAL_FILES" ]
+      },
+      {
         "ammo_scale": 0,
         "target": "laptop",
         "msg": "You stop lighting up the screen.",
@@ -619,6 +626,13 @@
       "EINKTABLETPC",
       "EBOOKSAVE",
       "EBOOKREAD",
+      {
+        "type": "effect_on_conditions",
+        "menu_text": "Dig into local files and logs",
+        "description": "You can take a look at the local files stored on this smartphone.",
+        "need_charges_msg": "The smartphone's charge is too low.",
+        "effect_on_conditions": [ "EOC_READ_LOCAL_FILES" ]
+      },
       {
         "ammo_scale": 0,
         "target": "smart_phone",

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4765,9 +4765,13 @@ void effect_on_conditons_actor::info( const item &, std::vector<iteminfo> &dump 
     dump.emplace_back( "DESCRIPTION", description );
 }
 
-std::optional<int> effect_on_conditons_actor::use( Character &p, item &it, bool,
+std::optional<int> effect_on_conditons_actor::use( Character &p, item &it, bool t,
         const tripoint & ) const
 {
+    if( t ) {
+        return std::nullopt;
+    }
+
     Character *char_ptr = nullptr;
     if( avatar *u = p.as_avatar() ) {
         char_ptr = u;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4755,9 +4755,18 @@ std::unique_ptr<iuse_actor> effect_on_conditons_actor::clone() const
 void effect_on_conditons_actor::load( const JsonObject &obj )
 {
     description = obj.get_string( "description" );
+    obj.read( "menu_text", menu_text );
     for( JsonValue jv : obj.get_array( "effect_on_conditions" ) ) {
         eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
     }
+}
+
+std::string effect_on_conditons_actor::get_name() const
+{
+    if( !menu_text.empty() ) {
+        return menu_text.translated();
+    }
+    return iuse_actor::get_name();
 }
 
 void effect_on_conditons_actor::info( const item &, std::vector<iteminfo> &dump ) const

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1103,6 +1103,7 @@ class effect_on_conditons_actor : public iuse_actor
     public:
         std::vector<effect_on_condition_id> eocs;
         std::string description;
+        translation menu_text;
         explicit effect_on_conditons_actor( const std::string &type = "effect_on_conditions" ) : iuse_actor(
                 type ) {}
 
@@ -1110,6 +1111,7 @@ class effect_on_conditons_actor : public iuse_actor
         void load( const JsonObject &obj ) override;
         std::optional<int> use( Character &p, item &it, bool, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
+        std::string get_name() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };
 #endif // CATA_SRC_IUSE_ACTOR_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #64858. #64904 has already been merged as a fix for it, but that solution removes snippet reading from lit devices; this alternative solution prevents the spam while also letting you read lit devices. I also added menu_text functionality so the device menu shows "Dig into local files and logs" as [GuardianDll intended](https://github.com/CleverRaven/Cataclysm-DDA/pull/63565/files#r1155100174) instead of "Activate item".
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This fixes the issue on the C++ side by adding an early exit from the iuse if it's being called via active item processing, as is done in a number of other iuse actors. The EOC iuse can only use activation EOCs so it shouldn't be calling it every turn anyway.

For the menu_text I gave it the appropriate code from iuse_transform, which is the only iuse that actually implements menu_text.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Leaving the merged solution lie.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added the snippet iuse back to the items, saw that the spam bug was back. Did my code changes, saw that it was fixed. Also saw that the menu text changes. Spawned other items with iuse EOC to confirm they load properly and just show the default "Activate item".
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->