### PR TITLE
Move damage indicators to json

### DIFF
--- a/data/core/damage_indicators.json
+++ b/data/core/damage_indicators.json
@@ -1,0 +1,44 @@
+[
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DAMAGE_INDICATOR_LEVEL_0",
+    "info": "Damage indicator string to show for damage level 0",
+    "stype": "string_input",
+    "value": "<color_c_green>++</color>"
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DAMAGE_INDICATOR_LEVEL_1",
+    "info": "Damage indicator string to show for damage level 1",
+    "stype": "string_input",
+    "value": "<color_c_light_green>||</color>"
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DAMAGE_INDICATOR_LEVEL_2",
+    "info": "Damage indicator string to show for damage level 2",
+    "stype": "string_input",
+    "value": "<color_c_yellow>|\\</color>"
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DAMAGE_INDICATOR_LEVEL_3",
+    "info": "Damage indicator string to show for damage level 3",
+    "stype": "string_input",
+    "value": "<color_c_light_red>|.</color>"
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DAMAGE_INDICATOR_LEVEL_4",
+    "info": "Damage indicator string to show for damage level 4",
+    "stype": "string_input",
+    "value": "<color_c_red>\\.</color>"
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DAMAGE_INDICATOR_LEVEL_5",
+    "info": "Damage indicator string to show for damage level 5",
+    "stype": "string_input",
+    "value": "<color_c_dark_gray>XX</color>"
+  }
+]

--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -24,6 +24,11 @@ int pixel_minimap_g;
 int pixel_minimap_b;
 int pixel_minimap_a;
 
+namespace cata::options
+{
+std::vector<std::string> damage_indicators;
+} // namespace cata::options
+
 #ifndef CATA_IN_TOOL
 error_log_format_t error_log_format = error_log_format_t::human_readable;
 check_plural_t check_plural = check_plural_t::certain;

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -1,6 +1,9 @@
 #ifndef CATA_SRC_CACHED_OPTIONS_H
 #define CATA_SRC_CACHED_OPTIONS_H
 
+#include <string>
+#include <vector>
+
 // A collection of options which are accessed frequently enough that we don't
 // want to pay the overhead of a string lookup each time one is tested.
 // They should be updated when the corresponding option is changed (in
@@ -26,6 +29,11 @@ extern int pixel_minimap_r;
 extern int pixel_minimap_g;
 extern int pixel_minimap_b;
 extern int pixel_minimap_a;
+
+namespace cata::options
+{
+extern std::vector<std::string> damage_indicators;
+} // namespace cata::options
 
 // test_mode is not a regular game option; it's true when we are running unit
 // tests.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8701,46 +8701,9 @@ item::armor_status item::damage_armor_transforms( damage_unit &du ) const
     return armor_status::UNDAMAGED;
 }
 
-nc_color item::damage_color() const
+std::string item::damage_indicator() const
 {
-    switch( damage_level() ) {
-        case 0:
-            return c_green;
-        case 1:
-            return c_light_green;
-        case 2:
-            return c_yellow;
-        case 3:
-            return c_light_red;
-        case 4:
-            return c_red;
-        case 5:
-            return c_dark_gray;
-        default:
-            debugmsg( "damage_level returned unexpected value %d", damage_level() );
-            return c_dark_gray;
-    }
-}
-
-std::string item::damage_symbol() const
-{
-    switch( damage_level() ) {
-        case 0:
-            return _( R"(++)" );
-        case 1:
-            return _( R"(||)" );
-        case 2:
-            return _( R"(|\)" );
-        case 3:
-            return _( R"(|.)" );
-        case 4:
-            return _( R"(\.)" );
-        case 5:
-            return _( R"(XX)" );
-        default:
-            debugmsg( "damage_level returned unexpected value %d", damage_level() );
-            return _( R"(??)" ); // negative damage is invalid
-    }
+    return cata::options::damage_indicators[damage_level()];
 }
 
 std::string item::durability_indicator( bool include_intact ) const
@@ -8765,7 +8728,7 @@ std::string item::durability_indicator( bool include_intact ) const
             }
         }
     } else if( get_option<bool>( "ITEM_HEALTH_BAR" ) ) {
-        outputstring = colorize( damage_symbol(), damage_color() ) + degradation_symbol() + "\u00A0";
+        outputstring = damage_indicator() + degradation_symbol() + "\u00A0";
     } else {
         outputstring = string_format( "%s ", get_base_material().dmg_adj( damage_level() ) );
         if( include_intact && outputstring == " " ) {

--- a/src/item.h
+++ b/src/item.h
@@ -1357,11 +1357,8 @@ class item : public visitable
          */
         armor_status damage_armor_transforms( damage_unit &du ) const;
 
-        /** Provide color for UI display dependent upon current item damage level */
-        nc_color damage_color() const;
-
-        /** Provide prefix symbol for UI display dependent upon current item damage level */
-        std::string damage_symbol() const;
+        // @return colorize()-ed damage indicator as string, e.g. "<color_green>++</color>"
+        std::string damage_indicator() const;
 
         /**
          * Provides a prefix for the durability state of the item. with ITEM_HEALTH_BAR enabled,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3817,7 +3817,7 @@ std::string options_manager::migrateOptionValue( const std::string &name,
     return iter_val != iter->second.second.end() ? iter_val->second : val;
 }
 
-static void update_options_cache()
+void options_manager::update_options_cache()
 {
     // cache to global due to heavy usage.
     trigdist = ::get_option<bool>( "CIRCLEDIST" );
@@ -3831,7 +3831,7 @@ static void update_options_cache()
 
     // if the tilesets are identical don't duplicate
     use_far_tiles = ::get_option<bool>( "USE_DISTANT_TILES" ) ||
-                    get_option<std::string>( "TILES" ) == get_option<std::string>( "DISTANT_TILES" );
+                    ::get_option<std::string>( "TILES" ) == ::get_option<std::string>( "DISTANT_TILES" );
     use_tiles_overmap = ::get_option<bool>( "USE_OVERMAP_TILES" );
     log_from_top = ::get_option<std::string>( "LOG_FLOW" ) == "new_top";
     message_ttl = ::get_option<int>( "MESSAGE_TTL" );
@@ -3840,6 +3840,15 @@ static void update_options_cache()
     fov_3d_z_range = ::get_option<int>( "FOV_3D_Z_RANGE" );
     keycode_mode = ::get_option<std::string>( "SDL_KEYBOARD_MODE" ) == "keycode";
     use_pinyin_search = ::get_option<bool>( "USE_PINYIN_SEARCH" );
+
+    cata::options::damage_indicators.clear();
+    for( int i = 0; i < 6; i++ ) {
+        const std::string opt_name = "DAMAGE_INDICATOR_LEVEL_" + std::to_string( i );
+        const std::string val = ::has_option( opt_name )
+                                ? ::get_option<std::string>( opt_name )
+                                : "<color_pink>\?\?</color>";
+        cata::options::damage_indicators.emplace_back( val );
+    }
 }
 
 bool options_manager::save() const

--- a/src/options.h
+++ b/src/options.h
@@ -215,6 +215,9 @@ class options_manager
         std::string migrateOptionName( const std::string &name ) const;
         std::string migrateOptionValue( const std::string &name, const std::string &val ) const;
 
+        // updates the caches in options_cache.h
+        static void update_options_cache();
+
         /**
          * Returns a copy of the options in the "world default" page. The options have their
          * current value, which acts as the default for new worlds.
@@ -419,7 +422,6 @@ struct option_slider {
         static void finalize_all();
         static void check_consistency();
         void load( const JsonObject &jo, const std::string &src );
-        void finalize();
         void check() const;
         static const std::vector<option_slider> &get_all();
 
@@ -471,8 +473,6 @@ struct option_slider {
         int random_level() const;
 };
 
-bool use_narrow_sidebar(); // short-circuits to on if terminal is too small
-
 /** A mapping(string:string) that stores all tileset values.
  * Firsts string is tileset NAME from config.
  * Second string is directory that contain tileset.
@@ -485,6 +485,11 @@ extern std::map<std::string, cata_path> TILESETS;
 extern std::map<std::string, cata_path> SOUNDPACKS;
 
 options_manager &get_options();
+
+inline bool has_option( const std::string &name )
+{
+    return get_options().has_option( name );
+}
 
 template<typename T>
 inline T get_option( const std::string &name )

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -157,8 +157,7 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who, const std::str
 
     // If part is broken, it will be destroyed and references invalidated
     std::string partname = pt.name( false );
-    const std::string startdurability = colorize( pt.get_base().damage_symbol(),
-                                        pt.get_base().damage_color() );
+    const std::string startdurability = pt.get_base().damage_indicator();
     bool wasbroken = pt.is_broken();
     if( wasbroken ) {
         const units::angle dir = pt.direction;

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -123,8 +123,7 @@ std::string vehicle_part::name( bool with_prefix ) const
     }
 
     if( with_prefix ) {
-        res.insert( 0, colorize( base.damage_symbol(),
-                                 base.damage_color() ) + base.degradation_symbol() + " " );
+        res.insert( 0, base.damage_indicator() + base.degradation_symbol() + " " );
     }
     return res;
 }

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -2023,6 +2023,7 @@ void load_external_option( const JsonObject &jo )
     if( jo.has_member( "info" ) ) {
         jo.get_string( "info" );
     }
+    options_manager::update_options_cache();
 }
 
 mod_manager &worldfactory::get_mod_manager()

--- a/tests/degradation_test.cpp
+++ b/tests/degradation_test.cpp
@@ -48,21 +48,20 @@ static float get_avg_degradation( const itype_id &it, int count, int damage )
     return deg / count;
 }
 
-TEST_CASE( "Damage level thresholds", "[item][damage_level]" )
+TEST_CASE( "Damage indicator thresholds", "[item][damage_level]" )
 {
     struct damage_level_threshold {
         int min_damage;
         int max_damage;
-        std::string expect_symbol;
-        nc_color expect_color;
+        std::string expect_indicator;
     };
     const std::vector<damage_level_threshold> thresholds {
-        {    0,    0, R"(++)", c_green       },
-        {    1,  999, R"(||)", c_light_green },
-        { 1000, 1999, R"(|\)", c_yellow      },
-        { 2000, 2999, R"(|.)", c_light_red   },
-        { 3000, 3999, R"(\.)", c_red         },
-        { 4000, 4000, R"(XX)", c_dark_gray   },
+        {    0,    0, "<color_c_green>++</color>" },
+        {    1,  999, "<color_c_light_green>||</color>" },
+        { 1000, 1999, "<color_c_yellow>|\\</color>" },
+        { 2000, 2999, "<color_c_light_red>|.</color>" },
+        { 3000, 3999, "<color_c_red>\\.</color>" },
+        { 4000, 4000, "<color_c_dark_gray>XX</color>" },
     };
     item it( itype_test_baseball );
     CHECK( it.damage() == 0 );
@@ -71,14 +70,12 @@ TEST_CASE( "Damage level thresholds", "[item][damage_level]" )
         it.set_damage( dmg );
         CHECK( it.damage() == dmg );
         CAPTURE( it.damage() );
-        CAPTURE( it.damage_level() );
-        CAPTURE( it.damage_symbol() );
+        CAPTURE( it.damage_indicator() );
         bool matched_threshold = false;
         for( size_t i = 0; i < thresholds.size(); i++ ) {
             const damage_level_threshold &threshold = thresholds[i];
             if( threshold.min_damage <= dmg && dmg <= threshold.max_damage ) {
-                CHECK( it.damage_symbol() == threshold.expect_symbol );
-                CHECK( it.damage_color() == threshold.expect_color );
+                CHECK( it.damage_indicator() == threshold.expect_indicator );
                 CHECK( it.damage_level() == static_cast<int>( i ) );
                 matched_threshold = true;
                 break;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

A few people mentioned being bothered by damage indicators being different after #64622
This change should allow mods change the indicators to any colorized string (also likely improves performance).

#### Describe the solution

Moves damage indicators to json, the new method might even have better performance as it just indexes into vector of strings, instead of calling damage_level() twice and then colorize().

Had to do a couple changes to options because EXTERNAL_OPTION couldn't be cached before.

#### Describe alternatives you've considered

#### Testing

Shouldn't be a user facing difference normally
Change the json value for the indicator to something different, check it appears in game
Or make a mod to override them, should also work

#### Additional context

Had to add vector/string includes to cached_options.h as you can't forward declare std stuff, on the other hand these headers are in the PCH anyway