### PR TITLE
Added small chance to increase follower npc relations during casual chatting

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -146,6 +146,12 @@
   },
   {
     "type": "effect_type",
+    "id": "socialized_recently",
+    "name": [ "Socialized Recently" ],
+    "desc": [ "AI tag for asking to NPCs to socialize.  This is a bug if you have it." ]
+  },
+  {
+    "type": "effect_type",
     "id": "npc_run_away",
     "name": [ "Running Away" ],
     "desc": [ "AI tag to enable NPCs to flee.  This is a bug if you have it." ]

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -91,6 +91,7 @@ static const efftype_id effect_lying_down( "lying_down" );
 static const efftype_id effect_npc_suspend( "npc_suspend" );
 static const efftype_id effect_pet( "pet" );
 static const efftype_id effect_sleep( "sleep" );
+static const efftype_id effect_socialized_recently( "socialized_recently" );
 
 static const faction_id faction_no_faction( "no_faction" );
 static const faction_id faction_your_followers( "your_followers" );
@@ -768,6 +769,23 @@ void talk_function::morale_chat_activity( npc &p )
         p.say( SNIPPET.random_from_category( "npc_socialize" ).value_or( translation() ).translated() );
     }
     add_msg( m_good, _( "That was a pleasant conversation with %s." ), p.disp_name() );
+    // 50% chance of increasing 1 npc opinion value each social chat after 6hr
+    if( !p.has_effect( effect_socialized_recently ) ) {
+        switch( rng( 1, 3 ) ) {
+            case 1:
+                p.op_of_u.trust += rng( 0, 1 );
+                break;
+            case 2:
+                p.op_of_u.value += rng( 0, 1 );
+                break;
+            case 3:
+                if( p.op_of_u.anger > 0 ) {
+                    p.op_of_u.anger += rng( 0, -1 );
+                }
+                break;
+        }
+        p.add_effect( effect_socialized_recently, 6_hours );
+    }
     player_character.add_morale( MORALE_CHAT, rng( 3, 10 ), 10, 200_minutes, 5_minutes / 2 );
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Added small chance to increase follower npc relations during casual chatting"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

If you have a npc follower without any quests.  There is only one thing available to you to do, to make them like you better.  Nothing.  You just wait a week, not interacting with the npc at all, and it will ever so slowly begin to like you.

This adds an alternative and more realistic interactive pathway toward follower npc relations.  The original method of do-nothing-but-wait is still valid, and this new method is entirely optional.  But it in my opinion adds verisimiltude, since friendships irl are built by communication.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

In the function that gives you a morale boost for idle chatting to a npc for 10 mins, it now will give the npc a small chance (50%) of increasing one of the following values - trust, value or (reducing) anger by one point.  After the chat, there is a 6hr cooldown, during which you can't idle chat again.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Staying with do-nothing-but-wait method.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ran ingame with a npc, recruited him and chatted over several days to observe relations slowly improving and the function appears to work well.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

If opinions on this differ and values / cooldowns, etc should be different, please let me know.   I think npc relations need more hands-on options than there are available.  

The chance breakdown is...  
33% chance of positive trust/value increase
16.5% chance of becoming less angry (or no change, if not angry)
50.5% chance of no change

Screenshots follow; 

Recruited a NPC, checked what his starting opinion was...

![image](https://user-images.githubusercontent.com/34361592/230650028-7de95cf6-9fce-4bb2-9e85-e0aaefcafb61.png)

Chose chitchat for a while option.
![image](https://user-images.githubusercontent.com/34361592/230650107-44017d66-a16f-4e48-ad92-d161d6fe9716.png)

Chitchat for a while option disappeared, after chitchat was completed.
![image](https://user-images.githubusercontent.com/34361592/230650185-645248c7-c469-40a5-bf01-7e588284e911.png)

It comes back after 6 hrs - I repeated this 3 times before a npc value increased (trust) from 5 to 6.
![image](https://user-images.githubusercontent.com/34361592/230650257-ccb5ea0e-922c-4eb4-a9fa-f9f68071933e.png)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->