### PR TITLE
[Bombastic Perks] More content, remove"no prereq" disclaimer since it works now

### DIFF
--- a/data/mods/BombasticPerks/corefiles/welcomemenu.json
+++ b/data/mods/BombasticPerks/corefiles/welcomemenu.json
@@ -62,7 +62,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_PERK_MENU_WELCOME_REQUIREMENTS",
-    "dynamic_line": "Should some perks be allowed to be locked behind prerequisites?\nCurrently not implemented but may be relevant for the future.",
+    "dynamic_line": "Should some perks be allowed to be locked behind prerequisites?",
     "responses": [
       {
         "text": "Prerequisites (default)",

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -45,6 +45,11 @@
         "topic": "TALK_PERK_MENU_VACATIONER"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_gymrat" } },
+        "text": "Gain [<trait_name:perk_gymrat>]",
+        "topic": "TALK_PERK_MENU_GYMRAT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_thick_skull" } },
         "text": "Gain [<trait_name:perk_thick_skull>]",
         "topic": "TALK_PERK_MENU_THICK_SKULL"
@@ -63,9 +68,14 @@
         "topic": "TALK_PERK_MENU_WAYOFTHEFIST"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_bloody_mess" } },
-        "text": "Gain [<trait_name:perk_bloody_mess>]",
-        "topic": "TALK_PERK_MENU_BLOODY_MESS"
+        "condition": { "not": { "or": [ { "u_has_trait": "perk_bloody_mess" }, { "u_has_trait": "perk_surgical_strikes" } ] } },
+        "text": "Gain [Killing Style]",
+        "topic": "TALK_PERK_MENU_KILLINGSTYLE"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_quickdraw" } },
+        "text": "Gain [<trait_name:perk_quickdraw>]",
+        "topic": "TALK_PERK_MENU_QUICKDRAW"
       },
       {
         "condition": { "not": { "u_has_trait": "perk_tuck_and_roll" } },
@@ -280,6 +290,38 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_PERK_MENU_GYMRAT",
+    "dynamic_line": "<trait_name:perk_gymrat>: \"<trait_description:perk_gymrat>\"\nRequires athletics 3.",
+    "responses": [
+      {
+        "text": "Select Perk.",
+        "topic": "TALK_PERK_MENU_MAIN",
+        "condition": {
+          "and": [
+            {
+              "or": [
+                { "compare_num": [ { "u_val": "var", "var_name": "no_prerecs" }, ">", { "const": 0 } ] },
+                { "or": [ { "u_has_skill": { "skill": "swimming", "level": 3 } } ] }
+              ]
+            },
+            { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] }
+          ]
+        },
+        "failure_explanation": "Requirements Not Met",
+        "failure_topic": "TALK_PERK_MENU_FAIL",
+        "effect": [
+          { "u_add_trait": "perk_gymrat" },
+          {
+            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
+          }
+        ]
+      },
+      { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_PERK_MENU_THICK_SKULL",
     "dynamic_line": "<trait_name:perk_thick_skull>: \"<trait_description:perk_thick_skull>\"",
     "responses": [
@@ -386,17 +428,74 @@
   },
   {
     "type": "talk_topic",
-    "id": "TALK_PERK_MENU_BLOODY_MESS",
-    "dynamic_line": "<trait_name:perk_bloody_mess>: \"<trait_description:perk_bloody_mess>\"",
+    "id": "TALK_PERK_MENU_KILLINGSTYLE",
+    "dynamic_line": "<trait_name:perk_bloody_mess>: \"<trait_description:perk_bloody_mess>\"\nNo requirements.\n<trait_name:perk_surgical_strikes>: \"<trait_description:perk_surgical_strikes>\"\nRequires melee or marksmanship 2.",
     "responses": [
       {
-        "text": "Select Perk.",
+        "text": "Select Perk Variant <trait_name:perk_bloody_mess>.",
         "topic": "TALK_PERK_MENU_MAIN",
         "condition": { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] },
         "failure_explanation": "Requirements Not Met",
         "failure_topic": "TALK_PERK_MENU_FAIL",
         "effect": [
           { "u_add_trait": "perk_bloody_mess" },
+          {
+            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
+          }
+        ]
+      },
+      {
+        "text": "Select Perk Variant <trait_name:perk_surgical_strikes>.",
+        "topic": "TALK_PERK_MENU_MAIN",
+        "condition": {
+          "and": [
+            {
+              "or": [
+                { "compare_num": [ { "u_val": "var", "var_name": "no_prerecs" }, ">", { "const": 0 } ] },
+                {
+                  "or": [ { "u_has_skill": { "skill": "melee", "level": 2 } }, { "u_has_skill": { "skill": "gun", "level": 2 } } ]
+                }
+              ]
+            },
+            { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] }
+          ]
+        },
+        "failure_explanation": "Requirements Not Met",
+        "failure_topic": "TALK_PERK_MENU_FAIL",
+        "effect": [
+          { "u_add_trait": "perk_surgical_strikes" },
+          {
+            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
+          }
+        ]
+      },
+      { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_PERK_MENU_QUICKDRAW",
+    "dynamic_line": "<trait_name:perk_quickdraw>: \"<trait_description:perk_quickdraw>\"\nRequires handguns 2.",
+    "responses": [
+      {
+        "text": "Select Perk.",
+        "topic": "TALK_PERK_MENU_MAIN",
+        "condition": {
+          "and": [
+            {
+              "or": [
+                { "compare_num": [ { "u_val": "var", "var_name": "no_prerecs" }, ">", { "const": 0 } ] },
+                { "or": [ { "u_has_skill": { "skill": "pistol", "level": 2 } } ] }
+              ]
+            },
+            { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] }
+          ]
+        },
+        "failure_explanation": "Requirements Not Met",
+        "failure_topic": "TALK_PERK_MENU_FAIL",
+        "effect": [
+          { "u_add_trait": "perk_quickdraw" },
           {
             "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
           }

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -107,6 +107,26 @@
   },
   {
     "type": "mutation",
+    "id": "perk_gymrat",
+    "name": { "str": "Gym Rat" },
+    "points": 0,
+    "description": "Your time exercising has gotten you used to being drenched in your own sweat.  Being wet doesn't bother you as much anymore.",
+    "category": [ "perk" ],
+    "wet_protection": [
+      { "part": "head", "neutral": 6 },
+      { "part": "leg_l", "neutral": 8 },
+      { "part": "leg_r", "neutral": 8 },
+      { "part": "foot_l", "neutral": 2 },
+      { "part": "foot_r", "neutral": 2 },
+      { "part": "arm_l", "neutral": 8 },
+      { "part": "arm_r", "neutral": 8 },
+      { "part": "hand_l", "neutral": 12 },
+      { "part": "hand_r", "neutral": 12 },
+      { "part": "torso", "neutral": 10 }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_thick_skull",
     "name": { "str": "Thick Skull" },
     "points": 0,
@@ -143,12 +163,30 @@
   },
   {
     "type": "mutation",
+    "id": "perk_quickdraw",
+    "name": { "str": "Quickdraw" },
+    "points": 0,
+    "description": "Practicing with handguns has improved your draw speed with pretty much everything.  Retrieve objects 25% faster from containers.",
+    "category": [ "perk" ],
+    "obtain_cost_multiplier": 0.75
+  },
+  {
+    "type": "mutation",
     "id": "perk_tuck_and_roll",
     "name": { "str": "Tuck and Roll" },
     "points": 0,
     "description": "At some point you got really good at falling off rooftops.  Take 40% less fall damage.",
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "FALL_DAMAGE", "multiply": -0.4 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_surgical_strikes",
+    "name": { "str": "Surgical Strikes" },
+    "points": 0,
+    "description": "Careful aim allows you to take down game with little tissue damage.  Enemies you kill tend to stay intact.",
+    "category": [ "perk" ],
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "OVERKILL_DAMAGE", "add": 30.0 } ] } ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Mods "[Bombastic Perks] More perks"

#### Purpose of change

Flesh out the mod
~~Also documentation by example of adding perks with types of requirements not yet used~~

#### Describe the solution

Surgical Strikes: Deathblows deal less overkill damage to the corpse(for skin, organ, & bionic hunters)
    -Bloody Mess is exclusive with this
    -Requires melee *or* marksmanship 2.
Quickdraw: Faster item retrieval speed. Requires handguns 2.
Gym Rat: Wet protection, requires athletics 3
#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
All: Attempt to take with no skills, take with skills, take with "no prereqs."
Surgical: Fail to take with marksman & melee < 2, succeed with marks 2/melee 0 & vice versa, succeed with both at 2.
Headshot zombie children w/ .50 BMG, corpse will not be pulped if perk is active😛

#### Additional context

Gym Rat/Surgical is athletics 3/melee 2 so you can't qualify for it as soon as you start the game using the always-available basic practices(or just finding any gun for marksman 2).