### PR TITLE
Correctly quantize part damage on removal

### DIFF
--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -93,9 +93,8 @@ item vehicle_part::properties_to_item() const
         tmp.active = true;
     }
 
-    // force rationalization of damage values to the middle value of each damage level so
-    // that parts will stack nicely
-    tmp.set_damage( tmp.damage_level() * itype::damage_scale );
+    // quantize damage to the middle of each damage_level so that items will stack nicely
+    tmp.set_damage( ( tmp.damage_level() - 0.5 ) * itype::damage_scale );
     return tmp;
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/64936

#### Describe the solution

Correct the code that quantizes damage, it should now result in an item with damage set to the middle of a damage level for item stacking purposes. Old code (pre-#64622) doesn't seem to work as advertised in comment, new code follows the comment

#### Describe alternatives you've considered

#### Testing

Spawn lightly damaged vehicle, part removal should display correct damage on the resulting part

#### Additional context
![image](https://user-images.githubusercontent.com/6560075/230723339-f1f7d713-f290-4789-bdfc-e00408a0647e.png)
![image](https://user-images.githubusercontent.com/6560075/230723388-2893acc1-b4f4-4dec-95ee-96238626eefe.png)
