### PR TITLE
Amalgamations no longer avoid player made traps

### DIFF
--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -112,8 +112,8 @@
     "families": [ "prof_wp_amalgamation" ],
     "harvest": "zombie_amalgamation",
     "//": "TODO: When effects/spells can mess with path settings + flags move smartness to the effect of dedicated coordinatiors",
-    "path_settings": { "avoid_sharp": true, "avoid_traps": true, "max_dist": 400 },
-    "flags": [ "SEES", "SMELLS", "HEARS", "PATH_AVOID_DANGER_1", "REVIVES", "NO_BREATHE" ]
+    "path_settings": { "avoid_sharp": false, "avoid_traps": false, "max_dist": 400 },
+    "flags": [ "SEES", "SMELLS", "HEARS", "PATH_AVOID_DANGER_2", "REVIVES", "NO_BREATHE" ]
   },
   {
     "type": "MONSTER",

--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -112,7 +112,7 @@
     "families": [ "prof_wp_amalgamation" ],
     "harvest": "zombie_amalgamation",
     "//": "TODO: When effects/spells can mess with path settings + flags move smartness to the effect of dedicated coordinatiors",
-    "path_settings": { "avoid_sharp": false, "avoid_traps": false, "max_dist": 400 },
+    "path_settings": { "avoid_sharp": true, "avoid_traps": false, "max_dist": 400 },
     "flags": [ "SEES", "SMELLS", "HEARS", "PATH_AVOID_DANGER_2", "REVIVES", "NO_BREATHE" ]
   },
   {

--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -113,7 +113,7 @@
     "harvest": "zombie_amalgamation",
     "//": "TODO: When effects/spells can mess with path settings + flags move smartness to the effect of dedicated coordinatiors",
     "path_settings": { "avoid_sharp": true, "avoid_traps": true, "max_dist": 400 },
-    "flags": [ "SEES", "SMELLS", "HEARS", "PATH_AVOID_DANGER_2", "REVIVES", "NO_BREATHE" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "PATH_AVOID_DANGER_1", "REVIVES", "NO_BREATHE" ]
   },
   {
     "type": "MONSTER",

--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -113,7 +113,7 @@
     "harvest": "zombie_amalgamation",
     "//": "TODO: When effects/spells can mess with path settings + flags move smartness to the effect of dedicated coordinatiors",
     "path_settings": { "avoid_sharp": true, "avoid_traps": false, "max_dist": 400 },
-    "flags": [ "SEES", "SMELLS", "HEARS", "PATH_AVOID_DANGER_2", "REVIVES", "NO_BREATHE" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "PATH_AVOID_DANGER_1", "REVIVES", "NO_BREATHE" ]
   },
   {
     "type": "MONSTER",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "All amalgamations no longer avoid player made traps"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
According to the original amalgamation PR, they are supposed to be discardable drones revived from biological mass. It doesn't make sense that they can avoid player made traps while i can concede that they will avoid fire,holes like most common animals. Even beside that they are the only monster group in the game with avoid_danger 2 other than the godly being Yrax. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed PATH_AVOID_DANGER_2 to PATH_AVOID_DANGER_1
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
There are a specific avoid trap json now, so if there is anything specific they would avoid, it could be avoided now.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Logged, they don't avoid nailboard traps but won't jump into fire or holes.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->