### PR TITLE
Refugee caravan

### DIFF
--- a/data/json/encounters/randenc_caravans.json
+++ b/data/json/encounters/randenc_caravans.json
@@ -75,5 +75,55 @@
       ],
       "remove_vehicles": [ { "vehicles": [ "FM_early_pickup" ], "x": [ 1, 15 ], "y": [ 1, 10 ] } ]
     }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_RandEnc_Roadstop_refugee_add",
+    "recurrence": 6000,
+    "global": true,
+    "condition": {
+      "and": [
+        { "u_near_om_location": "roadstop_a", "range": 2 },
+        "is_day",
+        { "one_in_chance": 10 },
+        {
+          "not": { "u_compare_time_since_var": "RandEnc", "type": "timer", "context": "caravan", "op": "<", "time": "1 d" }
+        },
+        { "not": { "u_at_om_location": "roadstop_a" } },
+        { "not": { "is_season": "winter" } }
+      ]
+    },
+    "effect": [
+      { "mapgen_update": "nest_RandEnc_roadstop_refugee_a_add", "om_terrain": "roadstop_a" },
+      { "u_add_var": "RandEnc", "type": "timer", "context": "refugee", "time": true }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_RandEnc_Roadstop_refugee_remove",
+    "recurrence": 200,
+    "global": true,
+    "condition": {
+      "and": [ { "u_compare_time_since_var": "RandEnc", "type": "timer", "context": "refugee", "op": ">", "time": "1 h" } ]
+    },
+    "effect": [
+      { "mapgen_update": "nest_RandEnc_roadstop_a_remove", "om_terrain": "roadstop_a" },
+      { "remove_npc": "NC_caravan_refugee_A" },
+      { "remove_npc": "NC_caravan_refugee_B" },
+      { "remove_npc": "NC_caravan_refugee_C" }
+    ]
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "nest_RandEnc_roadstop_refugee_a_add",
+    "//": "Adds a random encounter at this roadstop",
+    "object": {
+      "place_npcs": [
+        { "class": "NC_caravan_refugee_A", "x": 5, "y": 4 },
+        { "class": "NC_caravan_refugee_B", "x": 4, "y": 1 },
+        { "class": "NC_caravan_refugee_C", "x": 4, "y": 2 }
+      ]
+    }
   }
 ]

--- a/data/json/encounters/randenc_caravans.json
+++ b/data/json/encounters/randenc_caravans.json
@@ -78,51 +78,77 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_RandEnc_Roadstop_refugee_add",
+    "id": "EOC_RandEnc_Roadstop_Refugee_add",
     "recurrence": 3000,
     "global": true,
     "condition": {
       "and": [
-        { "u_near_om_location": "roadstop_a", "range": 2 },
+        { "u_near_om_location": "roadstop_a", "range": 30 },
         "is_day",
         { "one_in_chance": 10 },
+        { "days_since_cataclysm": 7 },
         {
-          "not": { "u_compare_time_since_var": "RandEnc", "type": "timer", "context": "caravan", "op": "<", "time": "1 d" }
+          "not": { "u_compare_time_since_var": "RandEnc", "type": "timer", "context": "refugee", "op": "<", "time": "1 d" }
         },
-        { "not": { "u_at_om_location": "roadstop_a" } },
+        { "not": { "u_near_om_location": "roadstop_a", "range": 2 } },
+        { "not": { "days_since_cataclysm": 45 } },
         { "not": { "is_season": "winter" } }
       ]
     },
     "effect": [
-      { "mapgen_update": "nest_RandEnc_roadstop_refugee_a_add", "om_terrain": "roadstop_a" },
-      { "u_add_var": "RandEnc", "type": "timer", "context": "refugee", "time": true }
+      { "mapgen_update": "nest_RandEnc_roadstop_a_refugee_add", "om_terrain": "roadstop_a" },
+      { "u_add_var": "RandEnc", "type": "timer", "context": "refugee", "time": true },
+      {
+        "u_location_variable": { "global_val": "randenc_refugee_loc" },
+        "target_params": { "om_terrain": "roadstop_a" }
+      },
+      { "arithmetic": [ { "global_val": "var", "var_name": "RandEnc_Refugee" }, "=", { "const": 1 } ] }
     ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_RandEnc_Roadstop_refugee_remove",
+    "id": "EOC_RandEnc_Roadstop_Refugee_remove",
     "recurrence": 200,
     "global": true,
     "condition": {
-      "and": [ { "u_compare_time_since_var": "RandEnc", "type": "timer", "context": "refugee", "op": ">", "time": "1 h" } ]
+      "and": [
+        { "u_compare_time_since_var": "RandEnc", "type": "timer", "context": "refugee", "op": ">", "time": "1 h" },
+        { "not": { "u_near_om_location": "roadstop_a", "range": 2 } },
+        { "compare_num": [ { "global_val": "var", "var_name": "RandEnc_Refugee" }, "==", { "const": 1 } ] }
+      ]
     },
     "effect": [
-      { "mapgen_update": "nest_RandEnc_roadstop_a_remove", "om_terrain": "roadstop_a" },
-      { "remove_npc": "NC_caravan_refugee_A" },
-      { "remove_npc": "NC_caravan_refugee_B" },
-      { "remove_npc": "NC_caravan_refugee_C" }
+      {
+        "mapgen_update": "nest_RandEnc_roadstop_a_refugee_remove",
+        "om_terrain": "roadstop_a",
+        "target_var": { "global_val": "randenc_refugee_loc" }
+      },
+      { "arithmetic": [ { "global_val": "var", "var_name": "RandEnc_Refugee" }, "=", { "const": 0 } ] }
     ]
   },
   {
     "type": "mapgen",
     "method": "json",
-    "update_mapgen_id": "nest_RandEnc_roadstop_refugee_a_add",
-    "//": "Adds a random encounter at this roadstop",
+    "update_mapgen_id": "nest_RandEnc_roadstop_a_refugee_add",
+    "//": "Adds refugee random encounter at this roadstop",
     "object": {
       "place_npcs": [
         { "class": "NC_caravan_refugee_A", "x": 5, "y": 4 },
         { "class": "NC_caravan_refugee_B", "x": 4, "y": 1 },
         { "class": "NC_caravan_refugee_C", "x": 4, "y": 2 }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "nest_RandEnc_roadstop_a_refugee_remove",
+    "//": "removes refugee random encounter at this roadstop",
+    "object": {
+      "remove_npcs": [
+        { "class": "NC_caravan_refugee_A", "x": 0, "y": 0 },
+        { "class": "NC_caravan_refugee_B", "x": 0, "y": 0 },
+        { "class": "NC_caravan_refugee_C", "x": 0, "y": 0 }
       ]
     }
   }

--- a/data/json/encounters/randenc_caravans.json
+++ b/data/json/encounters/randenc_caravans.json
@@ -114,7 +114,7 @@
       "and": [
         { "u_compare_time_since_var": "RandEnc", "type": "timer", "context": "refugee", "op": ">", "time": "1 h" },
         { "not": { "u_near_om_location": "roadstop_a", "range": 2 } },
-        { "compare_num": [ { "global_val": "var", "var_name": "RandEnc_Refugee" }, "==", { "const": 1 } ] }
+        { "math": [ "RandEnc_Refugee", "==", "1" ] }
       ]
     },
     "effect": [

--- a/data/json/encounters/randenc_caravans.json
+++ b/data/json/encounters/randenc_caravans.json
@@ -123,7 +123,7 @@
         "om_terrain": "roadstop_a",
         "target_var": { "global_val": "randenc_refugee_loc" }
       },
-      { "arithmetic": [ { "global_val": "var", "var_name": "RandEnc_Refugee" }, "=", { "const": 0 } ] }
+      { "math": [ "RandEnc_Refugee", "=", "0" ] }
     ]
   },
   {

--- a/data/json/encounters/randenc_caravans.json
+++ b/data/json/encounters/randenc_caravans.json
@@ -102,7 +102,7 @@
         "u_location_variable": { "global_val": "randenc_refugee_loc" },
         "target_params": { "om_terrain": "roadstop_a" }
       },
-      { "arithmetic": [ { "global_val": "var", "var_name": "RandEnc_Refugee" }, "=", { "const": 1 } ] }
+      { "math": [ "RandEnc_Refugee", "=", "1" ] }
     ]
   },
   {

--- a/data/json/encounters/randenc_caravans.json
+++ b/data/json/encounters/randenc_caravans.json
@@ -79,7 +79,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_RandEnc_Roadstop_refugee_add",
-    "recurrence": 6000,
+    "recurrence": 3000,
     "global": true,
     "condition": {
       "and": [

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -270,7 +270,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_REFUGEE_C",
-    "dynamic_line": "[tips their hat down from their eyes and looks at you, eyes bloodshot.]  \"Mmh?  Hey, just having a.  I was a.  Give me all your heroin.",
+    "dynamic_line": "[They moan, shake their head and look at you, eyes bloodshot.]  \"Mmh?  Hey, just having a.  I was a.  Give me all your heroin.",
     "responses": [
       { "text": "Oh, uh, sorry.", "topic": "TALK_DONE" },
       {

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -72,7 +72,11 @@
     "responses": [
       { "text": "That's it?  What's your story?", "topic": "TALK_CARAVAN_REFUGEE_A_Story" },
       { "text": "Good luck with that.  I'll be on my way.", "topic": "TALK_DONE" },
-      { "text": "You're never going to make it, you should just end it now.", "topic": "TALK_DONE" }
+      {
+        "text": "You're never going to make it, you should just end it now.",
+        "topic": "TALK_DONE",
+        "opinion": { "value": -1, "anger": 1 }
+      }
     ]
   },
   {

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -273,7 +273,11 @@
     "dynamic_line": "*tips their hat down from their eyes and looks at you, eyes bloodshot.  \"Mmh?  Hey, just having a.  I was a.  Give me all your heroin.",
     "responses": [
       { "text": "Oh, uh, sorry.", "topic": "TALK_DONE" },
-      { "text": "Never, that heroin is for me and me alone.", "condition": { "u_has_items": { "item": "heroin" } }, "topic": "TALK_DONE" }
+      {
+        "text": "Never, that heroin is for me and me alone.",
+        "condition": { "u_has_items": { "item": "heroin" } },
+        "topic": "TALK_DONE"
+      }
     ]
   }
 ]

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -62,7 +62,7 @@
     "responses": [
       { "text": "Oh, I wasn’t joking <name_b>.", "effect": "hostile", "topic": "TALK_DONE" },
       { "text": "What's your situation here?", "topic": "TALK_CARAVAN_REFUGEE_A1_Job" },
-      { "text": "Yes.  A joke.  Ha ha.", "topic": "TALK_DONE" }
+      { "text": "I’m sorry, I should be going.", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -52,7 +52,7 @@
     "dynamic_line": "You again.  Any good news?  Haven't heard any in a long time.",
     "responses": [
       { "text": "What's your story?", "topic": "TALK_CARAVAN_REFUGEE_A_Story" },
-      { "text": "No, dark days.", "topic": "TALK_DONE" }
+      { "text": "No, I don’t have any.", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -1,0 +1,276 @@
+[
+  {
+    "type": "npc",
+    "id": "NC_caravan_refugee_A",
+    "//": "Random NPC, can direct you to the free merchants and nearest FEMA camp.",
+    "name_suffix": "refugee",
+    "class": "NC_SCAVENGER",
+    "attitude": 0,
+    "mission": 7,
+    "chat": "TALK_CARAVAN_REFUGEE_A1",
+    "faction": "wasteland_scavengers"
+  },
+  {
+    "type": "npc",
+    "id": "NC_caravan_refugee_B",
+    "//": "Random NPC, can be recruited away.",
+    "name_suffix": "refugee",
+    "class": "NC_SCAVENGER",
+    "attitude": 0,
+    "mission": 8,
+    "chat": "TALK_CARAVAN_REFUGEE_B1",
+    "faction": "wasteland_scavengers"
+  },
+  {
+    "type": "npc",
+    "id": "NC_caravan_refugee_C",
+    "//": "Random NPC, demands heroin but can't accept.",
+    "name_suffix": "refugee",
+    "class": "NC_SCAVENGER",
+    "attitude": 0,
+    "mission": 7,
+    "chat": "TALK_CARAVAN_REFUGEE_C1",
+    "faction": "wasteland_scavengers"
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_A1",
+    "dynamic_line": "Please don't hurt us, we're just trying to get to safety.",
+    "speaker_effect": { "effect": { "npc_first_topic": "TALK_CARAVAN_REFUGEE_A2" } },
+    "responses": [
+      {
+        "text": "What if I want to hurt you?  I'm so good at it and I've had so much practice.",
+        "topic": "TALK_CARAVAN_REFUGEE_A1_Hurt"
+      },
+      { "text": "What's your situation here?", "topic": "TALK_CARAVAN_REFUGEE_A1_Job" },
+      { "text": "I don't have time for zombie bait like you.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_A2",
+    "dynamic_line": "You again.  Any good news?  Haven't heard any in a long time.",
+    "responses": [
+      { "text": "What's your story?", "topic": "TALK_CARAVAN_REFUGEE_A_Story" },
+      { "text": "No, dark days.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_A1_Hurt",
+    "dynamic_line": "Ha ha, love that funny joke.  I love funny jokes like that.  So funny.",
+    "responses": [
+      { "text": "I'm going to hurt you now.", "topic": "TALK_DONE" },
+      { "text": "What's your situation here?", "topic": "TALK_CARAVAN_REFUGEE_A1_Job" },
+      { "text": "Yes.  A joke.  Ha ha.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_A1_Job",
+    "dynamic_line": "We're just trying to find a safe place right now.  I think there's a FEMA camp nearby that should have room for us.",
+    "responses": [
+      { "text": "That's it?  What's your story?", "topic": "TALK_CARAVAN_REFUGEE_A_Story" },
+      { "text": "Good luck with that.  I'll be on my way.", "topic": "TALK_DONE" },
+      { "text": "You're never going to make it, you should just end it now.", "topic": "TALK_DONE" },
+      { "text": "I'm going to hurt you now.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_A_Story",
+    "dynamic_line": "We were at the same little evacuation hut, but it was all messed up, just used condoms and broken bottles and lipstick writing on the walls.  We found another group of refugees like us on the road, but they had all been killed, all ripped up, blood everywhere.  We took their food and made it all the way to the refugee center, but they told us there was no room and we should just go back where we came from and fight the dead.  We're not doing that, so we're going to a FEMA camp.  They should have more room and supplies.  No guarantees, but it's a chance.",
+    "responses": [
+      { "text": "They're right, you should just go back home and let it happen.", "topic": "TALK_DONE" },
+      {
+        "text": "Can you give me directions to that FEMA camp?  I want to go there too if it's so great.",
+        "topic": "TALK_CARAVAN_REFUGEE_A_FEMA"
+      },
+      {
+        "text": "I haven't been to the refugee center.  Can you tell me where it is?",
+        "topic": "TALK_CARAVAN_REFUGEE_A_CENTER",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
+            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+          ]
+        }
+      },
+      { "text": "Thanks for the story.  I'd better go.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_A_FEMA",
+    "dynamic_line": "Of course, we're all in this together.  Let me mark that on your map.",
+    "speaker_effect": { "effect": { "assign_mission": "MISSION_REACH_FEMA_CA" } },
+    "responses": [
+      {
+        "text": "I haven't been to the refugee center.  Can you tell me where it is?",
+        "topic": "TALK_CARAVAN_REFUGEE_A_CENTER",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
+            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+          ]
+        }
+      },
+      { "text": "Thanks for the information.  I'd better go.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "MISSION_REACH_FEMA_CA",
+    "type": "mission_definition",
+    "name": { "str": "Reach FEMA Camp" },
+    "goal": "MGOAL_GO_TO_TYPE",
+    "difficulty": 2,
+    "value": 60000,
+    "start": {
+      "assign_mission_target": { "om_terrain": "fema", "reveal_radius": 5, "om_special": "FEMA Camp", "search_range": 120 }
+    },
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "destination": "fema",
+    "dialogue": {
+      "describe": "Things must be better at the camp…",
+      "offer": "We're all in this together, looking forward to meeting you there.",
+      "accepted": "Everything is going to be all right.",
+      "rejected": "No worries friend, good luck to you.",
+      "advice": "The hard part is getting there.",
+      "inquire": "Any progress on getting to the camp?",
+      "success": "Well, success I guess.",
+      "success_lie": "Thanks for trying… I guess.",
+      "failure": "Such a disappointment…"
+    }
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_A_CENTER",
+    "dynamic_line": "Here, I'll mark it on your map.  I wouldn't bet they'll treat you any differently than us though.  You might try and bring something to trade, they like that.",
+    "speaker_effect": { "effect": { "assign_mission": "MISSION_REACH_REFUGEE_CENTER" } },
+    "responses": [
+      {
+        "text": "Can you give me directions to where you're going too?  I love cartography.",
+        "topic": "TALK_CARAVAN_REFUGEE_A_FEMA"
+      },
+      { "text": "Thanks for the information.  I'd better go.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_B1",
+    "dynamic_line": "Looking good there.  I like your whole setup.  What's your story?",
+    "speaker_effect": { "effect": { "npc_first_topic": "TALK_CARAVAN_REFUGEE_B2" } },
+    "responses": [
+      { "text": "What are you doing here?", "topic": "TALK_CARAVAN_REFUGEE_B1_Job" },
+      { "text": "Not interested.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_B2",
+    "dynamic_line": "Nice.  Good to see you again.  What do you want from me?",
+    "responses": [
+      { "text": "What are you doing here?", "topic": "TALK_CARAVAN_REFUGEE_B1_Job" },
+      {
+        "truefalsetext": { "true": "You should come with me instead.", "false": "You should definitely come with me instead." },
+        "trial": { "type": "SKILL_CHECK", "difficulty": 3, "skill_required": "speaking" },
+        "success": { "topic": "TALK_CARAVAN_REFUGEE_B1_Join_Yes" },
+        "failure": { "topic": "TALK_CARAVAN_REFUGEE_B1_Join_No" }
+      },
+      { "text": "Nothing, just saying hi.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_B1_Job",
+    "dynamic_line": "I'm a refugee, but don't get the wrong idea.  I've got big dreams of settling down after this and starting a big family.  I just need to find the right place and the right person.  Last couple of places didn't work out so well.",
+    "responses": [
+      { "text": "So you're not attached right now?", "topic": "TALK_CARAVAN_REFUGEE_B1_Attached" },
+      {
+        "truefalsetext": { "true": "You should come with me instead.", "false": "You should definitely come with me instead." },
+        "trial": { "type": "SKILL_CHECK", "difficulty": 3, "skill_required": "speaking" },
+        "success": { "topic": "TALK_CARAVAN_REFUGEE_B1_Join_Yes" },
+        "failure": { "topic": "TALK_CARAVAN_REFUGEE_B1_Join_No" }
+      },
+      {
+        "text": "Why, where you before?",
+        "topic": "TALK_CARAVAN_REFUGEE_B1_Directions",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
+            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+          ]
+        }
+      },
+      { "text": "Not interested.  I'd better get going.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_B1_Attached",
+    "dynamic_line": "No, I'm not really with them.  We just got stuck together in the same messed up evacuation place.  This one guy was really nice, but they wouldn't let us stay.  They got there first so they told us we needed to find our own place, but if we got anything they wanted they'd trade some of the stuff they have.  I tried to talk them into helping but they were so cold to me.",
+    "responses": [
+      {
+        "truefalsetext": { "true": "You should come with me instead.", "false": "You should definitely come with me instead." },
+        "trial": { "type": "SKILL_CHECK", "difficulty": 3, "skill_required": "speaking" },
+        "success": { "topic": "TALK_CARAVAN_REFUGEE_B1_Join_Yes" },
+        "failure": { "topic": "TALK_CARAVAN_REFUGEE_B1_Join_No" }
+      },
+      {
+        "text": "How do I get there?",
+        "topic": "TALK_CARAVAN_REFUGEE_B1_Directions",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
+            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+          ]
+        }
+      },
+      { "text": "Yeah, I guess it's hard all over.  I'd better get going.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_B1_Join_Yes",
+    "dynamic_line": "This is the beginning of a beautiful thing.  I'm with you.",
+    "speaker_effect": { "effect": "follow" },
+    "responses": [ { "text": "Yes!", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_B1_Join_No",
+    "dynamic_line": "Actually, I think I'm on the right track here, but you might have some luck finding a little something something back at the Free Merchant base.  They seemed pretty desperate.",
+    "responses": [
+      {
+        "text": "Yes.  Of course.  How do I get there?",
+        "topic": "TALK_CARAVAN_REFUGEE_B1_Directions",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
+            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+          ]
+        }
+      },
+      { "text": "Yes.  I'll be on my way then.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_B1_Directions",
+    "dynamic_line": "Sure, I can mark it on your map if you like.  Here.",
+    "speaker_effect": { "effect": { "assign_mission": "MISSION_REACH_REFUGEE_CENTER" } },
+    "responses": [
+      { "text": "Thanks for the tip!  What were you saying before?", "topic": "TALK_NONE" },
+      { "text": "Thanks for the tip!  I'll be on my way.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_C",
+    "dynamic_line": "*tips their hat down from their eyes and looks at you, eyes bloodshot.  \"Mmh?  Hey, just having a.  I was a.  Give me all your heroin.",
+    "responses": [
+      { "text": "Oh, uh, sorry.", "topic": "TALK_DONE" },
+      { "text": "Never, that heroin is for me and me alone.", "topic": "TALK_DONE" }
+    ]
+  }
+]

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -72,8 +72,7 @@
     "responses": [
       { "text": "That's it?  What's your story?", "topic": "TALK_CARAVAN_REFUGEE_A_Story" },
       { "text": "Good luck with that.  I'll be on my way.", "topic": "TALK_DONE" },
-      { "text": "You're never going to make it, you should just end it now.", "topic": "TALK_DONE" },
-      { "text": "I'm going to hurt you now.", "topic": "TALK_DONE" }
+      { "text": "You're never going to make it, you should just end it now.", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -193,7 +193,7 @@
         "failure": { "topic": "TALK_CARAVAN_REFUGEE_B1_Join_No" }
       },
       {
-        "text": "Why, where you before?",
+        "text": "Why, where were you before?",
         "topic": "TALK_CARAVAN_REFUGEE_B1_Directions",
         "condition": {
           "and": [

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -273,12 +273,12 @@
       { "text": "Oh, uh, sorry.", "topic": "TALK_DONE" },
       {
         "text": "Never, that heroin is for me and me alone.",
-        "condition": { "u_has_items": { "item": "heroin" } },
+        "condition": { "u_has_item": "heroin" },
         "topic": "TALK_DONE"
       },
       {
         "text": "I think you might need it even more than me.  Here you go.",
-        "condition": { "u_has_items": { "item": "heroin" } },
+        "condition": { "u_has_item": "heroin" },
         "effect": { "u_sell_item": "heroin" },
         "opinion": { "trust": 2, "value": 2 },
         "topic": "TALK_CARAVAN_REFUGEE_C_LOVE"

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -40,9 +40,14 @@
     "responses": [
       {
         "text": "What if I want to hurt you?  I'm so good at it and I've had so much practice.",
+        "condition": { "u_has_trait": "PSCYCHOPATH" },
         "topic": "TALK_CARAVAN_REFUGEE_A1_Hurt"
       },
-      { "text": "What's your situation here?", "topic": "TALK_CARAVAN_REFUGEE_A1_Job" },
+      {
+        "text": "What's your situation here?",
+        "topic": "TALK_CARAVAN_REFUGEE_A1_Job",
+        "condition": { "not": { "u_has_trait": "PSCYCHOPATH" } }
+      },
       { "text": "I don't have time for zombie bait like you.", "topic": "TALK_DONE" }
     ]
   },
@@ -61,8 +66,7 @@
     "dynamic_line": "I can’t tell if you’re joking or not, please don’t say such things.",
     "responses": [
       { "text": "Oh, I wasn’t joking <name_b>.", "effect": "hostile", "topic": "TALK_DONE" },
-      { "text": "What's your situation here?", "topic": "TALK_CARAVAN_REFUGEE_A1_Job" },
-      { "text": "I’m sorry, I should be going.", "topic": "TALK_DONE" }
+      { "text": "I’m sorry, I should be going before I do something bad again.", "topic": "TALK_DONE" }
     ]
   },
   {
@@ -82,15 +86,14 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_REFUGEE_A_Story",
-    "dynamic_line": "We were at the same little evacuation hut, but it was all messed up, just used condoms and broken bottles and lipstick writing on the walls.  We found another group of refugees like us on the road, but they had all been killed, all ripped up, blood everywhere.  We took their food and made it all the way to the refugee center, but they told us there was no room and we should just go back where we came from and fight the dead.  We're not doing that, so we're going to a FEMA camp.  They should have more room and supplies.  No guarantees, but it's a chance.",
+    "dynamic_line": "We were at the same little evacuation hut, but it was all messed up, just used condoms and broken bottles and lipstick writing on the walls.  We found another group of refugees like us on the road, but they had all been killed, all ripped up, blood everywhere.  We took their food and made it all the way to a big refugee center, but somebody there with a gun told us there was no room, so we're going to a FEMA camp.  They should have more room and supplies.  No guarantees, but it's a chance.",
     "responses": [
-      { "text": "They're right, you should just go back home and let it happen.", "topic": "TALK_DONE" },
       {
         "text": "Can you give me directions to that FEMA camp?  I want to go there too if it's so great.",
         "topic": "TALK_CARAVAN_REFUGEE_A_FEMA"
       },
       {
-        "text": "I haven't been to the refugee center.  Can you tell me where it is?",
+        "text": "I haven't been to any refugee center.  Can you tell me where it is?",
         "topic": "TALK_CARAVAN_REFUGEE_A_CENTER",
         "condition": {
           "and": [
@@ -109,7 +112,7 @@
     "speaker_effect": { "effect": { "assign_mission": "MISSION_REACH_FEMA_CA" } },
     "responses": [
       {
-        "text": "I haven't been to the refugee center.  Can you tell me where it is?",
+        "text": "I haven't been to any refugee center.  Can you tell me where it is?",
         "topic": "TALK_CARAVAN_REFUGEE_A_CENTER",
         "condition": {
           "and": [

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -40,13 +40,13 @@
     "responses": [
       {
         "text": "What if I want to hurt you?  I'm so good at it and I've had so much practice.",
-        "condition": { "u_has_trait": "PSCYCHOPATH" },
+        "condition": { "u_has_trait": "PSYCHOPATH" },
         "topic": "TALK_CARAVAN_REFUGEE_A1_Hurt"
       },
       {
         "text": "What's your situation here?",
         "topic": "TALK_CARAVAN_REFUGEE_A1_Job",
-        "condition": { "not": { "u_has_trait": "PSCYCHOPATH" } }
+        "condition": { "not": { "u_has_trait": "PSYCHOPATH" } }
       },
       { "text": "I don't have time for zombie bait like you.", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -60,7 +60,7 @@
     "id": "TALK_CARAVAN_REFUGEE_A1_Hurt",
     "dynamic_line": "I can’t tell if you’re joking or not, please don’t say such things.",
     "responses": [
-      { "text": "I'm going to hurt you now.", "topic": "TALK_DONE" },
+      { "text": "Oh, I wasn’t joking <name_b>.", "effect": "hostile", "topic": "TALK_DONE" },
       { "text": "What's your situation here?", "topic": "TALK_CARAVAN_REFUGEE_A1_Job" },
       { "text": "Yes.  A joke.  Ha ha.", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -242,7 +242,7 @@
     "dynamic_line": "Actually, I think I'm on the right track here, but you might have some luck finding a little something something back at the Free Merchant base.  They seemed pretty desperate.",
     "responses": [
       {
-        "text": "Yes.  Of course.  How do I get there?",
+        "text": "Of course.  How do I get there?",
         "topic": "TALK_CARAVAN_REFUGEE_B1_Directions",
         "condition": {
           "and": [

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -75,12 +75,7 @@
     "dynamic_line": "We're just trying to find a safe place right now.  I think there's a FEMA camp nearby that should have room for us.",
     "responses": [
       { "text": "That's it?  What's your story?", "topic": "TALK_CARAVAN_REFUGEE_A_Story" },
-      { "text": "Good luck with that.  I'll be on my way.", "topic": "TALK_DONE" },
-      {
-        "text": "You're never going to make it, you should just end it now.",
-        "topic": "TALK_DONE",
-        "opinion": { "value": -1, "anger": 1 }
-      }
+      { "text": "Good luck with that.  I'll be on my way.", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -273,7 +273,7 @@
     "dynamic_line": "*tips their hat down from their eyes and looks at you, eyes bloodshot.  \"Mmh?  Hey, just having a.  I was a.  Give me all your heroin.",
     "responses": [
       { "text": "Oh, uh, sorry.", "topic": "TALK_DONE" },
-      { "text": "Never, that heroin is for me and me alone.", "topic": "TALK_DONE" }
+      { "text": "Never, that heroin is for me and me alone.", "condition": { "u_has_items": { "item": "heroin" } }, "topic": "TALK_DONE" }
     ]
   }
 ]

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -58,7 +58,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_REFUGEE_A1_Hurt",
-    "dynamic_line": "Ha ha, love that funny joke.  I love funny jokes like that.  So funny.",
+    "dynamic_line": "I can’t tell if you’re joking or not, please don’t say such things.",
     "responses": [
       { "text": "I'm going to hurt you now.", "topic": "TALK_DONE" },
       { "text": "What's your situation here?", "topic": "TALK_CARAVAN_REFUGEE_A1_Job" },

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -24,7 +24,7 @@
   {
     "type": "npc",
     "id": "NC_caravan_refugee_C",
-    "//": "Random NPC, demands heroin but can't accept.",
+    "//": "Random NPC, demands heroin and can accept.",
     "name_suffix": "refugee",
     "class": "NC_SCAVENGER",
     "attitude": 0,

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -270,7 +270,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_REFUGEE_C",
-    "dynamic_line": "*tips their hat down from their eyes and looks at you, eyes bloodshot.  \"Mmh?  Hey, just having a.  I was a.  Give me all your heroin.",
+    "dynamic_line": "[tips their hat down from their eyes and looks at you, eyes bloodshot.]  \"Mmh?  Hey, just having a.  I was a.  Give me all your heroin.",
     "responses": [
       { "text": "Oh, uh, sorry.", "topic": "TALK_DONE" },
       {

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -270,7 +270,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_REFUGEE_C",
-    "dynamic_line": "[They moan, shake their head and look at you, eyes bloodshot.]  \"Mmh?  Hey, just having a.  I was a.  Give me all your heroin.",
+    "dynamic_line": "Hey man.  Do you have any heroin?  I'm in a bit of a bind.",
     "responses": [
       { "text": "Oh, uh, sorry.", "topic": "TALK_DONE" },
       {

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -277,7 +277,20 @@
         "text": "Never, that heroin is for me and me alone.",
         "condition": { "u_has_items": { "item": "heroin" } },
         "topic": "TALK_DONE"
+      },
+      {
+        "text": "I think you might need it even more than me.  Here you go.",
+        "condition": { "u_has_items": { "item": "heroin" } },
+        "effect": { "u_sell_item": "heroin" },
+        "opinion": { "trust": 2, "value": 2 },
+        "topic": "TALK_CARAVAN_REFUGEE_C_LOVE"
       }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_REFUGEE_C_LOVE",
+    "dynamic_line": "I love you.",
+    "responses": [ { "text": "Oh, uh, thanks.  I guess.", "topic": "TALK_DONE" }, { "text": "No thank you.", "topic": "TALK_DONE" } ]
   }
 ]


### PR DESCRIPTION
#### Summary
Content "refugee caravan"

#### Purpose of change

Make world feel more alive, at least in early game

#### Describe the solution

Builds off https://github.com/CleverRaven/Cataclysm-DDA/pull/56629 with different dialogue, removes trading and adds a new mission to go to a FEMA camp and a recruitable NPC using the new SKILL_CHECK

Second attempt at #57086 , which got lost in content freeze

Completely rebuilt EOC to match all of the changes since, which I'm guessing were related to why I couldn't test this before

#### Describe alternatives you've considered

More refugees, spawn them with monsters trying to murder them (map spawn will take care of that sometimes), more variations. Some kind of winter encounter, maybe a hungry hunting party? Place the correct corpses at the FEMA camp to be found, delete the originals when they are found if they haven't been deleted already. Create new custom classes instead of generic scavenger class. Create a new custom faction for them. Wandering bandits. Wandering scavengers. Wandering Old Guard. More strange/crazy dialogue options for the player (a blob-infected murder hobo).

#### Testing

Runs no errors, NPCs appear and behave as expected

<img width="1164" alt="Screenshot 2023-04-08 at 4 28 32 PM" src="https://user-images.githubusercontent.com/26608431/230741454-29e824e9-e09c-4d96-a647-4dc0afb9c19f.png">

<img width="1187" alt="Screenshot 2023-04-08 at 4 29 04 PM" src="https://user-images.githubusercontent.com/26608431/230741459-a13cc7fc-0a72-463f-a227-74b103b56505.png">

<img width="1108" alt="Screenshot 2023-04-08 at 4 30 10 PM" src="https://user-images.githubusercontent.com/26608431/230741460-daa4ca70-8aaa-4c32-98c6-806d1abd6e32.png">


#### Additional context

Thanks for all the recent NPC work making this possible, I've been wanting this forever