### PR TITLE
Activities can fire EOCs

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -55,5 +55,20 @@
     "recurrence": { "math": [ "math_test_result" ] },
     "global": true,
     "effect": { "u_message": "test recurrence" }
+  },
+  {
+    "id": "EOC_increment_var",
+    "//": "tests adding a variable to the player",
+    "effect": [
+      {
+        "arithmetic": [
+          { "u_val": "var", "var_name": "activitiy_incrementer" },
+          "=",
+          { "u_val": "var", "var_name": "activitiy_incrementer" },
+          "+",
+          { "const": 1 }
+        ]
+      }
+    ]
   }
 ]

--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -60,16 +60,6 @@
     "type": "effect_on_condition",
     "id": "EOC_increment_var",
     "//": "tests adding a variable to the player",
-    "effect": [
-      {
-        "arithmetic": [
-          { "u_val": "var", "var_name": "activitiy_incrementer" },
-          "=",
-          { "u_val": "var", "var_name": "activitiy_incrementer" },
-          "+",
-          { "const": 1 }
-        ]
-      }
-    ]
+    "effect": [ { "math": [ "u_activitiy_incrementer", "++" ] } ]
   }
 ]

--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -57,6 +57,7 @@
     "effect": { "u_message": "test recurrence" }
   },
   {
+    "type": "effect_on_condition",
     "id": "EOC_increment_var",
     "//": "tests adding a variable to the player",
     "effect": [

--- a/data/mods/TEST_DATA/activity.json
+++ b/data/mods/TEST_DATA/activity.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "ACT_ADD_VARIABLE_COMPLETE",
+    "type": "activity_type",
+    "activity_level": "MODERATE_EXERCISE",
+    "verb": "incrementing a variable",
+    "based_on": "time",
+    "completion_eoc": "EOC_increment_var"
+  },
+  {
+    "id": "ACT_ADD_VARIABLE_DURING",
+    "type": "activity_type",
+    "activity_level": "MODERATE_EXERCISE",
+    "verb": "incrementing a variable",
+    "based_on": "time",
+    "do_turn_eoc": "EOC_increment_var"
+  }
+]

--- a/doc/PLAYER_ACTIVITY.md
+++ b/doc/PLAYER_ACTIVITY.md
@@ -74,6 +74,10 @@ drink from specific auto_consume zones during long activities.
 * multi_activity(false): This activity will repeat until it cannot do
 any more work, used for NPC and avatar zone activities.
 
+* completion_eoc: an EOC that is run when this activity completes
+
+* do_turn_eoc: an EOC that is run when this activity performs a turn
+
 ## Termination
 
 There are several ways an activity can be ended:

--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -10,8 +10,6 @@
 #include "activity_handlers.h"
 #include "assign.h"
 #include "debug.h"
-#include "dialogue.h"
-#include "effect_on_condition.h"
 #include "enum_conversions.h"
 #include "generic_factory.h"
 #include "json.h"
@@ -114,16 +112,6 @@ void activity_type::call_do_turn( player_activity *act, Character *you ) const
     if( pair != activity_handlers::do_turn_functions.end() ) {
         pair->second( act, you );
     }
-
-    if( !do_turn_EOC.is_null() ) {
-        // if we have an EOC defined in json do that
-        dialogue d( get_talker_for( you ), nullptr );
-        if( do_turn_EOC->type == eoc_type::ACTIVATION ) {
-            do_turn_EOC->activate( d );
-        } else {
-            debugmsg( "Must use an activation eoc for player activities.  Otherwise, create a non-recurring effect_on_condition for this with its condition and effects, then have a recurring one queue it." );
-        }
-    }
 }
 
 bool activity_type::call_finish( player_activity *act, Character *you ) const
@@ -136,15 +124,6 @@ bool activity_type::call_finish( player_activity *act, Character *you ) const
         return true;
     }
 
-    if( !completion_EOC.is_null() ) {
-        // if we have an EOC defined in json do that
-        dialogue d( get_talker_for( you ), nullptr );
-        if( completion_EOC->type == eoc_type::ACTIVATION ) {
-            completion_EOC->activate( d );
-        } else {
-            debugmsg( "Must use an activation eoc for player activities.  Otherwise, create a non-recurring effect_on_condition for this with its condition and effects, then have a recurring one queue it." );
-        }
-    }
     return false;
 }
 

--- a/src/activity_type.h
+++ b/src/activity_type.h
@@ -7,6 +7,7 @@
 #include "game_constants.h"
 #include "string_id.h"
 #include "translations.h"
+#include "type_id.h"
 
 class JsonObject;
 class activity_type;
@@ -41,8 +42,10 @@ class activity_type
         bool refuel_fires = false;
         bool auto_needs = false;
         float activity_level = NO_EXERCISE;
-
     public:
+        effect_on_condition_id completion_EOC;
+        effect_on_condition_id do_turn_EOC;
+
         const activity_id &id() const {
             return id_;
         }

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -10,6 +10,7 @@
 #include "calendar.h"
 #include "character.h"
 #include "construction.h"
+#include "effect_on_condition.h"
 #include "field.h"
 #include "game.h"
 #include "item.h"
@@ -313,6 +314,16 @@ void player_activity::do_turn( Character &you )
         // Use the legacy turn function
         type->call_do_turn( this, &you );
     }
+
+    if( !type->do_turn_EOC.is_null() ) {
+        // if we have an EOC defined in json do that
+        dialogue d( get_talker_for( you ), nullptr );
+        if( type->do_turn_EOC->type == eoc_type::ACTIVATION ) {
+            type->do_turn_EOC->activate( d );
+        } else {
+            debugmsg( "Must use an activation eoc for player activities.  Otherwise, create a non-recurring effect_on_condition for this with its condition and effects, then have a recurring one queue it." );
+        }
+    }
     // Activities should never excessively drain stamina.
     // adjusted stamina because
     // autotravel doesn't reduce stamina after do_turn()
@@ -374,6 +385,17 @@ void player_activity::do_turn( Character &you )
             if( !type->call_finish( this, &you ) ) {
                 // "Finish" is never a misnomer for any activity without a finish function
                 set_to_null();
+            }
+        }
+
+
+        if( !type->completion_EOC.is_null() ) {
+            // if we have an EOC defined in json do that
+            dialogue d( get_talker_for( you ), nullptr );
+            if( type->completion_EOC->type == eoc_type::ACTIVATION ) {
+                type->completion_EOC->activate( d );
+            } else {
+                debugmsg( "Must use an activation eoc for player activities.  Otherwise, create a non-recurring effect_on_condition for this with its condition and effects, then have a recurring one queue it." );
             }
         }
     }

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -9,8 +9,8 @@
 #include "point.h"
 
 
-static const activity_id activity_ACT_ADD_VARIABLE_DURING( "ACT_ADD_VARIABLE_DURING" );
-static const activity_id activity_ACT_ADD_VARIABLE_COMPLETE( "ACT_ADD_VARIABLE_COMPLETE" );
+static const activity_id ACT_ADD_VARIABLE_DURING( "ACT_ADD_VARIABLE_DURING" );
+static const activity_id ACT_ADD_VARIABLE_COMPLETE( "ACT_ADD_VARIABLE_COMPLETE" );
 
 static const effect_on_condition_id
 effect_on_condition_EOC_TEST_TRANSFORM_LINE( "EOC_TEST_TRANSFORM_LINE" );
@@ -165,7 +165,7 @@ TEST_CASE( "EOC_activity_finish", "[eoc][timed_event]" )
 {
     clear_avatar();
     clear_map();
-    get_avatar().assign_activity( activity_ACT_ADD_VARIABLE_COMPLETE, 10 );
+    get_avatar().assign_activity( ACT_ADD_VARIABLE_COMPLETE, 10 );
 
     complete_activity( get_avatar() );
 
@@ -176,7 +176,7 @@ TEST_CASE( "EOC_activity_ongoing", "[eoc][timed_event]" )
 {
     clear_avatar();
     clear_map();
-    get_avatar().assign_activity( activity_ACT_ADD_VARIABLE_DURING, 300 );
+    get_avatar().assign_activity( ACT_ADD_VARIABLE_DURING, 300 );
 
     complete_activity( get_avatar() );
 

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -26,6 +26,14 @@ effect_on_condition_EOC_math_var( "EOC_math_var" );
 static const effect_on_condition_id effect_on_condition_EOC_teleport_test( "EOC_teleport_test" );
 namespace
 {
+static void complete_activity( Character &u )
+{
+    while( !u.activity.is_null() ) {
+        u.set_moves( u.get_speed() );
+        u.activity.do_turn( u );
+    }
+}
+
 void check_ter_in_radius( tripoint_abs_ms const &center, int range, ter_id const &ter )
 {
     map tm;
@@ -147,4 +155,27 @@ TEST_CASE( "EOC_transform_line", "[eoc][timed_event]" )
     check_ter_in_line( start, end, t_grass );
     effect_on_condition_EOC_TEST_TRANSFORM_LINE->activate( newDialog );
     check_ter_in_line( start, end, t_dirt );
+}
+
+TEST_CASE( "EOC_activity_finish", "[eoc][timed_event]" )
+{
+    clear_avatar();
+    clear_map();
+    get_avatar().assign_activity( activity_id( "ACT_ADD_VARIABLE_COMPLETE" ), 10 );
+
+    complete_activity( get_avatar() );
+
+    CHECK( stoi( get_avatar().get_value( "npctalk_var_activitiy_incrementer" ) ) == 1 );
+}
+
+TEST_CASE( "EOC_activity_ongoing", "[eoc][timed_event]" )
+{
+    clear_avatar();
+    clear_map();
+    get_avatar().assign_activity( activity_id( "ACT_ADD_VARIABLE_DURING" ), 300 );
+
+    complete_activity( get_avatar() );
+
+    // been going for 3 whole seconds should have incremented 3 times
+    CHECK( stoi( get_avatar().get_value( "npctalk_var_activitiy_incrementer" ) ) == 3 );
 }

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -9,8 +9,8 @@
 #include "point.h"
 
 
-static const activity_id ACT_ADD_VARIABLE_DURING( "ACT_ADD_VARIABLE_DURING" );
 static const activity_id ACT_ADD_VARIABLE_COMPLETE( "ACT_ADD_VARIABLE_COMPLETE" );
+static const activity_id ACT_ADD_VARIABLE_DURING( "ACT_ADD_VARIABLE_DURING" );
 
 static const effect_on_condition_id
 effect_on_condition_EOC_TEST_TRANSFORM_LINE( "EOC_TEST_TRANSFORM_LINE" );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -8,6 +8,10 @@
 #include "player_helpers.h"
 #include "point.h"
 
+
+static const activity_id activity_ACT_ADD_VARIABLE_DURING( "ACT_ADD_VARIABLE_DURING" );
+static const activity_id activity_ACT_ADD_VARIABLE_COMPLETE( "ACT_ADD_VARIABLE_COMPLETE" );
+
 static const effect_on_condition_id
 effect_on_condition_EOC_TEST_TRANSFORM_LINE( "EOC_TEST_TRANSFORM_LINE" );
 static const effect_on_condition_id
@@ -26,7 +30,7 @@ effect_on_condition_EOC_math_var( "EOC_math_var" );
 static const effect_on_condition_id effect_on_condition_EOC_teleport_test( "EOC_teleport_test" );
 namespace
 {
-static void complete_activity( Character &u )
+void complete_activity( Character &u )
 {
     while( !u.activity.is_null() ) {
         u.set_moves( u.get_speed() );
@@ -161,7 +165,7 @@ TEST_CASE( "EOC_activity_finish", "[eoc][timed_event]" )
 {
     clear_avatar();
     clear_map();
-    get_avatar().assign_activity( activity_id( "ACT_ADD_VARIABLE_COMPLETE" ), 10 );
+    get_avatar().assign_activity( activity_ACT_ADD_VARIABLE_COMPLETE, 10 );
 
     complete_activity( get_avatar() );
 
@@ -172,7 +176,7 @@ TEST_CASE( "EOC_activity_ongoing", "[eoc][timed_event]" )
 {
     clear_avatar();
     clear_map();
-    get_avatar().assign_activity( activity_id( "ACT_ADD_VARIABLE_DURING" ), 300 );
+    get_avatar().assign_activity( activity_ACT_ADD_VARIABLE_DURING, 300 );
 
     complete_activity( get_avatar() );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Activities can fire EOCs"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Wanted to be able to define an activity entirely in JSON, now you can.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added code for activities to define a do_turn_eoc and a completion_eoc. Each triggers when you would expect.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Unit tests have been added.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->