### PR TITLE
Updates to Survivor Mode Calcs

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -881,6 +881,8 @@ void Character::initialize()
 
     // Restart cardio accumulator
     reset_cardio_acc();
+
+    recalc_speed_bonus();
 }
 
 void avatar::initialize( character_type type )

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -7,13 +7,14 @@
 #include "profession.h"
 #include "skill.h"
 
+static const profession_id profession_unemployed( "unemployed" );
 
 player_difficulty::player_difficulty()
 {
     // set up an average NPC
     average = npc();
     reset_npc( average );
-    average.prof = &profession_id( "unemployed" ).obj();
+    average.prof = &profession_unemployed.obj();
 }
 
 // creates an npc with similar stats to an avatar for testing

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -13,6 +13,7 @@ player_difficulty::player_difficulty()
     // set up an average NPC
     average = npc();
     reset_npc( average );
+    average.prof = &profession_id( "unemployed" ).obj();
 }
 
 // creates an npc with similar stats to an avatar for testing
@@ -102,20 +103,27 @@ void player_difficulty::reset_npc( Character &dummy )
     dummy.set_per_bonus( 0 );
 }
 
-double player_difficulty::calc_armor_value( const Character &u, bodypart_id bp )
+double player_difficulty::calc_armor_value( const Character &u )
 {
     // a low damage value to be concerned about early
     // only concerned with bash damage since it is most
     // prevalent early game
 
+    const float head_protection = 0.2f;
+    const float torso_protection = 0.4f;
+    const float arms_protection = 0.2f;
+    const float legs_protection = 0.2f;
 
-
-    float armor_val = 0.0f;
+    // don't want divide by zeroes later
+    float armor_val = 0.01f;
 
     // check any other items the character has on them
     if( u.prof ) {
         for( const item &i : u.prof->items( true, std::vector<trait_id>() ) ) {
-            armor_val += i.resist( damage_type::BASH, false, bp );
+            armor_val += i.resist( damage_type::BASH, false, bodypart_id( "head" ) );
+            armor_val += i.resist( damage_type::BASH, false, bodypart_id( "torso" ) );
+            armor_val += i.resist( damage_type::BASH, false, bodypart_id( "arm_r" ) );
+            armor_val += i.resist( damage_type::BASH, false, bodypart_id( "leg_r" ) );
         }
     }
 
@@ -129,39 +137,32 @@ std::string player_difficulty::get_defense_difficulty( const Character &u ) cons
     // the percent margin between result bands
     const float percent_band = 0.5f;
 
-    // guess at the ammount of armor an average clothed person would have
-    float base_armor = 2.0f;
-
     // how much each portion is valued compared to the deviation of others
-    const float standard_movement = 1.0f;
-    const float difficult_movement = 2.0f;
+    // movement is negative since lower is better
+    // small deviations in movement value leads to massive defense value
+    const float standard_movement = -6.0f;
+    const float difficult_movement = -2.0f;
     const float dodge = 1.0f;
-    const float head_protection = 0.2f;
-    const float torso_protection = 0.4f;
-    const float arms_protection = 0.2f;
-    const float legs_protection = 0.2f;
+    const float armor_value = 0.2f;
 
     // calculate move cost on simple ground
-    int player_run_cost = u.run_cost( 100 );
-    int average_run_cost = average.run_cost( 100 );
+    float player_run_cost = static_cast<float>( u.run_cost( 100 ) ) / static_cast<float>
+                            ( u.get_speed() );
+    float average_run_cost = static_cast<float>( average.run_cost( 100 ) ) / static_cast<float>
+                             ( average.get_speed() );
     float per = standard_movement * ( player_run_cost - average_run_cost ) / average_run_cost;
 
     // calculate move cost on simple ground
-    player_run_cost = u.run_cost( 400 );
-    average_run_cost = average.run_cost( 400 );
+    player_run_cost = static_cast<float>( u.run_cost( 400 ) ) / static_cast<float>
+                      ( u.get_speed() );
+    average_run_cost = static_cast<float>( average.run_cost( 400 ) ) / static_cast<float>
+                       ( average.get_speed() );
     per += difficult_movement * ( player_run_cost - average_run_cost ) / average_run_cost;
 
-    // calculate head armor
-    per += head_protection * ( calc_armor_value( u, bodypart_id( "head" ) ) - base_armor ) / base_armor;
-    // calculate torso armor
-    per += torso_protection * ( calc_armor_value( u,
-                                bodypart_id( "torso" ) ) - base_armor ) / base_armor;
-    // calculate arm armor
-    per += arms_protection * ( calc_armor_value( u,
-                               bodypart_id( "arm_r" ) ) - base_armor ) / base_armor;
-    // calculate leg armor
-    per += legs_protection * ( calc_armor_value( u,
-                               bodypart_id( "leg_r" ) ) - base_armor ) / base_armor;
+    // calculate armor value
+    float player_armor = calc_armor_value( u );
+    float average_armor = calc_armor_value( average );
+    per += armor_value * ( player_armor - average_armor ) / average_armor;
     // calculate dodge
     per += dodge * ( u.get_dodge() - average.get_dodge() ) / average.get_dodge();
 
@@ -201,8 +202,9 @@ std::string player_difficulty::get_combat_difficulty( const Character &u ) const
     // the percent margin between result bands
     const float percent_band = 0.5f;
 
-    double npc_dps = calc_dps_value( average );
-    double player_dps = calc_dps_value( u );
+    // dps should be multiplied by speed which is a multiplier
+    double npc_dps = calc_dps_value( average ) * average.get_speed();
+    double player_dps = calc_dps_value( u ) * u.get_speed();
 
     float per = ( player_dps - npc_dps ) / npc_dps;
 
@@ -220,7 +222,7 @@ std::string player_difficulty::get_genetics_difficulty( const Character &u ) con
     // how much traits are valued at
     const int trait_value = 1;
     // the percent margin between result bands
-    const float percent_band = 0.1f;
+    const float percent_band = 2.5f;
 
 
     int genetics_total = u.str_max + u.dex_max + u.per_max + u.int_max;
@@ -238,8 +240,10 @@ std::string player_difficulty::get_genetics_difficulty( const Character &u ) con
         }
     }
 
-    float per = static_cast<float>( genetics_total - average_stats ) / static_cast<float>
-                ( average_stats );
+    // note, not doing a percent calc here just actually evaluating closeness average
+    // we subtract percent band from the average since "average" in the menu goes from
+    // 0 to 1 percent band
+    float per = static_cast<float>( genetics_total - ( average_stats - percent_band ) );
 
     return format_output( percent_band, per );
 }

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -120,10 +120,10 @@ double player_difficulty::calc_armor_value( const Character &u )
     // check any other items the character has on them
     if( u.prof ) {
         for( const item &i : u.prof->items( true, std::vector<trait_id>() ) ) {
-            armor_val += i.resist( damage_type::BASH, false, bodypart_id( "head" ) );
-            armor_val += i.resist( damage_type::BASH, false, bodypart_id( "torso" ) );
-            armor_val += i.resist( damage_type::BASH, false, bodypart_id( "arm_r" ) );
-            armor_val += i.resist( damage_type::BASH, false, bodypart_id( "leg_r" ) );
+            armor_val += head_protection * i.resist( damage_type::BASH, false, bodypart_id( "head" ) );
+            armor_val += torso_protection * i.resist( damage_type::BASH, false, bodypart_id( "torso" ) );
+            armor_val += arms_protection * i.resist( damage_type::BASH, false, bodypart_id( "arm_r" ) );
+            armor_val += legs_protection * i.resist( damage_type::BASH, false, bodypart_id( "leg_r" ) );
         }
     }
 

--- a/src/player_difficulty.h
+++ b/src/player_difficulty.h
@@ -28,7 +28,7 @@ class player_difficulty
         std::string get_social_difficulty( const Character &u ) const;
 
         // helpers for the above functions
-        static double calc_armor_value( const Character &u, bodypart_id bp );
+        static double calc_armor_value( const Character &u );
         static double calc_dps_value( const Character &u );
         static int calc_social_value( const Character &u, const npc &compare );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adjusted some missing stuff from Survivor Mode
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Did a few things in this PR:
 * Adjusted genetics downwards so a character with 6 additional points is average. Basically the bands were wrong for this.
 * Simplified genetics overall. Now it isn't a relative % but uses flat values for points making it easier to read.
 * Fixed an error with how fleet footed / parkour was contributing (they were considered bad for defense).
 * Changed a number of weightings to better reflect value (for example, armour is way less weighted).
 * DPS and movement now consider speed (like from quick)
 * Armor now calculates based on the armor of the survivor profession. It was assuming way to high of armor values to start with.


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Played around in game with values on, was happy with it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->