### PR TITLE
Add a rocky obstacle

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7840,7 +7840,7 @@
     "required_skills": [ [ "survival", 1 ] ],
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
     "time": "5 m",
-    "components": [ [ [ "rock_large", 6 ] ] ],
+    "components": [ [ [ "rock_large", 22 ] ] ],
     "pre_terrain": "t_dirt",
     "post_terrain": "t_rockyobstacle"
   }

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7831,5 +7831,17 @@
     "pre_special": "check_empty",
     "post_special": "done_appliance",
     "activity_level": "LIGHT_EXERCISE"
+  },
+  {
+    "type": "construction",
+    "id": "constr_obstacle_rock",
+    "group": "obstacle_rock",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "survival", 1 ] ],
+    "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
+    "time": "5 m",
+    "components": [ [ [ "rock_large", 6 ] ] ],
+    "pre_terrain": "t_dirt",
+    "post_terrain": "t_rockyobstacle"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1728,5 +1728,10 @@
     "type": "construction_group",
     "id": "place_hd_compressor_unit",
     "name": "Place High Pressure Compressor Unit"
+  },
+  {
+    "type": "construction_group",
+    "id": "obstacle_rock",
+    "name": "Build a Rocky Obstacle"
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -1240,6 +1240,28 @@
     "flags": [ "CONTAINER", "SEALED", "PLACE_ITEM", "WALL", "MINEABLE" ]
   },
   {
+    "id": "t_rockyobstacle",
+    "type": "terrain",
+    "name": "rocky obstacle",
+    "description": "Some larger rocks arranged and crudely rammed into the ground to slow down who or whatever is trying to cross.",
+    "symbol": "^",
+    "color": "light_gray",
+    "looks_like": "t_railroad_rubble",
+    "move_cost": 4,
+    "bash": {
+      "str_min": 20,
+      "str_max": 30,
+      "ter_set": "t_dirt",
+      "sound": "crunch!",
+      "sound_fail": "whack!",
+      "items": [
+        { "item": "rock_large", "count": [ 0, 5 ] },
+        { "item": "sharp_rock", "count": [ 0, 3 ] }
+      ]
+    },
+    "flags": [ "TRANSPARENT", "THIN_OBSTACLE", "SHORT", "ROUGH", "UNSTABLE", "PERMEABLE", "EASY_DECONSTRUCT" ]
+  },
+  {
     "type": "terrain",
     "id": "t_rootcellar",
     "name": "root cellar",

--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -1252,9 +1252,8 @@
       "str_min": 20,
       "str_max": 30,
       "ter_set": "t_dirt",
-      "sound": "crunch!",
-      "sound_fail": "whack!",
-      "items": [ { "item": "rock_large", "count": [ 0, 5 ] }, { "item": "sharp_rock", "count": [ 0, 3 ] } ]
+      "sound_fail": "whump!",
+      "items": [ { "item": "rock_large", "count": [ 0, 20 ] }, { "item": "sharp_rock", "count": [ 0, 16 ] } ]
     },
     "flags": [ "TRANSPARENT", "THIN_OBSTACLE", "SHORT", "ROUGH", "UNSTABLE", "PERMEABLE", "EASY_DECONSTRUCT" ]
   },

--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -1254,10 +1254,7 @@
       "ter_set": "t_dirt",
       "sound": "crunch!",
       "sound_fail": "whack!",
-      "items": [
-        { "item": "rock_large", "count": [ 0, 5 ] },
-        { "item": "sharp_rock", "count": [ 0, 3 ] }
-      ]
+      "items": [ { "item": "rock_large", "count": [ 0, 5 ] }, { "item": "sharp_rock", "count": [ 0, 3 ] } ]
     },
     "flags": [ "TRANSPARENT", "THIN_OBSTACLE", "SHORT", "ROUGH", "UNSTABLE", "PERMEABLE", "EASY_DECONSTRUCT" ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "New construction: rocky obstacle"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

While playtesting, I got some large rocks from digging pits to fortify my base. And I did wonder if they could have some other use.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Adds construction and terrain for the rocky obstacle. Note that this is different to rubble, which is more chaotic in nature and needs more energy and time to clear.

Could certainly be great for hastily constructed survivor camps, both player and mapgen-made.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Looking at rubble, I am unsure of my move_cost value. I was briefly thinking about letting payers construct rocky rubble, but pits have the same move cost value, making that both cheaper and easier to come by.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Loaded into the game locally, looks as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->