### PR TITLE
avatar/item: update cached flags when transforming items

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1187,6 +1187,9 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
             parent_pocket->handle_liquid_or_spill( you, loc.parent_item().get_item() );
         }
     }
+    if( loc ) {
+        loc.on_contents_changed();
+    }
 
     you.recoil = MAX_RECOIL;
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5423,10 +5423,10 @@ void item::properties_info( std::vector<iteminfo> &info, const iteminfo_query *p
 
     if( parts->test( iteminfo_parts::DESCRIPTION_FLAGS ) ) {
         // concatenate base and acquired flags...
-        std::vector<flag_id> flags;
-        std::set_union( type->get_flags().begin(), type->get_flags().end(),
-                        get_flags().begin(), get_flags().end(),
-                        std::back_inserter( flags ) );
+        cata::flat_set<flag_id> flags;
+        flags.insert( get_flags().begin(), get_flags().end() );
+        flags.insert( type->get_flags().begin(), type->get_flags().end() );
+        flags.insert( inherited_tags_cache.begin(), inherited_tags_cache.end() );
 
         // ...and display those which have an info description
         for( const flag_id &e : sorted_lex( flags ) ) {

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -632,8 +632,8 @@ class item_location::impl::item_in_container : public item_location::impl
         }
 
         void remove_item() override {
-            on_contents_changed();
             container->remove_item( *target() );
+            container->on_contents_changed();
         }
 
         void on_contents_changed() override {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4299,6 +4299,7 @@ std::optional<int> modify_gunmods_actor::use( Character &p, item &it, bool,
         // set gun to default in case this changes anything
         it.gun_set_mode( gun_mode_DEFAULT );
         p.invoke_item( mods[prompt.ret], "transform", pnt );
+        it.on_contents_changed();
         return 0;
     }
 

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "avatar.h"
+#include "avatar_action.h"
 #include "calendar.h"
 #include "enums.h"
 #include "flag.h"
@@ -39,6 +40,8 @@ static const itype_id itype_test_duffelbag( "test_duffelbag" );
 static const itype_id itype_test_mp3( "test_mp3" );
 static const itype_id itype_test_smart_phone( "test_smart_phone" );
 static const itype_id itype_test_waterproof_bag( "test_waterproof_bag" );
+
+static const json_character_flag json_flag_DEAF( "DEAF" );
 
 TEST_CASE( "item_volume", "[item]" )
 {
@@ -805,6 +808,17 @@ TEST_CASE( "module_inheritance", "[item][armor]" )
     guy.worn.wear_item( guy, test_exo, false, false, false );
 
     CHECK( guy.worn.worn_with_flag( json_flag_FIX_NEARSIGHT ) );
+
+    clear_avatar();
+    item miner_hat( "miner_hat" );
+    item ear_muffs( "attachable_ear_muffs" );
+    REQUIRE( miner_hat.put_in( ear_muffs, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( !miner_hat.has_flag( json_flag_DEAF ) );
+    guy.wear_item( miner_hat );
+    item_location worn_hat = guy.worn.top_items_loc( guy ).front();
+    item_location worn_muffs( worn_hat, &worn_hat->only_item() );
+    avatar_action::use_item( guy, worn_muffs, "transform" );
+    CHECK( worn_hat->has_flag( json_flag_DEAF ) );
 }
 
 TEST_CASE( "rigid_armor_compliance", "[item][armor]" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Inherited flags aren't updated for transforming contents
* Fixes: #64340
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Update cache whenever the avatar activates a mod/content. Also update the item info to display inherited flags too.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
* Reverting #63594: might still have to do that if this turns into a whack-a-mole
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Updated test unit.

Folding an Uzi properly updates its name and stats.
Activating ear muffs inside a worn miner helmet now makes you deaf.
Deactivating ear muffs inside a miner helmet on the ground also clears the deaf flag from the helmet.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Items that aren't transformed by the avatar (such as items with transform `countdown_action` and inheritable flags) can still lead to stale flags, but there are no such cases for now.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->