### PR TITLE
Refresh equipment spell duration on recast

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -2160,6 +2160,8 @@ class Character : public Creature, public visitable
         /** Returns the first worn item with a given flag. */
         item item_worn_with_flag( const flag_id &flag, const bodypart_id &bp ) const;
         item item_worn_with_flag( const flag_id &flag ) const;
+        /** Returns pointer of the first worn item with a given id. */
+        item *item_worn_with_id( const itype_id &id );
 
         // drawing related stuff
         /**

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -465,6 +465,12 @@ item Character::item_worn_with_flag( const flag_id &f ) const
     return worn.item_worn_with_flag( f );
 }
 
+item *Character::item_worn_with_id( const itype_id &i )
+{
+    return worn.item_worn_with_id( i );
+}
+
+
 bool Character::wearing_something_on( const bodypart_id &bp ) const
 {
     return worn.wearing_something_on( bp );

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -922,6 +922,18 @@ item outfit::item_worn_with_flag( const flag_id &f ) const
     return it_with_flag;
 }
 
+item *outfit::item_worn_with_id( const itype_id &i )
+{
+    item *it_with_id = nullptr;
+    for( item &it : worn ) {
+        if( it.typeId() == i ) {
+            it_with_id = &it;
+            break;
+        }
+    }
+    return it_with_id;
+}
+
 std::list<item> outfit::get_visible_worn_items( const Character &guy ) const
 {
     std::list<item> result;

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -81,6 +81,7 @@ class outfit
         bool is_barefoot() const;
         item item_worn_with_flag( const flag_id &f, const bodypart_id &bp ) const;
         item item_worn_with_flag( const flag_id &f ) const;
+        item *item_worn_with_id( const itype_id &i );
         std::optional<const item *> item_worn_with_inv_let( char invlet ) const;
         // get the best blocking value with the flag that allows worn.
         item *best_shield();

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1088,7 +1088,7 @@ void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const
         }
 
         if( it.ethereal && player_character.is_wearing( it.typeId() ) ) {
-        	// Ethereal equipment already exists so just update its duration
+            // Ethereal equipment already exists so just update its duration
             item *existing_item = player_character.item_worn_with_id( it.typeId() );
             existing_item->set_var( "ethereal", to_turns<int>( sp.duration_turns( caster ) ) );
         } else if( player_character.can_wear( it ).success() ) {

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1087,11 +1087,7 @@ void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const
             it.ethereal = true;
         }
 
-        if( it.ethereal && player_character.is_wearing( it.typeId() ) ) {
-        	// Ethereal equipment already exists so just update its duration
-            item *existing_item = player_character.item_worn_with_id( it.typeId() );
-            existing_item->set_var( "ethereal", to_turns<int>( sp.duration_turns( caster ) ) );
-        } else if( player_character.can_wear( it ).success() ) {
+        if( player_character.can_wear( it ).success() ) {
             it.set_flag( json_flag_FIT );
             player_character.wear_item( it, false );
         } else if( !player_character.has_wield_conflicts( it ) &&

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1087,7 +1087,11 @@ void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const
             it.ethereal = true;
         }
 
-        if( player_character.can_wear( it ).success() ) {
+        if( it.ethereal && player_character.is_wearing( it.typeId() ) ) {
+        	// Ethereal equipment already exists so just update its duration
+            item *existing_item = player_character.item_worn_with_id( it.typeId() );
+            existing_item->set_var( "ethereal", to_turns<int>( sp.duration_turns( caster ) ) );
+        } else if( player_character.can_wear( it ).success() ) {
             it.set_flag( json_flag_FIT );
             player_character.wear_item( it, false );
         } else if( !player_character.has_wield_conflicts( it ) &&


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Refresh equipment spell duration on recast"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When recasting a spell that summons wearable equipment before the previous cast wears off, a character will end up with a duplicate copy of the summoned equipment in either their wield slot (potentially disabling spell casting) or whatever containers the new item fits into. Allowing recasts to refresh duration will improve QoL, and will also fix #40204.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Equipment summoning spells now look through the caster's worn items for an existing copy of the item. If it exists, the duration of the item will be refreshed according to the current spell level. As such, this should not affect summoned weapons and other non-wearable items.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Extend equipment refresh functionality to all items instead of only wearable equipment. This might break some items like "ring of blades".
Instead of refreshing duration of the old item, the old item can be deleted and new item spawned in its place. This resets item durability but might break some spells like "flesh pouch".
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Started a world with the Magiclysm mod.
Character is given the "aura of protection" spell.
Spell is cast and duration of spawned aura item is noted.
Waited for a few turns and noted reduced duration.
Cast "aura of protection" again.
Aura item duration is refreshed to original duration when first cast.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->