### PR TITLE
[misc] red -> tomato & chilly subsitudes curry

### DIFF
--- a/data/json/items/comestibles/drink_other.json
+++ b/data/json/items/comestibles/drink_other.json
@@ -3,7 +3,7 @@
     "type": "COMESTIBLE",
     "id": "sauce_red",
     "looks_like": "tomato_juice",
-    "name": { "str": "red sauce" },
+    "name": { "str": "tomato sauce" },
     "weight": "68 g",
     "color": "red",
     "spoils_in": "3 days",

--- a/data/json/recipes/food/casseroles.json
+++ b/data/json/recipes/food/casseroles.json
@@ -17,20 +17,13 @@
     "components": [
       [ [ "veggy_any_corn_uncooked", 8, "LIST" ] ],
       [ [ "salt", 7 ], [ "seasoning_salt", 7 ], [ "soysauce", 4 ] ],
-      [
-        [ "seasoning_italian", 7 ],
-        [ "wild_herbs", 7 ],
-        [ "pepper", 7 ],
-        [ "cinnamon", 7 ],
-        [ "curry_powder", 7 ],
-        [ "mustard_powder", 7 ]
-      ],
+      [ [ "seasoning_italian", 7 ], [ "wild_herbs", 7 ], [ "pepper", 7 ], [ "cinnamon", 7 ], [ "mustard_powder", 7 ] ],
       [ [ "any_butter_or_oil", 4, "LIST" ] ],
       [ [ "bell_pepper", 1 ] ],
       [ [ "onion", 1 ] ],
       [ [ "cheese", 6 ], [ "can_cheese", 6 ], [ "cheese_hard", 6 ] ],
       [ [ "garlic_clove", 1 ] ],
-      [ [ "chilly-p", 7 ] ]
+      [ [ "chilly-p", 7 ], [ "curry_powder", 7 ] ]
     ]
   },
   {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
to continue on #34068 i renamed red sauce to tomato sauce and changed one recipe so curry_powder is a full substitute for chilly-p in every recipe (i only checked the others, no change necessary there)

#### Describe the solution
* renamed "red sauce" to "tomato sauce", because red sauce is actually Marinara sauce which needs spice
* moved curry_powder to be a substitute for chilly-powder to fit requirements as of issue #34068

#### Describe alternatives you've considered
also change the id of `sauce_red` to `sauce_tomato` which would break external tilesets and mods.

#### Testing
copy changed files into current experimental, start a game, debug all recipes and look if the substitute works.
also search for tomato sauce in crafting

#### Additional context
recipe hot corn casserole: ![image](https://user-images.githubusercontent.com/4641233/230804809-ac8dda78-9dba-4345-9d6b-1a72af456486.png)
tomato sauce: 
![image](https://user-images.githubusercontent.com/4641233/230804862-8c68deb4-263c-416a-8899-0488f99fce33.png)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->