### PR TITLE
Migrate some JSON APIs to string_view

### DIFF
--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -1,7 +1,7 @@
 #include "assign.h"
 
 void report_strict_violation( const JsonObject &jo, const std::string &message,
-                              const std::string &name )
+                              const std::string_view name )
 {
     try {
         // Let the json class do the formatting, it includes the context of the JSON data.

--- a/src/assign.h
+++ b/src/assign.h
@@ -39,7 +39,7 @@ class is_optional : public detail::is_optional_helper<typename std::decay<T>::ty
 };
 
 void report_strict_violation( const JsonObject &jo, const std::string &message,
-                              const std::string &name );
+                              std::string_view name );
 
 template <typename T, typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
 bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict = false,
@@ -94,7 +94,7 @@ bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict 
 bool assign( const JsonObject &jo, const std::string &name, bool &val, bool strict = false );
 
 template <typename T, typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
-bool assign( const JsonObject &jo, const std::string &name, std::pair<T, T> &val,
+bool assign( const JsonObject &jo, const std::string_view name, std::pair<T, T> &val,
              bool strict = false, T lo = std::numeric_limits<T>::lowest(), T hi = std::numeric_limits<T>::max() )
 {
     std::pair<T, T> out;
@@ -133,7 +133,7 @@ bool assign( const JsonObject &jo, const std::string &name, std::pair<T, T> &val
 // handled below in a separate function.
 template < typename T, typename std::enable_if < std::is_class<T>::value &&!is_optional<T>::value,
            int >::type = 0 >
-bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict = false )
+bool assign( const JsonObject &jo, std::string_view name, T &val, bool strict = false )
 {
     T out;
     if( !jo.read( name, out ) ) {
@@ -154,7 +154,7 @@ namespace details
 {
 
 template <typename T, typename Set>
-bool assign_set( const JsonObject &jo, const std::string &name, Set &val )
+bool assign_set( const JsonObject &jo, const std::string_view name, Set &val )
 {
     JsonObject add = jo.get_object( "extend" );
     add.allow_omitted_members();
@@ -192,14 +192,14 @@ bool assign_set( const JsonObject &jo, const std::string &name, Set &val )
 
 template <typename T>
 typename std::enable_if<std::is_constructible<T, std::string>::value, bool>::type assign(
-    const JsonObject &jo, const std::string &name, std::set<T> &val, bool = false )
+    const JsonObject &jo, const std::string_view name, std::set<T> &val, bool = false )
 {
     return details::assign_set<T, std::set<T>>( jo, name, val );
 }
 
 template <typename T>
 typename std::enable_if<std::is_constructible<T, std::string>::value, bool>::type assign(
-    const JsonObject &jo, const std::string &name, cata::flat_set<T> &val, bool = false )
+    const JsonObject &jo, const std::string_view name, cata::flat_set<T> &val, bool = false )
 {
     return details::assign_set<T, cata::flat_set<T>>( jo, name, val );
 }

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -650,6 +650,19 @@ bool string_empty_or_whitespace( const std::string &s )
     } );
 }
 
+int string_view_cmp( const std::string_view l, const std::string_view r )
+{
+    size_t min_len = std::min( l.size(), r.size() );
+    int result = memcmp( l.data(), r.data(), min_len );
+    if( result ) {
+        return result;
+    }
+    if( l.size() == r.size() ) {
+        return 0;
+    }
+    return l.size() < r.size() ? -1 : 1;
+}
+
 std::vector<std::string> string_split( const std::string &string, char delim )
 {
     std::vector<std::string> elems;

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -10,6 +10,9 @@
 #include <map>
 #include <memory>
 #include <numeric>
+#include <optional>
+#include <ostream>
+#include <sstream>
 #include <string> // IWYU pragma: keep
 #include <type_traits>
 #include <unordered_set>
@@ -17,7 +20,6 @@
 #include <vector>
 
 #include "enums.h"
-#include "json.h"
 #include "path_info.h"
 
 class JsonOut;
@@ -458,6 +460,10 @@ inline bool string_ends_with( const std::string &s1, const char( &s2 )[N] )
 }
 
 bool string_empty_or_whitespace( const std::string &s );
+
+/** strcmp, but for string_view objects.  In C++20 this can be replaced with
+ * operator<=> */
+int string_view_cmp( std::string_view, std::string_view );
 
 /** Used as a default filter in various functions */
 template<typename T>

--- a/src/flexbuffer_json-inl.h
+++ b/src/flexbuffer_json-inl.h
@@ -835,39 +835,22 @@ std::string JsonObject::get_string( const char *key, T &&fallback ) const
 }
 
 // Vanilla accessors. Just return the named member and use it's conversion function.
-inline int JsonObject::get_int( const std::string &key ) const
-{
-    return get_member( key.c_str() );
-}
-inline int JsonObject::get_int( const char *key ) const
+inline int JsonObject::get_int( const std::string_view key ) const
 {
     return get_member( key );
 }
 
-inline double JsonObject::get_float( const std::string &key ) const
-{
-    return get_member( key.c_str() );
-}
-inline double JsonObject::get_float( const char *key ) const
+inline double JsonObject::get_float( const std::string_view key ) const
 {
     return get_member( key );
 }
 
-inline bool JsonObject::get_bool( const std::string &key ) const
-{
-    return get_member( key.c_str() );
-}
-inline bool JsonObject::get_bool( const char *key ) const
+inline bool JsonObject::get_bool( const std::string_view key ) const
 {
     return get_member( key );
 }
 
-inline JsonArray JsonObject::get_array( const std::string &key ) const
-{
-    return get_array( key.c_str() );
-}
-
-inline JsonArray JsonObject::get_array( const char *key ) const
+inline JsonArray JsonObject::get_array( const std::string_view key ) const
 {
     std::optional<JsonValue> member_opt = get_member_opt( key );
     if( member_opt.has_value() ) {
@@ -876,12 +859,7 @@ inline JsonArray JsonObject::get_array( const char *key ) const
     return JsonArray{};
 }
 
-inline JsonObject JsonObject::get_object( const std::string &key ) const
-{
-    return get_object( key.c_str() );
-}
-
-inline JsonObject JsonObject::get_object( const char *key ) const
+inline JsonObject JsonObject::get_object( const std::string_view key ) const
 {
     std::optional<JsonValue> member_opt = get_member_opt( key );
     if( member_opt.has_value() ) {
@@ -961,105 +939,62 @@ inline std::vector<std::string> JsonObject::get_as_string_array( const std::stri
     return ret;
 }
 
-inline bool JsonObject::has_member( const std::string &key ) const
-{
-    return has_member( key.c_str() );
-}
-
-inline bool JsonObject::has_member( const char *key ) const
+inline bool JsonObject::has_member( const std::string_view key ) const
 {
     size_t idx;
     return find_map_key_idx( key, keys_, idx );
 }
 
-inline bool JsonObject::has_null( const char *key ) const
+inline bool JsonObject::has_null( const std::string_view key ) const
 {
     flexbuffers::Reference ref = find_value_ref( key );
     return ref.IsNull();
 }
-inline bool JsonObject::has_null( const std::string &key ) const
-{
-    return has_null( key.c_str() );
-}
 
-inline bool JsonObject::has_int( const char *key ) const
-{
-    return has_number( key );
-}
-inline bool JsonObject::has_int( const std::string &key ) const
+inline bool JsonObject::has_int( const std::string_view key ) const
 {
     return has_number( key );
 }
 
-inline bool JsonObject::has_float( const char *key ) const
-{
-    return has_number( key );
-}
-inline bool JsonObject::has_float( const std::string &key ) const
+inline bool JsonObject::has_float( const std::string_view key ) const
 {
     return has_number( key );
 }
 
-inline bool JsonObject::has_number( const char *key ) const
+inline bool JsonObject::has_number( const std::string_view key ) const
 {
     flexbuffers::Reference ref = find_value_ref( key );
     return ref.IsNumeric();
 }
-inline bool JsonObject::has_number( const std::string &key ) const
-{
-    return has_number( key.c_str() );
-}
 
-inline bool JsonObject::has_string( const std::string &key ) const
-{
-    return has_string( key.c_str() );
-}
-
-inline bool JsonObject::has_string( const char *key ) const
+inline bool JsonObject::has_string( const std::string_view key ) const
 {
     flexbuffers::Reference ref = find_value_ref( key );
     return ref.IsString();
 }
 
-inline bool JsonObject::has_bool( const std::string &key ) const
-{
-    return has_bool( key.c_str() );
-}
-inline bool JsonObject::has_bool( const char *key ) const
+inline bool JsonObject::has_bool( const std::string_view key ) const
 {
     flexbuffers::Reference ref = find_value_ref( key );
     return ref.IsBool();
 }
 
-inline bool JsonObject::has_array( const std::string &key ) const
-{
-    return has_array( key.c_str() );
-}
-
-inline bool JsonObject::has_array( const char *key ) const
+inline bool JsonObject::has_array( const std::string_view key ) const
 {
     flexbuffers::Reference ref = find_value_ref( key );
     return ref.IsAnyVector() && !ref.IsMap();
 }
 
-inline bool JsonObject::has_object( const char *key ) const
+inline bool JsonObject::has_object( const std::string_view key ) const
 {
     flexbuffers::Reference ref = find_value_ref( key );
     return ref.IsMap();
-}
-inline bool JsonObject::has_object( const std::string &key ) const
-{
-    return has_object( key.c_str() );
 }
 
 // Fallback accessors. Test if the named member exists, and if yes, return it,
 // else will return the fallback value. Does *not* test the member is the type
 // being requested.
-inline int JsonObject::get_int( const std::string &key, int fallback ) const
-{
-    return get_int( key.c_str(), fallback );
-}
-inline int JsonObject::get_int( const char *key, int fallback ) const
+inline int JsonObject::get_int( const std::string_view key, int fallback ) const
 {
     std::optional<JsonValue> member_opt = get_member_opt( key );
     if( member_opt.has_value() ) {
@@ -1068,11 +1003,7 @@ inline int JsonObject::get_int( const char *key, int fallback ) const
     return fallback;
 }
 
-inline double JsonObject::get_float( const std::string &key, double fallback ) const
-{
-    return get_float( key.c_str(), fallback );
-}
-inline double JsonObject::get_float( const char *key, double fallback ) const
+inline double JsonObject::get_float( const std::string_view key, double fallback ) const
 {
     std::optional<JsonValue> member_opt = get_member_opt( key );
     if( member_opt.has_value() ) {
@@ -1081,11 +1012,7 @@ inline double JsonObject::get_float( const char *key, double fallback ) const
     return fallback;
 }
 
-inline bool JsonObject::get_bool( const std::string &key, bool fallback ) const
-{
-    return get_bool( key.c_str(), fallback );
-}
-inline bool JsonObject::get_bool( const char *key, bool fallback ) const
+inline bool JsonObject::get_bool( const std::string_view key, bool fallback ) const
 {
     std::optional<JsonValue> member_opt = get_member_opt( key );
     if( member_opt.has_value() ) {
@@ -1095,7 +1022,7 @@ inline bool JsonObject::get_bool( const char *key, bool fallback ) const
 }
 
 // Tries to get the member, and if found, calls it visited.
-inline std::optional<JsonValue> JsonObject::get_member_opt( const char *key ) const
+inline std::optional<JsonValue> JsonObject::get_member_opt( const std::string_view key ) const
 {
     size_t idx = 0;
     bool found = find_map_key_idx( key, keys_, idx );
@@ -1106,11 +1033,7 @@ inline std::optional<JsonValue> JsonObject::get_member_opt( const char *key ) co
     return std::nullopt;
 }
 
-inline JsonValue JsonObject::get_member( const std::string &key ) const
-{
-    return get_member( key.c_str() );
-}
-inline JsonValue JsonObject::get_member( const char *key ) const
+inline JsonValue JsonObject::get_member( const std::string_view key ) const
 {
     // Manually bsearch for the key idx to store in visited_fields_bitset_.
     // flexbuffers::Map::operator[] will probably be faster but won't give us the idx,
@@ -1125,13 +1048,13 @@ inline JsonValue JsonObject::get_member( const char *key ) const
     return ( *this )[key];
 }
 
-inline JsonValue JsonObject::operator[]( const char *key ) const
+inline JsonValue JsonObject::operator[]( const std::string_view key ) const
 {
     return get_member( key );
 }
 
 template <typename T>
-bool JsonObject::read( const char *name, T &t, bool throw_on_error ) const
+bool JsonObject::read( std::string_view name, T &t, bool throw_on_error ) const
 {
     std::optional<JsonValue> member_opt = get_member_opt( name );
     if( !member_opt.has_value() ) {
@@ -1139,20 +1062,9 @@ bool JsonObject::read( const char *name, T &t, bool throw_on_error ) const
     }
     return ( *member_opt ).read( t, throw_on_error );
 }
-template <typename T>
-bool JsonObject::read( const std::string &name, T &t, bool throw_on_error ) const
-{
-    return read( name.c_str(), t, throw_on_error );
-}
 
 template <typename T, typename Res>
-Res JsonObject::get_tags( const std::string &name ) const
-{
-    return get_tags<T, Res>( name.c_str() );
-}
-
-template <typename T, typename Res>
-Res JsonObject::get_tags( const char *name ) const
+Res JsonObject::get_tags( const std::string_view name ) const
 {
     Res res;
     std::optional<JsonValue> member_opt = get_member_opt( name );

--- a/src/flexbuffer_json.cpp
+++ b/src/flexbuffer_json.cpp
@@ -272,7 +272,7 @@ void JsonObject::report_unvisited() const
     }
 }
 
-void JsonObject::error_no_member( const std::string &member ) const
+void JsonObject::error_no_member( const std::string_view member ) const
 {
     std::unique_ptr<std::istream> original_json = root_->get_source_stream();
     std::string source_path = [&] {
@@ -290,7 +290,7 @@ void JsonObject::error_no_member( const std::string &member ) const
     jo.allow_omitted_members();
     jo.get_member( member );
     // Just to make sure the compiler understands we will error earlier.
-    jo.throw_error( "Failed to report missing member " + member );
+    jo.throw_error( str_cat( "Failed to report missing member ", member ) );
 }
 
 void JsonObject::error_skipped_members( const std::vector<size_t> &skipped_members ) const
@@ -329,12 +329,7 @@ void JsonObject::throw_error( const std::string &err ) const
     Json::throw_error( path_, 0, err );
 }
 
-void JsonObject::throw_error_at( const std::string &member, const std::string &err ) const
-{
-    throw_error_at( member.c_str(), err );
-}
-
-void JsonObject::throw_error_at( const char *member, const std::string &err ) const
+void JsonObject::throw_error_at( const std::string_view member, const std::string &err ) const
 {
     std::optional<JsonValue> member_opt = get_member_opt( member );
     if( member_opt.has_value() ) {

--- a/src/flexbuffer_json.h
+++ b/src/flexbuffer_json.h
@@ -10,6 +10,7 @@
 
 #include "cata_bitset.h"
 #include "cata_small_literal_vector.h"
+#include "cata_utility.h"
 #include "flexbuffer_cache.h"
 #include "json.h"
 #include "json_error.h"
@@ -602,20 +603,11 @@ class JsonObject : JsonWithPath
         std::string get_string( const char *key, T && fallback ) const;
 
         // Vanilla accessors. Just return the named member and use it's conversion function.
-        bool get_bool( const std::string &key ) const;
-        bool get_bool( const char *key ) const;
-
-        int get_int( const std::string &key ) const;
-        int get_int( const char *key ) const;
-
-        double get_float( const std::string &key ) const;
-        double get_float( const char *key ) const;
-
-        JsonArray get_array( const std::string &key ) const;
-        JsonArray get_array( const char *key ) const;
-
-        JsonObject get_object( const std::string &key ) const;
-        JsonObject get_object( const char *key ) const;
+        bool get_bool( std::string_view key ) const;
+        int get_int( std::string_view key ) const;
+        double get_float( std::string_view key ) const;
+        JsonArray get_array( std::string_view key ) const;
+        JsonObject get_object( std::string_view key ) const;
 
         template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
         E get_enum_value( const std::string &name ) const;
@@ -632,67 +624,37 @@ class JsonObject : JsonWithPath
         std::vector<std::string> get_string_array( const std::string &name ) const;
         std::vector<std::string> get_as_string_array( const std::string &name ) const;
 
-        bool has_member( const std::string &key ) const;
-        bool has_member( const char *key ) const;
-
-        bool has_null( const char *key ) const;
-        bool has_null( const std::string &key ) const;
-
-        bool has_string( const std::string &key ) const;
-        bool has_string( const char *key ) const;
-
-        bool has_bool( const std::string &key ) const;
-        bool has_bool( const char *key ) const;
-
-        bool has_number( const char *key ) const;
-        bool has_number( const std::string &key ) const;
-
-        bool has_int( const char *key ) const;
-        bool has_int( const std::string &key ) const;
-
-        bool has_float( const char *key ) const;
-        bool has_float( const std::string &key ) const;
-
-        bool has_array( const std::string &key ) const;
-        bool has_array( const char *key ) const;
-
-        bool has_object( const char *key ) const;
-        bool has_object( const std::string &key ) const;
+        bool has_member( std::string_view key ) const;
+        bool has_null( std::string_view key ) const;
+        bool has_string( std::string_view key ) const;
+        bool has_bool( std::string_view key ) const;
+        bool has_number( std::string_view key ) const;
+        bool has_int( std::string_view key ) const;
+        bool has_float( std::string_view key ) const;
+        bool has_array( std::string_view key ) const;
+        bool has_object( std::string_view key ) const;
 
         // Fallback accessors. Test if the named member exists, and if yes, return it,
         // else will return the fallback value. Does *not* test the member is the type
         // being requested.
-        bool get_bool( const std::string &key, bool fallback ) const;
-        bool get_bool( const char *key, bool fallback ) const;
-
-        int get_int( const std::string &key, int fallback ) const;
-        int get_int( const char *key, int fallback ) const;
-
-        double get_float( const std::string &key, double fallback ) const;
-        double get_float( const char *key, double fallback ) const;
+        bool get_bool( std::string_view key, bool fallback ) const;
+        int get_int( std::string_view key, int fallback ) const;
+        double get_float( std::string_view key, double fallback ) const;
 
         // Tries to get the member, and if found, calls it visited.
-        std::optional<JsonValue> get_member_opt( const char *key ) const;
-        JsonValue get_member( const std::string &key ) const;
-        JsonValue get_member( const char *key ) const;
-        JsonValue operator[]( const char *key ) const;
+        std::optional<JsonValue> get_member_opt( std::string_view key ) const;
+        JsonValue get_member( std::string_view key ) const;
+        JsonValue operator[]( std::string_view key ) const;
 
         // Schwillions of read overloads
         template <typename T>
-        bool read( const char *name, T &t, bool throw_on_error = true ) const;
-        template <typename T>
-        bool read( const std::string &name, T &t, bool throw_on_error = true ) const;
+        bool read( std::string_view name, T &t, bool throw_on_error = true ) const;
 
         template <typename T = std::string, typename Res = std::set<T>>
-        Res get_tags( const std::string &name ) const;
-
-        template <typename T = std::string, typename Res = std::set<T>>
-        Res get_tags( const char *name ) const;
+        Res get_tags( std::string_view name ) const;
 
         [[noreturn]] void throw_error( const std::string &err ) const;
-
-        [[noreturn]] void throw_error_at( const std::string &member, const std::string &err ) const;
-        [[noreturn]] void throw_error_at( const char *member, const std::string &err ) const;
+        [[noreturn]] void throw_error_at( std::string_view member, const std::string &err ) const;
 
         void allow_omitted_members() const {
             visited_fields_bitset_.set_all();
@@ -715,7 +677,7 @@ class JsonObject : JsonWithPath
         JsonValue operator[]( size_t idx ) const;
 
         // NOLINTNEXTLINE(cata-large-inline-function)
-        flexbuffers::Reference find_value_ref( const char *key ) const {
+        flexbuffers::Reference find_value_ref( const std::string_view key ) const {
             size_t idx = 0;
             bool found = find_map_key_idx( key, keys_, idx );
             if( found ) {
@@ -725,15 +687,16 @@ class JsonObject : JsonWithPath
         }
 
         // NOLINTNEXTLINE(cata-large-inline-function)
-        static bool find_map_key_idx( const char *key, const flexbuffers::TypedVector &keys, size_t &idx ) {
+        static bool find_map_key_idx( const std::string_view key, const flexbuffers::TypedVector &keys,
+                                      size_t &idx ) {
             // Handlrolled binary search because the STL does not provide a version that just uses indexes.
             typename std::make_signed<size_t>::type low = 0;
             typename std::make_signed<size_t>::type high = keys.size() - 1;
             while( low <= high ) {
                 std::make_signed_t<size_t> mid = ( high - low ) / 2 + low;
 
-                const char *test_key = keys[ mid ].AsKey();
-                int res = strcmp( test_key, key );
+                const std::string_view test_key = keys[ mid ].AsKey();
+                int res = string_view_cmp( test_key, key );
 
                 if( res == 0 ) {
                     idx = mid;
@@ -754,7 +717,7 @@ class JsonObject : JsonWithPath
         void report_unvisited() const;
 
         // Reports an error via JsonObject at this location.
-        [[noreturn]] void error_no_member( const std::string &member ) const;
+        [[noreturn]] void error_no_member( std::string_view member ) const;
 
         // debugmsg prints all the skipped members.
         void error_skipped_members( const std::vector<size_t> &skipped_members ) const;

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -128,7 +128,7 @@ TextJsonObject::TextJsonObject( TextJsonIn &j )
     final_separator = jsin->get_ate_separator();
 }
 
-void TextJsonObject::mark_visited( const std::string &name ) const
+void TextJsonObject::mark_visited( const std::string_view name ) const
 {
 #ifndef CATA_IN_TOOL
     visited_members.emplace( name );
@@ -194,12 +194,12 @@ void TextJsonObject::copy_visited_members( const TextJsonObject &rhs ) const
 #endif
 }
 
-int TextJsonObject::verify_position( const std::string &name,
+int TextJsonObject::verify_position( const std::string_view name,
                                      const bool throw_exception ) const
 {
     if( !jsin ) {
         if( throw_exception ) {
-            throw JsonError( std::string( "member lookup on empty object: " ) + name );
+            throw JsonError( str_cat( "member lookup on empty object: ", name ) );
         }
         // 0 is always before the opening brace,
         // so it will never indicate a valid member position
@@ -209,7 +209,7 @@ int TextJsonObject::verify_position( const std::string &name,
     if( iter == positions.end() ) {
         if( throw_exception ) {
             jsin->seek( start );
-            jsin->error( "member not found: " + name );
+            jsin->error( str_cat( "member not found: ", name ) );
         }
         // 0 is always before the opening brace,
         // so it will never indicate a valid member position
@@ -292,7 +292,7 @@ void TextJsonObject::throw_error( const std::string &err ) const
     jsin->error( err );
 }
 
-TextJsonIn *TextJsonObject::get_raw( const std::string &name ) const
+TextJsonIn *TextJsonObject::get_raw( const std::string_view name ) const
 {
     int pos = verify_position( name );
     mark_visited( name );
@@ -2307,11 +2307,11 @@ TextJsonIn &TextJsonValue::seek() const
     return jsin_;
 }
 
-TextJsonValue TextJsonObject::get_member( const std::string &name ) const
+TextJsonValue TextJsonObject::get_member( const std::string_view name ) const
 {
     const auto iter = positions.find( name );
     if( !jsin || iter == positions.end() ) {
-        throw_error( "missing required field \"" + name + "\" in object: " + str() );
+        throw_error( str_cat( "missing required field \"", name, "\" in object: ", str() ) );
     }
     mark_visited( name );
     return TextJsonValue( *jsin, iter->second );

--- a/src/json.h
+++ b/src/json.h
@@ -1015,7 +1015,7 @@ class JsonOut
 class TextJsonObject
 {
     private:
-        std::map<std::string, int> positions;
+        std::map<std::string, int, std::less<>> positions;
         int start;
         int end_;
         bool final_separator;
@@ -1024,11 +1024,11 @@ class TextJsonObject
         mutable bool report_unvisited_members = true;
         mutable bool reported_unvisited_members = false;
 #endif
-        void mark_visited( const std::string &name ) const;
+        void mark_visited( std::string_view name ) const;
         void report_unvisited() const;
 
         TextJsonIn *jsin;
-        int verify_position( const std::string &name,
+        int verify_position( std::string_view name,
                              bool throw_exception = true ) const;
 
     public:
@@ -1064,8 +1064,8 @@ class TextJsonObject
         [[noreturn]] void throw_error( const std::string &err ) const;
         [[noreturn]] void throw_error_at( const std::string &name, const std::string &err ) const;
         // seek to a value and return a pointer to the TextJsonIn (member must exist)
-        TextJsonIn *get_raw( const std::string &name ) const;
-        TextJsonValue get_member( const std::string &name ) const;
+        TextJsonIn *get_raw( std::string_view name ) const;
+        TextJsonValue get_member( std::string_view name ) const;
         json_source_location get_source_location() const;
 
         // values by name

--- a/src/mmap_file.cpp
+++ b/src/mmap_file.cpp
@@ -18,6 +18,7 @@
 
 #include <ghc/fs_std_fwd.hpp>
 
+#include "cata_scope_helpers.h"
 #include "cata_utility.h"
 
 mmap_file::mmap_file() = default;

--- a/src/system_locale.cpp
+++ b/src/system_locale.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+#include <set>
 #include <vector>
 
 #if defined(_WIN32)
@@ -150,7 +152,7 @@ std::optional<std::string> Language()
     if( locale == nullptr ) {
         return std::nullopt;
     }
-    if( strcmp( locale, "C" ) == 0 ) {
+    if( std::strcmp( locale, "C" ) == 0 ) {
         return "en";
     }
     return matchGameLanguage( locale );

--- a/src/translation_cache.h
+++ b/src/translation_cache.h
@@ -105,7 +105,7 @@ inline local_translation_cache<const char *> get_local_translation_cache( const 
 }
 
 inline local_translation_cache<std::string> get_local_translation_cache(
-    const std::string & )
+    const std::string_view )
 {
     return local_translation_cache<std::string>();
 }

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -1,6 +1,7 @@
 #include <string>
 
 #include "cata_utility.h"
+#include "debug.h"
 #include "get_version.h"
 #include "name.h"
 #include "path_info.h"

--- a/src/units.h
+++ b/src/units.h
@@ -1087,7 +1087,7 @@ namespace detail
 {
 
 template<typename T, typename Error>
-T read_from_json_string_common( const std::string &s,
+T read_from_json_string_common( const std::string_view s,
                                 const std::vector<std::pair<std::string, T>> &units, Error &&error )
 {
     size_t i = 0;

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -1268,7 +1268,7 @@ TEST_CASE( "npc_compare_int", "[npc_talk]" )
     CHECK( d.responses[ 16 ].text == "Cash equals 13" );
     CHECK( d.responses[ 17 ].text == "Owed amount equals 14" );
     CHECK( d.responses[ 18 ].text == "Driving skill more than or equal to 5" );
-    // TODO: Relaibly test the random number generator.
+    // TODO: Reliably test the random number generator.
     CHECK( d.responses[ 19 ].text == "Temperature is 21." );
     CHECK( d.responses[ 20 ].text == "Windpower is 15." );
     CHECK( d.responses[ 21 ].text == "Humidity is 16." );

--- a/tests/stringmaker.h
+++ b/tests/stringmaker.h
@@ -4,6 +4,8 @@
 
 #include "cuboid_rectangle.h"
 #include "cata_catch.h"
+#include "string_formatter.h"
+#include "string_id.h"
 
 // StringMaker specializations for Cata types for reporting via Catch2 macros
 


### PR DESCRIPTION
#### Summary
Infrastructure "Migrate some JSON APIs to string_view"

#### Purpose of change
Now we're on C++17 we have access to `std::string_view`.  This allows simplification of some APIs.  In particular, cases where we have previously had separate `char*` and `std::string` overloads can now be merged into one function.

There are quite a few such overload sets in the JSON code.

#### Describe the solution
Migrate a bunch of the JSON code and associated stuff to `string_view`.

This is just an initial effort; it's supposed to be a minimum viable initial step.

Note that the conversion is quite viral; it led me to convert all the APIs used by the JSON code to string_view too.

Also, fixed a random unrelated typo in the tests.

#### Describe alternatives you've considered
I'm using the convention that `string_view` should be passed by value, since it can be passed in registers on some platforms.  However, IIRC that's not true on Windows, so we might actually want to pass by `const string_view&` for best performance on Windows.  Still, it shouldn't make much difference either way, and this option is less verbose.

#### Testing
Unit tests.

#### Additional context
I plan to migrate more stuff to `string_view`.  This PR is partly to test the waters for how much appetite there is to do that.