### PR TITLE
Prevent fire damaging unbreakable items

### DIFF
--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1759,7 +1759,8 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
         if( outermost && elem.type == damage_type::HEAT && elem.amount >= 1.0f ) {
             // TODO: Different fire intensity values based on damage
             fire_data frd{ 2 };
-            destroy = !armor.has_flag( flag_INTEGRATED ) && !armor.has_flag( flag_UNBREAKABLE ) && armor.burn( frd );
+            destroy = !armor.has_flag( flag_INTEGRATED ) && !armor.has_flag( flag_UNBREAKABLE ) &&
+                      armor.burn( frd );
             int fuel = roll_remainder( frd.fuel_produced );
             if( fuel > 0 ) {
                 guy.add_effect( effect_onfire, time_duration::from_turns( fuel + 1 ), bp, false, 0, false,

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1759,8 +1759,7 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
         if( outermost && elem.type == damage_type::HEAT && elem.amount >= 1.0f ) {
             // TODO: Different fire intensity values based on damage
             fire_data frd{ 2 };
-            destroy = !armor.has_flag( flag_INTEGRATED ) && !armor.has_flag( flag_UNBREAKABLE ) &&
-                      armor.burn( frd );
+            destroy = !armor.has_flag( flag_INTEGRATED ) && armor.burn( frd );
             int fuel = roll_remainder( frd.fuel_produced );
             if( fuel > 0 ) {
                 guy.add_effect( effect_onfire, time_duration::from_turns( fuel + 1 ), bp, false, 0, false,

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1759,7 +1759,7 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
         if( outermost && elem.type == damage_type::HEAT && elem.amount >= 1.0f ) {
             // TODO: Different fire intensity values based on damage
             fire_data frd{ 2 };
-            destroy = !armor.has_flag( flag_INTEGRATED ) && armor.burn( frd );
+            destroy = !armor.has_flag( flag_INTEGRATED ) && !armor.has_flag( flag_UNBREAKABLE ) && armor.burn( frd );
             int fuel = roll_remainder( frd.fuel_produced );
             if( fuel > 0 ) {
                 guy.add_effect( effect_onfire, time_duration::from_turns( fuel + 1 ), bp, false, 0, false,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11250,10 +11250,11 @@ float item::simulate_burn( fire_data &frd ) const
 
 bool item::burn( fire_data &frd )
 {
-if( has_flag( flag_UNBREAKABLE ) )
-{
-    return false;
-}
+    if( has_flag( flag_UNBREAKABLE ) ) {
+        return false;
+    }
+    
+    float burn_added = simulate_burn( frd );
 
     if( burn_added <= 0 ) {
         return false;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11249,10 +11249,14 @@ float item::simulate_burn( fire_data &frd ) const
 }
 
 bool item::burn( fire_data &frd )
-{
+
+    if( has_flag( flag_UNBREAKABLE ) ) {
+        return false;
+    }
+    
     float burn_added = simulate_burn( frd );
 
-    if( burn_added <= 0 || has_flag( flag_UNBREAKABLE ) ) {
+    if( burn_added <= 0 ) {
         return false;
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11253,7 +11253,6 @@ bool item::burn( fire_data &frd )
     if( has_flag( flag_UNBREAKABLE ) ) {
         return false;
     }
-    
     float burn_added = simulate_burn( frd );
 
     if( burn_added <= 0 ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11252,7 +11252,7 @@ bool item::burn( fire_data &frd )
 {
     float burn_added = simulate_burn( frd );
 
-    if( burn_added <= 0 ) {
+    if( burn_added <= 0 || has_flag( flag_UNBREAKABLE ) ) {
         return false;
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11249,7 +11249,7 @@ float item::simulate_burn( fire_data &frd ) const
 }
 
 bool item::burn( fire_data &frd )
-
+{
     if( has_flag( flag_UNBREAKABLE ) ) {
         return false;
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11250,11 +11250,10 @@ float item::simulate_burn( fire_data &frd ) const
 
 bool item::burn( fire_data &frd )
 {
-    if( has_flag( flag_UNBREAKABLE ) ) {
-        return false;
-    }
-    
-    float burn_added = simulate_burn( frd );
+if( has_flag( flag_UNBREAKABLE ) )
+{
+    return false;
+}
 
     if( burn_added <= 0 ) {
         return false;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent fire damaging unbreakable items"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Items flagged with "UNBREAKABLE" can be damaged by fire in two ways. Either by wearing them and getting set on fire, or by directly dropping the item into fd_fire. This might not be obvious because most "UNBREAKABLE" items are also "INTEGRATED" which, unlike the former flag, actually works to protect worn equipment from fire damage.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The "item::burn" and "outfit::absorb_damage" functions will now check for the "UNBREAKABLE" flag and exempt flagged items from sustaining damage.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
In addition to these changes, we can also remove damage immunity from "INTEGRATED" flagged items.  This opens the possibility of repairable bionic parts, but safeguards should be put in place to prevent them from being completely destroyed. Integrated parts with the "UNBREAKABLE" flag should retain their original invulnerability.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The "aura of protection" from the Magiclysm mod was modded to be "UNBREAKABLE" and unequipable. Its coverage and location in the outer aura slot makes it particularly vulnerable to fire
A character is given the aura of protection
fd_fire with intensity 1 is spawned next to the character
The character walks into fd_fire and waits for a few rounds
The aura of protection is undamaged (before the changes it would have been completely burnt)
The aura of protection is dropped into the fire
Waited a few more rounds
The aura on the burning ground remains undamaged

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Can be considered an intermediate step in addressing #64555 which I will work on after this.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->