### PR TITLE
[fix] energy consumption of taste mod CBM

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -500,9 +500,8 @@ std::pair<int, int> Character::fun_for( const item &comest, bool ignore_already_
         fun = fun - 13;
     }
 
-    if( has_active_bionic( bio_taste_blocker ) &&
-        get_power_level() > units::from_kilojoule( std::abs( comest.get_comestible_fun() ) ) &&
-        fun < 0 ) {
+    if( fun < 0 && has_active_bionic( bio_taste_blocker ) &&
+        get_power_level() > units::from_kilojoule( std::abs( comest.get_comestible_fun() ) ) ) {
         fun = 0;
     }
 
@@ -1057,8 +1056,9 @@ static bool eat( item &food, Character &you, bool force )
         you.use_charges( food.get_comestible()->tool, 1 );
     }
 
-    if( you.has_active_bionic( bio_taste_blocker ) ) {
-        you.mod_power_level( units::from_kilojoule( -std::abs( food.get_comestible_fun() ) ) );
+    if( you.has_active_bionic( bio_taste_blocker ) && food.get_comestible_fun() < 0 &&
+        you.get_power_level() > units::from_kilojoule( std::abs( food.get_comestible_fun() ) ) ) {
+        you.mod_power_level( units::from_kilojoule( food.get_comestible_fun() ) );
     }
 
     if( food.has_flag( flag_FUNGAL_VECTOR ) && !you.has_trait( trait_M_IMMUNE ) ) {


### PR DESCRIPTION
#### Summary
Bugfixes "fix Energy consumption of 'Taste Modifier CBM' when consuming food with positive enjoyment"

#### Purpose of change
When you consume food with a positive enjoyment value the CBM shouldn't do anything, it should neither change the enjoyment nor consume energy, as it is described in the item data.
fixes #64976

#### Describe the solution
* change order of conditionals in `fun_for()` to increase performance
* `mod_power_level(-foo)` only if negative fun would be applied without CBM
* ^also only if enough energy is available

#### Describe alternatives you've considered
1. leave it as it is.
2. for the case that more energy would be consumed than there is available:
    - one could consume the availabe energy (if >1kJ) and add only `int(energy_avail(kJ))` to joy
    - this would imply fundamental changes to `fun_for()` and data being processed (this function has nothing to do with energy consumption)
    - i dumped this idea because it's borderline

#### Testing
1. compile code, start game
2. create world with a character with a taste mod cbm (eg bionic soldier)
3. ensure taste mod cbm is the only active cbm
4. spawn them cheese, spawn them butter
5. eat them cheese, check morale and available bio energy
6. eat them butter, check morale and available bio energy
7. drain available bio energy to <1kJ && >0kJ
8. wait 2h to get morale back to 0
9. repeat 5&6
10. repeat 8
11. deactivate cbm
12. repeat 5&6
13. all good