### PR TITLE
alternative fix: item spawning spells with no min/max damage

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1068,7 +1068,8 @@ void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const
 
     std::vector<item> granted;
 
-    for( int i = 0; i < sp.damage( caster ); i++ ) {
+    int count = std::min( 1, sp.damage( caster ) );
+    for( int i = 0; i < count; i++ ) {
         if( sp.has_flag( spell_flag::SPAWN_GROUP ) ) {
             std::vector<item> group_items = item_group::items_from( item_group_id( sp.effect_data() ),
                                             calendar::turn );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Alternative to #64965, recreates the old behavior so it doesn't break existing json.

#### Describe the solution

Always spawn at least one item/item group, even with no damage defined.

#### Describe alternatives you've considered



#### Testing



#### Additional context

@casswedson probably of interest to you. I can't judge what the actually preferable solution would be since I don't know too much about spells.