### PR TITLE
Do not require battery for ups/bionic powered tools

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10238,9 +10238,9 @@ int item::ammo_remaining( const Character *carrier ) const
         }
     }
 
-    // UPS/bionic power can replace battery ammo requirement.
+    // UPS/bionic power can replace ammo requirement.
     // Only for tools. Guns should always use energy_drain for electricity use.
-    if( carrier != nullptr && type->tool && type->tool->ammo_id.count( ammo_battery ) ) {
+    if( carrier != nullptr && type->tool ) {
         if( has_flag( flag_USES_BIONIC_POWER ) ) {
             ret += units::to_kilojoule( carrier->get_power_level() );
         }
@@ -10401,9 +10401,9 @@ int item::ammo_consume( int qty, const tripoint &pos, Character *carrier )
         qty -= charg_used;
     }
 
-    // Modded tools can consume UPS/bionic energy instead of (battery)ammo.
+    // Modded tools can consume UPS/bionic energy instead of ammo.
     // Guns handle energy in energy_consume()
-    if( carrier != nullptr && type->tool && type->tool->ammo_id.count( ammo_battery ) ) {
+    if( carrier != nullptr && type->tool ) {
         units::energy wanted_energy = units::from_kilojoule( qty );
 
         if( has_flag( flag_USE_UPS ) ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -787,13 +787,14 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun )
         mounted_creature->has_flag( MF_RIDEABLE_MECH ) ) {
         is_mech_weapon = true;
     }
-
-    // cap our maximum burst size by ammo and energy
-    if( !gun.has_flag( flag_VEHICLE ) ) {
-        shots = std::min( shots, gun.shots_remaining( this ) );
-    } else {
-        // This checks ammo only. Vehicle turret energy drain is handled elsewhere.
+    // Number of shots to fire is limited by the amount of remaining ammo
+    if( gun.ammo_required() ) {
         shots = std::min( shots, static_cast<int>( gun.ammo_remaining() / gun.ammo_required() ) );
+    }
+
+    // cap our maximum burst size by the amount of UPS power left
+    if( !gun.has_flag( flag_VEHICLE ) && gun.get_gun_ups_drain() > 0_kJ ) {
+        shots = std::min( shots, static_cast<int>( available_ups() / gun.get_gun_ups_drain() ) );
     }
 
     if( shots <= 0 ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -787,14 +787,13 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun )
         mounted_creature->has_flag( MF_RIDEABLE_MECH ) ) {
         is_mech_weapon = true;
     }
-    // Number of shots to fire is limited by the amount of remaining ammo
-    if( gun.ammo_required() ) {
-        shots = std::min( shots, static_cast<int>( gun.ammo_remaining() / gun.ammo_required() ) );
-    }
 
-    // cap our maximum burst size by the amount of UPS power left
-    if( !gun.has_flag( flag_VEHICLE ) && gun.get_gun_ups_drain() > 0_kJ ) {
-        shots = std::min( shots, static_cast<int>( available_ups() / gun.get_gun_ups_drain() ) );
+    // cap our maximum burst size by ammo and energy
+    if( !gun.has_flag( flag_VEHICLE ) ) {
+        shots = std::min( shots, gun.shots_remaining( this ) );
+    } else {
+        // This checks ammo only. Vehicle turret energy drain is handled elsewhere.
+        shots = std::min( shots, static_cast<int>( gun.ammo_remaining() / gun.ammo_required() ) );
     }
 
     if( shots <= 0 ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Earlier I set tools that use UPS/bionic power to only do so if the tool uses battery as ammo. This was to reflect gun behavior where ups/Bionic power can only be used for electricity and not for replacing other ammo.
Various tools use UPS/bionic power without using battery as ammo causing them to break.
Using UPS/bionic power only for battery powered tools is not useful check at this point as tools can't use multiple different ammo types.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Remove the battery ammo check. All tools with UPS/bionic power flag are now able to use UPS/bionic power regardless of what ammo the tool uses (if any).

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Find all tools that do not use battery as ammo but may use bionic power/ups and add battery as ammo to them. I think that would be unnecessary busywork with no major benefits.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Compiles.
Tests pass.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->