### PR TITLE
Add bundling for synthetic fabric

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -489,6 +489,22 @@
     "color": "white"
   },
   {
+    "id": "bundle_nylon",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "bundle of synthetic fabric", "str_pl": "bundles of synthetic fabric" },
+    "description": "Fifty synthetic fabric patches, bundled tightly together for storage.  Disassemble to unpack.",
+    "//": "Weight is 50 x 5750mg per patch",
+    "weight": "287500 mg",
+    "//2": "Volume is 50 x 5ml per patch",
+    "volume": "250ml",
+    "price": 0,
+    "price_postapoc": 500,
+    "material": [ "nylon" ],
+    "symbol": ",",
+    "color": "white"
+  },
+  {
     "id": "bundle_plank",
     "type": "GENERIC",
     "category": "spare_parts",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -3509,6 +3509,7 @@
       "bundle_cotton",
       "bundle_leather",
       "bundle_wool",
+      "bundle_nylon",
       "bundle_plank",
       "bundle_rebar",
       "bundle_pipe",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -5093,15 +5093,6 @@
     "flags": [ "BLIND_EASY" ]
   },
   {
-    "result": "bundle_nylon",
-    "type": "uncraft",
-    "activity_level": "NO_EXERCISE",
-    "skill_used": "fabrication",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "nylon", 50 ] ], [ [ "thread", 8 ] ] ],
-    "flags": [ "BLIND_EASY" ]
-  },
-  {
     "result": "nomex",
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -5093,6 +5093,15 @@
     "flags": [ "BLIND_EASY" ]
   },
   {
+    "result": "bundle_nylon",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "fabrication",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "nylon", 50 ] ], [ [ "thread", 8 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
     "result": "nomex",
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -2649,6 +2649,20 @@
     "flags": [ "BLIND_HARD" ]
   },
   {
+    "result": "bundle_nylon",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "time": "1 m",
+    "autolearn": true,
+    "using": [ [ "filament", 8 ] ],
+    "qualities": [ { "id": "SEW", "level": 1 } ],
+    "components": [ [ [ "nylon", 50 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
     "result": "bundle_plank",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -2657,6 +2657,7 @@
     "skill_used": "fabrication",
     "time": "1 m",
     "autolearn": true,
+    "reversible": true,
     "using": [ [ "filament", 8 ] ],
     "qualities": [ { "id": "SEW", "level": 1 } ],
     "components": [ [ [ "nylon", 50 ] ] ],


### PR DESCRIPTION
#### Summary

Balance "Add bundling for synethic fabric"

#### Purpose of change

Synthetic patches could not be bundled, making them extremely slow to move in bulk. This adds bundling for them, just like we have for leather, cotton, etc.

#### Describe the solution

JSON edits.

#### Describe alternatives you've considered

Using bundles of 100 rather than 50.

#### Testing

Applied changes to my current game. Bundled some synthetic fabric. Took it back to base. Unbundled it.

#### Additional context

None