### PR TITLE
Replace flat modifiers for learning traits with multiplication

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -814,7 +814,7 @@
     "starting_trait": true,
     "valid": false,
     "cancels": [ "SLOWLEARNER" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "LEARNING_FOCUS", "add": 15 } ] } ]
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "LEARNING_FOCUS", "multiply": 0.15 } ] } ]
   },
   {
     "type": "mutation",
@@ -1477,7 +1477,7 @@
     "starting_trait": true,
     "valid": false,
     "cancels": [ "FASTLEARNER" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "LEARNING_FOCUS", "add": -15 } ] } ]
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "LEARNING_FOCUS", "multiply": -0.15 } ] } ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone in discord pointed, that having a flat -15 focus modifier makes impossible to learn anything, if your focus is lower than 15, which is kinda bad
#### Describe the solution
Replace flat -15 and +15 with -15% and 15% multiplier respectively
#### Describe alternatives you've considered
Use another number (issue author proposed `"add": 30, "multiply": -0.3`, but it looks like it buff the slow learner way too much)
#### Additional context
 FASTLEARNER

| Focus value | 125 | 100 | 75 | 50 | 25 | 15 | 10 |
| ----------- | --- | --- | -- | -- | -- | -- | -- |
| Old         | 140 | 115 | 90 | 65 | 40 | 30 | 25 |
| New         | 144 | 115 | 86 | 58 | 29 | 17 | 12 |

SLOWLEARNER

| Focus value | 125 | 100 | 75 | 50 | 25 | 15 | 10 |
| ----------- | --- | --- | -- | -- | -- | -- | -- |
| Old         | 110 | 85  | 60 | 35 | 10 | 0  | 0  |
| New         | 106 | 85  | 64 | 43 | 21 | 13 | 9  |