### PR TITLE
Allow arrays in "variant" field of sound_effect JSON

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -62,9 +62,16 @@ struct sound_effect_resource {
     };
     std::unique_ptr<Mix_Chunk, deleter> chunk;
 };
+
+static int add_sfx_path( const std::string &path );
+
 struct sound_effect {
-    int volume = 0;
-    int resource_id = 0;
+    const int volume = 0;
+    const int resource_id = 0;
+
+    sound_effect() = default;
+    sound_effect( int volume, const std::string &path )
+        : volume( volume ), resource_id( add_sfx_path( path ) ) {}
 };
 
 // Sound effects are primarily keyed by id
@@ -545,10 +552,10 @@ void sfx::load_sound_effects( const JsonObject &jsobj )
     }
     sfx_args key = {
         jsobj.get_string( "id" ),
-        jsobj.get_string( "variant", "default" ),
+        "", // actual variant string is filled in the variant loop
         jsobj.get_string( "season", "" ),
-        std::optional<bool>(),
-        std::optional<bool>()
+        std::nullopt,
+        std::nullopt,
     };
     if( jsobj.has_bool( "is_indoors" ) ) {
         key.indoors = jsobj.get_bool( "is_indoors" );
@@ -557,16 +564,19 @@ void sfx::load_sound_effects( const JsonObject &jsobj )
         key.night = jsobj.get_bool( "is_night" );
     }
     const int volume = jsobj.get_int( "volume", 100 );
-    auto &effects = sfx_resources.sound_effects[ key ];
-
-    for( const std::string file : jsobj.get_array( "files" ) ) {
-        sound_effect new_sound_effect;
-        new_sound_effect.volume = volume;
-        new_sound_effect.resource_id = add_sfx_path( file );
-
-        effects.push_back( new_sound_effect );
+    std::vector<std::string> variants = jsobj.get_as_string_array( "variant" );
+    if( variants.empty() ) {
+        variants.emplace_back( "default" );
+    }
+    for( const std::string &variant : variants ) {
+        key.variant = variant;
+        std::vector<sound_effect> &effects = sfx_resources.sound_effects[key];
+        for( const std::string file : jsobj.get_array( "files" ) ) {
+            effects.emplace_back( volume, file );
+        }
     }
 }
+
 void sfx::load_sound_effect_preload( const JsonObject &jsobj )
 {
     if( !sound_init_success ) {
@@ -576,10 +586,10 @@ void sfx::load_sound_effect_preload( const JsonObject &jsobj )
     for( JsonObject aobj : jsobj.get_array( "preload" ) ) {
         sfx_args preload_key = {
             aobj.get_string( "id" ),
-            aobj.get_string( "variant", "default" ),
+            "", // actual variant string is filled in the variant loop
             aobj.get_string( "season", "" ),
-            std::optional<bool>(),
-            std::optional<bool>()
+            std::nullopt,
+            std::nullopt,
         };
         if( aobj.has_bool( "is_indoors" ) ) {
             preload_key.indoors = aobj.get_bool( "is_indoors" );
@@ -587,7 +597,14 @@ void sfx::load_sound_effect_preload( const JsonObject &jsobj )
         if( aobj.has_bool( "is_night" ) ) {
             preload_key.night = aobj.get_bool( "is_night" );
         }
-        sfx_preload.push_back( preload_key );
+        std::vector<std::string> variants = jsobj.get_as_string_array( "variant" );
+        if( variants.empty() ) {
+            variants.emplace_back( "default" );
+        }
+        for( const std::string &variant : variants ) {
+            preload_key.variant = variant;
+            sfx_preload.push_back( preload_key );
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/50725

#### Describe the solution

Allows `variant` field in `sound_effect` and `sound_effect_preload` to load as single variant string, array of variant strings or defaults to `default` string

#### Describe alternatives you've considered

#### Testing

Game sounds still play, debugger shows the map filling up with variants if json is modified

#### Additional context
