### PR TITLE
inventory_ui: cache entry category

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -595,7 +595,8 @@ const item_category *inventory_entry::get_category_ptr() const
     if( !is_item() ) {
         return nullptr;
     }
-    return &any_item()->get_category_of_contents();
+    custom_category = &any_item()->get_category_of_contents();
+    return custom_category;
 }
 
 bool inventory_column::activatable() const

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -210,7 +210,7 @@ class inventory_entry
         void reset_entry_cell_cache() const;
 
     private:
-        const item_category *custom_category = nullptr;
+        mutable item_category const *custom_category = nullptr;
     protected:
         // indents the entry if it is contained in an item
         bool _indent = true;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Determining item category repeatedly can be really expensive for items with lots of contents and especially when collation is enabled
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Reuse `custom_category` to cache non-custom category too

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Opening the `a`ctivate menu in [TrailBalls-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/11203805/TrailBalls-trimmed.tar.gz) (provided by Karol1223)

<details>
<summary>Before</summary>

![before-perf](https://user-images.githubusercontent.com/68240139/231258902-bc120223-dc90-489e-8554-9bd10cda355a.png)
![before](https://user-images.githubusercontent.com/68240139/231258915-a2324e21-5a41-411f-acb1-f2f7574a0e28.png)


</details>


<details>
<summary>After</summary>

![after-perf](https://user-images.githubusercontent.com/68240139/231258937-6aa3d8ca-6d01-445b-9708-1ae4f51d4ff6.png)
![after](https://user-images.githubusercontent.com/68240139/231258948-9616479d-14e4-4469-bf21-14baee33e168.png)


</details>

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->