### PR TITLE
Clothing and Armor Coverage Conversion Part 4

### DIFF
--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -18,7 +18,16 @@
     "material_thickness": 2,
     "qualities": [ [ "COOK", 3 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "CHEM", 1 ] ],
     "techniques": [ "WBLOCK_1" ],
-    "armor": [ { "encumbrance_modifiers": [ "IMBALANCED" ], "coverage": 55, "covers": [ "head" ] } ]
+    "armor": [
+      {
+        "encumbrance_modifiers": [ "IMBALANCED" ],
+        "coverage": 100,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown" ]
+      },
+      { "coverage": 80, "covers": [ "head" ], "specifically_covers": [ "head_forehead" ] },
+      { "coverage": 20, "covers": [ "head" ], "specifically_covers": [ "head_ear_l", "head_ear_r" ] }
+    ]
   },
   {
     "id": "stockpot_helmet",
@@ -48,9 +57,27 @@
           { "type": "aluminum", "covered_by_mat": 40, "thickness": 4.0 }
         ],
         "covers": [ "head" ],
-        "coverage": 92,
+        "coverage": 100,
+        "specifically_covers": [ "head_ear_l", "head_ear_r" ],
         "layers": [ "NORMAL", "OUTER" ],
         "encumbrance_modifiers": [ "RESTRICTS_NECK", "IMBALANCED" ]
+      },
+      {
+        "material": [
+          { "type": "mc_steel", "covered_by_mat": 100, "thickness": 0.95 },
+          { "type": "cotton", "covered_by_mat": 98, "thickness": 2.5 }
+        ],
+        "covers": [ "head" ],
+        "coverage": 100,
+        "specifically_covers": [ "head_crown", "head_forehead" ],
+        "layers": [ "NORMAL", "OUTER" ]
+      },
+      {
+        "material": [ { "type": "mc_steel", "covered_by_mat": 100, "thickness": 0.95 } ],
+        "covers": [ "head" ],
+        "coverage": 80,
+        "specifically_covers": [ "head_throat", "head_nape" ],
+        "layers": [ "OUTER" ]
       },
       {
         "material": [ { "type": "mc_steel", "covered_by_mat": 100, "thickness": 0.95 } ],
@@ -62,8 +89,16 @@
       },
       {
         "material": [ { "type": "mc_steel", "covered_by_mat": 100, "thickness": 0.95 } ],
+        "coverage": 95,
         "covers": [ "mouth" ],
-        "coverage": 80,
+        "specifically_covers": [ "mouth_cheeks" ],
+        "layers": [ "OUTER" ]
+      },
+      {
+        "material": [ { "type": "mc_steel", "covered_by_mat": 100, "thickness": 0.95 } ],
+        "covers": [ "mouth" ],
+        "coverage": 40,
+        "specifically_covers": [ "mouth_lips", "mouth_nose", "mouth_chin" ],
         "encumbrance": 30,
         "layers": [ "OUTER" ],
         "rigid_layer_only": true
@@ -93,8 +128,28 @@
     "armor": [
       {
         "encumbrance_modifiers": [ "NONE" ],
-        "coverage": 75,
+        "coverage": 40,
         "covers": [ "head" ],
+        "specifically_covers": [ "head_crown" ],
+        "material": [
+          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 14 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 1.5 }
+        ]
+      },
+      {
+        "coverage": 95,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_forehead", "head_ear_l", "head_ear_r" ],
+        "material": [
+          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 14 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 1.5 }
+        ]
+      },
+      {
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 95,
+        "covers": [ "mouth" ],
+        "specifically_covers": [ "mouth_cheeks", "mouth_chin" ],
         "material": [
           { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 14 },
           { "type": "leather", "covered_by_mat": 100, "thickness": 1.5 }
@@ -123,7 +178,20 @@
     "material_thickness": 9,
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "PADDED" ],
-    "armor": [ { "encumbrance_modifiers": [ "NONE" ], "coverage": 85, "covers": [ "head" ] } ],
+    "armor": [
+      {
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 100,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_forehead" ]
+      },
+      {
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 50,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_ear_l", "head_ear_r" ]
+      }
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -226,7 +294,20 @@
     "material_thickness": 8,
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "PADDED" ],
-    "armor": [ { "encumbrance_modifiers": [ "NONE" ], "coverage": 95, "covers": [ "head" ] } ],
+    "armor": [
+      {
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 100,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_forehead" ]
+      },
+      {
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 10,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_ear_l", "head_ear_r" ]
+      }
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -301,7 +382,25 @@
     "material_thickness": 6,
     "environmental_protection": 6,
     "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "PADDED" ],
-    "armor": [ { "encumbrance_modifiers": [ "NONE" ], "coverage": 75, "covers": [ "head" ] } ]
+    "armor": [
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 5.0 },
+          { "type": "nomex", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 100,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_forehead" ]
+      },
+      {
+        "material": [ { "type": "nomex", "covered_by_mat": 100, "thickness": 1.0 } ],
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 100,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_ear_l", "head_ear_r", "head_nape" ]
+      }
+    ]
   },
   {
     "id": "helmet_ball",
@@ -327,13 +426,24 @@
     "flags": [ "PADDED" ],
     "armor": [
       {
-        "encumbrance_modifiers": [ "NONE" ],
-        "coverage": 95,
-        "covers": [ "head" ],
         "material": [
           { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 12 },
           { "type": "plastic", "covered_by_mat": 100, "thickness": 3 }
-        ]
+        ],
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 100,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_forehead" ]
+      },
+      {
+        "material": [
+          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 12 },
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 3 }
+        ],
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 95,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_ear_l", "head_ear_r" ]
       }
     ]
   },
@@ -353,8 +463,33 @@
     "looks_like": "helmet_plate",
     "color": "light_gray",
     "armor": [
-      { "covers": [ "head" ], "coverage": 95, "encumbrance_modifiers": [ "NONE" ] },
-      { "covers": [ "eyes", "mouth" ], "coverage": 65, "encumbrance": 0, "rigid_layer_only": true }
+      {
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_forehead", "head_crown", "head_ear_l", "head_ear_r" ],
+        "coverage": 100,
+        "encumbrance_modifiers": [ "NONE" ]
+      },
+      {
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_nape" ],
+        "coverage": 20,
+        "encumbrance_modifiers": [ "NONE" ]
+      },
+      { "covers": [ "eyes" ], "coverage": 65, "encumbrance": 0 },
+      {
+        "covers": [ "mouth" ],
+        "specifically_covers": [ "mouth_cheeks" ],
+        "coverage": 100,
+        "encumbrance": 0,
+        "rigid_layer_only": true
+      },
+      {
+        "covers": [ "mouth", "head" ],
+        "specifically_covers": [ "mouth_lips", "mouth_nose", "mouth_chin" ],
+        "coverage": 50,
+        "encumbrance": 0,
+        "rigid_layer_only": true
+      }
     ],
     "warmth": 10,
     "material_thickness": 4,
@@ -402,8 +537,18 @@
     "armor": [
       {
         "encumbrance_modifiers": [ "NONE" ],
-        "coverage": 75,
+        "coverage": 100,
         "covers": [ "head" ],
+        "specifically_covers": [ "head_crown" ],
+        "material": [
+          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 14 },
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 1.5 }
+        ]
+      },
+      {
+        "coverage": 80,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_forehead" ],
         "material": [
           { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 14 },
           { "type": "plastic", "covered_by_mat": 100, "thickness": 1.5 }
@@ -450,8 +595,27 @@
     "looks_like": "helmet_larmor",
     "color": "green",
     "armor": [
-      { "covers": [ "head" ], "coverage": 90, "encumbrance_modifiers": [ "NONE" ] },
-      { "covers": [ "mouth", "eyes" ], "rigid_layer_only": true, "coverage": 90, "encumbrance": 5 }
+      {
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_forehead", "head_ear_l", "head_ear_r" ],
+        "coverage": 95,
+        "encumbrance_modifiers": [ "NONE" ]
+      },
+      {
+        "covers": [ "mouth" ],
+        "rigid_layer_only": true,
+        "coverage": 70,
+        "specifically_covers": [ "mouth_lips", "mouth_nose" ],
+        "encumbrance": 5
+      },
+      {
+        "covers": [ "mouth" ],
+        "rigid_layer_only": true,
+        "specifically_covers": [ "mouth_cheeks", "mouth_chin" ],
+        "coverage": 95
+      },
+      { "covers": [ "head" ], "specifically_covers": [ "head_nape", "head_throat" ], "coverage": 60 },
+      { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 60, "encumbrance": 5 }
     ],
     "warmth": 20,
     "material_thickness": 4,
@@ -496,7 +660,15 @@
     "material_thickness": 3,
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "VARSIZE", "STURDY" ],
-    "armor": [ { "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ], "coverage": 90, "covers": [ "head" ] } ]
+    "armor": [
+      {
+        "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ],
+        "coverage": 100,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_forehead", "head_crown", "head_ear_l", "head_ear_r" ]
+      },
+      { "coverage": 90, "covers": [ "head" ], "specifically_covers": [ "head_nape" ] }
+    ]
   },
   {
     "id": "xl_helmet_conical",
@@ -568,8 +740,18 @@
     "armor": [
       {
         "covers": [ "head" ],
-        "coverage": 95,
+        "coverage": 100,
+        "specifically_covers": [ "head_crown", "head_forehead" ],
         "encumbrance_modifiers": [ "NONE" ],
+        "material": [
+          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 14 },
+          { "type": "thermo_resin", "covered_by_mat": 100, "thickness": 3 }
+        ]
+      },
+      {
+        "covers": [ "head" ],
+        "coverage": 95,
+        "specifically_covers": [ "head_ear_l", "head_ear_r" ],
         "material": [
           { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 14 },
           { "type": "thermo_resin", "covered_by_mat": 100, "thickness": 3 }
@@ -610,7 +792,23 @@
     "symbol": "[",
     "looks_like": "helmet_barbute",
     "color": "light_gray",
-    "armor": [ { "covers": [ "head" ], "coverage": 90, "encumbrance_modifiers": [ "NONE" ] } ],
+    "armor": [
+      {
+        "covers": [ "head" ],
+        "coverage": 100,
+        "specifically_covers": [ "head_crown", "head_forehead" ],
+        "encumbrance_modifiers": [ "NONE" ]
+      },
+      { "covers": [ "head" ], "coverage": 20, "specifically_covers": [ "head_ear_l", "head_ear_r" ] },
+      { "covers": [ "head" ], "coverage": 80, "specifically_covers": [ "head_nape" ] },
+      {
+        "covers": [ "mouth" ],
+        "coverage": 40,
+        "specifically_covers": [ "mouth_cheeks", "mouth_chin" ],
+        "encumbrance": 0,
+        "rigid_layer_only": true
+      }
+    ],
     "warmth": 10,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_1" ],
@@ -652,9 +850,32 @@
     "looks_like": "helmet_barbute",
     "color": "dark_gray",
     "armor": [
-      { "covers": [ "head" ], "coverage": 95, "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ] },
+      {
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_ear_l", "head_ear_r", "head_forehead", "head_nape" ],
+        "coverage": 100,
+        "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ]
+      },
+      {
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_throat" ],
+        "coverage": 95,
+        "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ]
+      },
       { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 35, "encumbrance": 0 },
-      { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 95, "encumbrance": 10 }
+      {
+        "covers": [ "mouth" ],
+        "specifically_covers": [ "mouth_lips" ],
+        "rigid_layer_only": true,
+        "coverage": 80,
+        "encumbrance": 10
+      },
+      {
+        "covers": [ "mouth" ],
+        "specifically_covers": [ "mouth_cheeks", "mouth_chin", "mouth_nose" ],
+        "rigid_layer_only": true,
+        "coverage": 100
+      }
     ],
     "warmth": 25,
     "material_thickness": 4,
@@ -699,7 +920,15 @@
     "material_thickness": 4.5,
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY" ],
-    "armor": [ { "encumbrance_modifiers": [ "NONE" ], "coverage": 85, "covers": [ "head" ] } ]
+    "armor": [
+      {
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 100,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_ear_l", "head_ear_r" ]
+      },
+      { "coverage": 90, "covers": [ "head" ], "specifically_covers": [ "head_forehead" ] }
+    ]
   },
   {
     "id": "xl_helmet_larmor",
@@ -734,7 +963,20 @@
     "color": "dark_gray",
     "material_thickness": 3,
     "flags": [ "WATER_FRIENDLY" ],
-    "armor": [ { "encumbrance_modifiers": [ "IMBALANCED" ], "coverage": 35, "covers": [ "head" ] } ]
+    "armor": [
+      {
+        "encumbrance_modifiers": [ "IMBALANCED" ],
+        "coverage": 100,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown" ]
+      },
+      {
+        "encumbrance_modifiers": [ "IMBALANCED" ],
+        "coverage": 60,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_forehead" ]
+      }
+    ]
   },
   {
     "id": "helmet_liner",
@@ -782,7 +1024,18 @@
         ],
         "covers": [ "head" ],
         "coverage": 100,
+        "specifically_covers": [ "head_crown", "head_ear_l", "head_ear_r", "head_forehead" ],
         "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ]
+      },
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 16 }
+        ],
+        "covers": [ "head" ],
+        "coverage": 40,
+        "specifically_covers": [ "head_nape", "head_throat" ]
       },
       {
         "material": [
@@ -801,10 +1054,33 @@
           { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 }
         ],
         "covers": [ "mouth" ],
+        "specifically_covers": [ "mouth_nose" ],
         "coverage": 100,
-        "encumbrance": 15,
+        "encumbrance": 5,
         "layers": [ "OUTER" ],
         "rigid_layer_only": true
+      },
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 16 }
+        ],
+        "covers": [ "mouth" ],
+        "coverage": 100,
+        "specifically_covers": [ "mouth_chin" ],
+        "encumbrance": 5
+      },
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "plastic_pad", "covered_by_mat": 50, "thickness": 16 }
+        ],
+        "covers": [ "mouth" ],
+        "coverage": 100,
+        "specifically_covers": [ "mouth_cheeks", "mouth_lips" ],
+        "encumbrance": 5
       }
     ],
     "use_action": { "type": "transform", "menu_text": "Raise visor", "target": "helmet_motor_raised", "msg": "You raise your visor." },
@@ -840,7 +1116,40 @@
         ],
         "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ],
         "coverage": 100,
-        "covers": [ "head" ]
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_ear_l", "head_ear_r", "head_forehead" ]
+      },
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 16 }
+        ],
+        "covers": [ "head" ],
+        "coverage": 40,
+        "specifically_covers": [ "head_nape", "head_throat" ]
+      },
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 16 }
+        ],
+        "covers": [ "mouth" ],
+        "coverage": 100,
+        "specifically_covers": [ "mouth_chin" ],
+        "encumbrance": 3
+      },
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 16 }
+        ],
+        "covers": [ "mouth" ],
+        "coverage": 50,
+        "specifically_covers": [ "mouth_cheeks", "mouth_lips" ],
+        "encumbrance": 2
       }
     ],
     "use_action": { "type": "transform", "menu_text": "Lower visor", "target": "helmet_motor", "msg": "You put down your visor." },
@@ -865,8 +1174,25 @@
     "looks_like": "helmet_barbute",
     "color": "light_gray",
     "armor": [
-      { "covers": [ "head" ], "coverage": 85, "encumbrance_modifiers": [ "NONE" ] },
-      { "covers": [ "eyes" ], "coverage": 25, "encumbrance": 0, "rigid_layer_only": true }
+      {
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_forehead" ],
+        "coverage": 100,
+        "encumbrance_modifiers": [ "NONE" ]
+      },
+      {
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_ear_l", "head_ear_r" ],
+        "coverage": 20,
+        "encumbrance_modifiers": [ "NONE" ]
+      },
+      {
+        "covers": [ "mouth" ],
+        "specifically_covers": [ "mouth_nose" ],
+        "coverage": 90,
+        "encumbrance": 0,
+        "rigid_layer_only": true
+      }
     ],
     "warmth": 10,
     "material_thickness": 3,
@@ -910,7 +1236,7 @@
     "armor": [
       { "covers": [ "head" ], "coverage": 100, "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ] },
       { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 30 },
-      { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 20 }
+      { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 95, "encumbrance": 20 }
     ],
     "warmth": 10,
     "material_thickness": 5,
@@ -952,7 +1278,14 @@
     "symbol": "n",
     "looks_like": "helmet_barbute",
     "color": "light_gray",
-    "armor": [ { "covers": [ "head" ], "coverage": 85, "encumbrance_modifiers": [ "NONE" ] } ],
+    "armor": [
+      {
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_forehead" ],
+        "coverage": 100,
+        "encumbrance_modifiers": [ "NONE" ]
+      }
+    ],
     "warmth": 5,
     "material_thickness": 4,
     "environmental_protection": 1,
@@ -994,7 +1327,8 @@
           { "type": "cotton", "covered_by_mat": 100, "thickness": 1.0 }
         ],
         "covers": [ "head" ],
-        "coverage": 80,
+        "specifically_covers": [ "head_crown", "head_ear_l", "head_ear_r", "head_ear_r" ],
+        "coverage": 100,
         "encumbrance_modifiers": [ "IMBALANCED" ]
       }
     ]
@@ -1052,7 +1386,7 @@
       {
         "material": [ { "type": "lc_steel", "covered_by_mat": 100, "thickness": 1.5 } ],
         "covers": [ "eyes" ],
-        "coverage": 100,
+        "coverage": 95,
         "encumbrance": 25
       },
       {
@@ -1084,7 +1418,7 @@
       {
         "material": [ { "type": "ch_steel", "covered_by_mat": 100, "thickness": 1.5 } ],
         "covers": [ "eyes" ],
-        "coverage": 100,
+        "coverage": 95,
         "encumbrance": 25
       },
       {
@@ -1122,6 +1456,7 @@
           { "type": "cotton", "covered_by_mat": 100, "thickness": 5 }
         ],
         "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_ear_l", "head_ear_r", "head_forehead", "head_nape" ],
         "coverage": 100,
         "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ]
       }
@@ -1142,6 +1477,7 @@
           { "type": "cotton", "covered_by_mat": 100, "thickness": 5 }
         ],
         "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_ear_l", "head_ear_r", "head_forehead", "head_nape" ],
         "coverage": 100,
         "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ]
       }
@@ -1166,7 +1502,14 @@
     "warmth": 10,
     "material_thickness": 4,
     "techniques": [ "WBLOCK_1" ],
-    "armor": [ { "encumbrance_modifiers": [ "NONE" ], "coverage": 65, "covers": [ "head" ] } ]
+    "armor": [
+      {
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 65,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_forehead" ]
+      }
+    ]
   },
   {
     "id": "pickelhaube",
@@ -1189,7 +1532,10 @@
     "warmth": 15,
     "material_thickness": 3,
     "flags": [ "STAB", "PADDED" ],
-    "armor": [ { "encumbrance_modifiers": [ "NONE" ], "coverage": 70, "covers": [ "head" ] } ],
+    "armor": [
+      { "encumbrance_modifiers": [ "NONE" ], "coverage": 100, "specifically_covers": [ "head_crown" ], "covers": [ "head" ] },
+      { "coverage": 90, "specifically_covers": [ "head_forehead" ], "covers": [ "head" ] }
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -1229,9 +1575,28 @@
     "looks_like": "helmet_plate",
     "color": "yellow",
     "armor": [
-      { "covers": [ "head" ], "coverage": 95, "encumbrance_modifiers": [ "NONE" ] },
-      { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 75, "encumbrance": 0 },
-      { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 75, "encumbrance": 0 }
+      {
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_forehead" ],
+        "coverage": 100,
+        "encumbrance_modifiers": [ "NONE" ]
+      },
+      { "covers": [ "head" ], "specifically_covers": [ "head_ear_l", "head_ear_r", "head_nape" ], "coverage": 50 },
+      { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 50, "encumbrance": 0 },
+      {
+        "covers": [ "mouth" ],
+        "specifically_covers": [ "mouth_nose", "mouth_cheeks" ],
+        "rigid_layer_only": true,
+        "coverage": 95,
+        "encumbrance": 0
+      },
+      {
+        "covers": [ "mouth" ],
+        "specifically_covers": [ "mouth_lips", "mouth_chin" ],
+        "rigid_layer_only": true,
+        "coverage": 75,
+        "encumbrance": 0
+      }
     ],
     "warmth": 10,
     "material_thickness": 3,
@@ -1272,7 +1637,12 @@
     "looks_like": "helmet_corinthian",
     "color": "yellow",
     "armor": [
-      { "covers": [ "head" ], "coverage": 85, "encumbrance_modifiers": [ "NONE" ] },
+      {
+        "covers": [ "head" ],
+        "coverage": 100,
+        "specifically_covers": [ "head_crown", "head_ear_l", "head_ear_r", "head_forehead" ],
+        "encumbrance_modifiers": [ "NONE" ]
+      },
       { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 85, "encumbrance": 10 },
       { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 85, "encumbrance": 10 }
     ],
@@ -1312,7 +1682,16 @@
     "copy-from": "pot_helmet",
     "material_thickness": 2,
     "extend": { "flags": [ "OVERSIZE" ] },
-    "armor": [ { "encumbrance_modifiers": [ "IMBALANCED" ], "coverage": 55, "covers": [ "head" ] } ]
+    "armor": [
+      {
+        "encumbrance_modifiers": [ "IMBALANCED" ],
+        "coverage": 100,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown" ]
+      },
+      { "coverage": 80, "covers": [ "head" ], "specifically_covers": [ "head_forehead" ] },
+      { "coverage": 20, "covers": [ "head" ], "specifically_covers": [ "head_ear_l", "head_ear_r" ] }
+    ]
   },
   {
     "id": "pot_helmet_xs",
@@ -1355,8 +1734,16 @@
           { "type": "lc_steel", "covered_by_mat": 100, "thickness": 1.25 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
-        "covers": [ "eyes", "mouth" ],
+        "covers": [ "mouth" ],
         "coverage": 100,
+        "encumbrance": 10,
+        "layers": [ "OUTER" ],
+        "rigid_layer_only": true
+      },
+      {
+        "material": [ { "type": "lc_steel", "covered_by_mat": 100, "thickness": 1.25 } ],
+        "covers": [ "eyes" ],
+        "coverage": 95,
         "encumbrance": 10,
         "layers": [ "OUTER" ],
         "rigid_layer_only": true
@@ -1440,8 +1827,16 @@
           { "type": "mc_steel", "covered_by_mat": 100, "thickness": 1.25 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
-        "covers": [ "eyes", "mouth" ],
+        "covers": [ "mouth" ],
         "coverage": 100,
+        "encumbrance": 10,
+        "layers": [ "OUTER" ],
+        "rigid_layer_only": true
+      },
+      {
+        "material": [ { "type": "mc_steel", "covered_by_mat": 100, "thickness": 1.25 } ],
+        "covers": [ "eyes" ],
+        "coverage": 95,
         "encumbrance": 10,
         "layers": [ "OUTER" ],
         "rigid_layer_only": true
@@ -1525,8 +1920,16 @@
           { "type": "hc_steel", "covered_by_mat": 100, "thickness": 1.25 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
-        "covers": [ "eyes", "mouth" ],
+        "covers": [ "mouth" ],
         "coverage": 100,
+        "encumbrance": 10,
+        "layers": [ "OUTER" ],
+        "rigid_layer_only": true
+      },
+      {
+        "material": [ { "type": "hc_steel", "covered_by_mat": 100, "thickness": 1.25 } ],
+        "covers": [ "eyes" ],
+        "coverage": 95,
         "encumbrance": 10,
         "layers": [ "OUTER" ],
         "rigid_layer_only": true
@@ -1610,8 +2013,16 @@
           { "type": "ch_steel", "covered_by_mat": 100, "thickness": 1.25 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
-        "covers": [ "eyes", "mouth" ],
+        "covers": [ "mouth" ],
         "coverage": 100,
+        "encumbrance": 10,
+        "layers": [ "OUTER" ],
+        "rigid_layer_only": true
+      },
+      {
+        "material": [ { "type": "ch_steel", "covered_by_mat": 100, "thickness": 1.25 } ],
+        "covers": [ "eyes" ],
+        "coverage": 95,
         "encumbrance": 10,
         "layers": [ "OUTER" ],
         "rigid_layer_only": true
@@ -1695,8 +2106,16 @@
           { "type": "qt_steel", "covered_by_mat": 100, "thickness": 1.25 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
-        "covers": [ "eyes", "mouth" ],
+        "covers": [ "mouth" ],
         "coverage": 100,
+        "encumbrance": 10,
+        "layers": [ "OUTER" ],
+        "rigid_layer_only": true
+      },
+      {
+        "material": [ { "type": "qt_steel", "covered_by_mat": 100, "thickness": 1.25 } ],
+        "covers": [ "eyes" ],
+        "coverage": 95,
         "encumbrance": 10,
         "layers": [ "OUTER" ],
         "rigid_layer_only": true
@@ -1771,13 +2190,24 @@
     "flags": [ "WATERPROOF", "PADDED" ],
     "armor": [
       {
-        "encumbrance_modifiers": [ "NONE" ],
-        "coverage": 85,
-        "covers": [ "head" ],
         "material": [
           { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 6 },
           { "type": "plastic", "covered_by_mat": 100, "thickness": 2.5 }
-        ]
+        ],
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 100,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_forehead" ]
+      },
+      {
+        "material": [
+          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 6 },
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 2.5 }
+        ],
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 50,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_ear_l", "head_ear_r" ]
       }
     ],
     "pocket_data": [

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -176,7 +176,7 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str": "chainmail leggings", "str_pl": "pairs of chainmail leggings" },
-    "description": "Customized chainmail leggings.  Their straps keep everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.  The metal shows signs of rust and corrosion.",
+    "description": "Customized chainmail leggings.  Their straps keep everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.  The metal shows signs of rust and corrosion, and some chain links have fallen away.",
     "weight": "4212 g",
     "volume": "1500 ml",
     "price": 7500,
@@ -423,7 +423,16 @@
     "warmth": 10,
     "material_thickness": 3,
     "flags": [ "OUTER" ],
-    "armor": [ { "encumbrance": 3, "coverage": 65, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [
+      {
+        "encumbrance": 3,
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r", "leg_knee_r", "leg_knee_l" ]
+      },
+      { "coverage": 20, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_r", "leg_hip_l" ] },
+      { "coverage": 90, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_r", "leg_upper_l" ] }
+    ]
   },
   {
     "id": "chaps_cut_resistant",
@@ -1716,7 +1725,7 @@
     "material_thickness": 4,
     "valid_mods": [ "steel_padded" ],
     "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY" ],
-    "armor": [ { "covers": [ "leg_l", "leg_r" ], "encumbrance": 7, "coverage": 85 } ]
+    "armor": [ { "covers": [ "leg_l", "leg_r" ], "encumbrance": 7, "coverage": 95 } ]
   },
   {
     "id": "xl_legguard_larmor",

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -25,7 +25,15 @@
     "warmth": 8,
     "material_thickness": 0.3,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "armor": [ { "encumbrance": [ 7, 11 ], "coverage": 90, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [
+      {
+        "encumbrance": [ 7, 11 ],
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_upper_l", "leg_upper_r", "leg_knee_r", "leg_knee_l" ]
+      },
+      { "coverage": 90, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_r", "leg_lower_l" ] }
+    ]
   },
   {
     "id": "b_shorts",
@@ -93,7 +101,15 @@
     "warmth": 10,
     "material_thickness": 0.4,
     "flags": [ "VARSIZE" ],
-    "armor": [ { "encumbrance": 8, "coverage": 80, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [
+      {
+        "encumbrance": 8,
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_upper_l", "leg_upper_r", "leg_knee_r", "leg_knee_l" ]
+      },
+      { "coverage": 10, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_r", "leg_lower_l" ] }
+    ]
   },
   {
     "id": "cheerleader_skirt",
@@ -153,7 +169,8 @@
     "looks_like": "pants_ski",
     "color": "green",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 19, 23 ] },
+      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 19, 23 ], "specifically_covers": [ "torso_lower" ] },
+      { "covers": [ "torso" ], "coverage": 20, "specifically_covers": [ "torso_upper" ] },
       { "covers": [ "leg_l", "leg_r" ], "coverage": 100, "encumbrance": [ 19, 21 ] },
       { "covers": [ "foot_l", "foot_r" ], "coverage": 100, "encumbrance": [ 19, 19 ] }
     ],
@@ -218,7 +235,7 @@
     "warmth": 10,
     "material_thickness": 0.2,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "armor": [ { "encumbrance": [ 6, 10 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 6, 10 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "hot_pants",
@@ -331,7 +348,7 @@
         "text": "An old pair of blue jeans.  You are not sure if they are faded through age or stone washed."
       }
     ],
-    "armor": [ { "encumbrance": [ 7, 11 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 7, 11 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "jeans_red",
@@ -382,7 +399,7 @@
     "material_thickness": 0.65,
     "//": "Lightweight 10 oz denim jeans.",
     "flags": [ "VARSIZE", "POCKETS" ],
-    "armor": [ { "encumbrance": [ 7, 11 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 7, 11 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "kilt",
@@ -411,7 +428,7 @@
     "flags": [ "VARSIZE" ],
     "armor": [
       { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
-      { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
     ]
   },
   {
@@ -441,7 +458,7 @@
     "flags": [ "VARSIZE" ],
     "armor": [
       { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
-      { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
     ]
   },
   {
@@ -598,7 +615,7 @@
     "warmth": 15,
     "material_thickness": 0.2,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "armor": [ { "encumbrance": [ 7, 11 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 7, 11 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "pants_army",
@@ -683,7 +700,7 @@
     "warmth": 20,
     "material_thickness": 0.25,
     "flags": [ "VARSIZE", "POCKETS", "SOFT" ],
-    "armor": [ { "encumbrance": 3, "coverage": 95, "covers": [ "leg_l", "leg_r" ], "volume_encumber_modifier": 0.6 } ]
+    "armor": [ { "encumbrance": 3, "coverage": 100, "covers": [ "leg_l", "leg_r" ], "volume_encumber_modifier": 0.6 } ]
   },
   {
     "id": "pants_cargo",
@@ -794,7 +811,7 @@
     "warmth": 15,
     "material_thickness": 0.2,
     "flags": [ "VARSIZE" ],
-    "armor": [ { "encumbrance": [ 2, 5 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 2, 5 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "pants_fur",
@@ -845,7 +862,7 @@
     "valid_mods": [ "steel_padded" ],
     "environmental_protection": 3,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "armor": [ { "encumbrance": [ 16, 20 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 16, 20 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "pants_faux_fur",
@@ -909,7 +926,7 @@
     "material_thickness": 0.75,
     "valid_mods": [ "steel_padded" ],
     "flags": [ "VARSIZE" ],
-    "armor": [ { "encumbrance": [ 15, 17 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 15, 17 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "pants_ski",
@@ -959,7 +976,7 @@
     "material_thickness": 1,
     "environmental_protection": 3,
     "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
-    "armor": [ { "encumbrance": [ 6, 10 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 6, 10 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "police_breeches",
@@ -976,7 +993,7 @@
     "symbol": "[",
     "looks_like": "pants",
     "color": "dark_gray",
-    "armor": [ { "covers": [ "leg_l", "leg_r" ], "coverage": 95, "encumbrance": [ 2, 5 ] } ],
+    "armor": [ { "covers": [ "leg_l", "leg_r" ], "coverage": 100, "encumbrance": [ 2, 5 ] } ],
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "1 kg", "moves": 80 },
@@ -1043,7 +1060,7 @@
         "volume_encumber_modifier": 0.7
       },
       {
-        "coverage": 50,
+        "coverage": 90,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "volume_encumber_modifier": 0.0
@@ -1125,7 +1142,7 @@
     "material_thickness": 1,
     "environmental_protection": 2,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "armor": [ { "encumbrance": [ 13, 17 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 13, 17 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "shorts",
@@ -1183,7 +1200,7 @@
         "volume_encumber_modifier": 0.7
       },
       {
-        "coverage": 50,
+        "coverage": 80,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "volume_encumber_modifier": 0.0
@@ -1260,7 +1277,7 @@
         "volume_encumber_modifier": 0.7
       },
       {
-        "coverage": 50,
+        "coverage": 90,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "volume_encumber_modifier": 0.0
@@ -1315,7 +1332,7 @@
         "volume_encumber_modifier": 0.7
       },
       {
-        "coverage": 50,
+        "coverage": 90,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "volume_encumber_modifier": 0.0
@@ -1441,7 +1458,7 @@
     "warmth": 15,
     "material_thickness": 0.2,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "armor": [ { "encumbrance": [ 2, 5 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 2, 5 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "technician_pants_gray",
@@ -1560,7 +1577,7 @@
     "material_thickness": 0.5,
     "valid_mods": [ "steel_padded" ],
     "flags": [ "VARSIZE", "POCKETS", "WATERPROOF" ],
-    "armor": [ { "encumbrance": [ 11, 22 ], "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 11, 22 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "zubon_gi",
@@ -1578,7 +1595,7 @@
     "warmth": 5,
     "material_thickness": 0.5,
     "flags": [ "VARSIZE", "STURDY" ],
-    "armor": [ { "coverage": 80, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "pants_hiking",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Converts most of the armor and clothing still using the old limb system to the new system with sub-limbs, part 4: Perfected pants and helpful helmets"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There are still a number of armors making use of the old coverage system that uses the entire limb for coverage data, instead of the sub-limb system. This series of PRs is meant to convert all the armors and clothing I can find that would have varied coverages that still use the old system, and then assigning the coverages to the specific sub-limbs instead if it were less than 100%. 

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
In part 4, I went through all the leg clothing, leg armor, and helmets, and converted as much of the coverage values as I felt necessary. If I found an item that needed changing, I would pull up a picture of the item in question and then assign coverages to the sub limbs of the body part it covers in accordance with the real item as best as I could. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this and saving myself the time. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Part 4 is good to go ingame without any errors.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
A continuation of my previous conversions #57911, #57940, and #64897

Helmets got a pretty big change. With the neck being a component of the head, a lot of helmets got lower overall coverage. Few helmets include complete nape protection, and far fewer include throat protection. Make sure to wear a coif underneath. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
