### PR TITLE
port: Fix spellcasting items consuming charges when canceled

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3622,6 +3622,12 @@ void activity_handlers::spellcasting_finish( player_activity *act, Character *yo
                     }
                 }
             }
+            if( !act->targets.empty() ) {
+                item &it = *act->targets.front();
+                if( !it.has_flag( flag_USE_PLAYER_ENERGY ) ) {
+                    you->consume_charges( it, it.type->charges_to_use() );
+                }
+            }
         }
     }
 }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2354,7 +2354,6 @@ std::optional<int> cast_spell_actor::use( Character &p, item &it, bool, const tr
     }
 
     spell casting = spell( spell_id( item_spell ) );
-    int charges = 1;
 
     player_activity cast_spell( ACT_SPELLCASTING, casting.casting_time( p ) );
     // [0] this is used as a spell level override for items casting spells
@@ -2370,13 +2369,14 @@ std::optional<int> cast_spell_actor::use( Character &p, item &it, bool, const tr
     if( it.has_flag( flag_USE_PLAYER_ENERGY ) ) {
         // [2] this value overrides the mana cost if set to 0
         cast_spell.values.emplace_back( 1 );
-        charges = 0;
     } else {
         // [2]
         cast_spell.values.emplace_back( 0 );
     }
     p.assign_activity( cast_spell, false );
-    return charges;
+    p.activity.targets.emplace_back( item_location( p, &it ) );
+    // Actual handling of charges_to_use is in activity_handlers::spellcasting_finish
+    return 0;
 }
 
 std::unique_ptr<iuse_actor> holster_actor::clone() const


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Spellcasting tools no longer waste charges if you cancel out and don't actually cast the spell"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
big disclaimer tho; I don't know code :P I just followed the compiler warnings - that's pretty much coding *right?* pls do review this

port of https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2622
Fix #57504
word by word what's on the original pr:
So, working on https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2617 revealed to me exactly what's needed to fix the "spellcasting items always consume charges, even if you back out of the spell aim menu or if it's interrupted" bug.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

-    In activity_handlers.cpp, changed activity_handlers::spellcasting_finish to have a check at the end for if the activity was assigned an item target, and if so checking whether the item has USE_PLAYER_ENERGY (since if it does, energy draw is already handled by the spell menu stuff). If the flag is absent, then call up charges_to_use like normal. Based off the finisher functions as seen with jackhammering and shearing.
-    In iuse_actor.cpp, changed cast_spell_actor::use to go ahead and not call charges_to_use even for items lacking USE_PLAYER_ENERGY, because we're deferring it to the activity finisher. Handling of player-energy spells, as noted, is handled via the value change in the if statement.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
*also followed the test steps*
- Compiled and load tested.
- Started up a world with magiclysm on, debugged me a wand of fireballs and a potion of cat's grace.
- Tried activating the fireball, then choosing to cancel out of the spellcasting menu. Didn't consume a charge.
- Activated again and actually fired it, consumed a charge as normal.
- Consumed potion of cat's grace, spell correctly triggers and potion is consumed.
- Debugged in a cougar voodoo doll, activated it and canceled out of the spellcasting menu, it correctly doesn't consume the doll.
- Went ahead and actually used the doll, it correctly vanishes and spawns decayed pouncers.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->