### PR TITLE
Add ROPE 2 and SUSPENDING 2 to hoists

### DIFF
--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -292,7 +292,7 @@
     "type": "TOOL",
     "name": { "str": "light hoist" },
     "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ],
-    "qualities": [ [ "LIFT", 2 ] ]
+    "qualities": [ [ "LIFT", 2 ], [ "ROPE", 2 ], [ "SUSPENDING", 2 ] ]
   },
   {
     "id": "fake_lift_medium",
@@ -300,7 +300,7 @@
     "type": "TOOL",
     "name": { "str": "sturdy hoist" },
     "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ],
-    "qualities": [ [ "LIFT", 8 ] ]
+    "qualities": [ [ "LIFT", 8 ], [ "ROPE", 2 ], [ "SUSPENDING", 2 ] ]
   },
   {
     "id": "fake_lift_heavy",
@@ -308,7 +308,7 @@
     "type": "TOOL",
     "name": { "str": "heavy-duty hoist" },
     "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ],
-    "qualities": [ [ "LIFT", 40 ] ]
+    "qualities": [ [ "LIFT", 40 ], [ "ROPE", 2 ], [ "SUSPENDING", 2 ] ]
   },
   {
     "id": "pseudo_app_oxygen_concentrator",


### PR DESCRIPTION
#### Summary

Bugfixes "Hoists now provide ROPE 2 and SUSPENDING 2 qualities"

#### Purpose of change

Hoist constructions provided LIFTING, but not ROPE and SUSPENDING qualities, despite being made from items which provide these (long ropes and trees). This meant they could not be used for butchering and other tasks.

#### Describe the solution

JSON edits.

#### Describe alternatives you've considered

None.

#### Testing

Applied changes to my game. Used a hoist I'd set up earlier for butchering, which I couldn't do before. E`x`amined the square with the hoist, and verified it displayed providing all three (LIFTING, ROPE, SUSPENDING) qualities.

#### Additional context

None.