### PR TITLE
[CR] [balance] adapt eye encumbrance of eyewear

### DIFF
--- a/data/json/items/armor/eyewear.json
+++ b/data/json/items/armor/eyewear.json
@@ -56,7 +56,7 @@
     "material_thickness": 1,
     "environmental_protection": 1,
     "flags": [ "FANCY", "WATER_FRIENDLY", "SUN_GLASSES", "FRAGILE", "SKINTIGHT" ],
-    "armor": [ { "encumbrance": 1, "coverage": 95, "covers": [ "eyes" ], "rigid_layer_only": true } ]
+    "armor": [ { "coverage": 95, "covers": [ "eyes" ], "rigid_layer_only": true } ]
   },
   {
     "id": "fitover_sunglasses",
@@ -76,7 +76,7 @@
     "material_thickness": 1,
     "environmental_protection": 1,
     "flags": [ "WATER_FRIENDLY", "SUN_GLASSES", "VARSIZE", "FRAGILE" ],
-    "armor": [ { "encumbrance": 1, "coverage": 90, "covers": [ "eyes" ], "rigid_layer_only": true } ]
+    "armor": [ { "coverage": 90, "covers": [ "eyes" ], "rigid_layer_only": true } ]
   },
   {
     "id": "glasses_bal",
@@ -304,7 +304,7 @@
     "material_thickness": 1,
     "environmental_protection": 1,
     "flags": [ "WATER_FRIENDLY", "SUN_GLASSES", "FRAGILE", "SKINTIGHT" ],
-    "armor": [ { "encumbrance": 1, "coverage": 85, "covers": [ "eyes" ], "rigid_layer_only": true } ]
+    "armor": [ { "coverage": 85, "covers": [ "eyes" ], "rigid_layer_only": true } ]
   },
   {
     "id": "sunglasses_bifocal",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
while having almost the same weight/volume some sunglasses have eye encumbrance and some do not.
the purpose of this PR is to balance this out

#### Describe the solution
balance sunglasses by removing eye encumbrance from those which have it

#### Describe alternatives you've considered
adding eye encumbrance to the sunglasses which don't have it, after talking about this on discord i choose the former solution

#### Testing
None

#### Additional context
data reduced:
```json
{
  "id": "sunglasses",
  "name": {
    "str": "pair of sunglasses",
    "str_pl": "pairs of sunglasses"
  },
  "weight": "35 g",
  "volume": "250 ml",
  "armor": [
    {
      "encumbrance": 1,
      "coverage": 85,
      "covers": [
        "eyes"
      ],
      "rigid_layer_only": true
    }
  ]
}
```
vs
```json
{
  "id": "sunglasses_eye",
  "repairs_like": "survivor_goggles",
  "type": "ARMOR",
  "name": {
    "str": "pair of corrective sunglasses",
    "str_pl": "pairs of corrective sunglasses"
  },
  "weight": "30 g",
  "volume": "250 ml",
  "armor": [
    {
      "coverage": 75,
      "covers": [
        "eyes"
      ],
      "rigid_layer_only": true
    }
  ]
}
```
None