### PR TITLE
Add Post-Apocalyptic Professions to BNW

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -440,6 +440,8 @@
     "start_name": "Old Evac Shelter",
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "custom_initial_date": { "season": "autumn", "year": 2 },
+    "add_professions": true,
+    "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
     "requirement": "achievement_survive_91_days",
     "eoc": [ "faction_camp_start" ],
     "flags": [ "CITY_START", "LONE_START" ]


### PR DESCRIPTION
#### Summary

Content "Added Winter professions to Brave New World Scenario."

#### Purpose of change

Practically speaking, if the extra professions for the timeskip scenarios generally reflect how survivors adapt after a year, newer scenarios like Brave New World should have the same range of options.

#### Describe the solution

Adding these professions upholds consistency between scenarios.

#### Describe alternatives you've considered

Simply deleting the relevant professions so we never have to remember to do this again.

#### Testing

I simply copied and pasted two lines to match the others. I can’t imagine screwing it up that badly.

#### Additional context

N/A

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->