### PR TITLE
Add natural sausage casings to Ye Scots Beuk o Cuikery

### DIFF
--- a/data/json/recipes/food/offal_dishes.json
+++ b/data/json/recipes/food/offal_dishes.json
@@ -449,7 +449,7 @@
     "charges": 60,
     "byproducts": [ [ "ruined_chunks", 2 ] ],
     "//": "Charcuterie: The Craft of Salting, Smoking, and Curing would be a good book for someone to use for further meat products recipes.",
-    "book_learn": [ [ "offalcooking", 3 ] ],
+    "book_learn": { "offalcooking": { "skill_level": 3 }, "scots_cookbook": { "skill_level": 3 } },
     "qualities": [ { "id": "COOK", "level": 2 }, { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "meat_stomach", 1, "LIST" ] ], [ [ "salt", 20 ] ], [ [ "water_clean", 2 ] ] ]
   },


### PR DESCRIPTION
#### Summary

Balance "Ye Scots Beuk o Cuikery can teach ye how ta make sausage casings"

#### Purpose of change

I was doing some wee cuikery and found I cannae make sausages from scratch with Ye Scots Beuk o Cuikery, as it husnae the recipe fer casings.

#### Describe the solution

JSON edits

#### Describe alternatives you've considered

None

#### Testing

Loaded changes in my game. Used Ye Scots Beuk o Cuikery to make casings from natural llama intestines. Enjoyed a delicious meal.

#### Additional context

I've only put natural casings in the cookbook, as it seems focused on traditional recipes. Given just how many of them are offal based, and how many different sausages are in the book, it seemed out of place not to have instructions for casings.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->