### PR TITLE
[GG]migrate feral guns

### DIFF
--- a/data/mods/Generic_Guns/firearms/gg_firearms_migration.json
+++ b/data/mods/Generic_Guns/firearms/gg_firearms_migration.json
@@ -379,5 +379,20 @@
     "id": [ "m26_mass_standalone" ],
     "type": "MIGRATION",
     "replace": "small_shotgun"
+  },
+  {
+    "id": [ "feral_militia_gun" ],
+    "type": "MIGRATION",
+    "replace": "feral_rifle"
+  },
+  {
+    "id": [ "feral_jackboot_gun" ],
+    "type": "MIGRATION",
+    "replace": "feral_shotgun"
+  },
+  {
+    "id": [ "feral_m9" ],
+    "type": "MIGRATION",
+    "replace": "feral_pistol"
   }
 ]

--- a/data/mods/Generic_Guns/firearms/pistol.json
+++ b/data/mods/Generic_Guns/firearms/pistol.json
@@ -110,5 +110,23 @@
         "rigid": true
       }
     ]
+  },
+  {
+    "id": "feral_pistol",
+    "copy-from": "feral_m9",
+    "type": "GUN",
+    "name": { "str_sp": "Beretta M9A1" },
+    "description": "A poorly maintained and inaccurate version of the M9 for feral security guards, feral preppers, etc.",
+    "ammo": [ "ammo_pistol" ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "holster": true,
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "20 kg",
+        "item_restriction": [ "pistol_mag", "pistol_smg_mag" ],
+        "rigid": true
+      }
+    ]
   }
 ]

--- a/data/mods/Generic_Guns/firearms/rifle.json
+++ b/data/mods/Generic_Guns/firearms/rifle.json
@@ -131,5 +131,14 @@
     "description": "A break action firearm comprised of a rifle barrel over two smooth bore shotgun barrels.  Historically used by egomaniac hunters in Africa, now used by their egomaniac descendants in New England.",
     "built_in_mods": [ "rifle_shotgun_combination_shotgun" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "ammo_rifle": 1 } } ]
+  },
+  {
+    "id": "feral_rifle",
+    "copy-from": "feral_militia_gun",
+    "type": "GUN",
+    "name": { "str": "mad militias' rifle" },
+    "description": "A fake semi-auto rifle for feral militiamen (because monster aiming is too lethal).",
+    "ammo": [ "ammo_rifle" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "ammo_rifle": 1 } } ]
   }
 ]

--- a/data/mods/Generic_Guns/firearms/shot.json
+++ b/data/mods/Generic_Guns/firearms/shot.json
@@ -84,5 +84,14 @@
     "name": { "str": "compact shotgun" },
     "description": "Small shotgun, assembled from underbarrel shotgun modification and a pistol grip.  Not the best weapon, but has a really small size and weight.",
     "ammo": [ "ammo_shot" ]
+  },
+  {
+    "id": "feral_shotgun",
+    "copy-from": "feral_jackboot_gun",
+    "type": "GUN",
+    "name": { "str": "feral bikers' shotgun" },
+    "description": "A fake shotgun for feral bikers (because monster aiming is too lethal).",
+    "ammo": [ "ammo_shot" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "ammo_shot": 1 }, "rigid": true } ]
   }
 ]

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -17,6 +17,7 @@
 #include "generic_factory.h"
 #include "gun_mode.h"
 #include "item.h"
+#include "item_factory.h"
 #include "item_pocket.h"
 #include "json.h"
 #include "line.h"
@@ -941,10 +942,11 @@ void gun_actor::shoot( monster &z, const tripoint &target, const gun_mode_id &mo
 {
     z.moves -= move_cost;
 
-    item gun( gun_type );
+    itype_id mig_gun_type = item_controller->migrate_id( gun_type );
+    item gun( mig_gun_type );
     gun.gun_set_mode( mode );
 
-    itype_id ammo = ammo_type;
+    itype_id ammo = item_controller->migrate_id( ammo_type );
     if( ammo.is_null() ) {
         if( gun.magazine_integral() ) {
             ammo = gun.ammo_default();
@@ -955,10 +957,10 @@ void gun_actor::shoot( monster &z, const tripoint &target, const gun_mode_id &mo
 
     if( !ammo.is_null() ) {
         if( gun.magazine_integral() ) {
-            gun.ammo_set( ammo, z.ammo[ammo] );
+            gun.ammo_set( ammo, z.ammo[ammo_type] );
         } else {
             item mag( gun.magazine_default() );
-            mag.ammo_set( ammo, z.ammo[ammo] );
+            mag.ammo_set( ammo, z.ammo[ammo_type] );
             gun.put_in( mag, item_pocket::pocket_type::MAGAZINE_WELL );
         }
     }
@@ -967,7 +969,7 @@ void gun_actor::shoot( monster &z, const tripoint &target, const gun_mode_id &mo
         return;
     }
 
-    add_msg_debug( debugmode::DF_MATTACK, "%d ammo (%s) remaining", z.ammo[ammo],
+    add_msg_debug( debugmode::DF_MATTACK, "%d ammo (%s) remaining", z.ammo[ammo_type],
                    gun.ammo_sort_name() );
 
     if( !gun.ammo_sufficient( nullptr ) ) {
@@ -1003,8 +1005,8 @@ void gun_actor::shoot( monster &z, const tripoint &target, const gun_mode_id &mo
 
     if( throwing ) {
         tmp.throw_item( target, item( ammo, calendar::turn, 1 ) );
-        z.ammo[ammo]--;
+        z.ammo[ammo_type]--;
     } else {
-        z.ammo[ammo] -= tmp.fire_gun( target, gun.gun_current_mode().qty );
+        z.ammo[ammo_type] -= tmp.fire_gun( target, gun.gun_current_mode().qty );
     }
 }

--- a/tools/json_tools/generic_guns_validator.py
+++ b/tools/json_tools/generic_guns_validator.py
@@ -50,9 +50,6 @@ ID_WHITELIST = {
     'l_bak_223',
     'pneumatic_shotgun',
     'rifle_223',
-    'feral_militia_gun',
-    'feral_jackboot_gun',
-    'feral_m9',
     # Magazines
     '223_speedloader5',
     'coin_wrapper',


### PR DESCRIPTION
#### Summary
Bugfixes "Ferals can use their guns in GG"

#### Purpose of change

Feral guns weren't migrated, so they were trying to use unmigrated ammo that isn't available.

#### Describe the solution

- add migrations for feral guns
- migrate gun and ammo types in `gun_actor::shoot`

#### Describe alternatives you've considered

Making GG versions of the ferals themselves with GG weapons instead of the C++ changes.

#### Testing

They hurt now.
![grafik](https://user-images.githubusercontent.com/38702195/231389337-0c0f2c00-8195-4f94-ac8d-f058f60699d7.png)

#### Additional context

