### PR TITLE
Fix and enhance camp radio tower

### DIFF
--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -658,7 +658,7 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
                     bool camp_to_npc = false;
                     bool camp_to_camp = false;
                     for( const camp_reference &i : camps_near_player ) {
-                        if( !( i.camp->has_provides( "radio" ) ) ) {
+                        if( !i.camp->has_provides( "radio" ) ) {
                             continue;
                         }
                         if( camp_to_camp ||

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -636,7 +636,7 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
                 see_color = c_light_red;
             } else {
                 // TODO: better range calculation than just elevation.
-                const int base_range = 100;
+                const int base_range = 200;
                 float send_elev_boost = ( 1 + ( player_character.pos().z * 0.1 ) );
                 float recv_elev_boost = ( 1 + ( pos().z * 0.1 ) );
                 if( ( square_dist( player_character.global_sm_location(),
@@ -655,9 +655,10 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
                                 player_character.global_sm_location(), send_range * radio_tower_boost );
                     const std::vector<camp_reference> &camps_near_npc = overmap_buffer.get_camps_near(
                                 global_sm_location(), recv_range * radio_tower_boost );
-                    bool camp_to_npc = false, camp_to_camp = false;
+                    bool camp_to_npc = false;
+                    bool camp_to_camp = false;
                     for( const camp_reference &i : camps_near_player ) {
-                        if( !( i.camp ->has_provides( "radio" ) ) ) {
+                        if( !( i.camp->has_provides( "radio" ) ) ) {
                             continue;
                         }
                         if( camp_to_camp ||

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -629,32 +629,62 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     if( rl_dist( player_abspos, global_omt_location() ) > 3 ||
         ( rl_dist( player_character.pos(), pos() ) > SEEX * 2 || !player_character.sees( pos() ) ) ) {
         if( u_has_radio && guy_has_radio ) {
-            // TODO: better range calculation than just elevation.
-            int max_range = 200;
-            max_range *= ( 1 + ( player_character.pos().z * 0.1 ) );
-            max_range *= ( 1 + ( pos().z * 0.1 ) );
-            if( is_stationed ) {
-                // if camp that NPC is at, has a radio tower
-                if( temp_camp->has_provides( "radio_tower" ) ) {
-                    max_range *= 5;
-                }
-            }
-            // if camp that player is at, has a radio tower
-            if( const std::optional<basecamp *> player_camp = overmap_buffer.find_camp(
-                        player_character.global_omt_location().xy() ) ) {
-                if( ( *player_camp )->has_provides( "radio_tower" ) ) {
-                    max_range *= 5;
-                }
-            }
-            if( ( ( player_character.pos().z >= 0 && pos().z >= 0 ) ||
-                  ( player_character.pos().z == pos().z ) ) &&
-                square_dist( player_character.global_sm_location(), global_sm_location() ) <= max_range ) {
-                retval = 2;
-                can_see = _( "Within radio range" );
-                see_color = c_light_green;
-            } else {
+            if( !( player_character.pos().z >= 0 && pos().z >= 0 ) &&
+                !( player_character.pos().z == pos().z ) ) {
+                //Early exit
                 can_see = _( "Not within radio range" );
                 see_color = c_light_red;
+            } else {
+                // TODO: better range calculation than just elevation.
+                const int base_range = 100;
+                float send_elev_boost = ( 1 + ( player_character.pos().z * 0.1 ) );
+                float recv_elev_boost = ( 1 + ( pos().z * 0.1 ) );
+                if( ( square_dist( player_character.global_sm_location(),
+                                   global_sm_location() ) <= base_range * send_elev_boost * recv_elev_boost ) ) {
+                    //Direct radio contact, both of their elevation are in effect
+                    retval = 2;
+                    can_see = _( "Within radio range" );
+                    see_color = c_light_green;
+                } else {
+                    //contact via camp radio tower
+                    int recv_range = base_range * recv_elev_boost;
+                    int send_range = base_range * send_elev_boost;
+                    const int radio_tower_boost = 5;
+                    // find camps that are near player or npc
+                    const std::vector<camp_reference> &camps_near_player = overmap_buffer.get_camps_near(
+                                player_character.global_sm_location(), send_range * radio_tower_boost );
+                    const std::vector<camp_reference> &camps_near_npc = overmap_buffer.get_camps_near(
+                                global_sm_location(), recv_range * radio_tower_boost );
+                    bool camp_to_npc = false, camp_to_camp = false;
+                    for( const camp_reference &i : camps_near_player ) {
+                        if( !( i.camp ->has_provides( "radio" ) ) ) {
+                            continue;
+                        }
+                        if( camp_to_camp ||
+                            square_dist( i.abs_sm_pos, global_sm_location() ) <= recv_range * radio_tower_boost ) {
+                            //one radio tower relay
+                            camp_to_npc = true;
+                            break;
+                        }
+                        for( const camp_reference &j : camps_near_npc ) {
+                            //two radio tower relays
+                            if( ( j.camp )->has_provides( "radio" ) &&
+                                ( square_dist( i.abs_sm_pos, j.abs_sm_pos ) <= base_range * radio_tower_boost *
+                                  radio_tower_boost ) ) {
+                                camp_to_camp = true;
+                                break;
+                            }
+                        }
+                    }
+                    if( camp_to_npc || camp_to_camp ) {
+                        retval = 2;
+                        can_see = _( "Within radio range" );
+                        see_color = c_light_green;
+                    } else {
+                        can_see = _( "Not within radio range" );
+                        see_color = c_light_red;
+                    }
+                }
             }
         } else if( guy_has_radio && !u_has_radio ) {
             can_see = _( "You do not have a radio" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Fix and enhance camp radio tower"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
1. To make camp's radio tower more powerful. To make it act like a cellular phone base station. 
2. To fix the bug that `has_provides( "radio_tower" )` actually should be `has_provides( "radio" )`
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. "Stand higher, call further" is still true.
2. Radio towers can relay radio calls, as detailed below:
- If there's a radio tower near the player, the player can call NPCs **through** that tower, and the effective distance (from the tower to the player, and from the tower to NPC ) gets boosted by the tower's enhanced sending and reception capabilities.
- If one tower isn't enough, and there's another radio tower near the NPC, the player can call that NPC through two towers. The range between those towers can be much longer ( up to 2500 overmap tiles). 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Only fix the bug, and keep radio tower specific to the very camp.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. Direct call, the effective range is correct.
2. Relayed once, the effective range is also correct.
3. Relayed twice, the call is successful. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
TODO: Add a path-finding ability to the radio system, making more relays possible.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->