### PR TITLE
'variant' field should be optional in sound_effect and preload

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -564,9 +564,13 @@ void sfx::load_sound_effects( const JsonObject &jsobj )
         key.night = jsobj.get_bool( "is_night" );
     }
     const int volume = jsobj.get_int( "volume", 100 );
-    std::vector<std::string> variants = jsobj.get_as_string_array( "variant" );
-    if( variants.empty() ) {
-        variants.emplace_back( "default" );
+    std::vector<std::string> variants;
+    if( jsobj.has_array( "variant" ) ) {
+        variants = jsobj.get_string_array( "variant" );
+    } else if( jsobj.has_string( "variant" ) ) {
+        variants = { jsobj.get_string( "variant" ) };
+    } else {
+        variants = { "default" };
     }
     for( const std::string &variant : variants ) {
         key.variant = variant;
@@ -597,9 +601,13 @@ void sfx::load_sound_effect_preload( const JsonObject &jsobj )
         if( aobj.has_bool( "is_night" ) ) {
             preload_key.night = aobj.get_bool( "is_night" );
         }
-        std::vector<std::string> variants = jsobj.get_as_string_array( "variant" );
-        if( variants.empty() ) {
-            variants.emplace_back( "default" );
+        std::vector<std::string> variants;
+        if( aobj.has_array( "variant" ) ) {
+            variants = aobj.get_string_array( "variant" );
+        } else if( aobj.has_string( "variant" ) ) {
+            variants = { aobj.get_string( "variant" ) };
+        } else {
+            variants = { "default" };
         }
         for( const std::string &variant : variants ) {
             preload_key.variant = variant;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix #65031

#### Describe the solution

Actually make variant optional

Didn't notice get_as_string_array is making the member mandatory, since some sounds (that load before the variant-less json entry) playing gave the illusion of sounds working, but actually invalid and unvisited member json errors for soundpacks are silenced and shunted into debug.log only, instead of raising a debugmsg.

#### Describe alternatives you've considered

Also make soundpack errors raise debugmsg so invalid json is actually visible, but I'm not sure what's the reason it isn't so already

#### Testing

Select basic sounds, left-right arrows in main menu should bleep, debug.log should not have message about soundpack json errors

#### Additional context
