### PR TITLE
Invalid soundpack json should be loud

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -877,7 +877,7 @@ void load_soundset()
         loading_ui ui( false );
         DynamicDataLoader::get_instance().load_data_from_path( soundpack_path, "core", ui );
     } catch( const std::exception &err ) {
-        dbg( D_ERROR ) << "failed to load sounds: " << err.what();
+        debugmsg( "failed to load sounds: %s", err.what() );
     }
 
     // Preload sound effects


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

If a soundpack has json errors they are only written to debug.log, the sounds that load before the error may play and give the illusion that everything works, but no sound entries after the error will load

#### Describe the solution

Make soundpack json errors "loud" by displaying a debugmsg instead of only writing to debug.log

#### Describe alternatives you've considered

#### Testing

Load the game on current master (should raise the invalid debugmsg below) with basic sounds pack selected or add some unvisited member to sound_effect - that should also appear with a debugmsg

#### Additional context

Disregard the error message itself as it's a bug fixed by #65034, but the debugmsg appears and is skippable with space or `i`
![image](https://user-images.githubusercontent.com/6560075/231589226-ff349f27-4f2e-497c-8531-7711cef49ca8.png)
