### PR TITLE
Item summoning spells now respect keep hands free option

### DIFF
--- a/src/character_martial_arts.h
+++ b/src/character_martial_arts.h
@@ -19,7 +19,6 @@ class character_martial_arts
     private:
         std::vector<matype_id> ma_styles;
         matype_id style_selected = matype_id( "style_none" );
-        bool keep_hands_free = false;
     public:
         character_martial_arts();
         character_martial_arts( const std::vector<matype_id> &styles,
@@ -33,6 +32,7 @@ class character_martial_arts
         void clear_style( const matype_id &id );
         // checks that style selected is one that is known, otherwise resets it
         void selected_style_check();
+        bool keep_hands_free = false;
         /** Creates the UI and handles player input for picking martial arts styles */
         bool pick_style( const avatar &you );
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1096,7 +1096,7 @@ void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const
             it.set_flag( json_flag_FIT );
             player_character.wear_item( it, false );
         } else if( !player_character.has_wield_conflicts( it ) &&
-        	       !player_character.martial_arts_data->keep_hands_free && //No wield if hands free
+                   !player_character.martial_arts_data->keep_hands_free && //No wield if hands free
                    player_character.wield( it, 0 ) ) {
             // nothing to do
         } else {

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -20,6 +20,7 @@
 #include "bodypart.h"
 #include "calendar.h"
 #include "character.h"
+#include "character_martial_arts.h"
 #include "colony.h"
 #include "color.h"
 #include "coordinates.h"
@@ -1095,6 +1096,7 @@ void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const
             it.set_flag( json_flag_FIT );
             player_character.wear_item( it, false );
         } else if( !player_character.has_wield_conflicts( it ) &&
+        	       !player_character.martial_arts_data->keep_hands_free && //No wield if hands free
                    player_character.wield( it, 0 ) ) {
             // nothing to do
         } else {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Item summoning spells now respect keep hands free option"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The martial arts option "keep hands free" prevents items from entering the wield slot and interfering with unarmed martial arts and spellcasting. Unfortunately, item summoning spells ignore this option and spawns non-wearable items in the wield slot if available.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Modified the "spawn_ethereal_item" function to check for the keep hands free option before attempting to spawn an item in the wield slot. If the keep hands free option is enabled, it will spawn in the inventory instead.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Create a world and character with the Magiclysm mod
Drop wielded item if any
Give the character the Magus Rune spell
Turn on "Keep hands free" in the martial arts menu
Cast Magus Rune
Rune is spawned in inventory
Turn off "Keep hands free" in the martial arts menu
Cast Magus Rune again
Rune is spawned wielded
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->