### PR TITLE
load correct stat_hp_mods

### DIFF
--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -1200,7 +1200,7 @@ void stat_hp_mods::load( const JsonObject &jsobj )
     optional( jsobj, was_loaded, "str_mod", str_mod, 3.0f );
     optional( jsobj, was_loaded, "dex_mod", dex_mod, 0.0f );
     optional( jsobj, was_loaded, "int_mod", int_mod, 0.0f );
-    optional( jsobj, was_loaded, "per_mod", str_mod, 0.0f );
+    optional( jsobj, was_loaded, "per_mod", per_mod, 0.0f );
 
     optional( jsobj, was_loaded, "health_mod", health_mod, 0.0f );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "The code was incorrectly overriding the strength modifier with the perception modifier and not writing anything to the perception modifier."
