### PR TITLE
math_parser/eoc: port u_val pain to math

### DIFF
--- a/data/json/effect_on_condition.json
+++ b/data/json/effect_on_condition.json
@@ -259,7 +259,7 @@
     "effect": [
       { "u_message": "Your malfunctioning bionic causes you to spasm and fall to the floor!", "type": "bad" },
       { "sound_effect": "elec_crackle_high", "id": "bionics", "volume": 100 },
-      { "arithmetic": [ { "u_val": "pain" }, "++" ] },
+      { "math": [ "u_pain()", "++" ] },
       { "u_add_effect": "stunned", "duration": 1 },
       { "u_add_effect": "downed", "duration": 1, "force": true }
     ]

--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -1433,10 +1433,7 @@
         {
           "id": "EOC_MIGO_BIO_TECH_PAIN",
           "condition": { "npc_has_var": "function", "type": "mbt", "context": "f", "value": "pain" },
-          "effect": [
-            { "u_message": "You feel your aches and pains fade away!" },
-            { "arithmetic": [ { "u_val": "pain" }, "-=", { "const": 30 } ] }
-          ]
+          "effect": [ { "u_message": "You feel your aches and pains fade away!" }, { "math": [ "u_pain()", "-=", "30" ] } ]
         },
         {
           "id": "EOC_MIGO_BIO_TECH_FATIGUE",

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -587,7 +587,7 @@
         "duration": "36 hours",
         "decay_start": "24 hours"
       },
-      { "arithmetic": [ { "u_val": "pain" }, "+=", { "const": 3 } ] }
+      { "math": [ "u_pain()", "+=", "3" ] }
     ]
   },
   {
@@ -718,7 +718,7 @@
     "condition": "u_can_see",
     "effect": [
       { "u_add_effect": "nightmares", "duration": "18 hours" },
-      { "arithmetic": [ { "u_val": "pain" }, "+=", { "const": 15 } ] },
+      { "math": [ "u_pain()", "+=", "15" ] },
       { "arithmetic": [ { "u_val": "stamina" }, "-=", { "const": 300 } ] }
     ]
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -4380,9 +4380,9 @@
     "type": "effect_on_condition",
     "id": "PAINREC1_EOC",
     "recurrence": "1 m",
-    "condition": { "and": [ { "compare_int": [ { "u_val": "pain" }, ">", { "const": 0 } ] }, { "u_has_trait": "PAINREC1" } ] },
+    "condition": { "and": [ { "math": [ "u_pain()", ">", "0" ] }, { "u_has_trait": "PAINREC1" } ] },
     "deactivate_condition": { "not": { "u_has_trait": "PAINREC1" } },
-    "effect": [ { "arithmetic": [ { "u_val": "pain" }, "-=", { "const": 3 } ] } ]
+    "effect": [ { "math": [ "u_pain()", "-=", "3" ] } ]
   },
   {
     "type": "mutation",
@@ -4399,9 +4399,9 @@
     "type": "effect_on_condition",
     "id": "PAINREC2_EOC",
     "recurrence": "1 m",
-    "condition": { "and": [ { "compare_int": [ { "u_val": "pain" }, ">", { "const": 0 } ] }, { "u_has_trait": "PAINREC2" } ] },
+    "condition": { "and": [ { "math": [ "u_pain()", ">", "0" ] }, { "u_has_trait": "PAINREC2" } ] },
     "deactivate_condition": { "not": { "u_has_trait": "PAINREC2" } },
-    "effect": [ { "arithmetic": [ { "u_val": "pain" }, "-=", { "const": 4 } ] } ]
+    "effect": [ { "math": [ "u_pain()", "-=", "4" ] } ]
   },
   {
     "type": "mutation",
@@ -4417,9 +4417,9 @@
     "type": "effect_on_condition",
     "id": "PAINREC3_EOC",
     "recurrence": "1 m",
-    "condition": { "and": [ { "compare_int": [ { "u_val": "pain" }, ">", { "const": 0 } ] }, { "u_has_trait": "PAINREC3" } ] },
+    "condition": { "and": [ { "math": [ "u_pain()", ">", "0" ] }, { "u_has_trait": "PAINREC3" } ] },
     "deactivate_condition": { "not": { "u_has_trait": "PAINREC3" } },
-    "effect": [ { "arithmetic": [ { "u_val": "pain" }, "-=", { "const": 5 } ] } ]
+    "effect": [ { "math": [ "u_pain()", "-=", "5" ] } ]
   },
   {
     "type": "mutation",

--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -1176,11 +1176,7 @@
         "topic": "TALK_DONE",
         "condition": { "compare_num": [ { "u_val": "pos_z" }, "=", { "const": 20 } ] }
       },
-      {
-        "text": "Pain level is 21.",
-        "topic": "TALK_DONE",
-        "condition": { "compare_num": [ { "u_val": "pain" }, "=", { "const": 21 } ] }
-      },
+      { "text": "Pain level is 21.", "topic": "TALK_DONE", "condition": { "math": [ "u_pain()", "==", "21" ] } },
       {
         "text": "Bionic power is 22.",
         "topic": "TALK_DONE",
@@ -1484,11 +1480,7 @@
         "topic": "TALK_DONE",
         "effect": { "arithmetic": [ { "u_val": "pos_z" }, "=", { "const": 16 } ] }
       },
-      {
-        "text": "Sets pain to 17.",
-        "topic": "TALK_DONE",
-        "effect": { "arithmetic": [ { "u_val": "pain" }, "=", { "const": 17 } ] }
-      },
+      { "text": "Sets pain to 17.", "topic": "TALK_DONE", "effect": { "math": [ "u_pain()", "=", "17" ] } },
       {
         "text": "Sets power to 18.",
         "topic": "TALK_DONE",

--- a/data/json/portal_dependent_effect_on_condition.json
+++ b/data/json/portal_dependent_effect_on_condition.json
@@ -81,7 +81,7 @@
     "//": "Your feel faintly more accepted by the world, it could be related with the decay of reality in here.",
     "effect": [
       { "u_message": "You suddenly feel a weight you didn't know you had on you, being lifted away.", "type": "good" },
-      { "arithmetic": [ { "u_val": "pain" }, "-=", { "const": 5 } ] }
+      { "math": [ "u_pain()", "-=", "5" ] }
     ]
   },
   {
@@ -357,7 +357,7 @@
         "u_message": "Faint sparks suddenly appear and disappear around you, as if rejecting your very existence.  Pain flares across your body.",
         "type": "bad"
       },
-      { "arithmetic": [ { "u_val": "pain" }, "+=", { "const": 10 } ] }
+      { "math": [ "u_pain()", "+=", "10" ] }
     ]
   },
   {

--- a/data/json/portal_storm_effect_on_condition.json
+++ b/data/json/portal_storm_effect_on_condition.json
@@ -558,7 +558,7 @@
         "u_message": "You awake with a start from what must have been a violent and horrifying daydream.  Your body aches as if the wounds were real.",
         "type": "bad"
       },
-      { "arithmetic": [ { "u_val": "pain" }, "+=", { "const": 30 } ] },
+      { "math": [ "u_pain()", "+=", "30" ] },
       { "u_set_field": "fd_blood", "radius": 2 }
     ]
   },

--- a/data/json/ui/spacebar/spacebar_separators.json
+++ b/data/json/ui/spacebar/spacebar_separators.json
@@ -9,29 +9,19 @@
         "id": "light",
         "text": "]>=---=---=---=< >=---=----=<>=----=---=< >=---=---=---=<[",
         "color": "yellow",
-        "condition": {
-          "and": [
-            { "compare_num": [ { "u_val": "pain" }, ">=", { "const": 3 } ] },
-            { "compare_num": [ { "u_val": "pain" }, "<", { "const": 40 } ] }
-          ]
-        }
+        "condition": { "and": [ { "math": [ "u_pain()", ">=", "3" ] }, { "math": [ "u_pain()", "<", "40" ] } ] }
       },
       {
         "id": "mid",
         "text": "]>=---=---=<>=---=<<>>=----=<>=----=<<>>=---=<>=---=---=<[",
         "color": "light_red",
-        "condition": {
-          "and": [
-            { "compare_num": [ { "u_val": "pain" }, ">=", { "const": 40 } ] },
-            { "compare_num": [ { "u_val": "pain" }, "<", { "const": 60 } ] }
-          ]
-        }
+        "condition": { "and": [ { "math": [ "u_pain()", ">=", "40" ] }, { "math": [ "u_pain()", "<", "60" ] } ] }
       },
       {
         "id": "haevy",
         "text": "]>=---=---=<>=---=<<>>=---=<<>>=---=<<>>=---=<>=---=---=<[",
         "color": "red",
-        "condition": { "compare_num": [ { "u_val": "pain" }, ">=", { "const": 60 } ] }
+        "condition": { "math": [ "u_pain()", ">=", "60" ] }
       }
     ],
     "default_clause": { "text": "]>=---=---=---=---=---=---=----=---=---=---=---=---=---=<[", "color": "dark_gray" },
@@ -46,29 +36,19 @@
         "id": "light",
         "text": "]>=---=---=---=---=<<>>=---=---=---=---=<[",
         "color": "yellow",
-        "condition": {
-          "and": [
-            { "compare_num": [ { "u_val": "pain" }, ">=", { "const": 3 } ] },
-            { "compare_num": [ { "u_val": "pain" }, "<", { "const": 40 } ] }
-          ]
-        }
+        "condition": { "and": [ { "math": [ "u_pain()", ">=", "3" ] }, { "math": [ "u_pain()", "<", "40" ] } ] }
       },
       {
         "id": "mid",
         "text": "]>=---=---=<<>>=----<>----=<<>>=---=---=<[",
         "color": "light_red",
-        "condition": {
-          "and": [
-            { "compare_num": [ { "u_val": "pain" }, ">=", { "const": 40 } ] },
-            { "compare_num": [ { "u_val": "pain" }, "<", { "const": 60 } ] }
-          ]
-        }
+        "condition": { "and": [ { "math": [ "u_pain()", ">=", "40" ] }, { "math": [ "u_pain()", "<", "60" ] } ] }
       },
       {
         "id": "haevy",
         "text": "]>=--=---=<<>>=---=<<>>=---=<<>>=---=--=<[",
         "color": "red",
-        "condition": { "compare_num": [ { "u_val": "pain" }, ">=", { "const": 60 } ] }
+        "condition": { "math": [ "u_pain()", ">=", "60" ] }
       }
     ],
     "default_clause": { "text": "]>=---=---=---=---=----=---=---=---=---=<[", "color": "dark_gray" }

--- a/data/mods/Magiclysm/enchantments/Gaias_Chosen.json
+++ b/data/mods/Magiclysm/enchantments/Gaias_Chosen.json
@@ -80,7 +80,7 @@
     "effect": [
       { "u_teleport": { "u_val": "dust_reborn_teleport" } },
       { "u_lose_trait": "DUST_REBORN" },
-      { "arithmetic": [ { "u_val": "pain" }, "=", { "const": 0 } ] },
+      { "math": [ "u_pain()", "=", "0" ] },
       { "arithmetic": [ { "u_val": "stored_kcal" }, "=", { "const": 15000 } ] },
       { "arithmetic": [ { "u_val": "thirst" }, "=", { "const": 0 } ] },
       { "arithmetic": [ { "u_val": "vitamin", "name": "bad_food" }, "=", { "const": 0 } ] },

--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -58,6 +58,23 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_mess_pass",
+    "effect": { "math": [ "weighted_var", "=", "1" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_mess_fail",
+    "effect": { "math": [ "weighted_var", "=", "-999" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_math_weighted_list",
+    "effect": {
+      "weighted_list_eocs": [ [ "EOC_mess_pass", { "math": [ "u_pain()" ] } ], [ "EOC_mess_fail", { "math": [ "u_val('stamina')" ] } ] ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_increment_var",
     "//": "tests adding a variable to the player",
     "effect": [ { "math": [ "u_activitiy_incrementer", "++" ] } ]

--- a/data/mods/TEST_DATA/mutations.json
+++ b/data/mods/TEST_DATA/mutations.json
@@ -58,7 +58,7 @@
           "msg_on": { "text": "You're very hungry and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_num": [ { "u_val": "pain" }, ">", { "const": 110 } ] },
+          "condition": { "math": [ "u_pain()", ">", "110" ] },
           "msg_on": { "text": "You're in pain and it triggers the trigger.", "rating": "mixed" }
         },
         {
@@ -99,7 +99,7 @@
           "msg_on": { "text": "You're no longer very hungry and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_num": [ { "u_val": "pain" }, "<", { "const": 110 } ] },
+          "condition": { "math": [ "u_pain()", "<", "110" ] },
           "msg_on": { "text": "You're no longer in pain and it triggers the trigger.", "rating": "mixed" }
         },
         {
@@ -130,7 +130,7 @@
           "condition": { "and": [ { "compare_num": [ "moon", ">", { "const": 3 } ] }, { "compare_num": [ "moon", "<", { "const": 5 } ] } ] }
         }
       ],
-      [ { "condition": { "compare_num": [ { "u_val": "pain" }, ">", { "const": 110 } ] } } ]
+      [ { "condition": { "math": [ "u_pain()", ">", "110" ] } } ]
     ],
     "transform": { "target": "TEST_TRIGGER_2_active", "msg_transform": "The trigger is triggered.", "active": true, "moves": 10 }
   },
@@ -148,7 +148,7 @@
           "msg_on": { "text": "This is not the full moon anymore and it triggers the trigger.", "rating": "mixed" }
         },
         {
-          "condition": { "compare_num": [ { "u_val": "pain" }, "<", { "const": 110 } ] },
+          "condition": { "math": [ "u_pain()", "<", "110" ] },
           "msg_on": { "text": "You're no longer in pain and it triggers the trigger.", "rating": "mixed" }
         }
       ]

--- a/data/mods/Xedra_Evolved/enchantments/weapon.json
+++ b/data/mods/Xedra_Evolved/enchantments/weapon.json
@@ -60,6 +60,6 @@
     "id": "PAIN_STR",
     "condition": "ALWAYS",
     "//": "proof of concept",
-    "values": [ { "value": "STRENGTH", "add": { "arithmetic": [ { "u_val": "pain" }, "/", { "const": 4 } ] } } ]
+    "values": [ { "value": "STRENGTH", "add": { "math": [ "u_pain() / 4" ] } } ]
   }
 ]

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1277,7 +1277,6 @@ Example | Description
 `"u_val": "effect_intensity"` | Intensity of an effect.  `effect` is the id of the effect to test and `bodypart` is optionally the body part to look at.  If the effect is not present a -1 is returned.
 `"u_val": "skill_level"` | Level in given skill. `"skill"` must also be specified.
 `"u_val": "pos_x"` | Player character x coordinate. "pos_y" and "pos_z" also works as expected.
-`"u_val": "pain"` | Pain level.
 `"u_val": "power"` | Bionic power in millijoule.
 `"u_val": "power_max"` | Max bionic power in millijoule. Can be read but not written to.
 `"u_val": "power_percentage"` | Percentage of max bionic power. Should be a number between 0 to 100.

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1406,7 +1406,15 @@ Function composition is also supported, for example `sin( rng(0, max( 0.5, u_sin
 #### Dialogue functions
 Dialogue functions take single-quoted strings as arguments and can return or manipulate game values. They are scoped just like [variables](#variables).
 
-This section is a work in progress as functions are ported from `arithmetic` to `math`. There is a `val()` shim available that can replace `u_val` and `npc_val`:
+This section is a work in progress as functions are ported from `arithmetic` to `math`.
+
+| Function | Eval | Assign |Scopes | Description |
+|----------|------|--------|-------|-------------|
+| pain     |  ✅  |   ✅   | u, n  | Return or set pain<br/> Example:<br/>`{ "math": [ "n_pain()", "=", "u_pain() + 9000" ] }`|
+
+
+##### u_val shim
+There is a `val()` shim available that can cover the missing arithmetic functions from `u_val` and `npc_val`:
 
 ```JSON
 { "math": [ "u_val('stamina')" ] }

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1666,10 +1666,6 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             return [is_npc]( const T & d ) {
                 return d.actor( is_npc )->posz();
             };
-        } else if( checked_value == "pain" ) {
-            return [is_npc]( const T & d ) {
-                return d.actor( is_npc )->pain_cur();
-            };
         } else if( checked_value == "power" ) {
             return [is_npc]( const T & d ) {
                 // Energy in milijoule
@@ -2288,11 +2284,6 @@ conditional_t<T>::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part<
             return [is_npc, min, max]( const T & d, double input ) {
                 d.actor( is_npc )->set_pos( tripoint( d.actor( is_npc )->posx(), d.actor( is_npc )->posy(),
                                                       handle_min_max<T>( d, input, min, max ) ) );
-            };
-        } else if( checked_value == "pain" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->mod_pain( handle_min_max<T>( d, input, min,
-                                             max ) - d.actor( is_npc )->pain_cur() );
             };
         } else if( checked_value == "power" ) {
             return [is_npc, min, max]( const T & d, double input ) {

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -22,6 +22,7 @@
 #include "dialogue_helpers.h"
 #include "global_vars.h"
 #include "math_parser_func.h"
+#include "math_parser_diag.h"
 #include "math_parser_impl.h"
 #include "mission.h"
 #include "string_formatter.h"

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -382,11 +382,6 @@ void math_exp<D>::math_exp_impl::parse_comma( parse_state &state )
         new_oper();
     }
     arity.top().current++;
-    if( arity.top().expected > 0 && arity.top().current > arity.top().expected ) {
-        throw std::invalid_argument( string_format(
-                                         "Too many arguments for function %s()",
-                                         arity.top().sym.data() ) );
-    }
     state.set( parse_state::expect::operand, true );
 }
 
@@ -424,11 +419,17 @@ void math_exp<D>::math_exp_impl::new_func()
 {
     if( !ops.empty() && is_function( ops.top() ) ) {
         typename std::vector<thingie<D>>::size_type const nparams = arity.top().current;
-        if( arity.top().expected > 0 && arity.top().current < arity.top().expected ) {
-            throw std::invalid_argument( string_format(
-                                             "Not enough arguments for function %s()",
-                                             arity.top().sym.data() ) );
+        if( arity.top().expected >= 0 ) {
+            if( arity.top().current < arity.top().expected ) {
+                throw std::invalid_argument(
+                    string_format( "Not enough arguments for function %s()", arity.top().sym.data() ) );
+            }
+            if( arity.top().current > arity.top().expected ) {
+                throw std::invalid_argument(
+                    string_format( "Too many arguments for function %s()", arity.top().sym.data() ) );
+            }
         }
+
         std::vector<thingie<D>> params( nparams );
         for( typename std::vector<thingie<D>>::size_type i = 0; i < nparams; i++ ) {
             params[nparams - i - 1] = std::move( output.top() );

--- a/src/math_parser_diag.h
+++ b/src/math_parser_diag.h
@@ -1,0 +1,84 @@
+#ifndef CATA_SRC_MATH_PARSER_DIAG_H
+#define CATA_SRC_MATH_PARSER_DIAG_H
+
+#include <array>
+#include <functional>
+#include <string_view>
+#include <vector>
+
+template<class D>
+struct dialogue_func {
+    dialogue_func<D>( std::string_view s_, std::string_view sc_, int n_ ) : symbol( s_ ),
+        scopes( sc_ ), num_params( n_ ) {}
+    std::string_view symbol;
+    std::string_view scopes;
+    int num_params{};
+};
+
+template <class D>
+struct dialogue_func_eval : dialogue_func<D> {
+    using f_t = std::function<double( D const & )> ( * )( char scope,
+                std::vector<std::string> const & );
+
+    dialogue_func_eval<D>( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
+        : dialogue_func<D>( s_, sc_, n_ ), f( f_ ) {}
+
+    f_t f;
+};
+
+template <class D>
+struct dialogue_func_ass : dialogue_func<D> {
+    using f_t = std::function<void( D const &, double )> ( * )( char scope,
+                std::vector<std::string> const & );
+
+    dialogue_func_ass<D>( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
+        : dialogue_func<D>( s_, sc_, n_ ), f( f_ ) {}
+
+    f_t f;
+};
+
+template<class D>
+using pdiag_func_eval = dialogue_func_eval<D> const *;
+template<class D>
+using pdiag_func_ass = dialogue_func_ass<D> const *;
+
+bool is_beta( char scope );
+
+template<class D>
+std::function<double( D const & )> u_val( char scope,
+        std::vector<std::string> const &params );
+template<class D>
+std::function<void( D const &, double )> u_val_ass( char scope,
+        std::vector<std::string> const &params );
+
+template<class D>
+std::function<double( D const & )> pain_eval( char scope,
+        std::vector<std::string> const &/* params */ )
+{
+    return [beta = is_beta( scope )]( D const & d ) {
+        return d.actor( beta )->pain_cur();
+    };
+}
+
+template<class D>
+std::function<void( D const &, double )> pain_ass( char scope,
+        std::vector<std::string> const &/* params */ )
+{
+    return [beta = is_beta( scope )]( D const & d, double val ) {
+        d.actor( beta )->set_pain( val );
+    };
+}
+
+template<class D>
+inline std::array<dialogue_func_eval<D>, 2> const dialogue_eval_f{
+    dialogue_func_eval{ "val", "un", -1, u_val<D> },
+    dialogue_func_eval{ "pain", "un", 0, pain_eval<D> },
+};
+
+template<class D>
+inline std::array<dialogue_func_ass<D>, 2> const dialogue_assign_f{
+    dialogue_func_ass{ "val", "un", -1, u_val_ass<D> },
+    dialogue_func_ass{ "pain", "un", 0, pain_ass<D> },
+};
+
+#endif // CATA_SRC_MATH_PARSER_DIAG_H

--- a/src/math_parser_func.cpp
+++ b/src/math_parser_func.cpp
@@ -1,5 +1,4 @@
 #include "math_parser_func.h"
-#include "math_parser_shim.h"
 
 #include <exception>
 #include <string_view>
@@ -7,6 +6,8 @@
 
 #include "condition.h"
 #include "dialogue.h"
+#include "math_parser_diag.h"
+#include "math_parser_shim.h"
 #include "mission.h"
 
 std::vector<std::string_view> tokenize( std::string_view str, std::string_view separators,
@@ -33,6 +34,17 @@ std::vector<std::string_view> tokenize( std::string_view str, std::string_view s
         start = pos + 1;
     }
     return ret;
+}
+
+bool is_beta( char scope )
+{
+    switch( scope ) {
+        case 'n':
+            return true;
+        case 'u':
+        default:
+            return false;
+    }
 }
 
 template<class D>

--- a/src/math_parser_func.h
+++ b/src/math_parser_func.h
@@ -25,42 +25,6 @@ struct math_const {
 };
 using pmath_const = math_const const *;
 
-template<class D>
-struct dialogue_func {
-    dialogue_func<D>( std::string_view s_, std::string_view sc_, int n_ ) : symbol( s_ ),
-        scopes( sc_ ), num_params( n_ ) {}
-    std::string_view symbol;
-    std::string_view scopes;
-    int num_params{};
-};
-
-template <class D>
-struct dialogue_func_eval : dialogue_func<D> {
-    using f_t = std::function<double( D const & )> ( * )( char scope,
-                std::vector<std::string> const & );
-
-    dialogue_func_eval<D>( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
-        : dialogue_func<D>( s_, sc_, n_ ), f( f_ ) {}
-
-    f_t f;
-};
-
-template <class D>
-struct dialogue_func_ass : dialogue_func<D> {
-    using f_t = std::function<void( D const &, double )> ( * )( char scope,
-                std::vector<std::string> const & );
-
-    dialogue_func_ass<D>( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
-        : dialogue_func<D>( s_, sc_, n_ ), f( f_ ) {}
-
-    f_t f;
-};
-
-template<class D>
-using pdiag_func_eval = dialogue_func_eval<D> const *;
-template<class D>
-using pdiag_func_ass = dialogue_func_ass<D> const *;
-
 inline double abs( std::vector<double> &params )
 {
     return std::abs( params[0] );
@@ -151,13 +115,6 @@ constexpr double test_( std::vector<double> &/* params */ )
     return 42;
 }
 
-template<class D>
-std::function<double( D const & )> u_val( char scope,
-        std::vector<std::string> const &params );
-template<class D>
-std::function<void( D const &, double )> u_val_ass( char scope,
-        std::vector<std::string> const &params );
-
 constexpr std::array<math_func, 16> functions{
     math_func{ "abs", 1, abs },
     math_func{ "max", -1, max },
@@ -175,16 +132,6 @@ constexpr std::array<math_func, 16> functions{
     math_func{ "cos", 1, cos },
     math_func{ "tan", 1, tan },
     math_func{ "_test_", 0, test_ },
-};
-
-template<class D>
-inline std::array<dialogue_func_eval<D>, 1> const dialogue_eval_f{
-    dialogue_func_eval{ "val", "un", -1, u_val<D> },
-};
-
-template<class D>
-inline std::array<dialogue_func_ass<D>, 1> const dialogue_assign_f{
-    dialogue_func_ass{ "val", "un", -1, u_val_ass<D> },
 };
 
 namespace math_constants

--- a/src/talker.h
+++ b/src/talker.h
@@ -487,6 +487,7 @@ class talker
             return true;
         }
         virtual void mod_pain( int ) {}
+        virtual void set_pain( int ) {}
         virtual int pain_cur() const {
             return 0;
         }

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -583,6 +583,11 @@ void talker_character::mod_pain( int amount )
     me_chr->mod_pain( amount );
 }
 
+void talker_character::set_pain( int amount )
+{
+    me_chr->set_pain( amount );
+}
+
 bool talker_character_const::worn_with_flag( const flag_id &flag, const bodypart_id &bp ) const
 {
     return me_chr_const->worn_with_flag( flag, bp );

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -216,6 +216,7 @@ class talker_character: public talker_character_const
 
         void set_fatigue( int amount ) override;
         void mod_pain( int amount ) override;
+        void set_pain( int amount ) override;
         void mod_daily_health( int, int ) override;
         void add_morale( const morale_type &new_morale, int bonus, int max_bonus, time_duration duration,
                          time_duration decay_started, bool capped ) override;

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -27,6 +27,8 @@ static const effect_on_condition_id
 effect_on_condition_EOC_math_test_greater_increment( "EOC_math_test_greater_increment" );
 static const effect_on_condition_id
 effect_on_condition_EOC_math_var( "EOC_math_var" );
+static const effect_on_condition_id
+effect_on_condition_EOC_math_weighted_list( "EOC_math_weighted_list" );
 static const effect_on_condition_id effect_on_condition_EOC_teleport_test( "EOC_teleport_test" );
 namespace
 {
@@ -116,6 +118,15 @@ TEST_CASE( "EOC_math_integration", "[eoc][math_parser]" )
     int const stam_pre = get_avatar().get_stamina();
     effect_on_condition_EOC_math_diag_assign->activate( d );
     CHECK( get_avatar().get_stamina() == stam_pre / 2 );
+
+    get_avatar().set_pain( 0 );
+    get_avatar().set_stamina( 9000 );
+    effect_on_condition_EOC_math_weighted_list->activate( d );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_weighted_var" ) ) == Approx( -999 ) );
+    get_avatar().set_pain( 9000 );
+    get_avatar().set_stamina( 0 );
+    effect_on_condition_EOC_math_weighted_list->activate( d );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_weighted_var" ) ) == Approx( 1 ) );
 }
 
 TEST_CASE( "EOC_transform_radius", "[eoc][timed_event]" )

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -119,6 +119,7 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
         CHECK_FALSE( testexp.parse( "sin(+)" ) );
         CHECK_FALSE( testexp.parse( "sin(-)" ) );
         CHECK_FALSE( testexp.parse( "_test_(-)" ) );
+        CHECK_FALSE( testexp.parse( "_test_(1)" ) );
         CHECK_FALSE( testexp.parse( "'string'" ) );
         CHECK_FALSE( testexp.parse( "('wrong')" ) );
         CHECK_FALSE( testexp.parse( "u_val('wr'ong')" ) ); // stray ' inside string


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Start porting `arithmetic` functions to `math`. bombasticSlacks used `"u_val": "pain"` in their latest devstream and it's a small enough target for this first port.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fix validation of number of arguments for nullary function.
Move the pain code to `math` and change all the JSON to match.
Also move the dialogue function bits to a new header to keep things clean.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
There are several uses of `"u_val": "pain"` in test units, both for assignment and evaluation, so we're already fully covered.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
So instead of
`{ "arithmetic": [ { "u_val": "pain" }, "-=", { "const": 30 } ] }`
or
`{ "math": [ "u_val('pain')", "-=", "30" ]}` (with the shim)
you can now use
`{ "math": [ "u_pain()", "-=", "30" ] }`

The `min` and `max` parameters from the old pain function can be replaced by `min()` and `max()` math functions.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->