### PR TITLE
eoc: untemplate all EOC code

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -58,9 +58,8 @@ static const efftype_id effect_currently_busy( "currently_busy" );
 
 static const json_character_flag json_flag_MUTATION_THRESHOLD( "MUTATION_THRESHOLD" );
 
-template<class T>
 std::string get_talk_varname( const JsonObject &jo, const std::string &member,
-                              bool check_value, dbl_or_var<T> &default_val )
+                              bool check_value, dbl_or_var &default_val )
 {
     if( check_value && !( jo.has_string( "value" ) || jo.has_member( "time" ) ||
                           jo.has_array( "possible_values" ) ) ) {
@@ -69,9 +68,9 @@ std::string get_talk_varname( const JsonObject &jo, const std::string &member,
     const std::string &var_basename = jo.get_string( member );
     const std::string &type_var = jo.get_string( "type", "" );
     const std::string &var_context = jo.get_string( "context", "" );
-    default_val = get_dbl_or_var<T>( jo, "default", false );
+    default_val = get_dbl_or_var( jo, "default", false );
     if( jo.has_member( "default_time" ) ) {
-        dbl_or_var<T> value;
+        dbl_or_var value;
         time_duration max_time;
         mandatory( jo, false, "default_time", max_time );
         value.min.dbl_val = to_turns<int>( max_time );
@@ -92,19 +91,18 @@ std::string get_talk_var_basename( const JsonObject &jo, const std::string &memb
     return var_basename;
 }
 
-template<class T>
-dbl_or_var_part<T> get_dbl_or_var_part( const JsonValue &jv, const std::string &member,
-                                        bool required,
-                                        double default_val )
+dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv, const std::string &member,
+                                     bool required,
+                                     double default_val )
 {
-    dbl_or_var_part<T> ret_val;
+    dbl_or_var_part ret_val;
     if( jv.test_float() ) {
         ret_val.dbl_val = jv.get_float();
     } else if( jv.test_object() ) {
         JsonObject jo = jv.get_object();
         jo.allow_omitted_members();
         if( jo.has_array( "arithmetic" ) ) {
-            talk_effect_fun_t<T> arith;
+            talk_effect_fun_t arith;
             arith.set_arithmetic( jo, "arithmetic", true );
             ret_val.arithmetic_val = arith;
         } else if( jo.has_array( "math" ) ) {
@@ -121,21 +119,20 @@ dbl_or_var_part<T> get_dbl_or_var_part( const JsonValue &jv, const std::string &
     return ret_val;
 }
 
-template<class T>
-dbl_or_var<T> get_dbl_or_var( const JsonObject &jo, std::string member, bool required,
-                              double default_val )
+dbl_or_var get_dbl_or_var( const JsonObject &jo, std::string member, bool required,
+                           double default_val )
 {
-    dbl_or_var<T> ret_val;
+    dbl_or_var ret_val;
     if( jo.has_array( member ) ) {
         JsonArray ja = jo.get_array( member );
-        ret_val.min = get_dbl_or_var_part<T>( ja.next_value(), member );
-        ret_val.max = get_dbl_or_var_part<T>( ja.next_value(), member );
+        ret_val.min = get_dbl_or_var_part( ja.next_value(), member );
+        ret_val.max = get_dbl_or_var_part( ja.next_value(), member );
         ret_val.pair = true;
     } else if( required ) {
-        ret_val.min = get_dbl_or_var_part<T>( jo.get_member( member ), member, required, default_val );
+        ret_val.min = get_dbl_or_var_part( jo.get_member( member ), member, required, default_val );
     } else {
         if( jo.has_member( member ) ) {
-            ret_val.min = get_dbl_or_var_part<T>( jo.get_member( member ), member, required, default_val );
+            ret_val.min = get_dbl_or_var_part( jo.get_member( member ), member, required, default_val );
         } else {
             ret_val.min.dbl_val = default_val;
         }
@@ -143,11 +140,10 @@ dbl_or_var<T> get_dbl_or_var( const JsonObject &jo, std::string member, bool req
     return ret_val;
 }
 
-template<class T>
-duration_or_var_part<T> get_duration_or_var_part( const JsonValue &jv, const std::string &member,
+duration_or_var_part get_duration_or_var_part( const JsonValue &jv, const std::string &member,
         bool required, time_duration default_val )
 {
-    duration_or_var_part<T> ret_val;
+    duration_or_var_part ret_val;
     if( jv.test_string() ) {
         if( jv.get_string() == "infinite" ) {
             ret_val.dur_val = time_duration::from_turns( calendar::INDEFINITELY_LONG );
@@ -160,7 +156,7 @@ duration_or_var_part<T> get_duration_or_var_part( const JsonValue &jv, const std
         JsonObject jo = jv.get_object();
         jo.allow_omitted_members();
         if( jo.has_array( "arithmetic" ) ) {
-            talk_effect_fun_t<T> arith;
+            talk_effect_fun_t arith;
             arith.set_arithmetic( jo, "arithmetic", true );
             ret_val.arithmetic_val = arith;
         } else if( jo.has_array( "math" ) ) {
@@ -177,21 +173,20 @@ duration_or_var_part<T> get_duration_or_var_part( const JsonValue &jv, const std
     return ret_val;
 }
 
-template<class T>
-duration_or_var<T> get_duration_or_var( const JsonObject &jo, std::string member, bool required,
-                                        time_duration default_val )
+duration_or_var get_duration_or_var( const JsonObject &jo, std::string member, bool required,
+                                     time_duration default_val )
 {
-    duration_or_var<T> ret_val;
+    duration_or_var ret_val;
     if( jo.has_array( member ) ) {
         JsonArray ja = jo.get_array( member );
-        ret_val.min = get_duration_or_var_part<T>( ja.next_value(), member );
-        ret_val.max = get_duration_or_var_part<T>( ja.next_value(), member );
+        ret_val.min = get_duration_or_var_part( ja.next_value(), member );
+        ret_val.max = get_duration_or_var_part( ja.next_value(), member );
         ret_val.pair = true;
     } else if( required ) {
-        ret_val.min = get_duration_or_var_part<T>( jo.get_member( member ), member, required, default_val );
+        ret_val.min = get_duration_or_var_part( jo.get_member( member ), member, required, default_val );
     } else {
         if( jo.has_member( member ) ) {
-            ret_val.min = get_duration_or_var_part<T>( jo.get_member( member ), member, required, default_val );
+            ret_val.min = get_duration_or_var_part( jo.get_member( member ), member, required, default_val );
         } else {
             ret_val.min.dur_val = default_val;
         }
@@ -199,11 +194,10 @@ duration_or_var<T> get_duration_or_var( const JsonObject &jo, std::string member
     return ret_val;
 }
 
-template<class T>
-str_or_var<T> get_str_or_var( const JsonValue &jv, const std::string &member, bool required,
-                              const std::string &default_val )
+str_or_var get_str_or_var( const JsonValue &jv, const std::string &member, bool required,
+                           const std::string &default_val )
 {
-    str_or_var<T> ret_val;
+    str_or_var ret_val;
     if( jv.test_string() ) {
         ret_val.str_val = jv.get_string();
     } else if( jv.test_object() ) {
@@ -217,12 +211,11 @@ str_or_var<T> get_str_or_var( const JsonValue &jv, const std::string &member, bo
     return ret_val;
 }
 
-template<class T>
-tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const T &d )
+tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, dialogue const &d )
 {
     tripoint_abs_ms target_pos = get_map().getglobal( d.actor( false )->pos() );
     if( var.has_value() ) {
-        std::string value = read_var_value<T>( var.value(), d );
+        std::string value = read_var_value( var.value(), d );
         if( !value.empty() ) {
             target_pos = tripoint_abs_ms( tripoint::from_string( value ) );
         }
@@ -233,7 +226,7 @@ tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const T &d )
 var_info read_var_info( const JsonObject &jo )
 {
     std::string default_val;
-    dbl_or_var<dialogue> empty;
+    dbl_or_var empty;
     var_type type;
     std::string name;
     if( jo.has_string( "default_str" ) ) {
@@ -323,11 +316,10 @@ static bodypart_id get_bp_from_str( const std::string &ctxt )
     return bid;
 }
 
-template<class T>
 void read_condition( const JsonObject &jo, const std::string &member_name,
-                     std::function<bool( const T & )> &condition, bool default_val )
+                     std::function<bool( dialogue const & )> &condition, bool default_val )
 {
-    const auto null_function = [default_val]( const T & ) {
+    const auto null_function = [default_val]( dialogue const & ) {
         return default_val;
     };
 
@@ -335,14 +327,14 @@ void read_condition( const JsonObject &jo, const std::string &member_name,
         condition = null_function;
     } else if( jo.has_string( member_name ) ) {
         const std::string type = jo.get_string( member_name );
-        conditional_t<T> sub_condition( type );
-        condition = [sub_condition]( const T & d ) {
+        conditional_t sub_condition( type );
+        condition = [sub_condition]( dialogue const & d ) {
             return sub_condition( d );
         };
     } else if( jo.has_object( member_name ) ) {
         JsonObject con_obj = jo.get_object( member_name );
-        conditional_t<T> sub_condition( con_obj );
-        condition = [sub_condition]( const T & d ) {
+        conditional_t sub_condition( con_obj );
+        condition = [sub_condition]( dialogue const & d ) {
             return sub_condition( d );
         };
     } else {
@@ -350,17 +342,16 @@ void read_condition( const JsonObject &jo, const std::string &member_name,
     }
 }
 
-template<class T>
-void conditional_t<T>::set_has_any_trait( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void conditional_t::set_has_any_trait( const JsonObject &jo, const std::string &member,
+                                       bool is_npc )
 {
-    std::vector<str_or_var<T>> traits_to_check;
+    std::vector<str_or_var> traits_to_check;
     for( JsonValue jv : jo.get_array( member ) ) {
-        traits_to_check.emplace_back( get_str_or_var<T>( jv, member ) );
+        traits_to_check.emplace_back( get_str_or_var( jv, member ) );
     }
-    condition = [traits_to_check, is_npc]( const T & d ) {
+    condition = [traits_to_check, is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
-        for( const str_or_var<T> &trait : traits_to_check ) {
+        for( const str_or_var &trait : traits_to_check ) {
             if( actor->has_trait( trait_id( trait.evaluate( d ) ) ) ) {
                 return true;
             }
@@ -369,31 +360,28 @@ void conditional_t<T>::set_has_any_trait( const JsonObject &jo, const std::strin
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_trait( const JsonObject &jo, const std::string &member, bool is_npc )
+void conditional_t::set_has_trait( const JsonObject &jo, const std::string &member, bool is_npc )
 {
-    str_or_var<T> trait_to_check = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [trait_to_check, is_npc]( const T & d ) {
+    str_or_var trait_to_check = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [trait_to_check, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->has_trait( trait_id( trait_to_check.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_martial_art( const JsonObject &jo, const std::string &member,
+void conditional_t::set_has_martial_art( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> style_to_check = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [style_to_check, is_npc]( const T & d ) {
+    str_or_var style_to_check = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [style_to_check, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->knows_martial_art( matype_id( style_to_check.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_flag( const JsonObject &jo, const std::string &member,
-                                     bool is_npc )
+void conditional_t::set_has_flag( const JsonObject &jo, const std::string &member,
+                                  bool is_npc )
 {
-    str_or_var<T> trait_flag_to_check = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [trait_flag_to_check, is_npc]( const T & d ) {
+    str_or_var trait_flag_to_check = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [trait_flag_to_check, is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
         if( json_character_flag( trait_flag_to_check.evaluate( d ) ) == json_flag_MUTATION_THRESHOLD ) {
             return actor->crossed_threshold();
@@ -402,37 +390,33 @@ void conditional_t<T>::set_has_flag( const JsonObject &jo, const std::string &me
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_activity( bool is_npc )
+void conditional_t::set_has_activity( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->has_activity();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_riding( bool is_npc )
+void conditional_t::set_is_riding( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->is_mounted();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_has_class( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void conditional_t::set_npc_has_class( const JsonObject &jo, const std::string &member,
+                                       bool is_npc )
 {
-    str_or_var<T> class_to_check = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [class_to_check, is_npc]( const T & d ) {
+    str_or_var class_to_check = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [class_to_check, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->is_myclass( npc_class_id( class_to_check.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_u_has_mission( const JsonObject &jo, const std::string &member )
+void conditional_t::set_u_has_mission( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> u_mission = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [u_mission]( const T & d ) {
+    str_or_var u_mission = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [u_mission]( dialogue const & d ) {
         for( mission *miss_it : get_avatar().get_active_missions() ) {
             if( miss_it->mission_id() == mission_type_id( u_mission.evaluate( d ) ) ) {
                 return true;
@@ -442,12 +426,11 @@ void conditional_t<T>::set_u_has_mission( const JsonObject &jo, const std::strin
     };
 }
 
-template<class T>
-void conditional_t<T>::set_u_monsters_in_direction( const JsonObject &jo,
+void conditional_t::set_u_monsters_in_direction( const JsonObject &jo,
         const std::string &member )
 {
-    str_or_var<T> dir = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [dir]( const T & d ) {
+    str_or_var dir = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [dir]( dialogue const & d ) {
         //This string_to_enum function is defined in widget.h. Should it be moved?
         const int card_dir = static_cast<int>( io::string_to_enum<cardinal_direction>( dir.evaluate(
                 d ) ) );
@@ -456,11 +439,10 @@ void conditional_t<T>::set_u_monsters_in_direction( const JsonObject &jo,
     };
 }
 
-template<class T>
-void conditional_t<T>::set_u_safe_mode_trigger( const JsonObject &jo, const std::string &member )
+void conditional_t::set_u_safe_mode_trigger( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> dir = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [dir]( const T & d ) {
+    str_or_var dir = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [dir]( dialogue const & d ) {
         //This string_to_enum function is defined in widget.h. Should it be moved?
         const int card_dir = static_cast<int>( io::string_to_enum<cardinal_direction>( dir.evaluate(
                 d ) ) );
@@ -468,106 +450,97 @@ void conditional_t<T>::set_u_safe_mode_trigger( const JsonObject &jo, const std:
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_strength( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void conditional_t::set_has_strength( const JsonObject &jo, const std::string &member,
+                                      bool is_npc )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    condition = [dov, is_npc]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    condition = [dov, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->str_cur() >= dov.evaluate( d );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_dexterity( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void conditional_t::set_has_dexterity( const JsonObject &jo, const std::string &member,
+                                       bool is_npc )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    condition = [dov, is_npc]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    condition = [dov, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->dex_cur() >= dov.evaluate( d );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_intelligence( const JsonObject &jo, const std::string &member,
+void conditional_t::set_has_intelligence( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    condition = [dov, is_npc]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    condition = [dov, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->int_cur() >= dov.evaluate( d );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_perception( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void conditional_t::set_has_perception( const JsonObject &jo, const std::string &member,
+                                        bool is_npc )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    condition = [dov, is_npc]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    condition = [dov, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->per_cur() >= dov.evaluate( d );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_hp( const JsonObject &jo, const std::string &member, bool is_npc )
+void conditional_t::set_has_hp( const JsonObject &jo, const std::string &member, bool is_npc )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    dbl_or_var dov = get_dbl_or_var( jo, member );
     std::optional<bodypart_id> bp;
     optional( jo, false, "bodypart", bp );
-    condition = [dov, bp, is_npc]( const T & d ) {
+    condition = [dov, bp, is_npc]( dialogue const & d ) {
         bodypart_id bid = bp.value_or( get_bp_from_str( d.reason ) );
         return d.actor( is_npc )->get_cur_hp( bid ) >= dov.evaluate( d );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_part_temp( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void conditional_t::set_has_part_temp( const JsonObject &jo, const std::string &member,
+                                       bool is_npc )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
+    dbl_or_var dov = get_dbl_or_var( jo, member );
     std::optional<bodypart_id> bp;
     optional( jo, false, "bodypart", bp );
-    condition = [dov, bp, is_npc]( const T & d ) {
+    condition = [dov, bp, is_npc]( dialogue const & d ) {
         bodypart_id bid = bp.value_or( get_bp_from_str( d.reason ) );
         return d.actor( is_npc )->get_cur_part_temp( bid ) >= dov.evaluate( d );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_wearing( const JsonObject &jo, const std::string &member,
-                                       bool is_npc )
+void conditional_t::set_is_wearing( const JsonObject &jo, const std::string &member,
+                                    bool is_npc )
 {
-    str_or_var<T> item_id = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [item_id, is_npc]( const T & d ) {
+    str_or_var item_id = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [item_id, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->is_wearing( itype_id( item_id.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_item( const JsonObject &jo, const std::string &member, bool is_npc )
+void conditional_t::set_has_item( const JsonObject &jo, const std::string &member, bool is_npc )
 {
-    str_or_var<T> item_id = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [item_id, is_npc]( const T & d ) {
+    str_or_var item_id = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [item_id, is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
         return actor->charges_of( itype_id( item_id.evaluate( d ) ) ) > 0 ||
                actor->has_amount( itype_id( item_id.evaluate( d ) ), 1 );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_items( const JsonObject &jo, const std::string &member, bool is_npc )
+void conditional_t::set_has_items( const JsonObject &jo, const std::string &member, bool is_npc )
 {
     JsonObject has_items = jo.get_object( member );
     if( !has_items.has_string( "item" ) || ( !has_items.has_int( "count" ) &&
             !has_items.has_int( "charges" ) ) ) {
-        condition = []( const T & ) {
+        condition = []( dialogue const & ) {
             return false;
         };
     } else {
-        str_or_var<T> item_id = get_str_or_var<T>( has_items.get_member( "item" ), "item", true );
-        dbl_or_var<T> count = get_dbl_or_var<T>( has_items, "count", false );
-        dbl_or_var<T> charges = get_dbl_or_var<T>( has_items, "charges", false );
-        condition = [item_id, count, charges, is_npc]( const T & d ) {
+        str_or_var item_id = get_str_or_var( has_items.get_member( "item" ), "item", true );
+        dbl_or_var count = get_dbl_or_var( has_items, "count", false );
+        dbl_or_var charges = get_dbl_or_var( has_items, "charges", false );
+        condition = [item_id, count, charges, is_npc]( dialogue const & d ) {
             const talker *actor = d.actor( is_npc );
             itype_id id = itype_id( item_id.evaluate( d ) );
             if( charges.evaluate( d ) == 0 && item::count_by_charges( id ) ) {
@@ -585,21 +558,19 @@ void conditional_t<T>::set_has_items( const JsonObject &jo, const std::string &m
     }
 }
 
-template<class T>
-void conditional_t<T>::set_has_item_with_flag( const JsonObject &jo, const std::string &member,
+void conditional_t::set_has_item_with_flag( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> flag = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [flag, is_npc]( const T & d ) {
+    str_or_var flag = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [flag, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->has_item_with_flag( flag_id( flag.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_item_category( const JsonObject &jo, const std::string &member,
+void conditional_t::set_has_item_category( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> category_id = get_str_or_var<T>( jo.get_member( member ), member, true );
+    str_or_var category_id = get_str_or_var( jo.get_member( member ), member, true );
     size_t count = 1;
     if( jo.has_int( "count" ) ) {
         int tcount = jo.get_int( "count" );
@@ -608,7 +579,7 @@ void conditional_t<T>::set_has_item_category( const JsonObject &jo, const std::s
         }
     }
 
-    condition = [category_id, count, is_npc]( const T & d ) {
+    condition = [category_id, count, is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
         const item_category_id cat_id = item_category_id( category_id.evaluate( d ) );
         const auto items_with = actor->const_items_with( [cat_id]( const item & it ) {
@@ -618,12 +589,11 @@ void conditional_t<T>::set_has_item_category( const JsonObject &jo, const std::s
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_bionics( const JsonObject &jo, const std::string &member,
-                                        bool is_npc )
+void conditional_t::set_has_bionics( const JsonObject &jo, const std::string &member,
+                                     bool is_npc )
 {
-    str_or_var<T> bionics_id = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [bionics_id, is_npc]( const T & d ) {
+    str_or_var bionics_id = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [bionics_id, is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
         if( bionics_id.evaluate( d ) == "ANY" ) {
             return actor->num_bionics() > 0 || actor->has_max_power();
@@ -632,19 +602,18 @@ void conditional_t<T>::set_has_bionics( const JsonObject &jo, const std::string 
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_effect( const JsonObject &jo, const std::string &member,
-                                       bool is_npc )
+void conditional_t::set_has_effect( const JsonObject &jo, const std::string &member,
+                                    bool is_npc )
 {
-    str_or_var<T> effect_id = get_str_or_var<T>( jo.get_member( member ), member, true );
-    dbl_or_var<T> intensity = get_dbl_or_var<T>( jo, "intensity", false, -1 );
-    str_or_var<T> bp;
+    str_or_var effect_id = get_str_or_var( jo.get_member( member ), member, true );
+    dbl_or_var intensity = get_dbl_or_var( jo, "intensity", false, -1 );
+    str_or_var bp;
     if( jo.has_member( "bodypart" ) ) {
-        bp = get_str_or_var<T>( jo.get_member( "target_part" ), "target_part", true );
+        bp = get_str_or_var( jo.get_member( "target_part" ), "target_part", true );
     } else {
         bp.str_val = "";
     }
-    condition = [effect_id, intensity, bp, is_npc]( const T & d ) {
+    condition = [effect_id, intensity, bp, is_npc]( dialogue const & d ) {
         bodypart_id bid = bp.evaluate( d ) == "" ? get_bp_from_str( d.reason ) : bodypart_id( bp.evaluate(
                               d ) );
         effect target = d.actor( is_npc )->get_effect( efftype_id( effect_id.evaluate( d ) ), bid );
@@ -652,15 +621,14 @@ void conditional_t<T>::set_has_effect( const JsonObject &jo, const std::string &
     };
 }
 
-template<class T>
-void conditional_t<T>::set_need( const JsonObject &jo, const std::string &member, bool is_npc )
+void conditional_t::set_need( const JsonObject &jo, const std::string &member, bool is_npc )
 {
-    str_or_var<T> need = get_str_or_var<T>( jo.get_member( member ), member, true );
-    dbl_or_var<T> dov;
+    str_or_var need = get_str_or_var( jo.get_member( member ), member, true );
+    dbl_or_var dov;
     if( jo.has_int( "amount" ) ) {
         dov.min.dbl_val = jo.get_int( "amount" );
     } else if( jo.has_object( "amount" ) ) {
-        dov = get_dbl_or_var<T>( jo, "amount" );
+        dov = get_dbl_or_var( jo, "amount" );
     } else if( jo.has_string( "level" ) ) {
         const std::string &level = jo.get_string( "level" );
         auto flevel = fatigue_level_strs.find( level );
@@ -668,7 +636,7 @@ void conditional_t<T>::set_need( const JsonObject &jo, const std::string &member
             dov.min.dbl_val = static_cast<int>( flevel->second );
         }
     }
-    condition = [need, dov, is_npc]( const T & d ) {
+    condition = [need, dov, is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
         int amount = dov.evaluate( d );
         return ( actor->get_fatigue() > amount && need.evaluate( d ) == "fatigue" ) ||
@@ -677,12 +645,11 @@ void conditional_t<T>::set_need( const JsonObject &jo, const std::string &member
     };
 }
 
-template<class T>
-void conditional_t<T>::set_at_om_location( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void conditional_t::set_at_om_location( const JsonObject &jo, const std::string &member,
+                                        bool is_npc )
 {
-    str_or_var<T> location = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [location, is_npc]( const T & d ) {
+    str_or_var location = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [location, is_npc]( dialogue const & d ) {
         const tripoint_abs_omt omt_pos = d.actor( is_npc )->global_omt_location();
         const oter_id &omt_ter = overmap_buffer.ter( omt_pos );
         const std::string &omt_str = omt_ter.id().c_str();
@@ -702,13 +669,12 @@ void conditional_t<T>::set_at_om_location( const JsonObject &jo, const std::stri
     };
 }
 
-template<class T>
-void conditional_t<T>::set_near_om_location( const JsonObject &jo, const std::string &member,
+void conditional_t::set_near_om_location( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> location = get_str_or_var<T>( jo.get_member( member ), member, true );
-    const dbl_or_var<T> range = get_dbl_or_var<T>( jo, "range", false, 1 );
-    condition = [location, range, is_npc]( const T & d ) {
+    str_or_var location = get_str_or_var( jo.get_member( member ), member, true );
+    const dbl_or_var range = get_dbl_or_var( jo, "range", false, 1 );
+    condition = [location, range, is_npc]( dialogue const & d ) {
         const tripoint_abs_omt omt_pos = d.actor( is_npc )->global_omt_location();
         for( const tripoint_abs_omt &curr_pos : points_in_radius( omt_pos,
                 range.evaluate( d ) ) ) {
@@ -738,14 +704,13 @@ void conditional_t<T>::set_near_om_location( const JsonObject &jo, const std::st
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_var( const JsonObject &jo, const std::string &member, bool is_npc )
+void conditional_t::set_has_var( const JsonObject &jo, const std::string &member, bool is_npc )
 {
-    dbl_or_var<dialogue> empty;
+    dbl_or_var empty;
     const std::string var_name = get_talk_varname( jo, member, false, empty );
     const std::string &value = jo.has_member( "value" ) ? jo.get_string( "value" ) : std::string();
     const bool time_check = jo.has_member( "time" ) && jo.get_bool( "time" );
-    condition = [var_name, value, time_check, is_npc]( const T & d ) {
+    condition = [var_name, value, time_check, is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
         if( time_check ) {
             return !actor->get_value( var_name ).empty();
@@ -754,16 +719,15 @@ void conditional_t<T>::set_has_var( const JsonObject &jo, const std::string &mem
     };
 }
 
-template<class T>
-void conditional_t<T>::set_compare_var( const JsonObject &jo, const std::string &member,
-                                        bool is_npc )
+void conditional_t::set_compare_var( const JsonObject &jo, const std::string &member,
+                                     bool is_npc )
 {
-    dbl_or_var<dialogue> empty;
+    dbl_or_var empty;
     const std::string var_name = get_talk_varname( jo, member, false, empty );
     const std::string &op = jo.get_string( "op" );
 
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, "value" );
-    condition = [var_name, op, dov, is_npc]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, "value" );
+    condition = [var_name, op, dov, is_npc]( dialogue const & d ) {
         double stored_value = 0;
         double value = dov.evaluate( d );
         const std::string &var = d.actor( is_npc )->get_value( var_name );
@@ -794,16 +758,15 @@ void conditional_t<T>::set_compare_var( const JsonObject &jo, const std::string 
     };
 }
 
-template<class T>
-void conditional_t<T>::set_compare_time_since_var( const JsonObject &jo, const std::string &member,
+void conditional_t::set_compare_time_since_var( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    dbl_or_var<dialogue> empty;
+    dbl_or_var empty;
     const std::string var_name = get_talk_varname( jo, member, false, empty );
     const std::string &op = jo.get_string( "op" );
     const int value = to_turns<int>( read_from_json_string<time_duration>( jo.get_member( "time" ),
                                      time_duration::units ) );
-    condition = [var_name, op, value, is_npc]( const T & d ) {
+    condition = [var_name, op, value, is_npc]( dialogue const & d ) {
         int stored_value = 0;
         const std::string &var = d.actor( is_npc )->get_value( var_name );
         if( var.empty() ) {
@@ -837,11 +800,10 @@ void conditional_t<T>::set_compare_time_since_var( const JsonObject &jo, const s
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_role_nearby( const JsonObject &jo, const std::string &member )
+void conditional_t::set_npc_role_nearby( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> role = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [role]( const T & d ) {
+    str_or_var role = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [role]( dialogue const & d ) {
         const std::vector<npc *> available = g->get_npcs_if( [&]( const npc & guy ) {
             return d.actor( false )->posz() == guy.posz() &&
                    guy.companion_mission_role_id == role.evaluate( d ) &&
@@ -851,20 +813,18 @@ void conditional_t<T>::set_npc_role_nearby( const JsonObject &jo, const std::str
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_allies( const JsonObject &jo, const std::string &member )
+void conditional_t::set_npc_allies( const JsonObject &jo, const std::string &member )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    condition = [dov]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    condition = [dov]( dialogue const & d ) {
         return g->allies().size() >= static_cast<std::vector<npc *>::size_type>( dov.evaluate( d ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_allies_global( const JsonObject &jo, const std::string &member )
+void conditional_t::set_npc_allies_global( const JsonObject &jo, const std::string &member )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    condition = [dov]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    condition = [dov]( dialogue const & d ) {
         const auto all_npcs = overmap_buffer.get_overmap_npcs();
         const size_t count = std::count_if( all_npcs.begin(),
         all_npcs.end(), []( const shared_ptr_fast<npc> &ptr ) {
@@ -875,97 +835,87 @@ void conditional_t<T>::set_npc_allies_global( const JsonObject &jo, const std::s
     };
 }
 
-template<class T>
-void conditional_t<T>::set_u_has_cash( const JsonObject &jo, const std::string &member )
+void conditional_t::set_u_has_cash( const JsonObject &jo, const std::string &member )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    condition = [dov]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    condition = [dov]( dialogue const & d ) {
         return d.actor( false )->cash() >= dov.evaluate( d );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_u_are_owed( const JsonObject &jo, const std::string &member )
+void conditional_t::set_u_are_owed( const JsonObject &jo, const std::string &member )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    condition = [dov]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    condition = [dov]( dialogue const & d ) {
         return d.actor( true )->debt() >= dov.evaluate( d );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_aim_rule( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void conditional_t::set_npc_aim_rule( const JsonObject &jo, const std::string &member,
+                                      bool is_npc )
 {
-    str_or_var<T> setting = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [setting, is_npc]( const T & d ) {
+    str_or_var setting = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [setting, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->has_ai_rule( "aim_rule", setting.evaluate( d ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_engagement_rule( const JsonObject &jo, const std::string &member,
+void conditional_t::set_npc_engagement_rule( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> setting = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [setting, is_npc]( const T & d ) {
+    str_or_var setting = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [setting, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->has_ai_rule( "engagement_rule", setting.evaluate( d ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_cbm_reserve_rule( const JsonObject &jo, const std::string &member,
+void conditional_t::set_npc_cbm_reserve_rule( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> setting = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [setting, is_npc]( const T & d ) {
+    str_or_var setting = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [setting, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->has_ai_rule( "cbm_reserve_rule", setting.evaluate( d ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_cbm_recharge_rule( const JsonObject &jo, const std::string &member,
+void conditional_t::set_npc_cbm_recharge_rule( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> setting = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [setting, is_npc]( const T & d ) {
+    str_or_var setting = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [setting, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->has_ai_rule( "cbm_recharge_rule", setting.evaluate( d ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_rule( const JsonObject &jo, const std::string &member, bool is_npc )
+void conditional_t::set_npc_rule( const JsonObject &jo, const std::string &member, bool is_npc )
 {
-    str_or_var<T> rule = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [rule, is_npc]( const T & d ) {
+    str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [rule, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->has_ai_rule( "ally_rule", rule.evaluate( d ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_override( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void conditional_t::set_npc_override( const JsonObject &jo, const std::string &member,
+                                      bool is_npc )
 {
-    str_or_var<T> rule = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [rule, is_npc]( const T & d ) {
+    str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [rule, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->has_ai_rule( "ally_override", rule.evaluate( d ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_days_since( const JsonObject &jo, const std::string &member )
+void conditional_t::set_days_since( const JsonObject &jo, const std::string &member )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    condition = [dov]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    condition = [dov]( dialogue const & d ) {
         return calendar::turn >= calendar::start_of_cataclysm + 1_days * dov.evaluate( d );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_season( const JsonObject &jo, const std::string &member )
+void conditional_t::set_is_season( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> season_name = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [season_name]( const T & d ) {
+    str_or_var season_name = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [season_name]( dialogue const & d ) {
         const season_type season = season_of_year( calendar::turn );
         return ( season == SPRING && season_name.evaluate( d ) == "spring" ) ||
                ( season == SUMMER && season_name.evaluate( d ) == "summer" ) ||
@@ -974,12 +924,11 @@ void conditional_t<T>::set_is_season( const JsonObject &jo, const std::string &m
     };
 }
 
-template<class T>
-void conditional_t<T>::set_mission_goal( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void conditional_t::set_mission_goal( const JsonObject &jo, const std::string &member,
+                                      bool is_npc )
 {
-    str_or_var<T> mission_goal_str = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [mission_goal_str, is_npc]( const T & d ) {
+    str_or_var mission_goal_str = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [mission_goal_str, is_npc]( dialogue const & d ) {
         mission *miss = d.actor( is_npc )->selected_mission();
         if( !miss ) {
             return false;
@@ -989,184 +938,162 @@ void conditional_t<T>::set_mission_goal( const JsonObject &jo, const std::string
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_gender( bool is_male, bool is_npc )
+void conditional_t::set_is_gender( bool is_male, bool is_npc )
 {
-    condition = [is_male, is_npc]( const T & d ) {
+    condition = [is_male, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->is_male() == is_male;
     };
 }
 
-template<class T>
-void conditional_t<T>::set_no_assigned_mission()
+void conditional_t::set_no_assigned_mission()
 {
-    condition = []( const T & d ) {
+    condition = []( dialogue const & d ) {
         return d.missions_assigned.empty();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_assigned_mission()
+void conditional_t::set_has_assigned_mission()
 {
-    condition = []( const T & d ) {
+    condition = []( dialogue const & d ) {
         return d.missions_assigned.size() == 1;
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_many_assigned_missions()
+void conditional_t::set_has_many_assigned_missions()
 {
-    condition = []( const T & d ) {
+    condition = []( dialogue const & d ) {
         return d.missions_assigned.size() >= 2;
     };
 }
 
-template<class T>
-void conditional_t<T>::set_no_available_mission( bool is_npc )
+void conditional_t::set_no_available_mission( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->available_missions().empty();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_available_mission( bool is_npc )
+void conditional_t::set_has_available_mission( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->available_missions().size() == 1;
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_many_available_missions( bool is_npc )
+void conditional_t::set_has_many_available_missions( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->available_missions().size() >= 2;
     };
 }
 
-template<class T>
-void conditional_t<T>::set_mission_complete( bool is_npc )
+void conditional_t::set_mission_complete( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         mission *miss = d.actor( is_npc )->selected_mission();
         return miss && miss->is_complete( d.actor( is_npc )->getID() );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_mission_incomplete( bool is_npc )
+void conditional_t::set_mission_incomplete( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         mission *miss = d.actor( is_npc )->selected_mission();
         return miss && !miss->is_complete( d.actor( is_npc )->getID() );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_mission_failed( bool is_npc )
+void conditional_t::set_mission_failed( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         mission *miss = d.actor( is_npc )->selected_mission();
         return miss && miss->has_failed();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_available( bool is_npc )
+void conditional_t::set_npc_available( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return !d.actor( is_npc )->has_effect( effect_currently_busy, bodypart_str_id::NULL_ID() );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_following( bool is_npc )
+void conditional_t::set_npc_following( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->is_following();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_friend( bool is_npc )
+void conditional_t::set_npc_friend( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->is_friendly( get_player_character() );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_hostile( bool is_npc )
+void conditional_t::set_npc_hostile( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->is_enemy();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_train_skills( bool is_npc )
+void conditional_t::set_npc_train_skills( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return !d.actor( is_npc )->skills_offered_to( *d.actor( !is_npc ) ).empty();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_train_styles( bool is_npc )
+void conditional_t::set_npc_train_styles( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return !d.actor( is_npc )->styles_offered_to( *d.actor( !is_npc ) ).empty();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_npc_train_spells( bool is_npc )
+void conditional_t::set_npc_train_spells( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return !d.actor( is_npc )->spells_offered_to( *d.actor( !is_npc ) ).empty();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_at_safe_space( bool is_npc )
+void conditional_t::set_at_safe_space( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return overmap_buffer.is_safe( d.actor( is_npc )->global_omt_location() ) &&
                d.actor( is_npc )->is_safe();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_can_stow_weapon( bool is_npc )
+void conditional_t::set_can_stow_weapon( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
         return !actor->unarmed_attack() && actor->can_stash_weapon();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_can_drop_weapon( bool is_npc )
+void conditional_t::set_can_drop_weapon( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
         return !actor->unarmed_attack() && !actor->wielded_with_flag( flag_NO_UNWIELD );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_weapon( bool is_npc )
+void conditional_t::set_has_weapon( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return !d.actor( is_npc )->unarmed_attack();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_driving( bool is_npc )
+void conditional_t::set_is_driving( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
         if( const optional_vpart_position vp = get_map().veh_at( actor->pos() ) ) {
             return vp->vehicle().is_moving() && actor->is_in_control_of( vp->vehicle() );
@@ -1175,53 +1102,47 @@ void conditional_t<T>::set_is_driving( bool is_npc )
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_stolen_item( bool /*is_npc*/ )
+void conditional_t::set_has_stolen_item( bool /*is_npc*/ )
 {
-    condition = []( const T & d ) {
+    condition = []( dialogue const & d ) {
         return d.actor( false )->has_stolen_item( *d.actor( true ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_day()
+void conditional_t::set_is_day()
 {
-    condition = []( const T & ) {
+    condition = []( dialogue const & ) {
         return !is_night( calendar::turn );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_outside( bool is_npc )
+void conditional_t::set_is_outside( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return is_creature_outside( *d.actor( is_npc )->get_creature() );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_underwater( bool is_npc )
+void conditional_t::set_is_underwater( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return get_map().is_divable( d.actor( is_npc )->pos() );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_one_in_chance( const JsonObject &jo, const std::string &member )
+void conditional_t::set_one_in_chance( const JsonObject &jo, const std::string &member )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    condition = [dov]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    condition = [dov]( dialogue const & d ) {
         return one_in( dov.evaluate( d ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_query( const JsonObject &jo, const std::string &member, bool is_npc )
+void conditional_t::set_query( const JsonObject &jo, const std::string &member, bool is_npc )
 {
-    str_or_var<T> message = get_str_or_var<T>( jo.get_member( member ), member, true );
+    str_or_var message = get_str_or_var( jo.get_member( member ), member, true );
     bool default_val = jo.get_bool( "default" );
-    condition = [message, default_val, is_npc]( const T & d ) {
+    condition = [message, default_val, is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
         if( actor->get_character() && actor->get_character()->is_avatar() ) {
             std::string translated_message = _( message.evaluate( d ) );
@@ -1232,32 +1153,29 @@ void conditional_t<T>::set_query( const JsonObject &jo, const std::string &membe
     };
 }
 
-template<class T>
-void conditional_t<T>::set_x_in_y_chance( const JsonObject &jo, const std::string &member )
+void conditional_t::set_x_in_y_chance( const JsonObject &jo, const std::string &member )
 {
     const JsonObject &var_obj = jo.get_object( member );
-    dbl_or_var<T> dovx = get_dbl_or_var<T>( var_obj, "x" );
-    dbl_or_var<T> dovy = get_dbl_or_var<T>( var_obj, "y" );
-    condition = [dovx, dovy]( const T & d ) {
+    dbl_or_var dovx = get_dbl_or_var( var_obj, "x" );
+    dbl_or_var dovy = get_dbl_or_var( var_obj, "y" );
+    condition = [dovx, dovy]( dialogue const & d ) {
         return x_in_y( dovx.evaluate( d ),
                        dovy.evaluate( d ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_weather( const JsonObject &jo, const std::string &member )
+void conditional_t::set_is_weather( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> weather = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [weather]( const T & d ) {
+    str_or_var weather = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [weather]( dialogue const & d ) {
         return get_weather().weather_id == weather_type_id( weather.evaluate( d ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_mod_is_loaded( const JsonObject &jo, const std::string &member )
+void conditional_t::set_mod_is_loaded( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> compared_mod = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [compared_mod]( const T & d ) {
+    str_or_var compared_mod = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [compared_mod]( dialogue const & d ) {
         mod_id comp_mod = mod_id( compared_mod.evaluate( d ) );
         for( const mod_id &mod : world_generator->active_world->active_mod_order ) {
             if( comp_mod == mod ) {
@@ -1268,11 +1186,10 @@ void conditional_t<T>::set_mod_is_loaded( const JsonObject &jo, const std::strin
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_faction_trust( const JsonObject &jo, const std::string &member )
+void conditional_t::set_has_faction_trust( const JsonObject &jo, const std::string &member )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    condition = [dov]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    condition = [dov]( dialogue const & d ) {
         return d.actor( true )->get_faction()->trusts_u >= dov.evaluate( d );
     };
 }
@@ -1285,7 +1202,7 @@ static std::string get_string_from_input( const JsonArray &objects, int index )
             return type;
         }
     }
-    dbl_or_var<dialogue> empty;
+    dbl_or_var empty;
     JsonObject object = objects.get_object( index );
     if( object.has_string( "u_val" ) ) {
         return "u_" + get_talk_varname( object, "u_val", false, empty );
@@ -1302,8 +1219,7 @@ static std::string get_string_from_input( const JsonArray &objects, int index )
     return "";
 }
 
-template<class T>
-static tripoint_abs_ms get_tripoint_from_string( const std::string &type, T &d )
+static tripoint_abs_ms get_tripoint_from_string( const std::string &type, dialogue const &d )
 {
     if( type == "u" ) {
         return d.actor( false )->global_pos();
@@ -1328,109 +1244,105 @@ static tripoint_abs_ms get_tripoint_from_string( const std::string &type, T &d )
     return tripoint_abs_ms();
 }
 
-template<class T>
-void conditional_t<T>::set_compare_string( const JsonObject &jo, const std::string &member )
+void conditional_t::set_compare_string( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> first;
-    str_or_var<T> second;
+    str_or_var first;
+    str_or_var second;
     JsonArray objects = jo.get_array( member );
     if( objects.size() != 2 ) {
         jo.throw_error( "incorrect number of values.  Expected 2 in " + jo.str() );
-        condition = []( const T & ) {
+        condition = []( dialogue const & ) {
             return false;
         };
         return;
     }
 
     if( objects.has_object( 0 ) ) {
-        first = get_str_or_var<T>( objects.next_value(), member, true );
+        first = get_str_or_var( objects.next_value(), member, true );
     } else {
         first.str_val = objects.next_string();
     }
     if( objects.has_object( 1 ) ) {
-        second = get_str_or_var<T>( objects.next_value(), member, true );
+        second = get_str_or_var( objects.next_value(), member, true );
     } else {
         second.str_val = objects.next_string();
     }
 
-    condition = [first, second]( const T & d ) {
+    condition = [first, second]( dialogue const & d ) {
         return first.evaluate( d ) == second.evaluate( d );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_compare_num( const JsonObject &jo, const std::string &member )
+void conditional_t::set_compare_num( const JsonObject &jo, const std::string &member )
 {
     JsonArray objects = jo.get_array( member );
     if( objects.size() != 3 ) {
         jo.throw_error( "incorrect number of values.  Expected three in " + jo.str() );
-        condition = []( const T & ) {
+        condition = []( dialogue const & ) {
             return false;
         };
         return;
     }
-    std::function<double( const T & )> get_first_dbl = objects.has_object( 0 ) ? get_get_dbl(
+    std::function<double( dialogue const & )> get_first_dbl = objects.has_object( 0 ) ? get_get_dbl(
                 objects.get_object( 0 ) ) : get_get_dbl( objects.get_string( 0 ), jo );
-    std::function<double( const T & )> get_second_dbl = objects.has_object( 2 ) ? get_get_dbl(
+    std::function<double( dialogue const & )> get_second_dbl = objects.has_object( 2 ) ? get_get_dbl(
                 objects.get_object( 2 ) ) : get_get_dbl( objects.get_string( 2 ), jo );
     const std::string &op = objects.get_string( 1 );
 
     if( op == "==" || op == "=" ) {
-        condition = [get_first_dbl, get_second_dbl]( const T & d ) {
+        condition = [get_first_dbl, get_second_dbl]( dialogue const & d ) {
             return get_first_dbl( d ) == get_second_dbl( d );
         };
     } else if( op == "!=" ) {
-        condition = [get_first_dbl, get_second_dbl]( const T & d ) {
+        condition = [get_first_dbl, get_second_dbl]( dialogue const & d ) {
             return get_first_dbl( d ) != get_second_dbl( d );
         };
     } else if( op == "<=" ) {
-        condition = [get_first_dbl, get_second_dbl]( const T & d ) {
+        condition = [get_first_dbl, get_second_dbl]( dialogue const & d ) {
             return get_first_dbl( d ) <= get_second_dbl( d );
         };
     } else if( op == ">=" ) {
-        condition = [get_first_dbl, get_second_dbl]( const T & d ) {
+        condition = [get_first_dbl, get_second_dbl]( dialogue const & d ) {
             return get_first_dbl( d ) >= get_second_dbl( d );
         };
     } else if( op == "<" ) {
-        condition = [get_first_dbl, get_second_dbl]( const T & d ) {
+        condition = [get_first_dbl, get_second_dbl]( dialogue const & d ) {
             return get_first_dbl( d ) < get_second_dbl( d );
         };
     } else if( op == ">" ) {
-        condition = [get_first_dbl, get_second_dbl]( const T & d ) {
+        condition = [get_first_dbl, get_second_dbl]( dialogue const & d ) {
             return get_first_dbl( d ) > get_second_dbl( d );
         };
     } else {
         jo.throw_error( "unexpected operator " + jo.get_string( "op" ) + " in " + jo.str() );
-        condition = []( const T & ) {
+        condition = []( dialogue const & ) {
             return false;
         };
     }
 }
 
-template<class T>
-void conditional_t<T>::set_math( const JsonObject &jo, const std::string &member )
+void conditional_t::set_math( const JsonObject &jo, const std::string &member )
 {
-    eoc_math<T> math;
+    eoc_math math;
     math.from_json( jo, member );
-    condition = [math = std::move( math )]( const T & d ) {
+    condition = [math = std::move( math )]( dialogue const & d ) {
         return math.act( d );
     };
 }
 
-template<class T>
 template<class J>
 // NOLINTNEXTLINE(readability-function-cognitive-complexity): not my problem!!
-std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
+std::function<double( dialogue const & )> conditional_t::get_get_dbl( J const &jo )
 {
     if( jo.has_member( "const" ) ) {
         const double const_value = jo.get_float( "const" );
-        return [const_value]( const T & ) {
+        return [const_value]( dialogue const & ) {
             return const_value;
         };
     } else if( jo.has_member( "time" ) ) {
         const int value = to_turns<int>( read_from_json_string<time_duration>( jo.get_member( "time" ),
                                          time_duration::units ) );
-        return [value]( const T & ) {
+        return [value]( dialogue const & ) {
             return value;
         };
     } else if( jo.has_member( "power" ) ) {
@@ -1439,7 +1351,7 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             assign( jo, "power", power, false, 0_kJ );
         }
         const int power_value = units::to_millijoule( power );
-        return [power_value]( const T & ) {
+        return [power_value]( dialogue const & ) {
             return power_value;
         };
     } else if( jo.has_member( "time_since_cataclysm" ) ) {
@@ -1459,49 +1371,49 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
                 jo.throw_error( "unrecognized time unit in " + jo.str() );
             }
         }
-        return [given_unit]( const T & ) {
+        return [given_unit]( dialogue const & ) {
             return ( to_turn<int>( calendar::turn ) - to_turn<int>( calendar::start_of_cataclysm ) ) /
                    to_turns<int>( given_unit );
         };
     } else if( jo.has_member( "rand" ) ) {
         int max_value = jo.get_int( "rand" );
-        return [max_value]( const T & ) {
+        return [max_value]( dialogue const & ) {
             return rng( 0, max_value );
         };
     } else if( jo.has_member( "weather" ) ) {
         std::string weather_aspect = jo.get_string( "weather" );
         if( weather_aspect == "temperature" ) {
-            return []( const T & ) {
+            return []( dialogue const & ) {
                 return static_cast<int>( units::to_fahrenheit( get_weather().weather_precise->temperature ) );
             };
         } else if( weather_aspect == "windpower" ) {
-            return []( const T & ) {
+            return []( dialogue const & ) {
                 return static_cast<int>( get_weather().weather_precise->windpower );
             };
         } else if( weather_aspect == "humidity" ) {
-            return []( const T & ) {
+            return []( dialogue const & ) {
                 return static_cast<int>( get_weather().weather_precise->humidity );
             };
         } else if( weather_aspect == "pressure" ) {
-            return []( const T & ) {
+            return []( dialogue const & ) {
                 return static_cast<int>( get_weather().weather_precise->pressure );
             };
         }
     } else if( jo.has_member( "faction_trust" ) ) {
-        str_or_var<T> name = get_str_or_var<T>( jo.get_member( "faction_trust" ), "faction_trust" );
-        return [name]( const T & d ) {
+        str_or_var name = get_str_or_var( jo.get_member( "faction_trust" ), "faction_trust" );
+        return [name]( dialogue const & d ) {
             faction *fac = g->faction_manager_ptr->get( faction_id( name.evaluate( d ) ) );
             return fac->trusts_u;
         };
     } else if( jo.has_member( "faction_like" ) ) {
-        str_or_var<T> name = get_str_or_var<T>( jo.get_member( "faction_like" ), "faction_like" );
-        return [name]( const T & d ) {
+        str_or_var name = get_str_or_var( jo.get_member( "faction_like" ), "faction_like" );
+        return [name]( dialogue const & d ) {
             faction *fac = g->faction_manager_ptr->get( faction_id( name.evaluate( d ) ) );
             return fac->likes_u;
         };
     } else if( jo.has_member( "faction_respect" ) ) {
-        str_or_var<T> name = get_str_or_var<T>( jo.get_member( "faction_respect" ), "faction_respect" );
-        return [name]( const T & d ) {
+        str_or_var name = get_str_or_var( jo.get_member( "faction_respect" ), "faction_respect" );
+        return [name]( dialogue const & d ) {
             faction *fac = g->faction_manager_ptr->get( faction_id( name.evaluate( d ) ) );
             return fac->respects_u;
         };
@@ -1512,51 +1424,51 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
         const std::string checked_value = is_npc ? jo.get_string( "npc_val" ) :
                                           ( is_global ? jo.get_string( "global_val" ) : jo.get_string( "u_val" ) );
         if( checked_value == "strength" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->str_cur();
             };
         } else if( checked_value == "dexterity" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->dex_cur();
             };
         } else if( checked_value == "intelligence" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->int_cur();
             };
         } else if( checked_value == "perception" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->per_cur();
             };
         } else if( checked_value == "strength_base" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_str_max();
             };
         } else if( checked_value == "dexterity_base" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_dex_max();
             };
         } else if( checked_value == "intelligence_base" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_int_max();
             };
         } else if( checked_value == "perception_base" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_per_max();
             };
         } else if( checked_value == "strength_bonus" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_str_bonus();
             };
         } else if( checked_value == "dexterity_bonus" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_dex_bonus();
             };
         } else if( checked_value == "intelligence_bonus" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_int_bonus();
             };
         } else if( checked_value == "perception_bonus" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_per_bonus();
             };
         } else if( checked_value == "hp" ) {
@@ -1564,7 +1476,7 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             if constexpr( std::is_same_v<JsonObject, J> ) {
                 optional( jo, false, "bodypart", bp );
             }
-            return [is_npc, bp]( const T & d ) {
+            return [is_npc, bp]( dialogue const & d ) {
                 bodypart_id bid = bp.value_or( get_bp_from_str( d.reason ) );
                 return d.actor( is_npc )->get_cur_hp( bid );
             };
@@ -1573,7 +1485,7 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             if constexpr( std::is_same_v<JsonObject, J> ) {
                 optional( jo, false, "bodypart", bp );
             }
-            return [is_npc, bp]( const T & d ) {
+            return [is_npc, bp]( dialogue const & d ) {
                 bodypart_id bid = bp.value_or( get_bp_from_str( d.reason ) );
                 return d.actor( is_npc )->get_cur_part_temp( bid );
             };
@@ -1583,7 +1495,7 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             if constexpr( std::is_same_v<JsonObject, J> ) {
                 optional( jo, false, "bodypart", bp );
             }
-            return [effect_id, bp, is_npc]( const T & d ) {
+            return [effect_id, bp, is_npc]( dialogue const & d ) {
                 bodypart_id bid = bp.value_or( get_bp_from_str( d.reason ) );
                 effect target = d.actor( is_npc )->get_effect( efftype_id( effect_id ), bid );
                 return target.is_null() ? -1 : target.get_intensity();
@@ -1593,7 +1505,7 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             if constexpr( std::is_same_v<JsonObject, J> ) {
                 info = read_var_info( jo );
             }
-            return [info]( const T & d ) {
+            return [info]( dialogue const & d ) {
                 std::string var = read_var_value( info, d );
                 if( !var.empty() ) {
                     // NOLINTNEXTLINE(cert-err34-c)
@@ -1605,12 +1517,12 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
                 return 0.0;
             };
         } else if( checked_value == "time_since_var" ) {
-            dbl_or_var<dialogue> empty;
+            dbl_or_var empty;
             std::string var_name;
             if constexpr( std::is_same_v<JsonObject, J> ) {
                 var_name = get_talk_varname( jo, "var_name", false, empty );
             }
-            return [is_npc, var_name]( const T & d ) {
+            return [is_npc, var_name]( dialogue const & d ) {
                 int stored_value = 0;
                 const std::string &var = d.actor( is_npc )->get_value( var_name );
                 if( !var.empty() ) {
@@ -1622,7 +1534,7 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             if( is_npc ) {
                 jo.throw_error( "allies count not supported for NPCs.  In " + jo.str() );
             } else {
-                return []( const T & ) {
+                return []( dialogue const & ) {
                     return static_cast<int>( g->allies().size() );
                 };
             }
@@ -1630,7 +1542,7 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             if( is_npc ) {
                 jo.throw_error( "cash count not supported for NPCs.  In " + jo.str() );
             } else {
-                return [is_npc]( const T & d ) {
+                return [is_npc]( dialogue const & d ) {
                     return d.actor( is_npc )->cash();
                 };
             }
@@ -1638,7 +1550,7 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             if( is_npc ) {
                 jo.throw_error( "owed amount not supported for NPCs.  In " + jo.str() );
             } else {
-                return []( const T & d ) {
+                return []( dialogue const & d ) {
                     return d.actor( true )->debt();
                 };
             }
@@ -1646,39 +1558,39 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             if( is_npc ) {
                 jo.throw_error( "owed amount not supported for NPCs.  In " + jo.str() );
             } else {
-                return []( const T & d ) {
+                return []( dialogue const & d ) {
                     return d.actor( true )->sold();
                 };
             }
         } else if( checked_value == "skill_level" ) {
             const skill_id skill( jo.get_string( "skill" ) );
-            return [is_npc, skill]( const T & d ) {
+            return [is_npc, skill]( dialogue const & d ) {
                 return d.actor( is_npc )->get_skill_level( skill );
             };
         } else if( checked_value == "pos_x" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->posx();
             };
         } else if( checked_value == "pos_y" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->posy();
             };
         } else if( checked_value == "pos_z" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->posz();
             };
         } else if( checked_value == "power" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 // Energy in milijoule
                 return static_cast<int>( d.actor( is_npc )->power_cur().value() );
             };
         } else if( checked_value == "power_max" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 // Energy in milijoule
                 return static_cast<int>( d.actor( is_npc )->power_max().value() );
             };
         } else if( checked_value == "power_percentage" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 // Energy in milijoule
                 int power_max = d.actor( is_npc )->power_max().value();
                 if( power_max == 0 ) {
@@ -1688,23 +1600,23 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
                 }
             };
         } else if( checked_value == "morale" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->morale_cur();
             };
         } else if( checked_value == "focus" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->focus_cur();
             };
         } else if( checked_value == "mana" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->mana_cur();
             };
         } else if( checked_value == "mana_max" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->mana_max();
             };
         } else if( checked_value == "mana_percentage" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 int mana_max = d.actor( is_npc )->mana_max();
                 if( mana_max == 0 ) {
                     return 0; //Default value if character does not have mana, avoids division with 0.
@@ -1713,24 +1625,24 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
                 }
             };
         } else if( checked_value == "hunger" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_hunger();
             };
         } else if( checked_value == "thirst" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_thirst();
             };
         } else if( checked_value == "instant_thirst" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_instant_thirst();
             };
         } else if( checked_value == "stored_kcal" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_stored_kcal();
             };
         } else if( checked_value == "stored_kcal_percentage" ) {
             // 100% is 5 BMI's worth of kcal, which is considered healthy (this varies with height).
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 int divisor = d.actor( is_npc )->get_healthy_kcal() / 100;
                 //if no data default to default height of 175cm
                 if( divisor == 0 ) {
@@ -1740,12 +1652,12 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             };
         } else if( checked_value == "item_count" ) {
             const itype_id item_id( jo.get_string( "item" ) );
-            return [is_npc, item_id]( const T & d ) {
+            return [is_npc, item_id]( dialogue const & d ) {
                 return std::max( d.actor( is_npc )->charges_of( item_id ),
                                  d.actor( is_npc )->get_amount( item_id ) );
             };
         } else if( checked_value == "exp" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_kill_xp();
             };
         } else if( checked_value == "addiction_intensity" ) {
@@ -1755,31 +1667,31 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
                 JsonObject jobj = jo.get_object( "mod" );
                 const int val = jobj.get_int( "val", 0 );
                 const int step = jobj.get_int( "step", 0 );
-                return [is_npc, add_id, val, step]( const T & d ) {
+                return [is_npc, add_id, val, step]( dialogue const & d ) {
                     int intens = d.actor( is_npc )->get_addiction_intensity( add_id );
                     int denom = val - step * intens;
                     return denom == 0 ? 0 : ( val / std::max( 1, denom ) - 1 );
                 };
             }
             const int mod = jo.get_int( "mod", 1 );
-            return [is_npc, add_id, mod]( const T & d ) {
+            return [is_npc, add_id, mod]( dialogue const & d ) {
                 return d.actor( is_npc )->get_addiction_intensity( add_id ) * mod;
             };
         } else if( checked_value == "addiction_turns" ) {
             const addiction_id add_id( jo.get_string( "addiction" ) );
-            return [is_npc, add_id]( const T & d ) {
+            return [is_npc, add_id]( dialogue const & d ) {
                 return d.actor( is_npc )->get_addiction_turns( add_id );
             };
         } else if( checked_value == "stim" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_stim();
             };
         } else if( checked_value == "pkill" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_pkill();
             };
         } else if( checked_value == "rad" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_rad();
             };
         } else if( checked_value == "item_rad" ) {
@@ -1787,41 +1699,41 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
                 const std::string flag = jo.get_string( "flag" );
                 const aggregate_type agg = jo.template get_enum_value<aggregate_type>( "aggregate",
                                            aggregate_type::FIRST );
-                return [is_npc, flag, agg]( const T & d ) {
+                return [is_npc, flag, agg]( dialogue const & d ) {
                     return d.actor( is_npc )->item_rads( flag_id( flag ), agg );
                 };
             }
         } else if( checked_value == "focus" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->focus_cur();
             };
         } else if( checked_value == "activity_level" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_activity_level();
             };
         } else if( checked_value == "fatigue" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_fatigue();
             };
         } else if( checked_value == "stamina" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_stamina();
             };
         } else if( checked_value == "sleep_deprivation" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_sleep_deprivation();
             };
         } else if( checked_value == "anger" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_anger();
             };
         } else if( checked_value == "friendly" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_friendly();
             };
         } else if( checked_value == "vitamin" ) {
             std::string vitamin_name = jo.get_string( "name" );
-            return [is_npc, vitamin_name]( const T & d ) {
+            return [is_npc, vitamin_name]( dialogue const & d ) {
                 Character *you = d.actor( is_npc )->get_character();
                 if( you ) {
                     return you->vitamin_get( vitamin_id( vitamin_name ) );
@@ -1830,47 +1742,47 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
                 }
             };
         } else if( checked_value == "age" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_age();
             };
         } else if( checked_value == "height" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_height();
             };
         } else if( checked_value == "bmi_permil" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_bmi_permil();
             };
         } else if( checked_value == "fine_detail_vision_mod" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_fine_detail_vision_mod();
             };
         } else if( checked_value == "health" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_health();
             };
         } else if( checked_value == "body_temp" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_body_temp();
             };
         } else if( checked_value == "body_temp_delta" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_body_temp_delta();
             };
         } else if( checked_value == "npc_trust" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_npc_trust();
             };
         } else if( checked_value == "npc_fear" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_npc_fear();
             };
         } else if( checked_value == "npc_value" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_npc_value();
             };
         } else if( checked_value == "npc_anger" ) {
-            return [is_npc]( const T & d ) {
+            return [is_npc]( dialogue const & d ) {
                 return d.actor( is_npc )->get_npc_anger();
             };
         } else if( checked_value == "monsters_nearby" ) {
@@ -1878,19 +1790,19 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             if( jo.has_object( "target_var" ) ) {
                 read_var_info( jo.get_member( "target_var" ) );
             }
-            str_or_var<T> id;
+            str_or_var id;
             if( jo.has_member( "id" ) ) {
-                id = get_str_or_var<T>( jo.get_member( "id" ), "id", false, "" );
+                id = get_str_or_var( jo.get_member( "id" ), "id", false, "" );
             } else {
                 id.str_val = "";
             }
-            dbl_or_var<T> radius_dov;
-            dbl_or_var<T> number_dov;
+            dbl_or_var radius_dov;
+            dbl_or_var number_dov;
             if constexpr( std::is_same_v<JsonObject, J> ) {
-                radius_dov = get_dbl_or_var<T>( jo, "radius", false, 10000 );
-                number_dov = get_dbl_or_var<T>( jo, "number", false, 1 );
+                radius_dov = get_dbl_or_var( jo, "radius", false, 10000 );
+                number_dov = get_dbl_or_var( jo, "number", false, 1 );
             }
-            return [target_var, radius_dov, id, number_dov, is_npc]( const T & d ) {
+            return [target_var, radius_dov, id, number_dov, is_npc]( dialogue const & d ) {
                 tripoint_abs_ms loc;
                 if( target_var.has_value() ) {
                     loc = get_tripoint_from_var( target_var, d );
@@ -1916,24 +1828,24 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             if( jo.has_member( "school" ) ) {
                 const std::string school_name = jo.get_string( "school" );
                 const trait_id spell_school( school_name );
-                return [is_npc, spell_school]( const T & d ) {
+                return [is_npc, spell_school]( dialogue const & d ) {
                     return d.actor( is_npc )->get_spell_level( spell_school );
                 };
             } else if( jo.has_member( "spell" ) ) {
                 const std::string spell_name = jo.get_string( "spell" );
                 const spell_id this_spell_id( spell_name );
-                return [is_npc, this_spell_id]( const T & d ) {
+                return [is_npc, this_spell_id]( dialogue const & d ) {
                     return d.actor( is_npc )->get_spell_level( this_spell_id );
                 };
             } else {
-                return [is_npc]( const T & d ) {
+                return [is_npc]( dialogue const & d ) {
                     return d.actor( is_npc )->get_highest_spell_level();
                 };
             }
         } else if( checked_value == "spell_exp" ) {
             const std::string spell_name = jo.get_string( "spell" );
             const spell_id this_spell_id( spell_name );
-            return [is_npc, this_spell_id]( const T & d ) {
+            return [is_npc, this_spell_id]( dialogue const & d ) {
                 return d.actor( is_npc )->get_spell_exp( this_spell_id );
             };
         } else if( checked_value == "proficiency" ) {
@@ -1941,7 +1853,7 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             const proficiency_id the_proficiency_id( proficiency_name );
             if( jo.has_int( "format" ) ) {
                 const int format = jo.get_int( "format" );
-                return [is_npc, format, the_proficiency_id]( const T & d ) {
+                return [is_npc, format, the_proficiency_id]( dialogue const & d ) {
                     return static_cast<int>( ( d.actor( is_npc )->proficiency_practiced_time(
                                                    the_proficiency_id ) * format ) /
                                              the_proficiency_id->time_to_learn() );
@@ -1949,28 +1861,28 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             } else if( jo.has_member( "format" ) ) {
                 const std::string format = jo.get_string( "format" );
                 if( format == "time_spent" ) {
-                    return [is_npc, the_proficiency_id]( const T & d ) {
+                    return [is_npc, the_proficiency_id]( dialogue const & d ) {
                         return to_turns<int>( d.actor( is_npc )->proficiency_practiced_time( the_proficiency_id ) );
                     };
                 } else if( format == "percent" ) {
-                    return [is_npc, the_proficiency_id]( const T & d ) {
+                    return [is_npc, the_proficiency_id]( dialogue const & d ) {
                         return static_cast<int>( ( d.actor( is_npc )->proficiency_practiced_time(
                                                        the_proficiency_id ) * 100 ) /
                                                  the_proficiency_id->time_to_learn() );
                     };
                 } else if( format == "permille" ) {
-                    return [is_npc, the_proficiency_id]( const T & d ) {
+                    return [is_npc, the_proficiency_id]( dialogue const & d ) {
                         return static_cast<int>( ( d.actor( is_npc )->proficiency_practiced_time(
                                                        the_proficiency_id ) * 1000 ) /
                                                  the_proficiency_id->time_to_learn() );
                     };
                 } else if( format == "total_time_required" ) {
-                    return [the_proficiency_id]( const T & d ) {
+                    return [the_proficiency_id]( dialogue const & d ) {
                         static_cast<void>( d );
                         return to_turns<int>( the_proficiency_id->time_to_learn() );
                     };
                 } else if( format == "time_left" ) {
-                    return [is_npc, the_proficiency_id]( const T & d ) {
+                    return [is_npc, the_proficiency_id]( dialogue const & d ) {
                         return to_turns<int>( the_proficiency_id->time_to_learn() - d.actor(
                                                   is_npc )->proficiency_practiced_time( the_proficiency_id ) );
                     };
@@ -1980,11 +1892,11 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             }
         }
     } else if( jo.has_member( "moon" ) ) {
-        return []( const T & ) {
+        return []( dialogue const & ) {
             return static_cast<int>( get_moon_phase( calendar::turn ) );
         };
     } else if( jo.has_member( "hour" ) ) {
-        return []( const T & ) {
+        return []( dialogue const & ) {
             return to_hours<int>( time_past_midnight( calendar::turn ) );
         };
     } else if( jo.has_array( "distance" ) ) {
@@ -1994,14 +1906,14 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
         }
         std::string first = get_string_from_input( objects, 0 );
         std::string second = get_string_from_input( objects, 1 );
-        return [first, second]( const T & d ) {
+        return [first, second]( dialogue const & d ) {
             tripoint_abs_ms first_point = get_tripoint_from_string( first, d );
             tripoint_abs_ms second_point = get_tripoint_from_string( second, d );
             return rl_dist( first_point, second_point );
         };
     } else if( jo.has_member( "mod_load_order" ) ) {
         const mod_id our_mod_id = mod_id( jo.get_string( "mod_load_order" ) );
-        return [our_mod_id]( const T & ) {
+        return [our_mod_id]( dialogue const & ) {
             int count = 0;
             for( const mod_id &mod : world_generator->active_world->active_mod_order ) {
                 if( our_mod_id == mod ) {
@@ -2012,11 +1924,11 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
             return -1;
         };
     } else if( jo.has_array( "arithmetic" ) ) {
-        talk_effect_fun_t<T> arith;
+        talk_effect_fun_t arith;
         if constexpr( std::is_same_v<JsonObject, J> ) {
             arith.set_arithmetic( jo, "arithmetic", true );
         }
-        return [arith]( const T & d ) {
+        return [arith]( dialogue const & d ) {
             arith( d );
             var_info info = var_info( var_type::global, "temp_var" );
             std::string val = read_var_value( info, d );
@@ -2030,41 +1942,39 @@ std::function<double( const T & )> conditional_t<T>::get_get_dbl( J const &jo )
     } else if( jo.has_array( "math" ) ) {
         // no recursive math through shim
         if constexpr( std::is_same_v<JsonObject, J> ) {
-            eoc_math<T> math;
+            eoc_math math;
             math.from_json( jo, "math" );
-            return [math = std::move( math )]( const T & d ) {
+            return [math = std::move( math )]( dialogue const & d ) {
                 return math.act( d );
             };
         }
     }
     jo.throw_error( "unrecognized number source in " + jo.str() );
-    return []( const T & ) {
+    return []( dialogue const & ) {
         return 0.0;
     };
 }
 
-template<class T>
-std::function<double( const T & )> conditional_t<T>::get_get_dbl( const std::string &value,
+std::function<double( dialogue const & )> conditional_t::get_get_dbl( const std::string &value,
         const JsonObject &jo )
 {
     if( value == "moon" ) {
-        return []( const T & ) {
+        return []( dialogue const & ) {
             return static_cast<int>( get_moon_phase( calendar::turn ) );
         };
     } else if( value == "hour" ) {
-        return []( const T & ) {
+        return []( dialogue const & ) {
             return to_hours<int>( time_past_midnight( calendar::turn ) );
         };
     }
     jo.throw_error( "unrecognized number source in " + value );
-    return []( const T & ) {
+    return []( dialogue const & ) {
         return 0.0;
     };
 }
 
-template<class T>
-static double handle_min_max( const T &d, double input, std::optional<dbl_or_var_part<T>> min,
-                              std::optional<dbl_or_var_part<T>> max )
+static double handle_min_max( dialogue const &d, double input, std::optional<dbl_or_var_part> min,
+                              std::optional<dbl_or_var_part> max )
 {
     if( min.has_value() ) {
         double min_val = min.value().evaluate( d );
@@ -2077,18 +1987,17 @@ static double handle_min_max( const T &d, double input, std::optional<dbl_or_var
     return input;
 }
 
-template <class T>
 template <class J>
-std::function<void( const T &, double )>
+std::function<void( dialogue const &, double )>
 // NOLINTNEXTLINE(readability-function-cognitive-complexity): not my problem!!
-conditional_t<T>::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part<T>> &min,
-                               const std::optional<dbl_or_var_part<T>> &max, bool temp_var )
+conditional_t::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part> &min,
+                            const std::optional<dbl_or_var_part> &max, bool temp_var )
 {
     if( temp_var ) {
         jo.allow_omitted_members();
-        return [min, max]( const T & d, double input ) {
+        return [min, max]( dialogue const & d, double input ) {
             write_var_value( var_type::global, "temp_var", d.actor( false ),
-                             std::to_string( handle_min_max<T>( d,
+                             std::to_string( handle_min_max( d,
                                              input, min,
                                              max ) ) );
         };
@@ -2114,8 +2023,8 @@ conditional_t<T>::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part<
                 jo.throw_error( "unrecognized time unit in " + jo.str() );
             }
         }
-        return [given_unit, min, max]( const T & d, double input ) {
-            calendar::turn = time_point( handle_min_max<T>( d, input, min,
+        return [given_unit, min, max]( dialogue const & d, double input ) {
+            calendar::turn = time_point( handle_min_max( d, input, min,
                                          max ) * to_turns<int>( given_unit ) );
         };
     } else if( jo.has_member( "rand" ) ) {
@@ -2123,45 +2032,45 @@ conditional_t<T>::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part<
     } else if( jo.has_member( "weather" ) ) {
         std::string weather_aspect = jo.get_string( "weather" );
         if( weather_aspect == "temperature" ) {
-            return [min, max]( const T & d, double input ) {
-                const int new_temperature = handle_min_max<T>( d, input, min, max );
+            return [min, max]( dialogue const & d, double input ) {
+                const int new_temperature = handle_min_max( d, input, min, max );
                 get_weather().weather_precise->temperature = units::from_fahrenheit( new_temperature );
                 get_weather().temperature = units::from_fahrenheit( new_temperature );
                 get_weather().clear_temp_cache();
             };
         } else if( weather_aspect == "windpower" ) {
-            return [min, max]( const T & d, double input ) {
-                get_weather().weather_precise->windpower = handle_min_max<T>( d, input, min, max );
+            return [min, max]( dialogue const & d, double input ) {
+                get_weather().weather_precise->windpower = handle_min_max( d, input, min, max );
                 get_weather().clear_temp_cache();
             };
         } else if( weather_aspect == "humidity" ) {
-            return [min, max]( const T & d, double input ) {
-                get_weather().weather_precise->humidity = handle_min_max<T>( d, input, min, max );
+            return [min, max]( dialogue const & d, double input ) {
+                get_weather().weather_precise->humidity = handle_min_max( d, input, min, max );
                 get_weather().clear_temp_cache();
             };
         } else if( weather_aspect == "pressure" ) {
-            return [min, max]( const T & d, double input ) {
-                get_weather().weather_precise->pressure = handle_min_max<T>( d, input, min, max );
+            return [min, max]( dialogue const & d, double input ) {
+                get_weather().weather_precise->pressure = handle_min_max( d, input, min, max );
                 get_weather().clear_temp_cache();
             };
         }
     } else if( jo.has_member( "faction_trust" ) ) {
-        str_or_var<T> name = get_str_or_var<T>( jo.get_member( "faction_trust" ), "faction_trust" );
-        return [name, min, max]( const T & d, double input ) {
+        str_or_var name = get_str_or_var( jo.get_member( "faction_trust" ), "faction_trust" );
+        return [name, min, max]( dialogue const & d, double input ) {
             faction *fac = g->faction_manager_ptr->get( faction_id( name.evaluate( d ) ) );
-            fac->trusts_u = handle_min_max<T>( d, input, min, max );
+            fac->trusts_u = handle_min_max( d, input, min, max );
         };
     } else if( jo.has_member( "faction_like" ) ) {
-        str_or_var<T> name = get_str_or_var<T>( jo.get_member( "faction_like" ), "faction_like" );
-        return [name, min, max]( const T & d, double input ) {
+        str_or_var name = get_str_or_var( jo.get_member( "faction_like" ), "faction_like" );
+        return [name, min, max]( dialogue const & d, double input ) {
             faction *fac = g->faction_manager_ptr->get( faction_id( name.evaluate( d ) ) );
-            fac->likes_u = handle_min_max<T>( d, input, min, max );
+            fac->likes_u = handle_min_max( d, input, min, max );
         };
     } else if( jo.has_member( "faction_respect" ) ) {
-        str_or_var<T> name = get_str_or_var<T>( jo.get_member( "faction_respect" ), "faction_respect" );
-        return [name, min, max]( const T & d, double input ) {
+        str_or_var name = get_str_or_var( jo.get_member( "faction_respect" ), "faction_respect" );
+        return [name, min, max]( dialogue const & d, double input ) {
             faction *fac = g->faction_manager_ptr->get( faction_id( name.evaluate( d ) ) );
-            fac->respects_u = handle_min_max<T>( d, input, min, max );
+            fac->respects_u = handle_min_max( d, input, min, max );
         };
     } else if( jo.has_member( "u_val" ) || jo.has_member( "npc_val" ) ||
                jo.has_member( "global_val" ) || jo.has_member( "faction_val" ) || jo.has_member( "party_val" ) ) {
@@ -2188,57 +2097,57 @@ conditional_t<T>::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part<
 
         const bool is_npc = type == var_type::npc;
         if( checked_value == "strength_base" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_str_max( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_str_max( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "dexterity_base" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_dex_max( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_dex_max( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "intelligence_base" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_int_max( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_int_max( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "perception_base" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_per_max( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_per_max( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "strength_bonus" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_str_max( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_str_max( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "dexterity_bonus" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_dex_max( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_dex_max( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "intelligence_bonus" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_int_max( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_int_max( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "perception_bonus" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_per_max( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_per_max( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "var" ) {
-            dbl_or_var<dialogue> empty;
+            dbl_or_var empty;
             std::string var_name;
             if constexpr( std::is_same_v<JsonObject, J> ) {
                 var_name = get_talk_varname( jo, "var_name", false, empty );
             }
-            return [is_npc, var_name, type, min, max]( const T & d, double input ) {
-                write_var_value( type, var_name, d.actor( is_npc ), std::to_string( handle_min_max<T>( d, input,
+            return [is_npc, var_name, type, min, max]( dialogue const & d, double input ) {
+                write_var_value( type, var_name, d.actor( is_npc ), std::to_string( handle_min_max( d, input,
                                  min,
                                  max ) ) );
             };
         } else if( checked_value == "time_since_var" ) {
             // This is a strange thing to want to adjust. But we allow it nevertheless.
-            dbl_or_var<dialogue> empty;
+            dbl_or_var empty;
             std::string var_name;
             if constexpr( std::is_same_v<JsonObject, J> ) {
                 var_name = get_talk_varname( jo, "var_name", false, empty );
             }
-            return [is_npc, var_name, min, max]( const T & d, double input ) {
-                int storing_value = to_turn<int>( calendar::turn ) - handle_min_max<T>( d, input, min, max );
+            return [is_npc, var_name, min, max]( dialogue const & d, double input ) {
+                int storing_value = to_turn<int>( calendar::turn ) - handle_min_max( d, input, min, max );
                 d.actor( is_npc )->set_value( var_name, std::to_string( storing_value ) );
             };
         } else if( checked_value == "allies" ) {
@@ -2252,84 +2161,84 @@ conditional_t<T>::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part<
             if( is_npc ) {
                 jo.throw_error( "owed amount not supported for NPCs.  In " + jo.str() );
             } else {
-                return [min, max]( const T & d, double input ) {
-                    d.actor( true )->add_debt( handle_min_max<T>( d, input, min, max ) - d.actor( true )->debt() );
+                return [min, max]( dialogue const & d, double input ) {
+                    d.actor( true )->add_debt( handle_min_max( d, input, min, max ) - d.actor( true )->debt() );
                 };
             }
         } else if( checked_value == "sold" ) {
             if( is_npc ) {
                 jo.throw_error( "sold amount not supported for NPCs.  In " + jo.str() );
             } else {
-                return [min, max]( const T & d, double input ) {
-                    d.actor( true )->add_sold( handle_min_max<T>( d, input, min, max ) - d.actor( true )->sold() );
+                return [min, max]( dialogue const & d, double input ) {
+                    d.actor( true )->add_sold( handle_min_max( d, input, min, max ) - d.actor( true )->sold() );
                 };
             }
         } else if( checked_value == "skill_level" ) {
             const skill_id skill( jo.get_string( "skill" ) );
-            return [is_npc, skill, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_skill_level( skill, handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, skill, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_skill_level( skill, handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "pos_x" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_pos( tripoint( handle_min_max<T>( d, input, min, max ),
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_pos( tripoint( handle_min_max( d, input, min, max ),
                                                       d.actor( is_npc )->posy(),
                                                       d.actor( is_npc )->posz() ) );
             };
         } else if( checked_value == "pos_y" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_pos( tripoint( d.actor( is_npc )->posx(), handle_min_max<T>( d, input, min,
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_pos( tripoint( d.actor( is_npc )->posx(), handle_min_max( d, input, min,
                                                       max ),
                                                       d.actor( is_npc )->posz() ) );
             };
         } else if( checked_value == "pos_z" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
+            return [is_npc, min, max]( dialogue const & d, double input ) {
                 d.actor( is_npc )->set_pos( tripoint( d.actor( is_npc )->posx(), d.actor( is_npc )->posy(),
-                                                      handle_min_max<T>( d, input, min, max ) ) );
+                                                      handle_min_max( d, input, min, max ) ) );
             };
         } else if( checked_value == "power" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
+            return [is_npc, min, max]( dialogue const & d, double input ) {
                 // Energy in milijoule
-                d.actor( is_npc )->set_power_cur( 1_mJ * handle_min_max<T>( d, input, min, max ) );
+                d.actor( is_npc )->set_power_cur( 1_mJ * handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "power_max" ) {
             jo.throw_error( "altering max power this way is currently not supported.  In " + jo.str() );
         } else if( checked_value == "power_percentage" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
+            return [is_npc, min, max]( dialogue const & d, double input ) {
                 // Energy in milijoule
-                d.actor( is_npc )->set_power_cur( ( d.actor( is_npc )->power_max() * handle_min_max<T>( d, input,
+                d.actor( is_npc )->set_power_cur( ( d.actor( is_npc )->power_max() * handle_min_max( d, input,
                                                     min,
                                                     max ) ) / 100 );
             };
         } else if( checked_value == "focus" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->mod_focus( handle_min_max<T>( d, input, min,
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->mod_focus( handle_min_max( d, input, min,
                                               max ) - d.actor( is_npc )->focus_cur() );
             };
         } else if( checked_value == "mana" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_mana_cur( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_mana_cur( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "mana_max" ) {
             jo.throw_error( "altering max mana this way is currently not supported.  In " + jo.str() );
         } else if( checked_value == "mana_percentage" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_mana_cur( ( d.actor( is_npc )->mana_max() * handle_min_max<T>( d, input, min,
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_mana_cur( ( d.actor( is_npc )->mana_max() * handle_min_max( d, input, min,
                                                    max ) ) / 100 );
             };
         } else if( checked_value == "hunger" ) {
             jo.throw_error( "altering hunger this way is currently not supported.  In " + jo.str() );
         } else if( checked_value == "thirst" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_thirst( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_thirst( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "stored_kcal" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_stored_kcal( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_stored_kcal( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "stored_kcal_percentage" ) {
             // 100% is 55'000 kcal, which is considered healthy.
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_stored_kcal( handle_min_max<T>( d, input, min, max ) * 5500 );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_stored_kcal( handle_min_max( d, input, min, max ) * 5500 );
             };
         } else if( checked_value == "item_count" ) {
             jo.throw_error( "altering items this way is currently not supported.  In " + jo.str() );
@@ -2337,120 +2246,120 @@ conditional_t<T>::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part<
             jo.throw_error( "altering max exp this way is currently not supported.  In " + jo.str() );
         } else if( checked_value == "addiction_turns" ) {
             const addiction_id add_id( jo.get_string( "addiction" ) );
-            return [is_npc, min, max, add_id]( const T & d, double input ) {
-                d.actor( is_npc )->set_addiction_turns( add_id, handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max, add_id]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_addiction_turns( add_id, handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "stim" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_stim( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_stim( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "pkill" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_pkill( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_pkill( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "rad" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_rad( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_rad( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "fatigue" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_fatigue( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_fatigue( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "stamina" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_stamina( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_stamina( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "sleep_deprivation" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_sleep_deprivation( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_sleep_deprivation( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "anger" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_anger( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_anger( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "morale" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_morale( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_morale( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "friendly" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_friendly( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_friendly( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "exp" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_kill_xp( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_kill_xp( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "vitamin" ) {
             std::string vitamin_name = jo.get_string( "name" );
-            return [is_npc, min, max, vitamin_name]( const T & d, double input ) {
+            return [is_npc, min, max, vitamin_name]( dialogue const & d, double input ) {
                 Character *you = d.actor( is_npc )->get_character();
                 if( you ) {
-                    you->vitamin_set( vitamin_id( vitamin_name ), handle_min_max<T>( d, input, min, max ) );
+                    you->vitamin_set( vitamin_id( vitamin_name ), handle_min_max( d, input, min, max ) );
                 }
             };
         } else if( checked_value == "age" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_age( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_age( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "height" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_height( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_height( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "npc_trust" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_npc_trust( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_npc_trust( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "npc_fear" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_npc_fear( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_npc_fear( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "npc_value" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_npc_value( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_npc_value( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "npc_anger" ) {
-            return [is_npc, min, max]( const T & d, double input ) {
-                d.actor( is_npc )->set_npc_anger( handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_npc_anger( handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "spell_level" ) {
             const std::string spell_name = jo.get_string( "spell" );
             const spell_id this_spell_id( spell_name );
-            return [is_npc, min, max, this_spell_id]( const T & d, double input ) {
-                d.actor( is_npc )->set_spell_level( this_spell_id, handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max, this_spell_id]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_spell_level( this_spell_id, handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "spell_exp" ) {
             const std::string spell_name = jo.get_string( "spell" );
             const spell_id this_spell_id( spell_name );
-            return [is_npc, min, max, this_spell_id]( const T & d, double input ) {
-                d.actor( is_npc )->set_spell_exp( this_spell_id, handle_min_max<T>( d, input, min, max ) );
+            return [is_npc, min, max, this_spell_id]( dialogue const & d, double input ) {
+                d.actor( is_npc )->set_spell_exp( this_spell_id, handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "proficiency" ) {
             const std::string proficiency_name = jo.get_string( "proficiency_id" );
             const proficiency_id the_proficiency_id( proficiency_name );
             if( jo.has_int( "format" ) ) {
                 const int format = jo.get_int( "format" );
-                return [is_npc, format, the_proficiency_id]( const T & d, double input ) {
+                return [is_npc, format, the_proficiency_id]( dialogue const & d, double input ) {
                     d.actor( is_npc )->set_proficiency_practiced_time( the_proficiency_id,
                             to_turns<int>( the_proficiency_id->time_to_learn() * input ) / format );
                 };
             } else if( jo.has_member( "format" ) ) {
                 const std::string format = jo.get_string( "format" );
                 if( format == "time_spent" ) {
-                    return [is_npc, the_proficiency_id]( const T & d, double input ) {
+                    return [is_npc, the_proficiency_id]( dialogue const & d, double input ) {
                         d.actor( is_npc )->set_proficiency_practiced_time( the_proficiency_id, input );
                     };
                 } else if( format == "percent" ) {
-                    return [is_npc, the_proficiency_id]( const T & d, double input ) {
+                    return [is_npc, the_proficiency_id]( dialogue const & d, double input ) {
                         d.actor( is_npc )->set_proficiency_practiced_time( the_proficiency_id,
                                 to_turns<int>( the_proficiency_id->time_to_learn()* input ) / 100 );
                     };
                 } else if( format == "permille" ) {
-                    return [is_npc, the_proficiency_id]( const T & d, double input ) {
+                    return [is_npc, the_proficiency_id]( dialogue const & d, double input ) {
                         d.actor( is_npc )->set_proficiency_practiced_time( the_proficiency_id,
                                 to_turns<int>( the_proficiency_id->time_to_learn() * input ) / 1000 );
                     };
                 } else if( format == "time_left" ) {
-                    return [is_npc, the_proficiency_id]( const T & d, double input ) {
+                    return [is_npc, the_proficiency_id]( dialogue const & d, double input ) {
                         d.actor( is_npc )->set_proficiency_practiced_time( the_proficiency_id,
                                 to_turns<int>( the_proficiency_id->time_to_learn() ) - input );
                     };
@@ -2461,33 +2370,28 @@ conditional_t<T>::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part<
         }
     }
     jo.throw_error( "error setting double destination in " + jo.str() );
-    return []( const T &, double ) {};
+    return []( dialogue const &, double ) {};
 }
 
-#if defined(__GNUC__) && defined(__MINGW32__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize("no-ipa-sra")
-#endif
-template<class T>
-void talk_effect_fun_t<T>::set_arithmetic( const JsonObject &jo, const std::string &member,
-        bool no_result )
+void talk_effect_fun_t::set_arithmetic( const JsonObject &jo, const std::string &member,
+                                        bool no_result )
 {
     JsonArray objects = jo.get_array( member );
-    std::optional<dbl_or_var_part<T>> min;
-    std::optional<dbl_or_var_part<T>> max;
+    std::optional<dbl_or_var_part> min;
+    std::optional<dbl_or_var_part> max;
     if( jo.has_member( "min" ) ) {
-        min = get_dbl_or_var_part<T>( jo.get_member( "min" ), "min" );
+        min = get_dbl_or_var_part( jo.get_member( "min" ), "min" );
     } else if( jo.has_member( "min_time" ) ) {
-        dbl_or_var_part<T> value;
+        dbl_or_var_part value;
         time_duration min_time;
         mandatory( jo, false, "min_time", min_time );
         value.dbl_val = to_turns<int>( min_time );
         min = value;
     }
     if( jo.has_member( "max" ) ) {
-        max = get_dbl_or_var_part<T>( jo.get_member( "max" ), "max" );
+        max = get_dbl_or_var_part( jo.get_member( "max" ), "max" );
     } else if( jo.has_member( "max_time" ) ) {
-        dbl_or_var_part<T> value;
+        dbl_or_var_part value;
         time_duration max_time;
         mandatory( jo, false, "max_time", max_time );
         value.dbl_val = to_turns<int>( max_time );
@@ -2495,7 +2399,7 @@ void talk_effect_fun_t<T>::set_arithmetic( const JsonObject &jo, const std::stri
     }
     std::string op = "none";
     std::string result = "none";
-    std::function<void( const T &, double )> set_dbl = conditional_t<T>::get_set_dbl(
+    std::function<void( dialogue const &, double )> set_dbl = conditional_t::get_set_dbl(
                 objects.get_object( 0 ), min,
                 max, no_result );
     int no_result_mod = no_result ? 2 : 0; //In the case of a no result we have fewer terms.
@@ -2506,42 +2410,42 @@ void talk_effect_fun_t<T>::set_arithmetic( const JsonObject &jo, const std::stri
             result = objects.get_string( 1 );
             if( result != "=" ) {
                 jo.throw_error( "invalid result " + op + " in " + jo.str() );
-                function = []( const T & ) {
+                function = []( dialogue const & ) {
                     return false;
                 };
             }
         }
-        std::function<double( const T & )> get_first_dbl = conditional_t< T >::get_get_dbl(
+        std::function<double( dialogue const & )> get_first_dbl = conditional_t::get_get_dbl(
                     objects.get_object( 2 - no_result_mod ) );
-        std::function<double( const T & )> get_second_dbl = conditional_t< T >::get_get_dbl(
+        std::function<double( dialogue const & )> get_second_dbl = conditional_t::get_get_dbl(
                     objects.get_object( 4 - no_result_mod ) );
         if( op == "*" ) {
-            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, get_second_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, get_first_dbl( d ) * get_second_dbl( d ) );
             };
         } else if( op == "/" ) {
-            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, get_second_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, get_first_dbl( d ) / get_second_dbl( d ) );
             };
         } else if( op == "+" ) {
-            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, get_second_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, get_first_dbl( d ) + get_second_dbl( d ) );
             };
         } else if( op == "-" ) {
-            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, get_second_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, get_first_dbl( d ) - get_second_dbl( d ) );
             };
         } else if( op == "%" ) {
-            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, get_second_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, static_cast<int>( get_first_dbl( d ) ) % static_cast<int>( get_second_dbl( d ) ) );
             };
         } else if( op == "^" ) {
-            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, get_second_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, pow( get_first_dbl( d ), get_second_dbl( d ) ) );
             };
         } else {
             jo.throw_error( "unexpected operator " + op + " in " + jo.str() );
-            function = []( const T & ) {
+            function = []( dialogue const & ) {
                 return false;
             };
         }
@@ -2551,19 +2455,19 @@ void talk_effect_fun_t<T>::set_arithmetic( const JsonObject &jo, const std::stri
         result = objects.get_string( 1 );
         if( result != "=" ) {
             jo.throw_error( "invalid result " + op + " in " + jo.str() );
-            function = []( const T & ) {
+            function = []( dialogue const & ) {
                 return false;
             };
         }
-        std::function<double( const T & )> get_first_dbl = conditional_t< T >::get_get_dbl(
+        std::function<double( dialogue const & )> get_first_dbl = conditional_t::get_get_dbl(
                     objects.get_object( 2 ) );
         if( op == "~" ) {
-            function = [get_first_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, ~static_cast<int>( get_first_dbl( d ) ) );
             };
         } else {
             jo.throw_error( "unexpected operator " + op + " in " + jo.str() );
-            function = []( const T & ) {
+            function = []( dialogue const & ) {
                 return false;
             };
         }
@@ -2571,89 +2475,84 @@ void talk_effect_fun_t<T>::set_arithmetic( const JsonObject &jo, const std::stri
         // =, -=, +=, *=, and /=
     } else if( objects.size() == 3 && !no_result ) {
         result = objects.get_string( 1 );
-        std::function<double( const T & )> get_first_dbl = conditional_t< T >::get_get_dbl(
+        std::function<double( dialogue const & )> get_first_dbl = conditional_t::get_get_dbl(
                     objects.get_object( 0 ) );
-        std::function<double( const T & )> get_second_dbl = conditional_t< T >::get_get_dbl(
+        std::function<double( dialogue const & )> get_second_dbl = conditional_t::get_get_dbl(
                     objects.get_object( 2 ) );
         if( result == "+=" ) {
-            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, get_second_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, get_first_dbl( d ) + get_second_dbl( d ) );
             };
         } else if( result == "-=" ) {
-            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, get_second_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, get_first_dbl( d ) - get_second_dbl( d ) );
             };
         } else if( result == "*=" ) {
-            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, get_second_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, get_first_dbl( d ) * get_second_dbl( d ) );
             };
         } else if( result == "/=" ) {
-            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, get_second_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, get_first_dbl( d ) / get_second_dbl( d ) );
             };
         } else if( result == "%=" ) {
-            function = [get_first_dbl, get_second_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, get_second_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, static_cast<int>( get_first_dbl( d ) ) % static_cast<int>( get_second_dbl( d ) ) );
             };
         } else if( result == "=" ) {
-            function = [get_second_dbl, set_dbl]( const T & d ) {
+            function = [get_second_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, get_second_dbl( d ) );
             };
         } else {
             jo.throw_error( "unexpected result " + result + " in " + jo.str() );
-            function = []( const T & ) {
+            function = []( dialogue const & ) {
                 return false;
             };
         }
         // ++ and --
     } else if( objects.size() == 2 && !no_result ) {
         op = objects.get_string( 1 );
-        std::function<double( const T & )> get_first_dbl = conditional_t< T >::get_get_dbl(
+        std::function<double( dialogue const & )> get_first_dbl = conditional_t::get_get_dbl(
                     objects.get_object( 0 ) );
         if( op == "++" ) {
-            function = [get_first_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, get_first_dbl( d ) + 1 );
             };
         } else if( op == "--" ) {
-            function = [get_first_dbl, set_dbl]( const T & d ) {
+            function = [get_first_dbl, set_dbl]( dialogue const & d ) {
                 set_dbl( d, get_first_dbl( d ) - 1 );
             };
         } else {
             jo.throw_error( "unexpected operator " + op + " in " + jo.str() );
-            function = []( const T & ) {
+            function = []( dialogue const & ) {
                 return false;
             };
         }
     } else if( objects.size() == 1 && no_result ) {
-        std::function<double( const T & )> get_first_dbl = conditional_t< T >::get_get_dbl(
+        std::function<double( dialogue const & )> get_first_dbl = conditional_t::get_get_dbl(
                     objects.get_object( 0 ) );
-        function = [get_first_dbl, set_dbl]( const T & d ) {
+        function = [get_first_dbl, set_dbl]( dialogue const & d ) {
             set_dbl( d, get_first_dbl( d ) );
         };
     } else {
         jo.throw_error( "Invalid number of args in " + jo.str() );
-        function = []( const T & ) {
+        function = []( dialogue const & ) {
             return false;
         };
         return;
     }
 }
-#if defined(__GNUC__) && defined(__MINGW32__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
-template<class T>
-void talk_effect_fun_t<T>::set_math( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_math( const JsonObject &jo, const std::string &member )
 {
-    eoc_math<T> math;
+    eoc_math math;
     math.from_json( jo, member );
-    function = [math = std::move( math )]( const T & d ) {
+    function = [math = std::move( math )]( dialogue const & d ) {
         return math.act( d );
     };
 }
 
-template<class T>
-void eoc_math<T>::from_json( const JsonObject &jo, std::string const &member )
+void eoc_math::from_json( const JsonObject &jo, std::string const &member )
 {
     JsonArray const objects = jo.get_array( member );
     if( objects.size() > 3 ) {
@@ -2712,8 +2611,7 @@ void eoc_math<T>::from_json( const JsonObject &jo, std::string const &member )
     }
 }
 
-template<class T>
-double eoc_math<T>::act( T const &d ) const
+double eoc_math::act( dialogue const &d ) const
 {
     switch( action ) {
         case oper::ret:
@@ -2761,83 +2659,75 @@ double eoc_math<T>::act( T const &d ) const
     return 0;
 }
 
-template<class T>
-void conditional_t<T>::set_u_has_camp()
+void conditional_t::set_u_has_camp()
 {
-    condition = []( const T & ) {
+    condition = []( dialogue const & ) {
         return !get_player_character().camps.empty();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_pickup_list( bool is_npc )
+void conditional_t::set_has_pickup_list( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->has_ai_rule( "pickup_rule", "any" );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_by_radio()
+void conditional_t::set_is_by_radio()
 {
-    condition = []( const T & d ) {
+    condition = []( dialogue const & d ) {
         return d.by_radio;
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_reason()
+void conditional_t::set_has_reason()
 {
-    condition = []( const T & d ) {
+    condition = []( dialogue const & d ) {
         return !d.reason.empty();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_skill( const JsonObject &jo, const std::string &member,
-                                      bool is_npc )
+void conditional_t::set_has_skill( const JsonObject &jo, const std::string &member,
+                                   bool is_npc )
 {
     JsonObject has_skill = jo.get_object( member );
     if( !has_skill.has_string( "skill" ) || !has_skill.has_int( "level" ) ) {
-        condition = []( const T & ) {
+        condition = []( dialogue const & ) {
             return false;
         };
     } else {
-        str_or_var<T> skill = get_str_or_var<T>( has_skill.get_member( "skill" ), "skill", true );
-        dbl_or_var<T> level = get_dbl_or_var<T>( has_skill, "level", true );
-        condition = [skill, level, is_npc]( const T & d ) {
+        str_or_var skill = get_str_or_var( has_skill.get_member( "skill" ), "skill", true );
+        dbl_or_var level = get_dbl_or_var( has_skill, "level", true );
+        condition = [skill, level, is_npc]( dialogue const & d ) {
             return d.actor( is_npc )->get_skill_level( skill_id( skill.evaluate( d ) ) ) >= level.evaluate( d );
         };
     }
 }
 
-template<class T>
-void conditional_t<T>::set_roll_contested( const JsonObject &jo, const std::string &member )
+void conditional_t::set_roll_contested( const JsonObject &jo, const std::string &member )
 {
-    std::function<double( const T & )> get_check = conditional_t< T >::get_get_dbl( jo.get_object(
+    std::function<double( dialogue const & )> get_check = conditional_t::get_get_dbl( jo.get_object(
                 member ) );
-    dbl_or_var<T> difficulty = get_dbl_or_var<T>( jo, "difficulty", true );
-    dbl_or_var<T> die_size = get_dbl_or_var<T>( jo, "die_size", false, 10 );
-    condition = [get_check, difficulty, die_size]( const T & d ) {
+    dbl_or_var difficulty = get_dbl_or_var( jo, "difficulty", true );
+    dbl_or_var die_size = get_dbl_or_var( jo, "die_size", false, 10 );
+    condition = [get_check, difficulty, die_size]( dialogue const & d ) {
         return rng( 1, die_size.evaluate( d ) ) + get_check( d ) > difficulty.evaluate( d );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_u_know_recipe( const JsonObject &jo, const std::string &member )
+void conditional_t::set_u_know_recipe( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> known_recipe_id = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [known_recipe_id]( const T & d ) {
+    str_or_var known_recipe_id = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [known_recipe_id]( dialogue const & d ) {
         const recipe &rep = recipe_id( known_recipe_id.evaluate( d ) ).obj();
         // should be a talker function but recipes aren't in Character:: yet
         return get_player_character().knows_recipe( &rep );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_mission_has_generic_rewards()
+void conditional_t::set_mission_has_generic_rewards()
 {
-    condition = []( const T & d ) {
+    condition = []( dialogue const & d ) {
         mission *miss = d.actor( true )->selected_mission();
         if( miss == nullptr ) {
             debugmsg( "mission_has_generic_rewards: mission_selected == nullptr" );
@@ -2847,62 +2737,56 @@ void conditional_t<T>::set_mission_has_generic_rewards()
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_worn_with_flag( const JsonObject &jo, const std::string &member,
+void conditional_t::set_has_worn_with_flag( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> flag = get_str_or_var<T>( jo.get_member( member ), member, true );
+    str_or_var flag = get_str_or_var( jo.get_member( member ), member, true );
     std::optional<bodypart_id> bp;
     optional( jo, false, "bodypart", bp );
-    condition = [flag, bp, is_npc]( const T & d ) {
+    condition = [flag, bp, is_npc]( dialogue const & d ) {
         bodypart_id bid = bp.value_or( get_bp_from_str( d.reason ) );
         return d.actor( is_npc )->worn_with_flag( flag_id( flag.evaluate( d ) ), bid );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_wielded_with_flag( const JsonObject &jo, const std::string &member,
+void conditional_t::set_has_wielded_with_flag( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> flag = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [flag, is_npc]( const T & d ) {
+    str_or_var flag = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [flag, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->wielded_with_flag( flag_id( flag.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_can_see( bool is_npc )
+void conditional_t::set_can_see( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->can_see();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_deaf( bool is_npc )
+void conditional_t::set_is_deaf( bool is_npc )
 {
-    condition = [is_npc]( const T & d ) {
+    condition = [is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->is_deaf();
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_on_terrain( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void conditional_t::set_is_on_terrain( const JsonObject &jo, const std::string &member,
+                                       bool is_npc )
 {
-    str_or_var<T> terrain_type = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [terrain_type, is_npc]( const T & d ) {
+    str_or_var terrain_type = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [terrain_type, is_npc]( dialogue const & d ) {
         map &here = get_map();
         return here.ter( d.actor( is_npc )->pos() ) == ter_id( terrain_type.evaluate( d ) );
     };
 }
 
-template<class T>
-void conditional_t<T>::set_is_in_field( const JsonObject &jo, const std::string &member,
-                                        bool is_npc )
+void conditional_t::set_is_in_field( const JsonObject &jo, const std::string &member,
+                                     bool is_npc )
 {
-    str_or_var<T> field_type = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [field_type, is_npc]( const T & d ) {
+    str_or_var field_type = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [field_type, is_npc]( dialogue const & d ) {
         map &here = get_map();
         field_type_id ft = field_type_id( field_type.evaluate( d ) );
         for( const std::pair<const field_type_id, field_entry> &f : here.field_at( d.actor(
@@ -2915,18 +2799,16 @@ void conditional_t<T>::set_is_in_field( const JsonObject &jo, const std::string 
     };
 }
 
-template<class T>
-void conditional_t<T>::set_has_move_mode( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void conditional_t::set_has_move_mode( const JsonObject &jo, const std::string &member,
+                                       bool is_npc )
 {
-    str_or_var<T> mode = get_str_or_var<T>( jo.get_member( member ), member, true );
-    condition = [mode, is_npc]( const T & d ) {
+    str_or_var mode = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [mode, is_npc]( dialogue const & d ) {
         return d.actor( is_npc )->get_move_mode() == move_mode_id( mode.evaluate( d ) );
     };
 }
 
-template<class T>
-conditional_t<T>::conditional_t( const JsonObject &jo )
+conditional_t::conditional_t( const JsonObject &jo )
 {
     // improve the clarity of NPC setter functions
     const bool is_npc = true;
@@ -2935,11 +2817,11 @@ conditional_t<T>::conditional_t( const JsonObject &jo )
         std::vector<conditional_t> conditionals;
         for( const JsonValue entry : jo.get_array( type ) ) {
             if( entry.test_string() ) {
-                conditional_t<T> type_condition( entry.get_string() );
+                conditional_t type_condition( entry.get_string() );
                 conditionals.emplace_back( type_condition );
             } else {
                 JsonObject cond = entry.get_object();
-                conditional_t<T> type_condition( cond );
+                conditional_t type_condition( cond );
                 conditionals.emplace_back( type_condition );
             }
         }
@@ -2948,7 +2830,7 @@ conditional_t<T>::conditional_t( const JsonObject &jo )
     if( jo.has_array( "and" ) ) {
         std::vector<conditional_t> and_conditionals = parse_array( jo, "and" );
         found_sub_member = true;
-        condition = [and_conditionals]( const T & d ) {
+        condition = [and_conditionals]( dialogue const & d ) {
             for( const auto &cond : and_conditionals ) {
                 if( !cond( d ) ) {
                     return false;
@@ -2959,7 +2841,7 @@ conditional_t<T>::conditional_t( const JsonObject &jo )
     } else if( jo.has_array( "or" ) ) {
         std::vector<conditional_t> or_conditionals = parse_array( jo, "or" );
         found_sub_member = true;
-        condition = [or_conditionals]( const T & d ) {
+        condition = [or_conditionals]( dialogue const & d ) {
             for( const auto &cond : or_conditionals ) {
                 if( cond( d ) ) {
                     return true;
@@ -2969,15 +2851,15 @@ conditional_t<T>::conditional_t( const JsonObject &jo )
         };
     } else if( jo.has_object( "not" ) ) {
         JsonObject cond = jo.get_object( "not" );
-        const conditional_t<T> sub_condition = conditional_t<T>( cond );
+        const conditional_t sub_condition = conditional_t( cond );
         found_sub_member = true;
-        condition = [sub_condition]( const T & d ) {
+        condition = [sub_condition]( dialogue const & d ) {
             return !sub_condition( d );
         };
     } else if( jo.has_string( "not" ) ) {
-        const conditional_t<T> sub_condition = conditional_t<T>( jo.get_string( "not" ) );
+        const conditional_t sub_condition = conditional_t( jo.get_string( "not" ) );
         found_sub_member = true;
-        condition = [sub_condition]( const T & d ) {
+        condition = [sub_condition]( dialogue const & d ) {
             return !sub_condition( d );
         };
     }
@@ -3197,8 +3079,8 @@ conditional_t<T>::conditional_t( const JsonObject &jo )
     } else {
         for( const std::string &sub_member : dialogue_data::simple_string_conds ) {
             if( jo.has_string( sub_member ) ) {
-                const conditional_t<T> sub_condition( jo.get_string( sub_member ) );
-                condition = [sub_condition]( const T & d ) {
+                const conditional_t sub_condition( jo.get_string( sub_member ) );
+                condition = [sub_condition]( dialogue const & d ) {
                     return sub_condition( d );
                 };
                 found_sub_member = true;
@@ -3211,8 +3093,7 @@ conditional_t<T>::conditional_t( const JsonObject &jo )
     }
 }
 
-template<class T>
-conditional_t<T>::conditional_t( const std::string &type )
+conditional_t::conditional_t( const std::string &type )
 {
     const bool is_npc = true;
     if( type == "u_male" ) {
@@ -3338,26 +3219,16 @@ conditional_t<T>::conditional_t( const std::string &type )
     } else if( type == "npc_is_deaf" ) {
         set_is_deaf( is_npc );
     } else {
-        condition = []( const T & ) {
+        condition = []( dialogue const & ) {
             return false;
         };
     }
 }
 
-template struct conditional_t<dialogue>;
-template void read_condition<dialogue>( const JsonObject &jo, const std::string &member_name,
-                                        std::function<bool( const dialogue & )> &condition, bool default_val );
-
-template duration_or_var<dialogue> get_duration_or_var( const JsonObject &jo, std::string member,
-        bool required, time_duration default_val );
-template std::string get_talk_varname<dialogue>( const JsonObject &jo, const std::string &member,
-        bool check_value, dbl_or_var<dialogue> &default_val );
-template struct talk_effect_fun_t<dialogue>;
-
 template std::function<double( const dialogue & )>
-conditional_t<dialogue>::get_get_dbl<>( kwargs_shim const & );
+conditional_t::get_get_dbl<>( kwargs_shim const & );
 
 template std::function<void( const dialogue &, double )>
-conditional_t<dialogue>::get_set_dbl<>( const kwargs_shim &,
-                                        const std::optional<dbl_or_var_part<dialogue>> &,
-                                        const std::optional<dbl_or_var_part<dialogue>> &, bool );
+conditional_t::get_set_dbl<>( const kwargs_shim &,
+                              const std::optional<dbl_or_var_part> &,
+                              const std::optional<dbl_or_var_part> &, bool );

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -3352,25 +3352,12 @@ template duration_or_var<dialogue> get_duration_or_var( const JsonObject &jo, st
         bool required, time_duration default_val );
 template std::string get_talk_varname<dialogue>( const JsonObject &jo, const std::string &member,
         bool check_value, dbl_or_var<dialogue> &default_val );
-#if !defined(MACOSX)
-template struct conditional_t<mission_goal_condition_context>;
-#endif
-template void read_condition<mission_goal_condition_context>( const JsonObject &jo,
-        const std::string &member_name,
-        std::function<bool( const mission_goal_condition_context & )> &condition, bool default_val );
 template struct talk_effect_fun_t<dialogue>;
 
 template std::function<double( const dialogue & )>
 conditional_t<dialogue>::get_get_dbl<>( kwargs_shim const & );
-template std::function<double( const mission_goal_condition_context & )>
-conditional_t<mission_goal_condition_context>::get_get_dbl<>( kwargs_shim const & );
 
 template std::function<void( const dialogue &, double )>
 conditional_t<dialogue>::get_set_dbl<>( const kwargs_shim &,
                                         const std::optional<dbl_or_var_part<dialogue>> &,
                                         const std::optional<dbl_or_var_part<dialogue>> &, bool );
-template std::function<void( const mission_goal_condition_context &, double )>
-conditional_t<mission_goal_condition_context>::get_set_dbl<>( const kwargs_shim &,
-        const std::optional<dbl_or_var_part<mission_goal_condition_context>> &,
-        const std::optional<dbl_or_var_part<mission_goal_condition_context>> &,
-        bool );

--- a/src/condition.h
+++ b/src/condition.h
@@ -57,12 +57,12 @@ const std::unordered_set<std::string> complex_conds = { {
 
 str_or_var get_str_or_var( const JsonValue &jv, const std::string &member, bool required = true,
                            const std::string &default_val = "" );
-dbl_or_var get_dbl_or_var( const JsonObject &jo, std::string member, bool required = true,
+dbl_or_var get_dbl_or_var( const JsonObject &jo, const std::string &member, bool required = true,
                            double default_val = 0.0 );
 dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv, const std::string &member,
                                      bool required = true,
                                      double default_val = 0.0 );
-duration_or_var get_duration_or_var( const JsonObject &jo, std::string member,
+duration_or_var get_duration_or_var( const JsonObject &jo, const std::string &member,
                                      bool required = true,
                                      time_duration default_val = 0_seconds );
 duration_or_var_part get_duration_or_var_part( const JsonValue &jv, const std::string &member,

--- a/src/condition.h
+++ b/src/condition.h
@@ -233,18 +233,11 @@ struct conditional_t {
 
 extern template std::function<double( const dialogue & )>
 conditional_t<dialogue>::get_get_dbl<>( kwargs_shim const & );
-extern template std::function<double( const mission_goal_condition_context & )>
-conditional_t<mission_goal_condition_context>::get_get_dbl<>( kwargs_shim const & );
 
 extern template std::function<void( const dialogue &, double )>
 conditional_t<dialogue>::get_set_dbl<>( const kwargs_shim &,
                                         const std::optional<dbl_or_var_part<dialogue>> &,
                                         const std::optional<dbl_or_var_part<dialogue>> &, bool );
-extern template std::function<void( const mission_goal_condition_context &, double )>
-conditional_t<mission_goal_condition_context>::get_set_dbl<>( const kwargs_shim &,
-        const std::optional<dbl_or_var_part<mission_goal_condition_context>> &,
-        const std::optional<dbl_or_var_part<mission_goal_condition_context>> &,
-        bool );
 
 #if !defined(MACOSX)
 extern template struct conditional_t<dialogue>;
@@ -257,10 +250,6 @@ extern template duration_or_var<dialogue> get_duration_or_var( const JsonObject 
 extern template std::string get_talk_varname<dialogue>( const JsonObject &jo,
         const std::string &member,
         bool check_value, dbl_or_var<dialogue> &default_val );
-extern template struct conditional_t<mission_goal_condition_context>;
-extern template void read_condition<mission_goal_condition_context>( const JsonObject &jo,
-        const std::string &member_name,
-        std::function<bool( const mission_goal_condition_context & )> &condition, bool default_val );
 extern template struct talk_effect_fun_t<dialogue>;
 #endif
 

--- a/src/condition.h
+++ b/src/condition.h
@@ -55,53 +55,30 @@ const std::unordered_set<std::string> complex_conds = { {
 };
 } // namespace dialogue_data
 
-template<class T>
-static dialogue copy_dialogue( const T &d )
-{
-    Creature *creature_alpha = d.has_alpha ? d.actor( false )->get_creature() : nullptr;
-    item_location *item_alpha = d.has_alpha ? d.actor( false )->get_item() : nullptr;
-    Creature *creature_beta = d.has_beta ? d.actor( true )->get_creature() : nullptr;
-    item_location *item_beta = d.has_beta ? d.actor( true )->get_item() : nullptr;
-    return dialogue(
-               creature_alpha ? get_talker_for( creature_alpha ) : item_alpha ? get_talker_for(
-                   item_alpha ) : nullptr,
-               creature_beta ? get_talker_for( creature_beta ) : item_beta ? get_talker_for(
-                   item_beta ) : nullptr
-           );
-}
-
-template<class T>
-str_or_var<T> get_str_or_var( const JsonValue &jv, const std::string &member, bool required = true,
-                              const std::string &default_val = "" );
-template<class T>
-dbl_or_var<T> get_dbl_or_var( const JsonObject &jo, std::string member, bool required = true,
-                              double default_val = 0.0 );
-template<class T>
-dbl_or_var_part<T> get_dbl_or_var_part( const JsonValue &jv, const std::string &member,
-                                        bool required = true,
-                                        double default_val = 0.0 );
-template<class T>
-duration_or_var<T> get_duration_or_var( const JsonObject &jo, std::string member,
-                                        bool required = true,
-                                        time_duration default_val = 0_seconds );
-template<class T>
-duration_or_var_part<T> get_duration_or_var_part( const JsonValue &jv, const std::string &member,
+str_or_var get_str_or_var( const JsonValue &jv, const std::string &member, bool required = true,
+                           const std::string &default_val = "" );
+dbl_or_var get_dbl_or_var( const JsonObject &jo, std::string member, bool required = true,
+                           double default_val = 0.0 );
+dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv, const std::string &member,
+                                     bool required = true,
+                                     double default_val = 0.0 );
+duration_or_var get_duration_or_var( const JsonObject &jo, std::string member,
+                                     bool required = true,
+                                     time_duration default_val = 0_seconds );
+duration_or_var_part get_duration_or_var_part( const JsonValue &jv, const std::string &member,
         bool required = true,
         time_duration default_val = 0_seconds );
-template<class T>
-tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const T &d );
+tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, dialogue const &d );
 var_info read_var_info( const JsonObject &jo );
 void write_var_value( var_type type, const std::string &name, talker *talk,
                       const std::string &value );
-template<class T>
 std::string get_talk_varname( const JsonObject &jo, const std::string &member,
-                              bool check_value, dbl_or_var<T> &default_val );
+                              bool check_value, dbl_or_var &default_val );
 std::string get_talk_var_basename( const JsonObject &jo, const std::string &member,
                                    bool check_value );
 // the truly awful declaration for the conditional_t loading helper_function
-template<class T>
 void read_condition( const JsonObject &jo, const std::string &member_name,
-                     std::function<bool( const T & )> &condition, bool default_val );
+                     std::function<bool( dialogue const & )> &condition, bool default_val );
 
 /**
  * A condition for a response spoken by the player.
@@ -110,10 +87,9 @@ void read_condition( const JsonObject &jo, const std::string &member_name,
  * Invoking the function operator with a dialog reference (so the function can access the NPC)
  * returns whether the response is allowed.
  */
-template<class T>
 struct conditional_t {
     private:
-        std::function<bool( const T & )> condition;
+        std::function<bool( dialogue const & )> condition;
 
     public:
         conditional_t() = default;
@@ -216,14 +192,14 @@ struct conditional_t {
         void set_compare_num( const JsonObject &jo, const std::string &member );
         void set_math( const JsonObject &jo, const std::string &member );
         template<class J>
-        static std::function<double( const T & )> get_get_dbl( J const &jo );
-        static std::function<double( const T & )> get_get_dbl( const std::string &value,
+        static std::function<double( dialogue const & )> get_get_dbl( J const &jo );
+        static std::function<double( dialogue const & )> get_get_dbl( const std::string &value,
                 const JsonObject &jo );
         template <class J>
-        std::function<void( const T &, double )>
-        static get_set_dbl( const J &jo, const std::optional<dbl_or_var_part<T>> &min,
-                            const std::optional<dbl_or_var_part<T>> &max, bool temp_var );
-        bool operator()( const T &d ) const {
+        std::function<void( dialogue const &, double )>
+        static get_set_dbl( const J &jo, const std::optional<dbl_or_var_part> &min,
+                            const std::optional<dbl_or_var_part> &max, bool temp_var );
+        bool operator()( dialogue const &d ) const {
             if( !condition ) {
                 return false;
             }
@@ -232,25 +208,11 @@ struct conditional_t {
 };
 
 extern template std::function<double( const dialogue & )>
-conditional_t<dialogue>::get_get_dbl<>( kwargs_shim const & );
+conditional_t::get_get_dbl<>( kwargs_shim const & );
 
 extern template std::function<void( const dialogue &, double )>
-conditional_t<dialogue>::get_set_dbl<>( const kwargs_shim &,
-                                        const std::optional<dbl_or_var_part<dialogue>> &,
-                                        const std::optional<dbl_or_var_part<dialogue>> &, bool );
-
-#if !defined(MACOSX)
-extern template struct conditional_t<dialogue>;
-extern template void read_condition<dialogue>( const JsonObject &jo, const std::string &member_name,
-        std::function<bool( const dialogue & )> &condition, bool default_val );
-
-extern template duration_or_var<dialogue> get_duration_or_var( const JsonObject &jo,
-        std::string member,
-        bool required, time_duration default_val );
-extern template std::string get_talk_varname<dialogue>( const JsonObject &jo,
-        const std::string &member,
-        bool check_value, dbl_or_var<dialogue> &default_val );
-extern template struct talk_effect_fun_t<dialogue>;
-#endif
+conditional_t::get_set_dbl<>( const kwargs_shim &,
+                              const std::optional<dbl_or_var_part> &,
+                              const std::optional<dbl_or_var_part> &, bool );
 
 #endif // CATA_SRC_CONDITION_H

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -96,7 +96,6 @@ struct talk_topic {
  * Defines what happens when the trial succeeds or fails. If trial is
  * TALK_TRIAL_NONE it always succeeds.
  */
-template<class T>
 struct talk_effect_t {
         /**
           * How (if at all) the NPCs opinion of the player character (@ref npc::op_of_u)
@@ -113,19 +112,19 @@ struct talk_effect_t {
           */
         talk_topic next_topic = talk_topic( "TALK_NONE" );
 
-        talk_topic apply( const T &d ) const;
-        void update_missions( T &d ) const;
-        dialogue_consequence get_consequence( const T &d ) const;
+        talk_topic apply( dialogue const &d ) const;
+        static void update_missions( dialogue &d );
+        dialogue_consequence get_consequence( dialogue const &d ) const;
 
         /**
           * Sets an effect and consequence based on function pointer.
           */
         void set_effect( talkfunction_ptr );
-        void set_effect( const talk_effect_fun_t<T> & );
+        void set_effect( const talk_effect_fun_t & );
         /**
           * Sets an effect to a function object and consequence to explicitly given one.
           */
-        void set_effect_consequence( const talk_effect_fun_t<T> &fun, dialogue_consequence con );
+        void set_effect_consequence( const talk_effect_fun_t &fun, dialogue_consequence con );
         void set_effect_consequence( const std::function<void( npc &p )> &ptr, dialogue_consequence con );
 
         void load_effect( const JsonObject &jo, const std::string &member_name );
@@ -138,7 +137,7 @@ struct talk_effect_t {
         /**
          * Functions that are called when the response is chosen.
          */
-        std::vector<talk_effect_fun_t<T>> effects;
+        std::vector<talk_effect_fun_t> effects;
     private:
         dialogue_consequence guaranteed_consequence = dialogue_consequence::none;
 };
@@ -169,8 +168,8 @@ struct talk_response {
     spell_id dialogue_spell = spell_id();
     proficiency_id proficiency = proficiency_id();
 
-    talk_effect_t<dialogue> success;
-    talk_effect_t<dialogue> failure;
+    talk_effect_t success;
+    talk_effect_t failure;
 
     talk_data create_option_line( const dialogue &d, const input_event &hotkey,
                                   bool is_computer = false );
@@ -373,7 +372,7 @@ class json_dynamic_line_effect
 {
     private:
         std::function<bool( const dialogue & )> condition;
-        talk_effect_t<dialogue> effect;
+        talk_effect_t effect;
     public:
         json_dynamic_line_effect( const JsonObject &jo, const std::string &id );
         bool test_condition( const dialogue &d ) const;

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -1,0 +1,159 @@
+#include "dialogue_helpers.h"
+
+#include <string>
+
+#include "dialogue.h"
+
+std::string read_var_value( const var_info &info, const dialogue &d )
+{
+    std::string ret_val;
+    global_variables &globvars = get_globals();
+    switch( info.type ) {
+        case var_type::global:
+            ret_val = globvars.get_global_value( info.name );
+            break;
+        case var_type::u:
+            ret_val = d.actor( false )->get_value( info.name );
+            break;
+        case var_type::npc:
+            ret_val = d.actor( true )->get_value( info.name );
+            break;
+        case var_type::faction:
+            debugmsg( "Not implemented yet." );
+            break;
+        case var_type::party:
+            debugmsg( "Not implemented yet." );
+            break;
+        default:
+            debugmsg( "Invalid type." );
+            break;
+    }
+    if( ret_val.empty() ) {
+        ret_val = info.default_val;
+    }
+    return ret_val;
+}
+
+std::string str_or_var::evaluate( dialogue const &d ) const
+{
+    if( str_val.has_value() ) {
+        return str_val.value();
+    }
+    if( var_val.has_value() ) {
+        std::string val = read_var_value( var_val.value(), d );
+        if( !val.empty() ) {
+            return val;
+        }
+        if( default_val.has_value() ) {
+            return default_val.value();
+        }
+        std::string var_name = var_val.value().name;
+        if( var_name.find( "npctalk_var" ) != std::string::npos ) {
+            var_name = var_name.substr( 12 );
+        }
+        debugmsg( "No default value provided for str_or_var_part while encountering unused "
+                  "variable %s.  Add a \"default_str\" member to prevent this.",
+                  var_name );
+        return "";
+    }
+    debugmsg( "No valid value for str_or_var_part." );
+    return "";
+}
+
+double dbl_or_var_part::evaluate( dialogue const &d ) const
+{
+    if( dbl_val.has_value() ) {
+        return dbl_val.value();
+    }
+    if( var_val.has_value() ) {
+        std::string val = read_var_value( var_val.value(), d );
+        if( !val.empty() ) {
+            return std::stof( val );
+        }
+        if( default_val.has_value() ) {
+            return default_val.value();
+        }
+        std::string var_name = var_val.value().name;
+        if( var_name.find( "npctalk_var" ) != std::string::npos ) {
+            var_name = var_name.substr( 12 );
+        }
+        debugmsg( "No default value provided for dbl_or_var_part while encountering unused "
+                  "variable %s.  Add a \"default\" member to prevent this.",
+                  var_name );
+        return 0;
+    }
+    if( arithmetic_val.has_value() ) {
+        arithmetic_val.value()( d );
+        var_info info = var_info( var_type::global, "temp_var" );
+        std::string val = read_var_value( info, d );
+        if( !val.empty() ) {
+            return std::stof( val );
+        }
+        debugmsg( "No valid arithmetic value for dbl_or_var_part." );
+        return 0;
+    }
+    if( math_val ) {
+        return math_val->act( d );
+    }
+    debugmsg( "No valid value for dbl_or_var_part." );
+    return 0;
+}
+
+double dbl_or_var::evaluate( dialogue const &d ) const
+{
+    if( pair ) {
+        return rng( min.evaluate( d ), max.evaluate( d ) );
+    }
+    return min.evaluate( d );
+}
+
+time_duration duration_or_var_part::evaluate( dialogue const &d ) const
+{
+    if( dur_val.has_value() ) {
+        return dur_val.value();
+    }
+    if( var_val.has_value() ) {
+        std::string val = read_var_value( var_val.value(), d );
+        if( !val.empty() ) {
+            time_duration ret_val;
+            ret_val = time_duration::from_turns( std::stoi( val ) );
+            return ret_val;
+        }
+        if( default_val.has_value() ) {
+            return default_val.value();
+        }
+        std::string var_name = var_val.value().name;
+        if( var_name.find( "npctalk_var" ) != std::string::npos ) {
+            var_name = var_name.substr( 12 );
+        }
+        debugmsg( "No default value provided for duration_or_var_part while encountering unused "
+                  "variable %s.  Add a \"default\" member to prevent this.",
+                  var_name );
+        return 0_seconds;
+    }
+    if( arithmetic_val.has_value() ) {
+        arithmetic_val.value()( d );
+        var_info info = var_info( var_type::global, "temp_var" );
+        std::string val = read_var_value( info, d );
+        if( !val.empty() ) {
+            time_duration ret_val;
+            ret_val = time_duration::from_turns( std::stoi( val ) );
+            return ret_val;
+        }
+        debugmsg( "No valid arithmetic value for duration_or_var_part." );
+        return 0_seconds;
+    }
+    if( math_val ) {
+        return time_duration::from_turns( math_val->act( d ) );
+    }
+    debugmsg( "No valid value for duration_or_var_part." );
+    return 0_seconds;
+}
+
+time_duration duration_or_var::evaluate( dialogue const &d ) const
+{
+    if( pair ) {
+        return rng( min.evaluate( d ), max.evaluate( d ) );
+    }
+    return min.evaluate( d );
+}

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -18,17 +18,16 @@ using dialogue_fun_ptr = std::add_pointer<void( npc & )>::type;
 
 using trial_mod = std::pair<std::string, int>;
 
-template<class T>
 struct talk_effect_fun_t {
     private:
-        std::function<void( const T &d )> function;
+        std::function<void( dialogue const &d )> function;
         std::vector<std::pair<int, itype_id>> likely_rewards;
 
     public:
         talk_effect_fun_t() = default;
         explicit talk_effect_fun_t( const talkfunction_ptr & );
         explicit talk_effect_fun_t( const std::function<void( npc & )> & );
-        explicit talk_effect_fun_t( const std::function<void( const T &d )> & );
+        explicit talk_effect_fun_t( const std::function<void( dialogue const &d )> & );
         void set_companion_mission( const std::string &role_id );
         void set_add_effect( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_remove_effect( const JsonObject &jo, const std::string &member, bool is_npc = false );
@@ -114,7 +113,7 @@ struct talk_effect_fun_t {
         void set_open_dialogue( const JsonObject &jo, const std::string &member );
         void set_take_control( const JsonObject &jo );
         void set_take_control_menu();
-        void operator()( const T &d ) const {
+        void operator()( dialogue const &d ) const {
             if( !function ) {
                 return;
             }
@@ -132,69 +131,15 @@ struct var_info {
     std::string default_val;
 };
 
-template<class T>
-static std::string read_var_value( const var_info &info, const T &d )
-{
-    std::string ret_val;
-    global_variables &globvars = get_globals();
-    switch( info.type ) {
-        case var_type::global:
-            ret_val = globvars.get_global_value( info.name );
-            break;
-        case var_type::u:
-            ret_val = d.actor( false )->get_value( info.name );
-            break;
-        case var_type::npc:
-            ret_val = d.actor( true )->get_value( info.name );
-            break;
-        case var_type::faction:
-            debugmsg( "Not implemented yet." );
-            break;
-        case var_type::party:
-            debugmsg( "Not implemented yet." );
-            break;
-        default:
-            debugmsg( "Invalid type." );
-            break;
-    }
-    if( ret_val.empty() ) {
-        ret_val = info.default_val;
-    }
-    return ret_val;
-}
+std::string read_var_value( const var_info &info, const dialogue &d );
 
-template<class T>
 struct str_or_var {
     std::optional<std::string> str_val;
     std::optional<var_info> var_val;
     std::optional<std::string> default_val;
-    std::string evaluate( const T &d ) const {
-        if( str_val.has_value() ) {
-            return str_val.value();
-        } else if( var_val.has_value() ) {
-            std::string val = read_var_value( var_val.value(), d );
-            if( !val.empty() ) {
-                return std::string( val );
-            }
-            if( default_val.has_value() ) {
-                return default_val.value();
-            } else {
-                std::string var_name = var_val.value().name;
-                if( var_name.find( "npctalk_var" ) != std::string::npos ) {
-                    var_name = var_name.substr( 12 );
-                }
-                debugmsg( "No default value provided for str_or_var_part while encountering unused variable %s.  Add a \"default_str\" member to prevent this.",
-                          var_name );
-                return "";
-            }
-        } else {
-            debugmsg( "No valid value for str_or_var_part." );
-            return "";
-        }
-    }
+    std::string evaluate( dialogue const &d ) const;
 };
 
-template<typename D>
 struct eoc_math {
     enum class oper : int {
         ret = 0,
@@ -216,135 +161,45 @@ struct eoc_math {
         greater,
         equal_or_greater,
     };
-    math_exp<D> lhs;
-    math_exp<D> mhs;
-    math_exp<D> rhs;
+    math_exp lhs;
+    math_exp mhs;
+    math_exp rhs;
     eoc_math::oper action;
 
     void from_json( const JsonObject &jo, std::string const &member );
-    double act( D const &d ) const;
+    double act( dialogue const &d ) const;
 };
 
-template<class T>
 struct dbl_or_var_part {
     std::optional<double> dbl_val;
     std::optional<var_info> var_val;
     std::optional<double> default_val;
-    std::optional<talk_effect_fun_t<T>> arithmetic_val;
-    std::optional<eoc_math<T>> math_val;
-    double evaluate( const T &d ) const {
-        if( dbl_val.has_value() ) {
-            return dbl_val.value();
-        } else if( var_val.has_value() ) {
-            std::string val = read_var_value( var_val.value(), d );
-            if( !val.empty() ) {
-                return std::stof( val );
-            }
-            if( default_val.has_value() ) {
-                return default_val.value();
-            } else {
-                std::string var_name = var_val.value().name;
-                if( var_name.find( "npctalk_var" ) != std::string::npos ) {
-                    var_name = var_name.substr( 12 );
-                }
-                debugmsg( "No default value provided for dbl_or_var_part while encountering unused variable %s.  Add a \"default\" member to prevent this.",
-                          var_name );
-                return 0;
-            }
-        } else if( arithmetic_val.has_value() ) {
-            arithmetic_val.value()( d );
-            var_info info = var_info( var_type::global, "temp_var" );
-            std::string val = read_var_value( info, d );
-            if( !val.empty() ) {
-                return std::stof( val );
-            } else {
-                debugmsg( "No valid arithmetic value for dbl_or_var_part." );
-                return 0;
-            }
-        } else if( math_val ) {
-            return math_val->act( d );
-        } else {
-            debugmsg( "No valid value for dbl_or_var_part." );
-            return 0;
-        }
-    }
+    std::optional<talk_effect_fun_t> arithmetic_val;
+    std::optional<eoc_math> math_val;
+    double evaluate( dialogue const &d ) const;
 };
 
-template<class T>
 struct dbl_or_var {
     bool pair = false;
-    dbl_or_var_part<T> min;
-    dbl_or_var_part<T> max;
-    double evaluate( const T &d ) const {
-        if( pair ) {
-            return rng( min.evaluate( d ), max.evaluate( d ) );
-        } else {
-            return min.evaluate( d );
-        }
-    }
+    dbl_or_var_part min;
+    dbl_or_var_part max;
+    double evaluate( dialogue const &d ) const;
 };
 
-template<class T>
 struct duration_or_var_part {
     std::optional<time_duration> dur_val;
     std::optional<var_info> var_val;
     std::optional<time_duration> default_val;
-    std::optional<talk_effect_fun_t<T>> arithmetic_val;
-    std::optional<eoc_math<T>> math_val;
-    time_duration evaluate( const T &d ) const {
-        if( dur_val.has_value() ) {
-            return dur_val.value();
-        } else if( var_val.has_value() ) {
-            std::string val = read_var_value( var_val.value(), d );
-            if( !val.empty() ) {
-                time_duration ret_val;
-                ret_val = time_duration::from_turns( std::stoi( val ) );
-                return ret_val;
-            }
-            if( default_val.has_value() ) {
-                return default_val.value();
-            } else {
-                std::string var_name = var_val.value().name;
-                if( var_name.find( "npctalk_var" ) != std::string::npos ) {
-                    var_name = var_name.substr( 12 );
-                }
-                debugmsg( "No default value provided for duration_or_var_part while encountering unused variable %s.  Add a \"default\" member to prevent this.",
-                          var_name );
-                return 0_seconds;
-            }
-        } else if( arithmetic_val.has_value() ) {
-            arithmetic_val.value()( d );
-            var_info info = var_info( var_type::global, "temp_var" );
-            std::string val = read_var_value( info, d );
-            if( !val.empty() ) {
-                time_duration ret_val;
-                ret_val = time_duration::from_turns( std::stoi( val ) );
-                return ret_val;
-            } else {
-                debugmsg( "No valid arithmetic value for duration_or_var_part." );
-                return 0_seconds;
-            }
-        } else if( math_val ) {
-            return time_duration::from_turns( math_val->act( d ) );
-        } else {
-            debugmsg( "No valid value for duration_or_var_part." );
-            return 0_seconds;
-        }
-    }
+    std::optional<talk_effect_fun_t> arithmetic_val;
+    std::optional<eoc_math> math_val;
+    time_duration evaluate( dialogue const &d ) const;
 };
 
-template<class T>
 struct duration_or_var {
     bool pair = false;
-    duration_or_var_part<dialogue> min;
-    duration_or_var_part<dialogue> max;
-    time_duration evaluate( const T &d ) const {
-        if( pair ) {
-            return rng( min.evaluate( d ), max.evaluate( d ) );
-        } else {
-            return min.evaluate( d );
-        }
-    }
+    duration_or_var_part min;
+    duration_or_var_part max;
+    time_duration evaluate( dialogue const &d ) const;
 };
 
 #endif // CATA_SRC_DIALOGUE_HELPERS_H

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -64,18 +64,18 @@ void effect_on_condition::load( const JsonObject &jo, const std::string & )
             jo.throw_error( "A recurring effect_on_condition must be of type RECURRING." );
         }
         type = eoc_type::RECURRING;
-        recurrence = get_duration_or_var<dialogue>( jo, "recurrence", false );
+        recurrence = get_duration_or_var( jo, "recurrence", false );
     }
     if( type == eoc_type::NUM_EOC_TYPES ) {
         type = eoc_type::ACTIVATION;
     }
 
     if( jo.has_member( "deactivate_condition" ) ) {
-        read_condition<dialogue>( jo, "deactivate_condition", deactivate_condition, false );
+        read_condition( jo, "deactivate_condition", deactivate_condition, false );
         has_deactivate_condition = true;
     }
     if( jo.has_member( "condition" ) ) {
-        read_condition<dialogue>( jo, "condition", condition, false );
+        read_condition( jo, "condition", condition, false );
         has_condition = true;
     }
     true_effect.load_effect( jo, "effect" );

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -50,13 +50,13 @@ struct effect_on_condition {
         eoc_type type;
         std::function<bool( const dialogue & )> condition;
         std::function<bool( const dialogue & )> deactivate_condition;
-        talk_effect_t<dialogue> true_effect;
-        talk_effect_t<dialogue> false_effect;
+        talk_effect_t true_effect;
+        talk_effect_t false_effect;
         bool has_deactivate_condition = false;
         bool has_condition = false;
         bool has_false_effect = false;
         event_type required_event;
-        duration_or_var<dialogue> recurrence;
+        duration_or_var recurrence;
         bool activate( dialogue &d ) const;
         bool check_deactivate( dialogue &d ) const;
         bool test_condition( dialogue &d ) const;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2139,7 +2139,7 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
             // only ever do the effect for a snippet the first time you see it
             if( !get_avatar().has_seen_snippet( snip_id ) ) {
                 // Have looked at the item so call the on examine EOC for the snippet
-                const std::optional<talk_effect_t<dialogue>> examine_effect = SNIPPET.get_EOC_by_id( snip_id );
+                const std::optional<talk_effect_t> examine_effect = SNIPPET.get_EOC_by_id( snip_id );
                 if( examine_effect.has_value() ) {
                     // activate the effect
                     dialogue d( get_talker_for( get_avatar() ), nullptr );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -316,135 +316,135 @@ void spell_type::load( const JsonObject &jo, const std::string & )
         field = field_type_id( field_input );
     }
     if( !was_loaded || jo.has_member( "field_chance" ) ) {
-        field_chance = get_dbl_or_var<dialogue>( jo, "field_chance", false, field_chance_default );
+        field_chance = get_dbl_or_var( jo, "field_chance", false, field_chance_default );
     }
     if( !was_loaded || jo.has_member( "min_field_intensity" ) ) {
-        min_field_intensity = get_dbl_or_var<dialogue>( jo, "min_field_intensity", false,
-                              min_field_intensity_default );
+        min_field_intensity = get_dbl_or_var( jo, "min_field_intensity", false,
+                                              min_field_intensity_default );
     }
     if( !was_loaded || jo.has_member( "max_field_intensity" ) ) {
-        max_field_intensity = get_dbl_or_var<dialogue>( jo, "max_field_intensity", false,
-                              max_field_intensity_default );
+        max_field_intensity = get_dbl_or_var( jo, "max_field_intensity", false,
+                                              max_field_intensity_default );
     }
     if( !was_loaded || jo.has_member( "field_intensity_increment" ) ) {
-        field_intensity_increment = get_dbl_or_var<dialogue>( jo, "field_intensity_increment", false,
+        field_intensity_increment = get_dbl_or_var( jo, "field_intensity_increment", false,
                                     field_intensity_increment_default );
     }
     if( !was_loaded || jo.has_member( "field_intensity_variance" ) ) {
-        field_intensity_variance = get_dbl_or_var<dialogue>( jo, "field_intensity_variance", false,
+        field_intensity_variance = get_dbl_or_var( jo, "field_intensity_variance", false,
                                    field_intensity_variance_default );
     }
 
     if( !was_loaded || jo.has_member( "min_accuracy" ) ) {
-        min_accuracy = get_dbl_or_var<dialogue>( jo, "min_accuracy", false, min_accuracy_default );
+        min_accuracy = get_dbl_or_var( jo, "min_accuracy", false, min_accuracy_default );
     }
     if( !was_loaded || jo.has_member( "accuracy_increment" ) ) {
-        accuracy_increment = get_dbl_or_var<dialogue>( jo, "accuracy_increment", false,
-                             accuracy_increment_default );
+        accuracy_increment = get_dbl_or_var( jo, "accuracy_increment", false,
+                                             accuracy_increment_default );
     }
     if( !was_loaded || jo.has_member( "max_accuracy" ) ) {
-        max_accuracy = get_dbl_or_var<dialogue>( jo, "max_accuracy", false, max_accuracy_default );
+        max_accuracy = get_dbl_or_var( jo, "max_accuracy", false, max_accuracy_default );
     }
     if( !was_loaded || jo.has_member( "min_damage" ) ) {
-        min_damage = get_dbl_or_var<dialogue>( jo, "min_damage", false, min_damage_default );
+        min_damage = get_dbl_or_var( jo, "min_damage", false, min_damage_default );
     }
     if( !was_loaded || jo.has_member( "damage_increment" ) ) {
-        damage_increment = get_dbl_or_var<dialogue>( jo, "damage_increment", false,
-                           damage_increment_default );
+        damage_increment = get_dbl_or_var( jo, "damage_increment", false,
+                                           damage_increment_default );
     }
     if( !was_loaded || jo.has_member( "max_damage" ) ) {
-        max_damage = get_dbl_or_var<dialogue>( jo, "max_damage", false, max_damage_default );
+        max_damage = get_dbl_or_var( jo, "max_damage", false, max_damage_default );
     }
 
     if( !was_loaded || jo.has_member( "min_range" ) ) {
-        min_range = get_dbl_or_var<dialogue>( jo, "min_range", false, min_range_default );
+        min_range = get_dbl_or_var( jo, "min_range", false, min_range_default );
     }
     if( !was_loaded || jo.has_member( "range_increment" ) ) {
-        range_increment = get_dbl_or_var<dialogue>( jo, "range_increment", false, range_increment_default );
+        range_increment = get_dbl_or_var( jo, "range_increment", false, range_increment_default );
     }
     if( !was_loaded || jo.has_member( "max_range" ) ) {
-        max_range = get_dbl_or_var<dialogue>( jo, "max_range", false, max_range_default );
+        max_range = get_dbl_or_var( jo, "max_range", false, max_range_default );
     }
 
     if( !was_loaded || jo.has_member( "min_aoe" ) ) {
-        min_aoe = get_dbl_or_var<dialogue>( jo, "min_aoe", false, min_aoe_default );
+        min_aoe = get_dbl_or_var( jo, "min_aoe", false, min_aoe_default );
     }
     if( !was_loaded || jo.has_member( "aoe_increment" ) ) {
-        aoe_increment = get_dbl_or_var<dialogue>( jo, "aoe_increment", false, aoe_increment_default );
+        aoe_increment = get_dbl_or_var( jo, "aoe_increment", false, aoe_increment_default );
     }
     if( !was_loaded || jo.has_member( "max_aoe" ) ) {
-        max_aoe = get_dbl_or_var<dialogue>( jo, "max_aoe", false, max_aoe_default );
+        max_aoe = get_dbl_or_var( jo, "max_aoe", false, max_aoe_default );
     }
     if( !was_loaded || jo.has_member( "min_dot" ) ) {
-        min_dot = get_dbl_or_var<dialogue>( jo, "min_dot", false, min_dot_default );
+        min_dot = get_dbl_or_var( jo, "min_dot", false, min_dot_default );
     }
     if( !was_loaded || jo.has_member( "dot_increment" ) ) {
-        dot_increment = get_dbl_or_var<dialogue>( jo, "dot_increment", false, dot_increment_default );
+        dot_increment = get_dbl_or_var( jo, "dot_increment", false, dot_increment_default );
     }
     if( !was_loaded || jo.has_member( "max_dot" ) ) {
-        max_dot = get_dbl_or_var<dialogue>( jo, "max_dot", false, max_dot_default );
+        max_dot = get_dbl_or_var( jo, "max_dot", false, max_dot_default );
     }
 
     if( !was_loaded || jo.has_member( "min_duration" ) ) {
-        min_duration = get_dbl_or_var<dialogue>( jo, "min_duration", false, min_duration_default );
+        min_duration = get_dbl_or_var( jo, "min_duration", false, min_duration_default );
     }
     if( !was_loaded || jo.has_member( "duration_increment" ) ) {
-        duration_increment = get_dbl_or_var<dialogue>( jo, "duration_increment", false,
-                             duration_increment_default );
+        duration_increment = get_dbl_or_var( jo, "duration_increment", false,
+                                             duration_increment_default );
     }
     if( !was_loaded || jo.has_member( "max_duration" ) ) {
-        max_duration = get_dbl_or_var<dialogue>( jo, "max_duration", false, max_duration_default );
+        max_duration = get_dbl_or_var( jo, "max_duration", false, max_duration_default );
     }
 
     if( !was_loaded || jo.has_member( "min_pierce" ) ) {
-        min_pierce = get_dbl_or_var<dialogue>( jo, "min_pierce", false, min_pierce_default );
+        min_pierce = get_dbl_or_var( jo, "min_pierce", false, min_pierce_default );
     }
     if( !was_loaded || jo.has_member( "pierce_increment" ) ) {
-        pierce_increment = get_dbl_or_var<dialogue>( jo, "pierce_increment", false,
-                           pierce_increment_default );
+        pierce_increment = get_dbl_or_var( jo, "pierce_increment", false,
+                                           pierce_increment_default );
     }
     if( !was_loaded || jo.has_member( "max_pierce" ) ) {
-        max_pierce = get_dbl_or_var<dialogue>( jo, "max_pierce", false, max_pierce_default );
+        max_pierce = get_dbl_or_var( jo, "max_pierce", false, max_pierce_default );
     }
 
     if( !was_loaded || jo.has_member( "base_energy_cost" ) ) {
-        base_energy_cost = get_dbl_or_var<dialogue>( jo, "base_energy_cost", false,
-                           base_energy_cost_default );
+        base_energy_cost = get_dbl_or_var( jo, "base_energy_cost", false,
+                                           base_energy_cost_default );
     }
     if( jo.has_member( "final_energy_cost" ) ) {
-        final_energy_cost = get_dbl_or_var<dialogue>( jo, "final_energy_cost" );
+        final_energy_cost = get_dbl_or_var( jo, "final_energy_cost" );
     } else if( !was_loaded ) {
         final_energy_cost = base_energy_cost;
     }
     if( !was_loaded || jo.has_member( "energy_increment" ) ) {
-        energy_increment = get_dbl_or_var<dialogue>( jo, "energy_increment", false,
-                           energy_increment_default );
+        energy_increment = get_dbl_or_var( jo, "energy_increment", false,
+                                           energy_increment_default );
     }
 
     optional( jo, was_loaded, "spell_class", spell_class, spell_class_default );
     optional( jo, was_loaded, "energy_source", energy_source, energy_source_default );
     optional( jo, was_loaded, "damage_type", dmg_type, dmg_type_default );
     if( !was_loaded || jo.has_member( "difficulty" ) ) {
-        difficulty = get_dbl_or_var<dialogue>( jo, "difficulty", false, difficulty_default );
+        difficulty = get_dbl_or_var( jo, "difficulty", false, difficulty_default );
     }
     if( !was_loaded || jo.has_member( "max_level" ) ) {
-        max_level = get_dbl_or_var<dialogue>( jo, "max_level", false, max_level_default );
+        max_level = get_dbl_or_var( jo, "max_level", false, max_level_default );
     }
 
     if( !was_loaded || jo.has_member( "base_casting_time" ) ) {
-        base_casting_time = get_dbl_or_var<dialogue>( jo, "base_casting_time", false,
-                            base_casting_time_default );
+        base_casting_time = get_dbl_or_var( jo, "base_casting_time", false,
+                                            base_casting_time_default );
     }
     if( jo.has_member( "final_casting_time" ) ) {
-        final_casting_time = get_dbl_or_var<dialogue>( jo, "final_casting_time" );
+        final_casting_time = get_dbl_or_var( jo, "final_casting_time" );
     } else if( !was_loaded ) {
         final_casting_time = base_casting_time;
     }
     if( !was_loaded || jo.has_member( "max_damage" ) ) {
-        max_damage = get_dbl_or_var<dialogue>( jo, "max_damage", false, max_damage_default );
+        max_damage = get_dbl_or_var( jo, "max_damage", false, max_damage_default );
     }
     if( !was_loaded || jo.has_member( "casting_time_increment" ) ) {
-        casting_time_increment = get_dbl_or_var<dialogue>( jo, "casting_time_increment", false,
+        casting_time_increment = get_dbl_or_var( jo, "casting_time_increment", false,
                                  casting_time_increment_default );
     }
 
@@ -2616,8 +2616,8 @@ static void draw_spellbook_info( const spell_type &sp, uilist *menu )
                                        //~ translation should not exceed 7 console cells
                                        left_justify( _( "max lvl" ), 7 ) ) );
 
-    const auto row = [&]( const std::string & label, const dbl_or_var<dialogue> &min_d,
-    const dbl_or_var<dialogue> &inc_d, const dbl_or_var<dialogue> &max_d, bool check_minmax = false ) {
+    const auto row = [&]( const std::string & label, const dbl_or_var & min_d,
+    const dbl_or_var & inc_d, const dbl_or_var & max_d, bool check_minmax = false ) {
         const int min = static_cast<int>( min_d.evaluate( d ) );
         const float inc = static_cast<float>( inc_d.evaluate( d ) );
         const int max = static_cast<int>( max_d.evaluate( d ) );

--- a/src/magic.h
+++ b/src/magic.h
@@ -233,98 +233,98 @@ class spell_type
         // if the spell has a field name defined, this is where it is
         std::optional<field_type_id> field = std::nullopt;
         // the chance one_in( field_chance ) that the field spawns at a tripoint in the area of the spell
-        dbl_or_var<dialogue> field_chance;
+        dbl_or_var field_chance;
         // field intensity at spell level 0
-        dbl_or_var<dialogue> min_field_intensity;
+        dbl_or_var min_field_intensity;
         // increment of field intensity per level
-        dbl_or_var<dialogue> field_intensity_increment;
+        dbl_or_var field_intensity_increment;
         // maximum field intensity allowed
-        dbl_or_var<dialogue> max_field_intensity;
+        dbl_or_var max_field_intensity;
         // field intensity added to the map is +- ( 1 + field_intensity_variance ) * field_intensity
-        dbl_or_var<dialogue> field_intensity_variance;
+        dbl_or_var field_intensity_variance;
 
         // accuracy is a bonus against dodge, block, and spellcraft
         // which allows the target to mitigate up to 33% damage for each type of resistance
         // this could theoretically add up to 100%
 
-        dbl_or_var<dialogue> min_accuracy;
-        dbl_or_var<dialogue> accuracy_increment;
-        dbl_or_var<dialogue> max_accuracy;
+        dbl_or_var min_accuracy;
+        dbl_or_var accuracy_increment;
+        dbl_or_var max_accuracy;
 
         // minimum damage this spell can cause
-        dbl_or_var<dialogue> min_damage;
+        dbl_or_var min_damage;
         // amount of damage increase per spell level
-        dbl_or_var<dialogue> damage_increment;
+        dbl_or_var damage_increment;
         // maximum damage this spell can cause
-        dbl_or_var<dialogue> max_damage;
+        dbl_or_var max_damage;
 
         // minimum range of a spell
-        dbl_or_var<dialogue> min_range;
+        dbl_or_var min_range;
         // amount of range increase per spell level
-        dbl_or_var<dialogue> range_increment;
+        dbl_or_var range_increment;
         // max range this spell can achieve
-        dbl_or_var<dialogue> max_range;
+        dbl_or_var max_range;
 
         // minimum area of effect of a spell (radius)
         // 0 means the spell only affects the target
-        dbl_or_var<dialogue> min_aoe;
+        dbl_or_var min_aoe;
         // amount of area of effect increase per spell level (radius)
-        dbl_or_var<dialogue> aoe_increment;
+        dbl_or_var aoe_increment;
         // max area of effect of a spell (radius)
-        dbl_or_var<dialogue> max_aoe;
+        dbl_or_var max_aoe;
 
         // damage over time deals damage per turn
 
         // minimum damage over time
-        dbl_or_var<dialogue> min_dot;
+        dbl_or_var min_dot;
         // increment per spell level
-        dbl_or_var<dialogue> dot_increment;
+        dbl_or_var dot_increment;
         // max damage over time
-        dbl_or_var<dialogue> max_dot;
+        dbl_or_var max_dot;
 
         // amount of time effect lasts
 
         // minimum time for effect in moves
-        dbl_or_var<dialogue> min_duration;
+        dbl_or_var min_duration;
         // increment per spell level in moves
         // DoT is per turn, but increments can be smaller
-        dbl_or_var<dialogue> duration_increment;
+        dbl_or_var duration_increment;
         // max time for effect in moves
-        dbl_or_var<dialogue> max_duration;
+        dbl_or_var max_duration;
 
         // amount of damage that is piercing damage
         // not added to damage stat
 
         // minimum pierce damage
-        dbl_or_var<dialogue> min_pierce;
+        dbl_or_var min_pierce;
         // increment of pierce damage per spell level
-        dbl_or_var<dialogue> pierce_increment;
+        dbl_or_var pierce_increment;
         // max pierce damage
-        dbl_or_var<dialogue> max_pierce;
+        dbl_or_var max_pierce;
 
         // base energy cost of spell
-        dbl_or_var<dialogue> base_energy_cost;
+        dbl_or_var base_energy_cost;
         // increment of energy cost per spell level
-        dbl_or_var<dialogue> energy_increment;
+        dbl_or_var energy_increment;
         // max or min energy cost, based on sign of energy_increment
-        dbl_or_var<dialogue> final_energy_cost;
+        dbl_or_var final_energy_cost;
 
         // spell is restricted to being cast by only this class
         // if spell_class is empty, spell is unrestricted
         trait_id spell_class;
 
         // the difficulty of casting a spell
-        dbl_or_var<dialogue> difficulty;
+        dbl_or_var difficulty;
 
         // max level this spell can achieve
-        dbl_or_var<dialogue> max_level;
+        dbl_or_var max_level;
 
         // base amount of time to cast the spell in moves
-        dbl_or_var<dialogue> base_casting_time;
+        dbl_or_var base_casting_time;
         // increment of casting time per level
-        dbl_or_var<dialogue> casting_time_increment;
+        dbl_or_var casting_time_increment;
         // max or min casting time
-        dbl_or_var<dialogue> final_casting_time;
+        dbl_or_var final_casting_time;
 
         // Does leveling this spell lead to learning another spell?
         std::map<std::string, int> learn_spells;

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -312,7 +312,7 @@ void enchantment::load( const JsonObject &jo, const std::string &,
         active_conditions.second = condition::ALWAYS;
     }
     if( active_conditions.second == condition::DIALOG_CONDITION ) {
-        read_condition<dialogue>( jo, "condition", dialog_condition, false );
+        read_condition( jo, "condition", dialog_condition, false );
     }
 
     for( JsonObject jsobj : jo.get_array( "ench_effects" ) ) {
@@ -329,9 +329,9 @@ void enchantment::load( const JsonObject &jo, const std::string &,
         for( const JsonObject value_obj : jo.get_array( "values" ) ) {
             const enchant_vals::mod value = io::string_to_enum<enchant_vals::mod>
                                             ( value_obj.get_string( "value" ) );
-            dbl_or_var<dialogue> add = get_dbl_or_var<dialogue>( value_obj, "add", false );
+            dbl_or_var add = get_dbl_or_var( value_obj, "add", false );
             values_add.emplace( value, add );
-            dbl_or_var<dialogue> mult = get_dbl_or_var<dialogue>( value_obj, "multiply", false );
+            dbl_or_var mult = get_dbl_or_var( value_obj, "multiply", false );
             if( value_obj.has_member( "multiply" ) ) {
                 if( value_obj.has_float( "multiply" ) ) {
                     mult.max.dbl_val = mult.min.dbl_val = value_obj.get_float( "multiply" );
@@ -347,15 +347,15 @@ void enchantment::load( const JsonObject &jo, const std::string &,
         for( const JsonObject value_obj : jo.get_array( "skills" ) ) {
             const skill_id value = skill_id( value_obj.get_string( "value" ) );
             if( value_obj.has_member( "add" ) ) {
-                dbl_or_var<dialogue> add = get_dbl_or_var<dialogue>( value_obj, "add", false );
+                dbl_or_var add = get_dbl_or_var( value_obj, "add", false );
                 skill_values_add.emplace( value, add );
             }
             if( value_obj.has_member( "multiply" ) ) {
-                dbl_or_var<dialogue> mult;
+                dbl_or_var mult;
                 if( value_obj.has_float( "multiply" ) ) {
                     mult.max.dbl_val = mult.min.dbl_val = value_obj.get_float( "multiply" );
                 } else {
-                    mult = get_dbl_or_var<dialogue>( value_obj, "multiply", false );
+                    mult = get_dbl_or_var( value_obj, "multiply", false );
 
                 }
                 skill_values_multiply.emplace( value, mult );
@@ -566,22 +566,22 @@ void enchant_cache::force_add( const enchant_cache &rhs )
 void enchant_cache::force_add( const enchantment &rhs, const Character &guy )
 {
     dialogue d( get_talker_for( guy ), nullptr );
-    for( const std::pair<const enchant_vals::mod, dbl_or_var<dialogue>> &pair_values :
+    for( const std::pair<const enchant_vals::mod, dbl_or_var> &pair_values :
          rhs.values_add ) {
         values_add[pair_values.first] += pair_values.second.evaluate( d );
     }
-    for( const std::pair<const enchant_vals::mod, dbl_or_var<dialogue>> &pair_values :
+    for( const std::pair<const enchant_vals::mod, dbl_or_var> &pair_values :
          rhs.values_multiply ) {
         // values do not multiply against each other, they add.
         // so +10% and -10% will add to 0%
         values_multiply[pair_values.first] += pair_values.second.evaluate( d );
     }
 
-    for( const std::pair<const skill_id, dbl_or_var<dialogue>> &pair_values :
+    for( const std::pair<const skill_id, dbl_or_var> &pair_values :
          rhs.skill_values_add ) {
         skill_values_add[pair_values.first] += pair_values.second.evaluate( d );
     }
-    for( const std::pair<const skill_id, dbl_or_var<dialogue>> &pair_values :
+    for( const std::pair<const skill_id, dbl_or_var> &pair_values :
          rhs.skill_values_multiply ) {
         // values do not multiply against each other, they add.
         // so +10% and -10% will add to 0%

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -22,7 +22,6 @@ class JsonObject;
 class JsonOut;
 class item;
 struct dialogue;
-template<class T>
 struct dbl_or_var;
 namespace enchant_vals
 {
@@ -198,14 +197,14 @@ class enchantment
         translation description;
 
         // values that add to the base value
-        std::map<enchant_vals::mod, dbl_or_var<dialogue>> values_add; // NOLINT(cata-serialize)
+        std::map<enchant_vals::mod, dbl_or_var> values_add; // NOLINT(cata-serialize)
         // values that get multiplied to the base value
         // multipliers add to each other instead of multiply against themselves
-        std::map<enchant_vals::mod, dbl_or_var<dialogue>> values_multiply; // NOLINT(cata-serialize)
+        std::map<enchant_vals::mod, dbl_or_var> values_multiply; // NOLINT(cata-serialize)
 
         // the exact same as above, though specifically for skills
-        std::map<skill_id, dbl_or_var<dialogue>> skill_values_add; // NOLINT(cata-serialize)
-        std::map<skill_id, dbl_or_var<dialogue>> skill_values_multiply; // NOLINT(cata-serialize)
+        std::map<skill_id, dbl_or_var> skill_values_add; // NOLINT(cata-serialize)
+        std::map<skill_id, dbl_or_var> skill_values_multiply; // NOLINT(cata-serialize)
 
         std::vector<fake_spell> hit_me_effect;
         std::vector<fake_spell> hit_you_effect;

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -620,4 +620,3 @@ void math_exp<D>::assign( D const &d, double val ) const
 }
 
 template class math_exp<dialogue>;
-template class math_exp<mission_goal_condition_context>;

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -99,16 +99,14 @@ std::optional<S> _get_dialogue_func( C const &cnt, std::string_view token )
     return std::nullopt;
 }
 
-template<class D>
-std::optional<scoped_diag_eval<D>> get_dialogue_eval( std::string_view token )
+std::optional<scoped_diag_eval> get_dialogue_eval( std::string_view token )
 {
-    return _get_dialogue_func<scoped_diag_eval<D>, pdiag_func_eval<D>>( dialogue_eval_f<D>, token );
+    return _get_dialogue_func<scoped_diag_eval, pdiag_func_eval>( dialogue_eval_f, token );
 }
 
-template<class D>
-std::optional<scoped_diag_ass<D>> get_dialogue_ass( std::string_view token )
+std::optional<scoped_diag_ass> get_dialogue_ass( std::string_view token )
 {
-    return _get_dialogue_func<scoped_diag_ass<D>, pdiag_func_ass<D>>( dialogue_assign_f<D>, token );
+    return _get_dialogue_func<scoped_diag_ass, pdiag_func_ass>( dialogue_assign_f, token );
 }
 
 constexpr std::optional<pbin_op> get_binary_op( std::string_view token )
@@ -166,25 +164,46 @@ struct parse_state {
     bool allows_prefix_unary = true;
 };
 
-template<class D>
-bool is_function( op_t<D> const &op )
+bool is_function( op_t const &op )
 {
     return std::holds_alternative<pmath_func>( op ) ||
-           std::holds_alternative<scoped_diag_eval<D>>( op ) ||
-           std::holds_alternative<scoped_diag_ass<D>>( op );
+           std::holds_alternative<scoped_diag_eval>( op ) ||
+           std::holds_alternative<scoped_diag_ass>( op );
 }
 
-template<class D>
-bool is_assign_target( thingie<D> const &thing )
+bool is_assign_target( thingie const &thing )
 {
-    return std::holds_alternative<var<D>>( thing.data ) ||
-           std::holds_alternative<func_diag_ass<D>>( thing.data );
+    return std::holds_alternative<var>( thing.data ) ||
+           std::holds_alternative<func_diag_ass>( thing.data );
 }
 
 } // namespace
 
-template<class D>
-class math_exp<D>::math_exp_impl
+func::func( std::vector<thingie> &&params_, math_func::f_t f_ ) : params( params_ ),
+    f( f_ ) {}
+
+double func::eval( dialogue const &d ) const
+{
+    std::vector<double> elems( params.size() );
+    std::transform( params.begin(), params.end(), elems.begin(),
+    [&d]( thingie const & e ) {
+        return e.eval( d );
+    } );
+    return f( elems );
+}
+
+
+oper::oper( thingie l_, thingie r_, binary_op::f_t op_ ):
+    l( std::make_shared<thingie>( std::move( l_ ) ) ),
+    r( std::make_shared<thingie>( std::move( r_ ) ) ),
+    op( op_ ) {}
+
+double oper::eval( dialogue const &d ) const
+{
+    return ( *op )( l->eval( d ), r->eval( d ) );
+}
+
+class math_exp::math_exp_impl
 {
     public:
         bool parse( std::string_view str, bool assignment ) {
@@ -198,21 +217,21 @@ class math_exp<D>::math_exp_impl
                 ops = {};
                 output = {};
                 arity = {};
-                tree = thingie<D> { 0.0 };
+                tree = thingie { 0.0 };
                 return false;
             }
             return true;
         }
-        double eval( D const &d ) const {
+        double eval( dialogue const &d ) const {
             return tree.eval( d );
         }
 
-        void assign( D const &d, double val ) const {
+        void assign( dialogue const &d, double val ) const {
             std::visit( overloaded{
-                [&d, val]( func_diag_ass<D> const & v ) {
+                [&d, val]( func_diag_ass const & v ) {
                     v.assign( d, val );
                 },
-                [&d, val]( var<D> const & v ) {
+                [&d, val]( var const & v ) {
                     write_var_value( v.varinfo.type, v.varinfo.name,
                                      d.actor( v.varinfo.type == var_type::npc ),
                                      std::to_string( val ) );
@@ -225,8 +244,8 @@ class math_exp<D>::math_exp_impl
         }
 
     private:
-        std::stack<op_t<D>> ops;
-        std::stack<thingie<D>> output;
+        std::stack<op_t> ops;
+        std::stack<thingie> output;
         struct arity_t {
             std::string_view sym;
             int current{};
@@ -234,7 +253,7 @@ class math_exp<D>::math_exp_impl
             bool stringy = false;
         };
         std::stack<arity_t> arity;
-        thingie<D> tree{ 0.0 };
+        thingie tree{ 0.0 };
         std::string_view last_token;
         parse_state state;
 
@@ -252,20 +271,18 @@ class math_exp<D>::math_exp_impl
         void maybe_first_argument();
         void error( std::string_view str, std::string_view what );
         void validate_string( std::string_view str, std::string_view label, std::string_view badlist );
-        std::vector<std::string> _get_strings( std::vector<thingie<D>> const &params,
+        std::vector<std::string> _get_strings( std::vector<thingie> const &params,
                                                size_t nparams ) const;
 };
 
-template<class D>
-void math_exp<D>::math_exp_impl::maybe_first_argument()
+void math_exp::math_exp_impl::maybe_first_argument()
 {
     if( !arity.empty() && !arity.top().sym.empty() && arity.top().current == 0 ) {
         arity.top().current++;
     }
 }
 
-template<class D>
-void math_exp<D>::math_exp_impl::_parse( std::string_view str, bool assignment )
+void math_exp::math_exp_impl::_parse( std::string_view str, bool assignment )
 {
     constexpr std::string_view expression_separators = "+-*/^,()%";
     state = {};
@@ -287,11 +304,11 @@ void math_exp<D>::math_exp_impl::_parse( std::string_view str, bool assignment )
             arity.emplace( arity_t{ ( *ftoken )->symbol, 0, ( *ftoken )->num_params } );
             state.set( parse_state::expect::lparen, false );
 
-        } else if( std::optional<scoped_diag_eval<D>> feval = get_dialogue_eval<D>( token ); feval &&
+        } else if( std::optional<scoped_diag_eval> feval = get_dialogue_eval( token ); feval &&
                    !assignment ) {
             parse_diag_f( *feval, state );
 
-        } else if( std::optional<scoped_diag_ass<D>> fass = get_dialogue_ass<D>( token ); fass &&
+        } else if( std::optional<scoped_diag_ass> fass = get_dialogue_ass( token ); fass &&
                    assignment ) {
             parse_diag_f( *fass, state );
 
@@ -338,8 +355,7 @@ void math_exp<D>::math_exp_impl::_parse( std::string_view str, bool assignment )
     output.pop();
 }
 
-template<class D>
-void math_exp<D>::math_exp_impl::parse_string( std::string_view str, parse_state &state )
+void math_exp::math_exp_impl::parse_string( std::string_view str, parse_state &state )
 {
     state.validate( parse_state::expect::operand );
     maybe_first_argument();
@@ -351,8 +367,7 @@ void math_exp<D>::math_exp_impl::parse_string( std::string_view str, parse_state
     state.set( parse_state::expect::oper, false );
 }
 
-template<class D>
-void math_exp<D>::math_exp_impl::parse_bin_op( pbin_op const &op, parse_state &state )
+void math_exp::math_exp_impl::parse_bin_op( pbin_op const &op, parse_state &state )
 {
     state.validate( parse_state::expect::oper );
     while( !ops.empty() && ops.top() > *op ) {
@@ -362,9 +377,8 @@ void math_exp<D>::math_exp_impl::parse_bin_op( pbin_op const &op, parse_state &s
     state.set( parse_state::expect::operand, true );
 }
 
-template<class D>
 template<typename T>
-void math_exp<D>::math_exp_impl::parse_diag_f( T const &token, parse_state &state )
+void math_exp::math_exp_impl::parse_diag_f( T const &token, parse_state &state )
 {
     state.validate( parse_state::expect::operand );
     ops.emplace( token );
@@ -372,8 +386,7 @@ void math_exp<D>::math_exp_impl::parse_diag_f( T const &token, parse_state &stat
     state.set( parse_state::expect::lparen, false );
 }
 
-template<class D>
-void math_exp<D>::math_exp_impl::parse_comma( parse_state &state )
+void math_exp::math_exp_impl::parse_comma( parse_state &state )
 {
     state.validate( parse_state::expect::oper );
     if( arity.empty() || arity.top().sym.empty() ) {
@@ -386,8 +399,7 @@ void math_exp<D>::math_exp_impl::parse_comma( parse_state &state )
     state.set( parse_state::expect::operand, true );
 }
 
-template<class D>
-void math_exp<D>::math_exp_impl::parse_lparen( parse_state &state )
+void math_exp::math_exp_impl::parse_lparen( parse_state &state )
 {
     state.validate( parse_state::expect::lparen );
     if( ops.empty() || !is_function( ops.top() ) ) {
@@ -397,8 +409,7 @@ void math_exp<D>::math_exp_impl::parse_lparen( parse_state &state )
     state.set( parse_state::expect::operand, true );
 }
 
-template<class D>
-void math_exp<D>::math_exp_impl::parse_rparen( parse_state &state )
+void math_exp::math_exp_impl::parse_rparen( parse_state &state )
 {
     state.validate( parse_state::expect::rparen );
     while( !ops.empty() && ops.top() > paren::left ) {
@@ -415,11 +426,10 @@ void math_exp<D>::math_exp_impl::parse_rparen( parse_state &state )
     state.set( parse_state::expect::oper, false );
 }
 
-template<class D>
-void math_exp<D>::math_exp_impl::new_func()
+void math_exp::math_exp_impl::new_func()
 {
     if( !ops.empty() && is_function( ops.top() ) ) {
-        typename std::vector<thingie<D>>::size_type const nparams = arity.top().current;
+        std::vector<thingie>::size_type const nparams = arity.top().current;
         if( arity.top().expected >= 0 ) {
             if( arity.top().current < arity.top().expected ) {
                 throw std::invalid_argument(
@@ -431,25 +441,25 @@ void math_exp<D>::math_exp_impl::new_func()
             }
         }
 
-        std::vector<thingie<D>> params( nparams );
-        for( typename std::vector<thingie<D>>::size_type i = 0; i < nparams; i++ ) {
+        std::vector<thingie> params( nparams );
+        for( std::vector<thingie>::size_type i = 0; i < nparams; i++ ) {
             params[nparams - i - 1] = std::move( output.top() );
             output.pop();
         }
         std::visit( overloaded{
-            [&params, nparams, this]( scoped_diag_eval<D> const & v )
+            [&params, nparams, this]( scoped_diag_eval const & v )
             {
                 std::vector<std::string> const strings = _get_strings( params, nparams );
-                output.emplace( std::in_place_type_t<func_diag_eval<D>>(), v.df->f( v.scope, strings ) );
+                output.emplace( std::in_place_type_t<func_diag_eval>(), v.df->f( v.scope, strings ) );
             },
-            [&params, nparams, this]( scoped_diag_ass<D> const & v )
+            [&params, nparams, this]( scoped_diag_ass const & v )
             {
                 std::vector<std::string> const strings = _get_strings( params, nparams );
-                output.emplace( std::in_place_type_t<func_diag_ass<D>>(), v.df->f( v.scope, strings ) );
+                output.emplace( std::in_place_type_t<func_diag_ass>(), v.df->f( v.scope, strings ) );
             },
             [&params, this]( pmath_func v )
             {
-                output.emplace( std::in_place_type_t<func<D>>(), std::move( params ), v->f );
+                output.emplace( std::in_place_type_t<func>(), std::move( params ), v->f );
             },
             []( auto /* v */ )
             {
@@ -461,12 +471,11 @@ void math_exp<D>::math_exp_impl::new_func()
     }
 }
 
-template<class D>
-std::vector<std::string> math_exp<D>::math_exp_impl::_get_strings( std::vector<thingie<D>> const
+std::vector<std::string> math_exp::math_exp_impl::_get_strings( std::vector<thingie> const
         &params, size_t nparams ) const
 {
     std::vector<std::string> strings( nparams );
-    std::transform( params.begin(), params.end(), strings.begin(), [this]( thingie<D> const & e ) {
+    std::transform( params.begin(), params.end(), strings.begin(), [this]( thingie const & e ) {
         if( std::holds_alternative<std::string>( e.data ) ) {
             return std::get<std::string>( e.data );
         }
@@ -478,8 +487,7 @@ std::vector<std::string> math_exp<D>::math_exp_impl::_get_strings( std::vector<t
     return strings;
 }
 
-template<class D>
-void math_exp<D>::math_exp_impl::new_oper()
+void math_exp::math_exp_impl::new_oper()
 {
     std::visit( overloaded{
         [this]( pbin_op v )
@@ -489,14 +497,14 @@ void math_exp<D>::math_exp_impl::new_oper()
             output.pop();
             thingie lhs = std::move( output.top() );
             output.pop();
-            output.emplace( std::in_place_type_t<oper<D>>(), lhs, rhs, v->f );
+            output.emplace( std::in_place_type_t<oper>(), lhs, rhs, v->f );
         },
         [this]( punary_op v )
         {
             cata_assert( !output.empty() );
             thingie rhs = std::move( output.top() );
             output.pop();
-            output.emplace( std::in_place_type_t<oper<D>>(), thingie<D> { 0.0 }, rhs, v->f );
+            output.emplace( std::in_place_type_t<oper>(), thingie { 0.0 }, rhs, v->f );
         },
         []( pmath_func v )
         {
@@ -504,13 +512,13 @@ void math_exp<D>::math_exp_impl::new_oper()
                                              "Unterminated math function %s()",
                                              v->symbol.data() ) );
         },
-        []( scoped_diag_eval<D> const & v )
+        []( scoped_diag_eval const & v )
         {
             throw std::invalid_argument( string_format(
                                              "Unterminated dialogue function %s()",
                                              v.df->symbol.data() ) );
         },
-        []( scoped_diag_ass<D> const & v )
+        []( scoped_diag_ass const & v )
         {
             throw std::invalid_argument( string_format(
                                              "Unterminated dialogue function %s()",
@@ -523,8 +531,7 @@ void math_exp<D>::math_exp_impl::new_oper()
     ops.pop();
 }
 
-template<class D>
-void math_exp<D>::math_exp_impl::new_var( std::string_view str )
+void math_exp::math_exp_impl::new_var( std::string_view str )
 {
     std::string_view scoped = str;
     var_type type = var_type::global;
@@ -542,11 +549,10 @@ void math_exp<D>::math_exp_impl::new_var( std::string_view str )
         }
     }
     validate_string( scoped, "variable", " \'" );
-    output.emplace( std::in_place_type_t<var<D>>(), type, "npctalk_var_" + std::string{ scoped } );
+    output.emplace( std::in_place_type_t<var>(), type, "npctalk_var_" + std::string{ scoped } );
 }
 
-template<class D>
-void math_exp<D>::math_exp_impl::error( std::string_view str, std::string_view what )
+void math_exp::math_exp_impl::error( std::string_view str, std::string_view what )
 {
     std::ptrdiff_t offset =
         std::max<std::ptrdiff_t>( 0, last_token.data() - str.data() );
@@ -558,17 +564,16 @@ void math_exp<D>::math_exp_impl::error( std::string_view str, std::string_view w
     // NOLINTNEXTLINE(cata-translate-string-literal): debug message
     std::string mess = string_format( "Expression parsing failed: %s", what.data() );
     if( last_token == "(" && state.expected == parse_state::expect::oper &&
-        std::holds_alternative<var<D>>( output.top().data ) ) {
+        std::holds_alternative<var>( output.top().data ) ) {
         // NOLINTNEXTLINE(cata-translate-string-literal): debug message
         mess = string_format( "%s (or unknown function %s)", mess,
-                              std::get<var<D>>( output.top().data ).varinfo.name.substr( 12 ) );
+                              std::get<var>( output.top().data ).varinfo.name.substr( 12 ) );
     }
 
     debugmsg( "%s\n\n%.80s\n%*s^\n", mess, str.data(), offset, " " );
 }
 
-template<class D>
-void math_exp<D>::math_exp_impl::validate_string( std::string_view str, std::string_view label,
+void math_exp::math_exp_impl::validate_string( std::string_view str, std::string_view label,
         std::string_view badlist )
 {
     std::string_view::size_type const pos = str.find_first_of( badlist );
@@ -580,43 +585,32 @@ void math_exp<D>::math_exp_impl::validate_string( std::string_view str, std::str
     }
 }
 
-template<class D>
-bool math_exp<D>::parse( std::string_view str, bool assignment )
+bool math_exp::parse( std::string_view str, bool assignment )
 {
     impl = std::make_unique<math_exp_impl>();
     return impl->parse( str, assignment );
 }
 
-template<class D>
-math_exp<D>::math_exp( math_exp<D> const &other ) :
+math_exp::math_exp( math_exp const &other ) :
     impl( other.impl ? std::make_unique<math_exp_impl>( *other.impl ) :
           std::make_unique<math_exp_impl>() ) {}
-template<class D>
-math_exp<D> &math_exp<D>::operator=( math_exp<D> const &other )
+math_exp &math_exp::operator=( math_exp const &other )
 {
     impl = other.impl ? std::make_unique<math_exp_impl>( *other.impl ) :
            std::make_unique<math_exp_impl>();
     return *this;
 }
-template<class D>
-math_exp<D>::math_exp() = default;
-template<class D>
-math_exp<D>::~math_exp() = default;
-template<class D>
-math_exp<D>::math_exp( math_exp<D> &&/* other */ ) noexcept = default;
-template<class D>
-math_exp<D> &math_exp<D>::operator=( math_exp<D> &&/* other */ )  noexcept = default;
+math_exp::math_exp() = default;
+math_exp::~math_exp() = default;
+math_exp::math_exp( math_exp &&/* other */ ) noexcept = default;
+math_exp &math_exp::operator=( math_exp &&/* other */ )  noexcept = default;
 
-template<class D>
-double math_exp<D>::eval( D const &d ) const
+double math_exp::eval( dialogue const &d ) const
 {
     return impl->eval( d );
 }
 
-template<class D>
-void math_exp<D>::assign( D const &d, double val ) const
+void math_exp::assign( dialogue const &d, double val ) const
 {
     return impl->assign( d, val );
 }
-
-template class math_exp<dialogue>;

--- a/src/math_parser.h
+++ b/src/math_parser.h
@@ -6,7 +6,6 @@
 
 struct dialogue;
 
-template<class D>
 class math_exp
 {
     public:
@@ -18,14 +17,12 @@ class math_exp
         math_exp &operator=( math_exp &&/* other */ ) noexcept;
 
         bool parse( std::string_view str, bool assignment = false );
-        double eval( D const &d ) const;
-        void assign( D const &d, double val ) const;
+        double eval( dialogue const &d ) const;
+        void assign( dialogue const &d, double val ) const;
 
     private:
         class math_exp_impl;
         std::unique_ptr<math_exp_impl> impl;
 };
-
-extern template class math_exp<dialogue>;
 
 #endif // CATA_SRC_MATH_PARSER_H

--- a/src/math_parser.h
+++ b/src/math_parser.h
@@ -5,7 +5,6 @@
 #include <string_view>
 
 struct dialogue;
-struct mission_goal_condition_context;
 
 template<class D>
 class math_exp
@@ -28,6 +27,5 @@ class math_exp
 };
 
 extern template class math_exp<dialogue>;
-extern template class math_exp<mission_goal_condition_context>;
 
 #endif // CATA_SRC_MATH_PARSER_H

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1,0 +1,66 @@
+#include "math_parser_diag.h"
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "condition.h"
+#include "dialogue.h"
+#include "math_parser_shim.h"
+#include "mission.h"
+
+namespace
+{
+bool is_beta( char scope )
+{
+    switch( scope ) {
+        case 'n':
+            return true;
+        case 'u':
+        default:
+            return false;
+    }
+}
+} // namespace
+
+std::function<double( dialogue const & )> u_val( char scope,
+        std::vector<std::string> const &params )
+{
+    kwargs_shim const shim( params, scope );
+    try {
+        return conditional_t::get_get_dbl( shim );
+    } catch( std::exception const &e ) {
+        debugmsg( "shim failed: %s", e.what() );
+        return []( dialogue const & ) {
+            return 0;
+        };
+    }
+}
+
+std::function<void( dialogue const &, double )> u_val_ass( char scope,
+        std::vector<std::string> const &params )
+{
+    kwargs_shim const shim( params, scope );
+    try {
+        return conditional_t::get_set_dbl( shim, {}, {}, false );
+    } catch( std::exception const &e ) {
+        debugmsg( "shim failed: %s", e.what() );
+        return []( dialogue const &, double ) {};
+    }
+}
+
+std::function<double( dialogue const & )> pain_eval( char scope,
+        std::vector<std::string> const &/* params */ )
+{
+    return [beta = is_beta( scope )]( dialogue const & d ) {
+        return d.actor( beta )->pain_cur();
+    };
+}
+
+std::function<void( dialogue const &, double )> pain_ass( char scope,
+        std::vector<std::string> const &/* params */ )
+{
+    return [beta = is_beta( scope )]( dialogue const & d, double val ) {
+        d.actor( beta )->set_pain( val );
+    };
+}

--- a/src/math_parser_diag.h
+++ b/src/math_parser_diag.h
@@ -6,79 +6,57 @@
 #include <string_view>
 #include <vector>
 
-template<class D>
+struct dialogue;
 struct dialogue_func {
-    dialogue_func<D>( std::string_view s_, std::string_view sc_, int n_ ) : symbol( s_ ),
+    dialogue_func( std::string_view s_, std::string_view sc_, int n_ ) : symbol( s_ ),
         scopes( sc_ ), num_params( n_ ) {}
     std::string_view symbol;
     std::string_view scopes;
     int num_params{};
 };
 
-template <class D>
-struct dialogue_func_eval : dialogue_func<D> {
-    using f_t = std::function<double( D const & )> ( * )( char scope,
+struct dialogue_func_eval : dialogue_func {
+    using f_t = std::function<double( dialogue const & )> ( * )( char scope,
                 std::vector<std::string> const & );
 
-    dialogue_func_eval<D>( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
-        : dialogue_func<D>( s_, sc_, n_ ), f( f_ ) {}
+    dialogue_func_eval( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
+        : dialogue_func( s_, sc_, n_ ), f( f_ ) {}
 
     f_t f;
 };
 
-template <class D>
-struct dialogue_func_ass : dialogue_func<D> {
-    using f_t = std::function<void( D const &, double )> ( * )( char scope,
+struct dialogue_func_ass : dialogue_func {
+    using f_t = std::function<void( dialogue const &, double )> ( * )( char scope,
                 std::vector<std::string> const & );
 
-    dialogue_func_ass<D>( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
-        : dialogue_func<D>( s_, sc_, n_ ), f( f_ ) {}
+    dialogue_func_ass( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
+        : dialogue_func( s_, sc_, n_ ), f( f_ ) {}
 
     f_t f;
 };
 
-template<class D>
-using pdiag_func_eval = dialogue_func_eval<D> const *;
-template<class D>
-using pdiag_func_ass = dialogue_func_ass<D> const *;
+using pdiag_func_eval = dialogue_func_eval const *;
+using pdiag_func_ass = dialogue_func_ass const *;
 
-bool is_beta( char scope );
-
-template<class D>
-std::function<double( D const & )> u_val( char scope,
+std::function<double( dialogue const & )> u_val( char scope,
         std::vector<std::string> const &params );
-template<class D>
-std::function<void( D const &, double )> u_val_ass( char scope,
+std::function<void( dialogue const &, double )> u_val_ass( char scope,
         std::vector<std::string> const &params );
 
-template<class D>
-std::function<double( D const & )> pain_eval( char scope,
-        std::vector<std::string> const &/* params */ )
-{
-    return [beta = is_beta( scope )]( D const & d ) {
-        return d.actor( beta )->pain_cur();
-    };
-}
+std::function<double( dialogue const & )> pain_eval( char scope,
+        std::vector<std::string> const &/* params */ );
 
-template<class D>
-std::function<void( D const &, double )> pain_ass( char scope,
-        std::vector<std::string> const &/* params */ )
-{
-    return [beta = is_beta( scope )]( D const & d, double val ) {
-        d.actor( beta )->set_pain( val );
-    };
-}
+std::function<void( dialogue const &, double )> pain_ass( char scope,
+        std::vector<std::string> const &/* params */ );
 
-template<class D>
-inline std::array<dialogue_func_eval<D>, 2> const dialogue_eval_f{
-    dialogue_func_eval{ "val", "un", -1, u_val<D> },
-    dialogue_func_eval{ "pain", "un", 0, pain_eval<D> },
+inline std::array<dialogue_func_eval, 2> const dialogue_eval_f{
+    dialogue_func_eval{ "val", "un", -1, u_val },
+    dialogue_func_eval{ "pain", "un", 0, pain_eval },
 };
 
-template<class D>
-inline std::array<dialogue_func_ass<D>, 2> const dialogue_assign_f{
-    dialogue_func_ass{ "val", "un", -1, u_val_ass<D> },
-    dialogue_func_ass{ "pain", "un", 0, pain_ass<D> },
+inline std::array<dialogue_func_ass, 2> const dialogue_assign_f{
+    dialogue_func_ass{ "val", "un", -1, u_val_ass },
+    dialogue_func_ass{ "pain", "un", 0, pain_ass },
 };
 
 #endif // CATA_SRC_MATH_PARSER_DIAG_H

--- a/src/math_parser_func.cpp
+++ b/src/math_parser_func.cpp
@@ -78,10 +78,5 @@ std::function<void( D const &, double )> u_val_ass( char scope,
 template std::function<double( dialogue const & )>
 u_val<dialogue>( char scope,
                  std::vector<std::string> const &params );
-template std::function<double( mission_goal_condition_context const & )>
-u_val<mission_goal_condition_context>( char scope,
-                                       std::vector<std::string> const &params );
 template std::function<void( dialogue const &, double )>
-u_val_ass( char, std::vector<std::string> const & );
-template std::function<void( mission_goal_condition_context const &, double )>
 u_val_ass( char, std::vector<std::string> const & );

--- a/src/math_parser_func.cpp
+++ b/src/math_parser_func.cpp
@@ -4,12 +4,6 @@
 #include <string_view>
 #include <vector>
 
-#include "condition.h"
-#include "dialogue.h"
-#include "math_parser_diag.h"
-#include "math_parser_shim.h"
-#include "mission.h"
-
 std::vector<std::string_view> tokenize( std::string_view str, std::string_view separators,
                                         bool include_seps )
 {
@@ -35,48 +29,3 @@ std::vector<std::string_view> tokenize( std::string_view str, std::string_view s
     }
     return ret;
 }
-
-bool is_beta( char scope )
-{
-    switch( scope ) {
-        case 'n':
-            return true;
-        case 'u':
-        default:
-            return false;
-    }
-}
-
-template<class D>
-std::function<double( D const & )> u_val( char scope,
-        std::vector<std::string> const &params )
-{
-    kwargs_shim const shim( params, scope );
-    try {
-        return conditional_t<D>::get_get_dbl( shim );
-    } catch( std::exception const &e ) {
-        debugmsg( "shim failed: %s", e.what() );
-        return []( D const & ) {
-            return 0;
-        };
-    }
-}
-
-template<class D>
-std::function<void( D const &, double )> u_val_ass( char scope,
-        std::vector<std::string> const &params )
-{
-    kwargs_shim const shim( params, scope );
-    try {
-        return conditional_t<D>::get_set_dbl( shim, {}, {}, false );
-    } catch( std::exception const &e ) {
-        debugmsg( "shim failed: %s", e.what() );
-        return []( D const &, double ) {};
-    }
-}
-
-template std::function<double( dialogue const & )>
-u_val<dialogue>( char scope,
-                 std::vector<std::string> const &params );
-template std::function<void( dialogue const &, double )>
-u_val_ass( char, std::vector<std::string> const & );

--- a/src/mission.h
+++ b/src/mission.h
@@ -177,20 +177,6 @@ bool set_update_mapgen( const JsonObject &jo,
 bool load_funcs( const JsonObject &jo, std::vector<std::function<void( mission *miss )>> &funcs );
 } // namespace mission_util
 
-struct mission_goal_condition_context {
-    mission_goal_condition_context() = default;
-    std::unique_ptr<talker> alpha;
-    std::unique_ptr<talker> beta;
-    bool has_alpha = false;
-    bool has_beta = false;
-    std::vector<mission *> missions_assigned;
-    mutable std::string reason;
-    bool by_radio = false;
-    talker *actor( const bool is_beta ) const {
-        return ( is_beta ? beta : alpha ).get();
-    }
-};
-
 struct mission_type {
     public:
         // Matches it to a mission_type_id above
@@ -244,7 +230,7 @@ struct mission_type {
         std::map<std::string, translation> dialogue;
 
         // A dynamic goal condition invoked by MGOAL_CONDITION.
-        std::function<bool( const mission_goal_condition_context & )> goal_condition;
+        std::function<bool( const struct dialogue & )> goal_condition;
 
         mission_type() = default;
 
@@ -269,7 +255,7 @@ struct mission_type {
          */
         static const std::vector<mission_type> &get_all();
 
-        bool test_goal_condition( const mission_goal_condition_context &d ) const;
+        bool test_goal_condition( const struct dialogue &d ) const;
 
         static void reset();
         static void load_mission_type( const JsonObject &jo, const std::string &src );

--- a/src/mission.h
+++ b/src/mission.h
@@ -125,26 +125,25 @@ struct mission_fail {
     static void standard( mission * ) {}
 };
 
-template<class T>
 struct mission_target_params {
-    str_or_var<T> overmap_terrain;
+    str_or_var overmap_terrain;
     ot_match_type overmap_terrain_match_type = ot_match_type::type;
     mission *mission_pointer = nullptr;
 
     bool origin_u = true;
     std::optional<tripoint_rel_omt> offset;
-    std::optional<str_or_var<T>> replaceable_overmap_terrain;
-    std::optional<str_or_var<T>> overmap_special;
-    std::optional<dbl_or_var<T>> reveal_radius;
+    std::optional<str_or_var> replaceable_overmap_terrain;
+    std::optional<str_or_var> overmap_special;
+    std::optional<dbl_or_var> reveal_radius;
     std::optional<var_info> target_var;
-    dbl_or_var<T> min_distance;
+    dbl_or_var min_distance;
 
     bool must_see = false;
     bool cant_see = false;
     bool random = false;
     bool create_if_necessary = true;
-    dbl_or_var<T> search_range;
-    std::optional<dbl_or_var<T>> z;
+    dbl_or_var search_range;
+    std::optional<dbl_or_var> z;
     npc *guy = nullptr;
 };
 
@@ -166,10 +165,10 @@ void set_reveal( const std::string &terrain,
                  std::vector<std::function<void( mission *miss )>> &funcs );
 void set_reveal_any( const JsonArray &ja,
                      std::vector<std::function<void( mission *miss )>> &funcs );
-mission_target_params<dialogue> parse_mission_om_target( const JsonObject &jo );
-std::optional<tripoint_abs_omt> assign_mission_target( const mission_target_params<dialogue>
+mission_target_params parse_mission_om_target( const JsonObject &jo );
+std::optional<tripoint_abs_omt> assign_mission_target( const mission_target_params
         &params );
-tripoint_abs_omt get_om_terrain_pos( const mission_target_params<dialogue> &params );
+tripoint_abs_omt get_om_terrain_pos( const mission_target_params &params );
 void set_assign_om_target( const JsonObject &jo,
                            std::vector<std::function<void( mission *miss )>> &funcs );
 bool set_update_mapgen( const JsonObject &jo,

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -294,21 +294,21 @@ void mission_start::place_book( mission * )
 
 void mission_start::reveal_refugee_center( mission *miss )
 {
-    mission_target_params<dialogue> t;
-    str_or_var<dialogue> overmap_terrain;
+    mission_target_params t;
+    str_or_var overmap_terrain;
     overmap_terrain.str_val = "refctr_S3e";
     t.overmap_terrain = overmap_terrain;
-    str_or_var<dialogue> overmap_special;
+    str_or_var overmap_special;
     overmap_special.str_val = "evac_center";
     t.overmap_special = overmap_special;
     t.mission_pointer = miss;
-    dbl_or_var<dialogue> search_range;
+    dbl_or_var search_range;
     search_range.min.dbl_val = 0;
     t.search_range = search_range;
-    dbl_or_var<dialogue> reveal_radius;
+    dbl_or_var reveal_radius;
     reveal_radius.min.dbl_val = 1;
     t.reveal_radius = reveal_radius;
-    dbl_or_var<dialogue> min_distance;
+    dbl_or_var min_distance;
     min_distance.min.dbl_val = 0;
     t.min_distance = min_distance;
 
@@ -326,10 +326,10 @@ void mission_start::reveal_refugee_center( mission *miss )
 
     if( overmap_buffer.reveal_route( source_road, dest_road, 1, true ) ) {
         //reset the mission target to the refugee center entrance and reveal path from the road
-        str_or_var<dialogue> overmap_terrain;
+        str_or_var overmap_terrain;
         overmap_terrain.str_val = "refctr_S3e";
         t.overmap_terrain = overmap_terrain;
-        dbl_or_var<dialogue> reveal_radius;
+        dbl_or_var reveal_radius;
         reveal_radius.min.dbl_val = 3;
         t.reveal_radius = reveal_radius;
         target_pos = mission_util::assign_mission_target( t );

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -402,7 +402,7 @@ void mission_type::load( const JsonObject &jo, const std::string &src )
     assign( jo, "destination", target_id, strict );
 
     if( jo.has_member( "goal_condition" ) ) {
-        read_condition<struct dialogue>( jo, "goal_condition", goal_condition, true );
+        read_condition( jo, "goal_condition", goal_condition, true );
     }
 
     optional( jo, was_loaded, "invisible_on_complete", invisible_on_complete, false );

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -402,13 +402,13 @@ void mission_type::load( const JsonObject &jo, const std::string &src )
     assign( jo, "destination", target_id, strict );
 
     if( jo.has_member( "goal_condition" ) ) {
-        read_condition<mission_goal_condition_context>( jo, "goal_condition", goal_condition, true );
+        read_condition<struct dialogue>( jo, "goal_condition", goal_condition, true );
     }
 
     optional( jo, was_loaded, "invisible_on_complete", invisible_on_complete, false );
 }
 
-bool mission_type::test_goal_condition( const mission_goal_condition_context &d ) const
+bool mission_type::test_goal_condition( const struct dialogue &d ) const
 {
     if( goal_condition ) {
         return goal_condition( d );

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -240,7 +240,7 @@ bool mut_transform::load( const JsonObject &jsobj, const std::string &member )
 
 void reflex_activation_data::load( const JsonObject &jsobj )
 {
-    read_condition<dialogue>( jsobj, "condition", trigger, false );
+    read_condition( jsobj, "condition", trigger, false );
     if( jsobj.has_object( "msg_on" ) ) {
         JsonObject jo = jsobj.get_object( "msg_on" );
         optional( jo, was_loaded, "text", msg_on.first );

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -263,7 +263,7 @@ void shopkeeper_item_group::deserialize( const JsonObject &jo )
     optional( jo, false, "rigid", rigid, false );
     optional( jo, false, "refusal", refusal );
     if( jo.has_member( "condition" ) ) {
-        read_condition<dialogue>( jo, "condition", condition, false );
+        read_condition( jo, "condition", condition, false );
     }
 }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2051,9 +2051,9 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
     actor( true )->store_chosen_training( chosen.skill, chosen.style, chosen.dialogue_spell,
                                           chosen.proficiency );
     const bool success = chosen.trial.roll( *this );
-    const auto &effects = success ? chosen.success : chosen.failure;
+    talk_effect_t const &effects = success ? chosen.success : chosen.failure;
     talk_topic ret_topic =  effects.apply( *this );
-    effects.update_missions( *this );
+    talk_effect_t::update_missions( *this );
     return ret_topic;
 }
 
@@ -2114,7 +2114,7 @@ talk_trial::talk_trial( const JsonObject &jo )
         jo.throw_error_at( "type", "invalid talk trial type" );
     }
     type = iter->second;
-    if( !( type == TALK_TRIAL_NONE || type == TALK_TRIAL_CONDITION ) ) {
+    if( type != TALK_TRIAL_NONE && type != TALK_TRIAL_CONDITION ) {
         difficulty = jo.get_int( "difficulty" );
     }
     if( type == TALK_TRIAL_SKILL_CHECK ) {
@@ -4143,7 +4143,7 @@ void talk_effect_fun_t::set_spawn_npc( const JsonObject &jo, const std::string &
         std::string cur_unique_id = unique_id.evaluate( d );
         std::vector<trait_id> cur_traits( traits.size() );
         for( const str_or_var &cur_trait : traits ) {
-            cur_traits.emplace_back( trait_id( cur_trait.evaluate( d ) ) );
+            cur_traits.emplace_back( cur_trait.evaluate( d ) );
         }
         std::optional<time_duration> lifespan;
         tripoint target_pos = d.actor( is_npc )->pos();

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -130,6 +130,23 @@ static bool friendly_teacher( const Character &student, const Character &teacher
            ( teacher.is_npc() && teacher.as_npc()->is_player_ally() );
 }
 
+namespace
+{
+dialogue copy_dialogue( dialogue const &d )
+{
+    Creature *creature_alpha = d.has_alpha ? d.actor( false )->get_creature() : nullptr;
+    item_location *item_alpha = d.has_alpha ? d.actor( false )->get_item() : nullptr;
+    Creature *creature_beta = d.has_beta ? d.actor( true )->get_creature() : nullptr;
+    item_location *item_beta = d.has_beta ? d.actor( true )->get_item() : nullptr;
+    return {
+        creature_alpha ? get_talker_for( creature_alpha ) : item_alpha ? get_talker_for(
+            item_alpha ) : nullptr,
+        creature_beta ? get_talker_for( creature_beta ) : item_beta ? get_talker_for(
+            item_beta ) : nullptr
+    };
+}
+} // namespace
+
 std::string talk_trial::name() const
 {
     static const std::array<std::string, NUM_TALK_TRIALS> texts = { {
@@ -1871,8 +1888,7 @@ std::set<dialogue_consequence> talk_response::get_consequences( const dialogue &
     return {{ success.get_consequence( d ), failure.get_consequence( d ) }};
 }
 
-template<class T>
-dialogue_consequence talk_effect_t<T>::get_consequence( const T &d ) const
+dialogue_consequence talk_effect_t::get_consequence( dialogue const &d ) const
 {
     if( d.actor( true )->check_hostile_response( opinion.anger ) ) {
         return dialogue_consequence::hostile;
@@ -2105,7 +2121,7 @@ talk_trial::talk_trial( const JsonObject &jo )
         skill_required = jo.get_string( "skill_required" );
     }
 
-    read_condition<dialogue>( jo, "condition", condition, false );
+    read_condition( jo, "condition", condition, false );
 
     if( jo.has_member( "mod" ) ) {
         for( JsonArray jmod : jo.get_array( "mod" ) ) {
@@ -2124,74 +2140,69 @@ static talk_topic load_inline_topic( const JsonObject &jo )
     return talk_topic( id );
 }
 
-template<class T>
-talk_effect_fun_t<T>::talk_effect_fun_t( const talkfunction_ptr &ptr )
+talk_effect_fun_t::talk_effect_fun_t( const talkfunction_ptr &ptr )
 {
-    function = [ptr]( const T & d ) {
+    function = [ptr]( dialogue const & d ) {
         if( d.actor( true )->get_npc() ) {
             ptr( *d.actor( true )->get_npc() );
         }
     };
 }
 
-template<class T>
-talk_effect_fun_t<T>::talk_effect_fun_t( const std::function<void( npc &p )> &ptr )
+talk_effect_fun_t::talk_effect_fun_t( const std::function<void( npc &p )> &ptr )
 {
-    function = [ptr]( const T & d ) {
+    function = [ptr]( dialogue const & d ) {
         if( d.actor( true )->get_npc() ) {
             ptr( *d.actor( true )->get_npc() );
         }
     };
 }
 
-template<class T>
-talk_effect_fun_t<T>::talk_effect_fun_t( const std::function<void( const T &d )> &fun )
+talk_effect_fun_t::talk_effect_fun_t( const std::function<void( dialogue const &d )> &fun )
 {
-    function = [fun]( const T & d ) {
+    function = [fun]( dialogue const & d ) {
         fun( d );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_companion_mission( const std::string &role_id )
+void talk_effect_fun_t::set_companion_mission( const std::string &role_id )
 {
-    function = [role_id]( const T & d ) {
+    function = [role_id]( dialogue const & d ) {
         d.actor( true )->set_companion_mission( role_id );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_add_effect( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void talk_effect_fun_t::set_add_effect( const JsonObject &jo, const std::string &member,
+                                        bool is_npc )
 {
-    str_or_var<T> new_effect = get_str_or_var<T>( jo.get_member( member ), member, true );
+    str_or_var new_effect = get_str_or_var( jo.get_member( member ), member, true );
     bool permanent = false;
     bool force = false;
-    duration_or_var<T> dov_duration;
-    dbl_or_var<T> dov_intensity;
+    duration_or_var dov_duration;
+    dbl_or_var dov_intensity;
     if( jo.has_string( "duration" ) ) {
         const std::string dur_string = jo.get_string( "duration" );
         if( dur_string == "PERMANENT" ) {
             permanent = true;
-            dov_duration = get_duration_or_var<T>( jo, "", false, 1_turns );
+            dov_duration = get_duration_or_var( jo, "", false, 1_turns );
         } else {
-            dov_duration = get_duration_or_var<T>( jo, "duration", false, 1000_turns );
+            dov_duration = get_duration_or_var( jo, "duration", false, 1000_turns );
         }
     } else {
-        dov_duration = get_duration_or_var<T>( jo, "duration", true );
+        dov_duration = get_duration_or_var( jo, "duration", true );
     }
-    dov_intensity = get_dbl_or_var<T>( jo, "intensity", false, 0 );
+    dov_intensity = get_dbl_or_var( jo, "intensity", false, 0 );
     if( jo.has_bool( "force" ) ) {
         force = jo.get_bool( "force" );
     }
-    str_or_var<T> target;
+    str_or_var target;
     if( jo.has_member( "target_part" ) ) {
-        target = get_str_or_var<T>( jo.get_member( "target_part" ), "target_part", false, "bp_null" );
+        target = get_str_or_var( jo.get_member( "target_part" ), "target_part", false, "bp_null" );
     } else {
         target.str_val = "bp_null";
     }
     function = [is_npc, new_effect, dov_duration, target, permanent, force,
-            dov_intensity]( const T & d ) {
+            dov_intensity]( dialogue const & d ) {
         d.actor( is_npc )->add_effect( efftype_id( new_effect.evaluate( d ) ),
                                        dov_duration.evaluate( d ),
                                        target.evaluate( d ), permanent, force,
@@ -2199,104 +2210,94 @@ void talk_effect_fun_t<T>::set_add_effect( const JsonObject &jo, const std::stri
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_remove_effect( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_remove_effect( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> old_effect = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [is_npc, old_effect]( const T & d ) {
+    str_or_var old_effect = get_str_or_var( jo.get_member( member ), member, true );
+    function = [is_npc, old_effect]( dialogue const & d ) {
         d.actor( is_npc )->remove_effect( efftype_id( old_effect.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_add_trait( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void talk_effect_fun_t::set_add_trait( const JsonObject &jo, const std::string &member,
+                                       bool is_npc )
 {
-    str_or_var<T> new_trait = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [is_npc, new_trait]( const T & d ) {
+    str_or_var new_trait = get_str_or_var( jo.get_member( member ), member, true );
+    function = [is_npc, new_trait]( dialogue const & d ) {
         d.actor( is_npc )->set_mutation( trait_id( new_trait.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_remove_trait( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_remove_trait( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> old_trait = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [is_npc, old_trait]( const T & d ) {
+    str_or_var old_trait = get_str_or_var( jo.get_member( member ), member, true );
+    function = [is_npc, old_trait]( dialogue const & d ) {
         d.actor( is_npc )->unset_mutation( trait_id( old_trait.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_learn_martial_art( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_learn_martial_art( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> ma_to_learn = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [is_npc, ma_to_learn]( const T & d ) {
+    str_or_var ma_to_learn = get_str_or_var( jo.get_member( member ), member, true );
+    function = [is_npc, ma_to_learn]( dialogue const & d ) {
         d.actor( is_npc )->learn_martial_art( matype_id( ma_to_learn.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_forget_martial_art( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_forget_martial_art( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> ma_to_forget = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [is_npc, ma_to_forget]( const T & d ) {
+    str_or_var ma_to_forget = get_str_or_var( jo.get_member( member ), member, true );
+    function = [is_npc, ma_to_forget]( dialogue const & d ) {
         d.actor( is_npc )->forget_martial_art( matype_id( ma_to_forget.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_mutate( const JsonObject &jo, const std::string &member,
-                                       bool is_npc )
+void talk_effect_fun_t::set_mutate( const JsonObject &jo, const std::string &member,
+                                    bool is_npc )
 {
-    dbl_or_var<T> highest_cat = get_dbl_or_var<T>( jo, member, true, 0 );
+    dbl_or_var highest_cat = get_dbl_or_var( jo, member, true, 0 );
     const bool use_vitamins = jo.get_bool( "use_vitamins", true );
-    function = [is_npc, highest_cat, use_vitamins]( const T & d ) {
+    function = [is_npc, highest_cat, use_vitamins]( dialogue const & d ) {
         d.actor( is_npc )->mutate( highest_cat.evaluate( d ), use_vitamins );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_mutate_category( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_mutate_category( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> mut_cat = get_str_or_var<T>( jo.get_member( member ), member, true, "" );
+    str_or_var mut_cat = get_str_or_var( jo.get_member( member ), member, true, "" );
     const bool use_vitamins = jo.get_bool( "use_vitamins", true );
-    function = [is_npc, mut_cat, use_vitamins]( const T & d ) {
+    function = [is_npc, mut_cat, use_vitamins]( dialogue const & d ) {
         d.actor( is_npc )->mutate_category( mutation_category_id( mut_cat.evaluate( d ) ), use_vitamins );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_add_bionic( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void talk_effect_fun_t::set_add_bionic( const JsonObject &jo, const std::string &member,
+                                        bool is_npc )
 {
-    str_or_var<T> new_bionic = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [is_npc, new_bionic]( const T & d ) {
+    str_or_var new_bionic = get_str_or_var( jo.get_member( member ), member, true );
+    function = [is_npc, new_bionic]( dialogue const & d ) {
         d.actor( is_npc )->add_bionic( bionic_id( new_bionic.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_lose_bionic( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_lose_bionic( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> old_bionic = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [is_npc, old_bionic]( const T & d ) {
+    str_or_var old_bionic = get_str_or_var( jo.get_member( member ), member, true );
+    function = [is_npc, old_bionic]( dialogue const & d ) {
         d.actor( is_npc )->remove_bionic( bionic_id( old_bionic.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_add_var( const JsonObject &jo, const std::string &member,
-                                        bool is_npc )
+void talk_effect_fun_t::set_add_var( const JsonObject &jo, const std::string &member,
+                                     bool is_npc )
 {
-    dbl_or_var<dialogue> empty;
-    const std::string var_name = get_talk_varname<dialogue>( jo, member, false, empty );
+    dbl_or_var empty;
+    const std::string var_name = get_talk_varname( jo, member, false, empty );
     const std::string var_base_name = get_talk_var_basename( jo, member, false );
     const bool time_check = jo.has_member( "time" ) && jo.get_bool( "time" );
     std::vector<std::string> possible_values = jo.get_string_array( "possible_values" );
@@ -2304,7 +2305,7 @@ void talk_effect_fun_t<T>::set_add_var( const JsonObject &jo, const std::string 
         const std::string value = time_check ? "" : jo.get_string( "value" );
         possible_values.push_back( value );
     }
-    function = [is_npc, var_name, possible_values, time_check, var_base_name]( const T & d ) {
+    function = [is_npc, var_name, possible_values, time_check, var_base_name]( dialogue const & d ) {
         talker *actor = d.actor( is_npc );
         if( time_check ) {
             actor->set_value( var_name, string_format( "%d", to_turn<int>( calendar::turn ) ) );
@@ -2316,26 +2317,24 @@ void talk_effect_fun_t<T>::set_add_var( const JsonObject &jo, const std::string 
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_remove_var( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void talk_effect_fun_t::set_remove_var( const JsonObject &jo, const std::string &member,
+                                        bool is_npc )
 {
-    dbl_or_var<dialogue> empty;
-    const std::string var_name = get_talk_varname<dialogue>( jo, member, false, empty );
-    function = [is_npc, var_name]( const T & d ) {
+    dbl_or_var empty;
+    const std::string var_name = get_talk_varname( jo, member, false, empty );
+    function = [is_npc, var_name]( dialogue const & d ) {
         d.actor( is_npc )->remove_value( var_name );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_adjust_var( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void talk_effect_fun_t::set_adjust_var( const JsonObject &jo, const std::string &member,
+                                        bool is_npc )
 {
-    dbl_or_var<dialogue> empty;
-    const std::string var_name = get_talk_varname<dialogue>( jo, member, false, empty );
+    dbl_or_var empty;
+    const std::string var_name = get_talk_varname( jo, member, false, empty );
     const std::string var_base_name = get_talk_var_basename( jo, member, false );
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, "adjustment" );
-    function = [is_npc, var_base_name, var_name, dov]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, "adjustment" );
+    function = [is_npc, var_base_name, var_name, dov]( dialogue const & d ) {
         int adjusted_value = dov.evaluate( d );
 
         const std::string &var = d.actor( is_npc )->get_value( var_name );
@@ -2392,25 +2391,25 @@ static void receive_item( itype_id &item_name, int count, const std::string &con
     }
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_u_spawn_item( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_u_spawn_item( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> item_name = get_str_or_var<T>( jo.get_member( member ), member, true );
-    str_or_var<T> container_name;
+    str_or_var item_name = get_str_or_var( jo.get_member( member ), member, true );
+    str_or_var container_name;
     if( jo.has_member( "container" ) ) {
-        container_name = get_str_or_var<T>( jo.get_member( "container" ), "container", true );
+        container_name = get_str_or_var( jo.get_member( "container" ), "container", true );
     } else {
         container_name.str_val = "";
     }
     bool use_item_group = jo.get_bool( "use_item_group", false );
     bool suppress_message = jo.get_bool( "suppress_message", false );
-    dbl_or_var<T> count;
+    dbl_or_var count;
     if( !jo.has_int( "charges" ) ) {
-        count = get_dbl_or_var<T>( jo, "count", false, 1 );
+        count = get_dbl_or_var( jo, "count", false, 1 );
     } else {
-        count = get_dbl_or_var<T>( jo, "count", false, 0 );
+        count = get_dbl_or_var( jo, "count", false, 0 );
     }
-    function = [item_name, count, container_name, use_item_group, suppress_message]( const T & d ) {
+    function = [item_name, count, container_name, use_item_group,
+               suppress_message]( dialogue const & d ) {
         itype_id iname = itype_id( item_name.evaluate( d ) );
         receive_item( iname, count.evaluate( d ),
                       container_name.evaluate( d ), d, use_item_group, suppress_message );
@@ -2420,30 +2419,29 @@ void talk_effect_fun_t<T>::set_u_spawn_item( const JsonObject &jo, const std::st
                                  itype_id( item_name.evaluate( d ) ) );
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_u_buy_item( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_u_buy_item( const JsonObject &jo, const std::string &member )
 {
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
-    dbl_or_var<T> cost = get_dbl_or_var<T>( jo, "cost", false, 0 );
-    dbl_or_var<T> count;
+    dbl_or_var cost = get_dbl_or_var( jo, "cost", false, 0 );
+    dbl_or_var count;
     if( !jo.has_int( "charges" ) ) {
-        count = get_dbl_or_var<T>( jo, "count", false, 1 );
+        count = get_dbl_or_var( jo, "count", false, 1 );
     } else {
-        count = get_dbl_or_var<T>( jo, "count", false, 0 );
+        count = get_dbl_or_var( jo, "count", false, 0 );
     }
     bool use_item_group = jo.get_bool( "use_item_group", false );
     bool suppress_message = jo.get_bool( "suppress_message", false );
-    str_or_var<T> container_name;
+    str_or_var container_name;
     if( jo.has_member( "container" ) ) {
-        container_name = get_str_or_var<T>( jo.get_member( "container" ), "container", true );
+        container_name = get_str_or_var( jo.get_member( "container" ), "container", true );
     } else {
         container_name.str_val = "";
     }
 
-    str_or_var<T> item_name = get_str_or_var<T>( jo.get_member( member ), member, true );
+    str_or_var item_name = get_str_or_var( jo.get_member( member ), member, true );
     function = [item_name, cost, count, container_name, true_eocs, false_eocs,
-               use_item_group, suppress_message]( const T & d ) {
+               use_item_group, suppress_message]( dialogue const & d ) {
         if( !d.actor( true )->buy_from( cost.evaluate( d ) ) ) {
             popup( _( "You can't afford it!" ) );
             run_eoc_vector( false_eocs, d );
@@ -2456,20 +2454,19 @@ void talk_effect_fun_t<T>::set_u_buy_item( const JsonObject &jo, const std::stri
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_u_sell_item( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_u_sell_item( const JsonObject &jo, const std::string &member )
 {
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
-    dbl_or_var<T> cost = get_dbl_or_var<T>( jo, "cost", false, 0 );
-    dbl_or_var<T> count;
+    dbl_or_var cost = get_dbl_or_var( jo, "cost", false, 0 );
+    dbl_or_var count;
     if( !jo.has_int( "charges" ) ) {
-        count = get_dbl_or_var<T>( jo, "count", false, 1 );
+        count = get_dbl_or_var( jo, "count", false, 1 );
     } else {
-        count = get_dbl_or_var<T>( jo, "count", false, 0 );
+        count = get_dbl_or_var( jo, "count", false, 0 );
     }
-    str_or_var<T> item_name = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [item_name, cost, count, true_eocs, false_eocs]( const T & d ) {
+    str_or_var item_name = get_str_or_var( jo.get_member( member ), member, true );
+    function = [item_name, cost, count, true_eocs, false_eocs]( dialogue const & d ) {
         int current_count = count.evaluate( d );
         itype_id current_item_name = itype_id( item_name.evaluate( d ) );
         if( item::count_by_charges( current_item_name ) &&
@@ -2501,20 +2498,19 @@ void talk_effect_fun_t<T>::set_u_sell_item( const JsonObject &jo, const std::str
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_consume_item( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_consume_item( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> item_name = get_str_or_var<T>( jo.get_member( member ), member, true );
-    dbl_or_var<T> charges = get_dbl_or_var<T>( jo, "charges", false, 0 );
-    dbl_or_var<T> count;
+    str_or_var item_name = get_str_or_var( jo.get_member( member ), member, true );
+    dbl_or_var charges = get_dbl_or_var( jo, "charges", false, 0 );
+    dbl_or_var count;
     if( !jo.has_int( "charges" ) ) {
-        count = get_dbl_or_var<T>( jo, "count", false, 1 );
+        count = get_dbl_or_var( jo, "count", false, 1 );
     } else {
-        count = get_dbl_or_var<T>( jo, "count", false, 0 );
+        count = get_dbl_or_var( jo, "count", false, 0 );
     }
     const bool do_popup = jo.get_bool( "popup", false );
-    function = [do_popup, is_npc, item_name, count, charges]( const T & d ) {
+    function = [do_popup, is_npc, item_name, count, charges]( dialogue const & d ) {
         // this is stupid, but I couldn't get the assignment to work
         int current_count = count.evaluate( d );
         int current_charges = charges.evaluate( d );
@@ -2557,12 +2553,11 @@ void talk_effect_fun_t<T>::set_consume_item( const JsonObject &jo, const std::st
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_remove_item_with( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_remove_item_with( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> item_name = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [is_npc, item_name]( const T & d ) {
+    str_or_var item_name = get_str_or_var( jo.get_member( member ), member, true );
+    function = [is_npc, item_name]( dialogue const & d ) {
         itype_id item_id = itype_id( item_name.evaluate( d ) );
         d.actor( is_npc )->remove_items_with( [item_id]( const item & it ) {
             return it.typeId() == item_id;
@@ -2570,13 +2565,12 @@ void talk_effect_fun_t<T>::set_remove_item_with( const JsonObject &jo, const std
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_u_spend_cash( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_u_spend_cash( const JsonObject &jo, const std::string &member )
 {
-    dbl_or_var<T> amount = get_dbl_or_var<T>( jo, member );
+    dbl_or_var amount = get_dbl_or_var( jo, member );
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
-    function = [amount, true_eocs, false_eocs]( const T & d ) {
+    function = [amount, true_eocs, false_eocs]( dialogue const & d ) {
         if( d.actor( true )->buy_from( amount.evaluate( d ) ) ) {
             run_eoc_vector( true_eocs, d );
         } else {
@@ -2585,37 +2579,33 @@ void talk_effect_fun_t<T>::set_u_spend_cash( const JsonObject &jo, const std::st
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_npc_change_faction( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_npc_change_faction( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> faction_name = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [faction_name]( const T & d ) {
+    str_or_var faction_name = get_str_or_var( jo.get_member( member ), member, true );
+    function = [faction_name]( dialogue const & d ) {
         d.actor( true )->set_fac( faction_id( faction_name.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_npc_change_class( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_npc_change_class( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> class_name = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [class_name]( const T & d ) {
+    str_or_var class_name = get_str_or_var( jo.get_member( member ), member, true );
+    function = [class_name]( dialogue const & d ) {
         d.actor( true )->set_class( npc_class_id( class_name.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_change_faction_rep( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_change_faction_rep( const JsonObject &jo, const std::string &member )
 {
-    dbl_or_var<T> rep_change = get_dbl_or_var<T>( jo, member );
-    function = [rep_change]( const T & d ) {
+    dbl_or_var rep_change = get_dbl_or_var( jo, member );
+    function = [rep_change]( dialogue const & d ) {
         d.actor( true )->add_faction_rep( rep_change.evaluate( d ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_add_debt( const std::vector<trial_mod> &debt_modifiers )
+void talk_effect_fun_t::set_add_debt( const std::vector<trial_mod> &debt_modifiers )
 {
-    function = [debt_modifiers]( const T & d ) {
+    function = [debt_modifiers]( dialogue const & d ) {
         int debt = 0;
         for( const trial_mod &this_mod : debt_modifiers ) {
             if( this_mod.first == "TOTAL" ) {
@@ -2628,84 +2618,76 @@ void talk_effect_fun_t<T>::set_add_debt( const std::vector<trial_mod> &debt_modi
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_toggle_npc_rule( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_toggle_npc_rule( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> rule = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [rule]( const T & d ) {
+    str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
+    function = [rule]( dialogue const & d ) {
         d.actor( true )->toggle_ai_rule( "ally_rule", rule.evaluate( d ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_set_npc_rule( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_set_npc_rule( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> rule = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [rule]( const T & d ) {
+    str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
+    function = [rule]( dialogue const & d ) {
         d.actor( true )->set_ai_rule( "ally_rule", rule.evaluate( d ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_clear_npc_rule( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_clear_npc_rule( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> rule = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [rule]( const T & d ) {
+    str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
+    function = [rule]( dialogue const & d ) {
         d.actor( true )->clear_ai_rule( "ally_rule", rule.evaluate( d ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_npc_engagement_rule( const JsonObject &jo,
+void talk_effect_fun_t::set_npc_engagement_rule( const JsonObject &jo,
         const std::string &member )
 {
-    str_or_var<T> rule = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [rule]( const T & d ) {
+    str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
+    function = [rule]( dialogue const & d ) {
         d.actor( true )->set_ai_rule( "engagement_rule", rule.evaluate( d ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_npc_aim_rule( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_npc_aim_rule( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> rule = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [rule]( const T & d ) {
+    str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
+    function = [rule]( dialogue const & d ) {
         d.actor( true )->set_ai_rule( "aim_rule", rule.evaluate( d ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_npc_cbm_reserve_rule( const JsonObject &jo,
+void talk_effect_fun_t::set_npc_cbm_reserve_rule( const JsonObject &jo,
         const std::string &member )
 {
-    str_or_var<T> rule = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [rule]( const T & d ) {
+    str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
+    function = [rule]( dialogue const & d ) {
         d.actor( true )->set_ai_rule( "cbm_reserve_rule", rule.evaluate( d ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_npc_cbm_recharge_rule( const JsonObject &jo,
+void talk_effect_fun_t::set_npc_cbm_recharge_rule( const JsonObject &jo,
         const std::string &member )
 {
-    str_or_var<T> rule = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [rule]( const T & d ) {
+    str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
+    function = [rule]( dialogue const & d ) {
         d.actor( true )->set_ai_rule( "cbm_recharge_rule", rule.evaluate( d ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_location_variable( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_location_variable( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    dbl_or_var<T> dov_min_radius = get_dbl_or_var<T>( jo, "min_radius", false, 0 );
-    dbl_or_var<T> dov_max_radius = get_dbl_or_var<T>( jo, "max_radius", false, 0 );
-    dbl_or_var<T> dov_z_adjust = get_dbl_or_var<T>( jo, "z_adjust", false, 0 );
-    dbl_or_var<T> dov_x_adjust = get_dbl_or_var<T>( jo, "x_adjust", false, 0 );
-    dbl_or_var<T> dov_y_adjust = get_dbl_or_var<T>( jo, "y_adjust", false, 0 );
+    dbl_or_var dov_min_radius = get_dbl_or_var( jo, "min_radius", false, 0 );
+    dbl_or_var dov_max_radius = get_dbl_or_var( jo, "max_radius", false, 0 );
+    dbl_or_var dov_z_adjust = get_dbl_or_var( jo, "z_adjust", false, 0 );
+    dbl_or_var dov_x_adjust = get_dbl_or_var( jo, "x_adjust", false, 0 );
+    dbl_or_var dov_y_adjust = get_dbl_or_var( jo, "y_adjust", false, 0 );
     bool z_override = jo.get_bool( "z_override", false );
     const bool outdoor_only = jo.get_bool( "outdoor_only", false );
-    std::optional<mission_target_params<dialogue>> target_params;
+    std::optional<mission_target_params> target_params;
     if( jo.has_object( "target_params" ) ) {
         JsonObject target_obj = jo.get_object( "target_params" );
         target_params = mission_util::parse_mission_om_target( target_obj );
@@ -2720,7 +2702,7 @@ void talk_effect_fun_t<T>::set_location_variable( const JsonObject &jo, const st
 
     function = [dov_min_radius, dov_max_radius, var_name, outdoor_only, target_params,
                                 is_npc, type, dov_x_adjust, dov_y_adjust, dov_z_adjust, z_override, true_eocs,
-                    false_eocs]( const T & d ) {
+                    false_eocs]( dialogue const & d ) {
         talker *target = d.actor( is_npc );
         tripoint talker_pos = get_map().getabs( target->pos() );
         tripoint target_pos = talker_pos;
@@ -2763,13 +2745,12 @@ void talk_effect_fun_t<T>::set_location_variable( const JsonObject &jo, const st
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_location_variable_adjust( const JsonObject &jo,
+void talk_effect_fun_t::set_location_variable_adjust( const JsonObject &jo,
         const std::string &member )
 {
-    dbl_or_var<T> dov_z_adjust = get_dbl_or_var<T>( jo, "z_adjust", false, 0 );
-    dbl_or_var<T> dov_x_adjust = get_dbl_or_var<T>( jo, "x_adjust", false, 0 );
-    dbl_or_var<T> dov_y_adjust = get_dbl_or_var<T>( jo, "y_adjust", false, 0 );
+    dbl_or_var dov_z_adjust = get_dbl_or_var( jo, "z_adjust", false, 0 );
+    dbl_or_var dov_x_adjust = get_dbl_or_var( jo, "x_adjust", false, 0 );
+    dbl_or_var dov_y_adjust = get_dbl_or_var( jo, "y_adjust", false, 0 );
     bool z_override = jo.get_bool( "z_override", false );
     bool overmap_tile = jo.get_bool( "overmap_tile", false );
 
@@ -2780,7 +2761,7 @@ void talk_effect_fun_t<T>::set_location_variable_adjust( const JsonObject &jo,
         output_var = read_var_info( jo.get_object( "output_var" ) );
     }
     function = [input_var, dov_x_adjust, dov_y_adjust, dov_z_adjust, z_override,
-               output_var, overmap_tile ]( const T & d ) {
+               output_var, overmap_tile ]( dialogue const & d ) {
         tripoint_abs_ms target_pos = get_tripoint_from_var( input_var, d );
 
         if( overmap_tile ) {
@@ -2805,29 +2786,28 @@ void talk_effect_fun_t<T>::set_location_variable_adjust( const JsonObject &jo,
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_transform_radius( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_transform_radius( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> transform = get_str_or_var<T>( jo.get_member( "ter_furn_transform" ),
-                              "ter_furn_transform", true );
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    duration_or_var<T> dov_time_in_future = get_duration_or_var<T>( jo, "time_in_future", false,
-                                            0_seconds );
+    str_or_var transform = get_str_or_var( jo.get_member( "ter_furn_transform" ),
+                                           "ter_furn_transform", true );
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    duration_or_var dov_time_in_future = get_duration_or_var( jo, "time_in_future", false,
+                                         0_seconds );
     std::optional<var_info> target_var;
     if( jo.has_member( "target_var" ) ) {
         target_var = read_var_info( jo.get_object( "target_var" ) );
     }
-    str_or_var<T> key;
+    str_or_var key;
     if( jo.has_member( "key" ) ) {
-        key = get_str_or_var<T>( jo.get_member( "key" ), "key", false, "" );
+        key = get_str_or_var( jo.get_member( "key" ), "key", false, "" );
     } else {
         key.str_val = "";
     }
-    function = [dov, transform, target_var, dov_time_in_future, key, is_npc]( const T & d ) {
+    function = [dov, transform, target_var, dov_time_in_future, key, is_npc]( dialogue const & d ) {
         tripoint_abs_ms target_pos = d.actor( is_npc )->global_pos();
         if( target_var.has_value() ) {
-            target_pos = get_tripoint_from_var<T>( target_var, d );
+            target_pos = get_tripoint_from_var( target_var, d );
         }
 
         int radius = dov.evaluate( d );
@@ -2845,16 +2825,15 @@ void talk_effect_fun_t<T>::set_transform_radius( const JsonObject &jo, const std
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_transform_line( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_transform_line( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> transform = get_str_or_var<T>( jo.get_member( member ), member, true );
+    str_or_var transform = get_str_or_var( jo.get_member( member ), member, true );
     var_info first = read_var_info( jo.get_object( "first" ) );
     var_info second = read_var_info( jo.get_object( "second" ) );
 
-    function = [transform, first, second]( const T & d ) {
-        tripoint_abs_ms const t_first = get_tripoint_from_var<T>( first, d );
-        tripoint_abs_ms const t_second = get_tripoint_from_var<T>( second, d );
+    function = [transform, first, second]( dialogue const & d ) {
+        tripoint_abs_ms const t_first = get_tripoint_from_var( first, d );
+        tripoint_abs_ms const t_second = get_tripoint_from_var( second, d );
         tripoint_abs_ms const orig = coord_min( t_first, t_second );
         map tm;
         tm.load( project_to<coords::sm>( orig ), false );
@@ -2862,18 +2841,17 @@ void talk_effect_fun_t<T>::set_transform_line( const JsonObject &jo, const std::
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_place_override( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_place_override( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> new_place = get_str_or_var<T>( jo.get_member( member ), member );
-    duration_or_var<T> dov_length = get_duration_or_var<T>( jo, "length", true );
-    str_or_var<T> key;
+    str_or_var new_place = get_str_or_var( jo.get_member( member ), member );
+    duration_or_var dov_length = get_duration_or_var( jo, "length", true );
+    str_or_var key;
     if( jo.has_member( "key" ) ) {
-        key = get_str_or_var<T>( jo.get_member( "key" ), "key", false, "" );
+        key = get_str_or_var( jo.get_member( "key" ), "key", false, "" );
     } else {
         key.str_val = "";
     }
-    function = [new_place, dov_length, key]( const T & d ) {
+    function = [new_place, dov_length, key]( dialogue const & d ) {
         get_timed_events().add( timed_event_type::OVERRIDE_PLACE,
                                 calendar::turn + dov_length.evaluate( d ) + 1_seconds,
                                 //Timed events happen before the player turn and eocs are during so we add a second here to sync them up using the same variable
@@ -2881,37 +2859,36 @@ void talk_effect_fun_t<T>::set_place_override( const JsonObject &jo, const std::
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_mapgen_update( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_mapgen_update( const JsonObject &jo, const std::string &member )
 {
-    mission_target_params<dialogue> target_params = mission_util::parse_mission_om_target( jo );
-    std::vector<str_or_var<T>> update_ids;
-    duration_or_var<T> dov_time_in_future = get_duration_or_var<T>( jo, "time_in_future", false,
-                                            0_seconds );
+    mission_target_params target_params = mission_util::parse_mission_om_target( jo );
+    std::vector<str_or_var> update_ids;
+    duration_or_var dov_time_in_future = get_duration_or_var( jo, "time_in_future", false,
+                                         0_seconds );
     if( jo.has_string( member ) ) {
-        update_ids.emplace_back( get_str_or_var<T>( jo.get_member( member ), member ) );
+        update_ids.emplace_back( get_str_or_var( jo.get_member( member ), member ) );
     } else if( jo.has_array( member ) ) {
         for( JsonValue jv : jo.get_array( member ) ) {
-            update_ids.emplace_back( get_str_or_var<T>( jv, member ) );
+            update_ids.emplace_back( get_str_or_var( jv, member ) );
         }
     }
     std::optional<var_info> target_var;
     if( jo.has_member( "target_var" ) ) {
         target_var = read_var_info( jo.get_object( "target_var" ) );
     }
-    str_or_var<T> key;
+    str_or_var key;
     if( jo.has_member( "key" ) ) {
-        key = get_str_or_var<T>( jo.get_member( "key" ), "key", false, "" );
+        key = get_str_or_var( jo.get_member( "key" ), "key", false, "" );
     } else {
         key.str_val = "";
     }
-    function = [target_params, update_ids, target_var, dov_time_in_future, key]( const T & d ) {
+    function = [target_params, update_ids, target_var, dov_time_in_future, key]( dialogue const & d ) {
         tripoint_abs_omt omt_pos;
         if( target_var.has_value() ) {
-            const tripoint_abs_ms abs_ms( get_tripoint_from_var<T>( target_var, d ) );
+            const tripoint_abs_ms abs_ms( get_tripoint_from_var( target_var, d ) );
             omt_pos = project_to<coords::omt>( abs_ms );
         } else {
-            mission_target_params<dialogue> update_params = target_params;
+            mission_target_params update_params = target_params;
             if( d.has_beta ) {
                 update_params.guy = d.actor( true )->get_npc();
             }
@@ -2921,13 +2898,13 @@ void talk_effect_fun_t<T>::set_mapgen_update( const JsonObject &jo, const std::s
         if( future > 0_seconds ) {
             time_point tif = calendar::turn + future + 1_seconds;
             //Timed events happen before the player turn and eocs are during so we add a second here to sync them up using the same variable
-            for( const str_or_var<T> &mapgen_update_id : update_ids ) {
+            for( const str_or_var &mapgen_update_id : update_ids ) {
                 get_timed_events().add( timed_event_type::UPDATE_MAPGEN, tif, -1, project_to<coords::ms>( omt_pos ),
                                         0, mapgen_update_id.evaluate( d ), key.evaluate( d ) );
             }
 
         } else {
-            for( const str_or_var<T> &mapgen_update_id : update_ids ) {
+            for( const str_or_var &mapgen_update_id : update_ids ) {
                 run_mapgen_update_func( update_mapgen_id( mapgen_update_id.evaluate( d ) ), omt_pos, {},
                                         d.actor( d.has_beta )->selected_mission() );
             }
@@ -2936,30 +2913,28 @@ void talk_effect_fun_t<T>::set_mapgen_update( const JsonObject &jo, const std::s
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_alter_timed_events( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_alter_timed_events( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> key = get_str_or_var<T>( jo.get_member( member ), member, true );
-    duration_or_var<T> time_in_future = get_duration_or_var<T>( jo, "time_in_future", false,
-                                        0_seconds );
-    function = [key, time_in_future]( const T & d ) {
+    str_or_var key = get_str_or_var( jo.get_member( member ), member, true );
+    duration_or_var time_in_future = get_duration_or_var( jo, "time_in_future", false,
+                                     0_seconds );
+    function = [key, time_in_future]( dialogue const & d ) {
         get_timed_events().set_all( key.evaluate( d ), time_in_future.evaluate( d ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_revert_location( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_revert_location( const JsonObject &jo, const std::string &member )
 {
-    duration_or_var<T> dov_time_in_future = get_duration_or_var<T>( jo, "time_in_future", true );
-    str_or_var<T> key;
+    duration_or_var dov_time_in_future = get_duration_or_var( jo, "time_in_future", true );
+    str_or_var key;
     if( jo.has_member( "key" ) ) {
-        key = get_str_or_var<T>( jo.get_member( "key" ), "key", false, "" );
+        key = get_str_or_var( jo.get_member( "key" ), "key", false, "" );
     } else {
         key.str_val = "";
     }
     std::optional<var_info> target_var = read_var_info( jo.get_object( member ) );
-    function = [target_var, dov_time_in_future, key]( const T & d ) {
-        const tripoint_abs_ms abs_ms( get_tripoint_from_var<T>( target_var, d ) );
+    function = [target_var, dov_time_in_future, key]( dialogue const & d ) {
+        const tripoint_abs_ms abs_ms( get_tripoint_from_var( target_var, d ) );
         tripoint_abs_omt omt_pos = project_to<coords::omt>( abs_ms );
         time_point tif = calendar::turn + dov_time_in_future.evaluate( d ) + 1_seconds;
         // Timed events happen before the player turn and eocs are during so we add a second here to sync them up using the same variable
@@ -2983,14 +2958,13 @@ void talk_effect_fun_t<T>::set_revert_location( const JsonObject &jo, const std:
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_npc_goal( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_npc_goal( const JsonObject &jo, const std::string &member )
 {
-    mission_target_params<dialogue> dest_params = mission_util::parse_mission_om_target( jo.get_object(
-                member ) );
+    mission_target_params dest_params = mission_util::parse_mission_om_target( jo.get_object(
+                                            member ) );
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
-    function = [dest_params, true_eocs, false_eocs]( const T & d ) {
+    function = [dest_params, true_eocs, false_eocs]( dialogue const & d ) {
         npc *guy = d.actor( true )->get_npc();
         if( guy ) {
             tripoint_abs_omt destination = mission_util::get_om_terrain_pos( dest_params );
@@ -3014,18 +2988,17 @@ void talk_effect_fun_t<T>::set_npc_goal( const JsonObject &jo, const std::string
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_bulk_trade_accept( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_bulk_trade_accept( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    dbl_or_var<T> dov_quantity;
+    dbl_or_var dov_quantity;
     if( jo.has_member( member ) ) {
-        dov_quantity = get_dbl_or_var<T>( jo, member, false, -1 );
+        dov_quantity = get_dbl_or_var( jo, member, false, -1 );
     } else {
         dov_quantity.min.dbl_val = -1;
     }
     bool is_trade = member == "u_bulk_trade_accept" || member == "npc_bulk_trade_accept";
-    function = [is_trade, is_npc, dov_quantity]( const T & d ) {
+    function = [is_trade, is_npc, dov_quantity]( dialogue const & d ) {
         talker *seller = d.actor( is_npc );
         talker *buyer = d.actor( !is_npc );
         item tmp( d.cur_item );
@@ -3088,46 +3061,42 @@ void talk_effect_fun_t<T>::set_bulk_trade_accept( const JsonObject &jo, const st
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_npc_gets_item( bool to_use )
+void talk_effect_fun_t::set_npc_gets_item( bool to_use )
 {
-    function = [to_use]( const T & d ) {
+    function = [to_use]( dialogue const & d ) {
         d.reason = d.actor( true )->give_item_to( to_use );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_add_mission( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_add_mission( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> mission_id = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [mission_id]( const T & d ) {
+    str_or_var mission_id = get_str_or_var( jo.get_member( member ), member, true );
+    function = [mission_id]( dialogue const & d ) {
         d.actor( true )->add_mission( mission_type_id( mission_id.evaluate( d ) ) );
     };
 }
 
-template<class T>
-const std::vector<std::pair<int, itype_id>> &talk_effect_fun_t<T>::get_likely_rewards() const
+const std::vector<std::pair<int, itype_id>> &talk_effect_fun_t::get_likely_rewards() const
 {
     return likely_rewards;
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_u_buy_monster( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_u_buy_monster( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> monster_type_id = get_str_or_var<T>( jo.get_member( member ), member, true );
-    dbl_or_var<T> cost = get_dbl_or_var<T>( jo, "cost", false, 0 );
-    dbl_or_var<T> count = get_dbl_or_var<T>( jo, "count", false, 1 );
+    str_or_var monster_type_id = get_str_or_var( jo.get_member( member ), member, true );
+    dbl_or_var cost = get_dbl_or_var( jo, "cost", false, 0 );
+    dbl_or_var count = get_dbl_or_var( jo, "count", false, 1 );
     const bool pacified = jo.get_bool( "pacified", false );
-    str_or_var<T> name;
+    str_or_var name;
     if( jo.has_member( "name" ) ) {
-        name = get_str_or_var<T>( jo.get_member( "name" ), "name", true );
+        name = get_str_or_var( jo.get_member( "name" ), "name", true );
     } else {
         name.str_val = "";
     }
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
     function = [monster_type_id, cost, count, pacified, name, true_eocs,
-                     false_eocs]( const T & d ) {
+                     false_eocs]( dialogue const & d ) {
         const mtype_id mtype( monster_type_id.evaluate( d ) );
         translation translated_name = to_translation( _( name.evaluate( d ) ) );
         if( d.actor( false )->buy_monster( *d.actor( true ), mtype, cost.evaluate( d ), count.evaluate( d ),
@@ -3139,52 +3108,49 @@ void talk_effect_fun_t<T>::set_u_buy_monster( const JsonObject &jo, const std::s
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_u_learn_recipe( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_u_learn_recipe( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> learned_recipe_id = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [learned_recipe_id]( const T & d ) {
+    str_or_var learned_recipe_id = get_str_or_var( jo.get_member( member ), member, true );
+    function = [learned_recipe_id]( dialogue const & d ) {
         const recipe &r = recipe_id( learned_recipe_id.evaluate( d ) ).obj();
         get_player_character().learn_recipe( &r );
         popup( _( "You learn how to craft %s." ), r.result_name() );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_npc_first_topic( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_npc_first_topic( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> chat_topic = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [chat_topic]( const T & d ) {
+    str_or_var chat_topic = get_str_or_var( jo.get_member( member ), member, true );
+    function = [chat_topic]( dialogue const & d ) {
         d.actor( true )->set_first_topic( chat_topic.evaluate( d ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_message( const JsonObject &jo, const std::string &member,
-                                        bool is_npc )
+void talk_effect_fun_t::set_message( const JsonObject &jo, const std::string &member,
+                                     bool is_npc )
 {
-    str_or_var<T> message = get_str_or_var<T>( jo.get_member( member ), member );
+    str_or_var message = get_str_or_var( jo.get_member( member ), member );
     const bool snippet = jo.get_bool( "snippet", false );
     const bool same_snippet = jo.get_bool( "same_snippet", false );
     const bool outdoor_only = jo.get_bool( "outdoor_only", false );
     const bool sound = jo.get_bool( "sound", false );
     const bool popup_msg = jo.get_bool( "popup", false );
     const bool popup_w_interrupt_query_msg = jo.get_bool( "popup_w_interrupt_query", false );
-    str_or_var<T> interrupt_type;
+    str_or_var interrupt_type;
     if( jo.has_member( "interrupt_type" ) ) {
-        interrupt_type = get_str_or_var<T>( jo.get_member( "interrupt_type" ), "interrupt_type", true );
+        interrupt_type = get_str_or_var( jo.get_member( "interrupt_type" ), "interrupt_type", true );
     } else {
         interrupt_type.str_val = "default";
     }
-    str_or_var<T> type_string;
+    str_or_var type_string;
     if( jo.has_member( "type" ) ) {
-        type_string = get_str_or_var<T>( jo.get_member( "type" ), "type", true );
+        type_string = get_str_or_var( jo.get_member( "type" ), "type", true );
     } else {
         type_string.str_val = "neutral";
     }
     function = [message, outdoor_only, sound, snippet, same_snippet, type_string, popup_msg,
                          popup_w_interrupt_query_msg, interrupt_type,
-             is_npc]( const T & d ) {
+             is_npc]( dialogue const & d ) {
         Character *target = d.actor( is_npc )->get_character();
         if( !target || target->is_npc() ) {
             return;
@@ -3283,13 +3249,12 @@ void talk_effect_fun_t<T>::set_message( const JsonObject &jo, const std::string 
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_assign_activity( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_assign_activity( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    duration_or_var<T> dov = get_duration_or_var<T>( jo, "duration", true );
-    str_or_var<T> act = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [is_npc, dov, act]( const T & d ) {
+    duration_or_var dov = get_duration_or_var( jo, "duration", true );
+    str_or_var act = get_str_or_var( jo.get_member( member ), member, true );
+    function = [is_npc, dov, act]( dialogue const & d ) {
         Character *target = d.actor( is_npc )->get_character();
         if( target ) {
             target->assign_activity( activity_id( act.evaluate( d ) ), to_moves<int>( dov.evaluate( d ) ) );
@@ -3297,12 +3262,11 @@ void talk_effect_fun_t<T>::set_assign_activity( const JsonObject &jo, const std:
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_add_wet( const JsonObject &jo, const std::string &member,
-                                        bool is_npc )
+void talk_effect_fun_t::set_add_wet( const JsonObject &jo, const std::string &member,
+                                     bool is_npc )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    function = [is_npc, dov]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    function = [is_npc, dov]( dialogue const & d ) {
         Character *target = d.actor( is_npc )->get_character();
         if( target ) {
             wet_character( *target, dov.evaluate( d ) );
@@ -3310,21 +3274,20 @@ void talk_effect_fun_t<T>::set_add_wet( const JsonObject &jo, const std::string 
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_open_dialogue( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_open_dialogue( const JsonObject &jo, const std::string &member )
 {
     std::vector<effect_on_condition_id> true_eocs;
     std::vector<effect_on_condition_id> false_eocs;
-    str_or_var<T> topic;
+    str_or_var topic;
     bool has_member = false;
     if( jo.has_object( member ) ) {
         has_member = true;
         JsonObject innerJo = jo.get_object( member );
         true_eocs = load_eoc_vector( innerJo, "true_eocs" );
         false_eocs = load_eoc_vector( innerJo, "false_eocs" );
-        topic = get_str_or_var<T>( innerJo.get_member( "topic" ), "topic" );
+        topic = get_str_or_var( innerJo.get_member( "topic" ), "topic" );
     }
-    function = [true_eocs, false_eocs, topic, has_member]( const T & d ) {
+    function = [true_eocs, false_eocs, topic, has_member]( dialogue const & d ) {
         std::string actual_topic;
         if( has_member ) {
             actual_topic = topic.evaluate( d );
@@ -3350,12 +3313,11 @@ void talk_effect_fun_t<T>::set_open_dialogue( const JsonObject &jo, const std::s
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_take_control( const JsonObject &jo )
+void talk_effect_fun_t::set_take_control( const JsonObject &jo )
 {
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
-    function = [true_eocs, false_eocs]( const T & d ) {
+    function = [true_eocs, false_eocs]( dialogue const & d ) {
         if( !d.actor( false )->get_character()->is_avatar() ) { //only take control if the avatar is alpha
             run_eoc_vector( false_eocs, d );
             return;
@@ -3366,27 +3328,25 @@ void talk_effect_fun_t<T>::set_take_control( const JsonObject &jo )
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_take_control_menu()
+void talk_effect_fun_t::set_take_control_menu()
 {
-    function = []( const T & ) {
+    function = []( dialogue const &/* d */ ) {
         get_avatar().control_npc_menu();
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_sound_effect( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_sound_effect( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> variant = get_str_or_var<T>( jo.get_member( member ), member, true );
-    str_or_var<T> id = get_str_or_var<T>( jo.get_member( "id" ), "id", true );
+    str_or_var variant = get_str_or_var( jo.get_member( member ), member, true );
+    str_or_var id = get_str_or_var( jo.get_member( "id" ), "id", true );
     const bool outdoor_event = jo.get_bool( "outdoor_event", false );
-    dbl_or_var<T> volume;
+    dbl_or_var volume;
     if( jo.has_member( "volume" ) ) {
-        volume = get_dbl_or_var<T>( jo, "volume", false, -1 );
+        volume = get_dbl_or_var( jo, "volume", false, -1 );
     } else {
         volume.min.dbl_val = -1;
     }
-    function = [variant, id, outdoor_event, volume]( const T & d ) {
+    function = [variant, id, outdoor_event, volume]( dialogue const & d ) {
         map &here = get_map();
         int local_volume = volume.evaluate( d );
         Character *target = &get_player_character(); //Only the player can hear sound effects.
@@ -3410,11 +3370,10 @@ void talk_effect_fun_t<T>::set_sound_effect( const JsonObject &jo, const std::st
 }
 
 
-template<class T>
-void talk_effect_fun_t<T>::set_give_achievment( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_give_achievment( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> achieve = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [achieve]( const T & d ) {
+    str_or_var achieve = get_str_or_var( jo.get_member( member ), member, true );
+    function = [achieve]( dialogue const & d ) {
         const achievement_id achievement_to_give( achieve.evaluate( d ) );
         // make sure the achievement is being tracked and that it is currently pending
         std::vector<const achievement *> all_achievements = get_achievements().valid_achievements();
@@ -3430,27 +3389,25 @@ void talk_effect_fun_t<T>::set_give_achievment( const JsonObject &jo, const std:
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_mod_healthy( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_mod_healthy( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    dbl_or_var<T> dov_amount = get_dbl_or_var<T>( jo, member );
-    dbl_or_var<T> dov_cap = get_dbl_or_var<T>( jo, "cap" );
+    dbl_or_var dov_amount = get_dbl_or_var( jo, member );
+    dbl_or_var dov_cap = get_dbl_or_var( jo, "cap" );
 
-    function = [is_npc, dov_amount, dov_cap]( const T & d ) {
+    function = [is_npc, dov_amount, dov_cap]( dialogue const & d ) {
         d.actor( is_npc )->mod_daily_health( dov_amount.evaluate( d ),
                                              dov_cap.evaluate( d ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_hp( const JsonObject &jo, const std::string &member,
-                                   bool is_npc )
+void talk_effect_fun_t::set_hp( const JsonObject &jo, const std::string &member,
+                                bool is_npc )
 {
-    dbl_or_var<T> new_hp = get_dbl_or_var<T>( jo, member, true );
-    std::optional<str_or_var<T>> target_part;
+    dbl_or_var new_hp = get_dbl_or_var( jo, member, true );
+    std::optional<str_or_var> target_part;
     if( jo.has_string( "target_part" ) ) {
-        target_part = get_str_or_var<T>( jo.get_member( "target_part" ), "target_part", true );
+        target_part = get_str_or_var( jo.get_member( "target_part" ), "target_part", true );
     }
     bool only_increase = jo.get_bool( "only_increase", false );
     bool max = jo.get_bool( "max", false );
@@ -3459,7 +3416,8 @@ void talk_effect_fun_t<T>::set_hp( const JsonObject &jo, const std::string &memb
     if( main_only && minor_only ) {
         jo.throw_error( "Can't be main_only and minor_only at the same time." );
     }
-    function = [only_increase, new_hp, target_part, is_npc, main_only, minor_only, max]( const T & d ) {
+    function = [only_increase, new_hp, target_part, is_npc, main_only, minor_only,
+                   max]( dialogue const & d ) {
         talker *target = d.actor( is_npc );
         for( const bodypart_id &part : target->get_all_body_parts( ( !main_only &&
                 !minor_only ), main_only ) ) {
@@ -3476,15 +3434,14 @@ void talk_effect_fun_t<T>::set_hp( const JsonObject &jo, const std::string &memb
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_cast_spell( const JsonObject &jo, const std::string &member,
-        bool is_npc, bool targeted )
+void talk_effect_fun_t::set_cast_spell( const JsonObject &jo, const std::string &member,
+                                        bool is_npc, bool targeted )
 {
     fake_spell fake;
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
     mandatory( jo, false, member, fake );
-    function = [is_npc, fake, targeted, true_eocs, false_eocs]( const T & d ) {
+    function = [is_npc, fake, targeted, true_eocs, false_eocs]( dialogue const & d ) {
         Creature *caster = d.actor( is_npc )->get_creature();
         if( !caster ) {
             debugmsg( "No valid caster for spell." );
@@ -3505,48 +3462,44 @@ void talk_effect_fun_t<T>::set_cast_spell( const JsonObject &jo, const std::stri
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_lightning()
+void talk_effect_fun_t::set_lightning()
 {
-    function = []( const T & ) {
+    function = []( dialogue const &/* d */ ) {
         if( get_player_character().posz() >= 0 ) {
             get_weather().lightning_active = true;
         }
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_next_weather()
+void talk_effect_fun_t::set_next_weather()
 {
-    function = []( const T & ) {
+    function = []( dialogue const &/* d */ ) {
         get_weather().set_nextweather( calendar::turn );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_set_string_var( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_set_string_var( const JsonObject &jo, const std::string &member )
 {
-    std::vector<str_or_var<T>> values;
+    std::vector<str_or_var> values;
     if( jo.has_array( member ) ) {
         for( JsonValue value : jo.get_array( member ) ) {
-            values.emplace_back( get_str_or_var<T>( value, member ) );
+            values.emplace_back( get_str_or_var( value, member ) );
         }
     } else {
-        values.emplace_back( get_str_or_var<T>( jo.get_member( member ), member ) );
+        values.emplace_back( get_str_or_var( jo.get_member( member ), member ) );
     }
     var_info var = read_var_info( jo.get_member( "target_var" ) );
-    function = [values, var]( const T & d ) {
+    function = [values, var]( dialogue const & d ) {
         int index = rng( 0, values.size() - 1 );
         write_var_value( var.type, var.name, d.actor( var.type == var_type::npc ),
                          values[index].evaluate( d ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_assign_mission( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_assign_mission( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> mission_name = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [mission_name]( const T & d ) {
+    str_or_var mission_name = get_str_or_var( jo.get_member( member ), member, true );
+    function = [mission_name]( dialogue const & d ) {
         avatar &player_character = get_avatar();
 
         const mission_type_id &mission_type = mission_type_id( mission_name.evaluate( d ) );
@@ -3555,10 +3508,9 @@ void talk_effect_fun_t<T>::set_assign_mission( const JsonObject &jo, const std::
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_finish_mission( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_finish_mission( const JsonObject &jo, const std::string &member )
 {
-    str_or_var<T> mission_name = get_str_or_var<T>( jo.get_member( member ), member, true );
+    str_or_var mission_name = get_str_or_var( jo.get_member( member ), member, true );
     bool success = false;
     std::optional<int> step;
     if( jo.has_int( "step" ) ) {
@@ -3566,7 +3518,7 @@ void talk_effect_fun_t<T>::set_finish_mission( const JsonObject &jo, const std::
     } else {
         success = jo.get_bool( "success" );
     }
-    function = [mission_name, success, step]( const T & d ) {
+    function = [mission_name, success, step]( dialogue const & d ) {
         avatar &player_character = get_avatar();
         const mission_type_id &mission_type = mission_type_id( mission_name.evaluate( d ) );
         std::vector<mission *> missions = player_character.get_active_missions();
@@ -3586,12 +3538,11 @@ void talk_effect_fun_t<T>::set_finish_mission( const JsonObject &jo, const std::
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_remove_active_mission( const JsonObject &jo,
+void talk_effect_fun_t::set_remove_active_mission( const JsonObject &jo,
         const std::string &member )
 {
-    str_or_var<T> mission_name = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [mission_name]( const T & d ) {
+    str_or_var mission_name = get_str_or_var( jo.get_member( member ), member, true );
+    function = [mission_name]( dialogue const & d ) {
         avatar &player_character = get_avatar();
         const mission_type_id &mission_type = mission_type_id( mission_name.evaluate( d ) );
         std::vector<mission *> missions = player_character.get_active_missions();
@@ -3604,8 +3555,7 @@ void talk_effect_fun_t<T>::set_remove_active_mission( const JsonObject &jo,
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_offer_mission( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_offer_mission( const JsonObject &jo, const std::string &member )
 {
     std::vector<std::string> mission_names;
 
@@ -3619,7 +3569,7 @@ void talk_effect_fun_t<T>::set_offer_mission( const JsonObject &jo, const std::s
         jo.throw_error( "Invalid input for set_offer_mission" );
     }
 
-    function = [mission_names]( const T & d ) {
+    function = [mission_names]( dialogue const & d ) {
         npc *p = d.actor( true )->get_npc();
 
         for( const std::string &mission_name : mission_names ) {
@@ -3628,11 +3578,10 @@ void talk_effect_fun_t<T>::set_offer_mission( const JsonObject &jo, const std::s
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_make_sound( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void talk_effect_fun_t::set_make_sound( const JsonObject &jo, const std::string &member,
+                                        bool is_npc )
 {
-    str_or_var<T> message = get_str_or_var<T>( jo.get_member( member ), member, true );
+    str_or_var message = get_str_or_var( jo.get_member( member ), member, true );
 
     int volume;
     mandatory( jo, false, "volume", volume );
@@ -3672,8 +3621,8 @@ void talk_effect_fun_t<T>::set_make_sound( const JsonObject &jo, const std::stri
         target_var = read_var_info( jo.get_object( "target_var" ) );
     }
     function = [is_npc, message, volume, type, target_var, snippet,
-            same_snippet]( const T & d ) {
-        tripoint_abs_ms target_pos = get_tripoint_from_var<T>( target_var, d );
+            same_snippet]( dialogue const & d ) {
+        tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d );
         std::string translated_message;
         if( snippet ) {
             if( same_snippet ) {
@@ -3696,15 +3645,14 @@ void talk_effect_fun_t<T>::set_make_sound( const JsonObject &jo, const std::stri
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_run_eocs( const JsonObject &jo,
-        const std::string &member )
+void talk_effect_fun_t::set_run_eocs( const JsonObject &jo,
+                                      const std::string &member )
 {
     std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member );
     if( eocs.empty() ) {
         jo.throw_error( "Invalid input for run_eocs" );
     }
-    function = [eocs]( const T & d ) {
+    function = [eocs]( dialogue const & d ) {
         dialogue newDialog = copy_dialogue( d );
         for( const effect_on_condition_id &eoc : eocs ) {
             eoc->activate( newDialog );
@@ -3712,14 +3660,13 @@ void talk_effect_fun_t<T>::set_run_eocs( const JsonObject &jo,
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_run_npc_eocs( const JsonObject &jo,
+void talk_effect_fun_t::set_run_npc_eocs( const JsonObject &jo,
         const std::string &member, bool is_npc )
 {
     std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member );
-    std::vector<str_or_var<T>> unique_ids;
+    std::vector<str_or_var> unique_ids;
     for( JsonValue jv : jo.get_array( "unique_ids" ) ) {
-        unique_ids.emplace_back( get_str_or_var<T>( jv, "unique_ids" ) );
+        unique_ids.emplace_back( get_str_or_var( jv, "unique_ids" ) );
     }
 
     bool local = jo.get_bool( "local", false );
@@ -3729,10 +3676,10 @@ void talk_effect_fun_t<T>::set_run_npc_eocs( const JsonObject &jo,
     }
     bool npc_must_see = jo.get_bool( "npc_must_see", false );
     if( local ) {
-        function = [eocs, unique_ids, npc_must_see, npc_range, is_npc]( const T & d ) {
+        function = [eocs, unique_ids, npc_must_see, npc_range, is_npc]( dialogue const & d ) {
             tripoint actor_pos = d.actor( is_npc )->pos();
             std::vector<std::string> ids( unique_ids.size() );
-            for( const str_or_var<T> &id : unique_ids ) {
+            for( const str_or_var &id : unique_ids ) {
                 ids.emplace_back( id.evaluate( d ) );
             }
             const std::vector<npc *> available = g->get_npcs_if( [npc_must_see, npc_range, actor_pos,
@@ -3756,8 +3703,8 @@ void talk_effect_fun_t<T>::set_run_npc_eocs( const JsonObject &jo,
             }
         };
     } else {
-        function = [eocs, unique_ids]( const T & d ) {
-            for( const str_or_var<T> &target : unique_ids ) {
+        function = [eocs, unique_ids]( dialogue const & d ) {
+            for( const str_or_var &target : unique_ids ) {
                 if( g->unique_npc_exists( target.evaluate( d ) ) ) {
                     for( const effect_on_condition_id &eoc : eocs ) {
                         npc *npc = g->find_npc_by_unique_id( target.evaluate( d ) );
@@ -3774,17 +3721,16 @@ void talk_effect_fun_t<T>::set_run_npc_eocs( const JsonObject &jo,
     }
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_queue_eocs( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_queue_eocs( const JsonObject &jo, const std::string &member )
 {
     std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member );
     if( eocs.empty() ) {
         jo.throw_error( "Invalid input for queue_eocs" );
     }
 
-    duration_or_var<T> dov_time_in_future = get_duration_or_var<T>( jo, "time_in_future", false,
-                                            0_seconds );
-    function = [dov_time_in_future, eocs]( const T & d ) {
+    duration_or_var dov_time_in_future = get_duration_or_var( jo, "time_in_future", false,
+                                         0_seconds );
+    function = [dov_time_in_future, eocs]( dialogue const & d ) {
         time_duration time_in_future = dov_time_in_future.evaluate( d );
         for( const effect_on_condition_id &eoc : eocs ) {
             if( eoc->type == eoc_type::ACTIVATION ) {
@@ -3803,8 +3749,7 @@ void talk_effect_fun_t<T>::set_queue_eocs( const JsonObject &jo, const std::stri
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_weighted_list_eocs( const JsonObject &jo,
+void talk_effect_fun_t::set_weighted_list_eocs( const JsonObject &jo,
         const std::string &member )
 {
     std::vector<std::pair<effect_on_condition_id, std::function<double( const dialogue & )>>> eoc_pairs;
@@ -3812,9 +3757,9 @@ void talk_effect_fun_t<T>::set_weighted_list_eocs( const JsonObject &jo,
         JsonValue eoc = ja.next_value();
         JsonObject weight = ja.next_object();
         eoc_pairs.emplace_back( effect_on_conditions::load_inline_eoc( eoc, "" ),
-                                conditional_t< dialogue >::get_get_dbl( weight ) );
+                                conditional_t::get_get_dbl( weight ) );
     }
-    function = [eoc_pairs]( const T & d ) {
+    function = [eoc_pairs]( dialogue const & d ) {
         weighted_int_list<effect_on_condition_id> eocs;
         for( const std::pair<effect_on_condition_id, std::function<double( const dialogue & )>> &eoc_pair :
              eoc_pairs ) {
@@ -3826,23 +3771,22 @@ void talk_effect_fun_t<T>::set_weighted_list_eocs( const JsonObject &jo,
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_switch( const JsonObject &jo,
-                                       const std::string &member )
+void talk_effect_fun_t::set_switch( const JsonObject &jo,
+                                    const std::string &member )
 {
-    std::function<double( const T & )> eoc_switch = conditional_t< T >::get_get_dbl(
+    std::function<double( dialogue const &/* d */ )> eoc_switch = conditional_t::get_get_dbl(
                 jo.get_object( member ) );
-    std::vector<std::pair<dbl_or_var<T>, talk_effect_t<T>>> case_pairs;
+    std::vector<std::pair<dbl_or_var, talk_effect_t>> case_pairs;
     for( const JsonValue jv : jo.get_array( "cases" ) ) {
         JsonObject array_case = jv.get_object();
-        talk_effect_t<T> case_effect;
+        talk_effect_t case_effect;
         case_effect.load_effect( array_case, "effect" );
-        case_pairs.emplace_back( get_dbl_or_var<T>( array_case, "case" ), case_effect );
+        case_pairs.emplace_back( get_dbl_or_var( array_case, "case" ), case_effect );
     }
-    function = [eoc_switch, case_pairs]( const T & d ) {
+    function = [eoc_switch, case_pairs]( dialogue const & d ) {
         const double switch_int = eoc_switch( d );
-        talk_effect_t<T> case_effect;
-        for( const std::pair<dbl_or_var<T>, talk_effect_t<T>> &case_pair :
+        talk_effect_t case_effect;
+        for( const std::pair<dbl_or_var, talk_effect_t> &case_pair :
              case_pairs ) {
             if( switch_int >= case_pair.first.evaluate( d ) ) {
                 case_effect = case_pair.second;
@@ -3852,27 +3796,26 @@ void talk_effect_fun_t<T>::set_switch( const JsonObject &jo,
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_roll_remainder( const JsonObject &jo,
+void talk_effect_fun_t::set_roll_remainder( const JsonObject &jo,
         const std::string &member, bool is_npc )
 {
-    std::vector<str_or_var<T>> list;
+    std::vector<str_or_var> list;
     for( JsonValue jv : jo.get_array( member ) ) {
-        list.emplace_back( get_str_or_var<T>( jv, member ) );
+        list.emplace_back( get_str_or_var( jv, member ) );
     }
-    str_or_var<T> type = get_str_or_var<T>( jo.get_member( "type" ), "type", true );
-    str_or_var<T> message;
+    str_or_var type = get_str_or_var( jo.get_member( "type" ), "type", true );
+    str_or_var message;
     if( jo.has_member( "message" ) ) {
-        message = get_str_or_var<T>( jo.get_member( "message" ), "message", true );
+        message = get_str_or_var( jo.get_member( "message" ), "message", true );
     } else {
         message.str_val = "";
     }
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
 
-    function = [list, type, is_npc, true_eocs, false_eocs, message]( const T & d ) {
+    function = [list, type, is_npc, true_eocs, false_eocs, message]( dialogue const & d ) {
         std::vector<std::string> not_had;
-        for( const str_or_var<T> &cur_string : list ) {
+        for( const str_or_var &cur_string : list ) {
             if( type.evaluate( d ) == "bionic" ) {
                 if( !d.actor( is_npc )->has_bionic( bionic_id( cur_string.evaluate( d ) ) ) ) {
                     not_had.push_back( cur_string.evaluate( d ) );
@@ -3930,18 +3873,17 @@ void talk_effect_fun_t<T>::set_roll_remainder( const JsonObject &jo,
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_add_morale( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void talk_effect_fun_t::set_add_morale( const JsonObject &jo, const std::string &member,
+                                        bool is_npc )
 {
-    str_or_var<T> new_type = get_str_or_var<T>( jo.get_member( member ), member, true );
-    dbl_or_var<T> dov_bonus = get_dbl_or_var<T>( jo, "bonus" );
-    dbl_or_var<T> dov_max_bonus = get_dbl_or_var<T>( jo, "max_bonus" );
-    duration_or_var<T> dov_duration = get_duration_or_var<T>( jo, "duration", false, 1_hours );
-    duration_or_var<T> dov_decay_start = get_duration_or_var<T>( jo, "decay_start", false, 30_minutes );
+    str_or_var new_type = get_str_or_var( jo.get_member( member ), member, true );
+    dbl_or_var dov_bonus = get_dbl_or_var( jo, "bonus" );
+    dbl_or_var dov_max_bonus = get_dbl_or_var( jo, "max_bonus" );
+    duration_or_var dov_duration = get_duration_or_var( jo, "duration", false, 1_hours );
+    duration_or_var dov_decay_start = get_duration_or_var( jo, "decay_start", false, 30_minutes );
     const bool capped = jo.get_bool( "capped", false );
     function = [is_npc, new_type, dov_bonus, dov_max_bonus, dov_duration, dov_decay_start,
-            capped]( const T & d ) {
+            capped]( dialogue const & d ) {
         d.actor( is_npc )->add_morale( morale_type( new_type.evaluate( d ) ),
                                        dov_bonus.evaluate( d ),
                                        dov_max_bonus.evaluate( d ),
@@ -3951,48 +3893,44 @@ void talk_effect_fun_t<T>::set_add_morale( const JsonObject &jo, const std::stri
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_lose_morale( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_lose_morale( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    str_or_var<T> old_morale = get_str_or_var<T>( jo.get_member( member ), member, true );
-    function = [is_npc, old_morale]( const T & d ) {
+    str_or_var old_morale = get_str_or_var( jo.get_member( member ), member, true );
+    function = [is_npc, old_morale]( dialogue const & d ) {
         d.actor( is_npc )->remove_morale( morale_type( old_morale.evaluate( d ) ) );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_add_faction_trust( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_add_faction_trust( const JsonObject &jo, const std::string &member )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    function = [dov]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    function = [dov]( dialogue const & d ) {
         d.actor( true )->get_faction()->trusts_u += dov.evaluate( d );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_lose_faction_trust( const JsonObject &jo,
+void talk_effect_fun_t::set_lose_faction_trust( const JsonObject &jo,
         const std::string &member )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member );
-    function = [dov]( const T & d ) {
+    dbl_or_var dov = get_dbl_or_var( jo, member );
+    function = [dov]( dialogue const & d ) {
         d.actor( true )->get_faction()->trusts_u -= dov.evaluate( d );
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_custom_light_level( const JsonObject &jo,
+void talk_effect_fun_t::set_custom_light_level( const JsonObject &jo,
         const std::string &member )
 {
-    dbl_or_var<T> dov = get_dbl_or_var<T>( jo, member, true );
-    duration_or_var<T> dov_length = get_duration_or_var<T>( jo, "length", false, 0_seconds );
-    str_or_var<T> key;
+    dbl_or_var dov = get_dbl_or_var( jo, member, true );
+    duration_or_var dov_length = get_duration_or_var( jo, "length", false, 0_seconds );
+    str_or_var key;
     if( jo.has_member( "key" ) ) {
-        key = get_str_or_var<T>( jo.get_member( "key" ), "key", false, "" );
+        key = get_str_or_var( jo.get_member( "key" ), "key", false, "" );
     } else {
         key.str_val = "";
     }
-    function = [dov_length, dov, key]( const T & d ) {
+    function = [dov_length, dov, key]( dialogue const & d ) {
         get_timed_events().add( timed_event_type::CUSTOM_LIGHT_LEVEL,
                                 calendar::turn + dov_length.evaluate( d ) +
                                 1_seconds/*We add a second here because this will get ticked on the turn its applied before it has an effect*/,
@@ -4000,8 +3938,7 @@ void talk_effect_fun_t<T>::set_custom_light_level( const JsonObject &jo,
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_give_equipment( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_give_equipment( const JsonObject &jo, const std::string &member )
 {
     JsonObject jobj = jo.get_object( member );
     int allowance = 0;
@@ -4016,7 +3953,7 @@ void talk_effect_fun_t<T>::set_give_equipment( const JsonObject &jo, const std::
             debt_modifiers.push_back( this_modifier );
         }
     }
-    function = [debt_modifiers, allowance]( const T & d ) {
+    function = [debt_modifiers, allowance]( dialogue const & d ) {
         int debt = allowance;
         for( const trial_mod &this_mod : debt_modifiers ) {
             if( this_mod.first == "TOTAL" ) {
@@ -4031,8 +3968,7 @@ void talk_effect_fun_t<T>::set_give_equipment( const JsonObject &jo, const std::
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_spawn_monster( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
     bool group = jo.get_bool( "group", false );
@@ -4043,11 +3979,11 @@ void talk_effect_fun_t<T>::set_spawn_monster( const JsonObject &jo, const std::s
     } else {
         new_monster = mtype_id( jo.get_string( member ) );
     }
-    dbl_or_var<T> dov_target_range = get_dbl_or_var<T>( jo, "target_range", false, 0 );
-    dbl_or_var<T> dov_hallucination_count = get_dbl_or_var<T>( jo, "hallucination_count", false, 0 );
-    dbl_or_var<T> dov_real_count = get_dbl_or_var<T>( jo, "real_count", false, 0 );
-    dbl_or_var<T> dov_min_radius = get_dbl_or_var<T>( jo, "min_radius", false, 1 );
-    dbl_or_var<T> dov_max_radius = get_dbl_or_var<T>( jo, "max_radius", false, 10 );
+    dbl_or_var dov_target_range = get_dbl_or_var( jo, "target_range", false, 0 );
+    dbl_or_var dov_hallucination_count = get_dbl_or_var( jo, "hallucination_count", false, 0 );
+    dbl_or_var dov_real_count = get_dbl_or_var( jo, "real_count", false, 0 );
+    dbl_or_var dov_min_radius = get_dbl_or_var( jo, "min_radius", false, 1 );
+    dbl_or_var dov_max_radius = get_dbl_or_var( jo, "max_radius", false, 10 );
 
     const bool outdoor_only = jo.get_bool( "outdoor_only", false );
     const bool indoor_only = jo.get_bool( "indoor_only", false );
@@ -4057,7 +3993,7 @@ void talk_effect_fun_t<T>::set_spawn_monster( const JsonObject &jo, const std::s
     const bool open_air_allowed = jo.get_bool( "open_air_allowed", false );
     const bool friendly = jo.get_bool( "friendly", false );
 
-    duration_or_var<T> dov_lifespan = get_duration_or_var<T>( jo, "lifespan", false, 0_seconds );
+    duration_or_var dov_lifespan = get_duration_or_var( jo, "lifespan", false, 0_seconds );
     std::optional<var_info> target_var;
     if( jo.has_member( "target_var" ) ) {
         target_var = read_var_info( jo.get_object( "target_var" ) );
@@ -4069,7 +4005,7 @@ void talk_effect_fun_t<T>::set_spawn_monster( const JsonObject &jo, const std::s
     function = [new_monster, dov_target_range, dov_hallucination_count, dov_real_count, dov_min_radius,
                              dov_max_radius, outdoor_only, indoor_only, group_id, dov_lifespan, target_var,
                              spawn_message, spawn_message_plural, true_eocs, false_eocs, open_air_allowed,
-                 friendly, is_npc]( const T & d ) {
+                 friendly, is_npc]( dialogue const & d ) {
         monster target_monster;
 
         if( group_id.is_valid() ) {
@@ -4098,7 +4034,7 @@ void talk_effect_fun_t<T>::set_spawn_monster( const JsonObject &jo, const std::s
         std::optional<time_duration> lifespan;
         tripoint target_pos = d.actor( is_npc )->pos();
         if( target_var.has_value() ) {
-            target_pos = get_map().getlocal( get_tripoint_from_var<T>( target_var, d ) );
+            target_pos = get_map().getlocal( get_tripoint_from_var( target_var, d ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -4157,27 +4093,26 @@ void talk_effect_fun_t<T>::set_spawn_monster( const JsonObject &jo, const std::s
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_spawn_npc( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void talk_effect_fun_t::set_spawn_npc( const JsonObject &jo, const std::string &member,
+                                       bool is_npc )
 {
-    str_or_var<T> sov_npc_class = get_str_or_var<T>( jo.get_member( member ), member );
-    str_or_var<T> unique_id;
+    str_or_var sov_npc_class = get_str_or_var( jo.get_member( member ), member );
+    str_or_var unique_id;
     if( jo.has_member( "unique_id" ) ) {
-        unique_id = get_str_or_var<T>( jo.get_member( "unique_id" ), "unique_id" );
+        unique_id = get_str_or_var( jo.get_member( "unique_id" ), "unique_id" );
     } else {
         unique_id.str_val = "";
     }
-    std::vector<str_or_var<T>> traits;
+    std::vector<str_or_var> traits;
     for( JsonValue jv : jo.get_array( "traits" ) ) {
-        str_or_var<T> entry = get_str_or_var<T>( jv, "traits" );
+        str_or_var entry = get_str_or_var( jv, "traits" );
         traits.emplace_back( entry );
     }
 
-    dbl_or_var<T> dov_hallucination_count = get_dbl_or_var<T>( jo, "hallucination_count", false, 0 );
-    dbl_or_var<T> dov_real_count = get_dbl_or_var<T>( jo, "real_count", false, 0 );
-    dbl_or_var<T> dov_min_radius = get_dbl_or_var<T>( jo, "min_radius", false, 1 );
-    dbl_or_var<T> dov_max_radius = get_dbl_or_var<T>( jo, "max_radius", false, 10 );
+    dbl_or_var dov_hallucination_count = get_dbl_or_var( jo, "hallucination_count", false, 0 );
+    dbl_or_var dov_real_count = get_dbl_or_var( jo, "real_count", false, 0 );
+    dbl_or_var dov_min_radius = get_dbl_or_var( jo, "min_radius", false, 1 );
+    dbl_or_var dov_max_radius = get_dbl_or_var( jo, "max_radius", false, 10 );
 
     const bool open_air_allowed = jo.get_bool( "open_air_allowed", false );
     const bool outdoor_only = jo.get_bool( "outdoor_only", false );
@@ -4187,7 +4122,7 @@ void talk_effect_fun_t<T>::set_spawn_npc( const JsonObject &jo, const std::strin
     }
 
 
-    duration_or_var<T> dov_lifespan = get_duration_or_var<T>( jo, "lifespan", false, 0_seconds );
+    duration_or_var dov_lifespan = get_duration_or_var( jo, "lifespan", false, 0_seconds );
     std::optional<var_info> target_var;
     if( jo.has_member( "target_var" ) ) {
         target_var = read_var_info( jo.get_object( "target_var" ) );
@@ -4199,7 +4134,7 @@ void talk_effect_fun_t<T>::set_spawn_npc( const JsonObject &jo, const std::strin
     function = [sov_npc_class, unique_id, traits, dov_hallucination_count, dov_real_count,
                                dov_min_radius,
                                dov_max_radius, outdoor_only, indoor_only, dov_lifespan, target_var, spawn_message,
-                   spawn_message_plural, true_eocs, false_eocs, open_air_allowed, is_npc]( const T & d ) {
+                   spawn_message_plural, true_eocs, false_eocs, open_air_allowed, is_npc]( dialogue const & d ) {
         int min_radius = dov_min_radius.evaluate( d );
         int max_radius = dov_max_radius.evaluate( d );
         int real_count = dov_real_count.evaluate( d );
@@ -4207,13 +4142,13 @@ void talk_effect_fun_t<T>::set_spawn_npc( const JsonObject &jo, const std::strin
         string_id<npc_template> cur_npc_class( sov_npc_class.evaluate( d ) );
         std::string cur_unique_id = unique_id.evaluate( d );
         std::vector<trait_id> cur_traits( traits.size() );
-        for( const str_or_var<T> &cur_trait : traits ) {
+        for( const str_or_var &cur_trait : traits ) {
             cur_traits.emplace_back( trait_id( cur_trait.evaluate( d ) ) );
         }
         std::optional<time_duration> lifespan;
         tripoint target_pos = d.actor( is_npc )->pos();
         if( target_var.has_value() ) {
-            target_pos = get_map().getlocal( get_tripoint_from_var<T>( target_var, d ) );
+            target_pos = get_map().getlocal( get_tripoint_from_var( target_var, d ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -4270,14 +4205,13 @@ void talk_effect_fun_t<T>::set_spawn_npc( const JsonObject &jo, const std::strin
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_field( const JsonObject &jo, const std::string &member,
-                                      bool is_npc )
+void talk_effect_fun_t::set_field( const JsonObject &jo, const std::string &member,
+                                   bool is_npc )
 {
-    str_or_var<T> new_field = get_str_or_var<T>( jo.get_member( member ), member, true );
-    dbl_or_var<T> dov_intensity = get_dbl_or_var<T>( jo, "intensity", false, 1 );
-    duration_or_var<T> dov_age = get_duration_or_var<T>( jo, "age", false, 1_turns );
-    dbl_or_var<T> dov_radius = get_dbl_or_var<T>( jo, "radius", false, 10000000 );
+    str_or_var new_field = get_str_or_var( jo.get_member( member ), member, true );
+    dbl_or_var dov_intensity = get_dbl_or_var( jo, "intensity", false, 1 );
+    duration_or_var dov_age = get_duration_or_var( jo, "age", false, 1_turns );
+    dbl_or_var dov_radius = get_dbl_or_var( jo, "radius", false, 10000000 );
 
     const bool outdoor_only = jo.get_bool( "outdoor_only", false );
     const bool indoor_only = jo.get_bool( "indoor_only", false );
@@ -4288,13 +4222,13 @@ void talk_effect_fun_t<T>::set_field( const JsonObject &jo, const std::string &m
         target_var = read_var_info( jo.get_object( "target_var" ) );
     }
     function = [new_field, dov_intensity, dov_age, dov_radius, outdoor_only,
-               hit_player, target_var, is_npc, indoor_only]( const T & d ) {
+               hit_player, target_var, is_npc, indoor_only]( dialogue const & d ) {
         int radius = dov_radius.evaluate( d );
         int intensity = dov_intensity.evaluate( d );
 
         tripoint_abs_ms target_pos = d.actor( is_npc )->global_pos();
         if( target_var.has_value() ) {
-            target_pos = get_tripoint_from_var<T>( target_var, d );
+            target_pos = get_tripoint_from_var( target_var, d );
         }
         for( const tripoint &dest : get_map().points_in_radius( get_map().getlocal( target_pos ),
                 radius ) ) {
@@ -4308,27 +4242,26 @@ void talk_effect_fun_t<T>::set_field( const JsonObject &jo, const std::string &m
     };
 }
 
-template<class T>
-void talk_effect_fun_t<T>::set_teleport( const JsonObject &jo, const std::string &member,
-        bool is_npc )
+void talk_effect_fun_t::set_teleport( const JsonObject &jo, const std::string &member,
+                                      bool is_npc )
 {
     std::optional<var_info> target_var = read_var_info( jo.get_object( member ) );
-    str_or_var<T> fail_message;
+    str_or_var fail_message;
     if( jo.has_member( "fail_message" ) ) {
-        fail_message = get_str_or_var<T>( jo.get_member( "fail_message" ), "fail_message", false, "" );
+        fail_message = get_str_or_var( jo.get_member( "fail_message" ), "fail_message", false, "" );
     } else {
         fail_message.str_val = "";
     }
-    str_or_var<T> success_message;
+    str_or_var success_message;
     if( jo.has_member( "success_message" ) ) {
-        success_message = get_str_or_var<T>( jo.get_member( "success_message" ), "success_message", false,
-                                             "" );
+        success_message = get_str_or_var( jo.get_member( "success_message" ), "success_message", false,
+                                          "" );
     } else {
         success_message.str_val = "";
     }
     bool force = jo.get_bool( "force", false );
-    function = [is_npc, target_var, fail_message, success_message, force]( const T & d ) {
-        tripoint_abs_ms target_pos = get_tripoint_from_var<T>( target_var, d );
+    function = [is_npc, target_var, fail_message, success_message, force]( dialogue const & d ) {
+        tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d );
         Creature *teleporter = d.actor( is_npc )->get_creature();
         if( teleporter ) {
             if( teleport::teleport_to_point( *teleporter, get_map().getlocal( target_pos ), true, false,
@@ -4341,33 +4274,29 @@ void talk_effect_fun_t<T>::set_teleport( const JsonObject &jo, const std::string
     };
 }
 
-template<class T>
-void talk_effect_t<T>::set_effect_consequence( const talk_effect_fun_t<T> &fun,
+void talk_effect_t::set_effect_consequence( const talk_effect_fun_t &fun,
         dialogue_consequence con )
 {
     effects.push_back( fun );
     guaranteed_consequence = std::max( guaranteed_consequence, con );
 }
 
-template<class T>
-void talk_effect_t<T>::set_effect_consequence( const std::function<void( npc &p )> &ptr,
+void talk_effect_t::set_effect_consequence( const std::function<void( npc &p )> &ptr,
         dialogue_consequence con )
 {
-    talk_effect_fun_t<T> npctalk_setter( ptr );
+    talk_effect_fun_t npctalk_setter( ptr );
     set_effect_consequence( npctalk_setter, con );
 }
 
-template<class T>
-void talk_effect_t<T>::set_effect( const talk_effect_fun_t<T> &fun )
+void talk_effect_t::set_effect( const talk_effect_fun_t &fun )
 {
     effects.push_back( fun );
     guaranteed_consequence = std::max( guaranteed_consequence, dialogue_consequence::none );
 }
 
-template<class T>
-void talk_effect_t<T>::set_effect( talkfunction_ptr ptr )
+void talk_effect_t::set_effect( talkfunction_ptr ptr )
 {
-    talk_effect_fun_t<T> npctalk_setter( ptr );
+    talk_effect_fun_t npctalk_setter( ptr );
     dialogue_consequence response;
     if( ptr == &talk_function::hostile ) {
         response = dialogue_consequence::hostile;
@@ -4381,13 +4310,12 @@ void talk_effect_t<T>::set_effect( talkfunction_ptr ptr )
     set_effect_consequence( npctalk_setter, response );
 }
 
-template<class T>
-talk_topic talk_effect_t<T>::apply( const T &d ) const
+talk_topic talk_effect_t::apply( dialogue const &d ) const
 {
     if( d.has_beta ) {
         // Need to get a reference to the mission before effects are applied, because effects can remove the mission
         const mission *miss = d.actor( true )->selected_mission();
-        for( const talk_effect_fun_t<T> &effect : effects ) {
+        for( const talk_effect_fun_t &effect : effects ) {
             effect( d );
         }
         d.actor( true )->add_opinion( opinion );
@@ -4406,7 +4334,7 @@ talk_topic talk_effect_t<T>::apply( const T &d ) const
             return talk_topic( "TALK_DONE" );
         }
     } else {
-        for( const talk_effect_fun_t<T> &effect : effects ) {
+        for( const talk_effect_fun_t &effect : effects ) {
             effect( d );
         }
     }
@@ -4414,8 +4342,7 @@ talk_topic talk_effect_t<T>::apply( const T &d ) const
     return next_topic;
 }
 
-template<class T>
-void talk_effect_t<T>::update_missions( T &d ) const
+void talk_effect_t::update_missions( dialogue &d )
 {
     auto &ma = d.missions_assigned;
     ma.clear();
@@ -4429,8 +4356,7 @@ void talk_effect_t<T>::update_missions( T &d ) const
     }
 }
 
-template<class T>
-talk_effect_t<T>::talk_effect_t( const JsonObject &jo, const std::string &member_name )
+talk_effect_t::talk_effect_t( const JsonObject &jo, const std::string &member_name )
 {
     load_effect( jo, member_name );
     if( jo.has_object( "topic" ) ) {
@@ -4440,10 +4366,9 @@ talk_effect_t<T>::talk_effect_t( const JsonObject &jo, const std::string &member
     }
 }
 
-template<class T>
-void talk_effect_t<T>::parse_sub_effect( const JsonObject &jo )
+void talk_effect_t::parse_sub_effect( const JsonObject &jo )
 {
-    talk_effect_fun_t<T> subeffect_fun;
+    talk_effect_fun_t subeffect_fun;
     const bool is_npc = true;
     if( jo.has_string( "companion_mission" ) ) {
         std::string role_id = jo.get_string( "companion_mission" );
@@ -4695,8 +4620,7 @@ void talk_effect_t<T>::parse_sub_effect( const JsonObject &jo )
     set_effect( subeffect_fun );
 }
 
-template<class T>
-void talk_effect_t<T>::parse_string_effect( const std::string &effect_id, const JsonObject &jo )
+void talk_effect_t::parse_string_effect( const std::string &effect_id, const JsonObject &jo )
 {
     static const std::unordered_map<std::string, void( * )( npc & )> static_functions_map = {
         {
@@ -4789,7 +4713,7 @@ void talk_effect_t<T>::parse_string_effect( const std::string &effect_id, const 
         return;
     }
 
-    talk_effect_fun_t<T> subeffect_fun;
+    talk_effect_fun_t subeffect_fun;
     if( effect_id == "u_bulk_trade_accept" || effect_id == "npc_bulk_trade_accept" ||
         effect_id == "u_bulk_donate" || effect_id == "npc_bulk_donate" ) {
         bool is_npc = effect_id == "npc_bulk_trade_accept" || effect_id == "npc_bulk_donate";
@@ -4835,8 +4759,7 @@ void talk_effect_t<T>::parse_string_effect( const std::string &effect_id, const 
     jo.throw_error_at( effect_id, "unknown effect string" );
 }
 
-template<class T>
-void talk_effect_t<T>::load_effect( const JsonObject &jo, const std::string &member_name )
+void talk_effect_t::load_effect( const JsonObject &jo, const std::string &member_name )
 {
     if( jo.has_member( "opinion" ) ) {
         JsonValue jv = jo.get_member( "opinion" );
@@ -4893,7 +4816,7 @@ talk_response::talk_response( const JsonObject &jo )
 {
     if( jo.has_member( "truefalsetext" ) ) {
         JsonObject truefalse_jo = jo.get_object( "truefalsetext" );
-        read_condition<dialogue>( truefalse_jo, "condition", truefalse_condition, true );
+        read_condition( truefalse_jo, "condition", truefalse_condition, true );
         truefalse_jo.read( "true", truetext );
         truefalse_jo.read( "false", falsetext );
     } else {
@@ -4908,7 +4831,7 @@ talk_response::talk_response( const JsonObject &jo )
     }
     if( jo.has_member( "success" ) ) {
         JsonObject success_obj = jo.get_object( "success" );
-        success = talk_effect_t<dialogue>( success_obj, "effect" );
+        success = talk_effect_t( success_obj, "effect" );
     } else if( jo.has_string( "topic" ) ) {
         // This is for simple topic switching without a possible failure
         success.next_topic = talk_topic( jo.get_string( "topic" ) );
@@ -4921,7 +4844,7 @@ talk_response::talk_response( const JsonObject &jo )
     }
     if( jo.has_member( "failure" ) ) {
         JsonObject failure_obj = jo.get_object( "failure" );
-        failure = talk_effect_t<dialogue>( failure_obj, "effect" );
+        failure = talk_effect_t( failure_obj, "effect" );
     }
 
     // TODO: mission_selected
@@ -4974,7 +4897,7 @@ void json_talk_response::load_condition( const JsonObject &jo )
     has_condition_ = jo.has_member( "condition" );
     is_switch = jo.get_bool( "switch", false );
     is_default = jo.get_bool( "default", false );
-    read_condition<dialogue>( jo, "condition", condition, true );
+    read_condition( jo, "condition", condition, true );
 
     optional( jo, true, "failure_explanation", failure_explanation );
     optional( jo, true, "failure_topic", failure_topic );
@@ -5138,7 +5061,7 @@ dynamic_line_t::dynamic_line_t( const JsonObject &jo )
             return translate_gendered_line( line, relevant_genders, d );
         };
     } else {
-        conditional_t<dialogue> dcondition;
+        conditional_t dcondition;
         const dynamic_line_t yes = from_member( jo, "yes" );
         const dynamic_line_t no = from_member( jo, "no" );
         for( const std::string &sub_member : dialogue_data::simple_string_conds ) {
@@ -5147,13 +5070,13 @@ dynamic_line_t::dynamic_line_t( const JsonObject &jo )
                 if( !jo.get_bool( sub_member ) ) {
                     jo.throw_error_at( sub_member, "value must be true" );
                 }
-                dcondition = conditional_t<dialogue>( sub_member );
+                dcondition = conditional_t( sub_member );
                 function = [dcondition, yes, no]( const dialogue & d ) {
                     return ( dcondition( d ) ? yes : no )( d );
                 };
                 return;
             } else if( jo.has_member( sub_member ) ) {
-                dcondition = conditional_t<dialogue>( sub_member );
+                dcondition = conditional_t( sub_member );
                 const dynamic_line_t yes_member = from_member( jo, sub_member );
                 function = [dcondition, yes_member, no]( const dialogue & d ) {
                     return ( dcondition( d ) ? yes_member : no )( d );
@@ -5163,7 +5086,7 @@ dynamic_line_t::dynamic_line_t( const JsonObject &jo )
         }
         for( const std::string &sub_member : dialogue_data::complex_conds ) {
             if( jo.has_member( sub_member ) ) {
-                dcondition = conditional_t<dialogue>( jo );
+                dcondition = conditional_t( jo );
                 function = [dcondition, yes, no]( const dialogue & d ) {
                     return ( dcondition( d ) ? yes : no )( d );
                 };
@@ -5200,8 +5123,8 @@ json_dynamic_line_effect::json_dynamic_line_effect( const JsonObject &jo,
         const std::string &id )
 {
     std::function<bool( const dialogue & )> tmp_condition;
-    read_condition<dialogue>( jo, "condition", tmp_condition, true );
-    talk_effect_t<dialogue> tmp_effect = talk_effect_t<dialogue>( jo, "effect" );
+    read_condition( jo, "condition", tmp_condition, true );
+    talk_effect_t tmp_effect = talk_effect_t( jo, "effect" );
     // if the topic has a sentinel, it means implicitly add a check for the sentinel value
     // and do not run the effects if it is set.  if it is not set, run the effects and
     // set the sentinel
@@ -5462,6 +5385,3 @@ const json_talk_topic *get_talk_topic( const std::string &id )
     }
     return &it->second;
 }
-
-template struct talk_effect_t<dialogue>;
-template struct talk_effect_fun_t<dialogue>;

--- a/src/shop_cons_rate.cpp
+++ b/src/shop_cons_rate.cpp
@@ -102,7 +102,7 @@ icg_entry icg_entry_reader::_part_get_next( JsonObject const &jo )
     optional( jo, false, "group", ret.item_group );
     optional( jo, false, "message", ret.message );
     if( jo.has_member( "condition" ) ) {
-        read_condition<dialogue>( jo, "condition", ret.condition, false );
+        read_condition( jo, "condition", ret.condition, false );
     }
     return ret;
 }

--- a/src/text_snippets.cpp
+++ b/src/text_snippets.cpp
@@ -67,7 +67,7 @@ void snippet_library::add_snippet_from_json( const std::string &category, const 
         snippets_by_category[category].ids.emplace_back( id );
         snippets_by_id[id] = text;
         if( jo.has_member( "effect_on_examine" ) ) {
-            EOC_by_id[id] = talk_effect_t<dialogue>( jo, "effect_on_examine" );
+            EOC_by_id[id] = talk_effect_t( jo, "effect_on_examine" );
         }
         translation name;
         optional( jo, false, "name", name );
@@ -98,7 +98,7 @@ std::optional<translation> snippet_library::get_snippet_by_id( const snippet_id 
     return it->second;
 }
 
-std::optional<talk_effect_t<dialogue>> snippet_library::get_EOC_by_id( const snippet_id &id ) const
+std::optional<talk_effect_t> snippet_library::get_EOC_by_id( const snippet_id &id ) const
 {
     const auto it = EOC_by_id.find( id );
     if( it == EOC_by_id.end() ) {

--- a/src/text_snippets.h
+++ b/src/text_snippets.h
@@ -50,7 +50,7 @@ class snippet_library
         * Returns the EOC connected with the snippet referenced by the id, or std::nullopt if there
         * is no snippet with such id.
         */
-        std::optional<talk_effect_t<dialogue>> get_EOC_by_id( const snippet_id &id ) const;
+        std::optional<talk_effect_t> get_EOC_by_id( const snippet_id &id ) const;
         /**
         * Returns the name connected with the snippet referenced by the id, or std::nullopt if there
         * is no snippet with such id.
@@ -119,7 +119,7 @@ class snippet_library
         std::unordered_map<snippet_id, translation> snippets_by_id;
         // front facing name
         std::unordered_map<snippet_id, translation> name_by_id;
-        std::unordered_map<snippet_id, talk_effect_t<dialogue>> EOC_by_id;
+        std::unordered_map<snippet_id, talk_effect_t> EOC_by_id;
 
         struct category_snippets {
             std::vector<snippet_id> ids;

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -138,7 +138,7 @@ void weather_type::load( const JsonObject &jo, const std::string & )
                    unicode_codepoint_from_symbol_reader );
     }
     optional( jo, was_loaded, "required_weathers", required_weathers );
-    read_condition<dialogue>( jo, "condition", condition, true );
+    read_condition( jo, "condition", condition, true );
 }
 
 void weather_types::reset()

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -288,7 +288,7 @@ void widget_clause::load( const JsonObject &jo )
     color = color_from_string( clr );
 
     if( jo.has_member( "condition" ) ) {
-        read_condition<dialogue>( jo, "condition", condition, false );
+        read_condition( jo, "condition", condition, false );
         has_condition = true;
     }
 

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -14,7 +14,7 @@ static const spell_id spell_test_spell_pew( "test_spell_pew" );
 TEST_CASE( "math_parser_parsing", "[math_parser]" )
 {
     dialogue const d( std::make_unique<talker>(), std::make_unique<talker>() );
-    math_exp<dialogue> testexp;
+    math_exp testexp;
 
     CHECK_FALSE( testexp.parse( "" ) );
     CHECK( testexp.eval( d ) == Approx( 0.0 ) );
@@ -135,7 +135,7 @@ TEST_CASE( "math_parser_dialogue_integration", "[math_parser]" )
 {
     standard_npc dude;
     dialogue const d( get_talker_for( get_avatar() ), get_talker_for( &dude ) );
-    math_exp<dialogue> testexp;
+    math_exp testexp;
     global_variables &globvars = get_globals();
 
     // reading scoped variables

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -628,7 +628,7 @@ TEST_CASE( "npc_talk_conditionals", "[npc_talk]" )
     talk_response &chosen = d.responses[2];
     bool trial_success = chosen.trial.roll( d );
     CHECK( trial_success == true );
-    talk_effect_t<dialogue> &trial_effect = trial_success ? chosen.success : chosen.failure;
+    talk_effect_t &trial_effect = trial_success ? chosen.success : chosen.failure;
     CHECK( trial_effect.next_topic.id == "TALK_TEST_TRUE_CONDITION_NEXT" );
     player_character.cash = 0;
     gen_response_lines( d, 3 );
@@ -678,7 +678,7 @@ TEST_CASE( "npc_talk_items", "[npc_talk]" )
     gen_response_lines( d, 19 );
     // add and remove effect
     REQUIRE_FALSE( player_character.has_effect( effect_infection ) );
-    talk_effect_t<dialogue> &effects = d.responses[1].success;
+    talk_effect_t &effects = d.responses[1].success;
     effects.apply( d );
     CHECK( player_character.has_effect( effect_infection ) );
     CHECK( player_character.get_effect_dur( effect_infection ) == time_duration::from_turns( 10 ) );
@@ -846,7 +846,7 @@ TEST_CASE( "npc_talk_vars", "[npc_talk]" )
     CHECK( d.responses[0].text == "This is a basic test response." );
     CHECK( d.responses[1].text == "This is a u_add_var test response." );
     CHECK( d.responses[2].text == "This is a npc_add_var test response." );
-    talk_effect_t<dialogue> &effects = d.responses[1].success;
+    talk_effect_t &effects = d.responses[1].success;
     effects.apply( d );
     effects = d.responses[2].success;
     effects.apply( d );
@@ -886,7 +886,7 @@ TEST_CASE( "npc_talk_adjust_vars", "[npc_talk]" )
     CHECK( d.responses[10].text == "This is a npc_compare_var test response for >= 0." );
 
     // Increment the u and npc vars by 1, so that it has a value of 1.
-    talk_effect_t<dialogue> &effects = d.responses[1].success;
+    talk_effect_t &effects = d.responses[1].success;
     effects.apply( d );
     effects = d.responses[3].success;
     effects.apply( d );
@@ -940,7 +940,7 @@ TEST_CASE( "npc_talk_vars_time", "[npc_talk]" )
     CHECK( d.responses[0].text == "This is a basic test response." );
     CHECK( d.responses[1].text == "This is a u_add_var time test response." );
     CHECK( d.responses[2].text == "This is a npc_add_var time test response." );
-    talk_effect_t<dialogue> &effects = d.responses[1].success;
+    talk_effect_t &effects = d.responses[1].success;
     effects.apply( d );
     gen_response_lines( d, 1 );
     CHECK( d.responses[0].text == "This is a basic test response." );
@@ -985,7 +985,7 @@ TEST_CASE( "npc_faction_trust", "[npc_talk]" )
     CHECK( d.responses[0].text == "This is a basic test response." );
     CHECK( d.responses[1].text == "Add 50 to faction trust." );
     CHECK( d.responses[2].text == "Start trade." );
-    talk_effect_t<dialogue> &effects = d.responses[1].success;
+    talk_effect_t &effects = d.responses[1].success;
     effects.apply( d );
     REQUIRE( beta.get_faction()->trusts_u == 50 );
     gen_response_lines( d, 4 );
@@ -1068,7 +1068,7 @@ TEST_CASE( "npc_talk_effects", "[npc_talk]" )
     talker_npc.myclass = NC_TEST_CLASS;
     d.add_topic( "TALK_TEST_EFFECTS" );
     gen_response_lines( d, 19 );
-    talk_effect_t<dialogue> &effects = d.responses[18].success;
+    talk_effect_t &effects = d.responses[18].success;
     effects.apply( d );
     CHECK( talker_npc.myclass == NC_NONE );
 }
@@ -1082,7 +1082,7 @@ TEST_CASE( "npc_change_topic", "[npc_talk]" )
     REQUIRE( original_chat != "TALK_TEST_SET_TOPIC" );
     d.add_topic( "TALK_TEST_SET_TOPIC" );
     gen_response_lines( d, 2 );
-    talk_effect_t<dialogue> &effects = d.responses[1].success;
+    talk_effect_t &effects = d.responses[1].success;
     effects.apply( d );
     CHECK( talker_npc.chatbin.first_topic != original_chat );
     CHECK( talker_npc.chatbin.first_topic == "TALK_TEST_SET_TOPIC" );
@@ -1195,7 +1195,7 @@ TEST_CASE( "npc_compare_int", "[npc_talk]" )
     calendar::turn = calendar::turn + time_duration( 4_days );
     REQUIRE( then < calendar::turn );
     // Increment the u var by 1, so that it has a value of 1.
-    talk_effect_t<dialogue> &effects = d.responses[ 0 ].success;
+    talk_effect_t &effects = d.responses[ 0 ].success;
     effects.apply( d );
     // Increment the npc var by 2, so that it has a value of 2.
     effects = d.responses[ 1 ].success;
@@ -1322,7 +1322,7 @@ TEST_CASE( "npc_arithmetic_op", "[npc_talk]" )
     calendar::turn = calendar::turn_zero;
     REQUIRE( calendar::turn == time_point( 0 ) );
     // "Sets time since cataclysm to 2 * 5 turns.  (10)"
-    talk_effect_t<dialogue> &effects = d.responses[ 0 ].success;
+    talk_effect_t &effects = d.responses[ 0 ].success;
     effects.apply( d );
     CHECK( calendar::turn == time_point( 10 ) );
 
@@ -1417,7 +1417,7 @@ TEST_CASE( "npc_arithmetic", "[npc_talk]" )
     calendar::turn = calendar::turn_zero;
     REQUIRE( calendar::turn == time_point( 0 ) );
     // "Sets time since cataclysm to 1."
-    talk_effect_t<dialogue> &effects = d.responses[ 0 ].success;
+    talk_effect_t &effects = d.responses[ 0 ].success;
     effects.apply( d );
     CHECK( calendar::turn == time_point( 1 ) );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
All EOC code is templated so it can work with either `dialogue` or `mission_goal_condition_context`, but `mission_goal_condition_context` is just a gimped `dialogue` used in only one place and the relevant code can be almost trivially ported to `dialogue`. Some functions are templated but use only `dialogue` anyway.

This templating makes the code hard to follow, especially while compiling and debugging, and needs either large headers or a lot of boilerplate from template instantiations.

For `math_parser` I want to use as little boilerplate as possible and not rely on gigantic monolithic if-else blocks like the current code for EOC functions (most significantly `get_get_dbl()` and `get_set_dbl()`).
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Trivially port `mission_goal_condition_context` code to `dialogue`

Semi-automatically untemplate all EOC code. I only had to intervene manually where code had to be moved around or out of headers (most notably in `math_parser_impl.h` and `dialogue_helpers.h`)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Since this is only a refactor, we should be good if the code compiles and the tests still pass.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I would have done this before writing `math_parser` if I had known about it.

All tests need to pass for this one.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->