### PR TITLE
Make safemode safe again: don't attack neutral creatures via move

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -354,7 +354,8 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
             if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
                 g->safe_mode != SAFE_MODE_OFF ) {
                 add_msg( m_warning,
-                         _( "Switch off safe mode to attack the %s." ), critter.name() );
+                         _( "Not attacking the %s -- safe mode is on!  (%2$s to turn it off)" ), critter.name(),
+                         press_x( ACTION_TOGGLE_SAFEMODE ) );
                 return false;
             }
 

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -353,9 +353,10 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
             }
             if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
                 g->safe_mode != SAFE_MODE_OFF ) {
+                const std::string msg_safe_mode = press_x( ACTION_TOGGLE_SAFEMODE );
                 add_msg( m_warning,
-                         _( "Not attacking the %s -- safe mode is on!  (%2$s to turn it off)" ), critter.name(),
-                         press_x( ACTION_TOGGLE_SAFEMODE ) );
+                         _( "Not attacking the %1$s -- safe mode is on!  (%2$s to turn it off)" ), critter.name(),
+                         msg_safe_mode );
                 return false;
             }
 

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -351,6 +351,13 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
                     return false;
                 }
             }
+            if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
+                g->safe_mode != SAFE_MODE_OFF ) {
+                add_msg( m_warning,
+                         _( "Switch off safe mode to attack the %s." ), critter.name() );
+                return false;
+            }
+
             you.melee_attack( critter, true );
             if( critter.is_hallucination() ) {
                 critter.die( &you );

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_CATA_UTILITY_H
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <ctime>
 #include <functional>

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1541,7 +1541,7 @@ void options_manager::add_options_general()
     add_empty_line();
 
     add( "SAFEMODE", "general", to_translation( "Safe mode" ),
-         to_translation( "If true, will hold the game and display a warning if a hostile monster/NPC is approaching. This will also prevent attacking neutral creatures on move. " ),
+         to_translation( "If true, will hold the game and display a warning if a hostile monster/NPC is approaching.  This will also prevent attacking neutral creatures on move." ),
          true
        );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1541,7 +1541,7 @@ void options_manager::add_options_general()
     add_empty_line();
 
     add( "SAFEMODE", "general", to_translation( "Safe mode" ),
-         to_translation( "If true, will hold the game and display a warning if a hostile monster/NPC is approaching.  This will also prevent attacking neutral creatures on move." ),
+         to_translation( "If true, will hold the game and display a warning if a hostile monster/NPC is approaching." ),
          true
        );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1541,7 +1541,7 @@ void options_manager::add_options_general()
     add_empty_line();
 
     add( "SAFEMODE", "general", to_translation( "Safe mode" ),
-         to_translation( "If true, will hold the game and display a warning if a hostile monster/NPC is approaching." ),
+         to_translation( "If true, will hold the game and display a warning if a hostile monster/NPC is approaching. This will also prevent attacking neutral creatures on move. " ),
          true
        );
 


### PR DESCRIPTION
#### Summary
Features "prevent attacking neutral critter via move in safemode"

#### Purpose of change
Due to popular demand, prevent attacking neutral creatures with the move command while safe mode is on.

#### Describe the solution
Upon moving to a tile which is occupied by a monster which has a neutral attitude towards the player in safemode, a warning message is displayed and the action is aborted.

#### Describe alternatives you've considered
Adding a separate option which allows a prompt/ignore/attack choice.
disregarded because of KISS and no-new-option-policy

#### Testing
spawn an exodii worker and move onto its tile with safemode turned on.

#### Additional context
thanks to irwiss and officer_dirtbag for halp

![image](https://user-images.githubusercontent.com/4641233/232132283-0cc1507f-f5e2-455e-979e-4e24b7ae4704.png)
