### PR TITLE
Changelog: prevent new changelog PRs from clobbering existing ones

### DIFF
--- a/.github/workflows/weekly-changelog.yml
+++ b/.github/workflows/weekly-changelog.yml
@@ -39,7 +39,7 @@ jobs:
           committer: David Seguin <davidseguin@live.ca>
           author: David Seguin <davidseguin@live.ca>
           token: ${{ secrets.TX_PR_CREATOR }}
-          branch: changelog-weekly
+          branch: changelog-weekly-${{ steps.getting-changes.outputs.date }}
           delete-branch: true
           base: master
           title: Weekly Changelog ${{ steps.getting-changes.outputs.old_date }} to ${{ steps.getting-changes.outputs.date }}


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The create-pull-request GHA has some weird bahaviour when trying to write changes to an existing branch with an existing PR. (Happened recently in #64802)

#### Describe the solution
Create a new branch each time a weekly-changelog PR is created, appending the current date.
