### PR TITLE
Port cata_utility to string_view

### DIFF
--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -627,17 +627,6 @@ void deserialize_wrapper( const std::function<void( const JsonValue & )> &callba
     callback( jsin );
 }
 
-bool string_starts_with( const std::string &s1, const std::string &s2 )
-{
-    return s1.compare( 0, s2.size(), s2 ) == 0;
-}
-
-bool string_ends_with( const std::string &s1, const std::string &s2 )
-{
-    return s1.size() >= s2.size() &&
-           s1.compare( s1.size() - s2.size(), s2.size(), s2 ) == 0;
-}
-
 bool string_empty_or_whitespace( const std::string &s )
 {
     if( s.empty() ) {
@@ -663,7 +652,7 @@ int string_view_cmp( const std::string_view l, const std::string_view r )
     return l.size() < r.size() ? -1 : 1;
 }
 
-std::vector<std::string> string_split( const std::string &string, char delim )
+std::vector<std::string> string_split( const std::string_view string, char delim )
 {
     std::vector<std::string> elems;
 
@@ -671,7 +660,7 @@ std::vector<std::string> string_split( const std::string &string, char delim )
         return elems; // Well, that was easy.
     }
 
-    std::stringstream ss( string );
+    std::stringstream ss( std::string{ string } );
     std::string item;
     while( std::getline( ss, item, delim ) ) {
         elems.push_back( item );

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -424,35 +424,18 @@ inline void deserialize_from_string( T &obj, const std::string &data )
 /**
  * \brief Returns true iff s1 starts with s2
  */
-bool string_starts_with( const std::string &s1, const std::string &s2 );
-
-/**
- * Returns true iff s1 starts with s2.
- * This version accepts constant string literals and is ≈1.5 times faster than std::string version.
- * Note: N is (size+1) for null-terminated strings.
- */
-template <std::size_t N>
-// NOLINTNEXTLINE(modernize-avoid-c-arrays)
-inline bool string_starts_with( const std::string &s1, const char( &s2 )[N] )
+inline bool string_starts_with( std::string_view s1, std::string_view s2 )
 {
-    return s1.compare( 0, N - 1, s2, N - 1 ) == 0;
+    return s1.compare( 0, s2.size(), s2 ) == 0;
 }
 
 /**
  * \brief Returns true iff s1 ends with s2
  */
-bool string_ends_with( const std::string &s1, const std::string &s2 );
-
-/**
- *  Returns true iff s1 ends with s2.
- *  This version accepts constant string literals and is ≈1.5 times faster than std::string version.
- *  Note: N is (size+1) for null-terminated strings.
- */
-template <std::size_t N>
-// NOLINTNEXTLINE(modernize-avoid-c-arrays)
-inline bool string_ends_with( const std::string &s1, const char( &s2 )[N] )
+inline bool string_ends_with( std::string_view s1, std::string_view s2 )
 {
-    return s1.size() >= N - 1 && s1.compare( s1.size() - ( N - 1 ), std::string::npos, s2, N - 1 ) == 0;
+    return s1.size() >= s2.size() &&
+           s1.compare( s1.size() - s2.size(), s2.size(), s2 ) == 0;
 }
 
 bool string_empty_or_whitespace( const std::string &s );
@@ -495,7 +478,7 @@ std::string string_join( const Container &iterable, const std::string &joiner )
 /**
 * Splits a string by delimiter into a vector of strings
 */
-std::vector<std::string> string_split( const std::string &string, char delim );
+std::vector<std::string> string_split( std::string_view string, char delim );
 
 /**
  * Append all arguments after the first to the first.

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -117,7 +117,7 @@ void debug();
 
 /* Splits a string by @param delimiter and push_back's the elements into _Container */
 template<typename Container>
-Container string_to_iterable( const std::string &str, const std::string &delimiter )
+Container string_to_iterable( const std::string_view str, const std::string_view delimiter )
 {
     Container res;
 
@@ -125,12 +125,12 @@ Container string_to_iterable( const std::string &str, const std::string &delimit
     size_t start = 0;
     while( ( pos = str.find( delimiter, start ) ) != std::string::npos ) {
         if( pos > start ) {
-            res.push_back( str.substr( start, pos - start ) );
+            res.emplace_back( str.substr( start, pos - start ) );
         }
         start = pos + delimiter.length();
     }
     if( start != str.length() ) {
-        res.push_back( str.substr( start, str.length() - start ) );
+        res.emplace_back( str.substr( start, str.length() - start ) );
     }
 
     return res;
@@ -141,7 +141,7 @@ Container string_to_iterable( const std::string &str, const std::string &delimit
  * @param f is callable that is called to transform each value
  * */
 template<typename Container, typename Mapper>
-std::string iterable_to_string( const Container &values, const std::string &delimiter,
+std::string iterable_to_string( const Container &values, const std::string_view delimiter,
                                 const Mapper &f )
 {
     std::string res;
@@ -155,9 +155,9 @@ std::string iterable_to_string( const Container &values, const std::string &deli
 }
 
 template<typename Container>
-std::string iterable_to_string( const Container &values, const std::string &delimiter )
+std::string iterable_to_string( const Container &values, const std::string_view delimiter )
 {
-    return iterable_to_string( values, delimiter, []( const std::string & f ) {
+    return iterable_to_string( values, delimiter, []( const std::string_view f ) {
         return f;
     } );
 }

--- a/src/flexbuffer_json-inl.h
+++ b/src/flexbuffer_json-inl.h
@@ -904,7 +904,7 @@ E JsonObject::get_enum_value( const char *name, E fallback ) const
     }
 }
 
-inline std::vector<int> JsonObject::get_int_array( const std::string &name ) const
+inline std::vector<int> JsonObject::get_int_array( const std::string_view name ) const
 {
     std::vector<int> ret;
     JsonArray ja = get_array( name );
@@ -914,7 +914,7 @@ inline std::vector<int> JsonObject::get_int_array( const std::string &name ) con
     }
     return ret;
 }
-inline std::vector<std::string> JsonObject::get_string_array( const std::string &name ) const
+inline std::vector<std::string> JsonObject::get_string_array( const std::string_view name ) const
 {
     std::vector<std::string> ret;
     JsonArray ja = get_array( name );
@@ -1106,7 +1106,7 @@ void deserialize( std::optional<T> &obj, const JsonValue &jsin )
 }
 
 inline void add_array_to_set( std::set<std::string> &s, const JsonObject &json,
-                              const std::string &name )
+                              const std::string_view name )
 {
     for( const std::string line : json.get_array( name ) ) {
         s.insert( line );

--- a/src/flexbuffer_json.h
+++ b/src/flexbuffer_json.h
@@ -620,8 +620,8 @@ class JsonObject : JsonWithPath
         E get_enum_value( const char *name, E fallback ) const;
 
         // Sigh.
-        std::vector<int> get_int_array( const std::string &name ) const;
-        std::vector<std::string> get_string_array( const std::string &name ) const;
+        std::vector<int> get_int_array( std::string_view name ) const;
+        std::vector<std::string> get_string_array( std::string_view name ) const;
         std::vector<std::string> get_as_string_array( const std::string &name ) const;
 
         bool has_member( std::string_view key ) const;
@@ -730,7 +730,7 @@ class JsonObject : JsonWithPath
 //void deserialize( std::optional<T> &obj, const JsonValue &jsin );
 
 void add_array_to_set( std::set<std::string> &s, const JsonObject &json,
-                       const std::string &name );
+                       std::string_view name );
 
 #include "flexbuffer_json-inl.h"
 

--- a/src/json.h
+++ b/src/json.h
@@ -1090,7 +1090,7 @@ class TextJsonObject
             return jsin->get_enum_value<E>();
         }
         template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-        E get_enum_value( const std::string &name ) const {
+        E get_enum_value( const std::string_view name ) const {
             mark_visited( name );
             jsin->seek( verify_position( name ) );
             return jsin->get_enum_value<E>();
@@ -1108,7 +1108,7 @@ class TextJsonObject
 
         // get_tags returns empty set if none found
         template<typename T = std::string, typename Res = std::set<T>>
-        Res get_tags( const std::string &name ) const;
+        Res get_tags( std::string_view name ) const;
 
         // TODO: some sort of get_map(), maybe
 
@@ -1132,7 +1132,7 @@ class TextJsonObject
         // throw_on_error dictates the behavior when the member was present
         // but the read fails.
         template <typename T>
-        bool read( const std::string &name, T &t, bool throw_on_error = true ) const {
+        bool read( const std::string_view name, T &t, bool throw_on_error = true ) const {
             int pos = verify_position( name, false );
             if( !pos ) {
                 return false;
@@ -1539,7 +1539,7 @@ Res TextJsonArray::get_tags( const size_t index ) const
 }
 
 template <typename T, typename Res>
-Res TextJsonObject::get_tags( const std::string &name ) const
+Res TextJsonObject::get_tags( const std::string_view name ) const
 {
     Res res;
     int pos = verify_position( name, false );

--- a/src/output.h
+++ b/src/output.h
@@ -1179,7 +1179,7 @@ void refresh_display();
  * @return Colorized string.
  */
 template<typename F>
-std::string colorize_symbols( const std::string &str, F color_of )
+std::string colorize_symbols( const std::string_view str, F color_of )
 {
     std::string res;
     nc_color prev_color = c_unset;


### PR DESCRIPTION
#### Summary
Infrastructure "Port cata_utility functions to string_view"

#### Purpose of change
Modernization and simplification of code.

#### Describe the solution
Convert various of our string utility functions to use `string_view` arguments.

#### Describe alternatives you've considered
Doing more in this PR.

#### Testing
Unit tests.

#### Additional context
This was a fairly formulaic change.  None of these functions had `char*` overloads, so we don't get to simplify any overload sets.  This is primarily so that other functions using these utility functions can be ported to `string_view` going forwards.