### PR TITLE
add widget var for remaining moves in current turn

### DIFF
--- a/doc/WIDGETS.md
+++ b/doc/WIDGETS.md
@@ -1023,6 +1023,7 @@ Many vars are numeric in nature. These may use style "number" or style "graph". 
 | `mana`            | available mana, 0-MAX_MANA
 | `morale_level`    | morale level, -100 to +100
 | `move`            | movement counter, 0-100+
+| `move_remainder`  | remaining moves for the current turn, 0-9999+
 | `pain`            | perceived pain, 0-80+
 | `sound`           | sound, 0-20+
 | `speed`           | speed, 0-500+

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -67,6 +67,8 @@ std::string enum_to_string<widget_var>( widget_var data )
             return "focus";
         case widget_var::move:
             return "move";
+        case widget_var::move_remainder:
+            return "move_remainder";
         case widget_var::move_cost:
             return "move_cost";
         case widget_var::mood:
@@ -628,7 +630,12 @@ void widget::set_default_var_range( const avatar &ava )
         case widget_var::move:
             _var_min = 0;
             _var_max = 1000; // TODO: Determine better max
-            // This is a counter of remaining moves, with no normal value
+            // Move cost of last action
+            break;
+        case widget_var::move_remainder:
+            _var_min = 0;
+            _var_max = 9999; // TODO: Determine better max
+            // remaining moves for the current turn
             break;
         case widget_var::move_cost:
             _var_min = 0;
@@ -775,6 +782,9 @@ int widget::get_var_value( const avatar &ava ) const
             break;
         case widget_var::move:
             value = ava.movecounter;
+            break;
+        case widget_var::move_remainder:
+            value = ava.moves;
             break;
         case widget_var::move_cost:
             value = ava.run_cost( 100 );

--- a/src/widget.h
+++ b/src/widget.h
@@ -18,6 +18,7 @@
 enum class widget_var : int {
     focus,          // Current focus, integer
     move,           // Current move counter, integer
+    move_remainder, // Current remaining moves, integer
     move_cost,      // Modified base movement cost, integer (from run_cost)
     pain,           // Current perceived pain, integer
     sound,          // Current sound level, integer


### PR DESCRIPTION
#### Summary
Interface "add widget var 'move_remainder' for remaining moves in current turn"

#### Purpose of change
IMHO the remaining moves in the current turn is an essential information for gameplay.
I was not aware of any way to display them.
This also helps players to understand how the speed system works.

#### Describe the solution
* add the widget_var "move_remainder" which uses avatar.moves
* change comment for widget_var "move" to reflect its value better
* update docs


#### Describe alternatives you've considered
change the widget_var "move" to reflect the value for remaining moves in the current turn, as it was described in `widget.cpp`
> // This is a counter of remaining moves, with no normal value

disregarded because it would probably break stuff

#### Testing
1. Add widget which uses `move_remainder` var
2. Add said widget to sidebar
3. perform actions and see how the value changes

#### Additional context
![image](https://user-images.githubusercontent.com/4641233/232219421-c2fd62e8-9ee4-46f2-bdb4-701d463e008c.png)
![image](https://user-images.githubusercontent.com/4641233/232219555-5b002ded-04cc-40c0-a5f5-50b31a1f94a7.png)
![image](https://user-images.githubusercontent.com/4641233/232219780-05728a06-d6fd-4a0d-bb1b-fd22410ef2a5.png)
