### PR TITLE
Make respirator bionic less hardcoded

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -997,7 +997,18 @@
     "description": "A complex respiration augmentation system.  Improves respiration ability in air and allows breathing water.  Will automatically turn on when drowning.  Turn on to recharge stamina faster, at moderate power cost.  Asthmatics may also use it to stop asthma attacks.",
     "occupied_bodyparts": [ [ "torso", 8 ], [ "head", 2 ], [ "mouth", 2 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
-    "trigger_cost": "25 kJ"
+    "act_cost": "250 J",
+    "react_cost": "250 J",
+    "time": "1 s",
+    "enchantments": [
+      {
+        "condition": "ACTIVE",
+        "values": [
+          { "value": "REGEN_STAMINA", "multiply": 1.0 }
+        ]
+      }
+    ],
+    "active_flags": [ "REBREATHER" ]
   },
   {
     "id": "bio_ground_sonar",

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1000,14 +1000,7 @@
     "act_cost": "250 J",
     "react_cost": "250 J",
     "time": "1 s",
-    "enchantments": [
-      {
-        "condition": "ACTIVE",
-        "values": [
-          { "value": "REGEN_STAMINA", "multiply": 1.0 }
-        ]
-      }
-    ],
+    "enchantments": [ { "condition": "ACTIVE", "values": [ { "value": "REGEN_STAMINA", "multiply": 1.0 } ] } ],
     "active_flags": [ "REBREATHER" ]
   },
   {

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -999,6 +999,7 @@
     "flags": [ "BIONIC_TOGGLED" ],
     "act_cost": "250 J",
     "react_cost": "250 J",
+    "trigger_cost": "1 kJ",
     "time": "1 s",
     "enchantments": [ { "condition": "ACTIVE", "values": [ { "value": "REGEN_STAMINA", "multiply": 1.0 } ] } ],
     "active_flags": [ "REBREATHER" ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -160,7 +160,6 @@ static const ammotype ammo_battery( "battery" );
 static const anatomy_id anatomy_human_anatomy( "human_anatomy" );
 
 static const bionic_id afs_bio_linguistic_coprocessor( "afs_bio_linguistic_coprocessor" );
-static const bionic_id bio_gills( "bio_gills" );
 static const bionic_id bio_ground_sonar( "bio_ground_sonar" );
 static const bionic_id bio_hydraulics( "bio_hydraulics" );
 static const bionic_id bio_memory( "bio_memory" );
@@ -6502,18 +6501,6 @@ void Character::update_stamina( int turns )
     }
 
     const int max_stam = get_stamina_max();
-    if( get_power_level() >= 3_kJ && has_active_bionic( bio_gills ) ) {
-        int bonus = std::min<int>( units::to_kilojoule( get_power_level() ) / 3,
-                                   max_stam - get_stamina() - stamina_recovery * turns );
-        // so the effective recovery is up to 5x default
-        bonus = std::min( bonus, 4 * static_cast<int>( effective_regen_rate ) );
-        if( bonus > 0 ) {
-            stamina_recovery += bonus;
-            bonus /= 10;
-            bonus = std::max( bonus, 1 );
-            mod_power_level( units::from_kilojoule( -bonus ) );
-        }
-    }
 
     // Roll to determine actual stamina recovery over this period
     int recover_amount = std::ceil( stamina_recovery * turns );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -290,12 +290,8 @@ void suffer::while_underwater( Character &you )
         you.oxygen += 12;
     }
     if( you.oxygen <= 5 ) {
-        if( you.has_bionic( bio_gills ) && you.activate_bionic( bio_gills ) ) {
-            you.add_msg_if_player( m_good, _( "Your bionic turns on to stop you from drowning." ) );
-        } else {
-            you.add_msg_if_player( m_bad, _( "You're drowning!" ) );
-            you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
-        }
+        you.add_msg_if_player( m_bad, _( "You're drowning!" ) );
+        you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
     }
     if( you.has_trait( trait_FRESHWATEROSMOSIS ) &&
         !get_map().has_flag_ter( ter_furn_flag::TFLAG_SALT_WATER, you.pos() ) &&

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -290,8 +290,12 @@ void suffer::while_underwater( Character &you )
         you.oxygen += 12;
     }
     if( you.oxygen <= 5 ) {
-        you.add_msg_if_player( m_bad, _( "You're drowning!" ) );
-        you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
+        if( you.has_bionic( bio_gills ) && you.activate_bionic( bio_gills ) ) {
+            you.add_msg_if_player( m_good, _( "Your bionic turns on to stop you from drowning." ) );
+        } else {
+            you.add_msg_if_player( m_bad, _( "You're drowning!" ) );
+            you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
+        }
     }
     if( you.has_trait( trait_FRESHWATEROSMOSIS ) &&
         !get_map().has_flag_ter( ter_furn_flag::TFLAG_SALT_WATER, you.pos() ) &&

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -285,7 +285,8 @@ void suffer::while_underwater( Character &you )
     if( !you.has_flag( json_flag_GILLS ) ) {
         you.oxygen--;
     }
-    if( you.oxygen < 12 && ( you.worn_with_flag( flag_REBREATHER ) || you.has_flag( flag_REBREATHER ) ) ) {
+    if( you.oxygen < 12 && ( you.worn_with_flag( flag_REBREATHER ) ||
+                             you.has_flag( flag_REBREATHER ) ) ) {
         you.oxygen += 12;
     }
     if( you.oxygen <= 5 ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -285,17 +285,12 @@ void suffer::while_underwater( Character &you )
     if( !you.has_flag( json_flag_GILLS ) ) {
         you.oxygen--;
     }
-    if( you.oxygen < 12 && you.worn_with_flag( flag_REBREATHER ) ) {
+    if( you.oxygen < 12 && ( you.worn_with_flag( flag_REBREATHER ) || you.has_flag( flag_REBREATHER ) ) ) {
         you.oxygen += 12;
     }
     if( you.oxygen <= 5 ) {
-        if( you.has_bionic( bio_gills ) && you.get_power_level() >= bio_gills->power_trigger ) {
-            you.oxygen += 5;
-            you.mod_power_level( -bio_gills->power_trigger );
-        } else {
-            you.add_msg_if_player( m_bad, _( "You're drowning!" ) );
-            you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
-        }
+        you.add_msg_if_player( m_bad, _( "You're drowning!" ) );
+        you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
     }
     if( you.has_trait( trait_FRESHWATEROSMOSIS ) &&
         !get_map().has_flag_ter( ter_furn_flag::TFLAG_SALT_WATER, you.pos() ) &&
@@ -730,7 +725,7 @@ void suffer::from_asthma( Character &you, const int current_stim )
     bool auto_use = you.has_charges( itype_inhaler, 1 ) || you.has_charges( itype_oxygen_tank, 1 ) ||
                     you.has_charges( itype_smoxygen_tank, 1 );
     bool oxygenator = you.has_bionic( bio_gills ) &&
-                      you.get_power_level() >= ( bio_gills->power_trigger / 8 );
+                      you.get_power_level() >= ( bio_gills->power_trigger );
     if( you.underwater ) {
         you.oxygen = you.oxygen / 2;
         auto_use = false;
@@ -749,8 +744,8 @@ void suffer::from_asthma( Character &you, const int current_stim )
                           map_inv.has_charges( itype_smoxygen_tank, 1 );
         // check if character has an oxygenator first
         if( oxygenator ) {
-            you.mod_power_level( -bio_gills->power_trigger / 8 );
-            you.add_msg_if_player( m_info, _( "You use your Oxygenator to clear it up, "
+            you.mod_power_level( -bio_gills->power_trigger );
+            you.add_msg_if_player( m_info, _( "You use your bionic to clear it up, "
                                               "then go back to sleep." ) );
         } else if( auto_use  && !you.has_bionic( bio_sleep_shutdown ) ) {
             if( you.use_charges_if_avail( itype_inhaler, 1 ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Respirator bionic jsonizing and balancing"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Respirator bionic was weird. It had a highly esoteric function in c++ code and used an obscene amount of power (1 kJ per stamina point it was regenerating, meaning it could use 50-100kJ in a single second).
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make the respirator bionic simply toggle a stamina regen enchantment and give you the REBREATHER flag. Adjust drowning code to check for if you has_flag( flag_REBREATHER ) instead of the Respirator bionic specifically.
Its interaction with asthma is still hardcoded.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
This solution has a few downsides:
- It is no longer as convenient as you could previously just leave it running and it would only deduct stamina while you were using stamina, rather than idling at full stamina. This could be solved by either leaving that as hardcode and lowering the power cost, making it deactivate specifically if you are at full stamina, or specifically not consume power if you are at full stamina (hardcoding in bionics.cpp) - alternatively flags could be created to make many bionics not use power if the user doesn't need them under specific circumstances.
- It no longer auto prevents drowning, it must be activated preemptively. It might be possible to get the pointer to a gills bionic you have and forcibly activate it instead of taking drowning damage.

The power cost could also be changed, as could the stamina regen enchantment. Previously the bionic gave up to a 400% increase in regen speed according to the c++ code but that used a ridiculous amount of power and was unsustainable.

The hardcoded check in asthma suffering could also be removed and make it just cancel the asthma mutation, but we have no logic in place for making you get asthma back if it is removed. As a result it could also be changed into a permanent bionic that replaces your lungs outright and requires a baseline power cost to upkeep or else you'd suffocate.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->