### PR TITLE
Hulks can see from afar

### DIFF
--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -562,6 +562,7 @@
       { "name": "the head", "armor_mult": { "physical": 0.5 }, "coverage": 3 },
       { "name": "the eye", "armor_mult": { "physical": 0 }, "coverage": 1 }
     ],
+    "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_hulk" ], 
     "vision_day": 83,
     "vision_night": 8,
     "harvest": "zombie",

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -562,7 +562,7 @@
       { "name": "the head", "armor_mult": { "physical": 0.5 }, "coverage": 3 },
       { "name": "the eye", "armor_mult": { "physical": 0 }, "coverage": 1 }
     ],
-    "vision_day": 50,
+    "vision_day": 83,
     "vision_night": 8,
     "harvest": "zombie",
     "special_attacks": [ [ "SMASH", 20 ] ],

--- a/data/json/monsters/zed_skeletal.json
+++ b/data/json/monsters/zed_skeletal.json
@@ -149,7 +149,7 @@
     "weakpoint_sets": [ "wps_humanoid_body", "wps_bone_armor", "wps_humanoid_head_small" ],
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton", "prof_wp_hulk" ],
     "bleed_rate": 0,
-    "vision_day": 50,
+    "vision_day": 83,
     "vision_night": 4,
     "harvest": "mr_bones",
     "special_attacks": [

--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -268,7 +268,7 @@
     "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ],
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_syn_armored", "prof_wp_nat_armored", "prof_wp_hulk" ],
     "bleed_rate": 0,
-    "vision_day": 50,
+    "vision_day": 60,
     "vision_night": 4,
     "harvest": "zombie_kevlar",
     "special_attacks": [


### PR DESCRIPTION
#### Summary
Balance "Improve LOS for Hulks"

#### Purpose of change
There's one thing that bugged me out: Why the heck do Mr. Hulks and his friends are the same sizes (aside from Kevlar Hulk), but their LOS are inconsistent? Plus, many people (including me), feels like we haven't had a real end-game threat for years.

#### Describe the solution
- Improve LOS of Hulks: Skeletal Juggernauts, Relentless Hulks now has 83 at daytime (heck, `No matter how far you run, it always seems to find you` now matters a lot more). Kevlar Hulks are 'smaller', so I buff his LOS only to 60 at daytime

#### Describe alternatives you've considered
Just not do this

#### Testing
Not yet tested, but changes are pretty simple, right?

#### Additional context
Guys, the Hunted scenario is 2x harder now, right?