### PR TITLE
Adds a key to toggle the language to English and back on the fly

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2102,6 +2102,15 @@
   },
   {
     "type": "keybinding",
+    "name": "Toggle language to English",
+    "category": "DEFAULTMODE",
+    "id": "toggle_language_to_en",
+    "bindings": [
+      {"input_method": "keyboard_char","key": ","}
+    ]
+  },
+  {
+    "type": "keybinding",
     "name": "Toggle map memory",
     "category": "DEFAULTMODE",
     "id": "toggle_map_memory"

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2103,7 +2103,6 @@
   {
     "type": "keybinding",
     "name": "Toggle language to English",
-    "category": "DEFAULTMODE",
     "id": "toggle_language_to_en"
   },
   {

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2105,9 +2105,7 @@
     "name": "Toggle language to English",
     "category": "DEFAULTMODE",
     "id": "toggle_language_to_en",
-    "bindings": [
-      { "input_method": "keyboard_char","key": "," }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "," } ]
   },
   {
     "type": "keybinding",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2104,8 +2104,7 @@
     "type": "keybinding",
     "name": "Toggle language to English",
     "category": "DEFAULTMODE",
-    "id": "toggle_language_to_en",
-    "bindings": [ { "input_method": "keyboard_char", "key": "," } ]
+    "id": "toggle_language_to_en"
   },
   {
     "type": "keybinding",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2106,7 +2106,7 @@
     "category": "DEFAULTMODE",
     "id": "toggle_language_to_en",
     "bindings": [
-      {"input_method": "keyboard_char","key": ","}
+      { "input_method": "keyboard_char","key": "," }
     ]
   },
   {

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -987,7 +987,6 @@ action_id handle_action_menu()
             REGISTER_ACTION( ACTION_CONTROL_VEHICLE );
             REGISTER_ACTION( ACTION_ITEMACTION );
             REGISTER_ACTION( ACTION_TOGGLE_THIEF_MODE );
-            REGISTER_ACTION( ACTION_TOGGLE_LANGUAGE_TO_EN );
 #if defined(TILES)
             if( use_tiles ) {
                 REGISTER_ACTION( ACTION_ZOOM_OUT );

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -987,7 +987,7 @@ action_id handle_action_menu()
             REGISTER_ACTION( ACTION_CONTROL_VEHICLE );
             REGISTER_ACTION( ACTION_ITEMACTION );
             REGISTER_ACTION( ACTION_TOGGLE_THIEF_MODE );
-            REGISTER_ACTION(ACTION_TOGGLE_LANGUAGE_TO_EN);
+            REGISTER_ACTION( ACTION_TOGGLE_LANGUAGE_TO_EN );
 #if defined(TILES)
             if( use_tiles ) {
                 REGISTER_ACTION( ACTION_ZOOM_OUT );

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -287,6 +287,8 @@ std::string action_ident( action_id act )
             return "autosafe";
         case ACTION_TOGGLE_THIEF_MODE:
             return "toggle_thief_mode";
+        case ACTION_TOGGLE_LANGUAGE_TO_EN:
+            return "toggle_language_to_en";
         case ACTION_IGNORE_ENEMY:
             return "ignore_enemy";
         case ACTION_WHITELIST_ENEMY:
@@ -985,6 +987,7 @@ action_id handle_action_menu()
             REGISTER_ACTION( ACTION_CONTROL_VEHICLE );
             REGISTER_ACTION( ACTION_ITEMACTION );
             REGISTER_ACTION( ACTION_TOGGLE_THIEF_MODE );
+            REGISTER_ACTION(ACTION_TOGGLE_LANGUAGE_TO_EN);
 #if defined(TILES)
             if( use_tiles ) {
                 REGISTER_ACTION( ACTION_ZOOM_OUT );

--- a/src/action.h
+++ b/src/action.h
@@ -229,6 +229,8 @@ enum action_id : int {
     ACTION_TOGGLE_AUTOSAFE,
     /** Toggle permanent attitude to stealing */
     ACTION_TOGGLE_THIEF_MODE,
+    /** Switch current language to English and back */
+    ACTION_TOGGLE_LANGUAGE_TO_EN,
     /** Ignore the enemy that triggered safemode */
     ACTION_IGNORE_ENEMY,
     /** Whitelist the enemy that triggered safemode */

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -718,9 +718,11 @@ construction_id construction_menu( const bool blueprint )
             }
         }
         isnew = false;
+        static int lang_version = detail::get_current_language_version();
 
-        if( update_info ) {
+        if( update_info || lang_version != detail::get_current_language_version() ) {
             update_info = false;
+            lang_version = detail::get_current_language_version();
 
             notes.clear();
             if( tabindex == tabcount - 1 && !filter.empty() ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -720,6 +720,7 @@ construction_id construction_menu( const bool blueprint )
         isnew = false;
         static int lang_version = detail::get_current_language_version();
 
+        //lang check here is needed to redraw the menu when using "Toggle language to English" option
         if( update_info || lang_version != detail::get_current_language_version() ) {
             update_info = false;
             lang_version = detail::get_current_language_version();

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -576,6 +576,7 @@ class recipe_result_info_cache
         int last_terminal_width = 0;
         int panel_width;
         int cached_batch_size = 1;
+        int lang_version = 0;
 
         void get_byproducts_data( const recipe *rec, std::vector<iteminfo> &summary_info,
                                   std::vector<iteminfo> &details_info );
@@ -674,8 +675,8 @@ void recipe_result_info_cache::get_item_header( item &dummy_item, const int quan
 item_info_data recipe_result_info_cache::get_result_data( const recipe *rec, const int batch_size,
         int &scroll_pos, const catacurses::window &window )
 {
-    //If lang_version has changed, cached data shouldn't be used
-    if( rec->lang_version == detail::get_current_language_version() ) {
+    //Use cached version if language has not changed
+    if( lang_version == detail::get_current_language_version() ) {
         /* If the recipe has not changed, return the cached version in info.
            Unfortunately, the separator lines are baked into info at a specific width, so if the terminal width
            has changed, the info needs to be regenerated */
@@ -685,7 +686,7 @@ item_info_data recipe_result_info_cache::get_result_data( const recipe *rec, con
             return data;
         }
     } else {
-        const_cast<recipe *>( rec )->lang_version = detail::get_current_language_version();
+        lang_version = detail::get_current_language_version();
     }
 
     cached_batch_size = batch_size;

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -675,7 +675,7 @@ void recipe_result_info_cache::get_item_header( item &dummy_item, const int quan
 item_info_data recipe_result_info_cache::get_result_data( const recipe *rec, const int batch_size,
         int &scroll_pos, const catacurses::window &window )
 {
-    //Use cached version if language has not changed
+    //lang check here is needed to redraw the menu when using "Toggle language to English" option
     if( lang_version == detail::get_current_language_version() ) {
         /* If the recipe has not changed, return the cached version in info.
            Unfortunately, the separator lines are baked into info at a specific width, so if the terminal width

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -818,15 +818,19 @@ static const std::vector<std::string> &cached_recipe_info( recipe_info_cache &in
         const recipe &recp, const availability &avail, Character &guy, const std::string &qry_comps,
         const int batch_size, const int fold_width, const nc_color &color )
 {
+    static int lang_version = detail::get_current_language_version();
+
     if( info_cache.recp != &recp ||
         info_cache.qry_comps != qry_comps ||
         info_cache.batch_size != batch_size ||
-        info_cache.fold_width != fold_width ) {
+        info_cache.fold_width != fold_width ||
+        lang_version != detail::get_current_language_version() ) {
         info_cache.recp = &recp;
         info_cache.qry_comps = qry_comps;
         info_cache.batch_size = batch_size;
         info_cache.fold_width = fold_width;
         info_cache.text = recipe_info( recp, avail, guy, qry_comps, batch_size, fold_width, color );
+        lang_version = detail::get_current_language_version();
     }
     return info_cache.text;
 }

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -675,7 +675,7 @@ void recipe_result_info_cache::get_item_header( item &dummy_item, const int quan
 item_info_data recipe_result_info_cache::get_result_data( const recipe *rec, const int batch_size,
         int &scroll_pos, const catacurses::window &window )
 {
-    //lang check here is needed to redraw the menu when using "Toggle language to English" option
+    //lang check here is needed to rebuild cache when using "Toggle language to English" option
     if( lang_version == detail::get_current_language_version() ) {
         /* If the recipe has not changed, return the cached version in info.
            Unfortunately, the separator lines are baked into info at a specific width, so if the terminal width

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -674,13 +674,18 @@ void recipe_result_info_cache::get_item_header( item &dummy_item, const int quan
 item_info_data recipe_result_info_cache::get_result_data( const recipe *rec, const int batch_size,
         int &scroll_pos, const catacurses::window &window )
 {
-    /* If the recipe has not changed, return the cached version in info.
-       Unfortunately, the separator lines are baked into info at a specific width, so if the terminal width
-       has changed, the info needs to be regenerated */
-    if( rec == last_recipe && rec != nullptr && TERMX == last_terminal_width &&
-        batch_size == cached_batch_size ) {
-        item_info_data data( "", "", info, {}, scroll_pos );
-        return data;
+    //If lang_version has changed, cached data shouldn't be used
+    if( rec->lang_version == detail::get_current_language_version() ) {
+        /* If the recipe has not changed, return the cached version in info.
+           Unfortunately, the separator lines are baked into info at a specific width, so if the terminal width
+           has changed, the info needs to be regenerated */
+        if( rec == last_recipe && rec != nullptr && TERMX == last_terminal_width &&
+            batch_size == cached_batch_size ) {
+            item_info_data data( "", "", info, {}, scroll_pos );
+            return data;
+        }
+    } else {
+        const_cast<recipe *>( rec )->lang_version = detail::get_current_language_version();
     }
 
     cached_batch_size = batch_size;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1974,119 +1974,129 @@ int game::inventory_item_menu( item_location locThisItem,
             add_key_to_quick_shortcuts( oThisItem.invlet, "INVENTORY", false );
         }
 #endif
-
+        static int lang_version = detail::get_current_language_version();
+        const bool bHPR = get_auto_pickup().has_rule( &oThisItem );
         std::vector<iteminfo> vThisItem;
         std::vector<iteminfo> vDummy;
-
-        const bool bHPR = get_auto_pickup().has_rule( &oThisItem );
-        const hint_rating rate_drop_item = u.get_wielded_item() &&
-                                           u.get_wielded_item()->has_flag( flag_NO_UNWIELD ) ?
-                                           hint_rating::cant : hint_rating::good;
-
-        uilist action_menu;
-        action_menu.allow_anykey = true;
-        const auto addentry = [&]( const char key, const std::string & text, const hint_rating hint ) {
-            // The char is used as retval from the uilist *and* as hotkey.
-            action_menu.addentry( key, true, key, text );
-            auto &entry = action_menu.entries.back();
-            switch( hint ) {
-                case hint_rating::cant:
-                    entry.text_color = c_light_gray;
-                    break;
-                case hint_rating::iffy:
-                    entry.text_color = c_light_red;
-                    break;
-                case hint_rating::good:
-                    entry.text_color = c_light_green;
-                    break;
-            }
-        };
-        addentry( 'a', pgettext( "action", "activate" ), rate_action_use( u, oThisItem ) );
-        addentry( 'R', pgettext( "action", "read" ), rate_action_read( u, oThisItem ) );
-        addentry( 'E', pgettext( "action", "eat" ), rate_action_eat( u, oThisItem ) );
-        addentry( 'W', pgettext( "action", "wear" ), rate_action_wear( u, oThisItem ) );
-        addentry( 'w', pgettext( "action", "wield" ), rate_action_wield( u, oThisItem ) );
-        addentry( 't', pgettext( "action", "throw" ), rate_action_wield( u, oThisItem ) );
-        addentry( 'c', pgettext( "action", "change side" ), rate_action_change_side( u, oThisItem ) );
-        addentry( 'T', pgettext( "action", "take off" ), rate_action_take_off( u, oThisItem ) );
-        addentry( 'd', pgettext( "action", "drop" ), rate_drop_item );
-        addentry( 'U', pgettext( "action", "unload" ), u.rate_action_unload( oThisItem ) );
-        addentry( 'r', pgettext( "action", "reload" ), u.rate_action_reload( oThisItem ) );
-        addentry( 'p', pgettext( "action", "part reload" ), u.rate_action_reload( oThisItem ) );
-        addentry( 'm', pgettext( "action", "mend" ), rate_action_mend( u, oThisItem ) );
-        addentry( 'D', pgettext( "action", "disassemble" ), rate_action_disassemble( u, oThisItem ) );
-        if( oThisItem.is_container() && !oThisItem.is_corpse() ) {
-            addentry( 'i', pgettext( "action", "insert" ), rate_action_insert( u, locThisItem ) );
-            if( oThisItem.num_item_stacks() > 0 ) {
-                addentry( 'o', pgettext( "action", "open" ), hint_rating::good );
-            }
-            addentry( 'v', pgettext( "action", "pocket settings" ), hint_rating::good );
-        }
-
-        if( oThisItem.is_favorite ) {
-            addentry( 'f', pgettext( "action", "unfavorite" ), hint_rating::good );
-        } else {
-            addentry( 'f', pgettext( "action", "favorite" ), hint_rating::good );
-        }
-
-        addentry( 'V', pgettext( "action", "view recipe" ), rate_action_view_recipe( u, oThisItem ) );
-        addentry( '>', pgettext( "action", "hide contents" ), rate_action_collapse( oThisItem ) );
-        addentry( '<', pgettext( "action", "show contents" ), rate_action_expand( oThisItem ) );
-        addentry( '=', pgettext( "action", "reassign" ), hint_rating::good );
-
-        if( bHPR ) {
-            addentry( '-', _( "Auto pickup" ), hint_rating::iffy );
-        } else {
-            addentry( '+', _( "Auto pickup" ), hint_rating::good );
-        }
-
+        item_info_data data;
         int iScrollPos = 0;
-        oThisItem.info( true, vThisItem );
-
-        action_menu.w_y_setup = 0;
-        action_menu.w_x_setup = [&]( const int popup_width ) -> int {
-            switch( position )
-            {
-                default:
-                case RIGHT_TERMINAL_EDGE:
-                    return 0;
-                case LEFT_OF_INFO:
-                    return iStartX() - popup_width;
-                case RIGHT_OF_INFO:
-                    return iStartX() + iWidth();
-                case LEFT_TERMINAL_EDGE:
-                    return TERMX - popup_width;
-            }
-        };
-        // Filtering isn't needed, the number of entries is manageable.
-        action_menu.filtering = false;
-        // Default menu border color is different, this matches the border of the item info window.
-        action_menu.border_color = BORDER_COLOR;
-
-        item_info_data data( oThisItem.tname(), oThisItem.type_name(), vThisItem, vDummy, iScrollPos );
-        data.without_getch = true;
-
-        catacurses::window w_info;
         int iScrollHeight = 0;
-
-        std::unique_ptr<ui_adaptor> ui = std::make_unique<ui_adaptor>();
-        ui->on_screen_resize( [&]( ui_adaptor & ui ) {
-            w_info = catacurses::newwin( TERMY, iWidth(), point( iStartX(), 0 ) );
-            iScrollHeight = TERMY - 2;
-            ui.position_from_window( w_info );
-        } );
-        ui->mark_resize();
-
-        ui->on_redraw( [&]( const ui_adaptor & ) {
-            draw_item_info( w_info, data );
-        } );
-
-        action_menu.additional_actions = {
-            { "RIGHT", translation() }
-        };
+        uilist action_menu;
+        std::unique_ptr<ui_adaptor> ui;
 
         bool exit = false;
+        bool first_execution = true;
         do {
+            //lang check here is needed to redraw the menu while using "Toggle language to English" option
+            if( first_execution || lang_version != detail::get_current_language_version() ) {
+
+                const hint_rating rate_drop_item = u.get_wielded_item() &&
+                                                   u.get_wielded_item()->has_flag( flag_NO_UNWIELD ) ?
+                                                   hint_rating::cant : hint_rating::good;
+                action_menu.reset();
+                action_menu.allow_anykey = true;
+                const auto addentry = [&]( const char key, const std::string & text, const hint_rating hint ) {
+                    // The char is used as retval from the uilist *and* as hotkey.
+                    action_menu.addentry( key, true, key, text );
+                    auto &entry = action_menu.entries.back();
+                    switch( hint ) {
+                        case hint_rating::cant:
+                            entry.text_color = c_light_gray;
+                            break;
+                        case hint_rating::iffy:
+                            entry.text_color = c_light_red;
+                            break;
+                        case hint_rating::good:
+                            entry.text_color = c_light_green;
+                            break;
+                    }
+                };
+                addentry( 'a', pgettext( "action", "activate" ), rate_action_use( u, oThisItem ) );
+                addentry( 'R', pgettext( "action", "read" ), rate_action_read( u, oThisItem ) );
+                addentry( 'E', pgettext( "action", "eat" ), rate_action_eat( u, oThisItem ) );
+                addentry( 'W', pgettext( "action", "wear" ), rate_action_wear( u, oThisItem ) );
+                addentry( 'w', pgettext( "action", "wield" ), rate_action_wield( u, oThisItem ) );
+                addentry( 't', pgettext( "action", "throw" ), rate_action_wield( u, oThisItem ) );
+                addentry( 'c', pgettext( "action", "change side" ), rate_action_change_side( u, oThisItem ) );
+                addentry( 'T', pgettext( "action", "take off" ), rate_action_take_off( u, oThisItem ) );
+                addentry( 'd', pgettext( "action", "drop" ), rate_drop_item );
+                addentry( 'U', pgettext( "action", "unload" ), u.rate_action_unload( oThisItem ) );
+                addentry( 'r', pgettext( "action", "reload" ), u.rate_action_reload( oThisItem ) );
+                addentry( 'p', pgettext( "action", "part reload" ), u.rate_action_reload( oThisItem ) );
+                addentry( 'm', pgettext( "action", "mend" ), rate_action_mend( u, oThisItem ) );
+                addentry( 'D', pgettext( "action", "disassemble" ), rate_action_disassemble( u, oThisItem ) );
+                if( oThisItem.is_container() && !oThisItem.is_corpse() ) {
+                    addentry( 'i', pgettext( "action", "insert" ), rate_action_insert( u, locThisItem ) );
+                    if( oThisItem.num_item_stacks() > 0 ) {
+                        addentry( 'o', pgettext( "action", "open" ), hint_rating::good );
+                    }
+                    addentry( 'v', pgettext( "action", "pocket settings" ), hint_rating::good );
+                }
+
+                if( oThisItem.is_favorite ) {
+                    addentry( 'f', pgettext( "action", "unfavorite" ), hint_rating::good );
+                } else {
+                    addentry( 'f', pgettext( "action", "favorite" ), hint_rating::good );
+                }
+
+                addentry( 'V', pgettext( "action", "view recipe" ), rate_action_view_recipe( u, oThisItem ) );
+                addentry( '>', pgettext( "action", "hide contents" ), rate_action_collapse( oThisItem ) );
+                addentry( '<', pgettext( "action", "show contents" ), rate_action_expand( oThisItem ) );
+                addentry( '=', pgettext( "action", "reassign" ), hint_rating::good );
+
+                if( bHPR ) {
+                    addentry( '-', _( "Auto pickup" ), hint_rating::iffy );
+                } else {
+                    addentry( '+', _( "Auto pickup" ), hint_rating::good );
+                }
+
+                oThisItem.info( true, vThisItem );
+
+                action_menu.w_y_setup = 0;
+                action_menu.w_x_setup = [&]( const int popup_width ) -> int {
+                    switch( position )
+                    {
+                        default:
+                        case RIGHT_TERMINAL_EDGE:
+                            return 0;
+                        case LEFT_OF_INFO:
+                            return iStartX() - popup_width;
+                        case RIGHT_OF_INFO:
+                            return iStartX() + iWidth();
+                        case LEFT_TERMINAL_EDGE:
+                            return TERMX - popup_width;
+                    }
+                };
+                // Filtering isn't needed, the number of entries is manageable.
+                action_menu.filtering = false;
+                // Default menu border color is different, this matches the border of the item info window.
+                action_menu.border_color = BORDER_COLOR;
+
+                data = item_info_data( oThisItem.tname(), oThisItem.type_name(), vThisItem, vDummy, iScrollPos );
+                data.without_getch = true;
+
+                catacurses::window w_info;
+
+                ui = std::make_unique<ui_adaptor>();
+                ui->on_screen_resize( [&]( ui_adaptor & ui ) {
+                    w_info = catacurses::newwin( TERMY, iWidth(), point( iStartX(), 0 ) );
+                    iScrollHeight = TERMY - 2;
+                    ui.position_from_window( w_info );
+                } );
+                ui->mark_resize();
+
+                ui->on_redraw( [&]( const ui_adaptor & ) {
+                    draw_item_info( w_info, data );
+                } );
+
+                action_menu.additional_actions = {
+                    { "RIGHT", translation() }
+                };
+
+                lang_version = detail::get_current_language_version();
+                first_execution = false;
+            }
+
             const int prev_selected = action_menu.selected;
             action_menu.query( false );
             if( action_menu.ret >= 0 ) {
@@ -2110,6 +2120,7 @@ int game::inventory_item_menu( item_location locThisItem,
                 exit = true;
                 ui = nullptr;
             }
+
 
             switch( cMenu ) {
                 case 'a': {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -635,12 +635,12 @@ void game::toggle_pixel_minimap() const
 
 void game::toggle_language_to_en()
 {
-    const std::string english = "en";
+    const std::string english = "en" ;
     static std::string secondary_lang = english;
     std::string current_lang = TranslationManager::GetInstance().GetCurrentLanguage();
     secondary_lang = current_lang != english ? current_lang : secondary_lang;
     std::string new_lang = current_lang != english ? english : secondary_lang;
-    set_language(new_lang);
+    set_language( new_lang );
 }
 
 bool game::is_tileset_isometric() const
@@ -2510,7 +2510,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "toggle_auto_foraging" );
     ctxt.register_action( "toggle_auto_pickup" );
     ctxt.register_action( "toggle_thief_mode" );
-    ctxt.register_action("toggle_language_to_en");
+    ctxt.register_action( "toggle_language_to_en" );
     ctxt.register_action( "toggle_prevent_occlusion" );
     ctxt.register_action( "diary" );
     ctxt.register_action( "action_menu" );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1974,7 +1974,6 @@ int game::inventory_item_menu( item_location locThisItem,
             add_key_to_quick_shortcuts( oThisItem.invlet, "INVENTORY", false );
         }
 #endif
-        static int lang_version = detail::get_current_language_version();
         const bool bHPR = get_auto_pickup().has_rule( &oThisItem );
         std::vector<iteminfo> vThisItem;
         std::vector<iteminfo> vDummy;
@@ -1986,6 +1985,7 @@ int game::inventory_item_menu( item_location locThisItem,
 
         bool exit = false;
         bool first_execution = true;
+        static int lang_version = detail::get_current_language_version();
         do {
             //lang check here is needed to redraw the menu while using "Toggle language to English" option
             if( first_execution || lang_version != detail::get_current_language_version() ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2510,7 +2510,6 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "toggle_auto_foraging" );
     ctxt.register_action( "toggle_auto_pickup" );
     ctxt.register_action( "toggle_thief_mode" );
-    ctxt.register_action( "toggle_language_to_en" );
     ctxt.register_action( "toggle_prevent_occlusion" );
     ctxt.register_action( "diary" );
     ctxt.register_action( "action_menu" );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -640,7 +640,7 @@ void game::toggle_language_to_en()
     std::string current_lang = TranslationManager::GetInstance().GetCurrentLanguage();
     secondary_lang = current_lang != english ? current_lang : secondary_lang;
     std::string new_lang = current_lang != english ? english : secondary_lang;
-    set_language( new_lang );
+    change_language( new_lang );
 }
 
 bool game::is_tileset_isometric() const

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1987,7 +1987,7 @@ int game::inventory_item_menu( item_location locThisItem,
         bool first_execution = true;
         static int lang_version = detail::get_current_language_version();
         do {
-            //lang check here is needed to redraw the menu while using "Toggle language to English" option
+            //lang check here is needed to redraw the menu when using "Toggle language to English" option
             if( first_execution || lang_version != detail::get_current_language_version() ) {
 
                 const hint_rating rate_drop_item = u.get_wielded_item() &&

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -640,7 +640,7 @@ void game::toggle_language_to_en()
     std::string current_lang = TranslationManager::GetInstance().GetCurrentLanguage();
     secondary_lang = current_lang != english ? current_lang : secondary_lang;
     std::string new_lang = current_lang != english ? english : secondary_lang;
-    change_language( new_lang );
+    set_language( new_lang );
 }
 
 bool game::is_tileset_isometric() const

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -633,6 +633,16 @@ void game::toggle_pixel_minimap() const
 #endif // TILES
 }
 
+void game::toggle_language_to_en()
+{
+    const std::string english = "en";
+    static std::string secondary_lang = english;
+    std::string current_lang = TranslationManager::GetInstance().GetCurrentLanguage();
+    secondary_lang = current_lang != english ? current_lang : secondary_lang;
+    std::string new_lang = current_lang != english ? english : secondary_lang;
+    set_language(new_lang);
+}
+
 bool game::is_tileset_isometric() const
 {
 #if defined(TILES)
@@ -2500,6 +2510,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "toggle_auto_foraging" );
     ctxt.register_action( "toggle_auto_pickup" );
     ctxt.register_action( "toggle_thief_mode" );
+    ctxt.register_action("toggle_language_to_en");
     ctxt.register_action( "toggle_prevent_occlusion" );
     ctxt.register_action( "diary" );
     ctxt.register_action( "action_menu" );

--- a/src/game.h
+++ b/src/game.h
@@ -671,6 +671,7 @@ class game
 
         void toggle_fullscreen();
         void toggle_pixel_minimap() const;
+        void toggle_language_to_en();
         bool is_tileset_isometric() const;
         void reload_tileset();
         void temp_exit_fullscreen();

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2074,7 +2074,6 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
         item_info_data item_info_first;
         item_info_data item_info_second;
 
-        const int offset_y = confirm_message.empty() ? 0 : 3;
         int page_size = 0;
 
         int scroll_pos_first = 0;
@@ -2117,6 +2116,7 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
             ui.on_screen_resize( [&]( ui_adaptor & ui ) {
                 const int half_width = TERMX / 2;
                 const int height = TERMY;
+                const int offset_y = confirm_message.empty() ? 0 : 3;
                 page_size = TERMY - offset_y - 2;
                 wnd_first = catacurses::newwin( height - offset_y, half_width, point_zero );
                 wnd_second = catacurses::newwin( height - offset_y, half_width, point( half_width, 0 ) );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2074,8 +2074,6 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
         item_info_data item_info_first;
         item_info_data item_info_second;
 
-        const int half_width = TERMX / 2;
-        const int height = TERMY;
         const int offset_y = confirm_message.empty() ? 0 : 3;
         const int page_size = TERMY - offset_y - 2;
 
@@ -2117,6 +2115,8 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
 
             ui.reset();
             ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+                const int half_width = TERMX / 2;
+                const int height = TERMY;
                 wnd_first = catacurses::newwin( height - offset_y, half_width, point_zero );
                 wnd_second = catacurses::newwin( height - offset_y, half_width, point( half_width, 0 ) );
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2069,19 +2069,14 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
     std::string action;
     input_context ctxt;
     ui_adaptor ui;
+    item_info_data item_info_first;
+    item_info_data item_info_second;
+    int page_size = 0;
+    int scroll_pos_first = 0;
+    int scroll_pos_second = 0;
     bool first_execution = true;
+    static int lang_version = detail::get_current_language_version();
     do {
-
-        item_info_data item_info_first;
-        item_info_data item_info_second;
-
-        int page_size = 0;
-
-        int scroll_pos_first = 0;
-        int scroll_pos_second = 0;
-
-        static int lang_version = detail::get_current_language_version();
-
         if( first_execution || lang_version != detail::get_current_language_version() ) {
             std::vector<iteminfo> v_item_first;
             std::vector<iteminfo> v_item_second;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2069,6 +2069,7 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
     std::string action;
     input_context ctxt;
     ui_adaptor ui;
+    bool first_execution = true;
     do {
 
         item_info_data item_info_first;
@@ -2079,7 +2080,6 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
         int scroll_pos_first = 0;
         int scroll_pos_second = 0;
 
-        bool first_execution = true;
         static int lang_version = detail::get_current_language_version();
 
         if( first_execution || lang_version != detail::get_current_language_version() ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2075,7 +2075,7 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
         item_info_data item_info_second;
 
         const int offset_y = confirm_message.empty() ? 0 : 3;
-        const int page_size = TERMY - offset_y - 2;
+        int page_size = 0;
 
         int scroll_pos_first = 0;
         int scroll_pos_second = 0;
@@ -2117,6 +2117,7 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
             ui.on_screen_resize( [&]( ui_adaptor & ui ) {
                 const int half_width = TERMX / 2;
                 const int height = TERMY;
+                page_size = TERMY - offset_y - 2;
                 wnd_first = catacurses::newwin( height - offset_y, half_width, point_zero );
                 wnd_second = catacurses::newwin( height - offset_y, half_width, point( half_width, 0 ) );
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2141,6 +2141,7 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
                 draw_item_info( wnd_second, item_info_second );
             } );
             lang_version = detail::get_current_language_version();
+            first_execution = false;
         }
 
         ui_manager::redraw();

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2077,7 +2077,7 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
     bool first_execution = true;
     static int lang_version = detail::get_current_language_version();
     do {
-        //lang check here is needed to redraw the menu while using "Toggle language to English" option
+        //lang check here is needed to redraw the menu when using "Toggle language to English" option
         if( first_execution || lang_version != detail::get_current_language_version() ) {
             std::vector<iteminfo> v_item_first;
             std::vector<iteminfo> v_item_second;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2066,72 +2066,82 @@ drop_locations game_menus::inv::smoke_food( Character &you, units::volume total_
 bool game_menus::inv::compare_items( const item &first, const item &second,
                                      const std::string &confirm_message )
 {
-    std::vector<iteminfo> v_item_first;
-    std::vector<iteminfo> v_item_second;
-
-    first.info( true, v_item_first );
-    second.info( true, v_item_second );
-
-    int scroll_pos_first = 0;
-    int scroll_pos_second = 0;
-
-    item_info_data item_info_first( first.tname(), first.type_name(),
-                                    v_item_first, v_item_second, scroll_pos_first );
-
-    item_info_data item_info_second( second.tname(), second.type_name(),
-                                     v_item_second, v_item_first, scroll_pos_second );
-
-    item_info_first.without_getch = true;
-    item_info_second.without_getch = true;
-
-    input_context ctxt;
-    ctxt.register_action( "HELP_KEYBINDINGS" );
-    if( !confirm_message.empty() ) {
-        ctxt.register_action( "CONFIRM" );
-    }
-    ctxt.register_action( "QUIT" );
-    ctxt.register_action( "UP" );
-    ctxt.register_action( "DOWN" );
-    ctxt.register_action( "PAGE_UP" );
-    ctxt.register_action( "PAGE_DOWN" );
-
-    catacurses::window wnd_first;
-    catacurses::window wnd_second;
-    catacurses::window wnd_message;
-
-    const int half_width = TERMX / 2;
-    const int height = TERMY;
-    const int offset_y = confirm_message.empty() ? 0 : 3;
-    const int page_size = TERMY - offset_y - 2;
-
-    ui_adaptor ui;
-    ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        wnd_first = catacurses::newwin( height - offset_y, half_width, point_zero );
-        wnd_second = catacurses::newwin( height - offset_y, half_width, point( half_width, 0 ) );
-
-        if( !confirm_message.empty() ) {
-            wnd_message = catacurses::newwin( offset_y, TERMX, point( 0, height - offset_y ) );
-        }
-
-        ui.position( point_zero, point( half_width * 2, height ) );
-    } );
-    ui.mark_resize();
-    ui.on_redraw( [&]( const ui_adaptor & ) {
-        if( !confirm_message.empty() ) {
-            draw_border( wnd_message );
-            mvwputch( wnd_message, point( 3, 1 ), c_white, confirm_message
-                      + " " + ctxt.describe_key_and_name( "CONFIRM" )
-                      + " " + ctxt.describe_key_and_name( "QUIT" ) );
-            wnoutrefresh( wnd_message );
-        }
-
-        draw_item_info( wnd_first, item_info_first );
-        draw_item_info( wnd_second, item_info_second );
-    } );
-
     std::string action;
-
+    input_context ctxt;
+    ui_adaptor ui;
     do {
+
+        item_info_data item_info_first;
+        item_info_data item_info_second;
+
+        const int half_width = TERMX / 2;
+        const int height = TERMY;
+        const int offset_y = confirm_message.empty() ? 0 : 3;
+        const int page_size = TERMY - offset_y - 2;
+
+        int scroll_pos_first = 0;
+        int scroll_pos_second = 0;
+
+        bool first_execution = true;
+        static int lang_version = detail::get_current_language_version();
+
+        if( first_execution || lang_version != detail::get_current_language_version() ) {
+            std::vector<iteminfo> v_item_first;
+            std::vector<iteminfo> v_item_second;
+
+            first.info( true, v_item_first );
+            second.info( true, v_item_second );
+
+            item_info_first = item_info_data( first.tname(), first.type_name(),
+                                              v_item_first, v_item_second, scroll_pos_first );
+
+            item_info_second = item_info_data( second.tname(), second.type_name(),
+                                               v_item_second, v_item_first, scroll_pos_second );
+
+            item_info_first.without_getch = true;
+            item_info_second.without_getch = true;
+
+            ctxt.register_action( "HELP_KEYBINDINGS" );
+            if( !confirm_message.empty() ) {
+                ctxt.register_action( "CONFIRM" );
+            }
+            ctxt.register_action( "QUIT" );
+            ctxt.register_action( "UP" );
+            ctxt.register_action( "DOWN" );
+            ctxt.register_action( "PAGE_UP" );
+            ctxt.register_action( "PAGE_DOWN" );
+
+            catacurses::window wnd_first;
+            catacurses::window wnd_second;
+            catacurses::window wnd_message;
+
+            ui.reset();
+            ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+                wnd_first = catacurses::newwin( height - offset_y, half_width, point_zero );
+                wnd_second = catacurses::newwin( height - offset_y, half_width, point( half_width, 0 ) );
+
+                if( !confirm_message.empty() ) {
+                    wnd_message = catacurses::newwin( offset_y, TERMX, point( 0, height - offset_y ) );
+                }
+
+                ui.position( point_zero, point( half_width * 2, height ) );
+            } );
+            ui.mark_resize();
+            ui.on_redraw( [&]( const ui_adaptor & ) {
+                if( !confirm_message.empty() ) {
+                    draw_border( wnd_message );
+                    mvwputch( wnd_message, point( 3, 1 ), c_white, confirm_message
+                              + " " + ctxt.describe_key_and_name( "CONFIRM" )
+                              + " " + ctxt.describe_key_and_name( "QUIT" ) );
+                    wnoutrefresh( wnd_message );
+                }
+
+                draw_item_info( wnd_first, item_info_first );
+                draw_item_info( wnd_second, item_info_second );
+            } );
+            lang_version = detail::get_current_language_version();
+        }
+
         ui_manager::redraw();
 
         action = ctxt.handle_input();

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2077,6 +2077,7 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
     bool first_execution = true;
     static int lang_version = detail::get_current_language_version();
     do {
+        //lang check here is needed to redraw the menu while using "Toggle language to English" option
         if( first_execution || lang_version != detail::get_current_language_version() ) {
             std::vector<iteminfo> v_item_first;
             std::vector<iteminfo> v_item_second;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2695,6 +2695,10 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             }
             break;
 
+        case ACTION_TOGGLE_LANGUAGE_TO_EN:
+            toggle_language_to_en();
+            break;
+
         case ACTION_TOGGLE_AUTO_FORAGING:
             get_options().get_option( "AUTO_FORAGING" ).setNext();
             get_options().save();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2695,10 +2695,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             }
             break;
 
-        case ACTION_TOGGLE_LANGUAGE_TO_EN:
-            toggle_language_to_en();
-            break;
-
         case ACTION_TOGGLE_AUTO_FORAGING:
             get_options().get_option( "AUTO_FORAGING" ).setNext();
             get_options().save();

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1197,6 +1197,21 @@ const std::string &input_context::handle_input( const int timeout )
     next_action.type = input_event_t::error;
     const std::string *result = &CATA_ERROR;
     while( true ) {
+
+        //Allows "toggle_language_to_en" to also work on contexts other than "DEFAULTMODE"
+        const std::string pressed_key = next_action.text;
+        if( !pressed_key.empty() ) {
+            action_attributes attributes = inp_mngr.get_action_attributes( "toggle_language_to_en",
+                                           "DEFAULTMODE" );
+            char keybind = attributes.input_events.front().sequence.front();
+
+            if( *pressed_key.c_str() == keybind ) {
+                g->toggle_language_to_en();
+                g->invalidate_main_ui_adaptor();
+                ui_manager::redraw_invalidated();
+            }
+        } //
+
         next_action = inp_mngr.get_input_event( preferred_keyboard_mode );
         if( next_action.type == input_event_t::timeout ) {
             result = &TIMEOUT;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1199,15 +1199,12 @@ const std::string &input_context::handle_input( const int timeout )
     while( true ) {
 
         //Allows "toggle_language_to_en" to also work on contexts other than "DEFAULTMODE"
-        const std::string pressed_key = next_action.text;
-        if( !pressed_key.empty() ) {
-            action_attributes attributes = inp_mngr.get_action_attributes( "toggle_language_to_en",
-                                           "DEFAULTMODE" );
-            if( !attributes.input_events.empty() ) {
-                input_event input = attributes.input_events.front();
+        if( !next_action.sequence.empty() ) {
+            auto attr = inp_mngr.get_action_attributes( "toggle_language_to_en", "DEFAULTMODE" );
+            if( !attr.input_events.empty() ) {
+                input_event input = attr.input_events.front();
                 if( !input.sequence.empty() ) {
-                    char keybind = input.sequence.front();
-                    if( *pressed_key.c_str() == keybind ) {
+                    if( next_action.sequence.front() == input.sequence.front() ) {
                         g->toggle_language_to_en();
                         g->invalidate_main_ui_adaptor();
                         ui_manager::redraw_invalidated();

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1200,9 +1200,9 @@ const std::string &input_context::handle_input( const int timeout )
 
         //Allows "toggle_language_to_en" to also work on contexts other than "DEFAULTMODE"
         if( !next_action.sequence.empty() ) {
-            auto attr = inp_mngr.get_action_attributes( "toggle_language_to_en", "DEFAULTMODE" );
+            const auto &attr = inp_mngr.get_action_attributes( "toggle_language_to_en", "DEFAULTMODE" );
             if( !attr.input_events.empty() ) {
-                input_event input = attr.input_events.front();
+                const input_event &input = attr.input_events.front();
                 if( !input.sequence.empty() ) {
                     if( next_action.sequence.front() == input.sequence.front() ) {
                         g->toggle_language_to_en();

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1207,15 +1207,10 @@ const std::string &input_context::handle_input( const int timeout )
         const std::string &action = input_to_action( next_action );
 
         if( action == "toggle_language_to_en" ) {
-            //Allows "toggle_language_to_en" to also work on contexts other than "DEFAULTMODE"
             g->toggle_language_to_en();
             g->invalidate_main_ui_adaptor();
             ui_manager::redraw_invalidated();
         }
-
-
-
-
 
         // Special help action
         if( action == "HELP_KEYBINDINGS" ) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1203,12 +1203,16 @@ const std::string &input_context::handle_input( const int timeout )
         if( !pressed_key.empty() ) {
             action_attributes attributes = inp_mngr.get_action_attributes( "toggle_language_to_en",
                                            "DEFAULTMODE" );
-            char keybind = attributes.input_events.front().sequence.front();
-
-            if( *pressed_key.c_str() == keybind ) {
-                g->toggle_language_to_en();
-                g->invalidate_main_ui_adaptor();
-                ui_manager::redraw_invalidated();
+            if( !attributes.input_events.empty() ) {
+                input_event input = attributes.input_events.front();
+                if( !input.sequence.empty() ) {
+                    char keybind = input.sequence.front();
+                    if( *pressed_key.c_str() == keybind ) {
+                        g->toggle_language_to_en();
+                        g->invalidate_main_ui_adaptor();
+                        ui_manager::redraw_invalidated();
+                    }
+                }
             }
         } //
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1198,21 +1198,6 @@ const std::string &input_context::handle_input( const int timeout )
     const std::string *result = &CATA_ERROR;
     while( true ) {
 
-        //Allows "toggle_language_to_en" to also work on contexts other than "DEFAULTMODE"
-        if( !next_action.sequence.empty() ) {
-            const auto &attr = inp_mngr.get_action_attributes( "toggle_language_to_en", "DEFAULTMODE" );
-            if( !attr.input_events.empty() ) {
-                const input_event &input = attr.input_events.front();
-                if( !input.sequence.empty() ) {
-                    if( next_action.sequence.front() == input.sequence.front() ) {
-                        g->toggle_language_to_en();
-                        g->invalidate_main_ui_adaptor();
-                        ui_manager::redraw_invalidated();
-                    }
-                }
-            }
-        } //
-
         next_action = inp_mngr.get_input_event( preferred_keyboard_mode );
         if( next_action.type == input_event_t::timeout ) {
             result = &TIMEOUT;
@@ -1220,6 +1205,17 @@ const std::string &input_context::handle_input( const int timeout )
         }
 
         const std::string &action = input_to_action( next_action );
+
+        if( action == "toggle_language_to_en" ) {
+            //Allows "toggle_language_to_en" to also work on contexts other than "DEFAULTMODE"
+            g->toggle_language_to_en();
+            g->invalidate_main_ui_adaptor();
+            ui_manager::redraw_invalidated();
+        }
+
+
+
+
 
         // Special help action
         if( action == "HELP_KEYBINDINGS" ) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1206,9 +1206,10 @@ const std::string &input_context::handle_input( const int timeout )
 
         const std::string &action = input_to_action( next_action );
 
+        //Special global key to toggle language to english and back
         if( action == "toggle_language_to_en" ) {
             g->toggle_language_to_en();
-            g->invalidate_main_ui_adaptor();
+            ui_manager::invalidate_all_ui_adaptors();
             ui_manager::redraw_invalidated();
         }
 

--- a/src/input.h
+++ b/src/input.h
@@ -561,6 +561,7 @@ class input_context
             input_context_stack.push_back( this );
             allow_text_entry = false;
 #endif
+            register_action( "toggle_language_to_en" );
         }
         // TODO: consider making the curses WINDOW an argument to the constructor, so that mouse input
         // outside that window can be ignored
@@ -573,6 +574,7 @@ class input_context
             input_context_stack.push_back( this );
             allow_text_entry = false;
 #endif
+            register_action( "toggle_language_to_en" );
         }
 
 #if defined(__ANDROID__)

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -971,7 +971,7 @@ void inventory_entry::make_entry_cell_cache(
     }
     entry_cell_cache.emplace( entry_cell_cache_t{
         preset.get_color( *this ),
-        { preset.get_cells_count(), std::string() }, detail::get_current_language_version() } );
+        { preset.get_cells_count(), std::string() } } );
 
     for( size_t i = 0, n = preset.get_cells_count(); i < n; ++i ) {
         entry_cell_cache->text[i] = preset.get_cell_text( *this, i );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -986,6 +986,7 @@ void inventory_entry::reset_entry_cell_cache() const
 const inventory_entry::entry_cell_cache_t &inventory_entry::get_entry_cell_cache(
     inventory_selector_preset const &preset ) const
 {
+    //lang check here is needed to redraw the menu when using "Toggle language to English" option
     if( !entry_cell_cache ||
         entry_cell_cache->lang_version != detail::get_current_language_version() ) {
         make_entry_cell_cache( preset, false );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -986,17 +986,12 @@ void inventory_entry::reset_entry_cell_cache() const
 const inventory_entry::entry_cell_cache_t &inventory_entry::get_entry_cell_cache(
     inventory_selector_preset const &preset ) const
 {
-    bool has_invalid_lang_version = entry_cell_cache->lang_version !=
-                                    detail::get_current_language_version();
-
-    if( !entry_cell_cache || has_invalid_lang_version ) {
+    if( !entry_cell_cache ||
+        entry_cell_cache->lang_version != detail::get_current_language_version() ) {
         make_entry_cell_cache( preset, false );
         cache_denial( preset );
         cata_assert( entry_cell_cache.has_value() );
-
-        if( has_invalid_lang_version ) {
-            entry_cell_cache->lang_version = detail::get_current_language_version();
-        }
+        entry_cell_cache->lang_version = detail::get_current_language_version();
     }
 
     return *entry_cell_cache;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -971,7 +971,7 @@ void inventory_entry::make_entry_cell_cache(
     }
     entry_cell_cache.emplace( entry_cell_cache_t{
         preset.get_color( *this ),
-        { preset.get_cells_count(), std::string() } } );
+        { preset.get_cells_count(), std::string() }, detail::get_current_language_version() } );
 
     for( size_t i = 0, n = preset.get_cells_count(); i < n; ++i ) {
         entry_cell_cache->text[i] = preset.get_cell_text( *this, i );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -986,14 +986,15 @@ void inventory_entry::reset_entry_cell_cache() const
 const inventory_entry::entry_cell_cache_t &inventory_entry::get_entry_cell_cache(
     inventory_selector_preset const &preset ) const
 {
-    bool has_invalid_lang_version = entry_cell_cache->lang_version != detail::get_current_language_version();
-   
-    if( !entry_cell_cache || has_invalid_lang_version) {
+    bool has_invalid_lang_version = entry_cell_cache->lang_version !=
+                                    detail::get_current_language_version();
+
+    if( !entry_cell_cache || has_invalid_lang_version ) {
         make_entry_cell_cache( preset, false );
         cache_denial( preset );
         cata_assert( entry_cell_cache.has_value() );
-        
-        if (has_invalid_lang_version) {
+
+        if( has_invalid_lang_version ) {
             entry_cell_cache->lang_version = detail::get_current_language_version();
         }
     }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -986,7 +986,7 @@ void inventory_entry::reset_entry_cell_cache() const
 const inventory_entry::entry_cell_cache_t &inventory_entry::get_entry_cell_cache(
     inventory_selector_preset const &preset ) const
 {
-    //lang check here is needed to rebuild cache when using "Toggle language to English" option
+    //lang check here is needed to rebuild cache when using "Toggle language to English" option 
     if( !entry_cell_cache ||
         entry_cell_cache->lang_version != detail::get_current_language_version() ) {
         make_entry_cell_cache( preset, false );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -986,7 +986,7 @@ void inventory_entry::reset_entry_cell_cache() const
 const inventory_entry::entry_cell_cache_t &inventory_entry::get_entry_cell_cache(
     inventory_selector_preset const &preset ) const
 {
-    //lang check here is needed to rebuild cache when using "Toggle language to English" option 
+    //lang check here is needed to rebuild cache when using "Toggle language to English" option
     if( !entry_cell_cache ||
         entry_cell_cache->lang_version != detail::get_current_language_version() ) {
         make_entry_cell_cache( preset, false );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -986,11 +986,16 @@ void inventory_entry::reset_entry_cell_cache() const
 const inventory_entry::entry_cell_cache_t &inventory_entry::get_entry_cell_cache(
     inventory_selector_preset const &preset ) const
 {
-
-    if( !entry_cell_cache ) {
+    bool has_invalid_lang_version = entry_cell_cache->lang_version != detail::get_current_language_version();
+   
+    if( !entry_cell_cache || has_invalid_lang_version) {
         make_entry_cell_cache( preset, false );
         cache_denial( preset );
         cata_assert( entry_cell_cache.has_value() );
+        
+        if (has_invalid_lang_version) {
+            entry_cell_cache->lang_version = detail::get_current_language_version();
+        }
     }
 
     return *entry_cell_cache;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -986,7 +986,7 @@ void inventory_entry::reset_entry_cell_cache() const
 const inventory_entry::entry_cell_cache_t &inventory_entry::get_entry_cell_cache(
     inventory_selector_preset const &preset ) const
 {
-    //lang check here is needed to redraw the menu when using "Toggle language to English" option
+    //lang check here is needed to rebuild cache when using "Toggle language to English" option
     if( !entry_cell_cache ||
         entry_cell_cache->lang_version != detail::get_current_language_version() ) {
         make_entry_cell_cache( preset, false );

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -202,6 +202,7 @@ class inventory_entry
         struct entry_cell_cache_t {
             nc_color color = c_unset;
             std::vector<std::string> text;
+            int lang_version;
         };
 
         const entry_cell_cache_t &get_entry_cell_cache( inventory_selector_preset const &preset ) const;

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -202,7 +202,7 @@ class inventory_entry
         struct entry_cell_cache_t {
             nc_color color = c_unset;
             std::vector<std::string> text;
-            int lang_version;
+            int lang_version = 0;
         };
 
         const entry_cell_cache_t &get_entry_cell_cache( inventory_selector_preset const &preset ) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -740,7 +740,7 @@ int main( int argc, const char *argv[] )
         get_options().load();
     }
 
-    set_language();
+    set_language_from_options();
 
     rng_set_engine_seed( cli.seed );
 
@@ -793,7 +793,7 @@ int main( int argc, const char *argv[] )
 #if defined(LOCALIZE)
     if( get_option<std::string>( "USE_LANG" ).empty() && !SystemLocale::Language().has_value() ) {
         select_language();
-        set_language();
+        set_language_from_options();
     }
 #endif
     replay_buffered_debugmsg_prompts();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3742,7 +3742,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
 
     if( lang_changed ) {
         update_global_locale();
-        set_language();
+        set_language_from_options();
     }
     calendar::set_eternal_season( ::get_option<bool>( "ETERNAL_SEASON" ) );
     calendar::set_season_length( ::get_option<int>( "SEASON_LENGTH" ) );

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -125,7 +125,6 @@ class recipe
         translation name_;
 
         int difficulty = 0;
-        int lang_version = 0;
 
         // Returns the recipe difficulty. For practice recipes, this is adjusted
         // for the crafter's current skill level.

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -125,6 +125,7 @@ class recipe
         translation name_;
 
         int difficulty = 0;
+        int lang_version = 0;
 
         // Returns the recipe difficulty. For practice recipes, this is adjusted
         // for the crafter's current skill level.

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3632,7 +3632,7 @@ void catacurses::init_interface()
 
     get_options().init();
     get_options().load();
-    set_language(); //Prevent translated language strings from causing an error if language not set
+    set_language_from_options(); //Prevent translated language strings from causing an error if language not set
 
     font_loader fl;
     fl.load();

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -73,20 +73,19 @@ std::string locale_dir()
     return loc_dir;
 }
 
-//If called without any parameter sets the language selected in the game's option menu,
+//if called without any parameters sets the language to the one selected in the options menu
 //if called with a parameter from code sets the language to that instead
 void set_language( std::string lang )
 {
 #if defined(LOCALIZE)
+    std::string temp_lang = lang;
     if( lang.empty() ) {
         const std::string system_lang = SystemLocale::Language().value_or( "en" );
-        std::string lang_opt = get_option<std::string>( "USE_LANG" ).empty() ? system_lang :
-                               get_option<std::string>( "USE_LANG" );
-        DebugLog( D_INFO, D_MAIN ) << "Setting language to: '" << lang_opt << '\'';
-        TranslationManager::GetInstance().SetLanguage( lang_opt );
-    } else {
-        TranslationManager::GetInstance().SetLanguage( lang );
+        temp_lang = get_option<std::string>( "USE_LANG" ).empty() ? system_lang :
+                    get_option<std::string>( "USE_LANG" );
     }
+        DebugLog( D_INFO, D_MAIN ) << "Setting language to: '" << temp_lang << '\'';
+        TranslationManager::GetInstance().SetLanguage( temp_lang );
 #if defined(_WIN32)
     // Use the ANSI code page 1252 to work around some language output bugs. (#8665)
     if( setlocale( LC_ALL, ".1252" ) == nullptr ) {

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -84,8 +84,7 @@ void set_language( std::string lang )
                                get_option<std::string>( "USE_LANG" );
         DebugLog( D_INFO, D_MAIN ) << "Setting language to: '" << lang_opt << '\'';
         TranslationManager::GetInstance().SetLanguage( lang_opt );
-    }
-    else {
+    } else {
         TranslationManager::GetInstance().SetLanguage( lang );
     }
 #if defined(_WIN32)

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -78,7 +78,7 @@ std::string locale_dir()
 void set_language( std::string lang )
 {
 #if defined(LOCALIZE)
-    if ( lang.empty() ) {
+    if( lang.empty() ) {
         const std::string system_lang = SystemLocale::Language().value_or( "en" );
         std::string lang_opt = get_option<std::string>( "USE_LANG" ).empty() ? system_lang :
                                get_option<std::string>( "USE_LANG" );

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -83,7 +83,7 @@ void set_language()
 #endif
 }
 
-void change_language( std::string &lang )
+void change_language( const std::string &lang )
 {
 #if defined(LOCALIZE)
     DebugLog( D_INFO, D_MAIN ) << "Setting language to: '" << lang << '\'';

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -73,19 +73,21 @@ std::string locale_dir()
     return loc_dir;
 }
 
-//if called without any parameters sets the language to the one selected in the options menu
-//if called with a parameter from code sets the language to that instead
-void set_language( std::string lang )
+void set_language()
 {
 #if defined(LOCALIZE)
-    std::string temp_lang = lang;
-    if( lang.empty() ) {
-        const std::string system_lang = SystemLocale::Language().value_or( "en" );
-        temp_lang = get_option<std::string>( "USE_LANG" ).empty() ? system_lang :
-                    get_option<std::string>( "USE_LANG" );
-    }
-    DebugLog( D_INFO, D_MAIN ) << "Setting language to: '" << temp_lang << '\'';
-    TranslationManager::GetInstance().SetLanguage( temp_lang );
+    const std::string system_lang = SystemLocale::Language().value_or( "en" );
+    std::string lang_opt = get_option<std::string>( "USE_LANG" ).empty() ? system_lang :
+                           get_option<std::string>( "USE_LANG" );
+    change_language( lang_opt );
+#endif
+}
+
+void change_language( std::string &lang )
+{
+#if defined(LOCALIZE)
+    DebugLog( D_INFO, D_MAIN ) << "Setting language to: '" << lang << '\'';
+    TranslationManager::GetInstance().SetLanguage( lang );
 #if defined(_WIN32)
     // Use the ANSI code page 1252 to work around some language output bugs. (#8665)
     if( setlocale( LC_ALL, ".1252" ) == nullptr ) {

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -73,17 +73,17 @@ std::string locale_dir()
     return loc_dir;
 }
 
-void set_language()
+void set_language_from_options()
 {
 #if defined(LOCALIZE)
     const std::string system_lang = SystemLocale::Language().value_or( "en" );
     std::string lang_opt = get_option<std::string>( "USE_LANG" ).empty() ? system_lang :
                            get_option<std::string>( "USE_LANG" );
-    change_language( lang_opt );
+    set_language( lang_opt );
 #endif
 }
 
-void change_language( const std::string &lang )
+void set_language( const std::string &lang )
 {
 #if defined(LOCALIZE)
     DebugLog( D_INFO, D_MAIN ) << "Setting language to: '" << lang << '\'';

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -75,10 +75,10 @@ std::string locale_dir()
 
 //If called without any parameter sets the language selected in the game's option menu,
 //if called with a parameter from code sets the language to that instead
-void set_language(std::string lang)
+void set_language( std::string lang )
 {
 #if defined(LOCALIZE)
-    if (lang.empty()) {
+    if ( lang.empty() ) {
         const std::string system_lang = SystemLocale::Language().value_or( "en" );
         std::string lang_opt = get_option<std::string>( "USE_LANG" ).empty() ? system_lang :
                                get_option<std::string>( "USE_LANG" );
@@ -86,7 +86,7 @@ void set_language(std::string lang)
         TranslationManager::GetInstance().SetLanguage( lang_opt );
     }
     else {
-        TranslationManager::GetInstance().SetLanguage(lang);
+        TranslationManager::GetInstance().SetLanguage( lang );
     }
 #if defined(_WIN32)
     // Use the ANSI code page 1252 to work around some language output bugs. (#8665)

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -73,14 +73,21 @@ std::string locale_dir()
     return loc_dir;
 }
 
-void set_language()
+//If called without any parameter sets the language selected in the game's option menu,
+//if called with a parameter from code sets the language to that instead
+void set_language(std::string lang)
 {
 #if defined(LOCALIZE)
-    const std::string system_lang = SystemLocale::Language().value_or( "en" );
-    std::string lang_opt = get_option<std::string>( "USE_LANG" ).empty() ? system_lang :
-                           get_option<std::string>( "USE_LANG" );
-    DebugLog( D_INFO, D_MAIN ) << "Setting language to: '" << lang_opt << '\'';
-    TranslationManager::GetInstance().SetLanguage( lang_opt );
+    if (lang.empty()) {
+        const std::string system_lang = SystemLocale::Language().value_or( "en" );
+        std::string lang_opt = get_option<std::string>( "USE_LANG" ).empty() ? system_lang :
+                               get_option<std::string>( "USE_LANG" );
+        DebugLog( D_INFO, D_MAIN ) << "Setting language to: '" << lang_opt << '\'';
+        TranslationManager::GetInstance().SetLanguage( lang_opt );
+    }
+    else {
+        TranslationManager::GetInstance().SetLanguage(lang);
+    }
 #if defined(_WIN32)
     // Use the ANSI code page 1252 to work around some language output bugs. (#8665)
     if( setlocale( LC_ALL, ".1252" ) == nullptr ) {

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -84,8 +84,8 @@ void set_language( std::string lang )
         temp_lang = get_option<std::string>( "USE_LANG" ).empty() ? system_lang :
                     get_option<std::string>( "USE_LANG" );
     }
-        DebugLog( D_INFO, D_MAIN ) << "Setting language to: '" << temp_lang << '\'';
-        TranslationManager::GetInstance().SetLanguage( temp_lang );
+    DebugLog( D_INFO, D_MAIN ) << "Setting language to: '" << temp_lang << '\'';
+    TranslationManager::GetInstance().SetLanguage( temp_lang );
 #if defined(_WIN32)
     // Use the ANSI code page 1252 to work around some language output bugs. (#8665)
     if( setlocale( LC_ALL, ".1252" ) == nullptr ) {

--- a/src/translations.h
+++ b/src/translations.h
@@ -97,6 +97,6 @@ inline const char *npgettext( const char *const context, const char *const msgid
 std::string locale_dir();
 
 void set_language();
-void change_language( std::string& lang );
+void change_language( const std::string &lang );
 
 #endif // CATA_SRC_TRANSLATIONS_H

--- a/src/translations.h
+++ b/src/translations.h
@@ -96,7 +96,7 @@ inline const char *npgettext( const char *const context, const char *const msgid
 
 std::string locale_dir();
 
-void set_language();
-void change_language( const std::string &lang );
+void set_language_from_options();
+void set_language( const std::string &lang );
 
 #endif // CATA_SRC_TRANSLATIONS_H

--- a/src/translations.h
+++ b/src/translations.h
@@ -96,6 +96,6 @@ inline const char *npgettext( const char *const context, const char *const msgid
 
 std::string locale_dir();
 
-void set_language(std::string lang = "" );
+void set_language( std::string lang = "" );
 
 #endif // CATA_SRC_TRANSLATIONS_H

--- a/src/translations.h
+++ b/src/translations.h
@@ -96,6 +96,6 @@ inline const char *npgettext( const char *const context, const char *const msgid
 
 std::string locale_dir();
 
-void set_language();
+void set_language(std::string lang = "" );
 
 #endif // CATA_SRC_TRANSLATIONS_H

--- a/src/translations.h
+++ b/src/translations.h
@@ -96,6 +96,7 @@ inline const char *npgettext( const char *const context, const char *const msgid
 
 std::string locale_dir();
 
-void set_language( std::string lang = "" );
+void set_language();
+void change_language( std::string& lang );
 
 #endif // CATA_SRC_TRANSLATIONS_H

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -474,5 +474,10 @@ void screen_resized()
 {
     ui_adaptor::screen_resized();
 }
-
+void invalidate_all_ui_adaptors()
+{
+    for( ui_adaptor &adaptor : ui_stack ) {
+        adaptor.invalidate_ui();
+    }
+}
 } // namespace ui_manager

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -276,6 +276,7 @@ void redraw_invalidated();
  * Not supposed to be directly called by the user.
  **/
 void screen_resized();
+void invalidate_all_ui_adaptors();
 } // namespace ui_manager
 
 #endif // CATA_SRC_UI_MANAGER_H

--- a/tests/translations_test.cpp
+++ b/tests/translations_test.cpp
@@ -81,7 +81,7 @@ TEST_CASE( "translations_macro_char_address", "[translations]" )
 // requires .mo file for "en" language
 TEST_CASE( "translations_macro_char_address_translated", "[.][translations]" )
 {
-    set_language();
+    set_language_from_options();
     // translated string
     const char *test_string = "thread";
 


### PR DESCRIPTION
Adds to Keybind an entry called "Toggle language to English" (default assigned to the key "," for testing purposes). If from the game options a language different from English was selected, when using this key while playing the language will toggle between that language and English on the fly every time it is pressed.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Adds a key to toggle the language to English and back on the fly while playing"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This feature is of great value to two categories of people: **language learners** and **translators**.
**・For language learner** this would instantly turn the game into one of the best language learning games currently available. It's  often the case a language learner can read and maybe understand all the words in a sentence but fail to put the meaning together because of the grammar, and showing them the translation would bridge that gap. The ability of comparing two languages is found in many language learning platforms, and with 180.000 string of text, adding the power to compare two versions of a text could turn this game into a very powerful language learning tool for thousands of people if not more.
**・For translators**, I can tell you I was told someone in the Italian translation team was not Italian to begin with and was submitting horrible translations blatantly made using Google Translate, there is no telling to the damages already done from this individual and something similar might have already happened for the other translations as well. With this functionality when a translator spots an iffy translation all he has to do is press a key to be shown the source material, in turn pushing them towards continued improvement and polish of the translations, where otherwise they might not even have bothered to check.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I've tested it in game without any problems.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Video of it working:
https://vimeo.com/820629407

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->