### PR TITLE
item_pocket: add support for default pocket settings

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -18,6 +18,7 @@
         "max_contains_volume": "25 L",
         "max_contains_weight": "30 kg",
         "max_item_length": "40 cm",
+        "priority": 1,
         "moves": 300
       },
       {
@@ -87,6 +88,7 @@
         "max_contains_weight": "50 kg",
         "max_item_length": "60 cm",
         "magazine_well": "12 L",
+        "priority": 1,
         "moves": 450
       },
       {
@@ -95,6 +97,7 @@
         "max_contains_weight": "8 kg",
         "max_item_length": "35 cm",
         "magazine_well": "1 L",
+        "priority": 1,
         "moves": 450
       },
       {
@@ -103,6 +106,7 @@
         "max_contains_weight": "2 kg",
         "max_item_length": "25 cm",
         "magazine_well": "500 ml",
+        "priority": 1,
         "moves": 450
       },
       {
@@ -111,6 +115,7 @@
         "max_contains_weight": "2 kg",
         "max_item_length": "25 cm",
         "magazine_well": "500 ml",
+        "priority": 1,
         "moves": 450
       },
       {
@@ -119,6 +124,7 @@
         "max_contains_weight": "2 kg",
         "max_item_length": "70 cm",
         "moves": 40,
+        "priority": 1,
         "flag_restriction": [ "SHEATH_KNIFE", "SHEATH_SWORD" ]
       },
       {
@@ -127,6 +133,7 @@
         "max_contains_weight": "2 kg",
         "max_item_length": "70 cm",
         "moves": 40,
+        "priority": 1,
         "flag_restriction": [ "SHEATH_KNIFE", "SHEATH_SWORD" ]
       },
       {
@@ -136,6 +143,7 @@
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,
+        "priority": 1,
         "description": "Pouch sized for a hydration pack."
       },
       {
@@ -220,6 +228,7 @@
         "max_contains_volume": "72 L",
         "max_contains_weight": "50 kg",
         "max_item_length": "80 cm",
+        "priority": 1,
         "moves": 450
       },
       {
@@ -227,6 +236,7 @@
         "max_contains_volume": "8 L",
         "max_contains_weight": "5 kg",
         "max_item_length": "33 cm",
+        "priority": 1,
         "moves": 200
       },
       {
@@ -260,6 +270,7 @@
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,
+        "priority": 1,
         "description": "Pouch sized for a hydration pack."
       },
       {
@@ -361,6 +372,7 @@
         "max_contains_weight": "40 kg",
         "max_item_length": "96 cm",
         "magazine_well": "8750 ml",
+        "priority": 1,
         "moves": 300
       }
     ],
@@ -402,6 +414,7 @@
         "max_contains_volume": "25 L",
         "max_contains_weight": "30 kg",
         "max_item_length": "40 cm",
+        "priority": 1,
         "moves": 300
       }
     ],
@@ -438,6 +451,7 @@
         "max_contains_weight": "70 kg",
         "max_item_length": "70 cm",
         "magazine_well": "10 L",
+        "priority": 1,
         "moves": 300
       },
       {
@@ -446,6 +460,7 @@
         "max_contains_weight": "10 kg",
         "max_item_length": "40 cm",
         "magazine_well": "1 L",
+        "priority": 1,
         "moves": 200
       },
       {
@@ -454,6 +469,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "30 cm",
         "magazine_well": "800 ml",
+        "priority": 1,
         "moves": 120
       },
       {
@@ -462,6 +478,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "30 cm",
         "magazine_well": "800 ml",
+        "priority": 1,
         "moves": 120
       },
       {
@@ -540,6 +557,7 @@
         "max_contains_volume": "50 L",
         "max_contains_weight": "50 kg",
         "max_item_length": "80 cm",
+        "priority": 1,
         "moves": 300
       }
     ],
@@ -566,6 +584,7 @@
         "max_contains_weight": "70 kg",
         "max_item_length": "75 cm",
         "magazine_well": "10 L",
+        "priority": 1,
         "moves": 300
       },
       {
@@ -574,6 +593,7 @@
         "max_contains_weight": "10 kg",
         "max_item_length": "40 cm",
         "magazine_well": "1 L",
+        "priority": 1,
         "moves": 200
       },
       {
@@ -582,6 +602,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "30 cm",
         "magazine_well": "800 ml",
+        "priority": 1,
         "moves": 120
       },
       {
@@ -590,6 +611,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "30 cm",
         "magazine_well": "800 ml",
+        "priority": 1,
         "moves": 120
       },
       {
@@ -670,6 +692,7 @@
         "max_contains_volume": "15 L",
         "max_contains_weight": "60 kg",
         "max_item_length": "50 cm",
+        "priority": 1,
         "moves": 300
       },
       {
@@ -792,6 +815,7 @@
         "max_contains_weight": "32 kg",
         "max_item_length": "60 cm",
         "magazine_well": "2 L",
+        "priority": 1,
         "moves": 300
       },
       {
@@ -862,6 +886,7 @@
         "max_contains_volume": "3400 ml",
         "max_contains_weight": "6 kg",
         "max_item_length": "25 cm",
+        "priority": 1,
         "moves": 100
       },
       {
@@ -870,6 +895,7 @@
         "max_contains_volume": "1800 ml",
         "max_contains_weight": "6 kg",
         "max_item_length": "22 cm",
+        "priority": 1,
         "moves": 100
       },
       {
@@ -878,6 +904,7 @@
         "max_contains_volume": "600 ml",
         "max_contains_weight": "6 kg",
         "max_item_length": "15 cm",
+        "priority": 1,
         "moves": 100
       },
       {
@@ -886,6 +913,7 @@
         "max_contains_volume": "600 ml",
         "max_contains_weight": "6 kg",
         "max_item_length": "15 cm",
+        "priority": 1,
         "moves": 100
       }
     ],
@@ -921,6 +949,7 @@
         "max_contains_volume": "30 L",
         "max_contains_weight": "24 kg",
         "max_item_length": "70 cm",
+        "priority": 1,
         "moves": 300
       }
     ],
@@ -956,6 +985,7 @@
         "max_contains_weight": "60 kg",
         "max_item_length": "55 cm",
         "magazine_well": "5 L",
+        "priority": 1,
         "moves": 300
       },
       {
@@ -1009,6 +1039,7 @@
         "max_item_length": "20 cm",
         "magazine_well": "500 ml",
         "moves": 80,
+        "priority": 1,
         "volume_encumber_modifier": 0.3
       }
     ],
@@ -1038,6 +1069,7 @@
         "max_contains_weight": "5 kg",
         "max_item_length": "25 cm",
         "magazine_well": "1 L",
+        "priority": 1,
         "moves": 80
       }
     ],
@@ -1121,6 +1153,7 @@
         "max_contains_volume": "15 L",
         "max_contains_weight": "30 kg",
         "max_item_length": "50 cm",
+        "priority": 1,
         "moves": 300
       }
     ],
@@ -1156,6 +1189,7 @@
         "max_contains_volume": "15 L",
         "max_contains_weight": "30 kg",
         "max_item_length": "50 cm",
+        "priority": 1,
         "moves": 300
       }
     ],
@@ -1207,6 +1241,7 @@
         "max_contains_weight": "10 kg",
         "max_item_volume": "65 ml",
         "watertight": true,
+        "priority": 1,
         "rigid": true
       }
     ],
@@ -1589,6 +1624,7 @@
         "max_contains_weight": "18 kg",
         "max_item_length": "50 cm",
         "magazine_well": "2500 ml",
+        "priority": 1,
         "moves": 150
       }
     ],
@@ -1626,6 +1662,7 @@
         "max_contains_weight": "40 kg",
         "max_item_length": "50 cm",
         "magazine_well": "5 L",
+        "priority": 1,
         "moves": 300
       },
       {
@@ -1635,6 +1672,7 @@
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,
+        "priority": 1,
         "description": "Pouch sized for a hydration pack."
       },
       {
@@ -1715,6 +1753,7 @@
         "max_contains_weight": "70 kg",
         "max_item_length": "50 cm",
         "magazine_well": "5 L",
+        "priority": 1,
         "moves": 300
       },
       {
@@ -1724,6 +1763,7 @@
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,
+        "priority": 1,
         "description": "Pouch sized for a hydration pack."
       },
       {
@@ -1804,6 +1844,7 @@
         "max_contains_weight": "80 kg",
         "max_item_length": "55 cm",
         "magazine_well": "8 L",
+        "priority": 1,
         "moves": 300
       },
       {
@@ -1813,6 +1854,7 @@
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,
+        "priority": 1,
         "description": "Pouch sized for a hydration pack."
       },
       {
@@ -1889,6 +1931,7 @@
         "max_contains_volume": "15 L",
         "max_contains_weight": "8 kg",
         "max_item_length": "40 cm",
+        "priority": 1,
         "moves": 300
       }
     ],
@@ -2049,6 +2092,7 @@
         "max_contains_weight": "60 kg",
         "max_item_length": "55 cm",
         "magazine_well": "8 L",
+        "priority": 1,
         "moves": 300
       },
       {
@@ -2057,6 +2101,7 @@
         "max_contains_weight": "10 kg",
         "max_item_length": "35 cm",
         "magazine_well": "1 L",
+        "priority": 1,
         "moves": 200
       },
       {
@@ -2065,6 +2110,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "30 cm",
         "magazine_well": "800 ml",
+        "priority": 1,
         "moves": 120
       },
       {
@@ -2073,6 +2119,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "30 cm",
         "magazine_well": "800 ml",
+        "priority": 1,
         "moves": 120
       },
       {
@@ -2082,6 +2129,7 @@
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,
+        "priority": 1,
         "description": "Pouch sized for a hydration pack."
       },
       {
@@ -2170,6 +2218,7 @@
         "max_contains_weight": "14 kg",
         "max_item_length": "40 cm",
         "magazine_well": "1 L",
+        "priority": 1,
         "moves": 250
       }
     ],
@@ -2209,6 +2258,7 @@
         "max_contains_weight": "16 kg",
         "max_item_length": "40 cm",
         "magazine_well": "2 L",
+        "priority": 1,
         "moves": 200
       }
     ],
@@ -2338,6 +2388,7 @@
         "max_contains_volume": "25 L",
         "max_contains_weight": "30 kg",
         "max_item_length": "60 cm",
+        "priority": 1,
         "moves": 300
       }
     ],
@@ -2364,6 +2415,7 @@
         "max_contains_weight": "40 kg",
         "max_item_length": "50 cm",
         "magazine_well": "4 L",
+        "priority": 1,
         "moves": 300
       },
       {
@@ -2372,6 +2424,7 @@
         "max_contains_weight": "10 kg",
         "max_item_length": "35 cm",
         "magazine_well": "500 ml",
+        "priority": 1,
         "moves": 200
       },
       {
@@ -2380,6 +2433,7 @@
         "max_contains_weight": "2 kg",
         "max_item_length": "20 cm",
         "magazine_well": "200 ml",
+        "priority": 1,
         "moves": 120
       },
       {
@@ -2388,6 +2442,7 @@
         "max_contains_weight": "2 kg",
         "max_item_length": "20 cm",
         "magazine_well": "200 ml",
+        "priority": 1,
         "moves": 120
       },
       {
@@ -2510,6 +2565,7 @@
         "max_contains_volume": "15 L",
         "max_contains_weight": "20 kg",
         "max_item_length": "35 cm",
+        "priority": 1,
         "moves": 300
       }
     ],
@@ -2567,6 +2623,7 @@
         "max_contains_weight": "80 kg",
         "max_item_length": "150 cm",
         "magazine_well": "10 L",
+        "priority": 1,
         "moves": 300
       }
     ],
@@ -2907,6 +2964,7 @@
         "max_contains_weight": "100 kg",
         "moves": 300,
         "rigid": true,
+        "priority": 1,
         "max_item_length": "150 cm"
       }
     ],
@@ -2936,6 +2994,7 @@
         "max_contains_volume": "25 L",
         "max_contains_weight": "50 kg",
         "moves": 300,
+        "priority": 1,
         "max_item_length": "60 cm"
       }
     ],

--- a/data/json/items/containers.json
+++ b/data/json/items/containers.json
@@ -22,6 +22,8 @@
         "rigid": true,
         "max_contains_volume": "2500 ml",
         "max_item_volume": "32 ml",
+        "priority": -1,
+        "collapsed": true,
         "max_contains_weight": "5 kg"
       }
     ],
@@ -36,7 +38,7 @@
         }
       ]
     },
-    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY", "COLLAPSE_CONTENTS" ]
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ]
   },
   {
     "id": "30gal_barrel",
@@ -59,12 +61,13 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "112500 ml",
         "max_contains_weight": "255 kg"
       }
     ],
-    "qualities": [ [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "CONTAIN", 1 ] ]
   },
   {
     "id": "30gal_drum",
@@ -87,12 +90,13 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "100 L",
         "max_contains_weight": "250 kg"
       }
     ],
-    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "55gal_drum",
@@ -115,12 +119,13 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "200 L",
         "max_contains_weight": "500 kg"
       }
     ],
-    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "bag_canvas",
@@ -135,10 +140,18 @@
     "price_postapoc": 10,
     "to_hit": -5,
     "material": [ "canvas" ],
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "15 L", "max_contains_weight": "15 kg", "moves": 400 } ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "15 L",
+        "max_contains_weight": "15 kg",
+        "priority": -1,
+        "collapsed": true,
+        "moves": 400
+      }
+    ],
     "symbol": ")",
-    "color": "brown",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "brown"
   },
   {
     "id": "bag_canvas_small",
@@ -153,10 +166,18 @@
     "price_postapoc": 10,
     "to_hit": -5,
     "material": [ "canvas" ],
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 400 } ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "3 kg",
+        "priority": -1,
+        "collapsed": true,
+        "moves": 400
+      }
+    ],
     "symbol": ")",
-    "color": "brown",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "brown"
   },
   {
     "id": "bag_plastic",
@@ -170,11 +191,19 @@
     "price": 0,
     "price_postapoc": 0,
     "to_hit": -1,
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "6 L", "max_contains_weight": "10 kg", "moves": 400 } ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "6 L",
+        "max_contains_weight": "10 kg",
+        "priority": -1,
+        "collapsed": true,
+        "moves": 400
+      }
+    ],
     "material": [ "plastic" ],
     "symbol": ")",
-    "color": "light_gray",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "light_gray"
   },
   {
     "id": "bag_garbage",
@@ -246,13 +275,14 @@
         "watertight": false,
         "max_contains_volume": "2500 ml",
         "max_contains_weight": "2 kg",
+        "priority": -1,
+        "collapsed": true,
         "moves": 200
       }
     ],
     "material": [ "paper" ],
     "symbol": ")",
-    "color": "white",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "white"
   },
   {
     "id": "bag_zipper",
@@ -273,12 +303,13 @@
         "max_contains_volume": "250 ml",
         "max_contains_weight": "750 g",
         "spoil_multiplier": 0.8,
+        "priority": -1,
+        "collapsed": true,
         "moves": 400
       }
     ],
     "symbol": ")",
-    "color": "light_gray",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "light_gray"
   },
   {
     "id": "bag_zipper_gallon",
@@ -374,10 +405,11 @@
         "watertight": true,
         "max_contains_volume": "500 ml",
         "max_contains_weight": "3 kg",
+        "priority": -1,
+        "collapsed": true,
         "moves": 400
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "bottle_glass",
@@ -405,11 +437,12 @@
         "max_contains_volume": "750 ml",
         "max_item_volume": "17 ml",
         "max_contains_weight": "3 kg",
+        "priority": -1,
+        "collapsed": true,
         "moves": 400
       }
     ],
-    "qualities": [ [ "BOIL", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 1 ] ]
   },
   {
     "id": "bottle_plastic",
@@ -429,6 +462,8 @@
         "max_item_volume": "17 ml",
         "max_contains_weight": "1250 g",
         "sealed_data": { "spoil_multiplier": 0.5 },
+        "priority": -1,
+        "collapsed": true,
         "moves": 400
       }
     ],
@@ -438,8 +473,7 @@
     "material": [ "plastic" ],
     "ascii_picture": "plastic_bottle",
     "symbol": ")",
-    "color": "light_cyan",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "light_cyan"
   },
   {
     "id": "condiment_bottle_sealed",
@@ -460,6 +494,8 @@
         "max_contains_weight": "1 kg",
         "spoil_multiplier": 0.5,
         "sealed_data": { "spoil_multiplier": 0.0 },
+        "priority": -1,
+        "collapsed": true,
         "moves": 400
       }
     ],
@@ -468,8 +504,7 @@
     "to_hit": 1,
     "material": [ "plastic" ],
     "symbol": ")",
-    "color": "brown",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "brown"
   },
   {
     "id": "bottle_plastic_small",
@@ -488,6 +523,8 @@
         "max_contains_volume": "250 ml",
         "max_item_volume": "17 ml",
         "max_contains_weight": "1 kg",
+        "priority": -1,
+        "collapsed": true,
         "moves": 400
       }
     ],
@@ -496,8 +533,7 @@
     "to_hit": 1,
     "material": [ "plastic" ],
     "symbol": ")",
-    "color": "white",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "white"
   },
   {
     "id": "bottle_plastic_pill_prescription",
@@ -516,6 +552,8 @@
         "max_contains_volume": "250 ml",
         "max_item_volume": "17 ml",
         "max_contains_weight": "1 kg",
+        "priority": -1,
+        "collapsed": true,
         "moves": 400
       }
     ],
@@ -524,8 +562,7 @@
     "to_hit": 1,
     "material": [ "plastic" ],
     "symbol": ")",
-    "color": "brown",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "brown"
   },
   {
     "id": "bottle_plastic_pill_painkiller",
@@ -567,10 +604,11 @@
         "max_contains_volume": "2 L",
         "max_item_volume": "17 ml",
         "max_contains_weight": "3 kg",
+        "priority": -1,
+        "collapsed": true,
         "moves": 400
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "bowl_clay",
@@ -665,8 +703,16 @@
     "ascii_picture": "box_cigarette",
     "symbol": ")",
     "color": "white",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "90 ml", "max_contains_weight": "3 kg" } ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "max_contains_volume": "90 ml",
+        "priority": -1,
+        "collapsed": true,
+        "max_contains_weight": "3 kg"
+      }
+    ]
   },
   {
     "id": "case_cigar",
@@ -707,6 +753,8 @@
         "rigid": true,
         "max_contains_volume": "540 ml",
         "max_contains_weight": "500 g",
+        "priority": -1,
+        "collapsed": true,
         "max_item_length": "11 cm"
       }
     ],
@@ -714,8 +762,7 @@
     "price_postapoc": 0,
     "material": [ "cardboard" ],
     "symbol": ")",
-    "color": "brown",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "color": "brown"
   },
   {
     "id": "box_small",
@@ -732,6 +779,8 @@
         "rigid": true,
         "max_contains_volume": "2100 ml",
         "max_contains_weight": "8 kg",
+        "priority": -1,
+        "collapsed": true,
         "max_item_length": "20 cm"
       }
     ],
@@ -748,8 +797,7 @@
       "type": "transform",
       "moves": 500,
       "need_empty": true
-    },
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    }
   },
   {
     "id": "box_small_folded",
@@ -1237,6 +1285,8 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "3000 ml",
         "max_item_volume": "32 ml",
         "max_contains_weight": "20 kg"
@@ -1255,7 +1305,7 @@
         }
       ]
     },
-    "flags": [ "BELTED", "COLLAPSE_CONTENTS" ]
+    "flags": [ "BELTED" ]
   },
   {
     "id": "can_drink",
@@ -1281,11 +1331,12 @@
         "max_contains_volume": "250 ml",
         "max_item_volume": "10 ml",
         "max_contains_weight": "1 kg",
+        "priority": -1,
+        "collapsed": true,
         "sealed_data": { "spoil_multiplier": 0.0 }
       }
     ],
-    "qualities": [ [ "BOIL", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 1 ] ]
   },
   {
     "id": "carton_sealed",
@@ -1309,11 +1360,12 @@
         "watertight": true,
         "max_contains_volume": "2 L",
         "max_contains_weight": "5 kg",
+        "priority": -1,
+        "collapsed": true,
         "//": "Calculated to keep shelf stable milk fresh for 304 days when sealed",
         "sealed_data": { "spoil_multiplier": 0.023 }
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "carton_milk",
@@ -1337,10 +1389,11 @@
         "watertight": true,
         "max_contains_volume": "2 L",
         "max_contains_weight": "5 kg",
+        "priority": -1,
+        "collapsed": true,
         "sealed_data": { "spoil_multiplier": 0.5 }
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "carton_egg",
@@ -1362,12 +1415,13 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": false,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "600 ml",
         "max_contains_weight": "1 kg",
         "max_item_length": "45 mm"
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "plastic_bag_vac",
@@ -1388,12 +1442,13 @@
         "pocket_type": "CONTAINER",
         "open_container": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "500 ml",
         "max_contains_weight": "1 kg",
         "sealed_data": { "spoil_multiplier": 0.5 }
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "can_food",
@@ -1416,13 +1471,14 @@
         "rigid": true,
         "watertight": true,
         "open_container": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "250 ml",
         "max_contains_weight": "1 kg",
         "sealed_data": { "spoil_multiplier": 0.0 }
       }
     ],
-    "qualities": [ [ "BOIL", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 1 ] ]
   },
   {
     "id": "can_medium",
@@ -1439,14 +1495,15 @@
         "rigid": true,
         "watertight": true,
         "open_container": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "500 ml",
         "max_contains_weight": "2 kg",
         "sealed_data": { "spoil_multiplier": 0.0 }
       }
     ],
     "qualities": [ [ "BOIL", 1 ] ],
-    "volume": "525 ml",
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "volume": "525 ml"
   },
   {
     "id": "canteen",
@@ -1468,6 +1525,8 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "1500 ml",
         "max_item_volume": "32 ml",
         "max_contains_weight": "3 kg"
@@ -1485,7 +1544,7 @@
         }
       ]
     },
-    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY", "COLLAPSE_CONTENTS" ]
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ]
   },
   {
     "id": "thermos",
@@ -1506,12 +1565,13 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "1 L",
         "max_contains_weight": "4 kg"
       }
     ],
-    "insulation": 10,
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "insulation": 10
   },
   {
     "id": "clay_canister",
@@ -1612,12 +1672,13 @@
         "rigid": true,
         "watertight": true,
         "open_container": true,
+        "priority": -1,
+        "collapsed": true,
         "sealed_data": { "spoil_multiplier": 0.0 },
         "max_contains_volume": "250 ml",
         "max_contains_weight": "1 kg"
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "cup_foil",
@@ -1637,12 +1698,14 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "open_container": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "250 ml",
         "max_contains_weight": "300 g"
       }
     ],
     "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "SOFT", "NO_REPAIR", "COLLAPSE_CONTENTS" ]
+    "flags": [ "SOFT", "NO_REPAIR" ]
   },
   {
     "id": "flask_glass",
@@ -1666,12 +1729,13 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "250 ml",
         "max_contains_weight": "1250 g"
       }
     ],
-    "qualities": [ [ "BOIL", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 1 ] ]
   },
   {
     "id": "test_tube",
@@ -1695,12 +1759,13 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "10 ml",
         "max_contains_weight": "50 g"
       }
     ],
-    "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "beaker",
@@ -1724,12 +1789,13 @@
         "rigid": true,
         "watertight": true,
         "open_container": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "250 ml",
         "max_contains_weight": "1 kg"
       }
     ],
-    "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "gradcylinder",
@@ -1753,14 +1819,15 @@
         "rigid": true,
         "watertight": true,
         "open_container": true,
+        "priority": -1,
+        "collapsed": true,
         "//": "sealed_data is here so the container can be sealed to avoid spilling",
         "sealed_data": { "spoil_multiplier": 1.0 },
         "max_contains_volume": "100 ml",
         "max_contains_weight": "500 g"
       }
     ],
-    "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "test_tube_micro",
@@ -1782,12 +1849,13 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "1 ml",
         "max_contains_weight": "5 g"
       }
     ],
-    "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "flask_hip",
@@ -1811,6 +1879,8 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "250 ml",
         "max_item_volume": "17 ml",
         "max_contains_weight": "1 kg"
@@ -1828,7 +1898,7 @@
       ]
     },
     "qualities": [ [ "BOIL", 1 ] ],
-    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY", "COLLAPSE_CONTENTS" ]
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ]
   },
   {
     "id": "jar_3l_glass_sealed",
@@ -1854,11 +1924,12 @@
         "watertight": true,
         "max_contains_volume": "3 L",
         "max_contains_weight": "6 kg",
+        "priority": -1,
+        "collapsed": true,
         "sealed_data": { "spoil_multiplier": 0.0 }
       }
     ],
-    "qualities": [ [ "CONTAIN", 1 ], [ "BOIL", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "CONTAIN", 1 ], [ "BOIL", 1 ] ]
   },
   {
     "id": "jar_glass_sealed",
@@ -1881,11 +1952,12 @@
         "watertight": true,
         "max_contains_volume": "500 ml",
         "max_contains_weight": "1 kg",
+        "priority": -1,
+        "collapsed": true,
         "sealed_data": { "spoil_multiplier": 0.0 }
       }
     ],
-    "qualities": [ [ "CONTAIN", 1 ], [ "BOIL", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "CONTAIN", 1 ], [ "BOIL", 1 ] ]
   },
   {
     "id": "jerrycan",
@@ -1906,12 +1978,13 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "10 L",
         "max_item_volume": "32 ml",
         "max_contains_weight": "15 kg"
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "jerrycan_big",
@@ -1935,13 +2008,14 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "20 L",
         "max_item_volume": "32 ml",
         "max_contains_weight": "25 kg"
       }
     ],
-    "qualities": [ [ "BOIL", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 1 ] ]
   },
   {
     "id": "jug_clay",
@@ -1989,13 +2063,14 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "3750 ml",
         "max_item_volume": "32 ml",
         "max_contains_weight": "8 kg",
         "sealed_data": { "spoil_multiplier": 0.5 }
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "keg",
@@ -2018,13 +2093,14 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "50 L",
         "max_item_volume": "50 ml",
         "max_contains_weight": "100 kg"
       }
     ],
-    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "keg_steel",
@@ -2047,13 +2123,14 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "50 L",
         "max_item_volume": "50 ml",
         "max_contains_weight": "120 kg"
       }
     ],
-    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "large_stomach_sealed",
@@ -2101,12 +2178,13 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "60 L",
         "max_contains_weight": "120 kg"
       }
     ],
-    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "metal_tank_little",
@@ -2130,12 +2208,13 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "2 L",
         "max_contains_weight": "4 kg"
       }
     ],
-    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "canteen_wood",
@@ -2404,12 +2483,13 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "100 L",
         "max_contains_weight": "200 kg"
       }
     ],
-    "qualities": [ [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "CONTAIN", 1 ] ]
   },
   {
     "id": "wrapper",
@@ -2425,8 +2505,15 @@
     "material": [ "paper" ],
     "symbol": ",",
     "color": "light_gray",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "6 kg" } ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "priority": -1,
+        "collapsed": true,
+        "max_contains_volume": "2500 ml",
+        "max_contains_weight": "6 kg"
+      }
+    ]
   },
   {
     "id": "wrapper_foil",
@@ -2441,9 +2528,17 @@
     "material": [ "aluminum" ],
     "symbol": ",",
     "color": "light_gray",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "6 kg" } ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "priority": -1,
+        "collapsed": true,
+        "max_contains_volume": "2500 ml",
+        "max_contains_weight": "6 kg"
+      }
+    ],
     "qualities": [ [ "COOK", 1 ] ],
-    "flags": [ "SOFT", "NO_REPAIR", "COLLAPSE_CONTENTS" ]
+    "flags": [ "SOFT", "NO_REPAIR" ]
   },
   {
     "id": "wrapper_pr",
@@ -2454,8 +2549,15 @@
       "str": "\"DaiZoom Protein Bar, brought to you by SoyPelusa\" is emblazoned proudly upon this greaseproof wrapper."
     },
     "copy-from": "wrapper",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "225 ml", "max_contains_weight": "1 kg" } ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "priority": -1,
+        "collapsed": true,
+        "max_contains_volume": "225 ml",
+        "max_contains_weight": "1 kg"
+      }
+    ]
   },
   {
     "id": "styrofoam_cup",
@@ -2476,11 +2578,12 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "500 ml",
         "max_contains_weight": "1 kg"
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "plastic_bucket",
@@ -2501,11 +2604,12 @@
         "watertight": true,
         "rigid": true,
         "open_container": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "4250 ml",
         "max_contains_weight": "9 kg"
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "condom",
@@ -2560,13 +2664,14 @@
         "watertight": true,
         "rigid": true,
         "open_container": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "3 L",
         "max_contains_weight": "6 kg",
         "sealed_data": { "spoil_multiplier": 0.0 }
       }
     ],
-    "qualities": [ [ "BOIL", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 1 ] ]
   },
   {
     "id": "survival_kit_box",
@@ -2638,13 +2743,14 @@
     "price_postapoc": 0,
     "to_hit": -2,
     "material": [ "plastic" ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "2700 ml",
         "max_contains_weight": "3 kg",
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "moves": 100
       }
     ],
@@ -2664,13 +2770,15 @@
     "price_postapoc": 10,
     "to_hit": -2,
     "material": [ "cotton", "neoprene" ],
-    "flags": [ "COLLAPSE_CONTENTS", "PALS_MEDIUM" ],
+    "flags": [ "PALS_MEDIUM" ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "3200 ml",
         "max_contains_weight": "4000 g",
         "moves": 100,
+        "priority": -1,
+        "collapsed": true,
         "rigid": false
       }
     ],
@@ -2846,12 +2954,13 @@
         "max_contains_weight": "4 kg",
         "airtight": true,
         "moves": 50,
+        "priority": -1,
+        "collapsed": true,
         "sealed_data": { "spoil_multiplier": 0.0 },
         "watertight": true
       }
     ],
     "material": [ "plastic", "aluminum" ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "symbol": ")",
     "color": "light_gray"
   },
@@ -2902,11 +3011,12 @@
         "airtight": true,
         "moves": 50,
         "sealed_data": { "spoil_multiplier": 0.0 },
+        "priority": -1,
+        "collapsed": true,
         "watertight": true
       }
     ],
     "material": [ "plastic" ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "symbol": ")",
     "color": "light_gray"
   },
@@ -3126,11 +3236,13 @@
         "airtight": true,
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "ammo_restriction": { "propane": 3000 }
       }
     ],
     "charges_per_use": 1,
-    "flags": [ "GAS_TANK", "COLLAPSE_CONTENTS" ]
+    "flags": [ "GAS_TANK" ]
   },
   {
     "id": "medium_propane_tank",
@@ -3155,11 +3267,13 @@
         "airtight": true,
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "ammo_restriction": { "propane": 15000 }
       }
     ],
     "charges_per_use": 1,
-    "flags": [ "GAS_TANK", "COLLAPSE_CONTENTS" ]
+    "flags": [ "GAS_TANK" ]
   },
   {
     "id": "large_propane_tank",
@@ -3184,11 +3298,13 @@
         "airtight": true,
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "ammo_restriction": { "propane": 60000 }
       }
     ],
     "charges_per_use": 1,
-    "flags": [ "GAS_TANK", "COLLAPSE_CONTENTS" ]
+    "flags": [ "GAS_TANK" ]
   },
   {
     "id": "xl_propane_tank",
@@ -3213,11 +3329,13 @@
         "airtight": true,
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "ammo_restriction": { "propane": 300000 }
       }
     ],
     "charges_per_use": 1,
-    "flags": [ "GAS_TANK", "COLLAPSE_CONTENTS" ]
+    "flags": [ "GAS_TANK" ]
   },
   {
     "id": "shot_glass",
@@ -3240,11 +3358,12 @@
         "watertight": true,
         "rigid": true,
         "open_container": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "44 ml",
         "max_contains_weight": "500 g"
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   },
   {
     "id": "30gal_drum_aluminum",
@@ -3267,12 +3386,13 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "100 L",
         "max_contains_weight": "250 kg"
       }
     ],
-    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "55gal_drum_aluminum",
@@ -3295,12 +3415,13 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "200 L",
         "max_contains_weight": "500 kg"
       }
     ],
-    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "squeeze_tube",
@@ -3323,12 +3444,13 @@
         "rigid": false,
         "watertight": true,
         "open_container": false,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "299 ml",
         "max_contains_weight": "2500 g"
       }
     ],
-    "qualities": [ [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "CONTAIN", 1 ] ]
   },
   {
     "id": "squeeze_tube_small",
@@ -3352,12 +3474,13 @@
         "rigid": false,
         "watertight": true,
         "open_container": false,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "82 ml",
         "max_contains_weight": "500 g"
       }
     ],
-    "qualities": [ [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "CONTAIN", 1 ] ]
   },
   {
     "id": "bottle_gourd",
@@ -3416,12 +3539,13 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "3785 ml",
         "max_contains_weight": "10 kg"
       }
     ],
-    "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ]
   },
   {
     "id": "paint_can_plastic",
@@ -3441,12 +3565,13 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "3785 ml",
         "max_contains_weight": "10 kg"
       }
     ],
-    "qualities": [ [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "CONTAIN", 1 ] ]
   },
   {
     "id": "lunchbox",
@@ -3468,12 +3593,13 @@
         "rigid": true,
         "watertight": false,
         "open_container": false,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "1100 ml",
         "max_contains_weight": "2 kg"
       }
     ],
-    "qualities": [ [ "CONTAIN", 1 ] ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "qualities": [ [ "CONTAIN", 1 ] ]
   },
   {
     "id": "pencil_case",
@@ -3494,11 +3620,12 @@
         "rigid": false,
         "watertight": false,
         "open_container": false,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "1000 ml",
         "max_contains_weight": "2 kg",
         "max_item_length": "20 cm"
       }
-    ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    ]
   }
 ]

--- a/data/json/items/containers/military.json
+++ b/data/json/items/containers/military.json
@@ -11,7 +11,6 @@
     "longest_side": "299 mm",
     "//": "<https://www.cleanammocans.com/new-m19a1-30-cal-ammo-can.html>, god, all of them has the different dimensions :pain:",
     "//2": "External: 29.85 x 9.53 x 17.78 cm, Internal: 25.4 x 8.9 x 16.5 cm",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "price": 1930,
     "price_postapoc": 10,
     "pocket_data": [
@@ -19,6 +18,8 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "3730 ml",
         "max_contains_weight": "50 kg",
         "max_item_length": "254 mm"
@@ -38,13 +39,14 @@
     "longest_side": "299 mm",
     "//": "<https://www.cleanammocans.com/new-50-cal-m2a1-usgi-ammo-can.html>",
     "//2": "External: 29.85 x 15.24 x 19.05 cm, Internal: 27.94 x 13.97 x 17.78 cm ",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "price": 1999,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "6940 ml",
         "max_contains_weight": "80 kg",
         "max_item_length": "279 mm"
@@ -61,13 +63,14 @@
     "longest_side": "318 mm",
     "//": "<https://www.cleanammocans.com/2-pack-new-fat-50-pa108-saw-ammo-cans.html>",
     "//2": "External: 31.75 x 18.42 x 21.59 cm, Internal: 29.85 x 17.15 x 20.96 cm ",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "price": 1999,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "10730 ml",
         "max_contains_weight": "120 kg",
         "max_item_length": "298 mm"
@@ -80,7 +83,6 @@
     "name": "PA-120 ammo can",
     "copy-from": "ammunition_can_30",
     "description": "A huge metal box with handles on each end.  It is almost inconveniently big, but can hold a lot of heavy items inside.",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "6350 g",
     "volume": "18572 ml",
     "longest_side": "470 mm",
@@ -92,6 +94,8 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "14772 ml",
         "max_contains_weight": "160 kg",
         "max_item_length": "438 mm"
@@ -104,7 +108,6 @@
     "category": "container",
     "name": "M289 container",
     "description": "A small, thick cylindrical container, designed to store one grenade.",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "411 g",
     "volume": "590 ml",
     "pocket_data": [
@@ -112,6 +115,8 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "550 ml",
         "max_contains_weight": "5000 g"
       }
@@ -127,7 +132,6 @@
     "name": "double 84mm container",
     "description": "A heavy and bulky container that can hold two 84mm rockets inside.",
     "//": "84mm heat 551 container, 265x700x124mm",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "1400 g",
     "volume": "23000 ml",
     "pocket_data": [
@@ -135,6 +139,8 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "5000 g",
         "max_item_length": "246mm"
@@ -143,6 +149,8 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "5000 g",
         "max_item_length": "246mm"
@@ -159,7 +167,6 @@
     "name": "huge 84mm crate",
     "description": "A big crate designed to store explosive 84x246mm rockets.",
     "//": "84mm heat551 transport box, 780X400X290mm",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "1400 g",
     "volume": "70000 ml",
     "pocket_data": [
@@ -167,6 +174,8 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "69000 ml",
         "max_contains_weight": "35000 g"
       }
@@ -182,13 +191,14 @@
     "name": { "str": "mini ammo box", "str_pl": "mini ammo boxes" },
     "description": "A lightweight box, labelled with a big, shiny image of an ammunition cartridge.",
     "//": "20x308mm, 100x9mm",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "17 g",
     "volume": "175 ml",
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "170 ml",
         "max_contains_weight": "800 g",
         "max_item_length": "100 mm"
@@ -204,13 +214,14 @@
     "copy-from": "ammunition_box_308",
     "name": { "str": "mini ammo box", "str_pl": "mini ammo boxes" },
     "//": "30x223 clips or 50x223 or 20x300",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "14 g",
     "volume": "235 ml",
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
+        "priority": -1,
+        "collapsed": true,
         "max_contains_volume": "230 ml",
         "max_contains_weight": "800 g",
         "max_item_length": "100 mm"
@@ -223,9 +234,17 @@
     "copy-from": "ammunition_box_308",
     "name": { "str": "small ammo box", "str_pl": "small ammo boxes" },
     "//": "10x50bmg, 20x12 gauge",
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "22 g",
     "volume": "480 ml",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "470 ml", "max_contains_weight": "2000 g" } ]
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "priority": -1,
+        "collapsed": true,
+        "max_contains_volume": "470 ml",
+        "max_contains_weight": "2000 g"
+      }
+    ]
   }
 ]

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -3745,7 +3745,6 @@
     "price": 1,
     "price_postapoc": 10,
     "material": [ "plastic" ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "symbol": ")",
     "color": "dark_gray",
     "pocket_data": [
@@ -3756,6 +3755,8 @@
         "max_contains_weight": "60 g",
         "max_contains_volume": "150 ml",
         "moves": 100,
+        "priority": -1,
+        "collapsed": true,
         "item_restriction": [
           "FMCNote",
           "signed_chit",
@@ -3777,6 +3778,8 @@
         "max_contains_weight": "60 g",
         "max_contains_volume": "150 ml",
         "moves": 100,
+        "priority": -1,
+        "collapsed": true,
         "item_restriction": [
           "cash_card",
           "gasdiscount_silver",
@@ -3811,6 +3814,8 @@
         "max_contains_weight": "600 g",
         "max_contains_volume": "150 ml",
         "moves": 200,
+        "priority": -1,
+        "collapsed": true,
         "item_restriction": [
           "FMCNote",
           "RobofacCoin",
@@ -3957,7 +3962,7 @@
     "price": 15000,
     "price_postapoc": 250,
     "material": [ "plastic", "leather" ],
-    "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "TARDIS", "COLLAPSE_CONTENTS", "POWERARMOR_COMPATIBLE" ],
+    "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "TARDIS", "POWERARMOR_COMPATIBLE" ],
     "weight": "708 g",
     "volume": "500 ml",
     "bashing": 1,
@@ -3970,6 +3975,8 @@
         "max_contains_weight": "600 g",
         "max_contains_volume": "500 ml",
         "moves": 400,
+        "priority": -1,
+        "collapsed": true,
         "item_restriction": [
           "cash_card",
           "gasdiscount_silver",
@@ -4235,7 +4242,6 @@
     "price": 23600,
     "price_postapoc": 200,
     "material": [ "plastic", "steel" ],
-    "flags": [ "COLLAPSE_CONTENTS" ],
     "weight": "5 kg",
     "volume": "22 L",
     "longest_side": "36 cm",
@@ -4248,6 +4254,8 @@
         "max_contains_weight": "2 kg",
         "max_contains_volume": "1 L",
         "moves": 100,
+        "priority": -1,
+        "collapsed": true,
         "item_restriction": [
           "money_one",
           "money_two",

--- a/data/json/items/generic/bathroom_house.json
+++ b/data/json/items/generic/bathroom_house.json
@@ -386,7 +386,9 @@
         "max_item_volume": "17 ml",
         "max_contains_weight": "1250 g",
         "sealed_data": { "spoil_multiplier": 0.5 },
-        "moves": 400
+        "moves": 400,
+        "priority": -1,
+        "collapsed": true
       }
     ],
     "price": 0,

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -362,7 +362,7 @@
     "color": "dark_gray",
     "techniques": [ "WBLOCK_1" ],
     "qualities": [ [ "CUT", 2 ], [ "SAW_W", 1 ], [ "SAW_M", 1 ], [ "BUTCHER", 7 ] ],
-    "flags": [ "STAB", "SHEATH_SWORD", "COLLAPSE_CONTENTS" ],
+    "flags": [ "STAB", "SHEATH_SWORD" ],
     "weapon_category": [ "KNIVES" ],
     "pocket_data": [
       {
@@ -372,7 +372,9 @@
         "max_contains_volume": "50 ml",
         "max_contains_weight": "100 g",
         "moves": 300,
-        "description": "A hidden handle compartment.  Unscrew the compass to access ."
+        "description": "A hidden handle compartment.  Unscrew the compass to access .",
+        "priority": -1,
+        "collapsed": true
       }
     ]
   },

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -39,6 +39,33 @@
     ]
   },
   {
+    "type": "GENERIC",
+    "id": "pocket_settings_test",
+    "looks_like": "minifridge",
+    "symbol": "F",
+    "color": "light_blue",
+    "name": { "str": "fridge" },
+    "description": "A fridge for keeping food cool.  Provides some insulation from outside weather.",
+    "longest_side": "1700 mm",
+    "insulation": 10,
+    "volume": "800 L",
+    "weight": "70 kg",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "watertight": true,
+        "max_contains_volume": "500 L",
+        "max_contains_weight": "400 kg",
+        "priority": 9001,
+        "whitelist": "test_tools_group",
+        "blacklist": [ "fridge_test" ],
+        "category_whitelist": [ "food" ],
+        "category_blacklist": [ "ammo" ]
+      }
+    ]
+  },
+  {
     "id": "metal_tank_test",
     "type": "GENERIC",
     "category": "container",

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3444,6 +3444,13 @@ Any Item can be a container. To add the ability to contain things to an item, yo
     "item_restriction": [ "item_id" ],         // Only these item IDs can be placed into this pocket. Overrides ammo and flag restrictions.
     "material_restriction": [ "material_id" ], // Only items that are mainly made of this material can enter.
 	// If multiple of "flag_restriction", "material_restriction" and "item_restriction" are used simultaneously then any item that matches any of them will be accepted.
+    
+    // Default settings for this pocket. Default values are to 0/empty
+    "priority": 0,
+    "whitelist": [ "item_id", "item_id" ],  // either "item_group_id" or [ "item_id", ... ] for both blacklist and whitelist
+    "blacklist": "item_group_id",
+    "category_whitelist": [ "FOOD" ],
+    "category_blacklist": [ "MANUALS" ],
 
     "sealed_data": { "spoil_multiplier": 0.0 } // If a pocket has sealed_data, it will be sealed when the item spawns.  The sealed version of the pocket will override the unsealed version of the same datatype.
   }

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -65,7 +65,6 @@ const flag_id flag_CITY_START( "CITY_START" );
 const flag_id flag_COLD( "COLD" );
 const flag_id flag_COLD_IMMUNE( "COLD_IMMUNE" );
 const flag_id flag_COLLAPSED_STOCK( "COLLAPSED_STOCK" );
-const flag_id flag_COLLAPSE_CONTENTS( "COLLAPSE_CONTENTS" );
 const flag_id flag_COLLAPSIBLE_STOCK( "COLLAPSIBLE_STOCK" );
 const flag_id flag_COLLAR( "COLLAR" );
 const flag_id flag_COMBAT_TOGGLEABLE( "COMBAT_TOGGLEABLE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -75,7 +75,6 @@ extern const flag_id flag_CITY_START;
 extern const flag_id flag_COLD;
 extern const flag_id flag_COLD_IMMUNE;
 extern const flag_id flag_COLLAPSED_STOCK;
-extern const flag_id flag_COLLAPSE_CONTENTS;
 extern const flag_id flag_COLLAPSIBLE_STOCK;
 extern const flag_id flag_COLLAR;
 extern const flag_id flag_COMBAT_TOGGLEABLE;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -308,18 +308,12 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( 
         activate();
     }
 
-    if( has_flag( flag_COLLAPSE_CONTENTS ) ) {
-        for( item_pocket *pocket : contents.get_all_standard_pockets() ) {
-            pocket->settings.set_collapse( true );
-        }
-    } else {
-        auto const mag_filter = []( item_pocket const & pck ) {
-            return pck.is_type( item_pocket::pocket_type::MAGAZINE ) ||
-                   pck.is_type( item_pocket::pocket_type::MAGAZINE_WELL );
-        };
-        for( item_pocket *pocket : contents.get_pockets( mag_filter ) ) {
-            pocket->settings.set_collapse( true );
-        }
+    auto const mag_filter = []( item_pocket const & pck ) {
+        return pck.is_type( item_pocket::pocket_type::MAGAZINE ) ||
+               pck.is_type( item_pocket::pocket_type::MAGAZINE_WELL );
+    };
+    for( item_pocket *pocket : contents.get_pockets( mag_filter ) ) {
+        pocket->settings.set_collapse( true );
     }
 
     if( has_flag( flag_NANOFAB_TEMPLATE ) ) {

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -271,6 +271,7 @@ void pocket_data::load( const JsonObject &jo )
     optional( jo, was_loaded, "sealed_data", sealed_data );
 
     optional( jo, was_loaded, "priority", default_priority );
+    optional( jo, was_loaded, "collapsed", default_collapsed );
     _load_variant_list( jo, was_loaded, default_whitelist, "whitelist" );
     _load_variant_list( jo, was_loaded, default_blacklist, "blacklist" );
     optional( jo, was_loaded, "category_whitelist", default_cat_whitelist );
@@ -2370,7 +2371,7 @@ void item_pocket::favorite_settings::clear()
 
 item_pocket::favorite_settings::favorite_settings( const pocket_data *data )
     : priority_rating( data->default_priority ), category_whitelist( data->default_cat_whitelist ),
-      category_blacklist( data->default_cat_blacklist )
+      category_blacklist( data->default_cat_blacklist ), collapsed( data->default_collapsed )
 {
     _fill_set_from_variant( item_whitelist, data->default_whitelist );
     _fill_set_from_variant( item_blacklist, data->default_blacklist );

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <set>
 #include <type_traits>
+#include <variant>
 #include <vector>
 
 #include "enums.h"
@@ -74,6 +75,9 @@ class item_pocket
         class favorite_settings
         {
             public:
+                favorite_settings() = default;
+                explicit favorite_settings( const pocket_data *data );
+
                 void clear();
 
                 void set_priority( int priority );
@@ -133,7 +137,7 @@ class item_pocket
         };
 
         item_pocket() = default;
-        explicit item_pocket( const pocket_data *data ) : data( data ) {}
+        explicit item_pocket( const pocket_data *data ) : settings( data ), data( data ) {}
 
         bool stacks_with( const item_pocket &rhs, int depth = 0, int maxdepth = 2 ) const;
         bool is_funnel_container( units::volume &bigger_than ) const;
@@ -538,6 +542,13 @@ class pocket_data
         bool rigid = false;
         // if true, the pocket cannot be used by the player
         bool forbidden = false;
+
+        int default_priority = 0;
+        using id_set = std::variant<cata::flat_set<itype_id>, item_group_id>;
+        id_set default_whitelist;
+        id_set default_blacklist;
+        cata::flat_set<item_category_id> default_cat_whitelist;
+        cata::flat_set<item_category_id> default_cat_blacklist;
 
         bool operator==( const pocket_data &rhs ) const;
 

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -544,6 +544,7 @@ class pocket_data
         bool forbidden = false;
 
         int default_priority = 0;
+        bool default_collapsed = 0;
         using id_set = std::variant<cata::flat_set<itype_id>, item_group_id>;
         id_set default_whitelist;
         id_set default_blacklist;

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -2733,3 +2733,15 @@ TEST_CASE( "pocket_leak" )
         CHECK( bkit_has_water == top_watertight );
     }
 }
+
+TEST_CASE( "default_pocket_settings" )
+{
+    item pst( "pocket_settings_test" );
+    item_pocket *pkt = pst.get_all_standard_pockets().front();
+    CHECK( pkt->settings.priority() == 9001 );
+    CHECK( pkt->settings.get_item_whitelist()[0] == itype_id( "hammer" ) );
+    CHECK( pkt->settings.get_item_whitelist()[1] == itype_id( "bow_saw" ) );
+    CHECK( pkt->settings.get_item_blacklist()[0] == itype_id( "fridge_test" ) );
+    CHECK( pkt->settings.get_category_whitelist()[0] == item_category_id( "food" ) );
+    CHECK( pkt->settings.get_category_blacklist()[0] == item_category_id( "ammo" ) );
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allow item definitions to specify default priority and white/blacklists for pockets. This can be used to reduce the incidence of items getting picked up into snack boxes or canteens instead of backpacks.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add the minor infrastructure for default pocket settings.

Migrate all items with `COLLAPSE_CONTENTS` to default priority -1 and default collapsed

Add priority 1 to all backpack pockets that didn't have `ripoff` or `extra_encumbrance`

TODO:
- [x] add some default priorities to start things off
- [x] migrate `COLLAPSE_CONTENTS` to a pocket setting too
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Test unit.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This can be reviewed by commit.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->