### PR TITLE
Scenario additions

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -1018,5 +1018,33 @@
     "allowed_locs": [ "sloc_mobile_home", "sloc_motel" ],
     "eoc": [ "EOC_scenario_drunk" ],
     "flags": [ "LONE_START" ]
+  },
+  {
+    "type": "scenario",
+    "id": "mass_quarantine_start",
+    "name": "Mass Quarantine",
+    "points": -1,
+    "description": "When FEMA camps ran out of space the authorities used what was left of their manpower to round up people at gunpoint.  The stadiums they forced everyone into did nothing to slow down the madness and it spread like wildfire.  You managed to slip away from the worst violence but you are now surrounded and need to escape quickly!",
+    "start_name": "In Town",
+    "allowed_locs": [ "sloc_stadium" ],
+    "map_extra": "mx_corpses"
+  },
+  {
+    "type": "scenario",
+    "id": "road_start",
+    "name": "Middle of nowhere",
+    "points": 1,
+    "description": "During your escape you got lost and ended up at the wrong location.  Get your bearings and make a plan.  You'll need it.",
+    "start_name": "Middle of Nowhere",
+    "allowed_locs": [ "sloc_middle_of_nowhere" ]
+  },
+  {
+    "type": "scenario",
+    "id": "sewer_start",
+    "name": "Challenge - Lost Underground",
+    "points": 1,
+    "description": "When the riots came to your home, you ran underground and hid.  Now days later you are lost and hear movement echoing in the dark.",
+    "start_name": "In Town",
+    "allowed_locs": [ "sloc_sewer" ]
   }
 ]

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -640,5 +640,43 @@
     "id": "sloc_mobile_home",
     "name": "Mobile Home",
     "terrain": [ "trailer_hub_00", "trailer_hub_11", "trailer_caravan_00", "trailer_public_00" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_stadium",
+    "name": "Stadium",
+    "terrain": [
+      "stadium_football_1_1",
+      "stadium_football_2_1",
+      "stadium_football_3_1",
+      "stadium_football_4_1",
+      "stadium_football_5_1",
+      "stadium_football_6_1",
+      "stadium_football_7_1",
+      "stadium_football_1_2",
+      "stadium_football_7_2",
+      "stadium_football_1_3",
+      "stadium_football_7_3",
+      "stadium_football_1_4",
+      "stadium_football_7_4",
+      "stadium_football_1_5",
+      "stadium_football_2_5",
+      "stadium_football_3_5",
+      "stadium_football_4_5",
+      "stadium_football_6_5",
+      "stadium_football_7_5"
+    ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_middle_of_nowhere",
+    "name": "Middle of Nowhere",
+    "terrain": [ "state_park_1_0", "sewage_treatment_1_0_0", "pwr_sub_s", "derelict_property", "ws_regional_dump_2_0", "waiting_area" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_sewer",
+    "name": "Sewer",
+    "terrain": [ "sewer" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Three new Scenarios and corresponding starting locations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
More easy access less challenge starting scenarios.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Made more scenarios
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not making more scenarios.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Created and tested new scenarios, trimmed any locations which caused "cannot find player start locations such as Trailheads even if the error was benign. Repeatedly spawned into the scenarios. They may not always be ideal and safe but they are functional. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Created Mass Quarantine (Stadium), Middle of Nowhere (Low loot semi-rural locations), and Lost underground (Sewer) scenarios. 

![CDDA-Stadium-start](https://user-images.githubusercontent.com/14862800/232315423-02aad057-b154-487a-9e0d-f24b4bfd699b.png)
![CDDA-Nowherestart](https://user-images.githubusercontent.com/14862800/232315425-5461525c-2599-4baa-9377-d0d9823301cf.png)
![CDDA-sewerstart](https://user-images.githubusercontent.com/14862800/232315428-13981a4f-a914-4e28-8349-57e522747521.png)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->