### PR TITLE
Reduce repetitive output color changes

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -144,30 +144,32 @@ void draw_explosion_curses( game &g, const tripoint_bub_ms &center, const int r,
     int frame = 0;
     shared_ptr_fast<game::draw_callback_t> explosion_cb =
     make_shared_fast<game::draw_callback_t>( [&]() {
+        wattron( g.w_terrain, col );
         if( r == 0 ) {
-            mvwputch( g.w_terrain, point( p.y(), p.x() ), col, '*' );
+            mvwaddch( g.w_terrain, point( p.y(), p.x() ), '*' );
         }
 
         for( int i = 1; i <= frame; ++i ) {
             // corner: top left
-            mvwputch( g.w_terrain, p.xy().raw() + point( -i, -i ), col, '/' );
+            mvwaddch( g.w_terrain, p.xy().raw() + point( -i, -i ), '/' );
             // corner: top right
-            mvwputch( g.w_terrain, p.xy().raw() + point( i, -i ), col, '\\' );
+            mvwaddch( g.w_terrain, p.xy().raw() + point( i, -i ), '\\' );
             // corner: bottom left
-            mvwputch( g.w_terrain, p.xy().raw() + point( -i, i ), col, '\\' );
+            mvwaddch( g.w_terrain, p.xy().raw() + point( -i, i ), '\\' );
             // corner: bottom right
-            mvwputch( g.w_terrain, p.xy().raw() + point( i, i ), col, '/' );
+            mvwaddch( g.w_terrain, p.xy().raw() + point( i, i ), '/' );
             for( int j = 1 - i; j < 0 + i; j++ ) {
                 // edge: top
-                mvwputch( g.w_terrain, p.xy().raw() + point( j, -i ), col, '-' );
+                mvwaddch( g.w_terrain, p.xy().raw() + point( j, -i ), '-' );
                 // edge: bottom
-                mvwputch( g.w_terrain, p.xy().raw() + point( j, i ), col, '-' );
+                mvwaddch( g.w_terrain, p.xy().raw() + point( j, i ), '-' );
                 // edge: left
-                mvwputch( g.w_terrain, p.xy().raw() + point( -i, j ), col, '|' );
+                mvwaddch( g.w_terrain, p.xy().raw() + point( -i, j ), '|' );
                 // edge: right
-                mvwputch( g.w_terrain, p.xy().raw() + point( i, j ), col, '|' );
+                mvwaddch( g.w_terrain, p.xy().raw() + point( i, j ), '|' );
             }
         }
+        wattroff( g.w_terrain, col );
     } );
     g.add_draw_callback( explosion_cb );
 
@@ -889,9 +891,12 @@ namespace
 {
 void draw_weather_curses( const catacurses::window &win, const weather_printable &w )
 {
+    wattron( win, w.colGlyph );
+    const std::string symbol = w.get_symbol();
     for( const auto &drop : w.vdrops ) {
-        mvwputch( win, point( drop.first, drop.second ), w.colGlyph, w.get_symbol() );
+        mvwprintw( win, point( drop.first, drop.second ), symbol );
     }
+    wattroff( win, w.colGlyph );
 }
 } //namespace
 
@@ -965,12 +970,10 @@ void draw_zones_curses( const catacurses::window &w, const tripoint_bub_ms &star
     }
 
     nc_color    const col = invert_color( c_light_green );
-    const std::string line( end.x() - start.x() + 1, '~' );
-    int         const x = start.x() - offset.x;
 
-    for( int y = start.y(); y <= end.y(); ++y ) {
-        mvwprintz( w, point( x, y - offset.y ), col, line );
-    }
+    wattron( w, col );
+    mvwrectf( w, ( start.raw() - offset ).xy(), '~', end.x() - start.x() + 1, end.y() - start.y() + 1 );
+    wattroff( w, col );
 }
 } //namespace
 

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -583,21 +583,23 @@ static void draw_grid( const catacurses::window &w, int left_pane_w, int mid_pan
     const int win_h = getmaxy( w );
 
     draw_border( w );
+
+    wattron( w, BORDER_COLOR );
     mvwhline( w, point( 1, 2 ), 0, win_w - 2 );
     mvwhline( w, point( left_pane_w + 2, encumb_top - 1 ), 0, mid_pane_w );
     mvwvline( w, point( left_pane_w + 1, 3 ), 0, win_h - 4 );
     mvwvline( w, point( left_pane_w + mid_pane_w + 2, 3 ), 0, win_h - 4 );
 
     // intersections
-    mvwputch( w, point( 0, 2 ), BORDER_COLOR, LINE_XXXO ); // '|-'
-    mvwputch( w, point( win_w - 1, 2 ), BORDER_COLOR, LINE_XOXX ); // '-|'
-    mvwputch( w, point( left_pane_w + 1, encumb_top - 1 ), BORDER_COLOR, LINE_XXXO ); // '|-'
-    mvwputch( w, point( left_pane_w + mid_pane_w + 2, encumb_top - 1 ), BORDER_COLOR,
-              LINE_XOXX ); // '-|'
-    mvwputch( w, point( left_pane_w + 1, 2 ), BORDER_COLOR, LINE_OXXX ); // '^|^'
-    mvwputch( w, point( left_pane_w + 1, win_h - 1 ), BORDER_COLOR, LINE_XXOX ); // '_|_'
-    mvwputch( w, point( left_pane_w + mid_pane_w + 2, 2 ), BORDER_COLOR, LINE_OXXX ); // '^|^'
-    mvwputch( w, point( left_pane_w + mid_pane_w + 2, win_h - 1 ), BORDER_COLOR, LINE_XXOX ); // '_|_'
+    mvwaddch( w, point( 0, 2 ), LINE_XXXO ); // '|-'
+    mvwaddch( w, point( win_w - 1, 2 ), LINE_XOXX ); // '-|'
+    mvwaddch( w, point( left_pane_w + 1, encumb_top - 1 ), LINE_XXXO ); // '|-'
+    mvwaddch( w, point( left_pane_w + mid_pane_w + 2, encumb_top - 1 ), LINE_XOXX ); // '-|'
+    mvwaddch( w, point( left_pane_w + 1, 2 ), LINE_OXXX ); // '^|^'
+    mvwaddch( w, point( left_pane_w + 1, win_h - 1 ), LINE_XXOX ); // '_|_'
+    mvwaddch( w, point( left_pane_w + mid_pane_w + 2, 2 ), LINE_OXXX ); // '^|^'
+    mvwaddch( w, point( left_pane_w + mid_pane_w + 2, win_h - 1 ), LINE_XXOX ); // '_|_'
+    wattroff( w, BORDER_COLOR );
 
     wnoutrefresh( w );
 }

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -354,10 +354,12 @@ void auto_note_manager_gui::show()
     ui.on_redraw( [&]( const ui_adaptor & ) {
         // == Draw border
         draw_border( w_border, BORDER_COLOR, _( "Auto notes manager" ) );
-        mvwputch( w_border, point( 0, iHeaderHeight - 1 ), c_light_gray, LINE_XXXO );
-        mvwputch( w_border, point( 79, iHeaderHeight - 1 ), c_light_gray, LINE_XOXX );
-        mvwputch( w_border, point( 52, FULL_SCREEN_HEIGHT - 1 ), c_light_gray, LINE_XXOX );
-        mvwputch( w_border, point( 61, FULL_SCREEN_HEIGHT - 1 ), c_light_gray, LINE_XXOX );
+        wattron( w_border, c_light_gray );
+        mvwaddch( w_border, point( 0, iHeaderHeight - 1 ), LINE_XXXO );
+        mvwaddch( w_border, point( 79, iHeaderHeight - 1 ), LINE_XOXX );
+        mvwaddch( w_border, point( 52, FULL_SCREEN_HEIGHT - 1 ), LINE_XXOX );
+        mvwaddch( w_border, point( 61, FULL_SCREEN_HEIGHT - 1 ), LINE_XXOX );
+        wattroff( w_border, c_light_gray );
         wnoutrefresh( w_border );
 
         // == Draw header
@@ -367,14 +369,13 @@ void auto_note_manager_gui::show()
         shortcut_print( w_header, point( tmpx, 0 ), c_white, c_light_green, _( "<Enter> - Toggle" ) );
 
         // Draw horizontal line and corner pieces of the table
-        for( int x = 0; x < 78; x++ ) {
-            if( x == 51 || x == 60 ) {
-                mvwputch( w_header, point( x, iHeaderHeight - 2 ), c_light_gray, LINE_OXXX );
-                mvwputch( w_header, point( x, iHeaderHeight - 1 ), c_light_gray, LINE_XOXO );
-            } else {
-                mvwputch( w_header, point( x, iHeaderHeight - 2 ), c_light_gray, LINE_OXOX );
-            }
-        }
+        wattron( w_header, c_light_gray );
+        mvwhline( w_header, point( 0, iHeaderHeight - 2 ), LINE_OXOX, 78 );
+        mvwaddch( w_header, point( 51, iHeaderHeight - 2 ), LINE_OXXX );
+        mvwaddch( w_header, point( 51, iHeaderHeight - 1 ), LINE_XOXO );
+        mvwaddch( w_header, point( 60, iHeaderHeight - 2 ), LINE_OXXX );
+        mvwaddch( w_header, point( 60, iHeaderHeight - 1 ), LINE_XOXO );
+        wattroff( w_header, c_light_gray );
         tmpx = 17;
         tmpx += shortcut_print( w_header, point( tmpx, iHeaderHeight - 2 ),
                                 bCharacter ? hilite( c_white ) : c_white, c_light_green, _( "Character" ) ) + 2;
@@ -414,23 +415,16 @@ void auto_note_manager_gui::show()
                         _( "<Tab> to change pages." ) );
 
         // Clear table
-        for( int y = 0; y < iContentHeight; y++ ) {
-            for( int x = 0; x < 79; x++ ) {
-                // The middle beams needs special treatment
-                if( x == 51 || x == 60 ) {
-                    mvwputch( w, point( x, y ), c_light_gray, LINE_XOXO );
-                } else {
-                    mvwputch( w, point( x, y ), c_black, ' ' );
-                }
-            }
-        }
+        mvwrectf( w, point_zero, c_black, ' ', 79, iContentHeight );
+        mvwvline( w, point( 51, 0 ), c_light_gray, LINE_XOXO, iContentHeight );
+        mvwvline( w, point( 60, 0 ), c_light_gray, LINE_XOXO, iContentHeight );
         int cacheSize = bCharacter ? char_cacheSize : global_cacheSize;
         draw_scrollbar( w_border, currentLine, iContentHeight, cacheSize, point( 0, iHeaderHeight + 1 ) );
 
         if( bCharacter ? char_emptyMode : global_emptyMode ) {
             // NOLINTNEXTLINE(cata-use-named-point-constants)
-            mvwprintz( w, point( 1, 0 ), c_light_gray,
-                       _( "Discover more special encounters to populate this list" ) );
+            fold_and_print( w, point( 1, 0 ), 49, c_light_gray,
+                            _( "Discover more special encounters to populate this list" ) );
         } else {
             calcStartPos( startPosition, currentLine, iContentHeight,
                           ( bCharacter ? char_displayCache : global_displayCache ).size() );

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -330,14 +330,17 @@ void user_interface::show()
     ui.on_redraw( [&]( const ui_adaptor & ) {
         // Redraw the border
         draw_border( w_border, BORDER_COLOR, title );
+
+        wattron( w, c_light_gray );
         // |-
-        mvwputch( w_border, point( 0, 3 ), c_light_gray, LINE_XXXO );
+        mvwaddch( w_border, point( 0, 3 ), LINE_XXXO );
         // -|
-        mvwputch( w_border, point( 79, 3 ), c_light_gray, LINE_XOXX );
+        mvwaddch( w_border, point( 79, 3 ), LINE_XOXX );
         // _|_
-        mvwputch( w_border, point( 5, FULL_SCREEN_HEIGHT - 1 ), c_light_gray, LINE_XXOX );
-        mvwputch( w_border, point( 51, FULL_SCREEN_HEIGHT - 1 ), c_light_gray, LINE_XXOX );
-        mvwputch( w_border, point( 61, FULL_SCREEN_HEIGHT - 1 ), c_light_gray, LINE_XXOX );
+        mvwaddch( w_border, point( 5, FULL_SCREEN_HEIGHT - 1 ), LINE_XXOX );
+        mvwaddch( w_border, point( 51, FULL_SCREEN_HEIGHT - 1 ), LINE_XXOX );
+        mvwaddch( w_border, point( 61, FULL_SCREEN_HEIGHT - 1 ), LINE_XXOX );
+        wattroff( w, c_light_gray );
         wnoutrefresh( w_border );
 
         // Redraw the header
@@ -358,15 +361,15 @@ void user_interface::show()
                                 _( "<Enter>-Edit" ) ) + 2;
         shortcut_print( w_header, point( tmpx, 1 ), c_white, c_light_green, _( "<Tab>-Switch Page" ) );
 
-        for( int i = 0; i < 78; i++ ) {
-            if( i == 4 || i == 50 || i == 60 ) {
-                mvwputch( w_header, point( i, 2 ), c_light_gray, LINE_OXXX );
-                mvwputch( w_header, point( i, 3 ), c_light_gray, LINE_XOXO );
-            } else {
-                // Draw line under header
-                mvwputch( w_header, point( i, 2 ), c_light_gray, LINE_OXOX );
-            }
+        wattron( w_header, c_light_gray );
+        mvwhline( w_header, point( 0,  2 ), LINE_OXOX, 78 );
+        for( int x : {
+                 4, 50, 60
+             } ) {
+            mvwaddch( w_header, point( x, 2 ), LINE_OXXX );
+            mvwaddch( w_header, point( x, 3 ), LINE_XOXO );
         }
+        wattroff( w_header, c_light_gray );
         mvwprintz( w_header, point( 1, 3 ), c_white, "#" );
         mvwprintz( w_header, point( 8, 3 ), c_white, _( "Rules" ) );
         mvwprintz( w_header, point( 52, 3 ), c_white, _( "Inc/Exc" ) );
@@ -390,14 +393,11 @@ void user_interface::show()
         wnoutrefresh( w_header );
 
         // Clear the lines
-        for( int i = 0; i < iContentHeight; i++ ) {
-            for( int j = 0; j < 79; j++ ) {
-                if( j == 4 || j == 50 || j == 60 ) {
-                    mvwputch( w, point( j, i ), c_light_gray, LINE_XOXO );
-                } else {
-                    mvwputch( w, point( j, i ), c_black, ' ' );
-                }
-            }
+        mvwrectf( w, point_zero, c_black, ' ', 79, iContentHeight );
+        for( int x : {
+                 4, 50, 60
+             } ) {
+            mvwvline( w, point( x, 0 ), c_light_gray, LINE_XOXO, iContentHeight );
         }
 
         draw_scrollbar( w_border, iLine, iContentHeight, cur_rules.size(), point( 0, 5 ) );
@@ -700,11 +700,7 @@ void rule::test_pattern() const
         wnoutrefresh( w_test_rule_border );
 
         // Clear the lines
-        for( int i = 0; i < iContentHeight; i++ ) {
-            for( int j = 0; j < 79; j++ ) {
-                mvwputch( w_test_rule_content, point( j, i ), c_black, ' ' );
-            }
-        }
+        mvwrectf( w_test_rule_content, point_zero, c_black, ' ', 79, iContentHeight );
 
         calcStartPos( iStartPos, iLine, iContentHeight, vMatchingItems.size() );
 

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -272,15 +272,13 @@ static void draw_bionics_titlebar( const catacurses::window &window, avatar *p,
                                          string_format( _( "Bionic Power: <color_light_blue>%s</color>/<color_light_blue>%ikJ</color>" ),
                                                  power_string, units::to_kilojoule( p->get_max_power_level() ) ) );
 
-    mvwputch( window, point( pwr_str_pos - 1, 1 ), BORDER_COLOR, LINE_XOXO ); // |
-    mvwputch( window, point( pwr_str_pos - 1, 2 ), BORDER_COLOR, LINE_XXOO ); // |_
-    for( int i = pwr_str_pos; i < getmaxx( window ); i++ ) {
-        mvwputch( window, point( i, 2 ), BORDER_COLOR, LINE_OXOX ); // -
-    }
-    for( int i = 0; i < getmaxx( window ); i++ ) {
-        mvwputch( window, point( i, 0 ), BORDER_COLOR, LINE_OXOX ); // -
-    }
-    mvwputch( window, point( pwr_str_pos - 1, 0 ), BORDER_COLOR, LINE_OXXX ); // ^|^
+    wattron( window, BORDER_COLOR );
+    mvwaddch( window, point( pwr_str_pos - 1, 1 ), LINE_XOXO ); // |
+    mvwaddch( window, point( pwr_str_pos - 1, 2 ), LINE_XXOO ); // |_
+    mvwhline( window, point( pwr_str_pos, 2 ), LINE_OXOX, getmaxx( window ) - pwr_str_pos ); // -
+    mvwhline( window, point_zero, LINE_OXOX, getmaxx( window ) ); // -
+    mvwaddch( window, point( pwr_str_pos - 1, 0 ), LINE_OXXX ); // ^|^
+    wattroff( window, BORDER_COLOR );
     center_print( window, 0, c_light_red, _( "Bionics" ) );
 
     std::string desc_append = string_format(
@@ -387,16 +385,12 @@ static void draw_bionics_tabs( const catacurses::window &win, const size_t activ
     // Draw symbols to connect additional lines to border
     int width = getmaxx( win );
     int height = getmaxy( win );
-    for( int i = 0; i < height - 1; ++i ) {
-        // |
-        mvwputch( win, point( 0, i ), BORDER_COLOR, LINE_XOXO );
-        // |
-        mvwputch( win, point( width - 1, i ), BORDER_COLOR, LINE_XOXO );
-    }
-    // |-
-    mvwputch( win, point( 0, height - 1 ), BORDER_COLOR, LINE_XXXO );
-    // -|
-    mvwputch( win, point( width - 1, height - 1 ), BORDER_COLOR, LINE_XOXX );
+    wattron( win, BORDER_COLOR );
+    mvwvline( win, point_zero, LINE_XOXO, height - 1 ); // |
+    mvwvline( win, point( width - 1, 0 ), LINE_XOXO, height - 1 ); // |
+    mvwaddch( win, point( 0, height - 1 ), LINE_XXXO ); // |-
+    mvwaddch( win, point( width - 1, height - 1 ), LINE_XOXX ); // -|
+    wattroff( win, BORDER_COLOR );
 
     wnoutrefresh( win );
 }
@@ -444,9 +438,11 @@ static void draw_connectors( const catacurses::window &win, const point &start,
         return;
     }
 
+    wattron( win, BORDER_COLOR );
+
     // draw horizontal line from selected bionic
     const int turn_x = start.x + ( last_x - start.x ) * 2 / 3;
-    mvwputch( win, start, BORDER_COLOR, '>' );
+    mvwaddch( win, start, '>' );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwhline( win, start + point( 1, 0 ), LINE_OXOX, turn_x - start.x - 1 );
 
@@ -482,16 +478,18 @@ static void draw_connectors( const catacurses::window &win, const point &start,
             bp_chr = LINE_XXXO;
         }
 
-        mvwputch( win, point( turn_x, y ), BORDER_COLOR, bp_chr );
+        mvwaddch( win, point( turn_x, y ), bp_chr );
 
         // draw horizontal line to bodypart title
         mvwhline( win, point( turn_x + 1, y ), LINE_OXOX, last_x - turn_x - 1 );
-        mvwputch( win, point( last_x, y ), BORDER_COLOR, '<' );
+        mvwaddch( win, point( last_x, y ), '<' );
 
         // draw amount of consumed slots by this CBM
+        wattroff( win, BORDER_COLOR );
         const std::string fmt_num = string_format( "(%d)", elem.second );
         mvwprintz( win, point( turn_x + std::max( 1, ( last_x - turn_x - utf8_width( fmt_num ) ) / 2 ), y ),
                    c_yellow, fmt_num );
+        wattron( win, BORDER_COLOR );
     }
 
     // define and draw a proper intersection character
@@ -523,7 +521,8 @@ static void draw_connectors( const catacurses::window &win, const point &start,
         // '^|^'
         bionic_chr = LINE_OXXX;
     }
-    mvwputch( win, point( turn_x, start.y ), BORDER_COLOR, bionic_chr );
+    mvwaddch( win, point( turn_x, start.y ), bionic_chr );
+    wattroff( win, BORDER_COLOR );
 }
 
 //get a text color depending on the power/powering state of the bionic
@@ -691,9 +690,11 @@ void avatar::power_bionics()
         }
         const int pos_x = WIDTH - 2 - max_width;
         if( get_option < bool >( "CBM_SLOTS_ENABLED" ) ) {
+            wattron( wBio, c_light_gray );
             for( size_t i = 0; i < bps.size(); ++i ) {
-                mvwprintz( wBio, point( pos_x, i + list_start_y ), c_light_gray, bps[i] );
+                mvwprintw( wBio, point( pos_x, i + list_start_y ), bps[i] );
             }
+            wattroff( wBio, c_light_gray );
         }
 
         if( current_bionic_list->empty() ) {

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -434,9 +434,7 @@ void bodygraph_display::draw_info()
         int y = 0;
         for( unsigned i = top_info; i < info_txt.size() && y < all_height - 2; i++, y++ ) {
             if( info_txt[i] == "--" ) {
-                for( int x = 1; x < info_width - 2; x++ ) {
-                    mvwputch( w_info, point( x, y ), c_dark_gray, LINE_OXOX );
-                }
+                mvwhline( w_info, point( 1, y ), c_dark_gray, LINE_OXOX, info_width - 3 );
             } else {
                 trim_and_print( w_info, point( 1, y ), info_width - 2, c_white, info_txt[i] );
             }

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -821,8 +821,10 @@ static void draw_header( const catacurses::window &w )
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 0, 2 ), c_white, _( "Some color changes may require a restart." ) );
 
+    wattron( w, BORDER_COLOR );
     mvwhline( w, point( 0, 3 ), LINE_OXOX, getmaxx( w ) ); // Draw line under header
-    mvwputch( w, point( 48, 3 ), BORDER_COLOR, LINE_OXXX ); //^|^
+    mvwaddch( w, point( 48, 3 ), LINE_OXXX ); //^|^
+    wattroff( w, BORDER_COLOR );
 
     mvwprintz( w, point( 3, 4 ), c_white, _( "Colorname" ) );
     mvwprintz( w, point( 21, 4 ), c_white, _( "Normal" ) );
@@ -894,32 +896,25 @@ void color_manager::show_gui()
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         draw_border( w_colors_border, BORDER_COLOR, _( "Color manager" ) );
-        mvwputch( w_colors_border, point( 0, 3 ), BORDER_COLOR, LINE_XXXO ); // |-
-        mvwputch( w_colors_border, point( getmaxx( w_colors_border ) - 1, 3 ), BORDER_COLOR,
-                  LINE_XOXX ); // -|
+        wattron( w_colors_border, BORDER_COLOR );
+        mvwaddch( w_colors_border, point( 0, 4 ), LINE_XXXO ); // |-
+        mvwaddch( w_colors_border, point( getmaxx( w_colors_border ) - 1, 4 ), LINE_XOXX ); // -|
 
-        for( int &iCol : vLines ) {
+        for( const int &iCol : vLines ) {
             if( iCol > -1 ) {
-                mvwputch( w_colors_border, point( iCol + 1, FULL_SCREEN_HEIGHT - 1 ), BORDER_COLOR,
-                          LINE_XXOX ); // _|_
-                mvwputch( w_colors_header, point( iCol, 3 ), BORDER_COLOR, LINE_XOXO );
+                mvwaddch( w_colors_border, point( iCol + 1, FULL_SCREEN_HEIGHT - 1 ), LINE_XXOX ); // _|_
+                mvwaddch( w_colors_header, point( iCol, 4 ), LINE_XOXO );
             }
         }
+        wattroff( w_colors_border, BORDER_COLOR );
         wnoutrefresh( w_colors_border );
 
         draw_header( w_colors_header );
 
         // Clear all lines
-        for( int i = 0; i < iContentHeight; i++ ) {
-            for( int j = 0; j < 79; j++ ) {
-                mvwputch( w_colors, point( j, i ), c_black, ' ' );
-
-                for( int &iCol : vLines ) {
-                    if( iCol == j ) {
-                        mvwputch( w_colors, point( j, i ), BORDER_COLOR, LINE_XOXO );
-                    }
-                }
-            }
+        mvwrectf( w_colors, point_zero, c_black, ' ', 79, iContentHeight );
+        for( int &iCol : vLines ) {
+            mvwvline( w_colors, point( iCol, 0 ), BORDER_COLOR, LINE_XOXO, iContentHeight );
         }
 
         calcStartPos( iStartPos, iCurrentLine, iContentHeight, iMaxColors );

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -347,14 +347,19 @@ static void draw_grid( const catacurses::window &w, const int list_width )
 {
     draw_border( w );
     mvwprintz( w, point( 2, 0 ), c_light_red, _( " Construction " ) );
+
+    wattron( w, c_light_gray );
+
     // draw internal lines
     mvwvline( w, point( list_width, 1 ), LINE_XOXO, getmaxy( w ) - 2 );
     mvwhline( w, point( 1, 2 ), LINE_OXOX, list_width );
     // draw intersections
-    mvwputch( w, point( list_width, 0 ), c_light_gray, LINE_OXXX );
-    mvwputch( w, point( list_width, getmaxy( w ) - 1 ), c_light_gray, LINE_XXOX );
-    mvwputch( w, point( 0, 2 ), c_light_gray, LINE_XXXO );
-    mvwputch( w, point( list_width, 2 ), c_light_gray, LINE_XOXX );
+    mvwaddch( w, point( list_width, 0 ), LINE_OXXX );
+    mvwaddch( w, point( list_width, getmaxy( w ) - 1 ), LINE_XXOX );
+    mvwaddch( w, point( 0, 2 ), LINE_XXXO );
+    mvwaddch( w, point( list_width, 2 ), LINE_XOXX );
+
+    wattroff( w, c_light_gray );
 
     wnoutrefresh( w );
 }
@@ -828,7 +833,7 @@ construction_id construction_menu( const bool blueprint )
         draw_grid( w_con, w_list_width + w_list_x0 );
 
         // Erase existing tab selection & list of constructions
-        mvwhline( w_con, point_south_east, ' ', w_list_width );
+        mvwhline( w_con, point_south_east, BORDER_COLOR, ' ', w_list_width );
         werase( w_list );
         // Print new tab listing
         // NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -850,9 +855,7 @@ construction_id construction_menu( const bool blueprint )
         }
 
         // Clear out lines for tools & materials
-        for( int i = 1; i < w_height - 1; i++ ) {
-            mvwhline( w_con, point( pos_x, i ), ' ', available_window_width );
-        }
+        mvwrectf( w_con, point( pos_x, 1 ), BORDER_COLOR, ' ', available_window_width, w_height - 2 );
 
         // print the hotkeys regardless of if there are constructions
         for( size_t i = 0; i < notes.size(); ++i ) {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1439,15 +1439,13 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
         }
 
         // Draw borders
-        for( int i = 1; i < width - 1; ++i ) { // -
-            mvwputch( w_data, point( i, dataHeight - 1 ), BORDER_COLOR, LINE_OXOX );
-        }
-        for( int i = 0; i < dataHeight - 1; ++i ) { // |
-            mvwputch( w_data, point( 0, i ), BORDER_COLOR, LINE_XOXO );
-            mvwputch( w_data, point( width - 1, i ), BORDER_COLOR, LINE_XOXO );
-        }
-        mvwputch( w_data, point( 0, dataHeight - 1 ), BORDER_COLOR, LINE_XXOO ); // |_
-        mvwputch( w_data, point( width - 1, dataHeight - 1 ), BORDER_COLOR, LINE_XOOX ); // _|
+        wattron( w_data, BORDER_COLOR );
+        mvwhline( w_data, point( 1, dataHeight - 1 ), LINE_OXOX, width - 2 );
+        mvwvline( w_data, point_zero, LINE_XOXO, dataHeight - 1 );
+        mvwvline( w_data, point( width - 1, 0 ), LINE_XOXO, dataHeight - 1 );
+        mvwaddch( w_data, point( 0, dataHeight - 1 ), LINE_XXOO ); // |_
+        mvwaddch( w_data, point( width - 1, dataHeight - 1 ), LINE_XOOX ); // _|
+        wattroff( w_data, BORDER_COLOR );
 
         const int max_recipe_name_width = 27;
         const int recmax = current.size();
@@ -2295,8 +2293,10 @@ static void draw_hidden_amount( const catacurses::window &w, int amount, int num
                      num_recipe ) );
     }
     //Finish border connection with the recipe tabs
+    wattron( w, BORDER_COLOR );
     mvwhline( w, point( 0, getmaxy( w ) - 1 ), LINE_OXOX, getmaxx( w ) - 1 );
-    mvwputch( w, point( getmaxx( w ) - 1, getmaxy( w ) - 1 ), BORDER_COLOR, LINE_OOXX ); // ^|
+    mvwaddch( w, point( getmaxx( w ) - 1, getmaxy( w ) - 1 ), LINE_OOXX ); // ^|
+    wattroff( w, BORDER_COLOR );
     wnoutrefresh( w );
 }
 
@@ -2382,8 +2382,10 @@ static std::map<size_t, inclusive_rectangle<point>> draw_recipe_tabs( const cata
             break;
         }
         case FILTERED: {
-            mvwhline( w, point( 0, getmaxy( w ) - 1 ), LINE_OXOX, getmaxx( w ) - 1 );  // ─
-            mvwputch( w, point( 0, getmaxy( w ) - 1 ), BORDER_COLOR, LINE_OXXO );  // ┌
+            wattron( w, BORDER_COLOR );
+            mvwhline( w, point( 0, getmaxy( w ) - 1 ), LINE_OXOX, getmaxx( w ) - 1 );
+            mvwaddch( w, point( 0, getmaxy( w ) - 1 ), LINE_OXXO ); // ┌
+            wattroff( w, BORDER_COLOR );
             std::string tab_name = _( "Searched" );
             if( filtered_unread ) {
                 tab_name += " ";  // space for green "+"
@@ -2395,8 +2397,10 @@ static std::map<size_t, inclusive_rectangle<point>> draw_recipe_tabs( const cata
             break;
         }
         case BATCH:
-            mvwhline( w, point( 0, getmaxy( w ) - 1 ), LINE_OXOX, getmaxx( w ) - 1 );  // ─
-            mvwputch( w, point( 0, getmaxy( w ) - 1 ), BORDER_COLOR, LINE_OXXO );  // ┌
+            wattron( w, BORDER_COLOR );
+            mvwhline( w, point( 0, getmaxy( w ) - 1 ), LINE_OXOX, getmaxx( w ) - 1 );
+            mvwaddch( w, point( 0, getmaxy( w ) - 1 ), LINE_OXXO ); // ┌
+            wattroff( w, BORDER_COLOR );
             draw_tab( w, 2, _( "Batch" ), true );
             break;
     }
@@ -2416,8 +2420,10 @@ static std::map<size_t, inclusive_rectangle<point>> draw_recipe_subtabs(
     std::map<size_t, inclusive_rectangle<point>> subtab_map;
     int width = getmaxx( w );
 
+    wattron( w, BORDER_COLOR );
     mvwvline( w, point_zero, LINE_XOXO, getmaxy( w ) );  // |
     mvwvline( w, point( width - 1, 0 ), LINE_XOXO, getmaxy( w ) );  // |
+    wattroff( w, BORDER_COLOR );
 
     switch( mode ) {
         case NORMAL: {
@@ -2464,10 +2470,10 @@ static std::map<size_t, inclusive_rectangle<point>> draw_recipe_subtabs(
         case FILTERED:
         case BATCH:
             werase( w );
-            for( int i = 0; i < 3; i++ ) {
-                mvwputch( w, point( 0, i ), BORDER_COLOR, LINE_XOXO ); // |
-                mvwputch( w, point( width - 1, i ), BORDER_COLOR, LINE_XOXO ); // |
-            }
+            wattron( w, BORDER_COLOR );
+            mvwvline( w, point_zero, LINE_XOXO, 3 ); // |
+            mvwvline( w, point( width - 1, 0 ), LINE_XOXO, 3 ); // |
+            wattroff( w, BORDER_COLOR );
             break;
     }
 

--- a/src/cursesport.cpp
+++ b/src/cursesport.cpp
@@ -126,8 +126,6 @@ void catacurses::wborder( const window &win_, chtype ls, chtype rs, chtype ts, c
         // TODO: log this
         return;
     }
-    int i = 0;
-    int j = 0;
     point old = win->cursor; // methods below move the cursor, save the value!
 
     const chtype border_ls = ls ? ls : LINE_XOXO;
@@ -139,21 +137,16 @@ void catacurses::wborder( const window &win_, chtype ls, chtype rs, chtype ts, c
     const chtype border_bl = bl ? bl : LINE_XXOO;
     const chtype border_br = br ? br : LINE_XOOX;
 
-    for( j = 1; j < win->height - 1; j++ ) {
-        mvwaddch( win_, point( 0, j ), border_ls );
-    }
-    for( j = 1; j < win->height - 1; j++ ) {
-        mvwaddch( win_, point( win->width - 1, j ), border_rs );
-    }
-    for( i = 1; i < win->width - 1; i++ ) {
-        mvwaddch( win_, point( i, 0 ), border_ts );
-    }
-    for( i = 1; i < win->width - 1; i++ ) {
-        mvwaddch( win_, point( i, win->height - 1 ), border_bs );
-    }
-    mvwaddch( win_, point_zero, border_tl );
-    mvwaddch( win_, point( win->width - 1, 0 ), border_tr );
-    mvwaddch( win_, point( 0, win->height - 1 ), border_bl );
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    mvwvline( win_, point( 0,               1 ), border_ls, win->height - 2 );
+    mvwvline( win_, point( win->width - 1,  1 ), border_rs, win->height - 2 );
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    mvwhline( win_, point( 1,               0 ), border_ts, win->width - 2 );
+    mvwhline( win_, point( 1, win->height - 1 ), border_bs, win->width - 2 );
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    mvwaddch( win_, point( 0,                            0 ), border_tl );
+    mvwaddch( win_, point( win->width - 1,               0 ), border_tr );
+    mvwaddch( win_, point( 0,              win->height - 1 ), border_bl );
     mvwaddch( win_, point( win->width - 1, win->height - 1 ), border_br );
 
     // methods above move the cursor, put it back
@@ -163,22 +156,18 @@ void catacurses::wborder( const window &win_, chtype ls, chtype rs, chtype ts, c
 
 void catacurses::mvwhline( const window &win, const point &p, chtype ch, int n )
 {
-    wattron( win, BORDER_COLOR );
     const chtype hline_char = ch ? ch : LINE_OXOX;
     for( int i = 0; i < n; i++ ) {
         mvwaddch( win, p + point( i, 0 ), hline_char );
     }
-    wattroff( win, BORDER_COLOR );
 }
 
 void catacurses::mvwvline( const window &win, const point &p, chtype ch, int n )
 {
-    wattron( win, BORDER_COLOR );
     const chtype vline_char = ch ? ch : LINE_XOXO;
     for( int j = 0; j < n; j++ ) {
         mvwaddch( win, p + point( 0, j ), vline_char );
     }
-    wattroff( win, BORDER_COLOR );
 }
 
 void catacurses::wnoutrefresh( const window &win_ )

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3571,12 +3571,16 @@ static void show_sound()
         const point offset {
             player_character.view_offset.xy().raw() + point( POSX - player_character.posx(), POSY - player_character.posy() )
         };
+        wattron( g->w_terrain, c_yellow );
         for( const tripoint &sound : sounds_to_draw.first ) {
-            mvwputch( g->w_terrain, offset + sound.xy(), c_yellow, '?' );
+            mvwaddch( g->w_terrain, offset + sound.xy(), '?' );
         }
+        wattroff( g->w_terrain, c_yellow );
+        wattron( g->w_terrain, c_red );
         for( const tripoint &sound : sounds_to_draw.second ) {
-            mvwputch( g->w_terrain, offset + sound.xy(), c_red, '?' );
+            mvwaddch( g->w_terrain, offset + sound.xy(), '?' );
         }
+        wattroff( g->w_terrain, c_red );
     } );
     g->add_draw_callback( sound_cb );
 

--- a/src/dialogue_win.cpp
+++ b/src/dialogue_win.cpp
@@ -187,16 +187,16 @@ void dialogue_window::print_header( const std::string &name ) const
     }
 
     // Horizontal bar dividing history and responses
-    mvwputch( d_win, point( 0, ybar ), BORDER_COLOR, LINE_XXXO );
+    wattron( d_win, BORDER_COLOR );
+    mvwaddch( d_win, point( 0, ybar ), LINE_XXXO );
     mvwhline( d_win, point( 1, ybar ), LINE_OXOX, xmax - 1 );
-    mvwputch( d_win, point( xmax - 1, ybar ), BORDER_COLOR, LINE_XOXX );
+    mvwaddch( d_win, point( xmax - 1, ybar ), LINE_XOXX );
+    wattroff( d_win, BORDER_COLOR );
     if( is_computer ) {
-        // NOLINTNEXTLINE(cata-use-named-point-constants)
         mvwprintz( d_win, point( 2, ybar + 1 ), default_color(), _( "Your input:" ) );
     } else if( is_not_conversation ) {
         mvwprintz( d_win, point( 2, ybar + 1 ), default_color(), _( "What do you do?" ) );
     } else {
-        // NOLINTNEXTLINE(cata-use-named-point-constants)
         mvwprintz( d_win, point( 2, ybar + 1 ), default_color(), _( "Your response:" ) );
     }
 }

--- a/src/diary_ui.cpp
+++ b/src/diary_ui.cpp
@@ -102,63 +102,65 @@ void mvwprintwa( const catacurses::window &win, point p, Ts... args )
     }
 }
 
-void draw_diary_border( catacurses::window *win )
+void draw_diary_border( catacurses::window &win )
 {
-    const point max( getmaxx( *win ) - 1, getmaxy( *win ) - 1 );
+    const point max( getmaxx( win ) - 1, getmaxy( win ) - 1 );
     const point mid = max / 2;
+
+    wattron( win, BORDER_COLOR );
+
     // left, right vertical lines
     for( int i = 0; i < 4; i++ ) {
-        mvwvline( *win, point( 0     + i, 4 ), '|', max.y - 4 - 4 + 1 );
-        mvwvline( *win, point( max.x - i, 4 ), '|', max.y - 4 - 4 + 1 );
+        mvwvline( win, point( 0     + i, 4 ), '|', max.y - 4 - 4 + 1 );
+        mvwvline( win, point( max.x - i, 4 ), '|', max.y - 4 - 4 + 1 );
     }
     // middle vertical line
-    mvwvline( *win,     point( mid.x,     4 ), '|', max.y - 4 - 4 + 1 );
+    mvwvline( win,     point( mid.x,     4 ), '|', max.y - 4 - 4 + 1 );
     // top horizontal line
-    mvwhline( *win,     point( 4,         0 ), '_', max.x - 4 - 4 + 1 );
+    mvwhline( win,     point( 4,         0 ), '_', max.x - 4 - 4 + 1 );
     // bottom horizontal lines
-    mvwhline( *win,     point( 4, max.y - 2 ), '_', max.x - 4 - 4 + 1 );
-    mvwhline( *win,     point( 4, max.y - 1 ), '=', max.x - 4 - 4 + 1 );
-    mvwhline( *win,     point( 4, max.y - 0 ), '-', max.x - 4 - 4 + 1 );
+    mvwhline( win,     point( 4, max.y - 2 ), '_', max.x - 4 - 4 + 1 );
+    mvwhline( win,     point( 4, max.y - 1 ), '=', max.x - 4 - 4 + 1 );
+    mvwhline( win,     point( 4, max.y - 0 ), '-', max.x - 4 - 4 + 1 );
 
-    wattron( *win, BORDER_COLOR );
     //top left corner
-    mvwprintwa( *win, point_zero,
+    mvwprintwa( win, point_zero,
                 "    ",
                 ".-/|",
                 "||||",
                 "||||" );
     // bottom left corner
-    mvwprintwa( *win, point( 0, max.y - 3 ),
+    mvwprintwa( win, point( 0, max.y - 3 ),
                 "||||",
                 "||||",
                 "||/=",
                 "`'--" );
     // top right corner
-    mvwprintwa( *win, point( max.x - 3, 0 ),
+    mvwprintwa( win, point( max.x - 3, 0 ),
                 "    ",
                 "|\\-.",
                 "||||",
                 "||||" );
     // bottom right corner
-    mvwprintwa( *win, max + point( -3, -3 ),
+    mvwprintwa( win, max + point( -3, -3 ),
                 "||||",
                 "||||",
                 "=\\||",
                 "--''" );
     // top middle
-    mvwprintwa( *win, point( mid.x - 1, 0 ),
+    mvwprintwa( win, point( mid.x - 1, 0 ),
                 "   ",
                 "\\ /",
                 " | ",
                 " | " );
     // bottom middle
-    mvwprintwa( *win, point( mid.x - 1, max.y - 3 ),
+    mvwprintwa( win, point( mid.x - 1, max.y - 3 ),
                 " | ",
                 " | ",
                 "\\|/",
                 "___" );
 
-    wattroff( *win, BORDER_COLOR );
+    wattroff( win, BORDER_COLOR );
 }
 } // namespace
 
@@ -220,7 +222,7 @@ void diary::show_diary_ui( diary *c_diary )
         werase( w_border );
         werase( w_head );
 
-        draw_diary_border( &w_border );
+        draw_diary_border( w_border );
 
         print_list_scrollable( &w_changes, c_diary->get_change_list(), &selected[window_mode::CHANGE_WIN],
                                currwin == window_mode::CHANGE_WIN, false, report_color_error::yes );

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -89,9 +89,11 @@ void distraction_manager_gui::show()
     ui.on_redraw( [&]( const ui_adaptor & ) {
         // Draw border
         draw_border( w_border, BORDER_COLOR, _( "Distractions manager" ) );
-        mvwputch( w_border, point( 0, iHeaderHeight - 1 ), c_light_gray, LINE_XXXO );
-        mvwputch( w_border, point( 79, iHeaderHeight - 1 ), c_light_gray, LINE_XOXX );
-        mvwputch( w_border, point( 61, FULL_SCREEN_HEIGHT - 1 ), c_light_gray, LINE_XXOX );
+        wattron( w_border, c_light_gray );
+        mvwaddch( w_border, point( 0, iHeaderHeight - 1 ), LINE_XXXO );
+        mvwaddch( w_border, point( 79, iHeaderHeight - 1 ), LINE_XOXX );
+        mvwaddch( w_border, point( 61, FULL_SCREEN_HEIGHT - 1 ), LINE_XXOX );
+        wattroff( w_border, c_light_gray );
         wnoutrefresh( w_border );
 
         // Draw header
@@ -100,27 +102,17 @@ void distraction_manager_gui::show()
                         _( get_configurable_distractions()[currentLine].description.c_str() ) );
 
         // Draw horizontal line and corner pieces of the table
-        for( int x = 0; x < 78; x++ ) {
-            if( x == 60 ) {
-                mvwputch( w_header, point( x, iHeaderHeight - 2 ), c_light_gray, LINE_OXXX );
-                mvwputch( w_header, point( x, iHeaderHeight - 1 ), c_light_gray, LINE_XOXO );
-            } else {
-                mvwputch( w_header, point( x, iHeaderHeight - 2 ), c_light_gray, LINE_OXOX );
-            }
-        }
+        wattron( w_header, c_light_gray );
+        mvwhline( w_header, point( 0, iHeaderHeight - 2 ), LINE_OXOX, 78 );
+        mvwaddch( w_header, point( 60, iHeaderHeight - 2 ), LINE_OXXX );
+        mvwaddch( w_header, point( 60, iHeaderHeight - 1 ), LINE_XOXO );
+        wattroff( w_header, c_light_gray );
 
         wnoutrefresh( w_header );
 
         // Clear table
-        for( int y = 0; y < iContentHeight; y++ ) {
-            for( int x = 0; x < 79; x++ ) {
-                if( x == 60 ) {
-                    mvwputch( w, point( x, y ), c_light_gray, LINE_XOXO );
-                } else {
-                    mvwputch( w, point( x, y ), c_black, ' ' );
-                }
-            }
-        }
+        mvwrectf( w, point_zero, c_black, ' ', 79, iContentHeight );
+        mvwvline( w, point( 60, 0 ), c_light_gray, LINE_XOXO, iContentHeight ) ;
 
         draw_scrollbar( w_border, currentLine, iContentHeight, number_of_distractions, point( 0,
                         iHeaderHeight + 1 ) );

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -615,10 +615,12 @@ void editmap::draw_main_ui_overlay()
     // draw arrows if altblink is set (ie, [m]oving a large selection
     if( blink && altblink ) {
         const point mp = tmax / 2 + point_south_east;
-        mvwputch( g->w_terrain, point( 1, mp.y ), c_yellow, '<' );
-        mvwputch( g->w_terrain, point( tmax.x - 1, mp.y ), c_yellow, '>' );
-        mvwputch( g->w_terrain, point( mp.x, 1 ), c_yellow, '^' );
-        mvwputch( g->w_terrain, point( mp.x, tmax.y - 1 ), c_yellow, 'v' );
+        wattron( g->w_terrain, c_yellow );
+        mvwaddch( g->w_terrain, point( 1, mp.y ), '<' );
+        mvwaddch( g->w_terrain, point( tmax.x - 1, mp.y ), '>' );
+        mvwaddch( g->w_terrain, point( mp.x, 1 ), '^' );
+        mvwaddch( g->w_terrain, point( mp.x, tmax.y - 1 ), 'v' );
+        wattroff( g->w_terrain, c_yellow );
     }
 
     if( tmpmap_ptr ) {

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -920,9 +920,7 @@ void faction_manager::display() const
     ui.on_redraw( [&]( const ui_adaptor & ) {
         werase( w_missions );
 
-        for( int i = 3; i < FULL_SCREEN_HEIGHT - 1; i++ ) {
-            mvwputch( w_missions, point( 30, i ), BORDER_COLOR, LINE_XOXO );
-        }
+        mvwvline( w_missions, point( 30, 3 ), BORDER_COLOR, LINE_XOXO, FULL_SCREEN_HEIGHT - 4 );
 
         const std::vector<std::pair<tab_mode, std::string>> tabs = {
             { tab_mode::TAB_MYFACTION, _( "YOUR FACTION" ) },
@@ -934,9 +932,11 @@ void faction_manager::display() const
         draw_tabs( w_missions, tabs, tab );
         draw_border_below_tabs( w_missions );
 
-        mvwputch( w_missions, point( 30, 2 ), BORDER_COLOR,
+        wattron( w_missions, BORDER_COLOR );
+        mvwaddch( w_missions, point( 30, 2 ),
                   tab == tab_mode::TAB_FOLLOWERS ? ' ' : LINE_OXXX ); // ^|^
-        mvwputch( w_missions, point( 30, FULL_SCREEN_HEIGHT - 1 ), BORDER_COLOR, LINE_XXOX ); // _|_
+        mvwaddch( w_missions, point( 30, FULL_SCREEN_HEIGHT - 1 ), LINE_XXOX ); // _|_
+        wattroff( w_missions, BORDER_COLOR );
         const nc_color col = c_white;
 
         // entries_per_page * page number

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2283,9 +2283,7 @@ void basecamp::worker_assignment_ui()
         // entries_per_page * page number
         const size_t top_of_page = entries_per_page * ( selection / entries_per_page );
 
-        for( int i = 0; i < FULL_SCREEN_HEIGHT - 2; i++ ) {
-            mvwputch( w_followers, point( 45, i ), BORDER_COLOR, LINE_XOXO );
-        }
+        mvwvline( w_followers, point( 45, 0 ), BORDER_COLOR, LINE_XOXO, FULL_SCREEN_HEIGHT - 2 ) ;
         draw_border( w_followers );
         const nc_color col = c_white;
         const std::string no_npcs = _( "You have no companions following you." );
@@ -2374,9 +2372,7 @@ void basecamp::job_assignment_ui()
     ui.on_redraw( [&]( const ui_adaptor & ) {
         werase( w_jobs );
         const size_t top_of_page = entries_per_page * ( selection / entries_per_page );
-        for( int i = 0; i < FULL_SCREEN_HEIGHT - 2; i++ ) {
-            mvwputch( w_jobs, point( 45, i ), BORDER_COLOR, LINE_XOXO );
-        }
+        mvwvline( w_jobs, point( 45, 0 ), BORDER_COLOR, LINE_XOXO, FULL_SCREEN_HEIGHT - 2 );
         draw_border( w_jobs );
         mvwprintz( w_jobs, point( 46, 1 ), c_white, _( "Job/Priority" ) );
         const nc_color col = c_white;
@@ -4712,7 +4708,7 @@ void talk_function::draw_camp_tabs( const catacurses::window &win,
 {
     werase( win );
     const int width = getmaxx( win );
-    mvwhline( win, point( 0, 2 ), LINE_OXOX, width );
+    mvwhline( win, point( 0, 2 ), BORDER_COLOR, LINE_OXOX, width );
 
     std::vector<std::string> tabs( base_camps::all_directions.size() );
     for( const auto &direction : base_camps::all_directions ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3739,11 +3739,13 @@ void game::disp_NPCs()
             mvwprintz( w, point( 0, i + 4 ), c_white, "%s: %s", npcs[i]->get_name(),
                        apos.to_string() );
         }
+        wattron( w, c_white );
         for( const monster &m : all_monsters() ) {
-            mvwprintz( w, point( 0, i + 4 ), c_white, "%s: %d, %d, %d", m.name(),
+            mvwprintw( w, point( 0, i + 4 ), "%s: %d, %d, %d", m.name(),
                        m.posx(), m.posy(), m.posz() );
             ++i;
         }
+        wattroff( w, c_white );
         wnoutrefresh( w );
     } );
 
@@ -3764,14 +3766,16 @@ void game::disp_NPCs()
 // A little helper to draw footstep glyphs.
 static void draw_footsteps( const catacurses::window &window, const tripoint &offset )
 {
+    wattron( window, c_yellow );
     for( const tripoint &footstep : sounds::get_footstep_markers() ) {
         char glyph = '?';
         if( footstep.z != offset.z ) { // Here z isn't an offset, but a coordinate
             glyph = footstep.z > offset.z ? '^' : 'v';
         }
 
-        mvwputch( window, footstep.xy() + offset.xy(), c_yellow, glyph );
+        mvwaddch( window, footstep.xy() + offset.xy(), glyph );
     }
+    wattroff( window, c_yellow );
 }
 
 shared_ptr_fast<ui_adaptor> game::create_or_get_main_ui_adaptor()
@@ -4103,15 +4107,16 @@ void game::draw_panels( bool force_draw )
                     label = catacurses::newwin( h, 1,
                                                 point( sidebar_right ? TERMX - panel.get_width() - 1 : panel.get_width(), y ) );
                     werase( label );
+                    wattron( label, c_light_red );
                     if( h == 1 ) {
-                        mvwputch( label, point_zero, c_light_red, LINE_OXOX );
+                        mvwaddch( label, point_zero, LINE_OXOX );
                     } else {
-                        mvwputch( label, point_zero, c_light_red, LINE_OXXX );
-                        for( int i = 1; i < h - 1; i++ ) {
-                            mvwputch( label, point( 0, i ), c_light_red, LINE_XOXO );
-                        }
-                        mvwputch( label, point( 0, h - 1 ), c_light_red, sidebar_right ? LINE_XXOO : LINE_XOOX );
+                        mvwaddch( label, point_zero, LINE_OXXX );
+                        // NOLINTNEXTLINE(cata-use-named-point-constants)
+                        mvwvline( label, point( 0, 1 ), LINE_XOXO, h - 2 ) ;
+                        mvwaddch( label, point( 0, h - 1 ), sidebar_right ? LINE_XXOO : LINE_XOOX );
                     }
+                    wattroff( label, c_light_red );
                     wnoutrefresh( label );
                 }
                 y += h;
@@ -6420,9 +6425,11 @@ void game::print_terrain_info( const tripoint &lp, const catacurses::window &w_l
     std::string desc = string_format( m.ter( lp ).obj().description );
     std::vector<std::string> lines = foldstring( desc, max_width );
     int numlines = lines.size();
+    wattron( w_look, c_light_gray );
     for( int i = 0; i < numlines; i++ ) {
-        mvwprintz( w_look, point( column, line++ ), c_light_gray, lines[i] );
+        mvwprintw( w_look, point( column, line++ ), lines[i] );
     }
+    wattroff( w_look, c_light_gray );
 
     // Furniture, if any
     print_furniture_info( lp, w_look, column, line );
@@ -6441,9 +6448,11 @@ void game::print_terrain_info( const tripoint &lp, const catacurses::window &w_l
     // furnitures and terrains.
     lines = foldstring( m.features( lp ), max_width );
     numlines = lines.size();
+    wattron( w_look, c_light_gray );
     for( int i = 0; i < numlines; i++ ) {
-        mvwprintz( w_look, point( column, ++line ), c_light_gray, lines[i] );
+        mvwprintw( w_look, point( column, ++line ), lines[i] );
     }
+    wattroff( w_look, c_light_gray );
 
     // Move cost from terrain and furniture and vehicle parts.
     // Vehicle part information is printed in a different function.
@@ -6507,9 +6516,11 @@ void game::print_furniture_info( const tripoint &lp, const catacurses::window &w
     desc = string_format( f.obj().description );
     std::vector<std::string> lines = foldstring( desc, max_width );
     int numlines = lines.size();
+    wattron( w_look, c_light_gray );
     for( int i = 0; i < numlines; i++ ) {
-        mvwprintz( w_look, point( column, line++ ), c_light_gray, lines[i] );
+        mvwprintw( w_look, point( column, line++ ), lines[i] );
     }
+    wattroff( w_look, c_light_gray );
 
     // If this furniture has a crafting pseudo item, check for tool qualities and print them
     if( !f->crafting_pseudo_item.is_empty() ) {
@@ -6744,41 +6755,35 @@ static void zones_manager_draw_borders( const catacurses::window &w_border,
                                         const catacurses::window &w_info_border,
                                         const int iInfoHeight, const int width )
 {
-    for( int i = 1; i < TERMX; ++i ) {
-        if( i < width ) {
-            mvwputch( w_border, point( i, 0 ), c_light_gray, LINE_OXOX ); // -
-            mvwputch( w_border, point( i, TERMY - iInfoHeight - 1 ), c_light_gray,
-                      LINE_OXOX ); // -
-        }
+    wattron( w_border, c_light_gray );
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    mvwhline( w_border, point( 1,                       0 ), LINE_OXOX, width - 1 ); // -
+    mvwhline( w_border, point( 1, TERMY - iInfoHeight - 1 ), LINE_OXOX, width - 1 ); // -
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    mvwvline( w_border, point( 0,         1 ), LINE_XOXO, TERMY - iInfoHeight - 1 ); // |
+    mvwvline( w_border, point( width - 1, 1 ), LINE_XOXO, TERMY - iInfoHeight - 1 ); // |
 
-        if( i < TERMY - iInfoHeight ) {
-            mvwputch( w_border, point( 0, i ), c_light_gray, LINE_XOXO ); // |
-            mvwputch( w_border, point( width - 1, i ), c_light_gray, LINE_XOXO ); // |
-        }
-    }
+    mvwaddch( w_border, point_zero,            LINE_OXXO ); // |^
+    mvwaddch( w_border, point( width - 1, 0 ), LINE_OOXX ); // ^|
 
-    mvwputch( w_border, point_zero, c_light_gray, LINE_OXXO ); // |^
-    mvwputch( w_border, point( width - 1, 0 ), c_light_gray, LINE_OOXX ); // ^|
-
-    mvwputch( w_border, point( 0, TERMY - iInfoHeight - 1 ), c_light_gray,
-              LINE_XXXO ); // |-
-    mvwputch( w_border, point( width - 1, TERMY - iInfoHeight - 1 ), c_light_gray,
-              LINE_XOXX ); // -|
+    mvwaddch( w_border, point( 0,         TERMY - iInfoHeight - 1 ), LINE_XXXO ); // |-
+    mvwaddch( w_border, point( width - 1, TERMY - iInfoHeight - 1 ), LINE_XOXX ); // -|
+    wattroff( w_border, c_light_gray );
 
     mvwprintz( w_border, point( 2, 0 ), c_white, _( "Zones manager" ) );
+
     wnoutrefresh( w_border );
 
-    for( int j = 0; j < iInfoHeight - 1; ++j ) {
-        mvwputch( w_info_border, point( 0, j ), c_light_gray, LINE_XOXO );
-        mvwputch( w_info_border, point( width - 1, j ), c_light_gray, LINE_XOXO );
-    }
+    wattron( w_info_border, c_light_gray );
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    mvwvline( w_info_border, point( 0,               0 ), LINE_XOXO, iInfoHeight - 1 );
+    mvwvline( w_info_border, point( width - 1,       0 ), LINE_XOXO, iInfoHeight - 1 );
+    mvwhline( w_info_border, point( 0, iInfoHeight - 1 ), LINE_OXOX, width - 1 );
 
-    for( int j = 0; j < width - 1; ++j ) {
-        mvwputch( w_info_border, point( j, iInfoHeight - 1 ), c_light_gray, LINE_OXOX );
-    }
+    mvwaddch( w_info_border, point( 0,         iInfoHeight - 1 ), LINE_XXOO );
+    mvwaddch( w_info_border, point( width - 1, iInfoHeight - 1 ), LINE_XOOX );
+    wattroff( w_info_border, c_light_gray );
 
-    mvwputch( w_info_border, point( 0, iInfoHeight - 1 ), c_light_gray, LINE_XXOO );
-    mvwputch( w_info_border, point( width - 1, iInfoHeight - 1 ), c_light_gray, LINE_XOOX );
     wnoutrefresh( w_info_border );
 }
 
@@ -6910,11 +6915,13 @@ void game::zones_manager()
                 mvwprintz( w_zones_options, point( 1, 1 ), c_white, _( "Options" ) );
 
                 int y = 2;
+                wattron( w_zones_options, c_white );
                 for( const auto &desc : descriptions ) {
-                    mvwprintz( w_zones_options, point( 3, y ), c_white, desc.first );
-                    mvwprintz( w_zones_options, point( 20, y ), c_white, desc.second );
+                    mvwprintw( w_zones_options, point( 3, y ), desc.first );
+                    mvwprintw( w_zones_options, point( 20, y ), desc.second );
                     y++;
                 }
+                wattroff( w_zones_options, c_white );
             }
         }
 
@@ -8128,26 +8135,21 @@ bool game::take_screenshot() const
 void game::reset_item_list_state( const catacurses::window &window, int height, bool bRadiusSort )
 {
     const int width = getmaxx( window );
-    for( int i = 1; i < TERMX; i++ ) {
-        if( i < width ) {
-            mvwputch( window, point( i, 0 ), c_light_gray, LINE_OXOX ); // -
-            mvwputch( window, point( i, TERMY - height - 1 ), c_light_gray,
-                      LINE_OXOX ); // -
-        }
+    wattron( window, c_light_gray );
 
-        if( i < TERMY - height ) {
-            mvwputch( window, point( 0, i ), c_light_gray, LINE_XOXO ); // |
-            mvwputch( window, point( width - 1, i ), c_light_gray, LINE_XOXO ); // |
-        }
-    }
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    mvwhline( window, point( 1,                  0 ), LINE_OXOX, width - 1 ); // -
+    mvwhline( window, point( 1, TERMY - height - 1 ), LINE_OXOX, width - 1 ); // -
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    mvwvline( window, point( 0,         1 ), LINE_XOXO, TERMY - height - 1 ); // |
+    mvwvline( window, point( width - 1, 1 ), LINE_XOXO, TERMY - height - 1 ); // |
 
-    mvwputch( window, point_zero, c_light_gray, LINE_OXXO ); // |^
-    mvwputch( window, point( width - 1, 0 ), c_light_gray, LINE_OOXX ); // ^|
+    mvwaddch( window, point_zero, LINE_OXXO ); // |^
+    mvwaddch( window, point( width - 1, 0 ), LINE_OOXX ); // ^|
 
-    mvwputch( window, point( 0, TERMY - height - 1 ), c_light_gray,
-              LINE_XXXO ); // |-
-    mvwputch( window, point( width - 1, TERMY - height - 1 ), c_light_gray,
-              LINE_XOXX ); // -|
+    mvwaddch( window, point( 0, TERMY - height - 1 ), LINE_XXXO ); // |-
+    mvwaddch( window, point( width - 1, TERMY - height - 1 ), LINE_XOXX ); // -|
+    wattroff( window, c_light_gray );
 
     mvwprintz( window, point( 2, 0 ), c_light_green, "<Tab> " );
     wprintz( window, c_white, _( "Items" ) );
@@ -8985,9 +8987,11 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
                     mvwprintz( w_monsters, point( width - 31, y ), color, sText );
                     const int bar_max_width = 5;
                     const int bar_width = utf8_width( sText );
+                    wattron( w_monsters, c_white );
                     for( int i = 0; i < bar_max_width - bar_width; ++i ) {
-                        mvwprintz( w_monsters, point( width - 27 - i, y ), c_white, "." );
+                        mvwprintw( w_monsters, point( width - 27 - i, y ), "." );
                     }
+                    wattron( w_monsters, c_white );
 
                     if( m != nullptr ) {
                         const auto att = m->get_attitude();

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1113,11 +1113,12 @@ void iexamine::vending( Character &you, const tripoint_bub_ms &examp )
         const int page_size = std::min( num_items, list_lines );
 
         werase( w );
-        wborder( w, LINE_XOXO, LINE_XOXO, LINE_OXOX, LINE_OXOX,
-                 LINE_OXXO, LINE_OOXX, LINE_XXOO, LINE_XOOX );
+        draw_border( w );
+        wattron( w, BORDER_COLOR );
         mvwhline( w, point( 1, first_item_offset - 1 ), LINE_OXOX, w_items_w - 2 );
         mvwaddch( w, point( 0, first_item_offset - 1 ), LINE_XXXO ); // |-
         mvwaddch( w, point( w_items_w - 1, first_item_offset - 1 ), LINE_XOXX ); // -|
+        wattroff( w, BORDER_COLOR );
 
         trim_and_print( w, point( 2, 1 ), w_items_w - 3, c_light_gray,
                         _( "Money left: %s" ), format_money( money ) );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1670,9 +1670,7 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
                                      &entry );
 
         if( selected && visible_cells() > 1 ) {
-            for( int hx = x1; hx < hx_max; ++hx ) {
-                mvwputch( win, point( hx, yy ), h_white, ' ' );
-            }
+            mvwhline( win, point( x1, yy ), h_white, ' ', hx_max - x1 );
         }
 
         cata_assert( entry.denial.has_value() );
@@ -2509,7 +2507,7 @@ void inventory_selector::draw_header( const catacurses::window &w ) const
                     hint );
 
     int const bottom = border + get_header_height();
-    mvwhline( w, point( border, bottom ), LINE_OXOX, getmaxx( w ) - 2 * border );
+    mvwhline( w, point( border, bottom ), BORDER_COLOR, LINE_OXOX, getmaxx( w ) - 2 * border );
 
     if( display_stats ) {
         size_t y = border;
@@ -2779,8 +2777,10 @@ void inventory_selector::draw_frame( const catacurses::window &w ) const
     draw_border( w );
 
     const int y = border + get_header_height();
+    wattron( w, BORDER_COLOR );
     mvwhline( w, point( 0, y ), LINE_XXXO, 1 );
     mvwhline( w, point( getmaxx( w ) - border, y ), LINE_XOXX, 1 );
+    wattroff( w, BORDER_COLOR );
 }
 
 std::pair<std::string, nc_color> inventory_selector::get_footer( navigation_mode m ) const
@@ -2823,10 +2823,12 @@ void inventory_selector::draw_footer( const catacurses::window &w ) const
             const int y = getmaxy( w ) - border;
 
             mvwprintz( w, point( x1, y ), footer.second, footer.first );
-            mvwputch( w, point( x1 - 1, y ), c_light_gray, ' ' );
-            mvwputch( w, point( x2 + 1, y ), c_light_gray, ' ' );
-            mvwputch( w, point( x1 - 2, y ), c_light_gray, LINE_XOXX );
-            mvwputch( w, point( x2 + 2, y ), c_light_gray, LINE_XXXO );
+            wattron( w, c_light_gray );
+            mvwaddch( w, point( x1 - 1, y ), ' ' );
+            mvwaddch( w, point( x2 + 1, y ), ' ' );
+            mvwaddch( w, point( x1 - 2, y ), LINE_XOXX );
+            mvwaddch( w, point( x2 + 2, y ), LINE_XXXO );
+            wattroff( w, c_light_gray );
         }
     }
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2101,10 +2101,10 @@ class exosuit_interact
                 current_ui->mark_resize();
                 current_ui->on_redraw( [this]( const ui_adaptor & ) {
                     draw_border( w_border, c_white, suit->tname(), c_light_green );
-                    for( int i = 1; i < height - 1; i++ ) {
-                        mvwputch( w_border, point( width_menu + 1, i ), c_white, LINE_XOXO );
-                    }
-                    mvwputch( w_border, point( width_menu + 1, height - 1 ), c_white, LINE_XXOX );
+                    wattron( w_border, c_white );
+                    mvwvline( w_border, point( width_menu + 1, 1 ), LINE_XOXO, height - 2 );
+                    mvwaddch( w_border, point( width_menu + 1, height - 1 ), LINE_XXOX );
+                    wattroff( w_border, c_white );
                     wnoutrefresh( w_border );
                     draw_menu();
                     draw_iteminfo();

--- a/src/iuse_software_kitten.cpp
+++ b/src/iuse_software_kitten.cpp
@@ -125,9 +125,7 @@ void robot_finds_kitten::show() const
 
     werase( w );
     if( current_ui_state != ui_state::instructions ) {
-        for( int c = 0; c < rfkCOLS; c++ ) {
-            mvwputch( w, point( c, 2 ), BORDER_COLOR, '_' );
-        }
+        mvwhline( w, point( 0, 2 ), BORDER_COLOR, '_', rfkCOLS );
         wmove( w, kitten.pos );
         draw_kitten();
 
@@ -172,9 +170,11 @@ void robot_finds_kitten::show() const
             break;
         case ui_state::bogus_message: {
             std::vector<std::string> bogusvstr = foldstring( this_bogus_message, rfkCOLS );
+            wattron( w, c_white );
             for( size_t c = 0; c < bogusvstr.size(); c++ ) {
-                mvwprintz( w, point( 0, c ), c_white, bogusvstr[c] );
+                mvwprintw( w, point( 0, c ), bogusvstr[c] );
             }
+            wattroff( w, c_white );
             break;
         }
         case ui_state::end_animation: {

--- a/src/iuse_software_snake.cpp
+++ b/src/iuse_software_snake.cpp
@@ -41,11 +41,13 @@ void snake_game::snake_over( const catacurses::window &w_snake, int iScore )
 
     // Body of dead snake
     size_t body_length = 3;
+    wattron( w_snake, c_green );
     for( size_t i = 1; i <= body_length; i++ ) {
         for( size_t j = 0; j <= 1; j++ ) {
-            mvwprintz( w_snake, point( 4 + j * 65, i ), c_green, "|   |" );
+            mvwprintw( w_snake, point( 4 + j * 65, i ),  "|   |" );
         }
     }
+    wattroff( w_snake, c_green );
 
     // Head of dead snake
     mvwprintz( w_snake, point( 3, body_length + 1 ), c_green, "(     )" );
@@ -72,9 +74,11 @@ void snake_game::snake_over( const catacurses::window &w_snake, int iScore )
     game_over_text.emplace_back( R"( \_______  / \___/   /_______  / |____|_  / )" );
     game_over_text.emplace_back( R"(         \/                  \/         \/  )" );
 
+    wattron( w_snake, c_light_red );
     for( size_t i = 0; i < game_over_text.size(); i++ ) {
-        mvwprintz( w_snake, point( 17, i + 3 ), c_light_red, game_over_text[i] );
+        mvwprintw( w_snake, point( 17, i + 3 ), game_over_text[i] );
     }
+    wattroff( w_snake, c_light_red );
 
     center_print( w_snake, 17, c_yellow, string_format( _( "TOTAL SCORE: %d" ), iScore ) );
     // TODO: print actual bound keys
@@ -128,10 +132,15 @@ int snake_game::start_game()
     ui.on_redraw( [&]( const ui_adaptor & ) {
         werase( w_snake );
         print_header( w_snake );
+        wattron( w_snake, c_light_gray );
         for( auto it = vSnakeBody.begin(); it != vSnakeBody.end(); ++it ) {
-            const nc_color col = it + 1 == vSnakeBody.end() ? c_white : c_light_gray;
-            mvwputch( w_snake, point( it->second, it->first ), col, '#' );
+            if( it + 1 == vSnakeBody.end() ) {
+                wattroff( w_snake, c_light_gray );
+                wattron( w_snake, c_white );
+            }
+            mvwaddch( w_snake, point( it->second, it->first ), '#' );
         }
+        wattroff( w_snake, c_white );
         if( iFruitPosX != 0 && iFruitPosY != 0 ) {
             mvwputch( w_snake, point( iFruitPosX, iFruitPosY ), c_light_red, '*' );
         }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -353,9 +353,7 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
     int window_height = getmaxy( w_open );
 
     // Draw horizontal line
-    for( int i = 1; i < window_width - 1; ++i ) {
-        mvwputch( w_open, point( i, window_height - 4 ), c_white, LINE_OXOX );
-    }
+    mvwhline( w_open, point( 1, window_height - 4 ), c_white, LINE_OXOX, window_width - 2 );
 
     if( iSel == getopt( main_menu_opts::NEWCHAR ) ) {
         center_print( w_open, window_height - 2, c_yellow, vNewGameHints[sel2] );

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -110,7 +110,7 @@ class medical_column
                           const int BORDER_END ) const {
             mvwvline( window, point( COLUMN_START.x, BORDER_START ), LINE_XOXO,
                       BORDER_END - 4 ); // |
-            mvwputch( window, point( COLUMN_START.x, BORDER_END - 1 ), BORDER_COLOR,
+            mvwaddch( window, point( COLUMN_START.x, BORDER_END - 1 ),
                       LINE_XXOX ); // _|_
         }
 
@@ -232,16 +232,14 @@ static void draw_medical_titlebar( const catacurses::window &window, Character &
 
     int width = getmaxx( window );
     int height = getmaxy( window );
-    for( int i = 1; i < height - 1; ++i ) {
-        // |
-        mvwputch( window, point( 0, i ), BORDER_COLOR, LINE_XOXO );
-        // |
-        mvwputch( window, point( width - 1, i ), BORDER_COLOR, LINE_XOXO );
-    }
-    // |-
-    mvwputch( window, point( 0, height - 1 ), BORDER_COLOR, LINE_XXXO );
-    // -|
-    mvwputch( window, point( width - 1, height - 1 ), BORDER_COLOR, LINE_XOXX );
+    wattron( window, BORDER_COLOR );
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    mvwvline( window, point( 0,          1 ), LINE_XOXO, height - 2 ); // |
+    mvwvline( window, point( width - 1, 1 ), LINE_XOXO, height - 2 );  // |
+
+    mvwaddch( window, point( 0,         height - 1 ), LINE_XXXO ); // |-
+    mvwaddch( window, point( width - 1, height - 1 ), LINE_XOXX ); // -|
+    wattroff( window, BORDER_COLOR );
 
     int right_indent = 2;
     int cur_str_pos = 0;
@@ -254,11 +252,11 @@ static void draw_medical_titlebar( const catacurses::window &window, Character &
         cur_str_pos = right_print( window, 1, right_indent, pain_descriptor.second, pain_str );
 
         // Borders
-        for( int i = 1; i < getmaxy( window ) - 1; i++ ) {
-            mvwputch( window, point( cur_str_pos - 2, i ), BORDER_COLOR, LINE_XOXO ); // |
-        }
-        mvwputch( window, point( cur_str_pos - 2, 0 ), BORDER_COLOR, LINE_OXXX ); // ^|^
-        mvwputch( window, point( cur_str_pos - 2, 2 ), BORDER_COLOR, LINE_XXOX ); // _|_
+        wattron( window, BORDER_COLOR );
+        mvwvline( window, point( cur_str_pos - 2, 1 ), LINE_XOXO, getmaxy( window ) - 2 );
+        mvwaddch( window, point( cur_str_pos - 2, 0 ), LINE_OXXX ); // ^|^
+        mvwaddch( window, point( cur_str_pos - 2, 2 ), LINE_XXOX ); // _|_
+        wattroff( window, BORDER_COLOR );
         right_indent += utf8_width( remove_color_tags( pain_str ) ) + 3;
     }
 
@@ -271,11 +269,11 @@ static void draw_medical_titlebar( const catacurses::window &window, Character &
         cur_str_pos = right_print( window, 1, right_indent, hunger_pair.second, hunger_pair.first );
 
         // Borders
-        for( int i = 1; i < getmaxy( window ) - 1; i++ ) {
-            mvwputch( window, point( cur_str_pos - 2, i ), BORDER_COLOR, LINE_XOXO ); // |
-        }
-        mvwputch( window, point( cur_str_pos - 2, 0 ), BORDER_COLOR, LINE_OXXX ); // ^|^
-        mvwputch( window, point( cur_str_pos - 2, 2 ), BORDER_COLOR, LINE_XXOX ); // _|_
+        wattron( window, BORDER_COLOR );
+        mvwvline( window, point( cur_str_pos - 2, 1 ), LINE_XOXO, getmaxy( window ) - 2 ); // |
+        mvwaddch( window, point( cur_str_pos - 2, 0 ), LINE_OXXX ); // ^|^
+        mvwaddch( window, point( cur_str_pos - 2, 2 ), LINE_XXOX ); // _|_
+        wattroff( window, BORDER_COLOR );
 
         right_indent += utf8_width( hunger_pair.first ) + 3;
     }
@@ -285,11 +283,11 @@ static void draw_medical_titlebar( const catacurses::window &window, Character &
         cur_str_pos = right_print( window, 1, right_indent, thirst_pair.second, thirst_pair.first );
 
         // Borders
-        for( int i = 1; i < getmaxy( window ) - 1; i++ ) {
-            mvwputch( window, point( cur_str_pos - 2, i ), BORDER_COLOR, LINE_XOXO ); // |
-        }
-        mvwputch( window, point( cur_str_pos - 2, 0 ), BORDER_COLOR, LINE_OXXX ); // ^|^
-        mvwputch( window, point( cur_str_pos - 2, 2 ), BORDER_COLOR, LINE_XXOX ); // _|_
+        wattron( window, BORDER_COLOR );
+        mvwvline( window, point( cur_str_pos - 2, 1 ), LINE_XOXO, getmaxy( window ) - 2 ); // |
+        mvwaddch( window, point( cur_str_pos - 2, 0 ), LINE_OXXX ); // ^|^
+        mvwaddch( window, point( cur_str_pos - 2, 2 ), LINE_XXOX ); // _|_
+        wattroff( window, BORDER_COLOR );
 
         right_indent += utf8_width( thirst_pair.first ) + 3;
     }
@@ -299,11 +297,11 @@ static void draw_medical_titlebar( const catacurses::window &window, Character &
         cur_str_pos = right_print( window, 1, right_indent, sleepiness_pair.second, sleepiness_pair.first );
 
         // Borders
-        for( int i = 1; i < getmaxy( window ) - 1; i++ ) {
-            mvwputch( window, point( cur_str_pos - 2, i ), BORDER_COLOR, LINE_XOXO ); // |
-        }
-        mvwputch( window, point( cur_str_pos - 2, 0 ), BORDER_COLOR, LINE_OXXX ); // ^|^
-        mvwputch( window, point( cur_str_pos - 2, 2 ), BORDER_COLOR, LINE_XXOX ); // _|_
+        wattron( window, BORDER_COLOR );
+        mvwvline( window, point( cur_str_pos - 2, 1 ), LINE_XOXO, getmaxy( window ) - 2 ); // |
+        mvwaddch( window, point( cur_str_pos - 2, 0 ), LINE_OXXX ); // ^|^
+        mvwaddch( window, point( cur_str_pos - 2, 2 ), LINE_XXOX ); // _|_
+        wattroff( window, BORDER_COLOR );
 
         right_indent += utf8_width( sleepiness_pair.first ) + 3;
     }
@@ -814,10 +812,13 @@ void Character::disp_medical()
                                            static_cast<int>( textformatted.size() ) );
 
             DESCRIPTION_WIN_OFFSET = DESC_W_BEGIN + DESCRIPTION_TEXT_Y;
-            mvwputch( wMedical, point( 0, DESCRIPTION_WIN_OFFSET - 1 ), BORDER_COLOR, LINE_XXXO );
-            mvwhline( wMedical, point( 1, DESCRIPTION_WIN_OFFSET - 1 ), LINE_OXOX, getmaxx( wMedical ) - 2 );
-            mvwputch( wMedical, point( getmaxx( wMedical ) - 1, DESCRIPTION_WIN_OFFSET - 1 ), BORDER_COLOR,
+            wattron( wMedical, BORDER_COLOR );
+            mvwaddch( wMedical, point( 0, DESCRIPTION_WIN_OFFSET - 1 ), LINE_XXXO );
+            mvwhline( wMedical, point( 1, DESCRIPTION_WIN_OFFSET - 1 ), LINE_OXOX,
+                      getmaxx( wMedical ) - 2 );
+            mvwaddch( wMedical, point( getmaxx( wMedical ) - 1, DESCRIPTION_WIN_OFFSET - 1 ),
                       LINE_XOXX );
+            wattroff( wMedical, BORDER_COLOR );
             fold_and_print( w_description, point( 1, DESCRIPTION_TEXT_Y ), WIDTH - 2, c_light_gray,
                             desc_str );
         } else {
@@ -835,11 +836,13 @@ void Character::disp_medical()
             mvwprintz( wMedical, point( third_column_x + 2, INFO_START_Y + 1 ), c_light_blue,
                        detail_str.first );
 
-            mvwputch( wMedical, point( third_column_x, INFO_START_Y ), BORDER_COLOR, LINE_XXXO ); // |-
+            wattron( wMedical, BORDER_COLOR );
+            mvwaddch( wMedical, point( third_column_x, INFO_START_Y ), LINE_XXXO ); // |-
             mvwhline( wMedical, point( third_column_x + 1, INFO_START_Y ), LINE_OXOX,
                       getmaxx( wMedical ) - 2 ); // -
-            mvwputch( wMedical, point( getmaxx( wMedical ) - 1, INFO_START_Y ), BORDER_COLOR, // -|
+            mvwaddch( wMedical, point( getmaxx( wMedical ) - 1, INFO_START_Y ), // -|
                       LINE_XOXX );
+            wattroff( wMedical, BORDER_COLOR );
 
             const int info_width = WIDTH - third_column_x - 3;
             std::vector<std::string> textformatted = foldstring( detail_str.second, info_width,
@@ -878,8 +881,10 @@ void Character::disp_medical()
 
         // Draw Column Borders
 
+        wattron( wMedical, BORDER_COLOR );
         effects_column.draw_column( wMedical, HEADER_Y, DESCRIPTION_WIN_OFFSET );
         stats_column.draw_column( wMedical, HEADER_Y, DESCRIPTION_WIN_OFFSET );
+        wattroff( wMedical, BORDER_COLOR );
 
         // Draw Scrollbars
 
@@ -890,7 +895,7 @@ void Character::disp_medical()
         .offset_y( HEADER_Y )
         .content_size( content_size )
         .viewport_pos( cursor.y * 2 )
-        .viewport_size( DESC_W_BEGIN - 3 )
+        .viewport_size( DESCRIPTION_WIN_OFFSET - 4 )
         .scroll_to_last( true )
         .apply( wMedical );
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -720,14 +720,11 @@ void Messages::dialog::show()
             // Print line brackets to mark ranges of time
             if( printing_range ) {
                 const size_t last_line = log_from_top ? line - 1 : line + 1;
-                wattron( w, bracket_color );
-                mvwaddch( w, point( border_width + time_width - 1, border_width + last_line ), LINE_XOXO );
-                wattroff( w, bracket_color );
+                mvwputch( w, point( border_width + time_width - 1, border_width + last_line ), bracket_color,
+                          LINE_XOXO );
             }
-            wattron( w, bracket_color );
-            mvwaddch( w, point( border_width + time_width - 1, border_width + line ),
+            mvwputch( w, point( border_width + time_width - 1, border_width + line ), bracket_color,
                       log_from_top ? LINE_XXOO : LINE_OXXO );
-            wattroff( w, bracket_color );
             printing_range = true;
         }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -967,8 +967,9 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
     // Monster description on following lines.
     std::vector<std::string> lines = foldstring( type->get_description(), max_width );
     int numlines = lines.size();
+    wattron( w, c_light_gray );
     for( int i = 0; i < numlines && vStart < vEnd; i++ ) {
-        mvwprintz( w, point( column, vStart++ ), c_light_gray, lines[i] );
+        mvwprintw( w, point( column, vStart++ ), lines[i] );
     }
 
     if( !mission_fused.empty() ) {
@@ -978,9 +979,10 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
         lines = foldstring( fused_desc, max_width );
         numlines = lines.size();
         for( int i = 0; i < numlines && vStart < vEnd; i++ ) {
-            mvwprintz( w, point( column, ++vStart ), c_light_gray, lines[i] );
+            mvwprintw( w, point( column, ++vStart ), lines[i] );
         }
     }
+    wattroff( w, c_light_gray );
 
     // Riding indicator on next line after description.
     if( has_effect( effect_ridden ) && mounted_player ) {

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -616,9 +616,11 @@ void player_morale::display( int focus_eq, int pain_penalty, int sleepiness_pena
             void draw( catacurses::window &w, const int posy ) const {
                 int width = getmaxx( w );
                 if( sep_line ) {
+                    wattron( w, BORDER_COLOR );
                     mvwhline( w, point( 0, posy ), LINE_XXXO, 1 );
                     mvwhline( w, point( 1, posy ), 0, width - 2 );
                     mvwhline( w, point( width - 1, posy ), LINE_XOXX, 1 );
+                    wattroff( w, BORDER_COLOR );
                 } else {
                     int text_width = width - left_padding - right_padding;
                     if( !right.empty() ) {

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -37,9 +37,11 @@ mutation_chars( "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\"#&()*+./:
 static void draw_exam_window( const catacurses::window &win, const int border_y )
 {
     const int width = getmaxx( win );
-    mvwputch( win, point( 0, border_y ), BORDER_COLOR, LINE_XXXO );
+    wattron( win, BORDER_COLOR );
+    mvwaddch( win, point( 0, border_y ), LINE_XXXO );
     mvwhline( win, point( 1, border_y ), LINE_OXOX, width - 2 );
-    mvwputch( win, point( width - 1, border_y ), BORDER_COLOR, LINE_XOXX );
+    mvwaddch( win, point( width - 1, border_y ), LINE_XOXX );
+    wattroff( win, BORDER_COLOR );
 }
 
 static const auto shortcut_desc = []( const std::string_view comment, const std::string &keys )
@@ -236,11 +238,13 @@ void avatar::power_mutations()
     ui.on_redraw( [&]( const ui_adaptor & ) {
         werase( wBio );
         draw_border( wBio, BORDER_COLOR, _( "Mutations" ) );
+        wattron( wBio, BORDER_COLOR );
         // Draw line under title
         mvwhline( wBio, point( 1, HEADER_LINE_Y ), LINE_OXOX, WIDTH - 2 );
         // Draw symbols to connect additional lines to border
-        mvwputch( wBio, point( 0, HEADER_LINE_Y ), BORDER_COLOR, LINE_XXXO ); // |-
-        mvwputch( wBio, point( WIDTH - 1, HEADER_LINE_Y ), BORDER_COLOR, LINE_XOXX ); // -|
+        mvwaddch( wBio, point( 0, HEADER_LINE_Y ), LINE_XXXO ); // |-
+        mvwaddch( wBio, point( WIDTH - 1, HEADER_LINE_Y ), LINE_XOXX ); // -|
+        wattroff( wBio, BORDER_COLOR );
 
         // Captions
         mvwprintz( wBio, point( 2, HEADER_LINE_Y + 1 ), c_light_blue, _( "Passive:" ) );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -151,11 +151,11 @@ void tab_manager::draw( const catacurses::window &w )
     window_pos = point( getbegx( w ), getbegy( w ) );
     draw_border_below_tabs( w );
 
-    for( int i = 1; i < TERMX - 1; i++ ) {
-        mvwputch( w, point( i, 5 ), BORDER_COLOR, LINE_OXOX );
-    }
-    mvwputch( w, point( 0, 5 ), BORDER_COLOR, LINE_XXXO ); // |-
-    mvwputch( w, point( TERMX - 1, 5 ), BORDER_COLOR, LINE_XOXX ); // -|
+    wattron( w, BORDER_COLOR );
+    mvwaddch( w, point( 0, 5 ), LINE_XXXO ); // |-
+    mvwhline( w, point( 1, 5 ), LINE_OXOX, TERMX - 2 ); // -
+    mvwaddch( w, point( TERMX - 1, 5 ), LINE_XOXX ); // -|
+    wattroff( w, BORDER_COLOR );
 }
 
 bool tab_manager::handle_input( const std::string &action, const input_context &ctxt )
@@ -1812,9 +1812,11 @@ void set_traits( tab_manager &tabs, avatar &u, pool_type pool )
         werase( w );
 
         tabs.draw( w );
+        wattron( w, BORDER_COLOR );
         for( int i = 1; i < 3; ++i ) {
-            mvwputch( w, point( i * page_width, iHeaderHeight - 1 ), BORDER_COLOR, LINE_OXXX );  // '┬'
+            mvwaddch( w, point( i * page_width, iHeaderHeight - 1 ), LINE_OXXX );  // '┬'
         }
+        wattroff( w, BORDER_COLOR );
         draw_filter_and_sorting_indicators( w, ctxt, filterstring, traits_sorter );
         draw_points( w, pool, u );
         int full_string_length = 0;
@@ -4131,15 +4133,11 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
         draw_points( w, pool, you );
 
         //Draw the line between editable and non-editable stuff.
-        for( int i = 0; i < getmaxx( w ); ++i ) {
-            if( i == 0 ) {
-                mvwputch( w, point( i, 9 ), BORDER_COLOR, LINE_XXXO );
-            } else if( i == getmaxx( w ) - 1 ) {
-                wputch( w, BORDER_COLOR, LINE_XOXX );
-            } else {
-                wputch( w, BORDER_COLOR, LINE_OXOX );
-            }
-        }
+        wattron( w, BORDER_COLOR );
+        mvwaddch( w, point( 0,                9 ), LINE_XXXO ); // |-
+        mvwhline( w, point( 1,                9 ), LINE_OXOX, getmaxx( w ) - 2 ); // |
+        mvwaddch( w, point( getmaxx( w ) - 1, 9 ), LINE_XOXX );  // -|
+        wattroff( w, BORDER_COLOR );
         wnoutrefresh( w );
 
         werase( w_stats );
@@ -4294,9 +4292,11 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
             if( prof_proficiencies.empty() ) {
                 mvwprintz( w_proficiencies, point_south, c_light_red, _( "None!" ) );
             } else {
+                wattron( w_proficiencies, c_light_gray );
                 for( const proficiency_id &prof : prof_proficiencies ) {
-                    wprintz( w_proficiencies, c_light_gray, "\n" + trim_by_length( prof->name(), 18 ) );
+                    wprintw( w_proficiencies, "\n" + trim_by_length( prof->name(), 18 ) );
                 }
+                wattroff( w_proficiencies, c_light_gray );
             }
             wnoutrefresh( w_proficiencies );
         }
@@ -4405,9 +4405,11 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
             if( you.hobbies.empty() ) {
                 mvwprintz( w_hobbies, point_south, c_light_red, _( "None!" ) );
             } else {
+                wattron( w_hobbies, c_light_gray );
                 for( const profession *prof : you.hobbies ) {
-                    wprintz( w_hobbies, c_light_gray, "\n%s", prof->gender_appropriate_name( you.male ) );
+                    wprintw( w_hobbies, "\n%s", prof->gender_appropriate_name( you.male ) );
                 }
+                wattroff( w_hobbies, c_light_gray );
             }
             wnoutrefresh( w_hobbies );
         }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2747,9 +2747,7 @@ int npc::print_info( const catacurses::window &w, int line, int vLines, int colu
     mvwprintz( w, point( column, line ), bar.second, bar.first );
     const int bar_max_width = 5;
     const int bar_width = utf8_width( bar.first );
-    for( int i = 0; i < bar_max_width - bar_width; ++i ) {
-        mvwprintz( w, point( column + 4 - i, line ), c_white, "." );
-    }
+    mvwhline( w, point( column + 3, line ), c_white, '.', bar_max_width - bar_width );
     line += fold_and_print( w, point( column + bar_max_width + 1, line ),
                             iWidth - bar_max_width - 1, basic_symbol_color(), get_name() );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3333,25 +3333,24 @@ static void draw_borders_external(
         draw_border( w, BORDER_COLOR, _( "Options" ) );
     }
     // intersections
-    mvwputch( w, point( 0, horizontal_level ), BORDER_COLOR, LINE_XXXO ); // |-
-    mvwputch( w, point( getmaxx( w ) - 1, horizontal_level ), BORDER_COLOR, LINE_XOXX ); // -|
+    wattron( w, BORDER_COLOR );
+    mvwaddch( w, point( 0, horizontal_level ), LINE_XXXO ); // |-
+    mvwaddch( w, point( getmaxx( w ) - 1, horizontal_level ), LINE_XOXX ); // -|
     for( const int &x : vert_lines ) {
-        mvwputch( w, point( x + 1, getmaxy( w ) - 1 ), BORDER_COLOR, LINE_XXOX ); // _|_
+        mvwaddch( w, point( x + 1, getmaxy( w ) - 1 ), LINE_XXOX ); // _|_
     }
+    wattroff( w, BORDER_COLOR );
     wnoutrefresh( w );
 }
 
 static void draw_borders_internal( const catacurses::window &w, std::set<int> &vert_lines )
 {
-    for( int i = 0; i < getmaxx( w ); ++i ) {
-        if( vert_lines.count( i ) != 0 ) {
-            // intersection
-            mvwputch( w, point( i, 0 ), BORDER_COLOR, LINE_OXXX );
-        } else {
-            // regular line
-            mvwputch( w, point( i, 0 ), BORDER_COLOR, LINE_OXOX );
-        }
+    wattron( w, BORDER_COLOR );
+    mvwhline( w, point_zero, LINE_OXOX, getmaxx( w ) ); // -
+    for( const int &x : vert_lines ) {
+        mvwaddch( w, point( x, 0 ), LINE_OXXX ); // -.-
     }
+    wattroff( w, BORDER_COLOR );
     wnoutrefresh( w );
 }
 
@@ -3609,11 +3608,11 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
         };
 
         // Draw separation lines
-        for( int x : vert_lines ) {
-            for( int y = 0; y < iContentHeight; y++ ) {
-                mvwputch( w_options, point( x, y ), BORDER_COLOR, LINE_XOXO );
-            }
+        wattron( w_options, BORDER_COLOR );
+        for( const int &x : vert_lines ) {
+            mvwvline( w_options, point( x, 0 ), LINE_XOXO, iContentHeight );
         }
+        wattroff( w_options, BORDER_COLOR );
 
         if( recalc_startpos ) {
             // Update scroll position

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -418,9 +418,11 @@ int fold_and_print_from( const catacurses::window &w, const point &begin, int wi
                     nc_color color = color_stack.empty() ? base_color : color_stack.top();
                     wprintz( w, color, l );
                 } else {
+                    wattron( w, c_dark_gray );
                     for( int i = 0; i < width; i++ ) {
-                        wputch( w, c_dark_gray, LINE_OXOX );
+                        waddch( w, LINE_OXOX ); // can't use mvwhline without cursor position
                     }
+                    wattroff( w, c_dark_gray );
                 }
             }
         }
@@ -579,58 +581,92 @@ int right_print( const catacurses::window &w, const int line, const int right_in
     return x;
 }
 
-void wputch( const catacurses::window &w, nc_color FG, int ch )
+void wputch( const catacurses::window &w, const nc_color &FG, int ch )
 {
     wattron( w, FG );
     waddch( w, ch );
     wattroff( w, FG );
 }
 
-void mvwputch( const catacurses::window &w, const point &p, nc_color FG, int ch )
+void mvwputch( const catacurses::window &w, const point &p, const nc_color &FG, int ch )
 {
     wattron( w, FG );
     mvwaddch( w, p, ch );
     wattroff( w, FG );
 }
 
-void mvwputch( const catacurses::window &w, const point &p, nc_color FG, const std::string &ch )
+void mvwputch( const catacurses::window &w, const point &p, const nc_color &FG,
+               const std::string &ch )
 {
     wattron( w, FG );
     mvwprintw( w, p, ch );
     wattroff( w, FG );
 }
 
-void mvwputch_inv( const catacurses::window &w, const point &p, nc_color FG, int ch )
+void mvwputch_inv( const catacurses::window &w, const point &p, const nc_color &FG, int ch )
 {
-    nc_color HC = invert_color( FG );
+    const nc_color HC = invert_color( FG );
     wattron( w, HC );
     mvwaddch( w, p, ch );
     wattroff( w, HC );
 }
 
-void mvwputch_inv( const catacurses::window &w, const point &p, nc_color FG,
+void mvwputch_inv( const catacurses::window &w, const point &p, const nc_color &FG,
                    const std::string &ch )
 {
-    nc_color HC = invert_color( FG );
+    const nc_color HC = invert_color( FG );
     wattron( w, HC );
     mvwprintw( w, p, ch );
     wattroff( w, HC );
 }
 
-void mvwputch_hi( const catacurses::window &w, const point &p, nc_color FG, int ch )
+void mvwputch_hi( const catacurses::window &w, const point &p, const nc_color &FG, int ch )
 {
-    nc_color HC = hilite( FG );
+    const nc_color HC = hilite( FG );
     wattron( w, HC );
     mvwaddch( w, p, ch );
     wattroff( w, HC );
 }
 
-void mvwputch_hi( const catacurses::window &w, const point &p, nc_color FG, const std::string &ch )
+void mvwputch_hi( const catacurses::window &w, const point &p, const nc_color &FG,
+                  const std::string &ch )
 {
-    nc_color HC = hilite( FG );
+    const nc_color HC = hilite( FG );
     wattron( w, HC );
     mvwprintw( w, p, ch );
     wattroff( w, HC );
+}
+
+void mvwhline( const catacurses::window &win, const point &p, const nc_color &color, int ch, int n )
+{
+    wattron( win, color );
+    mvwhline( win, p, ch, n );
+    wattroff( win, color );
+}
+
+void mvwvline( const catacurses::window &win, const point &p, const nc_color &color, int ch, int n )
+{
+    wattron( win, color );
+    mvwvline( win, p, ch, n );
+    wattroff( win, color );
+}
+
+void mvwrectf( const catacurses::window &win, const point &p, int ch, int w, int h )
+{
+    ch = ch ? ch : ' ';
+    for( int y = 0; y < h; y++ ) {
+        for( int x = 0; x < w; x++ ) {
+            mvwaddch( win, p + point( x, y ), ch );
+        }
+    }
+}
+
+void mvwrectf( const catacurses::window &win, const point &p, const nc_color &color, int ch,
+               int w, int h )
+{
+    wattron( win, color );
+    mvwrectf( win, p, ch, w, h );
+    wattroff( win, color );
 }
 
 void draw_custom_border(
@@ -639,48 +675,43 @@ void draw_custom_border(
     const catacurses::chtype tr, const catacurses::chtype bl, const catacurses::chtype br,
     const nc_color &FG, const point &pos, int height, int width )
 {
-    wattron( w, FG );
-
     height = ( height == 0 ) ? getmaxy( w ) - pos.y : height;
     width = ( width == 0 ) ? getmaxx( w ) - pos.x : width;
 
-    for( int j = pos.y; j < height + pos.y - 1; j++ ) {
-        if( ls > 0 ) {
-            mvwputch( w, point( pos.x, j ), c_light_gray, ( ls > 1 ) ? ls : LINE_XOXO ); // |
-        }
-
-        if( rs > 0 ) {
-            mvwputch( w, point( pos.x + width - 1, j ), c_light_gray, ( rs > 1 ) ? rs : LINE_XOXO ); // |
-        }
+    wattron( w, FG );
+    wattron( w, c_light_gray );
+    if( ls > 0 ) {
+        mvwvline( w, pos, ( ls > 1 ) ? ls : LINE_XOXO, height );
     }
 
-    for( int j = pos.x; j < width + pos.x - 1; j++ ) {
-        if( ts > 0 ) {
-            mvwputch( w, point( j, pos.y ), c_light_gray, ( ts > 1 ) ? ts : LINE_OXOX ); // --
-        }
+    if( rs > 0 ) {
+        mvwvline( w, pos + point( width - 1, 0 ), ( rs > 1 ) ? rs : LINE_XOXO, height );
+    }
 
-        if( bs > 0 ) {
-            mvwputch( w, point( j, pos.y + height - 1 ), c_light_gray, ( bs > 1 ) ? bs : LINE_OXOX ); // --
-        }
+    if( ts > 0 ) {
+        mvwhline( w, pos, ( ts > 1 ) ? ts : LINE_OXOX, width );
+    }
+
+    if( bs > 0 ) {
+        mvwhline( w, pos + point( 0, height - 1 ), ( bs > 1 ) ? bs : LINE_OXOX, width );
     }
 
     if( tl > 0 ) {
-        mvwputch( w, pos, c_light_gray, ( tl > 1 ) ? tl : LINE_OXXO ); // |^
+        mvwaddch( w, pos, ( tl > 1 ) ? tl : LINE_OXXO ); // |^
     }
 
     if( tr > 0 ) {
-        mvwputch( w, pos + point( -1 + width, 0 ), c_light_gray, ( tr > 1 ) ? tr : LINE_OOXX ); // ^|
+        mvwaddch( w, pos + point( -1 + width, 0 ), ( tr > 1 ) ? tr : LINE_OOXX ); // ^|
     }
 
     if( bl > 0 ) {
-        mvwputch( w, pos + point( 0, -1 + height ), c_light_gray, ( bl > 1 ) ? bl : LINE_XXOO ); // |_
+        mvwaddch( w, pos + point( 0, -1 + height ), ( bl > 1 ) ? bl : LINE_XXOO ); // |_
     }
 
     if( br > 0 ) {
-        mvwputch( w, pos + point( -1 + width, -1 + height ), c_light_gray,
-                  ( br > 1 ) ? br : LINE_XOOX ); // _|
+        mvwaddch( w, pos + point( -1 + width, -1 + height ), ( br > 1 ) ? br : LINE_XOOX ); // _|
     }
-
+    wattroff( w, c_light_gray );
     wattroff( w, FG );
 }
 
@@ -700,15 +731,13 @@ void draw_border_below_tabs( const catacurses::window &w, nc_color border_color 
 {
     int width = getmaxx( w );
     int height = getmaxy( w );
-    for( int i = 1; i < width - 1; i++ ) {
-        mvwputch( w, point( i, height - 1 ), border_color, LINE_OXOX );
-    }
-    for( int i = 3; i < height - 1; i++ ) {
-        mvwputch( w, point( 0, i ), border_color, LINE_XOXO );
-        mvwputch( w, point( width - 1, i ), border_color, LINE_XOXO );
-    }
-    mvwputch( w, point( 0, height - 1 ), border_color, LINE_XXOO ); // |_
-    mvwputch( w, point( width - 1, height - 1 ), border_color, LINE_XOOX ); // _|
+    wattron( w, border_color );
+    mvwhline( w, point( 1,         height - 1 ), LINE_OXOX, width - 2 ); // -
+    mvwvline( w, point( 0,                  3 ), LINE_XOXO, height - 4 ); // |
+    mvwvline( w, point( width - 1,         3 ), LINE_XOXO, height - 4 );  // |
+    mvwaddch( w, point( 0,         height - 1 ), LINE_XXOO ); // |_
+    mvwaddch( w, point( width - 1, height - 1 ), LINE_XOOX ); // _|
+    wattroff( w, border_color );
 }
 
 border_helper::border_info::border_info( border_helper &helper )
@@ -764,12 +793,14 @@ void border_helper::draw_border( const catacurses::window &win, nc_color border_
     }
     const point win_beg( getbegx( win ), getbegy( win ) );
     const point win_end = win_beg + point( getmaxx( win ), getmaxy( win ) );
+    wattron( win, border_color );
     for( const std::pair<const point, border_connection> &conn : border_connection_map.value() ) {
         if( conn.first.x >= win_beg.x && conn.first.x < win_end.x &&
             conn.first.y >= win_beg.y && conn.first.y < win_end.y ) {
-            mvwputch( win, conn.first - win_beg, border_color, conn.second.as_curses_line() );
+            mvwaddch( win, conn.first - win_beg, conn.second.as_curses_line() );
         }
     }
+    wattroff( win, border_color );
 }
 
 int border_helper::border_connection::as_curses_line() const
@@ -1109,9 +1140,7 @@ void draw_item_filter_rules( const catacurses::window &win, const int starty, co
 {
     // Clear every row, but the leftmost/rightmost pixels intact.
     const int len = getmaxx( win ) - 2;
-    for( int i = 0; i < height; i++ ) {
-        mvwprintz( win, point( 1, starty + i ), c_black, std::string( len, ' ' ) );
-    }
+    mvwrectf( win, point( 1, starty ), c_black, ' ', len, height );
 
     fold_and_print( win, point( 1, starty ), len, c_white, "%s", item_filter_rule_string( type ) );
 
@@ -1339,9 +1368,7 @@ input_event draw_item_info( const std::function<catacurses::window()> &init_wind
             const int idx = *data.ptr_selected + line;
             if( idx >= 0 && static_cast<size_t>( idx ) < folded.size() ) {
                 if( folded[idx] == "--" ) {
-                    for( int x = 0; x < width; x++ ) {
-                        mvwputch( win, point( b + x, line_num + line ), c_dark_gray, LINE_OXOX );
-                    }
+                    mvwhline( win, point( b, line_num + line ), c_dark_gray, LINE_OXOX, width );
                 } else {
                     trim_and_print( win, point( b, line_num + line ), width - 1, c_light_gray, folded[idx] );
                 }
@@ -1594,10 +1621,14 @@ void draw_tab( const catacurses::window &w, int iOffsetX, const std::string_view
 {
     int iOffsetXRight = iOffsetX + utf8_width( sText, true ) + 1;
 
-    mvwputch( w, point( iOffsetX, 0 ),      c_light_gray, LINE_OXXO ); // |^
-    mvwputch( w, point( iOffsetXRight, 0 ), c_light_gray, LINE_OOXX ); // ^|
-    mvwputch( w, point( iOffsetX, 1 ),      c_light_gray, LINE_XOXO ); // |
-    mvwputch( w, point( iOffsetXRight, 1 ), c_light_gray, LINE_XOXO ); // |
+    wattron( w, c_light_gray );
+    mvwaddch( w, point( iOffsetX, 0 ),      LINE_OXXO ); // |^
+    mvwaddch( w, point( iOffsetXRight, 0 ), LINE_OOXX ); // ^|
+    mvwaddch( w, point( iOffsetX, 1 ),      LINE_XOXO ); // |
+    mvwaddch( w, point( iOffsetXRight, 1 ), LINE_XOXO ); // |
+
+    mvwhline( w, point( iOffsetX + 1, 0 ), LINE_OXOX, iOffsetXRight - iOffsetX - 1 ); // -
+    wattroff( w, c_light_gray );
 
     nc_color selected = h_white;
     nc_color not_selected = c_light_gray;
@@ -1607,17 +1638,11 @@ void draw_tab( const catacurses::window &w, int iOffsetX, const std::string_view
         print_colored_text( w, point( iOffsetX + 1, 1 ), not_selected, not_selected, sText );
     }
 
-    for( int i = iOffsetX + 1; i < iOffsetXRight; i++ ) {
-        mvwputch( w, point( i, 0 ), c_light_gray, LINE_OXOX );  // -
-    }
-
     if( bSelected ) {
         mvwputch( w, point( iOffsetX - 1, 1 ),      h_white, '<' );
         mvwputch( w, point( iOffsetXRight + 1, 1 ), h_white, '>' );
 
-        for( int i = iOffsetX + 1; i < iOffsetXRight; i++ ) {
-            mvwputch( w, point( i, 2 ), c_black, ' ' );
-        }
+        mvwhline( w, point( iOffsetX + 1, 2 ), c_black, ' ', iOffsetXRight - iOffsetX - 1 );
 
         mvwputch( w, point( iOffsetX, 2 ),      c_light_gray, LINE_XOOX ); // _|
         mvwputch( w, point( iOffsetXRight, 2 ), c_light_gray, LINE_XXOO ); // |_
@@ -1641,16 +1666,16 @@ inclusive_rectangle<point> draw_subtab( const catacurses::window &w, int iOffset
     }
 
     if( bSelected ) {
-        if( !bDisabled ) {
-            mvwputch( w, point( iOffsetX - bDecorate, 0 ),      h_white, '<' );
-            mvwputch( w, point( iOffsetXRight + bDecorate, 0 ), h_white, '>' );
-        } else {
-            mvwputch( w, point( iOffsetX - bDecorate, 0 ),      h_dark_gray, '<' );
+        if( bDisabled ) {
+            mvwputch( w, point( iOffsetX - bDecorate,      0 ), h_dark_gray, '<' );
             mvwputch( w, point( iOffsetXRight + bDecorate, 0 ), h_dark_gray, '>' );
+        } else {
+            mvwputch( w, point( iOffsetX - bDecorate,      0 ), h_white, '<' );
+            mvwputch( w, point( iOffsetXRight + bDecorate, 0 ), h_white, '>' );
         }
 
-        for( int i = iOffsetX + 1; bDecorate && i < iOffsetXRight; i++ ) {
-            mvwputch( w, point( i, 1 ), c_black, ' ' );
+        if( bDecorate ) {
+            mvwhline( w, point( iOffsetX + 1, 1 ), c_black, ' ', iOffsetXRight - iOffsetX - 1 );
         }
     }
     return inclusive_rectangle<point>( point( iOffsetX, 0 ), point( iOffsetXRight, 0 ) );
@@ -1663,12 +1688,12 @@ std::map<size_t, inclusive_rectangle<point>> draw_tabs( const catacurses::window
     std::map<size_t, inclusive_rectangle<point>> tab_map;
 
     int width = getmaxx( w );
-    for( int i = 1; i < width - 1; i++ ) {
-        mvwputch( w, point( i, 2 ), BORDER_COLOR, LINE_OXOX );  // ─
-    }
+    wattron( w, BORDER_COLOR );
+    mvwhline( w, point( 1,         2 ), LINE_OXOX, width - 2 ); // ─
 
-    mvwputch( w, point( 0, 2 ), BORDER_COLOR, LINE_OXXO );  // ┌
-    mvwputch( w, point( width - 1, 2 ), BORDER_COLOR, LINE_OOXX );  // ┐
+    mvwaddch( w, point( 0,         2 ), LINE_OXXO ); // ┌
+    mvwaddch( w, point( width - 1, 2 ), LINE_OOXX ); // ┐
+    wattroff( w, BORDER_COLOR );
 
     const int tab_step = 3;
     int x = 2;
@@ -1810,7 +1835,7 @@ void draw_scrollbar( const catacurses::window &window, const int iCurrentLine,
     .viewport_size( iContentHeight )
     .slot_color( bar_color )
     .scroll_to_last( !bDoNotScrollToEnd )
-    .apply( window );
+    .apply( window, true );
 }
 
 scrollbar::scrollbar()
@@ -1881,15 +1906,15 @@ scrollbar &scrollbar::scroll_to_last( bool scr2last )
     return *this;
 }
 
-void scrollbar::apply( const catacurses::window &window )
+void scrollbar::apply( const catacurses::window &window, const bool draw_unneeded )
 {
     scrollbar_area = inclusive_rectangle<point>( point( getbegx( window ) + offset_x_v,
                      getbegy( window ) + offset_y_v ), point( getbegx( window ) + offset_x_v,
                              getbegy( window ) + offset_y_v + viewport_size_v ) );
     if( viewport_size_v >= content_size_v || content_size_v <= 0 ) {
-        // scrollbar not needed, fill output area with borders
-        for( int i = offset_y_v; i < offset_y_v + viewport_size_v; ++i ) {
-            mvwputch( window, point( offset_x_v, i ), border_color_v, LINE_XOXO );
+        // scrollbar not needed, optionally fill output area with vertical border line
+        if( draw_unneeded ) {
+            mvwvline( window, point( offset_x_v, offset_y_v ), border_color_v, LINE_XOXO, viewport_size_v );
         }
     } else {
         mvwputch( window, point( offset_x_v, offset_y_v ), arrow_color_v, '^' );
@@ -1910,13 +1935,11 @@ void scrollbar::apply( const catacurses::window &window )
         int bar_end = bar_start + bar_size;
         nc_color temp_bar_color = dragging ? c_magenta_magenta : bar_color_v;
 
-        for( int i = 0; i < slot_size; ++i ) {
-            if( i >= bar_start && i < bar_end ) {
-                mvwputch( window, point( offset_x_v, offset_y_v + 1 + i ), temp_bar_color, LINE_XOXO );
-            } else {
-                mvwputch( window, point( offset_x_v, offset_y_v + 1 + i ), slot_color_v, LINE_XOXO );
-            }
-        }
+        mvwvline( window, point( offset_x_v, offset_y_v + 1 ), slot_color_v,   LINE_XOXO, bar_start );
+        mvwvline( window, point( offset_x_v, offset_y_v + 1 + bar_start ), temp_bar_color, LINE_XOXO,
+                  bar_end - bar_start );
+        mvwvline( window, point( offset_x_v, offset_y_v + 1 + bar_end ), slot_color_v,   LINE_XOXO,
+                  slot_size - bar_end );
     }
 }
 
@@ -2142,7 +2165,7 @@ bool multiline_list::handle_navigation( std::string &action, input_context &ctxt
 
 void multiline_list::print_entries()
 {
-    werase( w );
+    werase( w ); // this undesirably erases the left border of the larger window
     entry_map.clear();
 
     int ycurrent = 0;
@@ -2163,7 +2186,7 @@ void multiline_list::print_entries()
     .content_size( total_length )
     .viewport_pos( offset_position )
     .viewport_size( getmaxy( w ) )
-    .apply( w );
+    .apply( w, true );
 
     wnoutrefresh( w );
 }
@@ -2291,9 +2314,7 @@ void scrolling_text_view::draw( const nc_color &base_color )
     } else {
         text_view_scrollbar = scrollbar();
         // No scrollbar; we need to draw the window edge instead
-        for( int i = 0; i < height; i++ ) {
-            mvwputch( w_, point( 0, i ), BORDER_COLOR, LINE_XOXO );
-        }
+        mvwvline( w_, point_zero, BORDER_COLOR, LINE_XOXO, height );
     }
 
     nc_color color = base_color;

--- a/src/output.h
+++ b/src/output.h
@@ -223,7 +223,7 @@ std::vector<std::string> foldstring( const std::string &str, int width, char spl
  * Print text with embedded @ref color_tags, x, y are in curses system.
  * The text is not word wrapped, but may automatically be wrapped on new line characters or
  * when it reaches the border of the window (both is done by the curses system).
- * If the text contains no color tags, it's equivalent to a simple mvprintz.
+ * If the text contains no color tags, it's equivalent to a simple mvwprintz.
  *
  * @param w Window we are drawing in
  * @param p Curses-style coordinates to print text at.
@@ -232,7 +232,7 @@ std::vector<std::string> foldstring( const std::string &str, int width, char spl
  * change to a color according to the color tags that are in the text.
  * @param base_color Base color that is used outside of any color tag.
  **/
-void print_colored_text( const catacurses::window &w, const point &p, nc_color &cur_color,
+void print_colored_text( const catacurses::window &w, const point &p, nc_color &color,
                          const nc_color &base_color, std::string_view text,
                          report_color_error color_error = report_color_error::yes );
 /**
@@ -360,20 +360,28 @@ std::string trimmed_name_and_value( const std::string &name, int value,
 std::string trimmed_name_and_value( const std::string &name, const std::string &value,
                                     int field_width );
 
-void wputch( const catacurses::window &w, int ch );
-void wputch( const catacurses::window &w, nc_color FG, int ch );
+void wputch( const catacurses::window &w, const nc_color &FG, int ch );
 // Using int ch is deprecated, use an UTF-8 encoded string instead
-void mvwputch( const catacurses::window &w, const point &p, int ch );
-void mvwputch( const catacurses::window &w, const point &p, nc_color FG, int ch );
-void mvwputch( const catacurses::window &w, const point &p, const std::string &ch );
-void mvwputch( const catacurses::window &w, const point &p, nc_color FG, const std::string &ch );
+void mvwputch( const catacurses::window &w, const point &p, const nc_color &FG, int ch );
+void mvwputch( const catacurses::window &w, const point &p, const nc_color &FG,
+               const std::string &ch );
 // Using int ch is deprecated, use an UTF-8 encoded string instead
-void mvwputch_inv( const catacurses::window &w, const point &p, nc_color FG, int ch );
-void mvwputch_inv( const catacurses::window &w, const point &p, nc_color FG,
+void mvwputch_inv( const catacurses::window &w, const point &p, const nc_color &FG, int ch );
+void mvwputch_inv( const catacurses::window &w, const point &p, const nc_color &FG,
                    const std::string &ch );
 // Using int ch is deprecated, use an UTF-8 encoded string instead
-void mvwputch_hi( const catacurses::window &w, const point &p, nc_color FG, int ch );
-void mvwputch_hi( const catacurses::window &w, const point &p, nc_color FG, const std::string &ch );
+void mvwputch_hi( const catacurses::window &w, const point &p, const nc_color &FG, int ch );
+void mvwputch_hi( const catacurses::window &w, const point &p, const nc_color &FG,
+                  const std::string &ch );
+// draws a colored line of characters
+void mvwhline( const catacurses::window &win, const point &p, const nc_color &color, int ch,
+               int n );
+void mvwvline( const catacurses::window &win, const point &p, const nc_color &color, int ch,
+               int n );
+// draws a filled rectangle starting at p
+void mvwrectf( const catacurses::window &win, const point &p, int ch, int w, int h );
+void mvwrectf( const catacurses::window &win, const point &p, const nc_color &color, int ch, int w,
+               int h );
 
 void mvwprintz( const catacurses::window &w, const point &p, const nc_color &FG,
                 const std::string &text );
@@ -942,7 +950,7 @@ class scrollbar
         // Sets up ability for the scrollbar to be dragged with the mouse
         scrollbar &set_draggable( input_context &ctxt );
         // draw the scrollbar to the window
-        void apply( const catacurses::window &window );
+        void apply( const catacurses::window &window, bool draw_unneeded = false );
         // Checks if the user is dragging the scrollbar with the mouse (set_draggable first)
         bool handle_dragging( const std::string &action, const std::optional<point> &coord,
                               int &position );

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -599,8 +599,12 @@ static void draw_border_win( catacurses::window &w, const std::vector<int> &colu
     werase( w );
     decorate_panel( _( "Sidebar options" ), w );
     // Draw vertical separators
-    mvwvline( w, point( column_widths[0] + 1, 1 ), 0, popup_height - 2 );
-    mvwvline( w, point( column_widths[0] + column_widths[1] + 2, 1 ), 0, popup_height - 2 );
+    wattron( w, BORDER_COLOR );
+    mvwvline( w, point( column_widths[0] + 1, 1 ), 0,
+              popup_height - 2 ); //FIXME char is zero?
+    mvwvline( w, point( column_widths[0] + column_widths[1] + 2, 1 ), 0,
+              popup_height - 2 ); //FIXME char is zero?
+    wattroff( w, BORDER_COLOR );
     wnoutrefresh( w );
 }
 

--- a/src/proficiency_ui.cpp
+++ b/src/proficiency_ui.cpp
@@ -247,17 +247,15 @@ void prof_window::draw_borders()
     const int h = catacurses::getmaxy( w_border );
     draw_border( w_border, c_white, _( "Proficiencies" ), c_yellow );
     // horizontal header separator
-    for( int i = 1; i < w - 1; i++ ) {
-        mvwputch( w_border, point( i, 4 ), c_white, LINE_OXOX );
-    }
-    mvwputch( w_border, point( 0, 4 ), c_white, LINE_XXXO );
-    mvwputch( w_border, point( w - 1, 4 ), c_white, LINE_XOXX );
+    wattron( w_border, c_white );
+    mvwhline( w_border, point( 1, 4 ), LINE_OXOX, w - 2 );
+    mvwaddch( w_border, point( 0, 4 ), LINE_XXXO );
+    mvwaddch( w_border, point( w - 1, 4 ), LINE_XOXX );
     // vertical column separator
-    for( int i = 5; i < h - 1; i++ ) {
-        mvwputch( w_border, point( column_width + 1, i ), c_white, LINE_XOXO );
-    }
-    mvwputch( w_border, point( column_width + 1, 4 ), c_white, LINE_OXXX );
-    mvwputch( w_border, point( column_width + 1, h - 1 ), c_white, LINE_XXOX );
+    mvwvline( w_border, point( column_width + 1, 5 ), LINE_XOXO, h - 6 );
+    mvwaddch( w_border, point( column_width + 1, 4 ), LINE_OXXX );
+    mvwaddch( w_border, point( column_width + 1, h - 1 ), LINE_XXOX );
+    wattroff( w_border, c_white );
 
     scrollbar()
     .border_color( c_white )

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3739,11 +3739,7 @@ void target_ui::draw_ui_window()
     // Clear target window and make it non-transparent.
     int width = getmaxx( w_target );
     int height = getmaxy( w_target );
-    for( int y = 0; y < height; y++ ) {
-        for( int x = 0; x < width; x++ ) {
-            mvwputch( w_target, point( x, y ), c_white, ' ' );
-        }
-    }
+    mvwrectf( w_target, point_zero, c_white, ' ', width, height );
 
     draw_border( w_target );
     draw_window_title();

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -134,12 +134,14 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
 
         draw_border( w_border, BORDER_COLOR, custom_name_in );
 
-        mvwputch( w_border, point( 0, 4 ), c_light_gray, LINE_XXXO ); // |-
-        mvwputch( w_border, point( getmaxx( w_border ) - 1, 4 ), c_light_gray, LINE_XOXX ); // -|
+        wattron( w_border, c_light_gray );
+        mvwaddch( w_border, point( 0, 4 ), LINE_XXXO ); // |-
+        mvwaddch( w_border, point( getmaxx( w_border ) - 1, 4 ), LINE_XOXX ); // -|
 
         for( auto &column : column_pos ) {
-            mvwputch( w_border, point( column.second + 1, TERMY - 1 ), c_light_gray, LINE_XXOX ); // _|_
+            mvwaddch( w_border, point( column.second + 1, TERMY - 1 ), LINE_XXOX ); // _|_
         }
+        wattroff( w_border, c_light_gray );
 
         wnoutrefresh( w_border );
 
@@ -163,9 +165,8 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
                                 _( "<Enter>-Edit" ) ) + 2;
         shortcut_print( w_header, point( tmpx, 1 ), c_white, c_light_green, _( "<Tab>-Switch Page" ) );
 
-        for( int i = 0; i < getmaxx( w_header ); i++ ) {
-            mvwputch( w_header, point( i, 3 ), c_light_gray, LINE_OXOX ); // Draw line under header
-        }
+        mvwhline( w_header, point( 0, 3 ), c_light_gray, LINE_OXOX,
+                  getmaxx( w_header ) ); // Draw line under header
 
         int locx = 0;
         const std::string safe_mode_enabled_text = _( "Safe mode enabled:" );
@@ -177,10 +178,12 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
         locx += shortcut_print( w_header, point( locx + 1, 2 ), c_white, c_light_green, "  " );
         locx += shortcut_print( w_header, point( locx, 2 ), c_white, c_light_green, _( "<S>witch" ) );
 
+        wattron( w_header, c_light_gray );
         for( auto &pos : column_pos ) {
-            mvwputch( w_header, point( pos.second, 3 ), c_light_gray, LINE_OXXX ); // ^|^
-            mvwputch( w_header, point( pos.second, 4 ), c_light_gray, LINE_XOXO ); // |
+            mvwaddch( w_header, point( pos.second, 3 ), LINE_OXXX ); // ^|^
+            mvwaddch( w_header, point( pos.second, 4 ), LINE_XOXO ); // |
         }
+        wattroff( w_header, c_light_gray );
 
         locx = getmaxx( w_header ) / 2 - 15;
         locx += shortcut_print( w_header, point( locx, 3 ), c_white,
@@ -199,14 +202,9 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
         wnoutrefresh( w_header );
 
         // Clear the lines
-        for( int i = 0; i < content_height; i++ ) {
-            for( int j = 0; j < getmaxx( w ) - 1; j++ ) {
-                mvwputch( w, point( j, i ), c_black, ' ' );
-            }
-
-            for( auto &pos : column_pos ) {
-                mvwputch( w, point( pos.second, i ), c_light_gray, LINE_XOXO ); // |
-            }
+        mvwrectf( w, point_zero, c_black, ' ', getmaxx( w ) - 1, content_height );
+        for( auto &pos : column_pos ) {
+            mvwvline( w, point( pos.second, 0 ), c_light_gray, LINE_XOXO, content_height ); // |
         }
 
         auto &current_tab = tab == GLOBAL_TAB ? global_rules : character_rules;
@@ -559,11 +557,7 @@ void safemode::test_pattern( const int tab_in, const int row_in )
         wnoutrefresh( w_test_rule_border );
 
         // Clear the lines
-        for( int i = 0; i < content_height; i++ ) {
-            for( int j = 0; j < 79; j++ ) {
-                mvwputch( w_test_rule_content, point( j, i ), c_black, ' ' );
-            }
-        }
+        mvwrectf( w_test_rule_content, point_zero, c_black, ' ', 79, content_height );
 
         calcStartPos( start_pos, line, content_height, creature_list.size() );
 

--- a/src/smart_controller_ui.cpp
+++ b/src/smart_controller_ui.cpp
@@ -49,7 +49,7 @@ void smart_controller_ui::refresh()
     // header
     const std::string title =  _( "Smart Engine Controller ® Interface" );
     mvwprintz( win, point( ( WIDTH - title.length() ) / 2, 1 ), white, title );
-    mvwhline( win, point( 1, 2 ), LINE_OXOX, WIDTH - 2 );
+    mvwhline( win, point( 1, 2 ), BORDER_COLOR, LINE_OXOX, WIDTH - 2 );
 
     // for menu items, y points to the center of the menu item vertical space
     int y = 3 + MENU_ITEM_HEIGHT / 2;

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -234,9 +234,11 @@ void string_input_popup::draw( ui_adaptor *const ui, const utf8_wrapper &ret,
 
         if( !_title.empty() ) {
             int pos_y = 0;
+            wattron( w_title_and_entry, _title_color );
             for( int i = 0; i < static_cast<int>( title_split.size() ) - 1; i++ ) {
-                mvwprintz( w_title_and_entry, point( i, pos_y++ ), _title_color, title_split[i] );
+                mvwprintw( w_title_and_entry, point( i, pos_y++ ), title_split[i] );
             }
+            wattroff( w_title_and_entry, _title_color );
             trim_and_print( w_title_and_entry, point( 0, pos_y ), titlesize, _title_color, title_split.back() );
         }
     }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2260,47 +2260,42 @@ void veh_interact::display_grid()
     // border window
     draw_border( w_border );
 
+    wattron( w_border, BORDER_COLOR );
+
     // match grid lines
     const int y_mode = getmaxy( w_mode ) + 1;
     // |-
-    mvwputch( w_border, point( 0, y_mode ), BORDER_COLOR, LINE_XXXO );
+    mvwaddch( w_border, point( 0, y_mode ), LINE_XXXO );
     // -|
-    mvwputch( w_border, point( TERMX - 1, y_mode ), BORDER_COLOR, LINE_XOXX );
+    mvwaddch( w_border, point( TERMX - 1, y_mode ), LINE_XOXX );
     const int y_list = getbegy( w_list ) + getmaxy( w_list );
     // |-
-    mvwputch( w_border, point( 0, y_list ), BORDER_COLOR, LINE_XXXO );
+    mvwaddch( w_border, point( 0, y_list ), LINE_XXXO );
     // -|
-    mvwputch( w_border, point( TERMX - 1, y_list ), BORDER_COLOR, LINE_XOXX );
+    mvwaddch( w_border, point( TERMX - 1, y_list ), LINE_XOXX );
 
     const int grid_w = getmaxx( w_border ) - 2;
 
     // Two lines dividing the three middle sections.
-    for( int i = 1 + getmaxy( w_mode ); i < ( 1 + getmaxy( w_mode ) + page_size ); ++i ) {
-        // |
-        mvwputch( w_border, point( getmaxx( w_disp ) + 1, i + 1 ), BORDER_COLOR, LINE_XOXO );
-        // |
-        mvwputch( w_border, point( getmaxx( w_disp ) + 2 + getmaxx( w_list ), i + 1 ), BORDER_COLOR,
-                  LINE_XOXO );
-    }
+    mvwvline( w_border, point( getmaxx( w_disp ) + 1,                     getmaxy( w_mode ) + 2 ),
+              LINE_XOXO, page_size );
+    mvwvline( w_border, point( getmaxx( w_disp ) + 2 + getmaxx( w_list ), getmaxy( w_mode ) + 2 ),
+              LINE_XOXO, page_size );
     // Two lines dividing the vertical menu sections.
-    for( int i = 0; i < grid_w; ++i ) {
-        // -
-        mvwputch( w_border, point( i + 1, getmaxy( w_mode ) + 1 ), BORDER_COLOR, LINE_OXOX );
-        // -
-        mvwputch( w_border, point( i + 1, getmaxy( w_mode ) + 2 + page_size ), BORDER_COLOR, LINE_OXOX );
-    }
+    mvwhline( w_border, point( 1,             getmaxy( w_mode ) + 1 ), LINE_OXOX, grid_w );
+    mvwhline( w_border, point( 1, getmaxy( w_mode ) + 2 + page_size ), LINE_OXOX, grid_w );
     // Fix up the line intersections.
-    mvwputch( w_border, point( getmaxx( w_disp ) + 1, getmaxy( w_mode ) + 1 ), BORDER_COLOR,
+    mvwaddch( w_border, point( getmaxx( w_disp ) + 1, getmaxy( w_mode ) + 1 ), LINE_OXXX );
+    // _|_
+    mvwaddch( w_border, point( getmaxx( w_disp ) + 1, getmaxy( w_mode ) + 2 + page_size ), LINE_XXOX );
+    mvwaddch( w_border, point( getmaxx( w_disp ) + 2 + getmaxx( w_list ), getmaxy( w_mode ) + 1 ),
               LINE_OXXX );
     // _|_
-    mvwputch( w_border, point( getmaxx( w_disp ) + 1, getmaxy( w_mode ) + 2 + page_size ), BORDER_COLOR,
-              LINE_XXOX );
-    mvwputch( w_border, point( getmaxx( w_disp ) + 2 + getmaxx( w_list ), getmaxy( w_mode ) + 1 ),
-              BORDER_COLOR, LINE_OXXX );
-    // _|_
-    mvwputch( w_border, point( getmaxx( w_disp ) + 2 + getmaxx( w_list ),
+    mvwaddch( w_border, point( getmaxx( w_disp ) + 2 + getmaxx( w_list ),
                                getmaxy( w_mode ) + 2 + page_size ),
-              BORDER_COLOR, LINE_XXOX );
+              LINE_XXOX );
+
+    wattroff( w_border, BORDER_COLOR );
 
     wnoutrefresh( w_border );
 }
@@ -2326,35 +2321,20 @@ void veh_interact::display_veh()
         const point com_s = ( com + dd ).rotate( 3 ) + h_size;
         const point pivot_s = ( pivot + dd ).rotate( 3 ) + h_size;
 
-        for( int x = 0; x < getmaxx( w_disp ); ++x ) {
-            if( x <= com_s.x ) {
-                mvwputch( w_disp, point( x, com_s.y ), c_green, LINE_OXOX );
-            }
+        mvwhline( w_disp, point( 0, com_s.y ), c_green, LINE_OXOX, std::min( getmaxx( w_disp ),
+                  com_s.x + 1 ) );
+        mvwvline( w_disp, point( com_s.x, 0 ), c_green, LINE_XOXO, std::min( getmaxy( w_disp ),
+                  com_s.y + 1 ) );
 
-            if( x >= pivot_s.x ) {
-                mvwputch( w_disp, point( x, pivot_s.y ), c_red, LINE_OXOX );
-            }
-        }
-
-        for( int y = 0; y < getmaxy( w_disp ); ++y ) {
-            if( y <= com_s.y ) {
-                mvwputch( w_disp, point( com_s.x, y ), c_green, LINE_XOXO );
-            }
-
-            if( y >= pivot_s.y ) {
-                mvwputch( w_disp, point( pivot_s.x, y ), c_red, LINE_XOXO );
-            }
-        }
+        mvwhline( w_disp, point( std::max( 0, pivot_s.x ), pivot_s.y ), c_red, LINE_OXOX,
+                  getmaxx( w_disp ) - std::max( 0, pivot_s.x ) + 1 );
+        mvwvline( w_disp, point( pivot_s.x, std::max( 0, pivot_s.y ) ), c_red, LINE_XOXO,
+                  getmaxy( w_disp ) - std::max( 0, pivot_s.y ) + 1 );
     }
 
     // Draw guidelines to make current selection point more visible.
-    for( int y = 0; y < getmaxy( w_disp ); ++y ) {
-        mvwputch( w_disp, point( h_size.x, y ), c_dark_gray, LINE_XOXO );
-    }
-
-    for( int x = 0; x < getmaxx( w_disp ); ++x ) {
-        mvwputch( w_disp, point( x, h_size.y ), c_dark_gray, LINE_OXOX );
-    }
+    mvwvline( w_disp, point( h_size.x, 0 ), c_dark_gray, LINE_XOXO, getmaxy( w_disp ) );
+    mvwhline( w_disp, point( 0, h_size.y ), c_dark_gray, LINE_OXOX, getmaxx( w_disp ) );
 
     map &here = get_map();
     nc_color col_at_cursor = c_black;
@@ -2794,8 +2774,7 @@ void veh_interact::display_details( const vpart_info *part )
 
     werase( w_details );
 
-    wborder( w_details, LINE_XOXO, LINE_XOXO, LINE_OXOX, LINE_OXOX, LINE_OXXO, LINE_OOXX, LINE_XXOO,
-             LINE_XOOX );
+    draw_border( w_details );
 
     if( part == nullptr ) {
         wnoutrefresh( w_details );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Functions like mvwputch change the color then change it back, so calling them repeatedly, especially in a loop, results in a massive amount of duplication of effort.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use the non-color-changing versions of the function and specify the color explicitly before and after the loops and other calls.
I've also replaced many such loops with `mvwvline` and `mvwhline`, and added the new `mvwrectf` for 2d fill loops.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
See comments for testing at various versions of the PR.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->