### PR TITLE
Port generic_factory functions to string_view

### DIFF
--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -12,7 +12,7 @@ void report_strict_violation( const JsonObject &jo, const std::string &message,
     }
 }
 
-bool assign( const JsonObject &jo, const std::string &name, bool &val, bool strict )
+bool assign( const JsonObject &jo, const std::string_view name, bool &val, bool strict )
 {
     bool out;
 
@@ -109,7 +109,7 @@ bool assign( const JsonObject &jo, const std::string &name, units::volume &val, 
     return true;
 }
 
-bool assign( const JsonObject &jo, const std::string &name, units::mass &val, bool strict,
+bool assign( const JsonObject &jo, const std::string_view name, units::mass &val, bool strict,
              const units::mass lo, const units::mass hi )
 {
     const auto parse = [&name]( const JsonObject & obj, units::mass & out ) {
@@ -173,7 +173,7 @@ bool assign( const JsonObject &jo, const std::string &name, units::mass &val, bo
     return true;
 }
 
-bool assign( const JsonObject &jo, const std::string &name, units::length &val, bool strict,
+bool assign( const JsonObject &jo, const std::string_view name, units::length &val, bool strict,
              const units::length lo, const units::length hi )
 {
     const auto parse = [&name]( const JsonObject & obj, units::length & out ) {
@@ -237,7 +237,7 @@ bool assign( const JsonObject &jo, const std::string &name, units::length &val, 
     return true;
 }
 
-bool assign( const JsonObject &jo, const std::string &name, units::money &val, bool strict,
+bool assign( const JsonObject &jo, const std::string_view name, units::money &val, bool strict,
              const units::money lo, const units::money hi )
 {
     const auto parse = [&name]( const JsonObject & obj, units::money & out ) {
@@ -301,7 +301,7 @@ bool assign( const JsonObject &jo, const std::string &name, units::money &val, b
     return true;
 }
 
-bool assign( const JsonObject &jo, const std::string &name, units::energy &val, bool strict,
+bool assign( const JsonObject &jo, const std::string_view name, units::energy &val, bool strict,
              const units::energy lo, const units::energy hi )
 {
     const auto parse = [&name]( const JsonObject & obj, units::energy & out ) {
@@ -370,7 +370,7 @@ bool assign( const JsonObject &jo, const std::string &name, units::energy &val, 
     return true;
 }
 
-bool assign( const JsonObject &jo, const std::string &name, units::power &val, bool strict,
+bool assign( const JsonObject &jo, const std::string_view name, units::power &val, bool strict,
              const units::power lo, const units::power hi )
 {
     const auto parse = [&name]( const JsonObject & obj, units::power & out ) {
@@ -504,7 +504,7 @@ static void assign_dmg_relative( damage_instance &out, const damage_instance &va
     }
 }
 
-static void assign_dmg_proportional( const JsonObject &jo, const std::string &name,
+static void assign_dmg_proportional( const JsonObject &jo, const std::string_view name,
                                      damage_instance &out,
                                      const damage_instance &val,
                                      damage_instance proportional, bool &strict )
@@ -583,7 +583,7 @@ static void assign_dmg_proportional( const JsonObject &jo, const std::string &na
     }
 }
 
-static void check_assigned_dmg( const JsonObject &err, const std::string &name,
+static void check_assigned_dmg( const JsonObject &err, const std::string_view name,
                                 const damage_instance &out, const damage_instance &lo_inst, const damage_instance &hi_inst )
 {
     for( const damage_unit &out_dmg : out.damage_units ) {

--- a/src/assign.h
+++ b/src/assign.h
@@ -42,7 +42,7 @@ void report_strict_violation( const JsonObject &jo, const std::string &message,
                               std::string_view name );
 
 template <typename T, typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
-bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict = false,
+bool assign( const JsonObject &jo, std::string_view name, T &val, bool strict = false,
              T lo = std::numeric_limits<T>::lowest(), T hi = std::numeric_limits<T>::max() )
 {
     T out;
@@ -91,7 +91,7 @@ bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict 
 
 // Overload assign specifically for bool to avoid warnings,
 // and also to avoid potentially nonsensical interactions between relative and proportional.
-bool assign( const JsonObject &jo, const std::string &name, bool &val, bool strict = false );
+bool assign( const JsonObject &jo, std::string_view name, bool &val, bool strict = false );
 
 template <typename T, typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
 bool assign( const JsonObject &jo, const std::string_view name, std::pair<T, T> &val,
@@ -209,27 +209,27 @@ bool assign( const JsonObject &jo, const std::string &name, units::volume &val,
              units::volume lo = units::volume_min,
              units::volume hi = units::volume_max );
 
-bool assign( const JsonObject &jo, const std::string &name, units::mass &val,
+bool assign( const JsonObject &jo, std::string_view name, units::mass &val,
              bool strict = false,
              units::mass lo = units::mass_min,
              units::mass hi = units::mass_max );
 
-bool assign( const JsonObject &jo, const std::string &name, units::length &val,
+bool assign( const JsonObject &jo, std::string_view name, units::length &val,
              bool strict = false,
              units::length lo = units::length_min,
              units::length hi = units::length_max );
 
-bool assign( const JsonObject &jo, const std::string &name, units::money &val,
+bool assign( const JsonObject &jo, std::string_view name, units::money &val,
              bool strict = false,
              units::money lo = units::money_min,
              units::money hi = units::money_max );
 
-bool assign( const JsonObject &jo, const std::string &name, units::energy &val,
+bool assign( const JsonObject &jo, std::string_view name, units::energy &val,
              bool strict = false,
              units::energy lo = units::energy_min,
              units::energy hi = units::energy_max );
 
-bool assign( const JsonObject &jo, const std::string &name, units::power &val,
+bool assign( const JsonObject &jo, std::string_view name, units::power &val,
              bool strict = false,
              units::power lo = units::power_min,
              units::power hi = units::power_max );
@@ -241,7 +241,7 @@ class time_duration;
 template<typename T>
 inline typename
 std::enable_if<std::is_same<typename std::decay<T>::type, time_duration>::value, bool>::type
-read_with_factor( const JsonObject &jo, const std::string &name, T &val, const T &factor )
+read_with_factor( const JsonObject &jo, const std::string_view name, T &val, const T &factor )
 {
     int tmp;
     if( jo.read( name, tmp, false ) ) {
@@ -307,7 +307,7 @@ std::enable_if<std::is_same<typename std::decay<T>::type, time_duration>::value,
 }
 
 template<typename T>
-inline bool assign( const JsonObject &jo, const std::string &name, std::optional<T> &val,
+inline bool assign( const JsonObject &jo, const std::string_view name, std::optional<T> &val,
                     const bool strict = false )
 {
     if( !jo.has_member( name ) ) {

--- a/src/behavior_oracle.cpp
+++ b/src/behavior_oracle.cpp
@@ -11,7 +11,7 @@
 namespace behavior
 {
 
-status_t return_running( const oracle_t *, const std::string & )
+status_t return_running( const oracle_t *, const std::string_view )
 {
     return status_t::running;
 }

--- a/src/behavior_oracle.h
+++ b/src/behavior_oracle.h
@@ -22,7 +22,7 @@ class oracle_t
 {
 };
 
-status_t return_running( const oracle_t *, const std::string & );
+status_t return_running( const oracle_t *, std::string_view );
 
 extern std::unordered_map<std::string, std::function<status_t( const oracle_t *, const std::string & )>>
         predicate_map;

--- a/src/generic_factory.cpp
+++ b/src/generic_factory.cpp
@@ -1,6 +1,6 @@
 #include "generic_factory.h"
 
-bool one_char_symbol_reader( const JsonObject &jo, const std::string &member_name, int &sym,
+bool one_char_symbol_reader( const JsonObject &jo, const std::string_view member_name, int &sym,
                              bool )
 {
     std::string sym_as_string;
@@ -25,7 +25,7 @@ bool one_char_symbol_reader( const JsonObject &jo, const std::string &member_nam
 }
 
 bool unicode_codepoint_from_symbol_reader( const JsonObject &jo,
-        const std::string &member_name, uint32_t &member, bool )
+        const std::string_view member_name, uint32_t &member, bool )
 {
     int sym_as_int;
     std::string sym_as_string;
@@ -39,7 +39,8 @@ bool unicode_codepoint_from_symbol_reader( const JsonObject &jo,
     }
     uint32_t sym_as_codepoint = UTF8_getch( sym_as_string );
     if( mk_wcwidth( sym_as_codepoint ) != 1 ) {
-        jo.throw_error_at( member_name, member_name + " must be exactly one console cell wide" );
+        jo.throw_error_at(
+            member_name, str_cat( member_name, " must be exactly one console cell wide" ) );
     }
     member = sym_as_codepoint;
     return true;

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -596,29 +596,29 @@ data), it should throw.
 /** @name Implementation of `mandatory` and `optional`. */
 /**@{*/
 template<typename MemberType>
-inline void mandatory( const JsonObject &jo, const bool was_loaded, const std::string &name,
+inline void mandatory( const JsonObject &jo, const bool was_loaded, const std::string_view name,
                        MemberType &member )
 {
     if( !jo.read( name, member ) ) {
         if( !was_loaded ) {
             if( jo.has_member( name ) ) {
-                jo.throw_error( "failed to read mandatory member \"" + name + "\"" );
+                jo.throw_error( str_cat( "failed to read mandatory member \"", name, "\"" ) );
             } else {
-                jo.throw_error( "missing mandatory member \"" + name + "\"" );
+                jo.throw_error( str_cat( "missing mandatory member \"", name, "\"" ) );
             }
         }
     }
 }
 template<typename MemberType, typename ReaderType>
-inline void mandatory( const JsonObject &jo, const bool was_loaded, const std::string &name,
+inline void mandatory( const JsonObject &jo, const bool was_loaded, const std::string_view name,
                        MemberType &member, const ReaderType &reader )
 {
     if( !reader( jo, name, member, was_loaded ) ) {
         if( !was_loaded ) {
             if( jo.has_member( name ) ) {
-                jo.throw_error( "failed to read mandatory member \"" + name + "\"" );
+                jo.throw_error( str_cat( "failed to read mandatory member \"", name, "\"" ) );
             } else {
-                jo.throw_error( "missing mandatory member \"" + name + "\"" );
+                jo.throw_error( str_cat( "missing mandatory member \"", name, "\"" ) );
             }
         }
     }
@@ -701,7 +701,7 @@ static_assert( !supports_proportional<DebugLevel>::value, "enums should not supp
 // return.
 template < typename MemberType, std::enable_if_t < !supports_proportional<MemberType>::value > * =
            nullptr >
-inline bool handle_proportional( const JsonObject &jo, const std::string &name, MemberType & )
+inline bool handle_proportional( const JsonObject &jo, const std::string_view name, MemberType & )
 {
     if( jo.has_object( "proportional" ) ) {
         JsonObject proportional = jo.get_object( "proportional" );
@@ -720,7 +720,8 @@ inline bool handle_proportional( const JsonObject &jo, const std::string &name, 
 // So, check if there is a proportional entry, check if it's got a valid value
 // and if it does, multiply the member by it.
 template<typename MemberType, std::enable_if_t<supports_proportional<MemberType>::value>* = nullptr>
-inline bool handle_proportional( const JsonObject &jo, const std::string &name, MemberType &member )
+inline bool handle_proportional( const JsonObject &jo, const std::string_view name,
+                                 MemberType &member )
 {
     if( jo.has_object( "proportional" ) ) {
         JsonObject proportional = jo.get_object( "proportional" );
@@ -738,7 +739,7 @@ inline bool handle_proportional( const JsonObject &jo, const std::string &name, 
             member *= scalar;
             return true;
         } else {
-            jo.throw_error_at( name, "Invalid scalar for " + name );
+            jo.throw_error_at( name, str_cat( "Invalid scalar for ", name ) );
         }
     }
     return false;
@@ -750,7 +751,7 @@ inline bool handle_proportional( const JsonObject &jo, const std::string &name, 
 template < typename MemberType,
            std::enable_if_t < !supports_relative<MemberType>::value > * = nullptr
            >
-inline bool handle_relative( const JsonObject &jo, const std::string &name, MemberType & )
+inline bool handle_relative( const JsonObject &jo, const std::string_view name, MemberType & )
 {
     if( jo.has_object( "relative" ) ) {
         JsonObject relative = jo.get_object( "relative" );
@@ -769,7 +770,7 @@ inline bool handle_relative( const JsonObject &jo, const std::string &name, Memb
 // this, so member will contain the value of the thing we inherit from
 // So, check if there is a relative entry, then add it to our member
 template<typename MemberType, std::enable_if_t<supports_relative<MemberType>::value>* = nullptr>
-inline bool handle_relative( const JsonObject &jo, const std::string &name, MemberType &member )
+inline bool handle_relative( const JsonObject &jo, const std::string_view name, MemberType &member )
 {
     if( jo.has_object( "relative" ) ) {
         JsonObject relative = jo.get_object( "relative" );
@@ -783,7 +784,7 @@ inline bool handle_relative( const JsonObject &jo, const std::string &name, Memb
             member += adder;
             return true;
         } else {
-            jo.throw_error_at( name, "Invalid adder for " + name );
+            jo.throw_error_at( name, str_cat( "Invalid adder for ", name ) );
         }
     }
     return false;
@@ -791,7 +792,7 @@ inline bool handle_relative( const JsonObject &jo, const std::string &name, Memb
 
 // No template magic here, yay!
 template<typename MemberType>
-inline void optional( const JsonObject &jo, const bool was_loaded, const std::string &name,
+inline void optional( const JsonObject &jo, const bool was_loaded, const std::string_view name,
                       MemberType &member )
 {
     if( !jo.read( name, member ) && !handle_proportional( jo, name, member ) &&
@@ -813,7 +814,7 @@ otherwise it is assumed to be the reader.
 */
 template<typename MemberType, typename DefaultType = MemberType,
          typename = typename std::enable_if<std::is_constructible<MemberType, const DefaultType &>::value>::type>
-inline void optional( const JsonObject &jo, const bool was_loaded, const std::string &name,
+inline void optional( const JsonObject &jo, const bool was_loaded, const std::string_view name,
                       MemberType &member, const DefaultType &default_value )
 {
     if( !jo.read( name, member ) && !handle_proportional( jo, name, member ) &&
@@ -826,7 +827,7 @@ inline void optional( const JsonObject &jo, const bool was_loaded, const std::st
 template < typename MemberType, typename ReaderType, typename DefaultType = MemberType,
            typename = typename std::enable_if <
                !std::is_constructible<MemberType, const ReaderType &>::value >::type >
-inline void optional( const JsonObject &jo, const bool was_loaded, const std::string &name,
+inline void optional( const JsonObject &jo, const bool was_loaded, const std::string_view name,
                       MemberType &member, const ReaderType &reader )
 {
     if( !reader( jo, name, member, was_loaded ) ) {
@@ -836,7 +837,7 @@ inline void optional( const JsonObject &jo, const bool was_loaded, const std::st
     }
 }
 template<typename MemberType, typename ReaderType, typename DefaultType = MemberType>
-inline void optional( const JsonObject &jo, const bool was_loaded, const std::string &name,
+inline void optional( const JsonObject &jo, const bool was_loaded, const std::string_view name,
                       MemberType &member, const ReaderType &reader, const DefaultType &default_value )
 {
     if( !reader( jo, name, member, was_loaded ) ) {
@@ -851,7 +852,7 @@ inline void optional( const JsonObject &jo, const bool was_loaded, const std::st
  * Reads a string and stores the first byte of it in `sym`. Throws if the input contains more
  * or less than one byte.
  */
-bool one_char_symbol_reader( const JsonObject &jo, const std::string &member_name, int &sym,
+bool one_char_symbol_reader( const JsonObject &jo, std::string_view member_name, int &sym,
                              bool );
 
 /**
@@ -859,7 +860,7 @@ bool one_char_symbol_reader( const JsonObject &jo, const std::string &member_nam
  * Throws if the inputs width is more than one console cell wide.
  */
 bool unicode_codepoint_from_symbol_reader(
-    const JsonObject &jo, const std::string &member_name, uint32_t &member, bool );
+    const JsonObject &jo, std::string_view member_name, uint32_t &member, bool );
 
 namespace reader_detail
 {
@@ -978,7 +979,7 @@ class generic_typed_reader
 {
     public:
         template<typename C>
-        void insert_values_from( const JsonObject &jo, const std::string &member_name,
+        void insert_values_from( const JsonObject &jo, const std::string_view member_name,
                                  C &container ) const {
             const Derived &derived = static_cast<const Derived &>( *this );
             if( !jo.has_member( member_name ) ) {
@@ -1003,7 +1004,8 @@ class generic_typed_reader
         }
 
         template<typename C>
-        void erase_values_from( const JsonObject &jo, const std::string &member_name, C &container ) const {
+        void erase_values_from( const JsonObject &jo, const std::string_view member_name,
+                                C &container ) const {
             const Derived &derived = static_cast<const Derived &>( *this );
             if( !jo.has_member( member_name ) ) {
                 return;
@@ -1032,7 +1034,7 @@ class generic_typed_reader
          * when called on a simple data member, the other `operator()` will be used.
          */
         template<typename C, typename std::enable_if<reader_detail::handler<C>::is_container, int>::type = 0>
-        bool operator()( const JsonObject &jo, const std::string &member_name,
+        bool operator()( const JsonObject &jo, const std::string_view member_name,
                          C &container, bool was_loaded ) const {
             const Derived &derived = static_cast<const Derived &>( *this );
             // If you get an error about "incomplete type 'struct reader_detail::handler...",
@@ -1070,14 +1072,15 @@ class generic_typed_reader
                    int >::type = 0,
                    std::enable_if_t < !supports_relative<C>::value > * = nullptr
                    >
-        bool do_relative( const JsonObject &jo, const std::string &name, C & ) const {
+        bool do_relative( const JsonObject &jo, const std::string_view name, C & ) const {
             if( jo.has_object( "relative" ) ) {
                 JsonObject relative = jo.get_object( "relative" );
                 relative.allow_omitted_members();
                 if( !relative.has_member( name ) ) {
                     return false;
                 }
-                debugmsg( "Member %s of type %s does not support relative", name, demangle( typeid( C ).name() ) );
+                debugmsg( "Member %s of type %s does not support relative",
+                          name, demangle( typeid( C ).name() ) );
             }
             return false;
         }
@@ -1085,7 +1088,7 @@ class generic_typed_reader
         // Type supports relative
         template < typename C, typename std::enable_if < !reader_detail::handler<C>::is_container,
                    int >::type = 0, std::enable_if_t<supports_relative<C>::value> * = nullptr >
-        bool do_relative( const JsonObject &jo, const std::string &name, C &member ) const {
+        bool do_relative( const JsonObject &jo, const std::string_view name, C &member ) const {
             if( jo.has_object( "relative" ) ) {
                 JsonObject relative = jo.get_object( "relative" );
                 relative.allow_omitted_members();
@@ -1102,7 +1105,7 @@ class generic_typed_reader
         }
 
         template<typename C>
-        bool read_normal( const JsonObject &jo, const std::string &name, C &member ) const {
+        bool read_normal( const JsonObject &jo, const std::string_view name, C &member ) const {
             if( jo.has_member( name ) ) {
                 const Derived &derived = static_cast<const Derived &>( *this );
                 member = derived.get_next( jo.get_member( name ) );
@@ -1118,7 +1121,7 @@ class generic_typed_reader
         // the caller, which will take action on their own.
         template < typename C, typename std::enable_if < !reader_detail::handler<C>::is_container,
                    int >::type = 0 >
-        bool operator()( const JsonObject &jo, const std::string &member_name,
+        bool operator()( const JsonObject &jo, const std::string_view member_name,
                          C &member, bool /*was_loaded*/ ) const {
             return read_normal( jo, member_name, member ) ||
                    handle_proportional( jo, member_name, member ) ||
@@ -1152,7 +1155,7 @@ using string_reader = auto_flags_reader<>;
 class volume_reader : public generic_typed_reader<units::volume>
 {
     public:
-        bool operator()( const JsonObject &jo, const std::string &member_name,
+        bool operator()( const JsonObject &jo, const std::string_view member_name,
                          units::volume &member, bool /* was_loaded */ ) const {
             if( !jo.has_member( member_name ) ) {
                 return false;
@@ -1168,7 +1171,7 @@ class volume_reader : public generic_typed_reader<units::volume>
 class mass_reader : public generic_typed_reader<units::mass>
 {
     public:
-        bool operator()( const JsonObject &jo, const std::string &member_name,
+        bool operator()( const JsonObject &jo, const std::string_view member_name,
                          units::mass &member, bool /* was_loaded */ ) const {
             if( !jo.has_member( member_name ) ) {
                 return false;
@@ -1184,7 +1187,7 @@ class mass_reader : public generic_typed_reader<units::mass>
 class money_reader : public generic_typed_reader<units::money>
 {
     public:
-        bool operator()( const JsonObject &jo, const std::string &member_name,
+        bool operator()( const JsonObject &jo, const std::string_view member_name,
                          units::money &member, bool /* was_loaded */ ) const {
             if( !jo.has_member( member_name ) ) {
                 return false;
@@ -1220,12 +1223,12 @@ class typed_flag_reader : public generic_typed_reader<typed_flag_reader<T>>
         const std::string flag_type;
 
     public:
-        typed_flag_reader( const map_t &flag_map, const std::string &flag_type )
+        typed_flag_reader( const map_t &flag_map, const std::string_view flag_type )
             : flag_map( flag_map )
             , flag_type( flag_type ) {
         }
 
-        explicit typed_flag_reader( const std::string &flag_type )
+        explicit typed_flag_reader( const std::string_view flag_type )
             : flag_map( io::get_enum_lookup_map<T>() )
             , flag_type( flag_type ) {
         }
@@ -1244,7 +1247,7 @@ class typed_flag_reader : public generic_typed_reader<typed_flag_reader<T>>
 
 template<typename T>
 typed_flag_reader<T> make_flag_reader( const std::unordered_map<std::string, T> &m,
-                                       const std::string &e )
+                                       const std::string_view e )
 {
     return typed_flag_reader<T>( m, e );
 }
@@ -1289,7 +1292,7 @@ class string_id_reader : public generic_typed_reader<string_id_reader<T>>
  * Reads a volume value from legacy format: JSON contains a integer which represents multiples
  * of `units::legacy_volume_factor` (250 ml).
  */
-inline bool legacy_volume_reader( const JsonObject &jo, const std::string &member_name,
+inline bool legacy_volume_reader( const JsonObject &jo, const std::string_view member_name,
                                   units::volume &value, bool )
 {
     int legacy_value;

--- a/src/mod_tracker.h
+++ b/src/mod_tracker.h
@@ -42,7 +42,7 @@ struct has_src_member<T, std::void_t<decltype( std::declval<T &>().src.emplace_b
 
     /** Dummy function, for if those conditions are not satisfied */
     template < typename T, typename std::enable_if_t < !has_src_member<T>::value > * = nullptr >
-    static void assign_src( T &, const std::string & ) {
+    static void assign_src( T &, const std::string_view ) {
     }
 
     /** If those conditions are satisfied, keep track of where this item has been modified */

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -17,6 +17,12 @@ void volume::serialize( JsonOut &jsout ) const
 }
 
 template<>
+void volume::deserialize( const JsonValue &jv )
+{
+    *this = read_from_json_string( jv, units::volume_units );
+}
+
+template<>
 void mass::serialize( JsonOut &jsout ) const
 {
     if( value_ % 1000000 == 0 ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Code modernization and simplification.

Migrating more APIs to `string_view`.

#### Describe the solution
This batch is mostly stuff related to `generic_factory`, `assign`, `optional`, and `mandatory`, with a couple of other random functions.

I had to add `volume::deserialize` after these changes because there was a linking error about it being missing.  I don't understand how this ever compiled before, because we were definitely deserializing some volume values.

#### Describe alternatives you've considered
I could have done a much bigger PR with more changes, and I will soon, but I still want to keep this one smaller to verify I'm not breaking stuff unexpectedly before more sweeping changes.

#### Testing
Unit tests.

#### Additional context