### PR TITLE
Add EOC condition for time until a scheduled EOC runs

### DIFF
--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1256,6 +1256,7 @@ Example | Description
 `"const": 5` | A constant value, in this case 5. Can be read but not written to.
 `"time": "5 days"` | A constant time value. Will be converted to turns. Can be read but not written to.
 `"time_since_cataclysm": "turns"` | Time since the start of the cataclysm in turns. Can instead take other time units such as minutes, hours, days, weeks, seasons, and years.
+`"time_until_eoc": "eoc_id"` | Time from now until the next scheduled run of `eoc_id`. Optional member `unit` can sepcify a member to use instead of turns such as minutes, hours, days, weeks, seasons, and years.
 `"rand": 20` | A random value between 0 and a given value, in this case 20. Can be read but not written to.
 `"faction_trust": "free_merchants"` | The trust the faction has for the player (see [FACTIONS.md](FACTIONS.md)) for details.
 `"faction_like": "free_merchants"` | How much the faction likes the player (see [FACTIONS.md](FACTIONS.md)) for details.

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1375,6 +1375,43 @@ std::function<double( dialogue const & )> conditional_t::get_get_dbl( J const &j
             return ( to_turn<int>( calendar::turn ) - to_turn<int>( calendar::start_of_cataclysm ) ) /
                    to_turns<int>( given_unit );
         };
+    } else if( jo.has_member( "time_until_eoc" ) ) {
+        time_duration given_unit = 1_turns;
+        effect_on_condition_id eoc_id = effect_on_condition_id( jo.get_string( "time_until_eoc" ) );
+        if( jo.has_string( "unit" ) ) {
+            std::string given_unit_str = jo.get_string( "unit" );
+            bool found = false;
+            for( const auto &pair : time_duration::units ) {
+                const std::string &unit = pair.first;
+                if( unit == given_unit_str ) {
+                    given_unit = pair.second;
+                    found = true;
+                    break;
+                }
+            }
+            if( !found ) {
+                jo.throw_error( "unrecognized time unit in " + jo.str() );
+            }
+        }
+        return [eoc_id, given_unit]( dialogue const & ) {
+            std::priority_queue<queued_eoc, std::vector<queued_eoc>, eoc_compare> copy_queue =
+                g->queued_global_effect_on_conditions;
+            time_point turn;
+            bool found = false;
+            while( !copy_queue.empty() ) {
+                if( copy_queue.top().eoc == eoc_id ) {
+                    turn = copy_queue.top().time;
+                    found = true;
+                    break;
+                }
+                copy_queue.pop();
+            }
+            if( !found ) {
+                return -1;
+            } else {
+                return to_turns<int>( turn - calendar::turn ) / to_turns<int>( given_unit );
+            }
+        };
     } else if( jo.has_member( "rand" ) ) {
         int max_value = jo.get_int( "rand" );
         return [max_value]( dialogue const & ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This will be needed for Portal Storm advance warning.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Used this json
```
{
    "type": "effect_on_condition",
    "id": "EOC_TEST",
    "effect": [
      { "arithmetic": [ { "global_val": "var", "var_name": "test" }, "=", { "time_until_eoc": "EOC_PORTAL_STORM_WARN_OR_CAUSE_RECURRING", "unit":"day" }  ] }
    ]
  }
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->