### PR TITLE
actual fix for real this time: item spawning spells with no min/max damage

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1069,7 +1069,7 @@ void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const
 
     std::vector<item> granted;
 
-    int count = std::min( 1, sp.damage( caster ) );
+    int count = std::max( 1, sp.damage( caster ) );
     for( int i = 0; i < count; i++ ) {
         if( sp.has_flag( spell_flag::SPAWN_GROUP ) ) {
             std::vector<item> group_items = item_group::items_from( item_group_id( sp.effect_data() ),


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Actually fix the thing instead of break it more.

#### Describe the solution

Use max instead of min.

#### Describe alternatives you've considered



#### Testing

Casted repelling arc and got the aura.

#### Additional context

The UI still says it spawns 0, but I swear I didn't break that.