### PR TITLE
Stop clairvoyance breaking Hub 01 and other fixes

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10188,8 +10188,8 @@ bool Character::sees( const Creature &critter ) const
     // This handles only the player/npc specific stuff (monsters don't have traits or bionics).
     const int dist = rl_dist( pos(), critter.pos() );
     // No seeing across z-levels with experimental 3D vision disabled
-    if ( !fov_3d && pos().z != critter.pos().z ) {
-    	return false;
+    if( !fov_3d && pos().z != critter.pos().z ) {
+        return false;
     }
     if( dist <= 3 && has_active_mutation( trait_ANTENNAE ) ) {
         return true;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10187,13 +10187,18 @@ bool Character::sees( const Creature &critter ) const
 {
     // This handles only the player/npc specific stuff (monsters don't have traits or bionics).
     const int dist = rl_dist( pos(), critter.pos() );
+    // No seeing across z-levels with experimental 3D vision disabled
+    if ( !fov_3d && pos().z != critter.pos().z ) {
+    	return false;
+    }
     if( dist <= 3 && has_active_mutation( trait_ANTENNAE ) ) {
         return true;
     }
     if( dist < MAX_CLAIRVOYANCE && dist < clairvoyance() ) {
         return true;
     }
-    if( field_fd_clairvoyant.is_valid() &&
+    // Only players can spot creatures through clairvoyance fields
+    if( is_avatar() && field_fd_clairvoyant.is_valid() &&
         get_map().get_field( critter.pos(), field_fd_clairvoyant ) ) {
         return true;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Stop clairvoyance breaking Hub 01 and other fixes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Clairvoyance comes in two flavors, as a clairvoyance field (used in the Aftershock, Magiclysm and Xedra Evolved mods), and as a mutation (accessible through debug).
Clairvoyance fields have the issue of allowing NPCs to detect creatures standing in it. This includes the player character that created the field. Doing this near the Hub 01 intercom NPC will make them hostile and refuse further communication with the player. (Most abilities do not create the field at the character's immediate location, so you have to walk into the field and wait a few turns to reproduce.)
All clairvoyance effects work across z-levels regardless of experimental 3D vision settings. Combined with the previous issue, this means that a character standing in their own clairvoyance field can trigger hostile NPCs across z-levels. Again, this is best reproduced in Hub 01. Allowing the player to see across Z-levels allows spells to be cast on those levels and can also trigger unnecessary danger notifications.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Only players can see creatures in clairvoyance fields. The will prevent triggering hostile NPCs and breaking Hub 01.
Clairvoyance now respects experimental 3D vision settings.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Clairvoyance z-levels were tested on a character with the debug clairvoyance mutation standing near the intercom in Hub 01. With experimental 3D vision enabled, 4 Hub 01 NPCs show up on the compass widget in the sidebar. When disabled, only the intercom NPC is detected.
Clairvoyance hostility was tested using both the structural imager from Aftershock and the X-ray Vision spell from Magiclysm. These were used in the vicinity of the Hub 01 intercom and the character was made to move into the created clairvoyance field and wait a few turns. Normally this would trigger the "get angry" message from nearby Hub 01 NPCs including those underground, but with this fix that no longer happens.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->