### PR TITLE
Add debug mutation to disable skill rust

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8099,6 +8099,18 @@
   },
   {
     "type": "mutation",
+    "id": "DEBUG_SKILL_RUST",
+    "name": { "str": "Debug Skill Rust" },
+    "points": 99,
+    "description": "Disable skill rust.",
+    "types": [ "MEMORY" ],
+    "skill_rust_multiplier": 0.0,
+    "valid": false,
+    "debug": true,
+    "cancels": [ "FORGETFUL", "GOODMEMORY" ]
+  },
+  {
+    "type": "mutation",
     "id": "SQUEAMISH",
     "name": { "str": "Squeamish" },
     "points": -1,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Add debug mutation to disable skill rust"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

With the merge of #64708, there is no way to disable skill rust in-game without a mod. This PR adds a debug mutation to disable skill rust.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

A new mutation with ID `DEBUG_SKILL_RUST` has been added to `mutations.json`. This mutation sets `skill_rust_multiplier` to zero.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

1. Return the global menu option to disable skill rust. (#64916)
    - Because this solution is a mutation that takes advantage of an existing property, it is purely json-based and does not add the extra overhead maintained by the previous debug option.
3. Create a mod that contains the added mutation instead of a debug option.
   - I think that being able to maintain a character without skill rust offers more utility as a toggle debug option than as a mod. It would make it easier to test things that require long wait time without having a character's skills rust.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

1. I created a new character WITHOUT `DEBUG_SKILL_RUST` and WITH `DEBUG_LS` (so that I could wait without having to eat)
4. I practiced athletics. I waited one day and observed the athletics skill rust down as expected.
5. I debug-added the trait to the test character and waited a week. I confirmed that no skill rust occurred.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Skill rust is and has been a polarising topic. This could easily be left as a mod, but it adds accessibility value for both testing purposes as well as for people who just don't like skill rust to include a debug option in this manner.

If the development team does not believe this should be merged into mainline, please just let me know and I'd be happy to withdraw this PR and re-implement this option as a standalone mod.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->