### PR TITLE
Fix android missing header in system_locale.cpp

### DIFF
--- a/src/system_locale.cpp
+++ b/src/system_locale.cpp
@@ -13,6 +13,7 @@
 #elif defined(__ANDROID__)
 #include <jni.h>
 #include "sdl_wrappers.h" // for SDL_AndroidGetJNIEnv()
+#include "debug.h" // for DebugLog/D_INFO/D_MAIN
 #elif defined(__linux__)
 #include <langinfo.h>
 #endif


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/65090
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4717703241/jobs/8366579428#step:21:587

#### Describe the solution
Add missing include for debug.h

#### Testing
I haven't tested this, and CI doesn't test this. It's a pretty obvious change, and will be exercised after this PR is merged.

#### Additional context
I don't know why this has started to pop up.