### PR TITLE
Adjust vehicle part name to align degradation symbol

### DIFF
--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -100,29 +100,28 @@ item vehicle_part::properties_to_item() const
 
 std::string vehicle_part::name( bool with_prefix ) const
 {
-    std::string res = info().name();
-
-    if( base.engine_displacement() > 0 ) {
-        res.insert( 0, string_format( _( "%gL " ), base.engine_displacement() / 100.0 ) );
-
-    } else if( wheel_diameter() > 0 ) {
-        res.insert( 0, string_format( _( "%d\" " ), wheel_diameter() ) );
+    std::string res;
+    if( with_prefix ) {
+        res += base.damage_indicator() + base.degradation_symbol() + " ";
+        if( !base.type->degrade_increments() ) {
+            res += " "; // aligns names when printing degrading and non-degrading parts with prefixes
+        }
     }
-
-    if( base.is_faulty() ) {
-        res += _( " (faulty)" );
+    if( base.engine_displacement() ) {
+        res += string_format( _( "%gL " ), base.engine_displacement() / 100.0 );
     }
-
+    if( wheel_diameter() ) {
+        res += string_format( _( "%d\" " ), wheel_diameter() );
+    }
+    res += info().name();
     if( base.has_var( "contained_name" ) ) {
         res += string_format( _( " holding %s" ), base.get_var( "contained_name" ) );
     }
-
+    if( base.is_faulty() ) {
+        res += _( " (faulty)" );
+    }
     if( is_leaking() ) {
         res += _( " (draining)" );
-    }
-
-    if( with_prefix ) {
-        res.insert( 0, base.damage_indicator() + base.degradation_symbol() + " " );
     }
     return res;
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Align vehicle part names between ones with degradation symbol with and the ones without

#### Describe the solution

A small change split from https://github.com/CleverRaven/Cataclysm-DDA/pull/65148 in case there's friction with this change as it's borderline an OCD preference one, the screenshots display the difference - a space is used in place of degradation symbol allowing the names to align, previously the parts without degradation symbol would be off-by-1 character

Rearranged the function a bit so it's just appends without insert( 0, ... )

#### Describe alternatives you've considered

#### Testing

#### Additional context

![image](https://user-images.githubusercontent.com/6560075/232641181-0a9ff465-21e6-4fae-8d64-6fe5b4c40169.png)
