### PR TITLE
Magic scenario additions

### DIFF
--- a/data/mods/Magiclysm/scenarios.json
+++ b/data/mods/Magiclysm/scenarios.json
@@ -56,7 +56,16 @@
     "description": "You are an exile, whether because of people shunning you because of who you are or from a personal choice.  The dead aren't willing to leave you be.",
     "start_name": "Exiled",
     "allowed_locs": [ "sloc_hermit_shack", "sloc_cabin", "sloc_lmoe", "sloc_lighthouse_ground", "sloc_cabin_lake" ],
-    "professions": [ "druid", "novice_necromancer", "magic_grim_reaper" ]
+    "professions": [
+      "druid",
+      "novice_necromancer",
+      "ranger",
+      "vengpreacher",
+      "techno_prepper",
+      "fleshmender",
+      "moose_rider",
+      "magic_grim_reaper"
+    ]
   },
   {
     "copy-from": "alcatraz",
@@ -81,5 +90,17 @@
     "type": "scenario",
     "extend": { "professions": [ "whitedeath_expy" ] },
     "id": "heli_crash"
+  },
+  {
+    "copy-from": "presort",
+    "type": "scenario",
+    "extend": { "professions": [ "magic_vamp", "biomancer_musician", "magic_knifethrower" ] },
+    "id": "presort"
+  },
+  {
+    "copy-from": "Mansion",
+    "type": "scenario",
+    "extend": { "professions": [ "magic_vamp", "biomancer_musician" ] },
+    "id": "Mansion"
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Expands some scenario professions with relevant magic professions"

#### Purpose of change
Many magic professions are just... There. They exist, but lack specific scenarios where they are part of the main focus, this PR adds some of them to the relevant scenarios wherever it makes sense.

#### Describe the solution
Adds isolated, shady, or paranoid magic professions to the exile scenario, as well as magic staff and guests to the crazy party and mansion scenarios. 

#### Describe alternatives you've considered
To add other isolated, shady or paranoid professions from vanilla (Non-magical) to the exile scenario, since it is not a magical scenario...

#### Testing
It works!

#### Additional context