### PR TITLE
Minor adjustment to the mansion escape EOC

### DIFF
--- a/data/json/effect_on_condition.json
+++ b/data/json/effect_on_condition.json
@@ -41,9 +41,30 @@
     "id": "scenario_mansion_pursuit",
     "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
-      { "u_spawn_monster": "GROUP_MANSION_ARMORED", "group": true, "real_count": 1, "min_radius": 15, "max_radius": 30 },
-      { "u_spawn_monster": "GROUP_MANSION_START", "group": true, "real_count": 2, "min_radius": 10, "max_radius": 18 },
-      { "u_spawn_monster": "GROUP_MANSION_START", "group": true, "real_count": 2, "min_radius": 15, "max_radius": 25 }
+      {
+        "u_spawn_monster": "GROUP_MANSION_ARMORED",
+        "group": true,
+        "real_count": 1,
+        "min_radius": 30,
+        "max_radius": 45,
+        "indoor_only": true
+      },
+      {
+        "u_spawn_monster": "GROUP_MANSION_START",
+        "group": true,
+        "real_count": 2,
+        "min_radius": 20,
+        "max_radius": 35,
+        "indoor_only": true
+      },
+      {
+        "u_spawn_monster": "GROUP_MANSION_START",
+        "group": true,
+        "real_count": 2,
+        "min_radius": 25,
+        "max_radius": 40,
+        "indoor_only": true
+      }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
#64603 added the option to spawning only indoor with an EOC at my request, so I took the time to update the mansion escape EOC to use it, freeing the monsters from spawning close to the player, else they could end up outside of the mansion.

#### Describe the solution
Makes use of the new functionality implemented in the linked PR.

#### Describe alternatives you've considered
To make a revision of the monsters spawns as I want... But well, I don't have the time right now.

#### Testing
It works!

#### Additional context
