### PR TITLE
Fix reactor power

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -921,7 +921,7 @@
         "using": [ [ "repair_welding_standard", 5 ], [ "soldering_standard", 5 ] ]
       }
     },
-    "flags": [ "OBSTACLE", "RADIOACTIVE", "COVERED", "ENABLED_DRAINS_EPOWER", "APPLIANCE", "PERPETUAL", "REACTOR" ],
+    "flags": [ "OBSTACLE", "RADIOACTIVE", "COVERED", "APPLIANCE", "PERPETUAL", "REACTOR" ],
     "breaks_into": [
       { "item": "scrap", "count": [ 4, 16 ] },
       { "item": "steel_chunk", "count": [ 1, 6 ] },

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -234,7 +234,7 @@ void veh_app_interact::draw_info()
 
     // Reactor power output
     if( !veh->reactors.empty() ) {
-        units::power rate = veh->active_reactor_epower( true );
+        const units::power rate = veh->active_reactor_epower();
         print_charge( _( "Reactor power output: " ), rate, row );
         row++;
     }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1357,7 +1357,7 @@ class vehicle
         // reactors is only drawn when batteries are empty.
         units::power max_reactor_epower() const;
         // Active power from reactors that is actually being drained by batteries.
-        units::power active_reactor_epower( bool connected_vehicles ) const;
+        units::power active_reactor_epower() const;
         // Produce and consume electrical power, with excess power stored or
         // taken from batteries.
         void power_parts();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #65155

Fixes appliance ui to show correct numbers and fix asrg appliance double-dipping

#### Describe the solution

ENABLED_DRAINS_EPOWER on asrg appliance part caused it to double dip and produce 260W instead of 130W, flag was removed

Simplify `vehicle::active_reactor_epower`, don't clamp min to 1kW so the display is correct for non-minireactors

The display is still not exact as it doesn't know how much charge reactor actually charged, so it makes assumptions that are sometimes incorrect such as when battery is full and drain is less than what reactor produces, fixing it would require storing the energy drain somewhere

#### Describe alternatives you've considered

#### Testing

Put a couple reactors, couple appliances, solar panel, a battery, connect all of them together and check the situations:
1) non-full battery - should display full power from reactors
2) almost full battery - should display reactor power contribution after other parts
3) full battery should display 0
4) Connect just asrg to battery, wait an hour, it should produce ~470 kJ

#### Additional context
