### PR TITLE
Use average NPC's stats to calculate faction camp gained calories

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -4940,6 +4940,12 @@ int time_to_food( time_duration work )
     return 2500 * to_hours<int>( work ) / 24;
 }
 
+static const npc &getAverageJoe()
+{
+    static npc averageJoe;
+    return averageJoe;
+}
+
 // mission support
 bool basecamp::distribute_food()
 {
@@ -4999,8 +5005,9 @@ bool basecamp::distribute_food()
         if( it.rotten() ) {
             return false;
         }
-        const int kcal = it.get_comestible()->default_nutrition.kcal() * it.count() * rot_multip( it,
-                         container );
+        const int kcal = getAverageJoe().compute_effective_nutrients( it ).kcal() * it.count() * rot_multip(
+                             it,
+                             container );
         if( kcal <= 0 ) {
             // can happen if calories is low and rot is high.
             return false;


### PR DESCRIPTION
#### Summary
Bugfixes "Faction camps now distribute calories based on actual calories and not default calories"

#### Purpose of change
Fixes #50805

#### Describe the solution
Initialize a blank npc. Pass it to character::compute_effective_nutrients so it calculates calories from components, instead of simply taking the default.

We use this 'average NPC' as a baseline since we can't (reasonably) know what NPCs are going to eat the food at the time of adding it to the larder. By avoiding using the player avatar we avoid extra crediting/penalizing for CBMs, mutations, etc. that they may have.

#### Describe alternatives you've considered
Implement some sort of hellish tracking & averaging system to more accurately determine the actual nutritional value your NPCs would get based on past distributions

#### Testing
Made 1 meat jerky (default 348 calories) out of porkbelly+salt water, worth 975 calories with those ingredients. Installed expanded digestive system CBM on my character, making the inherited meat jerky worth 1,462 calories (to me). Used distribute food mission, got 975 calories, as expected for average NPC. The player character's mutations/CBMs/etc do not influence the outcome, but inherited calories from crafting do.

![image](https://user-images.githubusercontent.com/84619419/232689361-fa0e2f2d-c45d-4701-9b8f-996f01373fc6.png)

Repeated test with 5x meat jerky (same method). Received 4,875 calories. Confirmed this is the correct amount.

Debug spawn meat jerky. Distribute food, get 348 calories. Confirmed this is the default amount - and correct for a debug spawned item.

#### Additional context
Special thanks to @bombasticSlacks