### PR TITLE
Mouse thumb button support

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -664,6 +664,14 @@ void input_manager::init_keycode_mapping()
                             translate_marker_context( "key name", "SCROLL_DOWN" ) );
     add_mouse_keycode_pair( MouseInput::Move,
                             translate_marker_context( "key name", "MOUSE_MOVE" ) );
+    add_mouse_keycode_pair( MouseInput::X1ButtonPressed,
+                            translate_marker_context( "key name", "MOUSE_BACK_PRESSED" ) );
+    add_mouse_keycode_pair( MouseInput::X1ButtonReleased,
+                            translate_marker_context( "key name", "MOUSE_BACK" ) );
+    add_mouse_keycode_pair( MouseInput::X2ButtonPressed,
+                            translate_marker_context( "key name", "MOUSE_FORWARD_PRESSED" ) );
+    add_mouse_keycode_pair( MouseInput::X2ButtonReleased,
+                            translate_marker_context( "key name", "MOUSE_FORWARD" ) );
 
 }
 

--- a/src/input.h
+++ b/src/input.h
@@ -167,7 +167,13 @@ enum class MouseInput : int {
     ScrollWheelUp,
     ScrollWheelDown,
 
-    Move
+    Move,
+
+    X1ButtonPressed,
+    X1ButtonReleased,
+
+    X2ButtonPressed,
+    X2ButtonReleased
 
 };
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3276,6 +3276,12 @@ static void CheckMessages()
                     case SDL_BUTTON_RIGHT:
                         last_input = input_event( MouseInput::RightButtonPressed, input_event_t::mouse );
                         break;
+                    case SDL_BUTTON_X1:
+                        last_input = input_event( MouseInput::X1ButtonPressed, input_event_t::mouse );
+                        break;
+                    case SDL_BUTTON_X2:
+                        last_input = input_event( MouseInput::X2ButtonPressed, input_event_t::mouse );
+                        break;
                 }
                 break;
 
@@ -3286,6 +3292,12 @@ static void CheckMessages()
                         break;
                     case SDL_BUTTON_RIGHT:
                         last_input = input_event( MouseInput::RightButtonReleased, input_event_t::mouse );
+                        break;
+                    case SDL_BUTTON_X1:
+                        last_input = input_event( MouseInput::X1ButtonReleased, input_event_t::mouse );
+                        break;
+                    case SDL_BUTTON_X2:
+                        last_input = input_event( MouseInput::X2ButtonReleased, input_event_t::mouse );
                         break;
                 }
                 break;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Mouse thumb button support"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
CDDA uses a lot of keys. Having 2 more would be great. Currently standard mouse keys are supported but not the thumb buttons.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Enable support for the mouse "Forward" and "Back" thumb buttons, allowing them to be bound in the keybindings menu in the same way most other keys can. Only works for Tiles at the moment.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested binding the thumb buttons to various actions in different menus. Works like a charm. Keybinds persist properly after saving and loading.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->