### PR TITLE
Allow vertical movement for avatar in water

### DIFF
--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -37,7 +37,7 @@
     "looks_like": "t_water_sh",
     "color": "blue",
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "DEEP_WATER", "FISHABLE" ],
+    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "DEEP_WATER", "FISHABLE", "GOES_DOWN" ],
     "connect_groups": "WATER",
     "connects_to": "WATER",
     "examine_action": "water_source"
@@ -299,7 +299,7 @@
     "symbol": "~",
     "color": "blue",
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "DEEP_WATER", "GOES_DOWN", "GOES_UP" ],
+    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "DEEP_WATER", "WATER_CUBE", "GOES_DOWN", "GOES_UP" ],
     "connect_groups": "WATER",
     "connects_to": "WATER",
     "examine_action": "water_source"
@@ -314,7 +314,7 @@
     "looks_like": "t_sand",
     "color": "blue",
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "DEEP_WATER", "GOES_UP" ],
+    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "DEEP_WATER", "WATER_CUBE", "GOES_UP" ],
     "connect_groups": "WATER",
     "connects_to": "WATER",
     "examine_action": "water_source"

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -170,6 +170,7 @@ std::string enum_to_string<ter_furn_flag>( ter_furn_flag data )
         case ter_furn_flag::TFLAG_WALL: return "WALL";
         case ter_furn_flag::TFLAG_DEEP_WATER: return "DEEP_WATER";
         case ter_furn_flag::TFLAG_SHALLOW_WATER: return "SHALLOW_WATER";
+        case ter_furn_flag::TFLAG_WATER_CUBE: return "WATER_CUBE";
         case ter_furn_flag::TFLAG_CURRENT: return "CURRENT";
         case ter_furn_flag::TFLAG_HARVESTED: return "HARVESTED";
         case ter_furn_flag::TFLAG_PERMEABLE: return "PERMEABLE";

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -219,6 +219,7 @@ enum class ter_furn_flag : int {
     TFLAG_WALL,
     TFLAG_DEEP_WATER,
     TFLAG_SHALLOW_WATER,
+    TFLAG_WATER_CUBE,
     TFLAG_CURRENT,
     TFLAG_HARVESTED,
     TFLAG_PERMEABLE,

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -169,6 +169,28 @@ void build_test_map( const ter_id &terrain )
     here.build_map_cache( 0, true );
 }
 
+void build_water_test_map( const ter_id &surface, const ter_id &mid, const ter_id &bottom )
+{
+    constexpr int z_surface = 0;
+    constexpr int z_bottom = -2;
+
+    map &here = get_map();
+    for( const tripoint &p : here.points_in_rectangle( tripoint_zero,
+            tripoint( MAPSIZE * SEEX, MAPSIZE * SEEY, z_bottom ) ) ) {
+
+        if( p.z == z_surface ) {
+            here.ter_set( p, surface );
+        } else if( p.z < z_surface && p.z > z_bottom ) {
+            here.ter_set( p, mid );
+        } else if( p.z == z_bottom ) {
+            here.ter_set( p, bottom );
+        }
+    }
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+}
+
 void player_add_headlamp()
 {
     item headlamp( "wearable_light_on" );

--- a/tests/map_helpers.h
+++ b/tests/map_helpers.h
@@ -24,6 +24,7 @@ monster &spawn_test_monster( const std::string &monster_type, const tripoint &st
                              bool death_drops = true );
 void clear_vehicles( map *target = nullptr );
 void build_test_map( const ter_id &terrain );
+void build_water_test_map( const ter_id &surface, const ter_id &mid, const ter_id &bottom );
 void player_add_headlamp();
 void player_wear_blindfold();
 void set_time_to_day();

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -116,6 +116,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
 
     // Make sure we don't carry around weird effects.
     dummy.clear_effects();
+    dummy.set_underwater( false );
 
     // Make stats nominal.
     dummy.str_max = 8;

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -14,6 +14,7 @@
 #include "item.h"
 #include "itype.h"
 #include "map.h"
+#include "map_helpers.h"
 #include "map_selector.h"
 #include "pimpl.h"
 #include "player_helpers.h"
@@ -60,6 +61,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
     Character &p = get_player_character();
     p.worn.wear_item( p, item( "backpack" ), false, false );
     p.wear_item( item( "backpack" ) ); // so we don't drop anything
+    clear_map();
     map &here = get_map();
 
     // check if all tiles within radius are loaded within current submap and passable

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -1,0 +1,136 @@
+#include <memory>
+
+#include "avatar.h"
+#include "cata_catch.h"
+#include "creature.h"
+#include "game.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "player_helpers.h"
+#include "type_id.h"
+
+TEST_CASE( "avatar diving", "[diving]" )
+{
+    const ter_id t_water_dp( "t_water_dp" );
+    const ter_id t_water_cube( "t_water_cube" );
+    const ter_id t_lake_bed( "t_lake_bed" );
+
+    build_water_test_map( t_water_dp, t_water_cube, t_lake_bed );
+    map &here = get_map();
+
+    clear_avatar();
+    Character &dummy = get_player_character();
+    const tripoint test_origin( 60, 60, 0 );
+
+    REQUIRE( here.ter( test_origin ) == t_water_dp );
+    REQUIRE( here.ter( test_origin + tripoint_below ) == t_water_cube );
+    REQUIRE( here.ter( test_origin + tripoint( 0, 0, -2 ) ) == t_lake_bed );
+
+    GIVEN( "avatar is above water at z0" ) {
+        dummy.set_underwater( false );
+        dummy.setpos( test_origin );
+        g->vertical_shift( 0 );
+
+        WHEN( "avatar dives down" ) {
+            g->vertical_move( -1, false );
+
+            THEN( "avatar is underwater at z0" ) {
+                REQUIRE( dummy.pos() == test_origin );
+                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_water_dp" ) );
+                REQUIRE( dummy.is_underwater() );
+            }
+        }
+
+        WHEN( "avatar swims up" ) {
+            g->vertical_move( 1, false );
+
+            THEN( "avatar is not underwater at z0" ) {
+                REQUIRE( dummy.pos() == test_origin );
+                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_water_dp" ) );
+                REQUIRE( !dummy.is_underwater() );
+            }
+        }
+    }
+
+    GIVEN( "avatar is underwater at z0" ) {
+        dummy.set_underwater( true );
+        dummy.setpos( test_origin );
+        g->vertical_shift( 0 );
+
+        WHEN( "avatar dives down" ) {
+            g->vertical_move( -1, false );
+
+            THEN( "avatar is underwater at z-1" ) {
+                REQUIRE( dummy.pos() == test_origin + tripoint_below );
+                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_water_cube" ) );
+                REQUIRE( dummy.is_underwater() );
+            }
+        }
+
+        WHEN( "avatar swims up" ) {
+            g->vertical_move( 1, false );
+
+            THEN( "avatar is not underwater at z0" ) {
+                REQUIRE( dummy.pos() == test_origin );
+                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_water_dp" ) );
+                REQUIRE( !dummy.is_underwater() );
+            }
+        }
+    }
+
+    GIVEN( "avatar is underwater at z-1" ) {
+        dummy.set_underwater( true );
+        dummy.setpos( test_origin + tripoint_below );
+        g->vertical_shift( -1 );
+
+        WHEN( "avatar dives down" ) {
+            g->vertical_move( -1, false );
+
+            THEN( "avatar is underwater at z-2" ) {
+                REQUIRE( dummy.pos() == test_origin + tripoint( 0, 0, -2 ) );
+                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_lake_bed" ) );
+                REQUIRE( dummy.is_underwater() );
+            }
+        }
+
+        WHEN( "avatar swims up" ) {
+            g->vertical_move( 1, false );
+
+            THEN( "avatar is underwater at z0" ) {
+                REQUIRE( dummy.pos() == test_origin );
+                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_water_dp" ) );
+                REQUIRE( dummy.is_underwater() );
+            }
+        }
+    }
+
+    GIVEN( "avatar is underwater at z-2" ) {
+        dummy.set_underwater( true );
+        dummy.setpos( test_origin + tripoint( 0, 0, -2 ) );
+        g->vertical_shift( -2 );
+
+        WHEN( "avatar dives down" ) {
+            g->vertical_move( -1, false );
+
+            THEN( "avatar is underwater at z-2" ) {
+                REQUIRE( dummy.pos() == test_origin + tripoint( 0, 0, -2 ) );
+                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_lake_bed" ) );
+                REQUIRE( dummy.is_underwater() );
+            }
+        }
+
+        WHEN( "avatar swims up" ) {
+            g->vertical_move( 1, false );
+
+            THEN( "avatar is underwater at z-1" ) {
+                REQUIRE( dummy.pos() == test_origin + tripoint_below );
+                REQUIRE( here.ter( dummy.pos() ) == ter_id( "t_water_cube" ) );
+                REQUIRE( dummy.is_underwater() );
+            }
+        }
+    }
+
+    // Put us back at 0. We shouldn't have to do this but other tests are
+    // making assumptions about what z-level they're on.
+    g->vertical_shift( 0 );
+}


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Allow the player to swim up and down in water.

#### Describe the solution

* Write new avatar movement tests for vertical movement in water.
* Add a new terrain flag that indicates the terrain is completely water such that the player could swim up out of the location.
* Update the avatar vertical movement code to handle both diving beneath the surface of water and moving up and down in the water column.

#### Describe alternatives you've considered

This set of changes could be so much bigger, but this is deliberately bite-sized.

When I added the z-levels to lakes in #39318, it was because the consensus at the time was that we had a bit of a chicken-and-egg problem where no one would work on underwater game code because there was no content, and no one would work on content because there was no game code. Since I created the lakes and knew mapgen well, it was easy to add z-levels to them to at least give the minimum content needed with a place to go so that someone could write some code... but it's been three years (almost to the day) and no one has tackled this.

There are endless things to still be addressed here: bugs this exposes, weird inconsistencies in how being "underwater" has worked up to this point, weird mapgen things, weird npc/monster things, missing items/vehicles/terrain/furniture, mechanics like buoyancy, and so on.

Much as I said in #39318, I don't really have the time to do all that. But I think this at least gets us closer.

#### Testing

Added the aforementioned tests, and also went diving in a lake.
