### PR TITLE
Ignore hostile_spotted_far while aiming, jsonify activity ignored distractions

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -610,7 +610,7 @@
     "verb": "aiming",
     "suspendable": false,
     "based_on": "neither",
-    "ignored_distractions": [ "hunger", "thirst", "hostile_spotted_near" ],
+    "ignored_distractions": [ "hunger", "thirst", "hostile_spotted_near", "hostile_spotted_far" ],
     "no_resume": true
   },
   {

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -610,6 +610,7 @@
     "verb": "aiming",
     "suspendable": false,
     "based_on": "neither",
+    "ignored_distractions": [ "hunger", "thirst", "hostile_spotted_near" ],
     "no_resume": true
   },
   {
@@ -919,6 +920,7 @@
     "suspendable": false,
     "rooted": true,
     "based_on": "neither",
+    "ignored_distractions": [ "hunger", "thirst" ],
     "no_resume": true
   },
   {
@@ -939,6 +941,7 @@
     "suspendable": false,
     "rooted": true,
     "based_on": "neither",
+    "ignored_distractions": [ "hunger", "thirst" ],
     "no_resume": true
   },
   {
@@ -979,6 +982,7 @@
     "verb": "drinking",
     "suspendable": false,
     "based_on": "neither",
+    "ignored_distractions": [ "hunger", "thirst" ],
     "no_resume": true
   },
   {
@@ -988,6 +992,7 @@
     "verb": "using drugs",
     "suspendable": false,
     "based_on": "neither",
+    "ignored_distractions": [ "hunger", "thirst" ],
     "no_resume": true
   },
   {
@@ -1021,6 +1026,7 @@
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "consuming",
+    "ignored_distractions": [ "hunger", "thirst" ],
     "based_on": "time"
   },
   {

--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -40,6 +40,36 @@ static const std::unordered_map< std::string, based_on_type > based_on_type_valu
     { "neither", based_on_type::NEITHER }
 };
 
+namespace io
+{
+template<>
+std::string enum_to_string<distraction_type>( distraction_type data )
+{
+    switch( data ) {
+        // *INDENT-OFF*
+        case distraction_type::noise: return "noise";
+        case distraction_type::pain: return "pain";
+        case distraction_type::attacked: return "attacked";
+        case distraction_type::hostile_spotted_far: return "hostile_spotted_far";
+        case distraction_type::hostile_spotted_near: return "hostile_spotted_near";
+        case distraction_type::talked_to: return "talked_to";
+        case distraction_type::asthma: return "asthma";
+        case distraction_type::motion_alarm: return "motion_alarm";
+        case distraction_type::weather_change: return "weather_change";
+        case distraction_type::portal_storm_popup: return "portal_storm_popup";
+        case distraction_type::eoc: return "eoc";
+        case distraction_type::dangerous_field: return "dangerous_field";
+        case distraction_type::hunger: return "hunger";
+        case distraction_type::thirst: return "thirst";
+        case distraction_type::temperature: return "temperature";
+        case distraction_type::mutation: return "mutation";
+        // *INDENT-ON*
+        default:
+            cata_fatal( "Invalid distraction_type in enum_to_string" );
+    }
+}
+}  // namespace io
+
 void activity_type::load( const JsonObject &jo )
 {
     activity_type result;
@@ -56,6 +86,7 @@ void activity_type::load( const JsonObject &jo )
     assign( jo, "auto_needs", result.auto_needs, false );
     optional( jo, false, "completion_eoc", result.completion_EOC );
     optional( jo, false, "do_turn_eoc", result.do_turn_EOC );
+    optional( jo, false, "ignored_distractions", result.default_ignored_distractions_ );
 
     std::string activity_level = jo.get_string( "activity_level", "" );
     if( activity_level.empty() ) {

--- a/src/activity_type.h
+++ b/src/activity_type.h
@@ -23,7 +23,13 @@ const activity_type &string_id<activity_type>::obj() const;
 enum class based_on_type : int {
     TIME = 0,
     SPEED,
-    NEITHER
+    NEITHER,
+    last,
+};
+
+template<>
+struct enum_traits<based_on_type> {
+    static constexpr based_on_type last = based_on_type::last;
 };
 
 /** A class that stores constant information that doesn't differ between activities of the same type */

--- a/src/activity_type.h
+++ b/src/activity_type.h
@@ -42,12 +42,16 @@ class activity_type
         bool refuel_fires = false;
         bool auto_needs = false;
         float activity_level = NO_EXERCISE;
+        std::set<distraction_type> default_ignored_distractions_;
     public:
         effect_on_condition_id completion_EOC;
         effect_on_condition_id do_turn_EOC;
 
         const activity_id &id() const {
             return id_;
+        }
+        const std::set<distraction_type> &default_ignored_distractions() const {
+            return default_ignored_distractions_;
         }
         bool rooted() const {
             return rooted_;

--- a/src/enums.h
+++ b/src/enums.h
@@ -331,7 +331,13 @@ enum class distraction_type : int {
     hunger,
     thirst,
     temperature,
-    mutation
+    mutation,
+    last,
+};
+
+template<>
+struct enum_traits<distraction_type> {
+    static constexpr distraction_type last = distraction_type::last;
 };
 
 enum game_message_type : int {

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -35,29 +35,20 @@ static const activity_id ACT_CHOP_LOGS( "ACT_CHOP_LOGS" );
 static const activity_id ACT_CHOP_PLANKS( "ACT_CHOP_PLANKS" );
 static const activity_id ACT_CHOP_TREE( "ACT_CHOP_TREE" );
 static const activity_id ACT_CLEAR_RUBBLE( "ACT_CLEAR_RUBBLE" );
-static const activity_id ACT_CONSUME( "ACT_CONSUME" );
 static const activity_id ACT_CONSUME_DRINK_MENU( "ACT_CONSUME_DRINK_MENU" );
 static const activity_id ACT_CONSUME_FOOD_MENU( "ACT_CONSUME_FOOD_MENU" );
 static const activity_id ACT_CONSUME_MEDS_MENU( "ACT_CONSUME_MEDS_MENU" );
 static const activity_id ACT_EAT_MENU( "ACT_EAT_MENU" );
-static const activity_id ACT_FIRSTAID( "ACT_FIRSTAID" );
-static const activity_id ACT_FISH( "ACT_FISH" );
-static const activity_id ACT_GAME( "ACT_GAME" );
-static const activity_id ACT_GUNMOD_ADD( "ACT_GUNMOD_ADD" );
 static const activity_id ACT_HACKSAW( "ACT_HACKSAW" );
-static const activity_id ACT_HAND_CRANK( "ACT_HAND_CRANK" );
 static const activity_id ACT_HEATING( "ACT_HEATING" );
 static const activity_id ACT_JACKHAMMER( "ACT_JACKHAMMER" );
 static const activity_id ACT_MIGRATION_CANCEL( "ACT_MIGRATION_CANCEL" );
 static const activity_id ACT_NULL( "ACT_NULL" );
-static const activity_id ACT_OXYTORCH( "ACT_OXYTORCH" );
 static const activity_id ACT_PICKAXE( "ACT_PICKAXE" );
 static const activity_id ACT_PICKUP_MENU( "ACT_PICKUP_MENU" );
 static const activity_id ACT_READ( "ACT_READ" );
-static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
-static const activity_id ACT_VIBE( "ACT_VIBE" );
 static const activity_id ACT_VIEW_RECIPE( "ACT_VIEW_RECIPE" );
 static const activity_id ACT_WAIT_STAMINA( "ACT_WAIT_STAMINA" );
 static const activity_id ACT_WORKOUT_ACTIVE( "ACT_WORKOUT_ACTIVE" );
@@ -90,24 +81,6 @@ player_activity::player_activity( const activity_actor &actor ) : type( actor.ge
         for( const distraction_type dt : type->default_ignored_distractions() ) {
             ignored_distractions.emplace( dt );
         }
-    }
-}
-
-void player_activity::migrate_item_position( Character &guy )
-{
-    const bool simple_action_replace =
-        type == ACT_FIRSTAID || type == ACT_GAME ||
-        type == ACT_PICKAXE || type == ACT_START_FIRE ||
-        type == ACT_HAND_CRANK || type == ACT_VIBE ||
-        type == ACT_OXYTORCH || type == ACT_FISH ||
-        type == ACT_ATM;
-
-    if( simple_action_replace ) {
-        targets.emplace_back( guy, &guy.i_at( position ) );
-    } else if( type == ACT_GUNMOD_ADD ) {
-        // this activity has two indices; "position" = gun and "values[0]" = mod
-        targets.emplace_back( guy, &guy.i_at( position ) );
-        targets.emplace_back( guy, &guy.i_at( values[0] ) );
     }
 }
 

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -140,9 +140,6 @@ class player_activity
 
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &data );
-        // used to migrate the item indices to item_location
-        // obsolete after 0.F stable
-        void migrate_item_position( Character &guy );
         /** Convert from the old enumeration to the new string_id */
         void deserialize_legacy_type( int legacy_type, activity_id &dest );
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -999,14 +999,6 @@ void Character::load( const JsonObject &data )
     if( data.has_member( "inv" ) ) {
         inv->json_load_items( data.get_member( "inv" ) );
     }
-    // this is after inventory is loaded to make it more obvious that
-    // it needs to be changed again when Character::i_at is removed for nested containers
-    if( savegame_loading_version < 28 ) {
-        activity.migrate_item_position( *this );
-        destination_activity.migrate_item_position( *this );
-        stashed_outbounds_activity.migrate_item_position( *this );
-        stashed_outbounds_backlog.migrate_item_position( *this );
-    }
 
     set_wielded_item( item() );
     data.read( "weapon", weapon );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Hostiles coming into view at edge of vision while you're aiming is one of the most annoying distractions while aiming, this fixes it.

#### Describe the solution

`hostile_spotted_near` was hardcoded to be ignored while aiming
hunger/thirst were hardcoded to be ignored for consumption activities

This PR moves the hardcoded ids into json, these get copied into player_activity::ignored_distractions in player_activity constructor so a specific activity can manage them "live" if needed

https://github.com/CleverRaven/Cataclysm-DDA/commit/09b69bbcfdde0910e0bed72ec5e4a37f24e1296f does some janitor work making enum use the io:: converters and removes a stale 0.F migration

#### Describe alternatives you've considered

#### Testing

Have a gunfight in city and spam `.` or use `p`/`c`/other long aiming activity, zombies coming for dinner will not pop the distraction manager as they come into view.

#### Additional context
