### PR TITLE
Lots of string view

### DIFF
--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -424,7 +424,7 @@ void achievement::reset()
     achievement_factory.reset();
 }
 
-void achievement::load( const JsonObject &jo, const std::string & )
+void achievement::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
     is_conduct_ = jo.get_string( "type" ) == "conduct";

--- a/src/achievement.h
+++ b/src/achievement.h
@@ -60,7 +60,7 @@ class achievement
     public:
         achievement() = default;
 
-        void load( const JsonObject &, const std::string & );
+        void load( const JsonObject &, std::string_view );
         void check() const;
         static void load_achievement( const JsonObject &, const std::string & );
         static void finalize();

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -345,7 +345,7 @@ bool addiction::run_effect( Character &u )
     return ret;
 }
 
-void add_type::load( const JsonObject &jo, const std::string & )
+void add_type::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
     mandatory( jo, was_loaded, "type_name", _type_name );

--- a/src/addiction.h
+++ b/src/addiction.h
@@ -27,7 +27,7 @@ struct add_type {
         static void load_add_types( const JsonObject &jo, const std::string &src );
         static void reset();
         static void check_add_types();
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         static const std::vector<add_type> &get_all();
 
         const translation &get_name() const {

--- a/src/ammo_effect.cpp
+++ b/src/ammo_effect.cpp
@@ -60,7 +60,7 @@ int_id<ammo_effect>::int_id( const string_id<ammo_effect> &id ) : _id( id.id() )
 {
 }
 
-void ammo_effect::load( const JsonObject &jo, const std::string & )
+void ammo_effect::load( const JsonObject &jo, const std::string_view )
 {
     optional( jo, was_loaded, "trigger_chance", trigger_chance, 1 );
 

--- a/src/ammo_effect.h
+++ b/src/ammo_effect.h
@@ -17,7 +17,7 @@ generic_factory<ammo_effect> &get_all_ammo_effects();
 
 struct ammo_effect {
     public:
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void finalize();
         void check() const;
 

--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -54,7 +54,7 @@ void anatomy::load_anatomy( const JsonObject &jo, const std::string &src )
     anatomy_factory.load( jo, src );
 }
 
-void anatomy::load( const JsonObject &jo, const std::string & )
+void anatomy::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "parts", unloaded_bps );

--- a/src/anatomy.h
+++ b/src/anatomy.h
@@ -58,7 +58,7 @@ class anatomy
         void add_body_part( const bodypart_str_id &new_bp );
         // TODO: remove_body_part
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void finalize();
         void check() const;
 

--- a/src/ascii_art.cpp
+++ b/src/ascii_art.cpp
@@ -34,7 +34,7 @@ void ascii_art::load_ascii_art( const JsonObject &jo, const std::string &src )
     ascii_art_factory.load( jo, src );
 }
 
-void ascii_art::load( const JsonObject &jo, const std::string & )
+void ascii_art::load( const JsonObject &jo, const std::string_view )
 {
     assign( jo, "id", id );
 

--- a/src/ascii_art.h
+++ b/src/ascii_art.h
@@ -15,7 +15,7 @@ class ascii_art
         static void load_ascii_art( const JsonObject &jo, const std::string &src );
         static void reset();
 
-        void load( const JsonObject &jo, const std::string & );
+        void load( const JsonObject &jo, std::string_view );
         bool was_loaded = false;
 
         ascii_art_id id;

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -623,7 +623,7 @@ static void check_assigned_dmg( const JsonObject &err, const std::string_view na
     }
 }
 
-bool assign( const JsonObject &jo, const std::string &name, damage_instance &val, bool strict,
+bool assign( const JsonObject &jo, const std::string_view name, damage_instance &val, bool strict,
              const damage_instance &lo, const damage_instance &hi )
 {
     // What we'll eventually be returning for the damage instance

--- a/src/assign.h
+++ b/src/assign.h
@@ -326,7 +326,7 @@ inline bool assign( const JsonObject &jo, const std::string_view name, std::opti
 constexpr float float_max = std::numeric_limits<float>::max();
 
 bool assign(
-    const JsonObject &jo, const std::string &name, damage_instance &val, bool strict = false,
+    const JsonObject &jo, std::string_view name, damage_instance &val, bool strict = false,
     const damage_instance &lo = damage_instance( damage_type::NONE, 0.0f, 0.0f, 0.0f, 0.0f ),
     const damage_instance &hi = damage_instance(
                                     damage_type::NONE, float_max, float_max, float_max, float_max ) );

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -38,7 +38,7 @@ using namespace auto_pickup;
 static const ammotype ammo_battery( "battery" );
 
 static bool check_special_rule( const std::map<material_id, int> &materials,
-                                const std::string &rule );
+                                std::string_view rule );
 
 auto_pickup::player_settings &get_auto_pickup()
 {
@@ -772,7 +772,7 @@ bool player_settings::empty() const
     return global_rules.empty() && character_rules.empty();
 }
 
-bool check_special_rule( const std::map<material_id, int> &materials, const std::string &rule )
+bool check_special_rule( const std::map<material_id, int> &materials, const std::string_view rule )
 {
     char type = ' ';
     std::vector<std::string> filter;
@@ -788,7 +788,7 @@ bool check_special_rule( const std::map<material_id, int> &materials, const std:
     if( type == 'm' ) {
         return std::any_of( materials.begin(),
         materials.end(), [&filter]( const std::pair<material_id, int> &mat ) {
-            return std::any_of( filter.begin(), filter.end(), [&mat]( const std::string & search ) {
+            return std::any_of( filter.begin(), filter.end(), [&mat]( const std::string_view search ) {
                 return lcmatch( mat.first->name(), search );
             } );
         } );
@@ -796,7 +796,7 @@ bool check_special_rule( const std::map<material_id, int> &materials, const std:
     } else if( type == 'M' ) {
         return std::all_of( materials.begin(),
         materials.end(), [&filter]( const std::pair<material_id, int> &mat ) {
-            return std::any_of( filter.begin(), filter.end(), [&mat]( const std::string & search ) {
+            return std::any_of( filter.begin(), filter.end(), [&mat]( const std::string_view search ) {
                 return lcmatch( mat.first->name(), search );
             } );
         } );

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -75,14 +75,14 @@ std::string base_camps::faction_encode_abs( const expansion_data &e, int number 
     return faction_encode_short( e.type ) + std::to_string( number );
 }
 
-std::string base_camps::faction_decode( const std::string &full_type )
+std::string base_camps::faction_decode( const std::string_view full_type )
 {
     if( full_type.size() < ( prefix_len + 2 ) ) {
         return "camp";
     }
     int last_bar = full_type.find_last_of( '_' );
 
-    return full_type.substr( prefix_len, size_t( last_bar - prefix_len ) );
+    return std::string{ full_type.substr( prefix_len, size_t( last_bar - prefix_len ) ) };
 }
 
 time_duration base_camps::to_workdays( const time_duration &work_time )
@@ -139,13 +139,13 @@ void basecamp::set_by_radio( bool access_by_radio )
 // find the last underbar, strip off the prefix of faction_base_ (which is 13 chars),
 // and the pull out the $TYPE and $CURLEVEL
 // This is legacy support for existing camps; future camps don't use cur_level at all
-expansion_data basecamp::parse_expansion( const std::string &terrain,
+expansion_data basecamp::parse_expansion( const std::string_view terrain,
         const tripoint_abs_omt &new_pos )
 {
     expansion_data e;
     size_t last_bar = terrain.find_last_of( '_' );
     e.type = terrain.substr( base_camps::prefix_len, last_bar - base_camps::prefix_len );
-    e.cur_level = std::stoi( "0" + terrain.substr( last_bar + 1 ) );
+    e.cur_level = std::stoi( str_cat( "0", terrain.substr( last_bar + 1 ) ) );
     e.pos = new_pos;
     return e;
 }
@@ -176,7 +176,7 @@ void basecamp::add_expansion( const std::string &bldg, const tripoint_abs_omt &n
     update_resources( bldg );
 }
 
-void basecamp::define_camp( const tripoint_abs_omt &p, const std::string &camp_type )
+void basecamp::define_camp( const tripoint_abs_omt &p, const std::string_view camp_type )
 {
     query_new_name( true );
     omt_pos = p;

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -91,7 +91,7 @@ const std::string id = "FACTION_CAMP";
 const int prefix_len = 13;
 std::string faction_encode_short( const std::string &type );
 std::string faction_encode_abs( const expansion_data &e, int number );
-std::string faction_decode( const std::string &full_type );
+std::string faction_decode( std::string_view full_type );
 time_duration to_workdays( const time_duration &work_time );
 int max_upgrade_by_type( const std::string &type );
 } // namespace base_camps
@@ -182,7 +182,7 @@ class basecamp
         void add_expansion( const std::string &terrain, const tripoint_abs_omt &new_pos );
         void add_expansion( const std::string &bldg, const tripoint_abs_omt &new_pos,
                             const point &dir );
-        void define_camp( const tripoint_abs_omt &p, const std::string &camp_type = "default" );
+        void define_camp( const tripoint_abs_omt &p, std::string_view camp_type );
 
         std::string expansion_tab( const point &dir ) const;
         // check whether the point is the part of camp
@@ -207,7 +207,7 @@ class basecamp
         // confirm there is at least 1 loot destination and 1 unsorted loot zone in the camp
         bool validate_sort_points();
         // Validates the expansion data
-        expansion_data parse_expansion( const std::string &terrain,
+        expansion_data parse_expansion( std::string_view terrain,
                                         const tripoint_abs_omt &new_pos );
         /**
          * Invokes the zone manager and validates that the necessary sort zones exist.

--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -131,7 +131,7 @@ void behavior::load_behavior( const JsonObject &jo, const std::string &src )
     behavior_factory.load( jo, src );
 }
 
-void node_t::load( const JsonObject &jo, const std::string & )
+void node_t::load( const JsonObject &jo, const std::string_view )
 {
     // We don't initialize the node unless it has no children (opportunistic optimization).
     // Instead we initialize a parallel struct that holds the labels until finalization.

--- a/src/behavior.h
+++ b/src/behavior.h
@@ -71,7 +71,7 @@ class node_t
         void add_child( const node_t *new_child );
 
         // Loading interface.
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void check() const;
         string_id<node_t> id;
         std::vector<std::pair<string_id<node_t>, mod_id>> src;

--- a/src/behavior_oracle.cpp
+++ b/src/behavior_oracle.cpp
@@ -17,19 +17,19 @@ status_t return_running( const oracle_t *, const std::string_view )
 }
 
 // Just a little helper to make populating predicate_map slightly less gross.
-static std::function < status_t( const oracle_t *, const std::string & ) >
-make_function( status_t ( character_oracle_t::* fun )( const std::string & ) const )
+static std::function < status_t( const oracle_t *, std::string_view ) >
+make_function( status_t ( character_oracle_t::* fun )( std::string_view ) const )
 {
-    return static_cast<status_t ( oracle_t::* )( const std::string & ) const>( fun );
+    return static_cast<status_t ( oracle_t::* )( const std::string_view ) const>( fun );
 }
 
-static std::function < status_t( const oracle_t *, const std::string & ) >
-make_function( status_t ( monster_oracle_t::* fun )( const std::string & ) const )
+static std::function < status_t( const oracle_t *, std::string_view ) >
+make_function( status_t ( monster_oracle_t::* fun )( std::string_view ) const )
 {
-    return static_cast<status_t ( oracle_t::* )( const std::string & ) const>( fun );
+    return static_cast<status_t ( oracle_t::* )( std::string_view ) const>( fun );
 }
 
-std::unordered_map<std::string, std::function<status_t( const oracle_t *, const std::string & ) >>
+std::unordered_map<std::string, std::function<status_t( const oracle_t *, std::string_view ) >>
 predicate_map = {{
         { "npc_needs_warmth_badly", make_function( &character_oracle_t::needs_warmth_badly ) },
         { "npc_needs_water_badly", make_function( &character_oracle_t::needs_water_badly ) },

--- a/src/behavior_oracle.h
+++ b/src/behavior_oracle.h
@@ -24,7 +24,7 @@ class oracle_t
 
 status_t return_running( const oracle_t *, std::string_view );
 
-extern std::unordered_map<std::string, std::function<status_t( const oracle_t *, const std::string & )>>
+extern std::unordered_map<std::string, std::function<status_t( const oracle_t *, std::string_view )>>
         predicate_map;
 
 } // namespace behavior

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -481,7 +481,7 @@ void bionic_data::load_bionic( const JsonObject &jo, const std::string &src )
 
 std::map<bionic_id, bionic_id> bionic_data::migrations;
 
-void bionic_data::load_bionic_migration( const JsonObject &jo, const std::string & )
+void bionic_data::load_bionic_migration( const JsonObject &jo, const std::string_view )
 {
     const bionic_id from( jo.get_string( "from" ) );
     const bionic_id to = jo.has_string( "to" )

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -190,7 +190,7 @@ struct bionic_data {
     static void check_bionic_consistency();
 
     static std::map<bionic_id, bionic_id> migrations;
-    static void load_bionic_migration( const JsonObject &jo, const std::string & );
+    static void load_bionic_migration( const JsonObject &jo, std::string_view );
 };
 
 struct bionic {

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -60,7 +60,7 @@ void bodygraph::check_all()
     bodygraph_factory.check();
 }
 
-void bodygraph::load( const JsonObject &jo, const std::string & )
+void bodygraph::load( const JsonObject &jo, const std::string_view )
 {
     optional( jo, was_loaded, "parent_bodypart", parent_bp );
     optional( jo, was_loaded, "fill_sym", fill_sym );

--- a/src/bodygraph.h
+++ b/src/bodygraph.h
@@ -58,7 +58,7 @@ struct bodygraph {
     static void check_all();
     static void reset();
     static const std::vector<bodygraph> &get_all();
-    void load( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view src );
     void finalize();
     void check() const;
 };

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -154,7 +154,7 @@ const std::vector<limb_score> &limb_score::get_all()
     return limb_score_factory.get_all();
 }
 
-void limb_score::load( const JsonObject &jo, const std::string & )
+void limb_score::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name", _name );
@@ -281,7 +281,7 @@ const std::vector<body_part_type> &body_part_type::get_all()
     return body_part_factory.get_all();
 }
 
-void body_part_type::load( const JsonObject &jo, const std::string & )
+void body_part_type::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
 

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -109,7 +109,7 @@ struct limb_score {
     public:
         static void load_limb_scores( const JsonObject &jo, const std::string &src );
         static void reset();
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         static const std::vector<limb_score> &get_all();
 
         const limb_score_id &getId() const {
@@ -335,7 +335,7 @@ struct body_part_type {
         // if secondary is true instead returns a part from only the secondary sublocations
         sub_bodypart_id random_sub_part( bool secondary ) const;
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void finalize();
         void check() const;
 

--- a/src/butchery_requirements.cpp
+++ b/src/butchery_requirements.cpp
@@ -52,7 +52,7 @@ bool butchery_requirements::is_valid() const
     return butchery_req_factory.is_valid( this->id );
 }
 
-void butchery_requirements::load( const JsonObject &jo, const std::string & )
+void butchery_requirements::load( const JsonObject &jo, const std::string_view )
 {
     for( const JsonMember member : jo.get_object( "requirements" ) ) {
         float modifier = std::stof( member.name() );

--- a/src/butchery_requirements.h
+++ b/src/butchery_requirements.h
@@ -33,7 +33,7 @@ class butchery_requirements
             const read_only_visitable &crafting_inv, creature_size size, butcher_type butcher ) const;
 
         static void load_butchery_req( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, const std::string & );
+        void load( const JsonObject &jo, std::string_view );
         static const std::vector<butchery_requirements> &get_all();
         static void check_consistency();
         static void reset();

--- a/src/cata_io.h
+++ b/src/cata_io.h
@@ -164,7 +164,7 @@ struct has_archive_tag<T, typename enable_if_type<typename T::archive_type_tag>:
         typename T::archive_type_tag::OutputArchive archive( stream );
         const_cast<T &>( value ).io( archive );
     }
-    static bool read( const JsonObject &obj, const std::string &key, T &value ) {
+    static bool read( const JsonObject &obj, const std::string_view key, T &value ) {
         if( !obj.has_member( key ) ) {
             return false;
         }
@@ -200,7 +200,7 @@ class JsonObjectInputArchive : public JsonObject
         /** Create archive from next object in the given Json array. */
         explicit JsonObjectInputArchive( JsonArray & );
         /** Create archive from named member object in the given Json object. */
-        JsonObjectInputArchive( const JsonObject &, const std::string &key );
+        JsonObjectInputArchive( const JsonObject &, std::string_view key );
 
         /**
          * @name Deserialization
@@ -348,7 +348,7 @@ class JsonArrayInputArchive : public JsonArray
         /** Create archive from next object in the giexplicit ven Json array. */
         explicit JsonArrayInputArchive( JsonArray & );
         /** Create archive from named member object in the given Json object. */
-        JsonArrayInputArchive( const JsonObject &, const std::string &key );
+        JsonArrayInputArchive( const JsonObject &, std::string_view key );
 
         template<typename T>
         bool io( T &value ) {
@@ -358,13 +358,14 @@ class JsonArrayInputArchive : public JsonArray
 
 inline JsonArrayInputArchive::JsonArrayInputArchive( JsonArray &arr )
     : JsonArray( arr.next_array() ) { }
-inline JsonArrayInputArchive::JsonArrayInputArchive( const JsonObject &obj, const std::string &key )
+inline JsonArrayInputArchive::JsonArrayInputArchive( const JsonObject &obj,
+        const std::string_view key )
     : JsonArray( obj.get_array( key ) ) { }
 
 inline JsonObjectInputArchive::JsonObjectInputArchive( JsonArray &arr )
     : JsonObject( arr.next_object() ) { }
 inline JsonObjectInputArchive::JsonObjectInputArchive( const JsonObject &obj,
-        const std::string &key )
+        const std::string_view key )
     : JsonObject( obj.get_object( key ) ) { }
 
 /**
@@ -476,7 +477,7 @@ class JsonObjectOutputArchive
          * and always return false.
          */
         template<typename T>
-        bool read( const std::string &, T & ) {
+        bool read( const std::string_view, T & ) {
             return false;
         }
 };

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1141,7 +1141,7 @@ tile_type &tileset_cache::loader::load_tile( const JsonObject &entry, const std:
 
 void tileset_cache::loader::load_tile_spritelists( const JsonObject &entry,
         weighted_int_list<std::vector<int>> &vs,
-        const std::string &objname ) const
+        const std::string_view objname ) const
 {
     // json array indicates rotations or variations
     if( entry.has_array( objname ) ) {
@@ -1857,7 +1857,7 @@ cata_tiles::find_tile_with_season( const std::string &id ) const
 
 template<typename T>
 std::optional<tile_lookup_res>
-cata_tiles::find_tile_looks_like_by_string_id( const std::string &id, TILE_CATEGORY category,
+cata_tiles::find_tile_looks_like_by_string_id( const std::string_view id, TILE_CATEGORY category,
         const int looks_like_jumps_limit ) const
 {
     const string_id<T> s_id( id );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -296,7 +296,7 @@ class tileset_cache::loader
         tile_type &load_tile( const JsonObject &entry, const std::string &id );
 
         void load_tile_spritelists( const JsonObject &entry, weighted_int_list<std::vector<int>> &vs,
-                                    const std::string &objname ) const;
+                                    std::string_view objname ) const;
 
         void load_ascii( const JsonObject &config );
         /** Load tileset, R,G,B, are the color components of the transparent color
@@ -417,7 +417,7 @@ class cata_tiles
         // this templated method is used only from it's own cpp file, so it's ok to declare it here
         template<typename T>
         std::optional<tile_lookup_res>
-        find_tile_looks_like_by_string_id( const std::string &id, TILE_CATEGORY category,
+        find_tile_looks_like_by_string_id( std::string_view id, TILE_CATEGORY category,
                                            int looks_like_jumps_limit ) const;
 
         bool find_overlay_looks_like( bool male, const std::string &overlay, const std::string &variant,

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -109,8 +109,8 @@ bool isBetween( int test, int down, int up );
  * @return true if the query string is found at least once within the subject
  *         string, otherwise returns false
  */
-bool lcmatch( const std::string &str, const std::string &qry );
-bool lcmatch( const translation &str, const std::string &qry );
+bool lcmatch( std::string_view str, std::string_view qry );
+bool lcmatch( const translation &str, std::string_view qry );
 
 /**
  * Matches text case insensitive with the include/exclude rules of the filter
@@ -125,7 +125,7 @@ bool lcmatch( const translation &str, const std::string &qry );
  *
  * @return true if include/exclude rules pass. See Example.
  */
-bool match_include_exclude( const std::string &text, std::string filter );
+bool match_include_exclude( std::string_view text, std::string filter );
 
 /**
  * Basic logistic function.
@@ -444,6 +444,11 @@ bool string_empty_or_whitespace( const std::string &s );
 /** strcmp, but for string_view objects.  In C++20 this can be replaced with
  * operator<=> */
 int string_view_cmp( std::string_view, std::string_view );
+
+template<typename Integer>
+Integer svto( std::string_view );
+
+extern template int svto<int>( std::string_view );
 
 /** Used as a default filter in various functions */
 template<typename T>

--- a/src/cata_variant.h
+++ b/src/cata_variant.h
@@ -133,7 +133,7 @@ struct convert_string {
     static T from_string( const std::string &v ) {
         return v;
     }
-    static bool is_valid( const std::string & ) {
+    static bool is_valid( const std::string_view ) {
         return true;
     }
 };
@@ -194,7 +194,7 @@ static_assert( static_cast<int>( cata_variant_type::num_types ) == 47,
 template<>
 struct convert<cata_variant_type::void_> {
     using type = void;
-    static bool is_valid( const std::string &s ) {
+    static bool is_valid( const std::string_view s ) {
         return s.empty();
     }
 };
@@ -236,7 +236,7 @@ struct convert<cata_variant_type::character_id> {
     static character_id from_string( const std::string &v ) {
         return character_id( std::stoi( v ) );
     }
-    static bool is_valid( const std::string & ) {
+    static bool is_valid( const std::string_view ) {
         // TODO: check for int-ness
         return true;
     }
@@ -251,7 +251,7 @@ struct convert<cata_variant_type::chrono_seconds> {
     static std::chrono::seconds from_string( const std::string &v ) {
         return std::chrono::seconds( std::stoll( v ) );
     }
-    static bool is_valid( const std::string & ) {
+    static bool is_valid( const std::string_view ) {
         // TODO: check for int-ness
         return true;
     }
@@ -293,7 +293,7 @@ struct convert<cata_variant_type::int_> {
     static int from_string( const std::string &v ) {
         return std::stoi( v );
     }
-    static bool is_valid( const std::string & ) {
+    static bool is_valid( const std::string_view ) {
         // TODO: check for int-ness
         return true;
     }
@@ -348,7 +348,7 @@ struct convert<cata_variant_type::point> {
     static point from_string( const std::string &v ) {
         return point::from_string( v );
     }
-    static bool is_valid( const std::string & ) {
+    static bool is_valid( const std::string_view ) {
         // TODO: check for point-ness
         return true;
     }
@@ -397,7 +397,7 @@ struct convert<cata_variant_type::tripoint> {
     static tripoint from_string( const std::string &v ) {
         return tripoint::from_string( v );
     }
-    static bool is_valid( const std::string & ) {
+    static bool is_valid( const std::string_view ) {
         // TODO: check for tripoint-ness
         return true;
     }

--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -101,13 +101,13 @@ uint32_t UTF8_getch( const char **src, int *srclen )
 //Calculate width of a Unicode string
 //Latin characters have a width of 1
 //CJK characters have a width of 2, etc
-int utf8_width( const char *s, const bool ignore_tags )
+int utf8_width( const std::string_view s, const bool ignore_tags )
 {
     if( ignore_tags ) {
         return utf8_width( remove_color_tags( s ) );
     }
-    int len = strlen( s );
-    const char *ptr = s;
+    int len = s.size();
+    const char *ptr = s.data();
     int w = 0;
     while( len > 0 ) {
         uint32_t ch = UTF8_getch( &ptr, &len );
@@ -117,11 +117,6 @@ int utf8_width( const char *s, const bool ignore_tags )
         w += mk_wcwidth( ch );
     }
     return w;
-}
-
-int utf8_width( const std::string &str, const bool ignore_tags )
-{
-    return utf8_width( str.c_str(), ignore_tags );
 }
 
 int utf8_width( const utf8_wrapper &str, const bool ignore_tags )
@@ -390,17 +385,17 @@ std::string wstr_to_native( const std::wstring &wstr )
 #endif
 }
 
-std::string utf32_to_utf8( const std::u32string &str )
+std::string utf32_to_utf8( const std::u32string_view str )
 {
     std::string ret;
     ret.reserve( str.length() );
-    for( auto it = str.begin(); it < str.end(); ++it ) {
-        ret += utf32_to_utf8( *it );
+    for( const char32_t c : str ) {
+        ret += utf32_to_utf8( c );
     }
     return ret;
 }
 
-std::u32string utf8_to_utf32( const std::string &str )
+std::u32string utf8_to_utf32( const std::string_view str )
 {
     int len = str.length();
     const char *dat = str.data();

--- a/src/catacharset.h
+++ b/src/catacharset.h
@@ -25,8 +25,7 @@ inline uint32_t UTF8_getch( const std::string &str )
 }
 // convert cursorx value to byte position
 int cursorx_to_position( const char *line, int cursorx, int *prevpos = nullptr, int maxlen = -1 );
-int utf8_width( const char *s, bool ignore_tags = false );
-int utf8_width( const std::string &str, bool ignore_tags = false );
+int utf8_width( std::string_view str, bool ignore_tags = false );
 int utf8_width( const utf8_wrapper &str, bool ignore_tags = false );
 
 std::string left_justify( const std::string &str, int width, bool ignore_tags = false );
@@ -54,8 +53,8 @@ std::string wstr_to_utf8( const std::wstring &wstr );
 
 std::string wstr_to_native( const std::wstring &wstr );
 
-std::string utf32_to_utf8( const std::u32string &str );
-std::u32string utf8_to_utf32( const std::string &str );
+std::string utf32_to_utf8( std::u32string_view str );
+std::u32string utf8_to_utf32( std::string_view str );
 
 // Split the given string into displayed characters.  Each element of the returned vector
 // contains one 'regular' codepoint and all subsequent combining characters.

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -88,7 +88,7 @@ static float load_float_or_maxmovecost( const JsonObject &jo, const std::string 
     return val;
 }
 
-void character_modifier::load( const JsonObject &jo, const std::string & )
+void character_modifier::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "description", desc );

--- a/src/character_modifier.h
+++ b/src/character_modifier.h
@@ -19,7 +19,7 @@ struct character_modifier {
 
         static void load_character_modifiers( const JsonObject &jo, const std::string &src );
         static void reset();
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         static const std::vector<character_modifier> &get_all();
 
         // Use this to obtain the calculated modifier

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -19,7 +19,7 @@ namespace behavior
 // To avoid a local minima when the character has access to warmth in a shelter but gets cold
 // when they go outside, this method needs to only alert when travel time to known shelter
 // approaches time to freeze.
-status_t character_oracle_t::needs_warmth_badly( const std::string & ) const
+status_t character_oracle_t::needs_warmth_badly( const std::string_view ) const
 {
     // Use player::temp_conv to predict whether the Character is "in trouble".
     for( const bodypart_id &bp : subject->get_all_body_parts() ) {
@@ -30,7 +30,7 @@ status_t character_oracle_t::needs_warmth_badly( const std::string & ) const
     return status_t::success;
 }
 
-status_t character_oracle_t::needs_water_badly( const std::string & ) const
+status_t character_oracle_t::needs_water_badly( const std::string_view ) const
 {
     // Check thirst threshold.
     if( subject->get_thirst() > 520 ) {
@@ -39,7 +39,7 @@ status_t character_oracle_t::needs_water_badly( const std::string & ) const
     return status_t::success;
 }
 
-status_t character_oracle_t::needs_food_badly( const std::string & ) const
+status_t character_oracle_t::needs_food_badly( const std::string_view ) const
 {
     // Check hunger threshold.
     if( subject->get_hunger() >= 300 && subject->get_starvation() > 2500 ) {
@@ -48,7 +48,7 @@ status_t character_oracle_t::needs_food_badly( const std::string & ) const
     return status_t::success;
 }
 
-status_t character_oracle_t::can_wear_warmer_clothes( const std::string & ) const
+status_t character_oracle_t::can_wear_warmer_clothes( const std::string_view ) const
 {
     // Check inventory for wearable warmer clothes, greedily.
     // Don't consider swapping clothes yet, just evaluate adding clothes.
@@ -59,7 +59,7 @@ status_t character_oracle_t::can_wear_warmer_clothes( const std::string & ) cons
     return found_clothes ? status_t::running : status_t::failure;
 }
 
-status_t character_oracle_t::can_make_fire( const std::string & ) const
+status_t character_oracle_t::can_make_fire( const std::string_view ) const
 {
     // Check inventory for firemaking tools and fuel
     bool tool = false;
@@ -81,14 +81,14 @@ status_t character_oracle_t::can_make_fire( const std::string & ) const
     return found_fire_stuff ? status_t::running : status_t::success;
 }
 
-status_t character_oracle_t::can_take_shelter( const std::string & ) const
+status_t character_oracle_t::can_take_shelter( const std::string_view ) const
 {
     // There be no shelter here.
     // The frontline is everywhere.
     return status_t::failure;
 }
 
-status_t character_oracle_t::has_water( const std::string & ) const
+status_t character_oracle_t::has_water( const std::string_view ) const
 {
     // Check if we know about water somewhere
     bool found_water = subject->has_item_with( []( const item & cand ) {
@@ -97,7 +97,7 @@ status_t character_oracle_t::has_water( const std::string & ) const
     return found_water ? status_t::running : status_t::failure;
 }
 
-status_t character_oracle_t::has_food( const std::string & ) const
+status_t character_oracle_t::has_food( const std::string_view ) const
 {
     // Check if we know about food somewhere
     bool found_food = subject->has_item_with( []( const item & cand ) {

--- a/src/character_oracle.h
+++ b/src/character_oracle.h
@@ -21,14 +21,14 @@ class character_oracle_t : public oracle_t
         /**
          * Predicates used by AI to determine goals.
          */
-        status_t needs_warmth_badly( const std::string & ) const;
-        status_t needs_water_badly( const std::string & ) const;
-        status_t needs_food_badly( const std::string & ) const;
-        status_t can_wear_warmer_clothes( const std::string & ) const;
-        status_t can_make_fire( const std::string & ) const;
-        status_t can_take_shelter( const std::string & ) const;
-        status_t has_water( const std::string & ) const;
-        status_t has_food( const std::string & ) const;
+        status_t needs_warmth_badly( std::string_view ) const;
+        status_t needs_water_badly( std::string_view ) const;
+        status_t needs_food_badly( std::string_view ) const;
+        status_t can_wear_warmer_clothes( std::string_view ) const;
+        status_t can_make_fire( std::string_view ) const;
+        status_t can_take_shelter( std::string_view ) const;
+        status_t has_water( std::string_view ) const;
+        status_t has_food( std::string_view ) const;
     private:
         const Character *subject;
 };

--- a/src/city.cpp
+++ b/src/city.cpp
@@ -70,7 +70,7 @@ void city::reset()
     get_city_factory().reset();
 }
 
-void city::load( const JsonObject &jo, const std::string & )
+void city::load( const JsonObject &jo, const std::string_view )
 {
 
     mandatory( jo, was_loaded, "id", id );

--- a/src/city.h
+++ b/src/city.h
@@ -14,7 +14,7 @@ class JsonObject;
 template <typename T> class generic_factory;
 
 struct city {
-    void load( const JsonObject &, const std::string & );
+    void load( const JsonObject &, std::string_view );
     void check() const;
     static void load_city( const JsonObject &, const std::string & );
     static void finalize();

--- a/src/clothing_mod.cpp
+++ b/src/clothing_mod.cpp
@@ -62,7 +62,7 @@ std::string enum_to_string<clothing_mod_type>( clothing_mod_type data )
 
 } // namespace io
 
-void clothing_mod::load( const JsonObject &jo, const std::string & )
+void clothing_mod::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "flag", flag );
     mandatory( jo, was_loaded, "item", item_string );

--- a/src/clothing_mod.h
+++ b/src/clothing_mod.h
@@ -40,7 +40,7 @@ struct mod_value {
 };
 
 struct clothing_mod {
-    void load( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view src );
     float get_mod_val( const clothing_mod_type &type, const item &it ) const;
     bool has_mod_type( const clothing_mod_type &type ) const;
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -185,7 +185,7 @@ void zone_type::reset()
     zone_type_factory.reset();
 }
 
-void zone_type::load( const JsonObject &jo, const std::string & )
+void zone_type::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "id", id );

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -60,7 +60,7 @@ class zone_type
 
         static void load_zones( const JsonObject &jo, const std::string &src );
         static void reset();
-        void load( const JsonObject &jo, const std::string & );
+        void load( const JsonObject &jo, std::string_view );
         /**
          * All spells in the game.
          */
@@ -368,7 +368,7 @@ class zone_data
         static std::string make_type_hash( const zone_type_id &_type, const faction_id &_fac ) {
             return _type.c_str() + type_fac_hash_str + _fac.c_str();
         }
-        static zone_type_id unhash_type( const std::string &hash_type ) {
+        static zone_type_id unhash_type( const std::string_view hash_type ) {
             size_t end = hash_type.find( type_fac_hash_str );
             if( end != std::string::npos && end < hash_type.size() ) {
                 return zone_type_id( hash_type.substr( 0, end ) );

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -614,13 +614,13 @@ std::string hilite_string( const std::string &text )
  * @param color The color to get, as a std::string.
  * @return The nc_color constant that matches the input.
  */
-nc_color color_from_string( const std::string &color,
+nc_color color_from_string( const std::string_view color,
                             const report_color_error color_error )
 {
     if( color.empty() ) {
         return c_unset;
     }
-    std::string new_color = color;
+    std::string new_color( color );
     if( new_color.substr( 1, 1 ) != "_" ) { //c_  //i_  //h_
         new_color = "c_" + new_color;
     }
@@ -697,7 +697,7 @@ nc_color bgcolor_from_string( const std::string &color )
     return i_white;
 }
 
-color_tag_parse_result get_color_from_tag( const std::string &s,
+color_tag_parse_result get_color_from_tag( const std::string_view s,
         const report_color_error color_error )
 {
     if( s.empty() || s[0] != '<' ) {
@@ -713,7 +713,7 @@ color_tag_parse_result get_color_from_tag( const std::string &s,
     if( tag_close == std::string::npos ) {
         return { color_tag_parse_result::non_color_tag, {} };
     }
-    std::string color_name = s.substr( 7, tag_close - 7 );
+    std::string_view color_name = s.substr( 7, tag_close - 7 );
     const nc_color color = color_from_string( color_name, color_error );
     if( color != c_unset ) {
         return { color_tag_parse_result::open_color_tag, color };
@@ -761,9 +761,11 @@ std::string get_note_string_from_color( const nc_color &color )
     return "Y";
 }
 
-nc_color get_note_color( const std::string &note_id )
+nc_color get_note_color( const std::string_view note_id )
 {
-    const auto candidate_color = color_by_string_map.find( note_id );
+    // TODO in C++20 we can pass a string_view in directly rather than
+    // constructing a string to use as the find argument
+    const auto candidate_color = color_by_string_map.find( std::string( note_id ) );
     if( candidate_color != std::end( color_by_string_map ) ) {
         return candidate_color->second.color;
     }

--- a/src/color.h
+++ b/src/color.h
@@ -511,18 +511,18 @@ nc_color magenta_background( const nc_color &c );
 nc_color cyan_background( const nc_color &c );
 std::string hilite_string( const std::string &text );
 
-nc_color color_from_string( const std::string &color,
+nc_color color_from_string( std::string_view color,
                             report_color_error color_error = report_color_error::yes );
 std::string string_from_color( const nc_color &color );
 nc_color bgcolor_from_string( const std::string &color );
-color_tag_parse_result get_color_from_tag( const std::string &s,
+color_tag_parse_result get_color_from_tag( std::string_view s,
         report_color_error color_error = report_color_error::yes );
 std::string get_tag_from_color( const nc_color &color );
 std::string colorize( const std::string &text, const nc_color &color );
 std::string colorize( const translation &text, const nc_color &color );
 
 std::string get_note_string_from_color( const nc_color &color );
-nc_color get_note_color( const std::string &note_id );
+nc_color get_note_color( std::string_view note_id );
 const std::unordered_map<std::string, note_color> &get_note_color_names();
 
 #endif // CATA_SRC_COLOR_H

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -528,7 +528,8 @@ void conditional_t::set_has_item( const JsonObject &jo, const std::string &membe
     };
 }
 
-void conditional_t::set_has_items( const JsonObject &jo, const std::string &member, bool is_npc )
+void conditional_t::set_has_items( const JsonObject &jo, const std::string_view member,
+                                   bool is_npc )
 {
     JsonObject has_items = jo.get_object( member );
     if( !has_items.has_string( "item" ) || ( !has_items.has_int( "count" ) &&
@@ -1153,7 +1154,7 @@ void conditional_t::set_query( const JsonObject &jo, const std::string &member, 
     };
 }
 
-void conditional_t::set_x_in_y_chance( const JsonObject &jo, const std::string &member )
+void conditional_t::set_x_in_y_chance( const JsonObject &jo, const std::string_view member )
 {
     const JsonObject &var_obj = jo.get_object( member );
     dbl_or_var dovx = get_dbl_or_var( var_obj, "x" );
@@ -1273,7 +1274,7 @@ void conditional_t::set_compare_string( const JsonObject &jo, const std::string 
     };
 }
 
-void conditional_t::set_compare_num( const JsonObject &jo, const std::string &member )
+void conditional_t::set_compare_num( const JsonObject &jo, const std::string_view member )
 {
     JsonArray objects = jo.get_array( member );
     if( objects.size() != 3 ) {
@@ -2410,7 +2411,7 @@ conditional_t::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part> &m
     return []( dialogue const &, double ) {};
 }
 
-void talk_effect_fun_t::set_arithmetic( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_arithmetic( const JsonObject &jo, const std::string_view member,
                                         bool no_result )
 {
     JsonArray objects = jo.get_array( member );
@@ -2589,7 +2590,7 @@ void talk_effect_fun_t::set_math( const JsonObject &jo, const std::string &membe
     };
 }
 
-void eoc_math::from_json( const JsonObject &jo, std::string const &member )
+void eoc_math::from_json( const JsonObject &jo, std::string_view member )
 {
     JsonArray const objects = jo.get_array( member );
     if( objects.size() > 3 ) {
@@ -2724,7 +2725,7 @@ void conditional_t::set_has_reason()
     };
 }
 
-void conditional_t::set_has_skill( const JsonObject &jo, const std::string &member,
+void conditional_t::set_has_skill( const JsonObject &jo, const std::string_view member,
                                    bool is_npc )
 {
     JsonObject has_skill = jo.get_object( member );
@@ -2741,7 +2742,7 @@ void conditional_t::set_has_skill( const JsonObject &jo, const std::string &memb
     }
 }
 
-void conditional_t::set_roll_contested( const JsonObject &jo, const std::string &member )
+void conditional_t::set_roll_contested( const JsonObject &jo, const std::string_view member )
 {
     std::function<double( dialogue const & )> get_check = conditional_t::get_get_dbl( jo.get_object(
                 member ) );
@@ -2850,7 +2851,7 @@ conditional_t::conditional_t( const JsonObject &jo )
     // improve the clarity of NPC setter functions
     const bool is_npc = true;
     bool found_sub_member = false;
-    const auto parse_array = []( const JsonObject & jo, const std::string & type ) {
+    const auto parse_array = []( const JsonObject & jo, const std::string_view type ) {
         std::vector<conditional_t> conditionals;
         for( const JsonValue entry : jo.get_array( type ) ) {
             if( entry.test_string() ) {

--- a/src/condition.h
+++ b/src/condition.h
@@ -121,13 +121,13 @@ struct conditional_t {
         void set_is_in_field( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_one_in_chance( const JsonObject &jo, const std::string &member );
         void set_query( const JsonObject &jo, const std::string &member, bool is_npc = false );
-        void set_x_in_y_chance( const JsonObject &jo, const std::string &member );
+        void set_x_in_y_chance( const JsonObject &jo, std::string_view member );
         void set_has_worn_with_flag( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_has_wielded_with_flag( const JsonObject &jo, const std::string &member,
                                         bool is_npc = false );
         void set_is_wearing( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_has_item( const JsonObject &jo, const std::string &member, bool is_npc = false );
-        void set_has_items( const JsonObject &jo, const std::string &member, bool is_npc = false );
+        void set_has_items( const JsonObject &jo, std::string_view member, bool is_npc = false );
         void set_has_item_with_flag( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_has_item_category( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_has_bionics( const JsonObject &jo, const std::string &member, bool is_npc = false );
@@ -183,13 +183,13 @@ struct conditional_t {
         void set_has_pickup_list( bool is_npc );
         void set_has_reason();
         void set_is_gender( bool is_male, bool is_npc = false );
-        void set_has_skill( const JsonObject &jo, const std::string &member, bool is_npc = false );
-        void set_roll_contested( const JsonObject &jo, const std::string &member );
+        void set_has_skill( const JsonObject &jo, std::string_view member, bool is_npc = false );
+        void set_roll_contested( const JsonObject &jo, std::string_view member );
         void set_u_know_recipe( const JsonObject &jo, const std::string &member );
         void set_mission_has_generic_rewards();
         void set_can_see( bool is_npc = false );
         void set_compare_string( const JsonObject &jo, const std::string &member );
-        void set_compare_num( const JsonObject &jo, const std::string &member );
+        void set_compare_num( const JsonObject &jo, std::string_view member );
         void set_math( const JsonObject &jo, const std::string &member );
         template<class J>
         static std::function<double( dialogue const & )> get_get_dbl( J const &jo );

--- a/src/construction_category.cpp
+++ b/src/construction_category.cpp
@@ -50,7 +50,7 @@ const string_id<construction_category> &int_id<construction_category>::id() cons
     return all_construction_categories.convert( *this );
 }
 
-void construction_category::load( const JsonObject &jo, const std::string & )
+void construction_category::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
 }

--- a/src/construction_category.h
+++ b/src/construction_category.h
@@ -12,7 +12,7 @@
 class JsonObject;
 
 struct construction_category {
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 
         construction_category_id id;
         std::vector<std::pair<construction_category_id, mod_id>> src;

--- a/src/construction_group.cpp
+++ b/src/construction_group.cpp
@@ -50,7 +50,7 @@ const string_id<construction_group> &int_id<construction_group>::id() const
     return all_construction_groups.convert( *this );
 }
 
-void construction_group::load( const JsonObject &jo, const std::string & )
+void construction_group::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
 }

--- a/src/construction_group.h
+++ b/src/construction_group.h
@@ -12,7 +12,7 @@
 class JsonObject;
 
 struct construction_group {
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 
         construction_group_str_id id;
         std::vector<std::pair<construction_group_str_id, mod_id>> src;

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -83,7 +83,7 @@ static const std::map<const CRAFTING_SPEED_STATE, translation> craft_speed_reaso
 static std::vector<std::string> craft_cat_list;
 static std::map<std::string, std::vector<std::string> > craft_subcat_list;
 
-static bool query_is_yes( const std::string &query );
+static bool query_is_yes( std::string_view query );
 static void draw_hidden_amount( const catacurses::window &w, int amount, int num_recipe );
 static void draw_can_craft_indicator( const catacurses::window &w, const recipe &rec );
 static std::map<size_t, inclusive_rectangle<point>> draw_recipe_tabs( const catacurses::window &w,
@@ -100,9 +100,9 @@ static int related_menu_fill( uilist &rmenu,
                               const std::vector<std::pair<itype_id, std::string>> &related_recipes,
                               const recipe_subset &available );
 
-static std::string get_cat_unprefixed( const std::string &prefixed_name )
+static std::string get_cat_unprefixed( const std::string_view prefixed_name )
 {
-    return prefixed_name.substr( 3, prefixed_name.size() - 3 );
+    return std::string( prefixed_name.substr( 3, prefixed_name.size() - 3 ) );
 }
 
 void load_recipe_category( const JsonObject &jsobj )
@@ -133,7 +133,8 @@ void load_recipe_category( const JsonObject &jsobj )
     }
 }
 
-static std::string get_subcat_unprefixed( const std::string &cat, const std::string &prefixed_name )
+static std::string get_subcat_unprefixed( const std::string_view cat,
+        const std::string &prefixed_name )
 {
     std::string prefix = "CSC_" + get_cat_unprefixed( cat ) + "_";
 
@@ -332,7 +333,7 @@ static std::vector<std::string> recipe_info(
     const recipe &recp,
     const availability &avail,
     Character &guy,
-    const std::string &qry_comps,
+    const std::string_view qry_comps,
     const int batch_size,
     const int fold_width,
     const nc_color &color )
@@ -830,7 +831,7 @@ struct item_info_cache {
 };
 
 static recipe_subset filter_recipes( const recipe_subset &available_recipes,
-                                     const std::string &qry,
+                                     const std::string_view qry,
                                      const Character &player_character,
                                      const std::function<void( size_t, size_t )> &progress_callback )
 {
@@ -2074,9 +2075,9 @@ int related_menu_fill( uilist &rmenu,
     return np_last;
 }
 
-static bool query_is_yes( const std::string &query )
+static bool query_is_yes( const std::string_view query )
 {
-    const std::string subquery = query.substr( 2 );
+    const std::string_view subquery = query.substr( 2 );
 
     return subquery == "yes" || subquery == "y" || subquery == "1" ||
            subquery == "true" || subquery == "t" || subquery == "on" ||

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -306,7 +306,7 @@ struct dynamic_line_t {
         explicit dynamic_line_t( const translation &line );
         explicit dynamic_line_t( const JsonObject &jo );
         explicit dynamic_line_t( const JsonArray &ja );
-        static dynamic_line_t from_member( const JsonObject &jo, const std::string &member_name );
+        static dynamic_line_t from_member( const JsonObject &jo, std::string_view member_name );
 
         std::string operator()( const dialogue &d ) const {
             if( !function ) {

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -47,14 +47,14 @@ struct talk_effect_fun_t {
         void set_remove_active_mission( const JsonObject &jo, const std::string &member );
         void set_offer_mission( const JsonObject &jo, const std::string &member );
         void set_make_sound( const JsonObject &jo, const std::string &member, bool is_npc );
-        void set_run_eocs( const JsonObject &jo, const std::string &member );
-        void set_run_npc_eocs( const JsonObject &jo, const std::string &member, bool is_npc );
-        void set_queue_eocs( const JsonObject &jo, const std::string &member );
-        void set_switch( const JsonObject &jo, const std::string &member );
+        void set_run_eocs( const JsonObject &jo, std::string_view member );
+        void set_run_npc_eocs( const JsonObject &jo, std::string_view member, bool is_npc );
+        void set_queue_eocs( const JsonObject &jo, std::string_view member );
+        void set_switch( const JsonObject &jo, std::string_view member );
         void set_roll_remainder( const JsonObject &jo, const std::string &member, bool is_npc );
-        void set_weighted_list_eocs( const JsonObject &jo, const std::string &member );
+        void set_weighted_list_eocs( const JsonObject &jo, std::string_view member );
         void set_mod_healthy( const JsonObject &jo, const std::string &member, bool is_npc );
-        void set_cast_spell( const JsonObject &jo, const std::string &member, bool is_npc,
+        void set_cast_spell( const JsonObject &jo, std::string_view member, bool is_npc,
                              bool targeted = false );
         void set_lightning();
         void set_next_weather();
@@ -81,15 +81,15 @@ struct talk_effect_fun_t {
         void set_npc_aim_rule( const JsonObject &jo, const std::string &member );
         void set_npc_cbm_reserve_rule( const JsonObject &jo, const std::string &member );
         void set_npc_cbm_recharge_rule( const JsonObject &jo, const std::string &member );
-        void set_location_variable( const JsonObject &jo, const std::string &member, bool is_npc );
-        void set_location_variable_adjust( const JsonObject &jo, const std::string &member );
+        void set_location_variable( const JsonObject &jo, std::string_view member, bool is_npc );
+        void set_location_variable_adjust( const JsonObject &jo, std::string_view member );
         void set_transform_radius( const JsonObject &jo, const std::string &member, bool is_npc );
         void set_transform_line( const JsonObject &jo, const std::string &member );
         void set_place_override( const JsonObject &jo, const std::string &member );
         void set_mapgen_update( const JsonObject &jo, const std::string &member );
         void set_alter_timed_events( const JsonObject &jo, const std::string &member );
-        void set_revert_location( const JsonObject &jo, const std::string &member );
-        void set_npc_goal( const JsonObject &jo, const std::string &member );
+        void set_revert_location( const JsonObject &jo, std::string_view member );
+        void set_npc_goal( const JsonObject &jo, std::string_view member );
         void set_bulk_trade_accept( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_npc_gets_item( bool to_use );
         void set_add_mission( const JsonObject &jo, const std::string &member );
@@ -101,16 +101,16 @@ struct talk_effect_fun_t {
         void set_lose_morale( const JsonObject &jo, const std::string &member, bool is_npc );
         void set_add_faction_trust( const JsonObject &jo, const std::string &member );
         void set_lose_faction_trust( const JsonObject &jo, const std::string &member );
-        void set_arithmetic( const JsonObject &jo, const std::string &member, bool no_result );
+        void set_arithmetic( const JsonObject &jo, std::string_view member, bool no_result );
         void set_math( const JsonObject &jo, const std::string &member );
         void set_set_string_var( const JsonObject &jo, const std::string &member );
         void set_custom_light_level( const JsonObject &jo, const std::string &member );
         void set_spawn_monster( const JsonObject &jo, const std::string &member, bool is_npc );
         void set_spawn_npc( const JsonObject &jo, const std::string &member, bool is_npc );
         void set_field( const JsonObject &jo, const std::string &member, bool is_npc );
-        void set_teleport( const JsonObject &jo, const std::string &member, bool is_npc );
-        void set_give_equipment( const JsonObject &jo, const std::string &member );
-        void set_open_dialogue( const JsonObject &jo, const std::string &member );
+        void set_teleport( const JsonObject &jo, std::string_view member, bool is_npc );
+        void set_give_equipment( const JsonObject &jo, std::string_view member );
+        void set_open_dialogue( const JsonObject &jo, std::string_view member );
         void set_take_control( const JsonObject &jo );
         void set_take_control_menu();
         void operator()( dialogue const &d ) const {
@@ -166,7 +166,7 @@ struct eoc_math {
     math_exp rhs;
     eoc_math::oper action;
 
-    void from_json( const JsonObject &jo, std::string const &member );
+    void from_json( const JsonObject &jo, std::string_view member );
     double act( dialogue const &d ) const;
 };
 

--- a/src/disease.cpp
+++ b/src/disease.cpp
@@ -26,7 +26,7 @@ void disease_type::load_disease_type( const JsonObject &jo, const std::string &s
     disease_factory.load( jo, src );
 }
 
-void disease_type::load( const JsonObject &jo, const std::string & )
+void disease_type::load( const JsonObject &jo, const std::string_view )
 {
     disease_type new_disease;
 

--- a/src/disease.h
+++ b/src/disease.h
@@ -18,7 +18,7 @@ class disease_type
     public:
         static void load_disease_type( const JsonObject &jo, const std::string &src );
         static void reset();
-        void load( const JsonObject &jo, const std::string & );
+        void load( const JsonObject &jo, std::string_view );
         static const std::vector<disease_type> &get_all();
         static void check_disease_consistency();
         bool was_loaded = false;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1124,7 +1124,8 @@ std::pair<std::string, nc_color> display::carry_weight_text_color( const avatar 
     return std::make_pair( weight_text, weight_color );
 }
 
-std::pair<std::string, nc_color> display::overmap_note_symbol_color( const std::string &note_text )
+std::pair<std::string, nc_color> display::overmap_note_symbol_color( const std::string_view
+        note_text )
 {
     std::string ter_sym = "N";
     nc_color ter_color = c_yellow;
@@ -1175,7 +1176,7 @@ std::pair<std::string, nc_color> display::overmap_note_symbol_color( const std::
             colorStart = symbolIndex + 1;
         }
 
-        std::string sym = note_text.substr( colorStart, colorIndex - colorStart );
+        std::string_view sym = note_text.substr( colorStart, colorIndex - colorStart );
 
         if( sym.length() == 2 ) {
             if( sym == "br" ) {
@@ -1186,7 +1187,7 @@ std::pair<std::string, nc_color> display::overmap_note_symbol_color( const std::
                 ter_color = c_dark_gray;
             }
         } else {
-            char colorID = sym.c_str()[0];
+            char colorID = sym[0];
             if( colorID == 'r' ) {
                 ter_color = c_light_red;
             } else if( colorID == 'R' ) {

--- a/src/display.h
+++ b/src/display.h
@@ -181,7 +181,7 @@ nc_color encumb_color( int level );
 std::pair<std::string, nc_color> overmap_tile_symbol_color( const avatar &u,
         const tripoint_abs_omt &omt, bool edge_tile, bool &found_mi );
 // Colorized symbol for an overmap note, given its full text
-std::pair<std::string, nc_color> overmap_note_symbol_color( const std::string &note_text );
+std::pair<std::string, nc_color> overmap_note_symbol_color( std::string_view note_text );
 // Mission marker position as an offset within an overmap of given width and height
 point mission_arrow_offset( const avatar &you, int width, int height );
 // Fully colorized newline-separated overmap string of the given size, centered on character

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -640,11 +640,11 @@ bool effect_type::is_show_in_info() const
 {
     return show_in_info;
 }
-bool effect_type::load_miss_msgs( const JsonObject &jo, const std::string &member )
+bool effect_type::load_miss_msgs( const JsonObject &jo, const std::string_view member )
 {
     return jo.read( member, miss_msgs );
 }
-bool effect_type::load_decay_msgs( const JsonObject &jo, const std::string &member )
+bool effect_type::load_decay_msgs( const JsonObject &jo, const std::string_view member )
 {
     if( jo.has_array( member ) ) {
         for( JsonArray inner : jo.get_array( member ) ) {

--- a/src/effect.h
+++ b/src/effect.h
@@ -149,8 +149,8 @@ class effect_type
 
         /** Loading helper functions */
         void load_mod_data( const JsonObject &jo );
-        bool load_miss_msgs( const JsonObject &jo, const std::string &member );
-        bool load_decay_msgs( const JsonObject &jo, const std::string &member );
+        bool load_miss_msgs( const JsonObject &jo, std::string_view member );
+        bool load_decay_msgs( const JsonObject &jo, std::string_view member );
 
         /** Verifies data is accurate */
         static void check_consistency();

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -55,7 +55,7 @@ void effect_on_conditions::check_consistency()
 {
 }
 
-void effect_on_condition::load( const JsonObject &jo, const std::string & )
+void effect_on_condition::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     optional( jo, was_loaded, "eoc_type", type, eoc_type::NUM_EOC_TYPES );

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -61,7 +61,7 @@ struct effect_on_condition {
         bool check_deactivate( dialogue &d ) const;
         bool test_condition( dialogue &d ) const;
         void apply_true_effects( dialogue &d ) const;
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void finalize();
         void check() const;
         effect_on_condition() = default;

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -697,7 +697,7 @@ std::unique_ptr<stats_tracker_state> event_transformation::watch( stats_tracker 
     return impl_->watch( stats );
 }
 
-void event_transformation::load( const JsonObject &jo, const std::string & )
+void event_transformation::load( const JsonObject &jo, const std::string_view )
 {
     std::map<std::string, new_field> new_fields;
     optional( jo, was_loaded, "new_fields", new_fields );
@@ -1213,7 +1213,7 @@ std::unique_ptr<stats_tracker_state> event_statistic::watch( stats_tracker &stat
     return impl_->watch( stats );
 }
 
-void event_statistic::load( const JsonObject &jo, const std::string & )
+void event_statistic::load( const JsonObject &jo, const std::string_view )
 {
     std::string type;
     mandatory( jo, was_loaded, "stat_type", type );
@@ -1293,7 +1293,7 @@ cata_variant score::value( stats_tracker &stats ) const
     return stats.value_of( stat_ );
 }
 
-void score::load( const JsonObject &jo, const std::string & )
+void score::load( const JsonObject &jo, const std::string_view )
 {
     optional( jo, was_loaded, "description", description_ );
     mandatory( jo, was_loaded, "statistic", stat_ );

--- a/src/event_statistics.h
+++ b/src/event_statistics.h
@@ -47,7 +47,7 @@ class event_transformation
         event_multiset value( stats_tracker & ) const;
         std::unique_ptr<stats_tracker_state> watch( stats_tracker & ) const;
 
-        void load( const JsonObject &, const std::string & );
+        void load( const JsonObject &, std::string_view );
         void check() const;
         static void load_transformation( const JsonObject &, const std::string & );
         static void check_consistency();
@@ -73,7 +73,7 @@ class event_statistic
         cata_variant value( stats_tracker & ) const;
         std::unique_ptr<stats_tracker_state> watch( stats_tracker & ) const;
 
-        void load( const JsonObject &, const std::string & );
+        void load( const JsonObject &, std::string_view );
         void check() const;
         static void load_statistic( const JsonObject &, const std::string & );
         static void check_consistency();
@@ -105,7 +105,7 @@ class score
         std::string description( stats_tracker & ) const;
         cata_variant value( stats_tracker & ) const;
 
-        void load( const JsonObject &, const std::string & );
+        void load( const JsonObject &, std::string_view );
         void check() const;
         static void load_score( const JsonObject &, const std::string & );
         static void check_consistency();

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -521,7 +521,7 @@ static bool extract_and_check_orientation_flags( const recipe_id &recipe,
         bool &mirror_horizontal,
         bool &mirror_vertical,
         int &rotation,
-        const std::string &base_error_message,
+        const std::string_view base_error_message,
         const std::string &actor )
 {
     mirror_horizontal = recipe->has_flag( "MAP_MIRROR_HORIZONTAL" );
@@ -612,7 +612,8 @@ static bool extract_and_check_orientation_flags( const recipe_id &recipe,
     return true;
 }
 
-static std::optional<basecamp *> get_basecamp( npc &p, const std::string &camp_type = "default" )
+static std::optional<basecamp *> get_basecamp( npc &p,
+        const std::string_view camp_type = "default" )
 {
     tripoint_abs_omt omt_pos = p.global_omt_location();
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( omt_pos.xy() );

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -175,7 +175,7 @@ const field_intensity_level &field_type::get_intensity_level( int level ) const
     return intensity_levels[level];
 }
 
-void field_type::load( const JsonObject &jo, const std::string & )
+void field_type::load( const JsonObject &jo, const std::string_view )
 {
     optional( jo, was_loaded, "legacy_enum_id", legacy_enum_id, -1 );
     for( const JsonObject jao : jo.get_array( "intensity_levels" ) ) {

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -170,7 +170,7 @@ struct field_type;
 
 struct field_type {
     public:
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void finalize();
         void check() const;
 

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -396,7 +396,7 @@ const json_flag &json_flag::get( const std::string &id )
     return f_id.is_valid() ? *f_id : null_value;
 }
 
-void json_flag::load( const JsonObject &jo, const std::string & )
+void json_flag::load( const JsonObject &jo, const std::string_view )
 {
     // TODO: mark fields as mandatory where appropriate
     optional( jo, was_loaded, "info", info_ );

--- a/src/flag.h
+++ b/src/flag.h
@@ -454,7 +454,7 @@ class json_flag
         int taste_mod_ = 0;
 
         /** Load flag definition from JSON */
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 
         /** Load all flags from JSON */
         static void load_all( const JsonObject &jo, const std::string &src );

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -67,7 +67,7 @@ struct gate_data {
     int bash_dmg;
     bool was_loaded;
 
-    void load( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view src );
     void check() const;
 
     bool is_suitable_wall( const tripoint &pos ) const;
@@ -82,7 +82,7 @@ generic_factory<gate_data> gates_data( "gate type" );
 
 } // namespace
 
-void gate_data::load( const JsonObject &jo, const std::string & )
+void gate_data::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "door", door );
     mandatory( jo, was_loaded, "floor", floor );

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -108,7 +108,7 @@ void harvest_drop_type::reset()
     harvest_drop_type_factory.reset();
 }
 
-void harvest_drop_type::load( const JsonObject &jo, const std::string & )
+void harvest_drop_type::load( const JsonObject &jo, const std::string_view )
 {
     harvest_skills.clear();
     optional( jo, was_loaded, "group", is_group_, false );
@@ -169,7 +169,7 @@ void harvest_list::finalize_all()
     }
 }
 
-void harvest_list::load( const JsonObject &obj, const std::string & )
+void harvest_list::load( const JsonObject &obj, const std::string_view )
 {
     mandatory( obj, was_loaded, "id", id );
     mandatory( obj, was_loaded, "entries", entries_ );

--- a/src/harvest.h
+++ b/src/harvest.h
@@ -23,7 +23,7 @@ class harvest_drop_type
     public:
         static void load_harvest_drop_types( const JsonObject &jo, const std::string &src );
         static void reset();
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         static const std::vector<harvest_drop_type> &get_all();
 
         const harvest_drop_type_id &getId() {
@@ -144,7 +144,7 @@ class harvest_list
         static void reset();
 
         bool was_loaded = false;
-        void load( const JsonObject &obj, const std::string & );
+        void load( const JsonObject &obj, std::string_view );
         static void load_harvest_list( const JsonObject &jo, const std::string &src );
         static const std::vector<harvest_list> &get_all();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -227,7 +227,7 @@ void DynamicDataLoader::add( const std::string &type,
 void DynamicDataLoader::add( const std::string &type,
                              const std::function<void( const JsonObject & )> &f )
 {
-    add( type, [f]( const JsonObject & obj, const std::string &,  const cata_path &,
+    add( type, [f]( const JsonObject & obj, const std::string_view,  const cata_path &,
     const cata_path & ) {
         f( obj );
     } );

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1927,7 +1927,7 @@ void input_context::set_iso( bool mode )
 }
 
 std::vector<std::string> input_context::filter_strings_by_phrase(
-    const std::vector<std::string> &strings, const std::string &phrase ) const
+    const std::vector<std::string> &strings, const std::string_view phrase ) const
 {
     std::vector<std::string> filtered_strings;
 

--- a/src/input.h
+++ b/src/input.h
@@ -923,7 +923,7 @@ class input_context
          * @return A vector of the filtered strings
          */
         std::vector<std::string> filter_strings_by_phrase( const std::vector<std::string> &strings,
-                const std::string &phrase ) const;
+                std::string_view phrase ) const;
 };
 
 /**

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1574,7 +1574,7 @@ int inventory_column::reassign_custom_invlets( const Character &p, int min_invle
     return cur_invlet;
 }
 
-int inventory_column::reassign_custom_invlets( int cur_idx, const std::string &pickup_chars )
+int inventory_column::reassign_custom_invlets( int cur_idx, const std::string_view pickup_chars )
 {
     for( inventory_entry &elem : entries ) {
         // Only items on map/in vehicles: those that the player does not possess.

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -443,7 +443,7 @@ class inventory_column
         virtual void reset_width( const std::vector<inventory_column *> &all_columns );
         /** Returns next custom inventory letter. */
         int reassign_custom_invlets( const Character &p, int min_invlet, int max_invlet );
-        int reassign_custom_invlets( int cur_idx, const std::string &pickup_chars );
+        int reassign_custom_invlets( int cur_idx, std::string_view pickup_chars );
         /** Reorder entries, repopulate titles, adjust to the new height. */
         virtual void prepare_paging( const std::string &filter = "" );
         /**

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5706,7 +5706,7 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
 
         const auto print_parts = [&info, &player_character](
                                      const std::vector<vpart_info> &vparts,
-                                     const std::string & install_where,
+                                     const std::string_view install_where,
                                      const std::function<bool( const vpart_info & )> &predicate
         ) {
             std::vector<std::string> result_parts;

--- a/src/item_category.cpp
+++ b/src/item_category.cpp
@@ -50,7 +50,7 @@ void item_category::reset()
     item_category_factory.reset();
 }
 
-void item_category::load( const JsonObject &jo, const std::string & )
+void item_category::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name", name_ );

--- a/src/item_category.h
+++ b/src/item_category.h
@@ -84,7 +84,7 @@ class item_category
         static const std::vector<item_category> &get_all();
         static void load_item_cat( const JsonObject &jo, const std::string &src );
         static void reset();
-        void load( const JsonObject &jo, const std::string & );
+        void load( const JsonObject &jo, std::string_view );
 };
 
 #endif // CATA_SRC_ITEM_CATEGORY_H

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -148,7 +148,7 @@ bool item_is_blacklisted( const itype_id &id )
     return item_blacklist.blacklist.count( id );
 }
 
-static void assign( const JsonObject &jo, const std::string &name,
+static void assign( const JsonObject &jo, const std::string_view name,
                     std::map<gun_mode_id, gun_modifier_data> &mods )
 {
     if( !jo.has_array( name ) ) {
@@ -2429,7 +2429,7 @@ void Item_factory::load_slot( cata::value_ptr<SlotType> &slotptr, const JsonObje
 
 template<typename SlotType>
 void Item_factory::load_slot_optional( cata::value_ptr<SlotType> &slotptr, const JsonObject &jo,
-                                       const std::string &member, const std::string &src )
+                                       const std::string_view member, const std::string &src )
 {
     if( !jo.has_member( member ) ) {
         return;
@@ -2827,7 +2827,8 @@ static void get_optional( const JsonObject &jo, bool was_loaded, const std::stri
 }
 
 template<typename T>
-static void get_relative( const JsonObject &jo, const std::string &member, std::optional<T> &value,
+static void get_relative( const JsonObject &jo, const std::string_view member,
+                          std::optional<T> &value,
                           T default_val )
 {
     if( jo.has_member( member ) ) {
@@ -2836,7 +2837,7 @@ static void get_relative( const JsonObject &jo, const std::string &member, std::
 }
 
 template<typename T>
-static void get_proportional( const JsonObject &jo, const std::string &member,
+static void get_proportional( const JsonObject &jo, const std::string_view member,
                               std::optional<T> &value, T default_val )
 {
     if( jo.has_member( member ) ) {
@@ -2955,7 +2956,7 @@ void Item_factory::load_tool( const JsonObject &jo, const std::string &src )
     }
 }
 
-void Item_factory::load( relic &slot, const JsonObject &jo, const std::string & )
+void Item_factory::load( relic &slot, const JsonObject &jo, const std::string_view )
 {
     slot.load( jo );
 }
@@ -4310,7 +4311,7 @@ void Item_factory::set_qualities_from_json( const JsonObject &jo, const std::str
     }
 }
 
-void Item_factory::extend_qualities_from_json( const JsonObject &jo, const std::string &member,
+void Item_factory::extend_qualities_from_json( const JsonObject &jo, const std::string_view member,
         itype &def )
 {
     for( JsonArray curr : jo.get_array( member ) ) {
@@ -4318,7 +4319,7 @@ void Item_factory::extend_qualities_from_json( const JsonObject &jo, const std::
     }
 }
 
-void Item_factory::delete_qualities_from_json( const JsonObject &jo, const std::string &member,
+void Item_factory::delete_qualities_from_json( const JsonObject &jo, const std::string_view member,
         itype &def )
 {
     for( JsonArray curr : jo.get_array( member ) ) {
@@ -4329,7 +4330,7 @@ void Item_factory::delete_qualities_from_json( const JsonObject &jo, const std::
     }
 }
 
-void Item_factory::set_properties_from_json( const JsonObject &jo, const std::string &member,
+void Item_factory::set_properties_from_json( const JsonObject &jo, const std::string_view member,
         itype &def )
 {
     if( jo.has_array( member ) ) {
@@ -4424,7 +4425,7 @@ bool load_min_max( std::pair<T, T> &pa, const JsonObject &obj, const std::string
 }
 
 template<typename T>
-bool load_str_arr( std::vector<T> &arr, const JsonObject &obj, const std::string &name )
+bool load_str_arr( std::vector<T> &arr, const JsonObject &obj, const std::string_view name )
 {
     if( obj.has_array( name ) ) {
         for( const std::string str : obj.get_array( name ) ) {
@@ -4499,7 +4500,7 @@ bool Item_factory::load_sub_ref( std::unique_ptr<Item_spawn_data> &ptr, const Js
 }
 
 bool Item_factory::load_string( std::vector<std::string> &vec, const JsonObject &obj,
-                                const std::string &name )
+                                const std::string_view name )
 {
     bool result = false;
     std::string temp;

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -321,7 +321,7 @@ class Item_factory
          */
         template<typename SlotType>
         void load_slot_optional( cata::value_ptr<SlotType> &slotptr, const JsonObject &jo,
-                                 const std::string &member, const std::string &src );
+                                 std::string_view member, const std::string &src );
 
         void load( islot_tool &slot, const JsonObject &jo, const std::string &src );
         void load( islot_comestible &slot, const JsonObject &jo, const std::string &src );
@@ -330,7 +330,7 @@ class Item_factory
         void load( islot_gunmod &slot, const JsonObject &jo, const std::string &src );
         void load( islot_magazine &slot, const JsonObject &jo, const std::string &src );
         void load( islot_bionic &slot, const JsonObject &jo, const std::string &src );
-        void load( relic &slot, const JsonObject &jo, const std::string &src );
+        void load( relic &slot, const JsonObject &jo, std::string_view src );
 
         //json data handlers
         void emplace_usage( std::map<std::string, use_function> &container,
@@ -358,14 +358,14 @@ class Item_factory
          */
         bool load_sub_ref( std::unique_ptr<Item_spawn_data> &ptr, const JsonObject &obj,
                            const std::string &name, const Item_group &parent );
-        bool load_string( std::vector<std::string> &vec, const JsonObject &obj, const std::string &name );
+        bool load_string( std::vector<std::string> &vec, const JsonObject &obj, std::string_view name );
         void add_entry( Item_group &ig, const JsonObject &obj, const std::string &context );
 
         void load_basic_info( const JsonObject &jo, itype &def, const std::string &src );
         void set_qualities_from_json( const JsonObject &jo, const std::string &member, itype &def );
-        void extend_qualities_from_json( const JsonObject &jo, const std::string &member, itype &def );
-        void delete_qualities_from_json( const JsonObject &jo, const std::string &member, itype &def );
-        void set_properties_from_json( const JsonObject &jo, const std::string &member, itype &def );
+        void extend_qualities_from_json( const JsonObject &jo, std::string_view member, itype &def );
+        void delete_qualities_from_json( const JsonObject &jo, std::string_view member, itype &def );
+        void set_properties_from_json( const JsonObject &jo, std::string_view member, itype &def );
 
         // declared here to have friendship status with itype
         static void npc_implied_flags( itype &item_template );

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -12,7 +12,7 @@
 #include "requirements.h"
 #include "type_id.h"
 
-static std::pair<std::string, std::string> get_both( const std::string &a );
+static std::pair<std::string, std::string> get_both( std::string_view a );
 
 std::function<bool( const item & )> basic_item_filter( std::string filter )
 {
@@ -88,9 +88,9 @@ std::function<bool( const item & )> item_filter_from_string( const std::string &
     return filter_from_string<item>( filter, basic_item_filter );
 }
 
-std::pair<std::string, std::string> get_both( const std::string &a )
+std::pair<std::string, std::string> get_both( const std::string_view a )
 {
     size_t split_mark = a.find( ';' );
-    return std::make_pair( a.substr( 0, split_mark ),
-                           a.substr( split_mark + 1 ) );
+    return std::pair( std::string( a.substr( 0, split_mark ) ),
+                      std::string( a.substr( split_mark + 1 ) ) );
 }

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -109,7 +109,7 @@ int itype::damage_level( int damage ) const
     return std::clamp( 1 + 4 * damage / damage_max(), 0, 5 );
 }
 
-bool itype::has_any_quality( const std::string &quality ) const
+bool itype::has_any_quality( const std::string_view quality ) const
 {
     return std::any_of( qualities.begin(),
     qualities.end(), [&quality]( const std::pair<quality_id, int> &e ) {

--- a/src/itype.h
+++ b/src/itype.h
@@ -1181,7 +1181,7 @@ struct itype {
         std::map<quality_id, int> charged_qualities;
 
         // True if this has given quality or charged_quality (regardless of current charge).
-        bool has_any_quality( const std::string &quality ) const;
+        bool has_any_quality( std::string_view quality ) const;
 
         // Properties are assigned to the type (belong to the item definition)
         std::map<std::string, std::string> properties;
@@ -1427,8 +1427,8 @@ struct itype {
         bool is_basic_component() const;
 };
 
-void load_charge_removal_blacklist( const JsonObject &jo, const std::string &src );
-void load_charge_migration_blacklist( const JsonObject &jo, const std::string &src );
-void load_temperature_removal_blacklist( const JsonObject &jo, const std::string &src );
+void load_charge_removal_blacklist( const JsonObject &jo, std::string_view src );
+void load_charge_migration_blacklist( const JsonObject &jo, std::string_view src );
+void load_temperature_removal_blacklist( const JsonObject &jo, std::string_view src );
 
 #endif // CATA_SRC_ITYPE_H

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -242,7 +242,7 @@ std::string TextJsonObject::str() const
     }
 }
 
-void TextJsonObject::throw_error_at( const std::string &name, const std::string &err ) const
+void TextJsonObject::throw_error_at( const std::string_view name, const std::string &err ) const
 {
     mark_visited( name );
     if( !jsin ) {
@@ -317,12 +317,12 @@ json_source_location TextJsonObject::get_source_location() const
 
 /* returning values by name */
 
-bool TextJsonObject::get_bool( const std::string &name ) const
+bool TextJsonObject::get_bool( const std::string_view name ) const
 {
     return get_member( name ).get_bool();
 }
 
-bool TextJsonObject::get_bool( const std::string &name, const bool fallback ) const
+bool TextJsonObject::get_bool( const std::string_view name, const bool fallback ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -333,12 +333,12 @@ bool TextJsonObject::get_bool( const std::string &name, const bool fallback ) co
     return jsin->get_bool();
 }
 
-int TextJsonObject::get_int( const std::string &name ) const
+int TextJsonObject::get_int( const std::string_view name ) const
 {
     return get_member( name ).get_int();
 }
 
-int TextJsonObject::get_int( const std::string &name, const int fallback ) const
+int TextJsonObject::get_int( const std::string_view name, const int fallback ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -349,12 +349,12 @@ int TextJsonObject::get_int( const std::string &name, const int fallback ) const
     return jsin->get_int();
 }
 
-double TextJsonObject::get_float( const std::string &name ) const
+double TextJsonObject::get_float( const std::string_view name ) const
 {
     return get_member( name ).get_float();
 }
 
-double TextJsonObject::get_float( const std::string &name, const double fallback ) const
+double TextJsonObject::get_float( const std::string_view name, const double fallback ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -365,12 +365,13 @@ double TextJsonObject::get_float( const std::string &name, const double fallback
     return jsin->get_float();
 }
 
-std::string TextJsonObject::get_string( const std::string &name ) const
+std::string TextJsonObject::get_string( const std::string_view name ) const
 {
     return get_member( name ).get_string();
 }
 
-std::string TextJsonObject::get_string( const std::string &name, const std::string &fallback ) const
+std::string TextJsonObject::get_string( const std::string_view name,
+                                        const std::string &fallback ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -383,7 +384,7 @@ std::string TextJsonObject::get_string( const std::string &name, const std::stri
 
 /* returning containers by name */
 
-TextJsonArray TextJsonObject::get_array( const std::string &name ) const
+TextJsonArray TextJsonObject::get_array( const std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -394,7 +395,7 @@ TextJsonArray TextJsonObject::get_array( const std::string &name ) const
     return TextJsonArray( *jsin );
 }
 
-std::vector<int> TextJsonObject::get_int_array( const std::string &name ) const
+std::vector<int> TextJsonObject::get_int_array( const std::string_view name ) const
 {
     std::vector<int> ret;
     for( const int entry : get_array( name ) ) {
@@ -403,7 +404,7 @@ std::vector<int> TextJsonObject::get_int_array( const std::string &name ) const
     return ret;
 }
 
-std::vector<std::string> TextJsonObject::get_string_array( const std::string &name ) const
+std::vector<std::string> TextJsonObject::get_string_array( const std::string_view name ) const
 {
     std::vector<std::string> ret;
     for( const std::string entry : get_array( name ) ) {
@@ -412,7 +413,7 @@ std::vector<std::string> TextJsonObject::get_string_array( const std::string &na
     return ret;
 }
 
-std::vector<std::string> TextJsonObject::get_as_string_array( const std::string &name ) const
+std::vector<std::string> TextJsonObject::get_as_string_array( const std::string_view name ) const
 {
     std::vector<std::string> ret;
     if( has_array( name ) ) {
@@ -425,7 +426,7 @@ std::vector<std::string> TextJsonObject::get_as_string_array( const std::string 
     return ret;
 }
 
-TextJsonObject TextJsonObject::get_object( const std::string &name ) const
+TextJsonObject TextJsonObject::get_object( const std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -438,7 +439,7 @@ TextJsonObject TextJsonObject::get_object( const std::string &name ) const
 
 /* non-fatal member existence and type testing */
 
-bool TextJsonObject::has_null( const std::string &name ) const
+bool TextJsonObject::has_null( const std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -449,7 +450,7 @@ bool TextJsonObject::has_null( const std::string &name ) const
     return jsin->test_null();
 }
 
-bool TextJsonObject::has_bool( const std::string &name ) const
+bool TextJsonObject::has_bool( const std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -459,7 +460,7 @@ bool TextJsonObject::has_bool( const std::string &name ) const
     return jsin->test_bool();
 }
 
-bool TextJsonObject::has_number( const std::string &name ) const
+bool TextJsonObject::has_number( const std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -469,7 +470,7 @@ bool TextJsonObject::has_number( const std::string &name ) const
     return jsin->test_number();
 }
 
-bool TextJsonObject::has_string( const std::string &name ) const
+bool TextJsonObject::has_string( const std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -479,7 +480,7 @@ bool TextJsonObject::has_string( const std::string &name ) const
     return jsin->test_string();
 }
 
-bool TextJsonObject::has_array( const std::string &name ) const
+bool TextJsonObject::has_array( const std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -489,7 +490,7 @@ bool TextJsonObject::has_array( const std::string &name ) const
     return jsin->test_array();
 }
 
-bool TextJsonObject::has_object( const std::string &name ) const
+bool TextJsonObject::has_object( const std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -789,7 +790,7 @@ bool TextJsonArray::has_object( const size_t i ) const
 }
 
 void add_array_to_set( std::set<std::string> &s, const TextJsonObject &json,
-                       const std::string &name )
+                       const std::string_view name )
 {
     for( const std::string line : json.get_array( name ) ) {
         s.insert( line );
@@ -2214,7 +2215,7 @@ void JsonOut::write_null()
     need_separator = true;
 }
 
-void JsonOut::write( const std::string &val )
+void JsonOut::write( const std::string_view val )
 {
     if( need_separator ) {
         write_separator();
@@ -2273,13 +2274,13 @@ void JsonOut::write( const std::bitset<N> &b )
     need_separator = true;
 }
 
-void JsonOut::member( const std::string &name )
+void JsonOut::member( const std::string_view name )
 {
     write( name );
     write_member_separator();
 }
 
-void JsonOut::null_member( const std::string &name )
+void JsonOut::null_member( const std::string_view name )
 {
     member( name );
     write_null();

--- a/src/json.h
+++ b/src/json.h
@@ -49,6 +49,13 @@ template<typename T>
 class optional;
 } // namespace cata
 
+// Traits class to distinguish sequences which are string like from others
+template< class, class = void >
+struct is_string_like : std::false_type { };
+template< class T >
+struct is_string_like<T, std::void_t<decltype( std::declval<T &>().substr() )>> :
+std::true_type { };
+
 template<typename T, typename Enable = void>
 struct key_from_json_string;
 
@@ -431,9 +438,10 @@ class TextJsonIn
         }
 
         // array ~> vector, deque, list
-        template < typename T, typename std::enable_if <
-                       !std::is_same<void, typename T::value_type>::value >::type * = nullptr
-                   >
+        template < typename T, typename std::enable_if_t <
+                       !std::is_same_v<void, typename T::value_type> &&
+                       !is_string_like<T>::value
+                       > * = nullptr >
         auto read( T &v, bool throw_on_error = false ) -> decltype( v.front(), true ) {
             if( !test_array() ) {
                 return error_or_false( throw_on_error, "Expected json array" );
@@ -784,7 +792,7 @@ class JsonOut
         }
 
         // strings need escaping and quoting
-        void write( const std::string &val );
+        void write( std::string_view val );
         void write( const char *val ) {
             write( std::string( val ) );
         }
@@ -852,9 +860,10 @@ class JsonOut
 
         // containers with front() ~> array
         // vector, deque, forward_list, list
-        template < typename T, typename std::enable_if <
-                       !std::is_same<void, typename T::value_type>::value >::type * = nullptr
-                   >
+        template < typename T, typename std::enable_if_t <
+                       !std::is_same_v<void, typename T::value_type> &&
+                       !is_string_like<T>::value
+                       > * = nullptr >
         auto write( const T &container ) -> decltype( container.front(), ( void )0 ) {
             write_as_array( container );
         }
@@ -920,19 +929,19 @@ class JsonOut
 
         // convenience methods for writing named object members
         // TODO: enforce value after
-        void member( const std::string &name );
-        void null_member( const std::string &name );
-        template <typename T> void member( const std::string &name, const T &value ) {
+        void member( std::string_view name );
+        void null_member( std::string_view name );
+        template <typename T> void member( const std::string_view name, const T &value ) {
             member( name );
             write( value );
         }
-        template <typename T> void member( const std::string &name, const T &value,
+        template <typename T> void member( const std::string_view name, const T &value,
                                            const T &value_default ) {
             if( value != value_default ) {
                 member( name, value );
             }
         }
-        template <typename T> void member_as_string( const std::string &name, const T &value ) {
+        template <typename T> void member_as_string( const std::string_view name, const T &value ) {
             member( name );
             write_as_string( value );
         }
@@ -1062,7 +1071,7 @@ class TextJsonObject
         bool has_member( const std::string &name ) const; // true iff named member exists
         std::string str() const; // copy object json as string
         [[noreturn]] void throw_error( const std::string &err ) const;
-        [[noreturn]] void throw_error_at( const std::string &name, const std::string &err ) const;
+        [[noreturn]] void throw_error_at( std::string_view name, const std::string &err ) const;
         // seek to a value and return a pointer to the TextJsonIn (member must exist)
         TextJsonIn *get_raw( std::string_view name ) const;
         TextJsonValue get_member( std::string_view name ) const;
@@ -1071,14 +1080,14 @@ class TextJsonObject
         // values by name
         // variants with no fallback throw an error if the name is not found.
         // variants with a fallback return the fallback value in stead.
-        bool get_bool( const std::string &name ) const;
-        bool get_bool( const std::string &name, bool fallback ) const;
-        int get_int( const std::string &name ) const;
-        int get_int( const std::string &name, int fallback ) const;
-        double get_float( const std::string &name ) const;
-        double get_float( const std::string &name, double fallback ) const;
-        std::string get_string( const std::string &name ) const;
-        std::string get_string( const std::string &name, const std::string &fallback ) const;
+        bool get_bool( std::string_view name ) const;
+        bool get_bool( std::string_view name, bool fallback ) const;
+        int get_int( std::string_view name ) const;
+        int get_int( std::string_view name, int fallback ) const;
+        double get_float( std::string_view name ) const;
+        double get_float( std::string_view name, double fallback ) const;
+        std::string get_string( std::string_view name ) const;
+        std::string get_string( std::string_view name, const std::string &fallback ) const;
 
         template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
         E get_enum_value( const std::string &name, const E fallback ) const {
@@ -1098,13 +1107,13 @@ class TextJsonObject
 
         // containers by name
         // get_array returns empty array if the member is not found
-        TextJsonArray get_array( const std::string &name ) const;
-        std::vector<int> get_int_array( const std::string &name ) const;
-        std::vector<std::string> get_string_array( const std::string &name ) const;
+        TextJsonArray get_array( std::string_view name ) const;
+        std::vector<int> get_int_array( std::string_view name ) const;
+        std::vector<std::string> get_string_array( std::string_view name ) const;
         // returns a single element array if the sype is string instead of array
-        std::vector<std::string> get_as_string_array( const std::string &name ) const;
+        std::vector<std::string> get_as_string_array( std::string_view name ) const;
         // get_object returns empty object if not found
-        TextJsonObject get_object( const std::string &name ) const;
+        TextJsonObject get_object( std::string_view name ) const;
 
         // get_tags returns empty set if none found
         template<typename T = std::string, typename Res = std::set<T>>
@@ -1113,18 +1122,18 @@ class TextJsonObject
         // TODO: some sort of get_map(), maybe
 
         // type checking
-        bool has_null( const std::string &name ) const;
-        bool has_bool( const std::string &name ) const;
-        bool has_number( const std::string &name ) const;
-        bool has_int( const std::string &name ) const {
+        bool has_null( std::string_view name ) const;
+        bool has_bool( std::string_view name ) const;
+        bool has_number( std::string_view name ) const;
+        bool has_int( const std::string_view name ) const {
             return has_number( name );
         }
-        bool has_float( const std::string &name ) const {
+        bool has_float( const std::string_view name ) const {
             return has_number( name );
         }
-        bool has_string( const std::string &name ) const;
-        bool has_array( const std::string &name ) const;
-        bool has_object( const std::string &name ) const;
+        bool has_string( std::string_view name ) const;
+        bool has_array( std::string_view name ) const;
+        bool has_object( std::string_view name ) const;
 
         // non-fatally read values by reference
         // return true if the value was set.
@@ -1570,7 +1579,7 @@ Res TextJsonObject::get_tags( const std::string_view name ) const
  * array (which should be a string) add it to the given set.
  */
 void add_array_to_set( std::set<std::string> &, const TextJsonObject &json,
-                       const std::string &name );
+                       std::string_view name );
 
 std::ostream &operator<<( std::ostream &stream, const JsonError &err );
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -265,7 +265,7 @@ static std::string moves_to_string( const int moves )
     }
 }
 
-void spell_type::load( const JsonObject &jo, const std::string & )
+void spell_type::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "description", description );

--- a/src/magic.h
+++ b/src/magic.h
@@ -347,7 +347,7 @@ class spell_type
         enum_bitset<spell_flag> spell_tags;
 
         static void load_spell( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, const std::string & );
+        void load( const JsonObject &jo, std::string_view );
         void serialize( JsonOut &json ) const;
         /**
          * All spells in the game.

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -174,7 +174,8 @@ void enchantment::reset()
     spell_factory.reset();
 }
 
-enchantment_id enchantment::load_inline_enchantment( const JsonValue &jv, const std::string &src,
+enchantment_id enchantment::load_inline_enchantment( const JsonValue &jv,
+        const std::string_view src,
         std::string &inline_id )
 {
     if( jv.test_string() ) {
@@ -267,7 +268,7 @@ void enchantment::bodypart_changes::serialize( JsonOut &jsout ) const
     jsout.end_object();
 }
 
-void enchantment::load( const JsonObject &jo, const std::string &,
+void enchantment::load( const JsonObject &jo, const std::string_view,
                         const std::optional<std::string> &inline_id, bool is_child )
 {
     optional( jo, was_loaded, "id", id, enchantment_id( inline_id.value_or( "" ) ) );
@@ -364,7 +365,7 @@ void enchantment::load( const JsonObject &jo, const std::string &,
     }
 }
 
-void enchant_cache::load( const JsonObject &jo, const std::string &,
+void enchant_cache::load( const JsonObject &jo, const std::string_view,
                           const std::optional<std::string> &inline_id )
 {
     enchantment::load( jo, "", inline_id, true );

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -143,12 +143,12 @@ class enchantment
 
         static void load_enchantment( const JsonObject &jo, const std::string &src );
         static void reset();
-        void load( const JsonObject &jo, const std::string &src = "",
+        void load( const JsonObject &jo, std::string_view src = {},
                    const std::optional<std::string> &inline_id = std::nullopt, bool is_child = false );
 
         // Takes in a JsonValue which can be either a string or an enchantment object and returns the id of the enchantment the caller will use.
         // If the input is a string return it as an enchantment_id otherwise create an enchantment with id inline_id and return inline_id as an enchantment id
-        static enchantment_id load_inline_enchantment( const JsonValue &jv, const std::string &src,
+        static enchantment_id load_inline_enchantment( const JsonValue &jv, std::string_view src,
                 std::string &inline_id );
 
         // this enchantment has a valid condition and is in the right location
@@ -259,7 +259,7 @@ class enchant_cache : public enchantment
         void add_value_mult( enchant_vals::mod value, float mult_value );
         void add_hit_you( const fake_spell &sp );
         void add_hit_me( const fake_spell &sp );
-        void load( const JsonObject &jo, const std::string &src = "",
+        void load( const JsonObject &jo, std::string_view src = {},
                    const std::optional<std::string> &inline_id = std::nullopt );
         bool operator==( const enchant_cache &rhs ) const;
 

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -83,7 +83,7 @@ void ter_furn_data<T>::load( const JsonObject &jo )
     message_good = jo.get_bool( "message_good", true );
 }
 
-void ter_furn_transform::load( const JsonObject &jo, const std::string & )
+void ter_furn_transform::load( const JsonObject &jo, const std::string_view )
 {
     std::string input;
     mandatory( jo, was_loaded, "id", input );

--- a/src/magic_ter_furn_transform.h
+++ b/src/magic_ter_furn_transform.h
@@ -82,7 +82,7 @@ class ter_furn_transform
 
         static void reset();
         static void load_transform( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, const std::string & );
+        void load( const JsonObject &jo, std::string_view );
 
         static const std::vector<ter_furn_transform> &get_all();
         static void reset_all();

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -2828,7 +2828,7 @@ bool map_extra::is_valid_for( const mapgendata &md ) const
     return true;
 }
 
-void map_extra::load( const JsonObject &jo, const std::string & )
+void map_extra::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "description", description_ );

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -68,7 +68,7 @@ class map_extra
 
         // Used by generic_factory
         bool was_loaded = false;
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void check() const;
     private:
         translation name_;

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -336,7 +336,7 @@ map_bash_info::map_bash_info() : str_min( -1 ), str_max( -1 ),
     drop_group( Item_spawn_data_EMPTY_GROUP ),
     ter_set( ter_str_id::NULL_ID() ), furn_set( furn_str_id::NULL_ID() ) {}
 
-bool map_bash_info::load( const JsonObject &jsobj, const std::string &member,
+bool map_bash_info::load( const JsonObject &jsobj, const std::string_view member,
                           map_object_type obj_type, const std::string &context )
 {
     if( !jsobj.has_object( member ) ) {
@@ -401,7 +401,7 @@ bool map_bash_info::load( const JsonObject &jsobj, const std::string &member,
 map_deconstruct_info::map_deconstruct_info() : can_do( false ), deconstruct_above( false ),
     ter_set( ter_str_id::NULL_ID() ), furn_set( furn_str_id::NULL_ID() ) {}
 
-bool map_deconstruct_info::load( const JsonObject &jsobj, const std::string &member,
+bool map_deconstruct_info::load( const JsonObject &jsobj, const std::string_view member,
                                  bool is_furniture, const std::string &context )
 {
     if( !jsobj.has_object( member ) ) {
@@ -421,7 +421,7 @@ bool map_deconstruct_info::load( const JsonObject &jsobj, const std::string &mem
     return true;
 }
 
-bool map_shoot_info::load( const JsonObject &jsobj, const std::string &member, bool was_loaded )
+bool map_shoot_info::load( const JsonObject &jsobj, const std::string_view member, bool was_loaded )
 {
     JsonObject j = jsobj.get_object( member );
 
@@ -450,7 +450,7 @@ bool map_shoot_info::load( const JsonObject &jsobj, const std::string &member, b
 furn_workbench_info::furn_workbench_info() : multiplier( 1.0f ), allowed_mass( units::mass_max ),
     allowed_volume( units::volume_max ) {}
 
-bool furn_workbench_info::load( const JsonObject &jsobj, const std::string &member )
+bool furn_workbench_info::load( const JsonObject &jsobj, const std::string_view member )
 {
     JsonObject j = jsobj.get_object( member );
 
@@ -464,7 +464,7 @@ bool furn_workbench_info::load( const JsonObject &jsobj, const std::string &memb
 plant_data::plant_data() : transform( furn_str_id::NULL_ID() ), base( furn_str_id::NULL_ID() ),
     growth_multiplier( 1.0f ), harvest_multiplier( 1.0f ) {}
 
-bool plant_data::load( const JsonObject &jsobj, const std::string &member )
+bool plant_data::load( const JsonObject &jsobj, const std::string_view member )
 {
     JsonObject j = jsobj.get_object( member );
 

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -66,7 +66,7 @@ struct map_bash_info {
         terrain,
         field
     };
-    bool load( const JsonObject &jsobj, const std::string &member, map_object_type obj_type,
+    bool load( const JsonObject &jsobj, std::string_view member, map_object_type obj_type,
                const std::string &context );
 };
 struct map_deconstruct_info {
@@ -79,7 +79,7 @@ struct map_deconstruct_info {
     ter_str_id ter_set;    // terrain to set (REQUIRED for terrain))
     furn_str_id furn_set;    // furniture to set (only used by furniture, not terrain)
     map_deconstruct_info();
-    bool load( const JsonObject &jsobj, const std::string &member, bool is_furniture,
+    bool load( const JsonObject &jsobj, std::string_view member, bool is_furniture,
                const std::string &context );
 };
 struct map_shoot_info {
@@ -99,7 +99,7 @@ struct map_shoot_info {
     int destroy_dmg_max = 0;
     // Are lasers incapable of destroying the object (defaults to false)
     bool no_laser_destroy = false;
-    bool load( const JsonObject &jsobj, const std::string &member, bool was_loaded );
+    bool load( const JsonObject &jsobj, std::string_view member, bool was_loaded );
 };
 struct furn_workbench_info {
     // Base multiplier applied for crafting here
@@ -108,7 +108,7 @@ struct furn_workbench_info {
     units::mass allowed_mass;
     units::volume allowed_volume;
     furn_workbench_info();
-    bool load( const JsonObject &jsobj, const std::string &member );
+    bool load( const JsonObject &jsobj, std::string_view member );
 };
 struct plant_data {
     // What the furniture turns into when it grows or you plant seeds in it
@@ -120,7 +120,7 @@ struct plant_data {
     // What percent of the normal harvest this crop gives
     float harvest_multiplier;
     plant_data();
-    bool load( const JsonObject &jsobj, const std::string &member );
+    bool load( const JsonObject &jsobj, std::string_view member );
 };
 
 /*

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -836,7 +836,7 @@ mapgen_function_json_nested::mapgen_function_json_nested(
 
 jmapgen_int::jmapgen_int( point p ) : val( p.x ), valmax( p.y ) {}
 
-jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string &tag )
+jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string_view tag )
 {
     if( jo.has_array( tag ) ) {
         JsonArray sparray = jo.get_array( tag );
@@ -854,7 +854,7 @@ jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string &tag )
     }
 }
 
-jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string &tag, const int &def_val,
+jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string_view tag, const int &def_val,
                           const int &def_valmax )
     : val( def_val )
     , valmax( def_valmax )
@@ -1061,7 +1061,7 @@ static bool is_null_helper( const int_id<T> &id )
     return id.id().is_null();
 }
 
-static bool is_null_helper( const std::string & )
+static bool is_null_helper( const std::string_view )
 {
     return false;
 }
@@ -1119,7 +1119,7 @@ static bool is_valid_helper( const int_id<T> & )
     return true;
 }
 
-static bool is_valid_helper( const std::string & )
+static bool is_valid_helper( const std::string_view )
 {
     return true;
 }
@@ -1756,7 +1756,7 @@ class jmapgen_field : public jmapgen_piece
         std::vector<int> intensities;
         time_duration age;
         bool remove;
-        jmapgen_field( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_field( const JsonObject &jsi, const std::string_view/*context*/ ) :
             ftype( jsi.get_member( "field" ) )
             , age( time_duration::from_turns( jsi.get_int( "age", 0 ) ) )
             , remove( jsi.get_bool( "remove", false ) ) {
@@ -1800,7 +1800,7 @@ class jmapgen_npc : public jmapgen_piece
         bool target;
         std::vector<trait_id> traits;
         std::string unique_id;
-        jmapgen_npc( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_npc( const JsonObject &jsi, const std::string_view/*context*/ ) :
             npc_class( jsi.get_member( "class" ) )
             , target( jsi.get_bool( "target", false ) ) {
             if( jsi.has_string( "add_trait" ) ) {
@@ -1856,7 +1856,7 @@ class jmapgen_faction : public jmapgen_piece
 {
     public:
         mapgen_value<faction_id> id;
-        jmapgen_faction( const JsonObject &jsi, const std::string &/*context*/ )
+        jmapgen_faction( const JsonObject &jsi, const std::string_view/*context*/ )
             : id( jsi.get_member( "id" ) ) {
         }
         mapgen_phase phase() const override {
@@ -1887,7 +1887,7 @@ class jmapgen_sign : public jmapgen_piece
     public:
         translation signage;
         std::string snippet;
-        jmapgen_sign( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_sign( const JsonObject &jsi, const std::string_view/*context*/ ) :
             snippet( jsi.get_string( "snippet", "" ) ) {
             jsi.read( "signage", signage );
             if( signage.empty() && snippet.empty() ) {
@@ -1940,7 +1940,7 @@ class jmapgen_graffiti : public jmapgen_piece
     public:
         translation text;
         std::string snippet;
-        jmapgen_graffiti( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_graffiti( const JsonObject &jsi, const std::string_view/*context*/ ) :
             snippet( jsi.get_string( "snippet", "" ) ) {
             jsi.read( "text", text );
             if( text.empty() && snippet.empty() ) {
@@ -1988,7 +1988,7 @@ class jmapgen_vending_machine : public jmapgen_piece
         bool reinforced;
         mapgen_value<item_group_id> group_id;
         bool lootable;
-        jmapgen_vending_machine( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_vending_machine( const JsonObject &jsi, const std::string_view/*context*/ ) :
             reinforced( jsi.get_bool( "reinforced", false ) )
             , lootable( jsi.get_bool( "lootable", false ) ) {
             if( jsi.has_member( "item_group" ) ) {
@@ -2025,7 +2025,7 @@ class jmapgen_toilet : public jmapgen_piece
 {
     public:
         jmapgen_int amount;
-        jmapgen_toilet( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_toilet( const JsonObject &jsi, const std::string_view/*context*/ ) :
             amount( jsi, "amount", 0, 0 ) {
         }
         mapgen_phase phase() const override {
@@ -2055,7 +2055,7 @@ class jmapgen_gaspump : public jmapgen_piece
     public:
         jmapgen_int amount;
         mapgen_value<itype_id> fuel;
-        jmapgen_gaspump( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_gaspump( const JsonObject &jsi, const std::string_view/*context*/ ) :
             amount( jsi, "amount", 0, 0 ) {
             if( jsi.has_member( "fuel" ) ) {
                 jsi.read( "fuel", fuel );
@@ -2109,7 +2109,7 @@ class jmapgen_liquid_item : public jmapgen_piece
         jmapgen_int amount;
         mapgen_value<itype_id> liquid;
         jmapgen_int chance;
-        jmapgen_liquid_item( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_liquid_item( const JsonObject &jsi, const std::string_view/*context*/ ) :
             amount( jsi, "amount", -1, -1 )
             , liquid( jsi.get_member( "liquid" ) )
             , chance( jsi, "chance", 1, 1 ) {
@@ -2157,7 +2157,7 @@ class jmapgen_corpse : public jmapgen_piece
     public:
         mongroup_id group;
         time_duration age;
-        jmapgen_corpse( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_corpse( const JsonObject &jsi, const std::string_view/*context*/ ) :
             group( jsi.get_member( "group" ) )
             , age( time_duration::from_days( jsi.get_int( "age", 0 ) ) ) {
         }
@@ -2186,11 +2186,11 @@ class jmapgen_item_group : public jmapgen_piece
         item_group_id group_id;
         jmapgen_int chance;
         std::string faction;
-        jmapgen_item_group( const JsonObject &jsi, const std::string &context ) :
+        jmapgen_item_group( const JsonObject &jsi, const std::string_view context ) :
             chance( jsi, "chance", 1, 1 ) {
             JsonValue group = jsi.get_member( "item" );
             group_id = item_group::load_item_group( group, "collection",
-                                                    "mapgen item group " + context );
+                                                    str_cat( "mapgen item group ", context ) );
             repeat = jmapgen_int( jsi, "repeat", 1, 1 );
             if( jsi.has_string( "faction" ) ) {
                 faction = jsi.get_string( "faction" );
@@ -2277,7 +2277,7 @@ class jmapgen_monster_group : public jmapgen_piece
         mapgen_value<mongroup_id> id;
         float density;
         jmapgen_int chance;
-        jmapgen_monster_group( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_monster_group( const JsonObject &jsi, const std::string_view/*context*/ ) :
             id( jsi.get_member( "monster" ) )
             , density( jsi.get_float( "density", -1.0f ) )
             , chance( jsi, "chance", 1, 1 ) {
@@ -2324,7 +2324,7 @@ class jmapgen_monster : public jmapgen_piece
         bool target;
         bool use_pack_size;
         struct spawn_data data;
-        jmapgen_monster( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_monster( const JsonObject &jsi, const std::string_view/*context*/ ) :
             chance( jsi, "chance", 100, 100 )
             , pack_size( jsi, "pack_size", 1, 1 )
             , one_or_none( jsi.get_bool( "one_or_none",
@@ -2464,7 +2464,7 @@ class jmapgen_vehicle : public jmapgen_piece
         int fuel;
         int status;
         std::string faction;
-        jmapgen_vehicle( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_vehicle( const JsonObject &jsi, const std::string_view/*context*/ ) :
             type( jsi.get_member( "vehicle" ) )
             , chance( jsi, "chance", 1, 1 )
             //, rotation( jsi.get_int( "rotation", 0 ) ) // unless there is a way for the json parser to
@@ -2647,7 +2647,7 @@ class jmapgen_spawn_item : public jmapgen_piece
         jmapgen_int amount;
         jmapgen_int chance;
         std::set<flag_id> flags;
-        jmapgen_spawn_item( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_spawn_item( const JsonObject &jsi, const std::string_view/*context*/ ) :
             type( jsi.get_member( "item" ) )
             , amount( jsi, "amount", 1, 1 )
             , chance( jsi, "chance", 100, 100 )
@@ -2697,7 +2697,7 @@ class jmapgen_trap : public jmapgen_piece
         mapgen_value<trap_id> id;
         bool remove = false;
 
-        jmapgen_trap( const JsonObject &jsi, const std::string &/*context*/ ) {
+        jmapgen_trap( const JsonObject &jsi, const std::string_view/*context*/ ) {
             init( jsi.get_member( "trap" ) );
             remove = jsi.get_bool( "remove", false );
         }
@@ -2748,7 +2748,7 @@ class jmapgen_furniture : public jmapgen_piece
 {
     public:
         mapgen_value<furn_id> id;
-        jmapgen_furniture( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_furniture( const JsonObject &jsi, const std::string_view/*context*/ ) :
             jmapgen_furniture( jsi.get_member( "furn" ) ) {}
         explicit jmapgen_furniture( const JsonValue &fid ) : id( fid ) {}
         mapgen_phase phase() const override {
@@ -2786,7 +2786,7 @@ class jmapgen_terrain : public jmapgen_piece
         };
     public:
         mapgen_value<ter_id> id;
-        jmapgen_terrain( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_terrain( const JsonObject &jsi, const std::string_view/*context*/ ) :
             jmapgen_terrain( jsi.get_member( "ter" ) ) {}
         explicit jmapgen_terrain( const JsonValue &tid ) : id( mapgen_value<ter_id>( tid ) ) {}
 
@@ -2950,7 +2950,7 @@ class jmapgen_ter_furn_transform: public jmapgen_piece
 {
     public:
         mapgen_value<ter_furn_transform_id> id;
-        jmapgen_ter_furn_transform( const JsonObject &jsi, const std::string &/*context*/ ) :
+        jmapgen_ter_furn_transform( const JsonObject &jsi, const std::string_view/*context*/ ) :
             id( jsi.get_member( "transform" ) ) {}
 
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y,
@@ -2979,7 +2979,7 @@ class jmapgen_make_rubble : public jmapgen_piece
         bool items = false;
         mapgen_value<ter_id> floor_type = mapgen_value<ter_id>( t_dirt );
         bool overwrite = false;
-        jmapgen_make_rubble( const JsonObject &jsi, const std::string &/*context*/ ) {
+        jmapgen_make_rubble( const JsonObject &jsi, const std::string_view/*context*/ ) {
             if( jsi.has_member( "rubble_type" ) ) {
                 rubble_type = mapgen_value<furn_id>( jsi.get_member( "rubble_type" ) );
             }
@@ -3028,7 +3028,7 @@ class jmapgen_computer : public jmapgen_piece
         std::vector<std::string> chat_topics;
         std::vector<effect_on_condition_id> eocs;
         bool target;
-        jmapgen_computer( const JsonObject &jsi, const std::string &/*context*/ ) {
+        jmapgen_computer( const JsonObject &jsi, const std::string_view/*context*/ ) {
             jsi.read( "name", name );
             jsi.read( "access_denied", access_denied );
             security = jsi.get_int( "security", 0 );
@@ -3232,7 +3232,7 @@ class jmapgen_translate : public jmapgen_piece
     public:
         mapgen_value<ter_id> from;
         mapgen_value<ter_id> to;
-        jmapgen_translate( const JsonObject &jsi, const std::string &/*context*/ )
+        jmapgen_translate( const JsonObject &jsi, const std::string_view/*context*/ )
             : from( jsi.get_member( "from" ) )
             , to( jsi.get_member( "to" ) ) {
         }
@@ -3264,7 +3264,7 @@ class jmapgen_zone : public jmapgen_piece
         mapgen_value<faction_id> faction;
         std::string name;
         std::string filter;
-        jmapgen_zone( const JsonObject &jsi, const std::string &/*context*/ )
+        jmapgen_zone( const JsonObject &jsi, const std::string_view/*context*/ )
             : zone_type( jsi.get_member( "type" ) )
             , faction( jsi.get_member( "faction" ) ) {
             if( jsi.has_string( "name" ) ) {
@@ -3301,7 +3301,7 @@ class jmapgen_remove_vehicles : public jmapgen_piece
 {
     public:
         std::vector<vproto_id> vehicles_to_remove;
-        jmapgen_remove_vehicles( const JsonObject &jo, const std::string &/*context*/ ) {
+        jmapgen_remove_vehicles( const JsonObject &jo, const std::string_view/*context*/ ) {
             for( std::string item_id : jo.get_string_array( "vehicles" ) ) {
                 vehicles_to_remove.emplace_back( vproto_id( item_id ) );
             }
@@ -3333,7 +3333,7 @@ class jmapgen_remove_npcs : public jmapgen_piece
     public:
         std::string npc_class;
         std::string unique_id;
-        jmapgen_remove_npcs( const JsonObject &jsi, const std::string & /*context*/ ) {
+        jmapgen_remove_npcs( const JsonObject &jsi, const std::string_view /*context*/ ) {
             optional( jsi, false, "class", npc_class );
             optional( jsi, false, "unique_id", unique_id );
         }
@@ -3361,7 +3361,7 @@ class jmapgen_remove_npcs : public jmapgen_piece
 class jmapgen_remove_all : public jmapgen_piece
 {
     public:
-        jmapgen_remove_all( const JsonObject &/*jo*/, const std::string &/*context*/ ) {
+        jmapgen_remove_all( const JsonObject &/*jo*/, const std::string_view/*context*/ ) {
         }
         mapgen_phase phase() const override {
             return mapgen_phase::removal;
@@ -3411,7 +3411,7 @@ class jmapgen_nested : public jmapgen_piece
                     }
                 }
 
-                void check( const std::string &/*oter_name*/, const mapgen_parameters & ) const {
+                void check( const std::string_view/*oter_name*/, const mapgen_parameters & ) const {
                     // The check is ot_match_type::contains, so actually these
                     // don't need to be valid ids, although they were until
                     // recently.  TODO: permit the JSON to specify which match
@@ -3465,7 +3465,7 @@ class jmapgen_nested : public jmapgen_piece
                     }
                 }
 
-                void check( const std::string &, const mapgen_parameters & ) const {
+                void check( const std::string_view, const mapgen_parameters & ) const {
                     // TODO: check join ids are valid
                 }
 
@@ -3494,7 +3494,7 @@ class jmapgen_nested : public jmapgen_piece
         weighted_int_list<mapgen_value<nested_mapgen_id>> else_entries;
         neighbor_oter_check neighbor_oters;
         neighbor_join_check neighbor_joins;
-        jmapgen_nested( const JsonObject &jsi, const std::string &/*context*/ )
+        jmapgen_nested( const JsonObject &jsi, const std::string_view/*context*/ )
             : neighbor_oters( jsi.get_object( "neighbors" ) )
             , neighbor_joins( jsi.get_object( "joins" ) ) {
             if( jsi.has_member( "chunks" ) ) {
@@ -3681,7 +3681,7 @@ void jmapgen_objects::add( const jmapgen_place &place,
 }
 
 template<typename PieceType>
-void jmapgen_objects::load_objects( const JsonArray &parray, const std::string &context )
+void jmapgen_objects::load_objects( const JsonArray &parray, const std::string_view context )
 {
     for( JsonObject jsi : parray ) {
         jmapgen_place where( jsi );
@@ -3697,7 +3697,7 @@ void jmapgen_objects::load_objects( const JsonArray &parray, const std::string &
 
 template<>
 void jmapgen_objects::load_objects<jmapgen_loot>(
-    const JsonArray &parray, const std::string &/*context*/ )
+    const JsonArray &parray, const std::string_view/*context*/ )
 {
     for( JsonObject jsi : parray ) {
         jmapgen_place where( jsi );
@@ -3943,13 +3943,13 @@ void mapgen_palette::check()
     }
 }
 
-mapgen_palette mapgen_palette::load_temp( const JsonObject &jo, const std::string &src,
+mapgen_palette mapgen_palette::load_temp( const JsonObject &jo, const std::string_view src,
         const std::string &context )
 {
     return load_internal( jo, src, context, false, true );
 }
 
-void mapgen_palette::load( const JsonObject &jo, const std::string &src )
+void mapgen_palette::load( const JsonObject &jo, const std::string_view src )
 {
     mapgen_palette ret = load_internal( jo, src, "", true, false );
     if( ret.id.is_empty() ) {
@@ -4066,7 +4066,7 @@ void mapgen_palette::add( const mapgen_palette &rh, const add_palette_context &c
     parameters.check_and_merge( rh.parameters, actual_context );
 }
 
-mapgen_palette mapgen_palette::load_internal( const JsonObject &jo, const std::string &,
+mapgen_palette mapgen_palette::load_internal( const JsonObject &jo, const std::string_view,
         const std::string &context, bool require_id, bool allow_recur )
 {
     mapgen_palette new_pal;

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -81,12 +81,12 @@ struct jmapgen_int {
     /**
      * Throws as usually if the json is invalid or missing.
      */
-    jmapgen_int( const JsonObject &jo, const std::string &tag );
+    jmapgen_int( const JsonObject &jo, std::string_view tag );
     /**
      * Throws is the json is malformed (e.g. a string not an integer, but does not throw
      * if the member is just missing (the default values are used instead).
      */
-    jmapgen_int( const JsonObject &jo, const std::string &tag, const int &def_val,
+    jmapgen_int( const JsonObject &jo, std::string_view tag, const int &def_val,
                  const int &def_valmax );
 
     int get() const;
@@ -321,13 +321,13 @@ class mapgen_palette
         /**
          * Loads a palette object and returns it. Doesn't save it anywhere.
          */
-        static mapgen_palette load_temp( const JsonObject &jo, const std::string &src,
+        static mapgen_palette load_temp( const JsonObject &jo, std::string_view src,
                                          const std::string &context );
         /**
          * Load a palette object and adds it to the global set of palettes.
          * If "palette" field is specified, those palettes will be loaded recursively.
          */
-        static void load( const JsonObject &jo, const std::string &src );
+        static void load( const JsonObject &jo, std::string_view src );
 
         /**
          * Returns a palette with given id. If not found, debugmsg and returns a dummy.
@@ -346,7 +346,7 @@ class mapgen_palette
         std::vector<mapgen_value<std::string>> palettes_used;
 
         static mapgen_palette load_internal(
-            const JsonObject &jo, const std::string &src, const std::string &context,
+            const JsonObject &jo, std::string_view src, const std::string &context,
             bool require_id, bool allow_recur );
 
         struct add_palette_context {
@@ -386,7 +386,7 @@ struct jmapgen_objects {
          * them in @ref objects.
          */
         template<typename PieceType>
-        void load_objects( const JsonArray &parray, const std::string &context );
+        void load_objects( const JsonArray &parray, std::string_view context );
 
         /**
          * Loads the mapgen objects from the array inside of jsi. If jsi has no member of that name,

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -82,7 +82,7 @@ void weapon_category::reset()
     weapon_category_factory.reset();
 }
 
-void weapon_category::load( const JsonObject &jo, const std::string & )
+void weapon_category::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
 }
@@ -189,7 +189,7 @@ class tech_effect_reader : public generic_typed_reader<tech_effect_reader>
         }
 };
 
-void ma_requirements::load( const JsonObject &jo, const std::string & )
+void ma_requirements::load( const JsonObject &jo, const std::string_view )
 {
     optional( jo, was_loaded, "unarmed_allowed", unarmed_allowed, false );
     optional( jo, was_loaded, "melee_allowed", melee_allowed, false );
@@ -292,7 +292,7 @@ bool string_id<ma_technique>::is_valid() const
     return ma_techniques.is_valid( *this );
 }
 
-void ma_buff::load( const JsonObject &jo, const std::string &src )
+void ma_buff::load( const JsonObject &jo, const std::string_view src )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "description", description );

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -33,7 +33,7 @@ class weapon_category
         static void load_weapon_categories( const JsonObject &jo, const std::string &src );
         static void reset();
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 
         static const std::vector<weapon_category> &get_all();
 
@@ -102,7 +102,7 @@ struct ma_requirements {
     bool is_valid_character( const Character &u ) const;
     bool is_valid_weapon( const item &i ) const;
 
-    void load( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view src );
 };
 
 struct tech_effect_data {
@@ -277,7 +277,7 @@ class ma_buff
         bool strictly_melee = false; // can we only use it with weapons?
         bool stealthy = false; // do we make less noise when moving?
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 };
 
 class martialart

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -81,7 +81,7 @@ static mat_burn_data load_mat_burn_data( const JsonObject &jsobj )
     return bd;
 }
 
-void material_type::load( const JsonObject &jsobj, const std::string & )
+void material_type::load( const JsonObject &jsobj, const std::string_view )
 {
     mandatory( jsobj, was_loaded, "name", _name );
 

--- a/src/material.h
+++ b/src/material.h
@@ -115,7 +115,7 @@ class material_type
     public:
         material_type();
 
-        void load( const JsonObject &jsobj, const std::string &src );
+        void load( const JsonObject &jsobj, std::string_view src );
         void check() const;
 
         material_id ident() const;

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -136,7 +136,8 @@ constexpr double thingie::eval( dialogue const &d ) const
         {
             return v;
         },
-        []( std::string const & v )
+        // NOLINTNEXTLINE(cata-use-string_view)
+        []( const std::string & v )
         {
             debugmsg( "Unexpected string operand %.*s", v.size(), v.data() );
             return 0.0;

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -67,7 +67,7 @@ memorial_log_entry::memorial_log_entry( const std::string &preformatted_msg ) :
 {}
 
 memorial_log_entry::memorial_log_entry( time_point time, const oter_type_str_id &oter_id,
-                                        const std::string &oter_name, const std::string &msg ) :
+                                        std::string_view oter_name, std::string_view msg ) :
     time_( time ), oter_id_( oter_id ), oter_name_( oter_name ), message_( msg )
 {}
 
@@ -115,11 +115,11 @@ void memorial_logger::clear()
  * the character dies. The message should contain only the informational string,
  * as the timestamp and location will be automatically prepended.
  */
-void memorial_logger::add( const std::string &male_msg,
-                           const std::string &female_msg )
+void memorial_logger::add( const std::string_view male_msg,
+                           const std::string_view female_msg )
 {
     Character &player_character = get_player_character();
-    const std::string &msg = player_character.male ? male_msg : female_msg;
+    const std::string_view msg = player_character.male ? male_msg : female_msg;
 
     if( msg.empty() ) {
         return;
@@ -246,7 +246,7 @@ void memorial_logger::write_text_memorial( std::ostream &file,
     //HP
 
     const auto limb_hp =
-    [&file, &indent, &u]( const std::string & desc, const bodypart_id & bp ) {
+    [&file, &indent, &u]( const std::string_view desc, const bodypart_id & bp ) {
         file << indent <<
              string_format( desc, u.get_part_hp_cur( bp ), u.get_part_hp_max( bp ) ) << eol;
     };

--- a/src/memorial_logger.h
+++ b/src/memorial_logger.h
@@ -24,8 +24,8 @@ class memorial_log_entry
     public:
         memorial_log_entry() = default;
         explicit memorial_log_entry( const std::string &preformatted_msg );
-        memorial_log_entry( time_point, const oter_type_str_id &, const std::string &oter_name,
-                            const std::string &msg );
+        memorial_log_entry( time_point, const oter_type_str_id &, std::string_view oter_name,
+                            std::string_view msg );
 
         std::string to_string() const;
 
@@ -48,18 +48,13 @@ class memorial_logger : public event_subscriber
     public:
         void clear();
 
-        void add( const std::string &male_msg,
-                  const std::string &female_msg );
-        template<typename ...Args>
-        void add( const char *const male_msg, const char *const female_msg, Args &&... args ) {
-            return add( string_format( male_msg, args... ),
-                        string_format( female_msg, args... ) );
-        }
-        template<typename ...Args>
-        void add( const std::string &male_msg, const std::string &female_msg,
-                  Args &&... args ) {
-            return add( string_format( male_msg, args... ),
-                        string_format( female_msg, args... ) );
+        void add( std::string_view male_msg,
+                  std::string_view female_msg );
+        template<typename Arg, typename ...Args>
+        void add( const std::string_view male_msg, const std::string &female_msg,
+                  Arg &&arg, Args &&... args ) {
+            return add( string_format( male_msg, arg, args... ),
+                        string_format( female_msg, arg, args... ) );
         }
 
         // Loads the memorial log from a file

--- a/src/mod_tileset.cpp
+++ b/src/mod_tileset.cpp
@@ -7,7 +7,7 @@
 
 std::vector<mod_tileset> all_mod_tilesets;
 
-void load_mod_tileset( const JsonObject &jsobj, const std::string &, const cata_path &base_path,
+void load_mod_tileset( const JsonObject &jsobj, const std::string_view, const cata_path &base_path,
                        const cata_path &full_path )
 {
     // This function only checks whether mod tileset is compatible.

--- a/src/mod_tileset.h
+++ b/src/mod_tileset.h
@@ -12,7 +12,7 @@ class mod_tileset;
 
 extern std::vector<mod_tileset> all_mod_tilesets;
 
-void load_mod_tileset( const JsonObject &jsobj, const std::string &, const cata_path &base_path,
+void load_mod_tileset( const JsonObject &jsobj, std::string_view, const cata_path &base_path,
                        const cata_path &full_path );
 void reset_mod_tileset();
 

--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -182,7 +182,7 @@ void monfactions::finalize()
     }
 }
 
-void monfaction::load( const JsonObject &jo, const std::string & )
+void monfaction::load( const JsonObject &jo, const std::string_view )
 {
     optional( jo, was_loaded, "base_faction", base_faction, mfaction_str_id() );
     optional( jo, was_loaded, "by_mood", _att_by_mood, string_id_reader<monfaction>() );

--- a/src/monfaction.h
+++ b/src/monfaction.h
@@ -91,7 +91,7 @@ class monfaction
         void populate_attitude_vec() const;
 
         /** Load from JSON */
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 
         friend void monfactions::finalize();
         friend class generic_factory<monfaction>;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -902,7 +902,7 @@ std::string monster::extended_description() const
 
     using flag_description = std::pair<m_flag, std::string>;
     const auto describe_flags = [this, &ss](
-                                    const std::string & format,
+                                    const std::string_view format,
                                     const std::vector<flag_description> &flags_names,
     const std::string &if_empty = "" ) {
         std::string flag_descriptions = enumerate_as_string( flags_names.begin(),
@@ -918,7 +918,7 @@ std::string monster::extended_description() const
 
     using property_description = std::pair<bool, std::string>;
     const auto describe_properties = [&ss](
-                                         const std::string & format,
+                                         const std::string_view format,
                                          const std::vector<property_description> &property_names,
     const std::string &if_empty = "" ) {
         std::string property_descriptions = enumerate_as_string( property_names.begin(),
@@ -2409,7 +2409,7 @@ void monster::disable_special( const std::string &special_name )
     special_attacks.at( special_name ).enabled = false;
 }
 
-bool monster::special_available( const std::string &special_name ) const
+bool monster::special_available( const std::string_view special_name ) const
 {
     std::map<std::string, mon_special_attack>::const_iterator iter = special_attacks.find(
                 special_name );

--- a/src/monster.h
+++ b/src/monster.h
@@ -431,7 +431,7 @@ class monster : public Creature
         /** Test whether the monster has the specified special regardless of readiness. */
         bool has_special( const std::string &special_name ) const;
         /** Test whether the specified special is ready. */
-        bool special_available( const std::string &special_name ) const;
+        bool special_available( std::string_view special_name ) const;
 
         void process_turn() override;
         /** Resets the value of all bonus fields to 0, clears special effect flags. */
@@ -588,7 +588,7 @@ class monster : public Creature
         void process_trigger( mon_trigger trig, const std::function<int()> &amount_func );
 
         int hp = 0;
-        std::map<std::string, mon_special_attack> special_attacks;
+        std::map<std::string, mon_special_attack, std::less<>> special_attacks;
         std::optional<tripoint_abs_ms> goal;
         bool dead = false;
         /** Normal upgrades **/

--- a/src/monster_oracle.cpp
+++ b/src/monster_oracle.cpp
@@ -10,12 +10,12 @@ struct tripoint;
 namespace behavior
 {
 
-status_t monster_oracle_t::not_hallucination( const std::string & ) const
+status_t monster_oracle_t::not_hallucination( const std::string_view ) const
 {
     return subject->is_hallucination() ? status_t::failure : status_t::running;
 }
 
-status_t monster_oracle_t::split_possible( const std::string & ) const
+status_t monster_oracle_t::split_possible( const std::string_view ) const
 {
     // check if subject has split to support inverting this predicate for absorb monsters without split
     if( subject->has_special( "SPLIT" ) && ( subject->get_hp() / 2 ) > subject->get_hp_max() ) {
@@ -24,7 +24,7 @@ status_t monster_oracle_t::split_possible( const std::string & ) const
     return status_t::failure;
 }
 
-status_t monster_oracle_t::items_available( const std::string & ) const
+status_t monster_oracle_t::items_available( const std::string_view ) const
 {
     if( !get_map().has_flag( ter_furn_flag::TFLAG_SEALED, subject->pos() ) &&
         get_map().has_items( subject->pos() ) ) {
@@ -47,7 +47,7 @@ status_t monster_oracle_t::items_available( const std::string & ) const
 }
 
 // TODO: Have it select a target and stash it somewhere.
-status_t monster_oracle_t::adjacent_plants( const std::string & ) const
+status_t monster_oracle_t::adjacent_plants( const std::string_view ) const
 {
     for( const tripoint &p : get_map().points_in_radius( subject->pos(), 1 ) ) {
         if( get_map().has_flag( ter_furn_flag::TFLAG_PLANT, p ) ) {
@@ -57,7 +57,7 @@ status_t monster_oracle_t::adjacent_plants( const std::string & ) const
     return status_t::failure;
 }
 
-status_t monster_oracle_t::special_available( const std::string &special_name ) const
+status_t monster_oracle_t::special_available( const std::string_view special_name ) const
 {
     bool only_if_present = false;
     std::string mspecial_name;

--- a/src/monster_oracle.h
+++ b/src/monster_oracle.h
@@ -21,11 +21,11 @@ class monster_oracle_t : public oracle_t
         /**
          * Predicates used by AI to determine goals.
          */
-        status_t not_hallucination( const std::string & ) const;
-        status_t items_available( const std::string & ) const;
-        status_t adjacent_plants( const std::string & ) const;
-        status_t special_available( const std::string &special_name ) const;
-        status_t split_possible( const std::string & ) const;
+        status_t not_hallucination( std::string_view ) const;
+        status_t items_available( std::string_view ) const;
+        status_t adjacent_plants( std::string_view ) const;
+        status_t special_available( std::string_view special_name ) const;
+        status_t split_possible( std::string_view ) const;
     private:
         const monster *subject;
 };

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1169,7 +1169,7 @@ void MonsterGenerator::load_species( const JsonObject &jo, const std::string &sr
     mon_species->load( jo, src );
 }
 
-void species_type::load( const JsonObject &jo, const std::string & )
+void species_type::load( const JsonObject &jo, const std::string_view )
 {
     optional( jo, was_loaded, "description", description );
     optional( jo, was_loaded, "footsteps", footsteps, to_translation( "footsteps." ) );
@@ -1325,7 +1325,7 @@ void mtype::add_special_attack( const JsonObject &obj, const std::string &src )
     special_attacks_names.push_back( new_attack->id );
 }
 
-void mtype::add_special_attack( const JsonArray &inner, const std::string & )
+void mtype::add_special_attack( const JsonArray &inner, const std::string_view )
 {
     MonsterGenerator &gen = MonsterGenerator::generator();
     const std::string name = inner.get_string( 0 );
@@ -1351,7 +1351,7 @@ void mtype::add_special_attack( const JsonArray &inner, const std::string & )
     special_attacks_names.push_back( name );
 }
 
-void mtype::add_special_attacks( const JsonObject &jo, const std::string &member,
+void mtype::add_special_attacks( const JsonObject &jo, const std::string_view member,
                                  const std::string &src )
 {
 
@@ -1370,8 +1370,8 @@ void mtype::add_special_attacks( const JsonObject &jo, const std::string &member
     }
 }
 
-void mtype::remove_special_attacks( const JsonObject &jo, const std::string &member_name,
-                                    const std::string & )
+void mtype::remove_special_attacks( const JsonObject &jo, const std::string_view member_name,
+                                    const std::string_view )
 {
     for( const std::string &name : jo.get_tags( member_name ) ) {
         special_attacks.erase( name );
@@ -1382,7 +1382,7 @@ void mtype::remove_special_attacks( const JsonObject &jo, const std::string &mem
     }
 }
 
-void mtype::add_regeneration_modifier( const JsonArray &inner, const std::string & )
+void mtype::add_regeneration_modifier( const JsonArray &inner, const std::string_view )
 {
     const std::string effect_name = inner.get_string( 0 );
     const efftype_id effect( effect_name );
@@ -1400,8 +1400,8 @@ void mtype::add_regeneration_modifier( const JsonArray &inner, const std::string
     regeneration_modifiers.emplace( effect, amount );
 }
 
-void mtype::add_regeneration_modifiers( const JsonObject &jo, const std::string &member,
-                                        const std::string &src )
+void mtype::add_regeneration_modifiers( const JsonObject &jo, const std::string_view member,
+                                        const std::string_view src )
 {
     if( !jo.has_array( member ) ) {
         return;
@@ -1419,8 +1419,8 @@ void mtype::add_regeneration_modifiers( const JsonObject &jo, const std::string 
     }
 }
 
-void mtype::remove_regeneration_modifiers( const JsonObject &jo, const std::string &member_name,
-        const std::string & )
+void mtype::remove_regeneration_modifiers( const JsonObject &jo, const std::string_view member_name,
+        const std::string_view )
 {
     for( const std::string &name : jo.get_tags( member_name ) ) {
         const efftype_id effect( name );

--- a/src/monstergenerator.h
+++ b/src/monstergenerator.h
@@ -46,7 +46,7 @@ struct species_type {
 
     }
 
-    void load( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view src );
 };
 
 class MonsterGenerator

--- a/src/mood_face.cpp
+++ b/src/mood_face.cpp
@@ -38,7 +38,7 @@ void mood_face::reset()
     mood_face_factory.reset();
 }
 
-void mood_face::load( const JsonObject &jo, const std::string & )
+void mood_face::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "values", values_ );
     std::sort( values_.begin(), values_.end(),

--- a/src/mood_face.h
+++ b/src/mood_face.h
@@ -18,7 +18,7 @@ class mood_face
         static void load_mood_faces( const JsonObject &jo, const std::string &src );
         static void reset();
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 
         static const std::vector<mood_face> &get_all();
 

--- a/src/morale_types.cpp
+++ b/src/morale_types.cpp
@@ -304,7 +304,7 @@ void morale_type_data::reset()
     morale_data.reset();
 }
 
-void morale_type_data::load( const JsonObject &jo, const std::string & )
+void morale_type_data::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "text", text );

--- a/src/morale_types.h
+++ b/src/morale_types.h
@@ -28,7 +28,7 @@ class morale_type_data
             return permanent;
         }
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void check() const;
 
         static void load_type( const JsonObject &jo, const std::string &src );

--- a/src/move_mode.cpp
+++ b/src/move_mode.cpp
@@ -47,7 +47,7 @@ void move_mode::load_move_mode( const JsonObject &jo, const std::string &src )
     move_mode_factory.load( jo, src );
 }
 
-void move_mode::load( const JsonObject &jo, const std::string &/*src*/ )
+void move_mode::load( const JsonObject &jo, const std::string_view/*src*/ )
 {
     mandatory( jo, was_loaded, "character", _letter, unicode_codepoint_from_symbol_reader );
     mandatory( jo, was_loaded, "name",  _name );

--- a/src/move_mode.h
+++ b/src/move_mode.h
@@ -68,7 +68,7 @@ class move_mode
 
     public:
         static void load_move_mode( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         static void finalize();
         static void reset();
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -257,20 +257,20 @@ struct mtype {
 
         behavior::node_t goals;
 
-        void add_special_attacks( const JsonObject &jo, const std::string &member_name,
+        void add_special_attacks( const JsonObject &jo, std::string_view member_name,
                                   const std::string &src );
-        void remove_special_attacks( const JsonObject &jo, const std::string &member_name,
-                                     const std::string &src );
+        void remove_special_attacks( const JsonObject &jo, std::string_view member_name,
+                                     std::string_view src );
 
-        void add_special_attack( const JsonArray &inner, const std::string &src );
+        void add_special_attack( const JsonArray &inner, std::string_view src );
         void add_special_attack( const JsonObject &obj, const std::string &src );
 
-        void add_regeneration_modifiers( const JsonObject &jo, const std::string &member_name,
-                                         const std::string &src );
-        void remove_regeneration_modifiers( const JsonObject &jo, const std::string &member_name,
-                                            const std::string &src );
+        void add_regeneration_modifiers( const JsonObject &jo, std::string_view member_name,
+                                         std::string_view src );
+        void remove_regeneration_modifiers( const JsonObject &jo, std::string_view member_name,
+                                            std::string_view src );
 
-        void add_regeneration_modifier( const JsonArray &inner, const std::string &src );
+        void add_regeneration_modifier( const JsonArray &inner, std::string_view src );
 
     public:
         mtype_id id;

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -89,7 +89,7 @@ struct mut_transform {
     /** subtracted from @ref Creature::moves when transformation is successful */
     int moves = 0;
     mut_transform();
-    bool load( const JsonObject &jsobj, const std::string &member );
+    bool load( const JsonObject &jsobj, std::string_view member );
 };
 
 struct reflex_activation_data {

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -69,7 +69,7 @@ bool string_id<Trait_group>::is_valid() const
 
 static void extract_mod(
     const JsonObject &j, std::unordered_map<std::pair<bool, std::string>, int, cata::tuple_hash> &data,
-    const std::string &mod_type, bool active, const std::string &type_key )
+    const std::string_view mod_type, bool active, const std::string &type_key )
 {
     int val = j.get_int( mod_type, 0 );
     if( val != 0 ) {
@@ -226,7 +226,7 @@ void mutation_branch::load_trait( const JsonObject &jo, const std::string &src )
 
 mut_transform::mut_transform() = default;
 
-bool mut_transform::load( const JsonObject &jsobj, const std::string &member )
+bool mut_transform::load( const JsonObject &jsobj, const std::string_view member )
 {
     JsonObject j = jsobj.get_object( member );
 

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -42,7 +42,7 @@ static void draw_exam_window( const catacurses::window &win, const int border_y 
     mvwputch( win, point( width - 1, border_y ), BORDER_COLOR, LINE_XOXX );
 }
 
-static const auto shortcut_desc = []( const std::string &comment, const std::string &keys )
+static const auto shortcut_desc = []( const std::string_view comment, const std::string &keys )
 {
     return string_format( comment, string_format( "[<color_yellow>%s</color>]", keys ) );
 };

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -939,14 +939,16 @@ static void draw_points( const catacurses::window &w, pool_type pool, const avat
 
 template <class Compare>
 static void draw_filter_and_sorting_indicators( const catacurses::window &w,
-        const input_context &ctxt, const std::string &filterstring, const Compare &sorter )
+        const input_context &ctxt, const std::string_view filterstring, const Compare &sorter )
 {
     const char *const sort_order = sorter.sort_by_points ? _( "points" ) : _( "name" );
     const std::string sorting_indicator = string_format( "[%1$s] %2$s: %3$s",
                                           colorize( ctxt.get_desc( "SORT" ), c_green ), _( "sort" ),
                                           sort_order );
-    const std::string filter_indicator = filterstring.empty() ? string_format( _( "[%s] filter" ),
-                                         colorize( ctxt.get_desc( "FILTER" ), c_green ) ) : filterstring;
+    const std::string filter_indicator =
+        filterstring.empty()
+        ? string_format( _( "[%s] filter" ), colorize( ctxt.get_desc( "FILTER" ), c_green ) )
+        : std::string( filterstring );
     nc_color current_color = BORDER_COLOR;
     print_colored_text( w, point( 2, getmaxy( w ) - 1 ), current_color, BORDER_COLOR,
                         string_format( "<%1s>-<%2s>", sorting_indicator, filter_indicator ) );

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -214,7 +214,7 @@ static distribution load_distribution( const JsonObject &jo )
     jo.throw_error( "Invalid distribution" );
 }
 
-static distribution load_distribution( const JsonObject &jo, const std::string &name )
+static distribution load_distribution( const JsonObject &jo, const std::string_view name )
 {
     if( !jo.has_member( name ) ) {
         return distribution();
@@ -267,7 +267,7 @@ void shopkeeper_item_group::deserialize( const JsonObject &jo )
     }
 }
 
-void npc_class::load( const JsonObject &jo, const std::string & )
+void npc_class::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "job_description", job_description );

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -128,7 +128,7 @@ class npc_class
         const time_duration &get_shop_restock_interval() const;
         faction_price_rule const *get_price_rules( item const &it, npc const &guy ) const;
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 
         static const npc_class_id &from_legacy_int( int i );
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -169,7 +169,7 @@ static void run_eoc_vector( const std::vector<effect_on_condition_id> &eocs, con
 }
 
 static std::vector<effect_on_condition_id> load_eoc_vector( const JsonObject &jo,
-        const std::string &member )
+        const std::string_view member )
 {
     std::vector<effect_on_condition_id> eocs;
     if( jo.has_array( member ) ) {
@@ -2678,7 +2678,7 @@ void talk_effect_fun_t::set_npc_cbm_recharge_rule( const JsonObject &jo,
     };
 }
 
-void talk_effect_fun_t::set_location_variable( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_location_variable( const JsonObject &jo, const std::string_view member,
         bool is_npc )
 {
     dbl_or_var dov_min_radius = get_dbl_or_var( jo, "min_radius", false, 0 );
@@ -2747,7 +2747,7 @@ void talk_effect_fun_t::set_location_variable( const JsonObject &jo, const std::
 }
 
 void talk_effect_fun_t::set_location_variable_adjust( const JsonObject &jo,
-        const std::string &member )
+        const std::string_view member )
 {
     dbl_or_var dov_z_adjust = get_dbl_or_var( jo, "z_adjust", false, 0 );
     dbl_or_var dov_x_adjust = get_dbl_or_var( jo, "x_adjust", false, 0 );
@@ -2924,7 +2924,7 @@ void talk_effect_fun_t::set_alter_timed_events( const JsonObject &jo, const std:
     };
 }
 
-void talk_effect_fun_t::set_revert_location( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_revert_location( const JsonObject &jo, const std::string_view member )
 {
     duration_or_var dov_time_in_future = get_duration_or_var( jo, "time_in_future", true );
     str_or_var key;
@@ -2959,7 +2959,7 @@ void talk_effect_fun_t::set_revert_location( const JsonObject &jo, const std::st
     };
 }
 
-void talk_effect_fun_t::set_npc_goal( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_npc_goal( const JsonObject &jo, const std::string_view member )
 {
     mission_target_params dest_params = mission_util::parse_mission_om_target( jo.get_object(
                                             member ) );
@@ -3275,7 +3275,7 @@ void talk_effect_fun_t::set_add_wet( const JsonObject &jo, const std::string &me
     };
 }
 
-void talk_effect_fun_t::set_open_dialogue( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_open_dialogue( const JsonObject &jo, const std::string_view member )
 {
     std::vector<effect_on_condition_id> true_eocs;
     std::vector<effect_on_condition_id> false_eocs;
@@ -3435,7 +3435,7 @@ void talk_effect_fun_t::set_hp( const JsonObject &jo, const std::string &member,
     };
 }
 
-void talk_effect_fun_t::set_cast_spell( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_cast_spell( const JsonObject &jo, const std::string_view member,
                                         bool is_npc, bool targeted )
 {
     fake_spell fake;
@@ -3646,8 +3646,7 @@ void talk_effect_fun_t::set_make_sound( const JsonObject &jo, const std::string 
     };
 }
 
-void talk_effect_fun_t::set_run_eocs( const JsonObject &jo,
-                                      const std::string &member )
+void talk_effect_fun_t::set_run_eocs( const JsonObject &jo, const std::string_view member )
 {
     std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member );
     if( eocs.empty() ) {
@@ -3662,7 +3661,7 @@ void talk_effect_fun_t::set_run_eocs( const JsonObject &jo,
 }
 
 void talk_effect_fun_t::set_run_npc_eocs( const JsonObject &jo,
-        const std::string &member, bool is_npc )
+        const std::string_view member, bool is_npc )
 {
     std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member );
     std::vector<str_or_var> unique_ids;
@@ -3722,7 +3721,7 @@ void talk_effect_fun_t::set_run_npc_eocs( const JsonObject &jo,
     }
 }
 
-void talk_effect_fun_t::set_queue_eocs( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_queue_eocs( const JsonObject &jo, const std::string_view member )
 {
     std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member );
     if( eocs.empty() ) {
@@ -3751,7 +3750,7 @@ void talk_effect_fun_t::set_queue_eocs( const JsonObject &jo, const std::string 
 }
 
 void talk_effect_fun_t::set_weighted_list_eocs( const JsonObject &jo,
-        const std::string &member )
+        const std::string_view member )
 {
     std::vector<std::pair<effect_on_condition_id, std::function<double( const dialogue & )>>> eoc_pairs;
     for( JsonArray ja : jo.get_array( member ) ) {
@@ -3772,8 +3771,7 @@ void talk_effect_fun_t::set_weighted_list_eocs( const JsonObject &jo,
     };
 }
 
-void talk_effect_fun_t::set_switch( const JsonObject &jo,
-                                    const std::string &member )
+void talk_effect_fun_t::set_switch( const JsonObject &jo, const std::string_view member )
 {
     std::function<double( dialogue const &/* d */ )> eoc_switch = conditional_t::get_get_dbl(
                 jo.get_object( member ) );
@@ -3939,7 +3937,7 @@ void talk_effect_fun_t::set_custom_light_level( const JsonObject &jo,
     };
 }
 
-void talk_effect_fun_t::set_give_equipment( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_give_equipment( const JsonObject &jo, const std::string_view member )
 {
     JsonObject jobj = jo.get_object( member );
     int allowance = 0;
@@ -4243,7 +4241,7 @@ void talk_effect_fun_t::set_field( const JsonObject &jo, const std::string &memb
     };
 }
 
-void talk_effect_fun_t::set_teleport( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_teleport( const JsonObject &jo, const std::string_view member,
                                       bool is_npc )
 {
     std::optional<var_info> target_var = read_var_info( jo.get_object( member ) );
@@ -4974,7 +4972,7 @@ static std::string translate_gendered_line(
 }
 
 dynamic_line_t dynamic_line_t::from_member( const JsonObject &jo,
-        const std::string &member_name )
+        const std::string_view member_name )
 {
     if( jo.has_array( member_name ) ) {
         return dynamic_line_t( jo.get_array( member_name ) );

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -588,7 +588,7 @@ struct overmap_special_migration {
     public:
         static void load_migrations( const JsonObject &jo, const std::string &src );
         static void reset();
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         static void check();
         // Check if the given overmap special should be migrated
         static bool migrated( const overmap_special_id &os_id );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -107,7 +107,7 @@ void option_slider::check_consistency()
     }
 }
 
-void option_slider::load( const JsonObject &jo, const std::string & )
+void option_slider::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
     optional( jo, was_loaded, "default", _default_level, 0 );

--- a/src/options.h
+++ b/src/options.h
@@ -421,7 +421,7 @@ struct option_slider {
         static void reset();
         static void finalize_all();
         static void check_consistency();
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void check() const;
         static const std::vector<option_slider> &get_all();
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -184,26 +184,26 @@ std::vector<std::string> foldstring( const std::string &str, int width, const ch
     return lines;
 }
 
-std::vector<std::string> split_by_color( const std::string &s )
+std::vector<std::string> split_by_color( const std::string_view s )
 {
     std::vector<std::string> ret;
     std::vector<size_t> tag_positions = get_tag_positions( s );
     size_t last_pos = 0;
     for( size_t tag_position : tag_positions ) {
-        ret.push_back( s.substr( last_pos, tag_position - last_pos ) );
+        ret.emplace_back( s.substr( last_pos, tag_position - last_pos ) );
         last_pos = tag_position;
     }
     // and the last (or only) one
-    ret.push_back( s.substr( last_pos, std::string::npos ) );
+    ret.emplace_back( s.substr( last_pos, std::string::npos ) );
     return ret;
 }
 
-std::string remove_color_tags( const std::string &s )
+std::string remove_color_tags( const std::string_view s )
 {
     std::string ret;
     std::vector<size_t> tag_positions = get_tag_positions( s );
     if( tag_positions.empty() ) {
-        return s;
+        return std::string( s );
     }
 
     size_t next_pos = 0;
@@ -217,7 +217,7 @@ std::string remove_color_tags( const std::string &s )
 }
 
 color_tag_parse_result::tag_type update_color_stack(
-    std::stack<nc_color> &color_stack, const std::string &seg,
+    std::stack<nc_color> &color_stack, const std::string_view seg,
     const report_color_error color_error )
 {
     color_tag_parse_result tag = get_color_from_tag( seg, color_error );
@@ -238,7 +238,7 @@ color_tag_parse_result::tag_type update_color_stack(
 }
 
 void print_colored_text( const catacurses::window &w, const point &p, nc_color &color,
-                         const nc_color &base_color, const std::string &text,
+                         const nc_color &base_color, const std::string_view text,
                          const report_color_error color_error )
 {
     if( p.y > -1 && p.x > -1 ) {
@@ -863,7 +863,7 @@ bool query_int( int &result, const std::string &text )
     return true;
 }
 
-std::vector<std::string> get_hotkeys( const std::string &s )
+std::vector<std::string> get_hotkeys( const std::string_view s )
 {
     std::vector<std::string> hotkeys;
     size_t start = s.find_first_of( '<' );
@@ -873,11 +873,11 @@ std::vector<std::string> get_hotkeys( const std::string &s )
         size_t lastsep = start;
         size_t sep = s.find_first_of( '|', start );
         while( sep < end ) {
-            hotkeys.push_back( s.substr( lastsep + 1, sep - lastsep - 1 ) );
+            hotkeys.emplace_back( s.substr( lastsep + 1, sep - lastsep - 1 ) );
             lastsep = sep;
             sep = s.find_first_of( '|', sep + 1 );
         }
-        hotkeys.push_back( s.substr( lastsep + 1, end - lastsep - 1 ) );
+        hotkeys.emplace_back( s.substr( lastsep + 1, end - lastsep - 1 ) );
     }
     return hotkeys;
 }
@@ -1295,20 +1295,17 @@ int special_symbol( char sym )
     return special_symbol( static_cast<uint8_t>( sym ) );
 }
 
-template<typename Prep>
-std::string trim( const std::string &s, Prep prep )
+template<typename Predicate>
+static std::string trim( std::string_view s, Predicate pred )
 {
-    auto wsfront = std::find_if_not( s.begin(), s.end(), [&prep]( int c ) {
-        return prep( c );
-    } );
-    return std::string( wsfront, std::find_if_not( s.rbegin(),
-    std::string::const_reverse_iterator( wsfront ), [&prep]( int c ) {
-        return prep( c );
-    } ).base() );
+    auto wsfront = std::find_if_not( s.begin(), s.end(), pred );
+    std::string_view::const_reverse_iterator wsfront_reverse( wsfront );
+    auto wsend = std::find_if_not( s.crbegin(), wsfront_reverse, pred );
+    return std::string( wsfront, wsend.base() );
 }
 
 template<typename Prep>
-std::string trim_trailing( const std::string &s, Prep prep )
+std::string trim_trailing( const std::string_view s, Prep prep )
 {
     return std::string( s.begin(), std::find_if_not(
     s.rbegin(), s.rend(), [&prep]( int c ) {
@@ -1316,14 +1313,14 @@ std::string trim_trailing( const std::string &s, Prep prep )
     } ).base() );
 }
 
-std::string trim( const std::string &s )
+std::string trim( const std::string_view s )
 {
     return trim( s, []( int c ) {
         return isspace( c );
     } );
 }
 
-std::string trim_trailing_punctuations( const std::string &s )
+std::string trim_trailing_punctuations( const std::string_view s )
 {
     return trim_trailing( s, []( int c ) {
         // '<' and '>' are used for tags and should not be removed
@@ -1331,7 +1328,7 @@ std::string trim_trailing_punctuations( const std::string &s )
     } );
 }
 
-std::string remove_punctuations( const std::string &s )
+std::string remove_punctuations( const std::string_view s )
 {
     std::string result;
     std::remove_copy_if( s.begin(), s.end(), std::back_inserter( result ),
@@ -1351,7 +1348,7 @@ std::string to_upper_case( const std::string &s )
 }
 
 // find the position of each non-printing tag in a string
-std::vector<size_t> get_tag_positions( const std::string &s )
+std::vector<size_t> get_tag_positions( const std::string_view s )
 {
     std::vector<size_t> ret;
     size_t pos = s.find( "<color_", 0, 7 );
@@ -3184,9 +3181,11 @@ std::string wildcard_trim_rule( const std::string &pattern_in )
 }
 
 // find substring (case insensitive)
-int ci_find_substr( const std::string &str1, const std::string &str2, const std::locale &loc )
+int ci_find_substr( const std::string_view str1, const std::string_view str2,
+                    const std::locale &loc )
 {
-    std::string::const_iterator it = std::search( str1.begin(), str1.end(), str2.begin(), str2.end(),
+    std::string_view::const_iterator it =
+        std::search( str1.begin(), str1.end(), str2.begin(), str2.end(),
     [&]( const char str1_in, const char str2_in ) {
         return std::toupper( str1_in, loc ) == std::toupper( str2_in, loc );
     } );

--- a/src/output.h
+++ b/src/output.h
@@ -174,14 +174,14 @@ std::string rm_prefix( std::string str, char c1 = '<', char c2 = '>' );
  * If color_error == report_color_error::yes a debugmsg will be shown when the tag is not valid.
  */
 color_tag_parse_result::tag_type update_color_stack(
-    std::stack<nc_color> &color_stack, const std::string &seg,
+    std::stack<nc_color> &color_stack, std::string_view seg,
     report_color_error color_error = report_color_error::yes );
 
 /**
  * Removes the color tags from the input string. This might be required when the string is to
  * be used for functions that don't handle color tags.
  */
-std::string remove_color_tags( const std::string &s );
+std::string remove_color_tags( std::string_view s );
 /*@}*/
 
 /**
@@ -208,7 +208,7 @@ std::vector<std::string> foldstring( const std::string &str, int width, char spl
  * @param base_color Base color that is used outside of any color tag.
  **/
 void print_colored_text( const catacurses::window &w, const point &p, nc_color &cur_color,
-                         const nc_color &base_color, const std::string &text,
+                         const nc_color &base_color, std::string_view text,
                          report_color_error color_error = report_color_error::yes );
 /**
  * Print word wrapped text (with @ref color_tags) into the window.
@@ -361,7 +361,7 @@ inline void mvwprintz( const catacurses::window &w, const point &p, const nc_col
 
 void wprintz( const catacurses::window &w, const nc_color &FG, const std::string &text );
 template<typename ...Args>
-inline void wprintz( const catacurses::window &w, const nc_color &FG, const char *const mes,
+inline void wprintz( const catacurses::window &w, const nc_color &FG, std::string_view mes,
                      Args &&... args )
 {
     wprintz( w, FG, string_format( mes, std::forward<Args>( args )... ) );
@@ -418,8 +418,8 @@ class border_helper
 };
 
 std::string word_rewrap( const std::string &ins, int width, uint32_t split = ' ' );
-std::vector<size_t> get_tag_positions( const std::string &s );
-std::vector<std::string> split_by_color( const std::string &s );
+std::vector<size_t> get_tag_positions( std::string_view s );
+std::vector<std::string> split_by_color( std::string_view s );
 
 bool query_yn( const std::string &text );
 template<typename ...Args>
@@ -435,7 +435,7 @@ inline bool query_int( int &result, const char *const msg, Args &&... args )
     return query_int( result, string_format( msg, std::forward<Args>( args )... ) );
 }
 
-std::vector<std::string> get_hotkeys( const std::string &s );
+std::vector<std::string> get_hotkeys( std::string_view s );
 
 /**
  * @name Popup windows
@@ -576,11 +576,11 @@ int special_symbol( int sym );
 int special_symbol( char sym );
 
 // Remove spaces from the start and the end of a string.
-std::string trim( const std::string &s );
+std::string trim( std::string_view s );
 // Removes trailing periods and exclamation marks.
-std::string trim_trailing_punctuations( const std::string &s );
+std::string trim_trailing_punctuations( std::string_view s );
 // Removes all punctuation except underscore.
-std::string remove_punctuations( const std::string &s );
+std::string remove_punctuations( std::string_view s );
 // Converts the string to upper case.
 std::string to_upper_case( const std::string &s );
 
@@ -1125,7 +1125,7 @@ extern scrollingcombattext SCT;
 
 std::string wildcard_trim_rule( const std::string &pattern_in );
 bool wildcard_match( const std::string &text_in, const std::string &pattern_in );
-int ci_find_substr( const std::string &str1, const std::string &str2,
+int ci_find_substr( std::string_view str1, std::string_view str2,
                     const std::locale &loc = std::locale() );
 
 std::string format_volume( const units::volume &volume );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3730,7 +3730,7 @@ void overmap::generate_bridgeheads( const std::vector<point_om_omt> &bridge_poin
     }
 }
 
-std::vector<point_abs_omt> overmap::find_terrain( const std::string &term, int zlevel ) const
+std::vector<point_abs_omt> overmap::find_terrain( const std::string_view term, int zlevel ) const
 {
     std::vector<point_abs_omt> found;
     for( int x = 0; x < OMAPX; x++ ) {
@@ -6706,7 +6706,7 @@ void overmap_special_migration::reset()
     migrations.reset();
 }
 
-void overmap_special_migration::load( const JsonObject &jo, const std::string & )
+void overmap_special_migration::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     optional( jo, was_loaded, "new_id", new_id, overmap_special_id() );

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -222,7 +222,7 @@ class overmap
          * @returns A vector of terrain coordinates (absolute overmap terrain
          * coordinates), or empty vector if no matching terrain is found.
          */
-        std::vector<point_abs_omt> find_terrain( const std::string &term, int zlevel ) const;
+        std::vector<point_abs_omt> find_terrain( std::string_view term, int zlevel ) const;
 
         void ter_set( const tripoint_om_omt &p, const oter_id &id );
         // ter has bounds checking, and returns ot_null when out of bounds.

--- a/src/overmap_connection.cpp
+++ b/src/overmap_connection.cpp
@@ -98,7 +98,7 @@ bool overmap_connection::has( const int_id<oter_t> &oter ) const
     } ) != subtypes.cend();
 }
 
-void overmap_connection::load( const JsonObject &jo, const std::string & )
+void overmap_connection::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, false, "subtypes", subtypes );
 }

--- a/src/overmap_connection.h
+++ b/src/overmap_connection.h
@@ -48,7 +48,7 @@ class overmap_connection
         const subtype *pick_subtype_for( const int_id<oter_t> &ground ) const;
         bool has( const int_id<oter_t> &oter ) const;
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void check() const;
         void finalize();
 

--- a/src/overmap_location.cpp
+++ b/src/overmap_location.cpp
@@ -40,7 +40,7 @@ oter_type_id overmap_location::get_random_terrain() const
     return random_entry( terrains );
 }
 
-void overmap_location::load( const JsonObject &jo, const std::string & )
+void overmap_location::load( const JsonObject &jo, const std::string_view )
 {
     optional( jo, was_loaded, "flags", flags );
     optional( jo, was_loaded, "terrains", terrains );

--- a/src/overmap_location.h
+++ b/src/overmap_location.h
@@ -15,7 +15,7 @@ struct overmap_location {
     public:
         using TerrColType = cata::flat_set<oter_type_str_id>;
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void check() const;
         void finalize();
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -115,7 +115,7 @@ namespace overmap_ui
 static void create_note( const tripoint_abs_omt &curs );
 
 // {note symbol, note color, offset to text}
-std::tuple<char, nc_color, size_t> get_note_display_info( const std::string &note )
+std::tuple<char, nc_color, size_t> get_note_display_info( const std::string_view note )
 {
     std::tuple<char, nc_color, size_t> result {'N', c_yellow, 0};
     bool set_color  = false;
@@ -179,7 +179,7 @@ static std::array<std::pair<nc_color, std::string>, npm_width *npm_height> get_o
     return map_around;
 }
 
-static void update_note_preview( const std::string &note,
+static void update_note_preview( const std::string_view note,
                                  const std::array<std::pair<nc_color, std::string>, npm_width *npm_height> &map_around,
                                  const std::tuple<catacurses::window *, catacurses::window *, catacurses::window *>
                                  &preview_windows )
@@ -187,7 +187,7 @@ static void update_note_preview( const std::string &note,
     auto om_symbol = get_note_display_info( note );
     const nc_color note_color = std::get<1>( om_symbol );
     const char symbol = std::get<0>( om_symbol );
-    const std::string note_text = note.substr( std::get<2>( om_symbol ), std::string::npos );
+    const std::string_view note_text = note.substr( std::get<2>( om_symbol ), std::string::npos );
 
     catacurses::window *w_preview = std::get<0>( preview_windows );
     catacurses::window *w_preview_title = std::get<1>( preview_windows );

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -111,6 +111,6 @@ extern tiles_redraw_info redraw_info;
 #endif
 
 weather_type_id get_weather_at_point( const tripoint_abs_omt &pos );
-std::tuple<char, nc_color, size_t> get_note_display_info( const std::string &note );
+std::tuple<char, nc_color, size_t> get_note_display_info( std::string_view note );
 } // namespace overmap_ui
 #endif // CATA_SRC_OVERMAP_UI_H

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1630,7 +1630,7 @@ void overmapbuffer::despawn_monster( const monster &critter )
     }
 }
 
-overmapbuffer::t_notes_vector overmapbuffer::get_notes( int z, const std::string *pattern )
+overmapbuffer::t_notes_vector overmapbuffer::get_notes( int z, const std::string_view pattern )
 {
     t_notes_vector result;
     for( auto &it : overmaps ) {
@@ -1642,7 +1642,7 @@ overmapbuffer::t_notes_vector overmapbuffer::get_notes( int z, const std::string
                 if( note.empty() ) {
                     continue;
                 }
-                if( pattern != nullptr && lcmatch( note, *pattern ) ) {
+                if( !lcmatch( note, pattern ) ) {
                     // pattern not found in note text
                     continue;
                 }
@@ -1656,7 +1656,7 @@ overmapbuffer::t_notes_vector overmapbuffer::get_notes( int z, const std::string
     return result;
 }
 
-overmapbuffer::t_extras_vector overmapbuffer::get_extras( int z, const std::string *pattern )
+overmapbuffer::t_extras_vector overmapbuffer::get_extras( int z, const std::string_view pattern )
 {
     overmapbuffer::t_extras_vector result;
     for( auto &it : overmaps ) {
@@ -1669,7 +1669,7 @@ overmapbuffer::t_extras_vector overmapbuffer::get_extras( int z, const std::stri
                     continue;
                 }
                 const std::string &extra_text = extra.c_str();
-                if( pattern != nullptr && lcmatch( extra_text, *pattern ) ) {
+                if( !lcmatch( extra_text, pattern ) ) {
                     // pattern not found in note text
                     continue;
                 }

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -400,18 +400,18 @@ class overmapbuffer
         using t_point_with_note = std::pair<point_abs_omt, std::string>;
         using t_notes_vector = std::vector<t_point_with_note>;
         t_notes_vector get_all_notes( int z ) {
-            return get_notes( z, nullptr ); // NULL => don't filter notes
+            return get_notes( z, {} ); // empty string => don't filter notes
         }
-        t_notes_vector find_notes( int z, const std::string &pattern ) {
-            return get_notes( z, &pattern ); // filter with pattern
+        t_notes_vector find_notes( int z, const std::string_view pattern ) {
+            return get_notes( z, pattern ); // filter with pattern
         }
         using t_point_with_extra = std::pair<point_abs_omt, map_extra_id>;
         using t_extras_vector = std::vector<t_point_with_extra>;
         t_extras_vector get_all_extras( int z ) {
-            return get_extras( z, nullptr ); // NULL => don't filter extras
+            return get_extras( z, {} ); // empty string => don't filter extras
         }
-        t_extras_vector find_extras( int z, const std::string &pattern ) {
-            return get_extras( z, &pattern ); // filter with pattern
+        t_extras_vector find_extras( int z, const std::string_view pattern ) {
+            return get_extras( z, pattern ); // filter with pattern
         }
         /**
          * Signal nearby hordes to move to given location.
@@ -549,14 +549,14 @@ class overmapbuffer
          * @param pattern only notes that contain this pattern are returned.
          * If the pattern is NULL, every note matches.
          */
-        t_notes_vector get_notes( int z, const std::string *pattern );
+        t_notes_vector get_notes( int z, std::string_view pattern );
         /**
          * Get a list of map extras in the (loaded) overmaps.
          * @param z only this specific z-level is search for map extras.
          * @param pattern only map extras that contain this pattern are returned.
          * If the pattern is NULL, every map extra matches.
          */
-        t_extras_vector get_extras( int z, const std::string *pattern );
+        t_extras_vector get_extras( int z, std::string_view pattern );
     public:
         /**
          * See overmap::check_ot, this uses global

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -286,13 +286,13 @@ void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const 
     }
 }
 
-static void decorate_panel( const std::string &name, const catacurses::window &w )
+static void decorate_panel( const std::string_view name, const catacurses::window &w )
 {
     werase( w );
     draw_border( w );
 
     static const char *title_prefix = " ";
-    const std::string &title = name;
+    const std::string_view title = name;
     static const char *title_suffix = " ";
     static const std::string full_title = string_format( "%s%s%s",
                                           title_prefix, title, title_suffix );

--- a/src/pinyin.cpp
+++ b/src/pinyin.cpp
@@ -9,7 +9,7 @@
 
 namespace pinyin
 {
-bool pinyin_match( const std::u32string &str, const std::u32string &qry )
+bool pinyin_match( const std::u32string_view str, const std::u32string_view qry )
 {
     // we convert the data to an unordered map to lower the cost of looking up entries.
     // O(1) instead of O(n)

--- a/src/pinyin.h
+++ b/src/pinyin.h
@@ -15,7 +15,7 @@ namespace pinyin
  *
  * @returns True if at least one possible pinyin combination of str contains qry
  */
-bool pinyin_match( const std::u32string &str, const std::u32string &qry );
+bool pinyin_match( std::u32string_view str, std::u32string_view qry );
 
 } // namespace pinyin
 #endif // CATA_SRC_PINYIN_H

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -151,9 +151,9 @@ bool player_activity::is_multi_type() const
     return type->multi_activity();
 }
 
-std::string player_activity::get_str_value( size_t index, const std::string &def ) const
+std::string player_activity::get_str_value( size_t index, const std::string_view def ) const
 {
-    return index < str_values.size() ? str_values[index] : def;
+    return std::string( index < str_values.size() ? str_values[index] : def );
 }
 
 std::optional<std::string> player_activity::get_progress_message( const avatar &u ) const

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -123,7 +123,7 @@ class player_activity
         const translation &get_verb() const;
 
         int get_value( size_t index, int def = 0 ) const;
-        std::string get_str_value( size_t index, const std::string &def = "" ) const;
+        std::string get_str_value( size_t index, std::string_view def = {} ) const;
 
         /**
          * Helper that returns an activity specific progress message.

--- a/src/popup.h
+++ b/src/popup.h
@@ -249,7 +249,7 @@ class query_popup
         void init() const;
 
         template <typename ...Args>
-        static void assert_format( const std::string &, Args &&... ) {
+        static void assert_format( const std::string_view, Args &&... ) {
             static_assert( sizeof...( Args ) > 0,
                            "Format string should take at least one argument.  "
                            "If your message is not a format string, "

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -149,7 +149,7 @@ class item_reader : public generic_typed_reader<item_reader>
         }
 };
 
-void profession::load( const JsonObject &jo, const std::string & )
+void profession::load( const JsonObject &jo, const std::string_view )
 {
     //If the "name" is an object then we have to deal with gender-specific titles,
     if( jo.has_object( "name" ) ) {

--- a/src/profession.h
+++ b/src/profession.h
@@ -85,7 +85,7 @@ class profession
 
         void check_item_definitions( const itypedecvec &items ) const;
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 
     public:
         //these three aren't meant for external use, but had to be made public regardless

--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -94,7 +94,7 @@ void proficiency_category::reset()
     proficiency_category_factory.reset();
 }
 
-void proficiency::load( const JsonObject &jo, const std::string & )
+void proficiency::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
     mandatory( jo, was_loaded, "description", _description );
@@ -119,7 +119,7 @@ void proficiency::load( const JsonObject &jo, const std::string & )
     }
 }
 
-void proficiency_category::load( const JsonObject &jo, const std::string & )
+void proficiency_category::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
     mandatory( jo, was_loaded, "description", _description );

--- a/src/proficiency.h
+++ b/src/proficiency.h
@@ -55,7 +55,7 @@ struct proficiency_category {
 
     static void load_proficiency_categories( const JsonObject &jo, const std::string &src );
     static void reset();
-    void load( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view src );
     static const std::vector<proficiency_category> &get_all();
 };
 
@@ -89,7 +89,7 @@ class proficiency
     public:
         static void load_proficiencies( const JsonObject &jo, const std::string &src );
         static void reset();
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 
         static const std::vector<proficiency> &get_all();
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1942,7 +1942,7 @@ static projectile make_gun_projectile( const item &gun )
 
     if( gun.ammo_data() ) {
         // Some projectiles have a chance of being recoverable
-        bool recover = std::any_of( fx.begin(), fx.end(), []( const std::string & e ) {
+        bool recover = std::any_of( fx.begin(), fx.end(), []( const std::string_view e ) {
             if( !string_starts_with( e, "RECOVER_" ) ) {
                 return false;
             }

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -89,7 +89,7 @@ const recipe &recipe_dictionary::get_craft( const itype_id &id )
 
 // searches for left-anchored partial match in the relevant recipe requirements set
 template <class group>
-bool search_reqs( group gp, const std::string &txt )
+bool search_reqs( const group &gp, const std::string_view txt )
 {
     return std::any_of( gp.begin(), gp.end(), [&]( const typename group::value_type & opts ) {
         return std::any_of( opts.begin(),
@@ -100,8 +100,8 @@ bool search_reqs( group gp, const std::string &txt )
 }
 // template specialization to make component searches easier
 template<>
-bool search_reqs( std::vector<std::vector<item_comp> >  gp,
-                  const std::string &txt )
+bool search_reqs( const std::vector<std::vector<item_comp> > &gp,
+                  const std::string_view txt )
 {
     return std::any_of( gp.begin(), gp.end(), [&]( const std::vector<item_comp> &opts ) {
         return std::any_of( opts.begin(), opts.end(), [&]( const item_comp & ic ) {

--- a/src/recipe_groups.cpp
+++ b/src/recipe_groups.cpp
@@ -29,7 +29,7 @@ struct recipe_group_data {
     std::map<recipe_id, std::set<std::string>> om_terrains;
     bool was_loaded = false;
 
-    void load( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view src );
     void check() const;
 };
 
@@ -37,7 +37,7 @@ generic_factory<recipe_group_data> recipe_groups_data( "recipe group type" );
 
 } // namespace
 
-void recipe_group_data::load( const JsonObject &jo, const std::string & )
+void recipe_group_data::load( const JsonObject &jo, const std::string_view )
 {
     building_type = jo.get_string( "building_type" );
     for( JsonObject ordering : jo.get_array( "recipes" ) ) {

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -781,7 +781,7 @@ void apply_region_overlay( const JsonObject &jo, regional_settings &region )
     cityjo.read( "park_radius", region.city_spec.park_radius );
     cityjo.read( "park_sigma", region.city_spec.park_sigma );
 
-    const auto load_building_types = [&cityjo]( const std::string & type, building_bin & dest ) {
+    const auto load_building_types = [&cityjo]( const std::string_view type, building_bin & dest ) {
         for( const JsonMember member : cityjo.get_object( type ) ) {
             if( member.is_comment() ) {
                 continue;

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -164,7 +164,7 @@ void relic_procgen_data::enchantment_active::deserialize( const JsonObject &jobj
     load( jobj );
 }
 
-void relic_procgen_data::load( const JsonObject &jo, const std::string & )
+void relic_procgen_data::load( const JsonObject &jo, const std::string_view )
 {
     for( const JsonObject jo_inner : jo.get_array( "passive_add_procgen_values" ) ) {
         int weight = 0;

--- a/src/relic.h
+++ b/src/relic.h
@@ -134,7 +134,7 @@ class relic_procgen_data
         static const std::vector<relic_procgen_data> &get_all();
         static void load_relic_procgen_data( const JsonObject &jo, const std::string &src );
         static void reset();
-        void load( const JsonObject &jo, const std::string & = "" );
+        void load( const JsonObject &jo, std::string_view = {} );
         void deserialize( const JsonObject &jobj );
 };
 

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -106,7 +106,7 @@ void quality::load_static( const JsonObject &jo, const std::string &src )
     quality_factory.load( jo, src );
 }
 
-void quality::load( const JsonObject &jo, const std::string & )
+void quality::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
 
@@ -734,7 +734,7 @@ void requirement_data::reset()
 std::vector<std::string> requirement_data::get_folded_components_list( int width, nc_color col,
         const read_only_visitable &crafting_inv, const std::function<bool( const item & )> &filter,
         int batch,
-        const std::string &hilite, requirement_display_flags flags ) const
+        const std::string_view hilite, requirement_display_flags flags ) const
 {
     std::vector<std::string> out_buffer;
     if( components.empty() ) {
@@ -752,7 +752,7 @@ std::vector<std::string> requirement_data::get_folded_components_list( int width
 template<typename T>
 std::vector<std::string> requirement_data::get_folded_list( int width,
         const read_only_visitable &crafting_inv, const std::function<bool( const item & )> &filter,
-        const std::vector< std::vector<T> > &objs, int batch, const std::string &hilite,
+        const std::vector< std::vector<T> > &objs, int batch, const std::string_view hilite,
         requirement_display_flags flags ) const
 {
     // hack: ensure 'cached' availability is up to date

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -49,7 +49,7 @@ struct quality {
 
     std::vector<std::pair<int, std::string>> usages;
 
-    void load( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view src );
 
     static void reset();
     static void load_static( const JsonObject &jo, const std::string &src );
@@ -349,7 +349,7 @@ struct requirement_data {
         /** @param filter see @ref can_make_with_inventory */
         std::vector<std::string> get_folded_components_list( int width, nc_color col,
                 const read_only_visitable &crafting_inv, const std::function<bool( const item & )> &filter,
-                int batch = 1, const std::string &hilite = "",
+                int batch = 1, std::string_view hilite = {},
                 requirement_display_flags = requirement_display_flags::none ) const;
 
         std::vector<std::string> get_folded_tools_list( int width, nc_color col,
@@ -416,7 +416,7 @@ struct requirement_data {
         std::vector<std::string> get_folded_list( int width, const read_only_visitable &crafting_inv,
                 const std::function<bool( const item & )> &filter,
                 const std::vector< std::vector<T> > &objs, int batch = 1,
-                const std::string &hilite = "",
+                std::string_view hilite = {},
                 requirement_display_flags = requirement_display_flags::none ) const;
 
         template<typename T>

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -610,7 +610,7 @@ void safemode::add_rule( const std::string &rule_in, const Creature::Attitude at
     }
 }
 
-bool safemode::has_rule( const std::string &rule_in, const Creature::Attitude attitude_in )
+bool safemode::has_rule( const std::string_view rule_in, const Creature::Attitude attitude_in )
 {
     for( safemode::rules_class &elem : character_rules ) {
         if( rule_in.length() == elem.rule.length()
@@ -622,7 +622,7 @@ bool safemode::has_rule( const std::string &rule_in, const Creature::Attitude at
     return false;
 }
 
-void safemode::remove_rule( const std::string &rule_in, const Creature::Attitude attitude_in )
+void safemode::remove_rule( const std::string_view rule_in, const Creature::Attitude attitude_in )
 {
     for( auto it = character_rules.begin();
          it != character_rules.end(); ++it ) {

--- a/src/safemode_ui.h
+++ b/src/safemode_ui.h
@@ -99,10 +99,10 @@ class safemode
     public:
         std::string lastmon_whitelist; // NOLINT(cata-serialize)
 
-        bool has_rule( const std::string &rule_in, Creature::Attitude attitude_in );
+        bool has_rule( std::string_view rule_in, Creature::Attitude attitude_in );
         void add_rule( const std::string &rule_in, Creature::Attitude attitude_in,
                        int proximity_in, rule_state state_in );
-        void remove_rule( const std::string &rule_in, Creature::Attitude attitude_in );
+        void remove_rule( std::string_view rule_in, Creature::Attitude attitude_in );
         void clear_character_rules();
         rule_state check_monster( const std::string &creature_name_in, Creature::Attitude attitude_in,
                                   int proximity_in, bool driving = false ) const;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2889,7 +2889,7 @@ static void load_legacy_craft_data( io::JsonObjectOutputArchive &, T & )
 
 static std::set<itype_id> charge_removal_blacklist;
 
-void load_charge_removal_blacklist( const JsonObject &jo, const std::string &/*src*/ )
+void load_charge_removal_blacklist( const JsonObject &jo, const std::string_view/*src*/ )
 {
     jo.allow_omitted_members();
     std::set<itype_id> new_blacklist;
@@ -2899,7 +2899,7 @@ void load_charge_removal_blacklist( const JsonObject &jo, const std::string &/*s
 
 static std::set<itype_id> charge_migration_blacklist;
 
-void load_charge_migration_blacklist( const JsonObject &jo, const std::string &/*src*/ )
+void load_charge_migration_blacklist( const JsonObject &jo, const std::string_view/*src*/ )
 {
     jo.allow_omitted_members();
     std::set<itype_id> new_blacklist;
@@ -2909,7 +2909,7 @@ void load_charge_migration_blacklist( const JsonObject &jo, const std::string &/
 
 static std::set<itype_id> temperature_removal_blacklist;
 
-void load_temperature_removal_blacklist( const JsonObject &jo, const std::string &/*src*/ )
+void load_temperature_removal_blacklist( const JsonObject &jo, const std::string_view/*src*/ )
 {
     jo.allow_omitted_members();
     std::set<itype_id> new_blacklist;
@@ -3596,7 +3596,7 @@ void vehicle::deserialize( const JsonObject &data )
     of_turn = 0;
 
     /** Legacy saved games did not store part enabled status within parts */
-    const auto set_legacy_state = [&]( const std::string & var, const std::string & flag ) {
+    const auto set_legacy_state = [&]( const std::string_view var, const std::string & flag ) {
         if( data.get_bool( var, false ) ) {
             for( const vpart_reference &vp : get_any_parts( flag ) ) {
                 vp.part().enabled = true;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -55,7 +55,7 @@ void scenario::load_scenario( const JsonObject &jo, const std::string &src )
     all_scenarios.load( jo, src );
 }
 
-void scenario::load( const JsonObject &jo, const std::string & )
+void scenario::load( const JsonObject &jo, const std::string_view )
 {
     // TODO: pretty much the same as in profession::load, but different contexts for pgettext.
     // TODO: maybe combine somehow?
@@ -293,12 +293,12 @@ bool scenario::scen_is_blacklisted() const
     return sc_blacklist.scenarios.count( id ) != 0;
 }
 
-void scen_blacklist::load_scen_blacklist( const JsonObject &jo, const std::string &src )
+void scen_blacklist::load_scen_blacklist( const JsonObject &jo, const std::string_view src )
 {
     sc_blacklist.load( jo, src );
 }
 
-void scen_blacklist::load( const JsonObject &jo, const std::string & )
+void scen_blacklist::load( const JsonObject &jo, const std::string_view )
 {
     if( !scenarios.empty() ) {
         DebugLog( D_INFO, DC_ALL ) <<

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -69,7 +69,7 @@ class scenario
 
         std::vector<std::pair<mongroup_id, float>> _surround_groups;
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         bool scenario_traits_conflict_with_profession_traits( const profession &p ) const;
 
     public:
@@ -162,8 +162,8 @@ struct scen_blacklist {
     std::set<string_id<scenario>> scenarios;
     bool whitelist = false;
 
-    static void load_scen_blacklist( const JsonObject &jo, const std::string &src );
-    void load( const JsonObject &jo, const std::string & );
+    static void load_scen_blacklist( const JsonObject &jo, std::string_view src );
+    void load( const JsonObject &jo, std::string_view );
     void finalize();
 };
 

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -281,7 +281,7 @@ void scent_type::load_scent_type( const JsonObject &jo, const std::string &src )
     scent_factory.load( jo, src );
 }
 
-void scent_type::load( const JsonObject &jo, const std::string & )
+void scent_type::load( const JsonObject &jo, const std::string_view )
 {
     assign( jo, "id", id );
     assign( jo, "receptive_species", receptive_species );

--- a/src/scent_map.h
+++ b/src/scent_map.h
@@ -30,7 +30,7 @@ class scent_type
 {
     public:
         static void load_scent_type( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, const std::string & );
+        void load( const JsonObject &jo, std::string_view );
         static const std::vector<scent_type> &get_all();
         static void check_scent_consistency();
         bool was_loaded = false;

--- a/src/shop_cons_rate.cpp
+++ b/src/shop_cons_rate.cpp
@@ -129,12 +129,12 @@ bool shopkeeper_cons_rate_entry::operator==( shopkeeper_cons_rate_entry const &r
     return icg_entry::operator==( rhs ) && rate == rhs.rate;
 }
 
-void shopkeeper_blacklist::load( JsonObject const &jo, std::string const &/*src*/ )
+void shopkeeper_blacklist::load( JsonObject const &jo, const std::string_view/*src*/ )
 {
     optional( jo, was_loaded, "entries", entries, icg_entry_reader {} );
 }
 
-void shopkeeper_cons_rates::load( JsonObject const &jo, std::string const &/*src*/ )
+void shopkeeper_cons_rates::load( JsonObject const &jo, const std::string_view/*src*/ )
 {
     optional( jo, was_loaded, "default_rate", default_rate );
     optional( jo, was_loaded, "junk_threshold", junk_threshold, money_reader {}, 1_cent );

--- a/src/shop_cons_rate.h
+++ b/src/shop_cons_rate.h
@@ -54,7 +54,7 @@ struct shopkeeper_cons_rates {
     static const std::vector<shopkeeper_cons_rates> &get_all();
     static void load_rate( const JsonObject &jo, std::string const &src );
     static void check_all();
-    void load( const JsonObject &jo, std::string const &src );
+    void load( const JsonObject &jo, std::string_view src );
     void check() const;
 
     int get_rate( item const &it, npc const &beta ) const;
@@ -70,7 +70,7 @@ struct shopkeeper_blacklist {
     static void reset();
     static const std::vector<shopkeeper_blacklist> &get_all();
     static void load_blacklist( const JsonObject &jo, std::string const &src );
-    void load( const JsonObject &jo, std::string const &src );
+    void load( const JsonObject &jo, std::string_view src );
     icg_entry const *matches( item const &it, npc const &beta ) const;
 };
 

--- a/src/skill_boost.cpp
+++ b/src/skill_boost.cpp
@@ -34,7 +34,7 @@ void skill_boost::load_boost( const JsonObject &jo, const std::string &src )
     all_skill_boosts.load( jo, src );
 }
 
-void skill_boost::load( const JsonObject &jo, const std::string & )
+void skill_boost::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "skills", _skills );
     mandatory( jo, was_loaded, "skill_offset", _offset );

--- a/src/skill_boost.h
+++ b/src/skill_boost.h
@@ -38,7 +38,7 @@ class skill_boost
         int _offset = 0;
         float _power = 0.0f;
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 };
 
 #endif // CATA_SRC_SKILL_BOOST_H

--- a/src/speed_description.cpp
+++ b/src/speed_description.cpp
@@ -32,7 +32,7 @@ void speed_description::reset()
     speed_description_factory.reset();
 }
 
-void speed_description::load( const JsonObject &jo, const std::string & )
+void speed_description::load( const JsonObject &jo, const std::string_view )
 {
     optional( jo, was_loaded, "values", values_ );
     std::sort( values_.begin(), values_.end(),

--- a/src/speed_description.h
+++ b/src/speed_description.h
@@ -19,7 +19,7 @@ class speed_description
         static void load_speed_descriptions( const JsonObject &jo, const std::string &src );
         static void reset();
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 
         static const std::vector<speed_description> &get_all();
 

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -133,9 +133,9 @@ void stomach_contents::serialize( JsonOut &json ) const
     json.end_object();
 }
 
-static units::volume string_to_ml( const std::string &str )
+static units::volume string_to_ml( const std::string_view str )
 {
-    return units::from_milliliter( std::stoi( str.substr( 0, str.size() - 3 ) ) );
+    return units::from_milliliter( svto<int>( str.substr( 0, str.size() - 3 ) ) );
 }
 
 void stomach_contents::deserialize( const JsonObject &jo )

--- a/src/string_id.h
+++ b/src/string_id.h
@@ -214,6 +214,10 @@ class string_id
         // a std::string, otherwise a "no matching function to call..." error is generated.
         template<typename S, class = std::enable_if_t<std::is_convertible<S, std::string>::value>>
         explicit string_id( S && id ) : _id( std::forward<S>( id ) ) {}
+
+        // string_view is not implicitly convertible to std::string, so need a
+        // separate constructor for that
+        explicit string_id( const std::string_view id ) : string_id( std::string( id ) ) {}
         /**
          * Default constructor constructs an empty id string.
          * Note that this id class does not enforce empty id strings (or any specific string at all)

--- a/src/subbodypart.cpp
+++ b/src/subbodypart.cpp
@@ -71,7 +71,7 @@ void sub_body_part_type::load_bp( const JsonObject &jo, const std::string &src )
     sub_body_part_factory.load( jo, src );
 }
 
-void sub_body_part_type::load( const JsonObject &jo, const std::string & )
+void sub_body_part_type::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name", name );

--- a/src/subbodypart.h
+++ b/src/subbodypart.h
@@ -74,7 +74,7 @@ struct sub_body_part_type {
 
     static void load_bp( const JsonObject &jo, const std::string &src );
 
-    void load( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view src );
 
     // combine matching body part strings together for printing
     static std::vector<translation> consolidate( std::vector<sub_bodypart_id> &covered );

--- a/src/system_locale.cpp
+++ b/src/system_locale.cpp
@@ -28,7 +28,7 @@ namespace
 // Try to match language code to a supported game language by prefix
 // For example, "fr_CA.UTF-8" -> "fr"
 // Returns std::nullopt if the language is not supported by the game
-std::optional<std::string> matchGameLanguage( const std::string &lang )
+std::optional<std::string> matchGameLanguage( const std::string_view lang )
 {
     const std::vector<options_manager::id_and_option> available_languages =
         get_options().get_option( "USE_LANG" ).getItems();

--- a/src/translation_manager_impl.cpp
+++ b/src/translation_manager_impl.cpp
@@ -36,7 +36,7 @@ std::optional<std::pair<std::size_t, std::size_t>> TranslationManager::Impl::Loo
     return std::nullopt;
 }
 
-std::string TranslationManager::Impl::LanguageCodeOfPath( const std::string &path )
+std::string TranslationManager::Impl::LanguageCodeOfPath( const std::string_view path )
 {
     const std::size_t end = path.rfind( "/LC_MESSAGES" );
     if( end == std::string::npos ) {
@@ -46,7 +46,7 @@ std::string TranslationManager::Impl::LanguageCodeOfPath( const std::string &pat
     if( begin == std::string::npos ) {
         return std::string();
     }
-    return path.substr( begin, end - begin );
+    return std::string( path.substr( begin, end - begin ) );
 }
 
 void TranslationManager::Impl::ScanTranslationDocuments()

--- a/src/translation_manager_impl.h
+++ b/src/translation_manager_impl.h
@@ -20,7 +20,7 @@ class TranslationManager::Impl
         std::optional<std::pair<std::size_t, std::size_t>> LookupString( const char *query ) const;
 
         std::unordered_map<std::string, std::vector<std::string>> mo_files;
-        static std::string LanguageCodeOfPath( const std::string &path );
+        static std::string LanguageCodeOfPath( std::string_view path );
         void ScanTranslationDocuments();
         std::string ConstructContextualQuery( const char *context, const char *message ) const;
         void Reset();

--- a/src/translation_plural_evaluator.cpp
+++ b/src/translation_plural_evaluator.cpp
@@ -210,7 +210,7 @@ Token TranslationPluralRulesEvaluator::GetNextToken( const char *&p )
     }
 }
 
-std::vector<Token> TranslationPluralRulesEvaluator::Lexer( const std::string &expr )
+std::vector<Token> TranslationPluralRulesEvaluator::Lexer( const std::string_view expr )
 {
     std::vector<ExprToken> tokens;
     const char *p = expr.data();

--- a/src/translation_plural_evaluator.h
+++ b/src/translation_plural_evaluator.h
@@ -89,7 +89,7 @@ class TranslationPluralRulesEvaluator
         };
 
         static ExprToken GetNextToken( const char *&p );
-        static std::vector<ExprToken> Lexer( const std::string &expr );
+        static std::vector<ExprToken> Lexer( std::string_view expr );
 
         struct ExprNode {
             std::size_t n_children;

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -125,7 +125,7 @@ void trap::load_trap( const JsonObject &jo, const std::string &src )
     trap_factory.load( jo, src );
 }
 
-void trap::load( const JsonObject &jo, const std::string & )
+void trap::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name", name_ );

--- a/src/trap.h
+++ b/src/trap.h
@@ -308,7 +308,7 @@ struct trap {
         /**
          * Loads this specific trap.
          */
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 
         std::string debug_describe() const;
 

--- a/src/try_parse_integer.cpp
+++ b/src/try_parse_integer.cpp
@@ -5,14 +5,14 @@
 #include "translations.h"
 
 template<typename T>
-ret_val<T> try_parse_integer( const std::string &s, bool use_locale )
+ret_val<T> try_parse_integer( const std::string_view s, bool use_locale )
 {
     // Using stringstream-based parsing because that's the only one in the
     // standard library for which it's possible to turn off the
     // locale-dependency.  Once we're using C++17 we could use a combination of
     // std::from_chars and std::strto* functions, but this should be fine so
     // long as the code is not performance-critical.
-    std::istringstream buffer( s );
+    std::istringstream buffer{ std::string( s ) };
 #ifdef __APPLE__
     // On Apple platforms we always use the classic locale, because the other
     // locales seem to behave strangely.  See
@@ -40,6 +40,6 @@ ret_val<T> try_parse_integer( const std::string &s, bool use_locale )
     return ret_val<T>::make_success( result );
 }
 
-template ret_val<int> try_parse_integer<int>( const std::string &, bool use_locale );
-template ret_val<long> try_parse_integer<long>( const std::string &, bool use_locale );
-template ret_val<long long> try_parse_integer<long long>( const std::string &, bool use_locale );
+template ret_val<int> try_parse_integer<int>( const std::string_view, bool use_locale );
+template ret_val<long> try_parse_integer<long>( const std::string_view, bool use_locale );
+template ret_val<long long> try_parse_integer<long long>( const std::string_view, bool use_locale );

--- a/src/try_parse_integer.h
+++ b/src/try_parse_integer.h
@@ -13,11 +13,11 @@
  * player-input values, and false for values from e.g. game data files.
  */
 template<typename T>
-ret_val<T> try_parse_integer( const std::string &, bool use_locale );
+ret_val<T> try_parse_integer( std::string_view, bool use_locale );
 
-extern template ret_val<int> try_parse_integer<int>( const std::string &, bool use_locale );
-extern template ret_val<long> try_parse_integer<long>( const std::string &, bool use_locale );
-extern template ret_val<long long> try_parse_integer<long long>(
-    const std::string &, bool use_locale );
+extern template ret_val<int> try_parse_integer<int>( std::string_view, bool use_locale );
+extern template ret_val<long> try_parse_integer<long>( std::string_view, bool use_locale );
+extern template ret_val<long long> try_parse_integer<long long>( std::string_view,
+        bool use_locale );
 
 #endif // CATA_SRC_TRY_PARSE_INTEGER_H

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -95,7 +95,7 @@ void VehicleGroup::reset()
     vgroups.clear();
 }
 
-VehicleFacings::VehicleFacings( const JsonObject &jo, const std::string &key )
+VehicleFacings::VehicleFacings( const JsonObject &jo, const std::string_view key )
 {
     if( jo.has_array( key ) ) {
         for( const int i : jo.get_array( key ) ) {
@@ -226,12 +226,12 @@ void VehicleSpawn::apply( const vspawn_id &id, map &m, const std::string &terrai
 namespace VehicleSpawnFunction
 {
 
-static void builtin_no_vehicles( map &, const std::string & )
+static void builtin_no_vehicles( map &, const std::string_view )
 {}
 
-static void builtin_jackknifed_semi( map &m, const std::string &terrainid )
+static void builtin_jackknifed_semi( map &m, const std::string_view terrainid )
 {
-    const VehicleLocation *loc = vplacement_id( terrainid + "_semi" ).obj().pick();
+    const VehicleLocation *loc = vplacement_id( str_cat( terrainid, "_semi" ) ).obj().pick();
     if( !loc ) {
         debugmsg( "builtin_jackknifed_semi unable to get location to place vehicle.  placement %s_semi",
                   terrainid );
@@ -263,7 +263,7 @@ static void builtin_jackknifed_semi( map &m, const std::string &terrainid )
                    units::fmod( facing + 90_degrees, 360_degrees ), -1, 1 );
 }
 
-static void builtin_pileup( map &m, const std::string &, const std::string &vg )
+static void builtin_pileup( map &m, const std::string_view, const std::string_view vg )
 {
     vehicle *last_added_car = nullptr;
     const int num_cars = rng( 5, 12 );
@@ -285,17 +285,17 @@ static void builtin_pileup( map &m, const std::string &, const std::string &vg )
     }
 }
 
-static void builtin_citypileup( map &m, const std::string &t )
+static void builtin_citypileup( map &m, const std::string_view t )
 {
     builtin_pileup( m, t, "city_pileup" );
 }
 
-static void builtin_policepileup( map &m, const std::string &t )
+static void builtin_policepileup( map &m, const std::string_view t )
 {
     builtin_pileup( m, t, "police_pileup" );
 }
 
-static void builtin_parkinglot( map &m, const std::string & )
+static void builtin_parkinglot( map &m, const std::string_view )
 {
     for( int v = 0; v < rng( 1, 4 ); v++ ) {
         tripoint pos_p;

--- a/src/vehicle_group.h
+++ b/src/vehicle_group.h
@@ -54,7 +54,7 @@ class VehicleGroup
  * The location and facing data needed to place a vehicle onto the map.
  */
 struct VehicleFacings {
-    VehicleFacings( const JsonObject &jo, const std::string &key );
+    VehicleFacings( const JsonObject &jo, std::string_view key );
 
     units::angle pick() const {
         return random_entry( values );
@@ -109,7 +109,7 @@ class VehicleFunction
         virtual void apply( map &m, const std::string &terrainid ) const = 0;
 };
 
-using vehicle_gen_pointer = void ( * )( map &, const std::string & );
+using vehicle_gen_pointer = void ( * )( map &, std::string_view );
 
 class VehicleFunction_builtin : public VehicleFunction
 {

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -591,7 +591,7 @@ void weakpoints::remove( const JsonArray &ja )
     }
 }
 
-void weakpoints::load( const JsonObject &jo, const std::string & )
+void weakpoints::load( const JsonObject &jo, const std::string_view )
 {
     load( jo.get_array( "weakpoints" ) );
 }

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -174,7 +174,7 @@ struct weakpoints {
 
     /********************* weakpoint_set handling ****************************/
     // load standalone JSON type
-    void load( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view src );
     void add_from_set( const weakpoints_id &set_id, bool replace_id );
     void add_from_set( const weakpoints &set, bool replace_id );
     void del_from_set( const weakpoints_id &set_id );

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -98,7 +98,7 @@ void weather_type::check() const
     }
 }
 
-void weather_type::load( const JsonObject &jo, const std::string & )
+void weather_type::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "id",  id );

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -116,7 +116,7 @@ struct weather_type {
         time_duration duration_max = 0_turns;
         std::optional<std::string> debug_cause_eoc;
         std::optional<std::string> debug_leave_eoc;
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void finalize();
         void check() const;
         std::string get_symbol() const {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -380,7 +380,7 @@ nc_color widget_clause::get_color_for_id( const std::string &clause_id, const wi
     return wp == nullptr ? c_white : wp->color;
 }
 
-void widget::load( const JsonObject &jo, const std::string & )
+void widget::load( const JsonObject &jo, const std::string_view )
 {
     optional( jo, was_loaded, "width", _width, 0 );
     optional( jo, was_loaded, "height", _height_max, 1 );

--- a/src/widget.h
+++ b/src/widget.h
@@ -289,7 +289,7 @@ class widget
 
         // Load JSON data for a widget (uses generic factory widget_factory)
         static void load_widget( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         // Finalize anything that must wait until all widgets are loaded
         static void finalize();
         // Recursively derive _label_width for nested layouts in this widget

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -2071,7 +2071,7 @@ size_t worldfactory::get_world_index( const std::string &name )
 }
 
 // Helper predicate to exclude files from deletion when resetting a world directory.
-static bool isForbidden( const std::string &candidate )
+static bool isForbidden( const std::string_view candidate )
 {
     return candidate.find( PATH_INFO::worldoptions() ) != std::string::npos ||
            candidate.find( "mods.json" ) != std::string::npos;

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -46,7 +46,7 @@ static behavior::node_t make_test_node( const std::string &goal, const behavior:
     if( !goal.empty() ) {
         node.set_goal( goal );
     }
-    node.add_predicate( [status]( const behavior::oracle_t *, const std::string & ) {
+    node.add_predicate( [status]( const behavior::oracle_t *, const std::string_view ) {
         return *status;
     } );
     return node;

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -748,7 +748,7 @@ TEST_CASE( "item_colony_ser_deser", "[json][item]" )
 {
     // calculates the number of substring (needle) occurrences withing the target string (haystack)
     // doesn't include overlaps
-    const auto count_occurences = []( const std::string & haystack, const std::string & needle ) {
+    const auto count_occurences = []( const std::string_view haystack, const std::string_view needle ) {
         int occurrences = 0;
         std::string::size_type pos = 0;
         while( ( pos = haystack.find( needle, pos ) ) != std::string::npos ) {

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -1308,7 +1308,7 @@ TEST_CASE( "widgets showing Sun and Moon position", "[widget]" )
 // Bodypart status strings are pulled from a std::map, which is
 // not guaranteed to be sorted in a deterministic way.
 // Just check if the layout string contains the specified status conditions.
-static void check_bp_has_status( const std::string &layout,
+static void check_bp_has_status( const std::string_view layout,
                                  const std::vector<std::string> &stat_str )
 {
     for( const std::string &stat : stat_str ) {

--- a/tools/clang-tidy-plugin/SimplifyPointConstructorsCheck.cpp
+++ b/tools/clang-tidy-plugin/SimplifyPointConstructorsCheck.cpp
@@ -21,7 +21,7 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::cata
 {
 
-static auto isMemberExpr( const std::string &/*type*/, const std::string &member_,
+static auto isMemberExpr( const std::string_view/*type*/, const std::string &member_,
                           const std::string &objBind )
 {
     return ignoringParenCasts(

--- a/tools/clang-tidy-plugin/StaticStringIdConstantsCheck.cpp
+++ b/tools/clang-tidy-plugin/StaticStringIdConstantsCheck.cpp
@@ -57,11 +57,15 @@ void StaticStringIdConstantsCheck::registerMatchers( MatchFinder *Finder )
     );
 }
 
-static std::string GetPrefixFor( const CXXRecordDecl *Type )
+static std::string GetPrefixFor( const CXXRecordDecl *Type, StaticStringIdConstantsCheck &Check )
 {
     const ClassTemplateSpecializationDecl *CTSDecl =
         dyn_cast<ClassTemplateSpecializationDecl>( Type );
-    assert( CTSDecl ); // NOLINT(cata-assert)
+    if( !CTSDecl ) {
+        Check.diag( Type->getBeginLoc(),
+                    "Declaration of string_id instantiation was not a tempalte specialization" );
+        return {};
+    }
     QualType ArgType = CTSDecl->getTemplateArgs()[0].getAsType();
     PrintingPolicy Policy( LangOptions{} );
     Policy.adjustForCPlusPlus();
@@ -107,9 +111,10 @@ static std::string GetPrefixFor( const CXXRecordDecl *Type )
     return TypeName + "_";
 }
 
-static std::string GetCanonicalName( const CXXRecordDecl *Type, const StringRef &Id )
+static std::string GetCanonicalName( const CXXRecordDecl *Type, const StringRef &Id,
+                                     StaticStringIdConstantsCheck &Check )
 {
-    std::string Result = ( GetPrefixFor( Type ) + Id ).str();
+    std::string Result = ( GetPrefixFor( Type, Check ) + Id ).str();
 
     for( char &c : Result ) {
         if( !isalnum( c ) ) {
@@ -163,7 +168,8 @@ void StaticStringIdConstantsCheck::CheckConstructor( const MatchFinder::MatchRes
         return;
     }
 
-    std::string CanonicalName = GetCanonicalName( ConstructorDecl->getParent(), Arg->getString() );
+    std::string CanonicalName =
+        GetCanonicalName( ConstructorDecl->getParent(), Arg->getString(), *this );
 
     if( VarDeclParent && TranslationUnit ) {
         if( VarDeclParent->isStaticDataMember() ) {
@@ -517,7 +523,8 @@ static void CheckDeclRef( StaticStringIdConstantsCheck &Check,
         return;
     }
 
-    std::string CanonicalName = GetCanonicalName( ConstructorDecl->getParent(), Arg->getString() );
+    std::string CanonicalName =
+        GetCanonicalName( ConstructorDecl->getParent(), Arg->getString(), Check );
     std::string CurrentName = VarDeclParent->getNameAsString();
 
     if( CurrentName != CanonicalName &&

--- a/tools/clang-tidy-plugin/TranslateStringLiteralCheck.cpp
+++ b/tools/clang-tidy-plugin/TranslateStringLiteralCheck.cpp
@@ -203,7 +203,7 @@ void TranslateStringLiteralCheck::registerMatchers( MatchFinder *Finder )
     );
 }
 
-std::string TranslateStringLiteralCheck::pruneFormatStrings( const std::string &str )
+std::string TranslateStringLiteralCheck::pruneFormatStrings( const std::string_view str )
 {
     std::string result;
     result.reserve( str.length() );
@@ -275,7 +275,7 @@ std::string TranslateStringLiteralCheck::removeSubstrings( const std::string &st
     return result;
 }
 
-std::string TranslateStringLiteralCheck::extractText( const std::string &str )
+std::string TranslateStringLiteralCheck::extractText( const std::string_view str )
 {
     std::string result;
     std::copy_if( str.begin(), str.end(), std::back_inserter( result ), []( const char ch ) {
@@ -313,7 +313,7 @@ bool TranslateStringLiteralCheck::isUnit( const std::string &str )
     return units.count( str );
 }
 
-bool TranslateStringLiteralCheck::containsTranslatableText( const std::string &str )
+bool TranslateStringLiteralCheck::containsTranslatableText( const std::string_view str )
 {
     std::string text = extractText( str );
     if( text.empty() ) {

--- a/tools/clang-tidy-plugin/TranslateStringLiteralCheck.h
+++ b/tools/clang-tidy-plugin/TranslateStringLiteralCheck.h
@@ -22,13 +22,13 @@ namespace cata
 class TranslateStringLiteralCheck : public ClangTidyCheck
 {
     private:
-        static std::string pruneFormatStrings( const std::string &str );
+        static std::string pruneFormatStrings( std::string_view str );
         static std::string pruneTags( const std::string &str );
         static std::string removeSubstrings( const std::string &str,
                                              const std::unordered_set<std::string> &substrings );
-        static std::string extractText( const std::string &str );
+        static std::string extractText( std::string_view str );
         static bool isUnit( const std::string &str );
-        static bool containsTranslatableText( const std::string &str );
+        static bool containsTranslatableText( std::string_view str );
     public:
         TranslateStringLiteralCheck( StringRef Name, ClangTidyContext *Context )
             : ClangTidyCheck( Name, Context ) {}


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Code modernization and simplification.

#### Describe the solution
Migrate lots more things to `std::string_view`.

These are mostly automated changes, achieved via a `clang-tidy` check (not yet made public).  My automation tries to be conservative about what it changes, but I did have to do manual fixup of a few things.
    
I plan to PR the clang-tidy check that automates these changes later, but I think more changes may be needed before that.

Some of the manual changes:
- Allow `string_id` to be constructed from a `string_view`.
- Added `svto<T>` where `T` is an integer type, which parses integers in string_views.  This is our first use of the low-level C++17 int conversion functions.
- Added a shortcut to `lcmatch` for empty queries, to allow for refactoring overmapbuffer searches.
- Fixed an apparent bug in `overmapbuffer::get_notes` and `get_extras`, where it was inverting the match result.  As far as I can tell, these functions aren't actually used anywhere, so I guess this bug wasn't breaking anything.
- Allow use of string_view in JSON serialization.  Previously these were misidentified as sequences and appeared as a list of integers rather than a string.

#### Describe alternatives you've considered
Continuing smaller PRs like my last few (#64971, #65014, #65089) but I've gained enough confidence in the automated changes that I think this should be relatively safe.

#### Testing
Unit tests.  Ran the game briefly.  Ran `clang-tidy`.

#### Additional context
I didn't attempt to measure any performance changes.  This is still just "things that are easy enough to migrate that it can be done automatically" so I'm not targeting any specific thing where we might be hoping for performance improvements.