### PR TITLE
Memory-Based Mutations Outside of Char Gen

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -859,8 +859,31 @@
     "types": [ "MEMORY" ],
     "skill_rust_multiplier": 0.66,
     "starting_trait": true,
-    "valid": false,
+    "changes_to": [ "IMMUTABLEMEMORY" ],
+    "category": [ "ALPHA", "CEPHALOPOD" ],
     "cancels": [ "FORGETFUL" ]
+  },
+  {
+    "type": "mutation",
+    "id": "DISTENDEDHEAD",
+    "name": { "str": "Distended Head" },
+    "points": 1,
+    "visibility": 3,
+    "ugliness": 3,
+    "description": "Your brain has grown to almost double the size and your head has distended to match. Despite its grotesque size, this hasn't resulted in any discernable differences to your mental capabilities.",
+    "leads_to": [ "IMMUTABLEMEMORY" ],
+    "category": [ "CEPHALOPOD" ]
+  },
+  {
+    "type": "mutation",
+    "id": "IMMUTABLEMEMORY",
+    "name": { "str": "Immutable Memory" },
+    "points": 4,
+    "description": "Your mind has been morphed by your mutations. Your knowledge and your skills, although not permanent, will erode much slower.",
+    "types": [ "MEMORY" ],
+    "skill_rust_multiplier": 0.1,
+    "prereqs": [ "GOODMEMORY", "DISTENDEDHEAD" ],
+    "category" : [ "CEPHALOPOD" ]
   },
   {
     "type": "mutation",
@@ -1615,7 +1638,8 @@
     "social_modifiers": { "lie": -5 },
     "skill_rust_multiplier": 1.33,
     "starting_trait": true,
-    "category": [ "BEAST", "MEDICAL", "CHIMERA", "MOUSE", "INSECT", "RABBIT" ]
+    "category": [ "BEAST", "MEDICAL", "CHIMERA", "MOUSE", "INSECT", "RABBIT" ],
+    "cancels": [ "GOODMEMORY", "IMMUTABLEMEMORY" ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -883,7 +883,7 @@
     "types": [ "MEMORY" ],
     "skill_rust_multiplier": 0.1,
     "prereqs": [ "GOODMEMORY", "DISTENDEDHEAD" ],
-    "category" : [ "CEPHALOPOD" ]
+    "category": [ "CEPHALOPOD" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Memory-Based Mutations Outside of Character Generation"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
With the recent patches and fixes to the memory system, I realized that the mutations for memory were a bit lacking. "Good Memory" wasn't available outside of character generation, "Forgetful" didn't have tags in the JSON to cancel "Good Memory", and there weren't any late-game mutations for further improving memory like CBMs have. This is tangentially related to #49696.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
JSON has been altered to cancel Forgetful/Good Memory. Good Memory has also become tied to the Cephalopod and Alpha mutation trees. In addition, two new mutations have been added to the Cephalopod tree.
**Distended Head:** A superficial mutation that doesn't add anything except beauty impact.
**Immutable Memory:** A upgrade to "Good Memory" that multiplies skill rust by a factor of 0.1. This has the prerequisite of "Good Memory" and "Distended Head".

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The relationship between Good Memory and Forgetful seems mutually exclusive, so there isn't much of an alternative for them. 

Originally I wanted to include an additional mutations for faster skill rust, but I noticed that the "Fish" mutation doesn't have Forgetful as a mutation. Thus, it seemed odd to include a worse mutation for the Fish.

The modifier for the "Immutable Memory" I've gone back and forth on. Looking at issues #64916 and #65141, it seems that completely removing skill rust will be met with resistance. Thus, I have settled on a number that allows for a character concept I've played with in the past. Basically, a Cthulhu type that bunkers down for long stretches (technically I was an Ursine post-threshold with some Cephalopod mutations, but I was role-playing so leave me alone) only to return and spread chaos. The other alternative would be to remove skill rust when asleep, but that would then mean that about a third of in-game time wouldn't have skill rust. Hence why I have created this mutation as it is. However, I'm good with changing this multiplier if requested.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The JSON has been extensively tested on the most recent experimental build. The mutations have been added, removed, and forced removed by the forgetful trait.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
If additional mutations for a worse version of forgetful are reasonable, then I would create a new pull request for a mutation called "Dementia" with a skill rust modifier of 3 (or something like that). Possibly tied to the Chimera and/or Fish mutation trees.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->