### PR TITLE
Add no damage message for ranged weakpoint hits

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -988,11 +988,17 @@ void Creature::messaging_projectile_attack( const Creature *source,
                 add_msg( source->is_avatar() ? _( "You miss!" ) : _( "The shot misses!" ) );
             }
         } else if( total_damage == 0 ) {
-            //~ 1$ - monster name, 2$ - character's bodypart or monster's skin/armor
-            add_msg( _( "The shot reflects off %1$s %2$s!" ), disp_name( true ),
-                     is_monster() ?
-                     skin_name() :
-                     body_part_name_accusative( hit_selection.bp_hit ) );
+            if( hit_selection.wp_hit.empty() ) {
+                //~ 1$ - monster name, 2$ - character's bodypart or monster's skin/armor
+                add_msg( _( "The shot reflects off %1$s %2$s!" ), disp_name( true ),
+                         is_monster() ?
+                         skin_name() :
+                         body_part_name_accusative( hit_selection.bp_hit ) );
+            } else if( !hit_selection.wp_hit.empty() ) {
+                //~ %1$s: creature name, %2$s: weakpoint hit
+                add_msg( _( "You shoot the %1$s in %2$s but it deals no damage." ),
+                         disp_name(), hit_selection.wp_hit );
+            }
         } else if( is_avatar() ) {
             //monster hits player ranged
             //~ Hit message. 1$s is bodypart name in accusative. 2$d is damage value.

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -996,7 +996,7 @@ void Creature::messaging_projectile_attack( const Creature *source,
                          body_part_name_accusative( hit_selection.bp_hit ) );
             } else if( !hit_selection.wp_hit.empty() ) {
                 //~ %1$s: creature name, %2$s: weakpoint hit
-                add_msg( _( "You shoot the %1$s in %2$s but it deals no damage." ),
+                add_msg( _( "The shot hits the %1$s in %2$s but it deals no damage." ),
                          disp_name(), hit_selection.wp_hit );
             }
         } else if( is_avatar() ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -994,7 +994,7 @@ void Creature::messaging_projectile_attack( const Creature *source,
                          is_monster() ?
                          skin_name() :
                          body_part_name_accusative( hit_selection.bp_hit ) );
-            } else if( !hit_selection.wp_hit.empty() ) {
+            } else {
                 //~ %1$s: creature name, %2$s: weakpoint hit
                 add_msg( _( "The shot hits the %1$s in %2$s but it deals no damage." ),
                          disp_name(), hit_selection.wp_hit );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -996,7 +996,7 @@ void Creature::messaging_projectile_attack( const Creature *source,
                          body_part_name_accusative( hit_selection.bp_hit ) );
             } else {
                 //~ %1$s: creature name, %2$s: weakpoint hit
-                add_msg( _( "The shot hits the %1$s in %2$s but it deals no damage." ),
+                add_msg( _( "The shot hits %1$s in %2$s but deals no damage." ),
                          disp_name(), hit_selection.wp_hit );
             }
         } else if( is_avatar() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Adds a message that details no damage hits against weakpoints with ranged weapons."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
To provide additional context for players when a shot fails to do damage to a monster especially when using low-powered weapons/rounds(eg. slings or .22) or when hitting strongpoints. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Expanded the no damage line to check if a weakpoint is being hit and if so to display the appropriate message.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I had some trouble with phrasing to make it work with how weakpoints are named. I think what I got works but I'm down to change it if better or more desirable phrasing is conceived. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned in a variety of armored monsters then shot them with .22 at various skill levels then checked the log to make sure the messages displayed. Had several monsters and npcs shoot other armored monsters (mostly the Titan Stag Beetle) as well. Also shot some unarmored monsters to make sure I didn't break anything. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
![the shot](https://user-images.githubusercontent.com/106233031/233409706-8a9f2dde-95c6-4ad5-b12d-1bc1c2279220.PNG)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->