### PR TITLE
Quadrupedal movement with paws

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6302,7 +6302,22 @@
       [
         {
           "condition": {
-            "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" }, { "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_CHIMERA", "THRESH_MOUSE", "THRESH_RABBIT" ] } ]
+            "and": [
+              { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] },
+              { "not": "u_can_drop_weapon" },
+              {
+                "u_has_any_trait": [
+                  "THRESH_BEAST",
+                  "THRESH_FELINE",
+                  "THRESH_LUPINE",
+                  "THRESH_URSINE",
+                  "THRESH_RAT",
+                  "THRESH_CHIMERA",
+                  "THRESH_MOUSE",
+                  "THRESH_RABBIT"
+                ]
+              }
+            ]
           },
           "msg_on": { "text": "You drop down on all fours." },
           "msg_off": { "text": "You prance up and walk on your hind feet." }
@@ -6312,7 +6327,22 @@
     "enchantments": [
       {
         "condition": {
-          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" }, { "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_CHIMERA", "THRESH_MOUSE", "THRESH_RABBIT" ] } ]
+          "and": [
+            { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] },
+            { "not": "u_can_drop_weapon" },
+            {
+              "u_has_any_trait": [
+                "THRESH_BEAST",
+                "THRESH_FELINE",
+                "THRESH_LUPINE",
+                "THRESH_URSINE",
+                "THRESH_RAT",
+                "THRESH_CHIMERA",
+                "THRESH_MOUSE",
+                "THRESH_RABBIT"
+              ]
+            }
+          ]
         },
         "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
       }
@@ -6348,7 +6378,22 @@
       [
         {
           "condition": {
-            "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" }, { "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_CHIMERA", "THRESH_MOUSE", "THRESH_RABBIT" ] } ]
+            "and": [
+              { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] },
+              { "not": "u_can_drop_weapon" },
+              {
+                "u_has_any_trait": [
+                  "THRESH_BEAST",
+                  "THRESH_FELINE",
+                  "THRESH_LUPINE",
+                  "THRESH_URSINE",
+                  "THRESH_RAT",
+                  "THRESH_CHIMERA",
+                  "THRESH_MOUSE",
+                  "THRESH_RABBIT"
+                ]
+              }
+            ]
           },
           "msg_on": { "text": "You drop down on all fours." },
           "msg_off": { "text": "You prance up and walk on your hind feet." }
@@ -6358,7 +6403,22 @@
     "enchantments": [
       {
         "condition": {
-          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" }, { "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_CHIMERA", "THRESH_MOUSE", "THRESH_RABBIT" ] } ]
+          "and": [
+            { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] },
+            { "not": "u_can_drop_weapon" },
+            {
+              "u_has_any_trait": [
+                "THRESH_BEAST",
+                "THRESH_FELINE",
+                "THRESH_LUPINE",
+                "THRESH_URSINE",
+                "THRESH_RAT",
+                "THRESH_CHIMERA",
+                "THRESH_MOUSE",
+                "THRESH_RABBIT"
+              ]
+            }
+          ]
         },
         "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
       }
@@ -8332,7 +8392,22 @@
       [
         {
           "condition": {
-            "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" }, { "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_CHIMERA", "THRESH_MOUSE", "THRESH_RABBIT" ] } ]
+            "and": [
+              { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] },
+              { "not": "u_can_drop_weapon" },
+              {
+                "u_has_any_trait": [
+                  "THRESH_BEAST",
+                  "THRESH_FELINE",
+                  "THRESH_LUPINE",
+                  "THRESH_URSINE",
+                  "THRESH_RAT",
+                  "THRESH_CHIMERA",
+                  "THRESH_MOUSE",
+                  "THRESH_RABBIT"
+                ]
+              }
+            ]
           },
           "msg_on": { "text": "You drop down on all fours." },
           "msg_off": { "text": "You prance up and walk on your hind feet." }
@@ -8342,7 +8417,22 @@
     "enchantments": [
       {
         "condition": {
-          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" }, { "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_CHIMERA", "THRESH_MOUSE", "THRESH_RABBIT" ] } ]
+          "and": [
+            { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] },
+            { "not": "u_can_drop_weapon" },
+            {
+              "u_has_any_trait": [
+                "THRESH_BEAST",
+                "THRESH_FELINE",
+                "THRESH_LUPINE",
+                "THRESH_URSINE",
+                "THRESH_RAT",
+                "THRESH_CHIMERA",
+                "THRESH_MOUSE",
+                "THRESH_RABBIT"
+              ]
+            }
+          ]
         },
         "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
       }

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6289,7 +6289,7 @@
     "visibility": 3,
     "ugliness": 2,
     "mixed_effect": true,
-    "description": "Your hands have fused into quasi-paws.  Fine manipulation is a challenge: permanent hand encumbrance of 10, difficulty with delicate craftwork, and your gloves don't fit.  But they handle water better.",
+    "description": "Your hands have fused into quasi-paws.  Fine manipulation is a challenge: permanent hand encumbrance of 10, difficulty with delicate craftwork, and your gloves don't fit.  But they handle water better and bear weight well, allowing you to move on all fours when crouching and unarmed.",
     "encumbrance_always": [ [ "hand_l", 10 ], [ "hand_r", 10 ] ],
     "restricts_gear": [ "hand_l", "hand_r" ],
     "craft_skill_bonus": [ [ "electronics", -2 ], [ "tailor", -2 ], [ "mechanics", -2 ] ],
@@ -6297,7 +6297,20 @@
     "prereqs": [ "CLAWS", "CLAWS_RETRACT", "CLAWS_RAT" ],
     "cancels": [ "TALONS" ],
     "changes_to": [ "PAWS_LARGE" ],
-    "category": [ "LUPINE", "RAT", "FELINE", "BEAST", "URSINE" ]
+    "category": [ "LUPINE", "RAT", "FELINE", "BEAST", "URSINE" ],
+    "triggers": [
+      [{
+        "condition": { "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ] },
+        "msg_on": { "text": "You drop down on all fours." },
+        "msg_off": { "text": "You prance up and walk on your hind feet." }
+      }]
+    ],
+    "enchantments": [
+      {
+        "condition": { "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ] },
+        "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -6307,7 +6320,7 @@
     "visibility": 4,
     "ugliness": 3,
     "mixed_effect": true,
-    "description": "Your paws are much larger now.  Manual dexterity is difficult: permanent hand encumbrance of 20, serious problems crafting, and no gloves.  In return, though, you can swim better.",
+    "description": "Your paws are much larger now.  Manual dexterity is difficult: permanent hand encumbrance of 20, serious problems crafting, and no gloves.  In return, though, you can swim better and move on all fours when crouching and unarmed.",
     "craft_skill_bonus": [
       [ "electronics", -4 ],
       [ "tailor", -4 ],
@@ -6324,7 +6337,20 @@
     "types": [ "HANDS" ],
     "prereqs": [ "PAWS" ],
     "cancels": [ "TALONS" ],
-    "category": [ "BEAST", "URSINE" ]
+    "category": [ "BEAST", "URSINE" ],
+    "triggers": [
+      [{
+        "condition": { "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ] },
+        "msg_on": { "text": "You drop down on all fours." },
+        "msg_off": { "text": "You prance up and walk on your hind feet." }
+      }]
+    ],
+    "enchantments": [
+      {
+        "condition": { "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ] },
+        "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -8283,13 +8309,26 @@
     "points": 0,
     "visibility": 2,
     "ugliness": 1,
-    "description": "Your hands have elongated and look a bit more like paws.  It makes fine manipulation a little more difficult, but you can still probably manage.",
+    "description": "Your hands have elongated and look a bit more like paws.  It makes fine manipulation a little more difficult, but you can still probably manage.  Plus, they allow you to move on all fours when crouching and unarmed.",
     "encumbrance_always": [ [ "hand_l", 5 ], [ "hand_r", 5 ] ],
     "craft_skill_bonus": [ [ "electronics", -1 ], [ "tailor", -1 ], [ "mechanics", -1 ] ],
     "types": [ "HANDS" ],
     "prereqs": [ "NAILS" ],
     "cancels": [ "TALONS" ],
-    "category": [ "RABBIT" ]
+    "category": [ "RABBIT" ],
+    "triggers": [
+      [{
+        "condition": { "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ] },
+        "msg_on": { "text": "You drop down on all fours." },
+        "msg_off": { "text": "You prance up and walk on your hind feet." }
+      }]
+    ],
+    "enchantments": [
+      {
+        "condition": { "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ] },
+        "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
+      }
+    ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6302,7 +6302,7 @@
       [
         {
           "condition": {
-            "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ]
+            "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" }, { "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_CHIMERA", "THRESH_MOUSE", "THRESH_RABBIT" ] } ]
           },
           "msg_on": { "text": "You drop down on all fours." },
           "msg_off": { "text": "You prance up and walk on your hind feet." }
@@ -6312,7 +6312,7 @@
     "enchantments": [
       {
         "condition": {
-          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ]
+          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" }, { "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_CHIMERA", "THRESH_MOUSE", "THRESH_RABBIT" ] } ]
         },
         "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
       }
@@ -6348,7 +6348,7 @@
       [
         {
           "condition": {
-            "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ]
+            "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" }, { "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_CHIMERA", "THRESH_MOUSE", "THRESH_RABBIT" ] } ]
           },
           "msg_on": { "text": "You drop down on all fours." },
           "msg_off": { "text": "You prance up and walk on your hind feet." }
@@ -6358,7 +6358,7 @@
     "enchantments": [
       {
         "condition": {
-          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ]
+          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" }, { "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_CHIMERA", "THRESH_MOUSE", "THRESH_RABBIT" ] } ]
         },
         "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
       }
@@ -8332,7 +8332,7 @@
       [
         {
           "condition": {
-            "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ]
+            "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" }, { "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_CHIMERA", "THRESH_MOUSE", "THRESH_RABBIT" ] } ]
           },
           "msg_on": { "text": "You drop down on all fours." },
           "msg_off": { "text": "You prance up and walk on your hind feet." }
@@ -8342,7 +8342,7 @@
     "enchantments": [
       {
         "condition": {
-          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ]
+          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" }, { "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_CHIMERA", "THRESH_MOUSE", "THRESH_RABBIT" ] } ]
         },
         "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
       }

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6299,15 +6299,21 @@
     "changes_to": [ "PAWS_LARGE" ],
     "category": [ "LUPINE", "RAT", "FELINE", "BEAST", "URSINE" ],
     "triggers": [
-      [{
-        "condition": { "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ] },
-        "msg_on": { "text": "You drop down on all fours." },
-        "msg_off": { "text": "You prance up and walk on your hind feet." }
-      }]
+      [
+        {
+          "condition": {
+            "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ]
+          },
+          "msg_on": { "text": "You drop down on all fours." },
+          "msg_off": { "text": "You prance up and walk on your hind feet." }
+        }
+      ]
     ],
     "enchantments": [
       {
-        "condition": { "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ] },
+        "condition": {
+          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ]
+        },
         "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
       }
     ]
@@ -6339,15 +6345,21 @@
     "cancels": [ "TALONS" ],
     "category": [ "BEAST", "URSINE" ],
     "triggers": [
-      [{
-        "condition": { "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ] },
-        "msg_on": { "text": "You drop down on all fours." },
-        "msg_off": { "text": "You prance up and walk on your hind feet." }
-      }]
+      [
+        {
+          "condition": {
+            "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ]
+          },
+          "msg_on": { "text": "You drop down on all fours." },
+          "msg_off": { "text": "You prance up and walk on your hind feet." }
+        }
+      ]
     ],
     "enchantments": [
       {
-        "condition": { "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ] },
+        "condition": {
+          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ]
+        },
         "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
       }
     ]
@@ -8317,15 +8329,21 @@
     "cancels": [ "TALONS" ],
     "category": [ "RABBIT" ],
     "triggers": [
-      [{
-        "condition": { "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ] },
-        "msg_on": { "text": "You drop down on all fours." },
-        "msg_off": { "text": "You prance up and walk on your hind feet." }
-      }]
+      [
+        {
+          "condition": {
+            "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ]
+          },
+          "msg_on": { "text": "You drop down on all fours." },
+          "msg_off": { "text": "You prance up and walk on your hind feet." }
+        }
+      ]
     ],
     "enchantments": [
       {
-        "condition": { "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ] },
+        "condition": {
+          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] }, { "not": "u_can_drop_weapon" } ]
+        },
         "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
       }
     ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6303,24 +6303,15 @@
         {
           "condition": {
             "and": [
-              { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] },
+              { "u_has_move_mode": "crouch" },
               { "not": "u_can_drop_weapon" },
               {
-                "u_has_any_trait": [
-                  "THRESH_BEAST",
-                  "THRESH_FELINE",
-                  "THRESH_LUPINE",
-                  "THRESH_URSINE",
-                  "THRESH_RAT",
-                  "THRESH_CHIMERA",
-                  "THRESH_MOUSE",
-                  "THRESH_RABBIT"
-                ]
+                "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_MOUSE", "THRESH_RABBIT" ]
               }
             ]
           },
           "msg_on": { "text": "You drop down on all fours." },
-          "msg_off": { "text": "You prance up and walk on your hind feet." }
+          "msg_off": { "text": "You rise up to walk on your hind feet." }
         }
       ]
     ],
@@ -6328,19 +6319,10 @@
       {
         "condition": {
           "and": [
-            { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] },
+            { "u_has_move_mode": "crouch" },
             { "not": "u_can_drop_weapon" },
             {
-              "u_has_any_trait": [
-                "THRESH_BEAST",
-                "THRESH_FELINE",
-                "THRESH_LUPINE",
-                "THRESH_URSINE",
-                "THRESH_RAT",
-                "THRESH_CHIMERA",
-                "THRESH_MOUSE",
-                "THRESH_RABBIT"
-              ]
+              "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_MOUSE", "THRESH_RABBIT" ]
             }
           ]
         },
@@ -6379,24 +6361,15 @@
         {
           "condition": {
             "and": [
-              { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] },
+              { "u_has_move_mode": "crouch" },
               { "not": "u_can_drop_weapon" },
               {
-                "u_has_any_trait": [
-                  "THRESH_BEAST",
-                  "THRESH_FELINE",
-                  "THRESH_LUPINE",
-                  "THRESH_URSINE",
-                  "THRESH_RAT",
-                  "THRESH_CHIMERA",
-                  "THRESH_MOUSE",
-                  "THRESH_RABBIT"
-                ]
+                "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_MOUSE", "THRESH_RABBIT" ]
               }
             ]
           },
           "msg_on": { "text": "You drop down on all fours." },
-          "msg_off": { "text": "You prance up and walk on your hind feet." }
+          "msg_off": { "text": "You rise up to walk on your hind feet." }
         }
       ]
     ],
@@ -6404,19 +6377,10 @@
       {
         "condition": {
           "and": [
-            { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] },
+            { "u_has_move_mode": "crouch" },
             { "not": "u_can_drop_weapon" },
             {
-              "u_has_any_trait": [
-                "THRESH_BEAST",
-                "THRESH_FELINE",
-                "THRESH_LUPINE",
-                "THRESH_URSINE",
-                "THRESH_RAT",
-                "THRESH_CHIMERA",
-                "THRESH_MOUSE",
-                "THRESH_RABBIT"
-              ]
+              "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_MOUSE", "THRESH_RABBIT" ]
             }
           ]
         },
@@ -8393,24 +8357,15 @@
         {
           "condition": {
             "and": [
-              { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] },
+              { "u_has_move_mode": "crouch" },
               { "not": "u_can_drop_weapon" },
               {
-                "u_has_any_trait": [
-                  "THRESH_BEAST",
-                  "THRESH_FELINE",
-                  "THRESH_LUPINE",
-                  "THRESH_URSINE",
-                  "THRESH_RAT",
-                  "THRESH_CHIMERA",
-                  "THRESH_MOUSE",
-                  "THRESH_RABBIT"
-                ]
+                "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_MOUSE", "THRESH_RABBIT" ]
               }
             ]
           },
           "msg_on": { "text": "You drop down on all fours." },
-          "msg_off": { "text": "You prance up and walk on your hind feet." }
+          "msg_off": { "text": "You rise up to walk on your hind feet." }
         }
       ]
     ],
@@ -8418,19 +8373,10 @@
       {
         "condition": {
           "and": [
-            { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "prone" } ] },
+            { "u_has_move_mode": "crouch" },
             { "not": "u_can_drop_weapon" },
             {
-              "u_has_any_trait": [
-                "THRESH_BEAST",
-                "THRESH_FELINE",
-                "THRESH_LUPINE",
-                "THRESH_URSINE",
-                "THRESH_RAT",
-                "THRESH_CHIMERA",
-                "THRESH_MOUSE",
-                "THRESH_RABBIT"
-              ]
+              "u_has_any_trait": [ "THRESH_BEAST", "THRESH_FELINE", "THRESH_LUPINE", "THRESH_URSINE", "THRESH_RAT", "THRESH_MOUSE", "THRESH_RABBIT" ]
             }
           ]
         },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Quadrupedal movement with paws"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Paws are a pretty specialized piece of anatomy. Being adapted for weight bearing and movement comes at the price of the versatility of hands, represented in game by various penalties to crafting and combat, as well as restricting armor use. Yet using them of their intended purpose is currently not an option. Quadrupedal movement fills this gap. While it is mostly intended as a flavor feature for roleplaying a beast mutant, I can see a few playstyles getting some utility out of it.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Quadrupedal movement uses a conditional enchantment which is activated when a character fulfills three conditions:

1. Has any paws mutation
2. Not wielding anything
3. Is crouching or prone

When triggered, it gives some flavor text as well as a move cost multiplier which negates the speed penalty of crouching. This allows a character to move at normal walking speed, yet maintain the lower profile of a crouch to represent quadrupedal movement. Prone receives a similar effect which leaves it at one-third walking speed. This is meant to emulate prowling.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Make a new movement mode, but that would make it available to all characters regardless of mutations, and cycling through the existing number of movement modes is already cumbersome enough so I did not want to clutter it further.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested the paws, broad paws, and little paws mutations on a fresh character by observing the move cost widget on the sidebar. No errors were encountered and movement cost when crouching and prone was calculated correctly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->