### PR TITLE
Add mutation ordering for hair variants

### DIFF
--- a/data/json/mutations/mutation_ordering.json
+++ b/data/json/mutations/mutation_ordering.json
@@ -118,6 +118,9 @@
       },
       {
         "id": [
+          "buzzcut",
+          "crewcut",
+          "fro",
           "hair_black_crewcut",
           "hair_black_mohawk",
           "hair_black_fro",
@@ -154,7 +157,16 @@
           "hair_white_short",
           "hair_white_medium",
           "hair_white_long",
-          "hair_bald"
+          "hair_bald",
+          "long",
+          "long_over_eye",
+          "medium",
+          "messy",
+          "mohawk",
+          "ponytail",
+          "short",
+          "short_no_fringe",
+          "short_over_eye"
         ],
         "order": 1600
       },


### PR DESCRIPTION
#### Summary
Bugfixes "Add mutation ordering for hair variants"

#### Purpose of change
The hair variants by Crow didn't have mutation ordering properly setup and thus didn't play nice with mutations that modify the head.

#### Describe the solution
Add mutation ordering for hair variants.

#### Describe alternatives you've considered
Leaving as is.

#### Testing
Tested and my hair no longer goes over my ears.
![изображение](https://user-images.githubusercontent.com/52408044/233114729-99f350fd-2eac-463f-b36b-0583904e5356.png)

#### Additional context
N/A.