### PR TITLE
Tidy up repaired_with field

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -92,8 +92,7 @@
     "description": "A pair of arm guards crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "material": [ "acidchitin" ],
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25, "encumbrance": 1.5, "warmth": 1.5 },
-    "material_thickness": 4,
-    "extend": { "flags": [ "NO_REPAIR" ] }
+    "material_thickness": 4
   },
   {
     "id": "xl_armguard_acidchitin",

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -266,8 +266,7 @@
     "material": [ "acidchitin" ],
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25, "encumbrance": 1.5, "warmth": 1.5 },
     "relative": { "melee_damage": { "bash": 2 } },
-    "material_thickness": 5,
-    "extend": { "flags": [ "NO_REPAIR" ] }
+    "material_thickness": 5
   },
   {
     "id": "xl_boots_acidchitin",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -319,8 +319,7 @@
     "price_postapoc": 1750,
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25, "encumbrance": 1.5, "warmth": 1.5 },
     "relative": { "melee_damage": { "bash": 1 } },
-    "material_thickness": 5,
-    "extend": { "flags": [ "NO_REPAIR" ] }
+    "material_thickness": 5
   },
   {
     "id": "xl_gauntlets_acidchitin",

--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -720,8 +720,7 @@
     "material": [ "acidchitin" ],
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25, "warmth": 1.5 },
     "relative": { "melee_damage": { "bash": 1 } },
-    "material_thickness": 5,
-    "extend": { "flags": [ "NO_REPAIR" ] }
+    "material_thickness": 5
   },
   {
     "id": "xl_helmet_acidchitin",

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -92,8 +92,7 @@
     "description": "A pair of leg guards crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "material": [ "acidchitin" ],
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25, "encumbrance": 1.5, "warmth": 1.5 },
-    "material_thickness": 5,
-    "extend": { "flags": [ "NO_REPAIR" ] }
+    "material_thickness": 5
   },
   {
     "id": "xl_legguard_acidchitin",

--- a/data/json/items/armor/pets_cow_armor.json
+++ b/data/json/items/armor/pets_cow_armor.json
@@ -33,12 +33,11 @@
     "description": "A makeshift assembly of criniere, peytral and croupiere made from biosilicified chitin fitted to a thin mesh.  You could put this on a friendly cow.  Acid-resistant but brittle.",
     "price": 145000,
     "price_postapoc": 10000,
-    "material": [ "acidchitin", "steel" ],
+    "material": [ "acidchitin" ],
     "weight": "40 kg",
     "volume": "180 L",
     "material_thickness": 5,
-    "environmental_protection": 7,
-    "extend": { "flags": [ "NO_REPAIR" ] }
+    "environmental_protection": 7
   },
   {
     "type": "PET_ARMOR",

--- a/data/json/items/armor/pets_dog_armor.json
+++ b/data/json/items/armor/pets_dog_armor.json
@@ -61,8 +61,7 @@
     "price_postapoc": 2500,
     "material": [ "acidchitin" ],
     "weight": "5362 g",
-    "environmental_protection": 7,
-    "extend": { "flags": [ "NO_REPAIR" ] }
+    "environmental_protection": 7
   },
   {
     "type": "PET_ARMOR",

--- a/data/json/items/armor/pets_horse_armor.json
+++ b/data/json/items/armor/pets_horse_armor.json
@@ -33,12 +33,11 @@
     "description": "A makeshift assembly of criniere, peytral and croupiere made from biosilicified chitin fitted to a thin mesh.  You could put this on a friendly horse.  Acid-resistant but brittle.",
     "price": 120000,
     "price_postapoc": 8000,
-    "material": [ "acidchitin", "steel" ],
+    "material": [ "acidchitin" ],
     "weight": "35 kg",
     "volume": "150 L",
     "material_thickness": 4,
-    "environmental_protection": 7,
-    "extend": { "flags": [ "NO_REPAIR" ] }
+    "environmental_protection": 7
   },
   {
     "type": "PET_ARMOR",

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -90,8 +90,7 @@
     "environmental_protection": 2,
     "price_postapoc": 3500,
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25, "encumbrance": 1.5, "warmth": 1.5 },
-    "relative": { "melee_damage": { "bash": 1 } },
-    "extend": { "flags": [ "NO_REPAIR" ] }
+    "relative": { "melee_damage": { "bash": 1 } }
   },
   {
     "id": "xl_armor_acidchitin",

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -700,7 +700,7 @@
       {
         "type": "repair_item",
         "item_action_type": "repair_metal",
-        "materials": [ "acidchitin", "bone", "chitin", "paper", "cardboard", "wood", "kevlar_rigid" ],
+        "materials": [ "bone", "chitin", "paper", "cardboard", "wood", "kevlar_rigid" ],
         "skill": "fabrication",
         "tool_quality": 5,
         "cost_scaling": 0.1,

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -19,7 +19,6 @@
     "name": "Thermoplastic Resin",
     "copy-from": "generic_polymer_resin",
     "//": "This material ID is for plastics that can be reshaped and molded by application of heat and return to their original properties when cooled, and these specific ones are quite hard and durable when in solid state.",
-    "repaired_with": "thermo_resin_chunk",
     "salvaged_into": "thermo_resin_chunk",
     "burn_data": [
       { "fuel": 1, "smoke": 2, "burn": 1, "volume_per_turn": "750 ml" },
@@ -33,7 +32,6 @@
     "name": "Epoxy",
     "copy-from": "generic_polymer_resin",
     "//": "'epoxy' is a general catch-all for strong, brittle polymers that cannot be reshaped with application of heat.  Not all of these are necessarily going to be literally epoxy, but it's close enough.",
-    "repaired_with": "epoxy_chunk",
     "salvaged_into": "epoxy_chunk",
     "burn_data": [
       { "fuel": 1, "smoke": 2, "burn": 1, "volume_per_turn": "750 ml" },
@@ -161,7 +159,7 @@
     "dmg_adj": [ "agitated", "thinned", "culled", "eradicated" ],
     "bash_dmg_verb": "ripples",
     "cut_dmg_verb": "passed through",
-    "repaired_with": "blood",
+    "repaired_with": "water",
     "soft": true,
     "resist": { "bash": 8, "cut": 0, "acid": 8, "heat": 4, "bullet": 4 }
   },
@@ -421,25 +419,6 @@
   },
   {
     "type": "material",
-    "id": "chitin_molt",
-    "name": "Molt Chitin",
-    "copy-from": "chitin",
-    "conductive": true,
-    "chip_resist": 0,
-    "wind_resist": 60,
-    "dmg_adj": [ "crinkled", "damaged", "crumpled", "deformed" ],
-    "bash_dmg_verb": "crumpled",
-    "cut_dmg_verb": "cut",
-    "burn_data": [
-      { "fuel": 0, "smoke": 3, "burn": 2, "volume_per_turn": "1250 ml" },
-      { "fuel": 1, "smoke": 5, "burn": 4 },
-      { "fuel": 1, "smoke": 7, "burn": 6 }
-    ],
-    "burn_products": [ [ "corpse_ash", 0.035 ] ],
-    "resist": { "bash": 0, "cut": 1, "acid": 3, "heat": 0, "bullet": 0 }
-  },
-  {
-    "type": "material",
     "id": "chitin_light",
     "name": "Light Chitin",
     "density": 1.45,
@@ -556,6 +535,7 @@
     "id": "cotton_quilted",
     "name": "Quilted Cotton",
     "copy-from": "cotton",
+    "repaired_with": "null",
     "wind_resist": 75,
     "resist": { "bash": 2, "cut": 2, "acid": 3, "heat": 0, "bullet": 1.5 }
   },
@@ -614,6 +594,7 @@
     "id": "canvas_quilted",
     "name": "Quilted Canvas",
     "copy-from": "canvas",
+    "repaired_with": "null",
     "wind_resist": 90,
     "resist": { "bash": 2, "cut": 3, "acid": 4, "heat": 0, "bullet": 2 }
   },
@@ -622,6 +603,7 @@
     "//": "duplicate material used to give gambesons an extra 95% coverage layer without causing weirdness",
     "id": "canvas_quilted_2",
     "copy-from": "canvas_quilted",
+    "repaired_with": "null",
     "name": "Quilted Canvas"
   },
   {
@@ -1890,7 +1872,7 @@
     "latent_heat": 273,
     "conductive": true,
     "chip_resist": 20,
-    "repaired_with": "mc_steel_chunk",
+    "repaired_with": "null",
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
@@ -1997,6 +1979,7 @@
     "id": "nylon_quilted",
     "name": "Quilted Nylon",
     "copy-from": "nylon",
+    "repaired_with": "null",
     "wind_resist": 65,
     "resist": { "bash": 1.5, "cut": 2, "acid": 9, "heat": 2, "bullet": 3 }
   },
@@ -2005,6 +1988,7 @@
     "//": "duplicate material used to give gambesons an extra 95% coverage layer without causing weirdness",
     "id": "nylon_quilted_2",
     "copy-from": "nylon_quilted",
+    "repaired_with": "null",
     "name": "Quilted Nylon"
   },
   {
@@ -2266,6 +2250,7 @@
     "id": "charcoal",
     "name": "Charcoal",
     "copy-from": "wood",
+    "repaired_with": "null",
     "fuel_data": { "energy": "6240 kJ" },
     "//": "physical density for charcoal estimated to sit at about 0.208 kg/liter, while energy density per kg is slightly lower than pure anthracite coal at 30 MJ/kg.",
     "//1": "208g of charcoal (1 liter) yields 6240 kJ (30MJ x .208), and a single chunk (8mL/1.664g) is worth 50kJ",
@@ -2277,6 +2262,7 @@
     "id": "coal",
     "name": "Coal",
     "copy-from": "wood",
+    "repaired_with": "null",
     "//": "mostly pure anthracite coal, 100% purity anthracite has 33.5MJ/kilogram.",
     "//1": "Raw density of anthracite is ~1.5g/cm^3 but bulk density is lower at slightly less than 1.0.",
     "//2": "Roughly 5x the energy content of charcoal per liter under that specific bulk density. Fuel data below assumes bulk density.",
@@ -2315,6 +2301,7 @@
     "id": "wool_quilted",
     "name": "Quilted Wool",
     "copy-from": "wool",
+    "repaired_with": "null",
     "wind_resist": 65,
     "resist": { "bash": 2, "cut": 2, "acid": 4, "heat": 0, "bullet": 1.5 }
   },
@@ -2323,6 +2310,7 @@
     "//": "duplicate material used to give gambesons an extra 95% coverage layer without causing weirdness",
     "id": "wool_quilted_2",
     "copy-from": "wool_quilted",
+    "repaired_with": "null",
     "name": "Quilted Wool"
   },
   {

--- a/data/mods/Aftershock/items/materials.json
+++ b/data/mods/Aftershock/items/materials.json
@@ -59,7 +59,6 @@
     "specific_heat_solid": 0.45,
     "latent_heat": 273,
     "chip_resist": 30,
-    "repaired_with": "scrap",
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "scratched",

--- a/data/mods/Magiclysm/materials.json
+++ b/data/mods/Magiclysm/materials.json
@@ -149,7 +149,8 @@
     "type": "material",
     "id": "magical_material",
     "name": "Magical Material",
-    "copy-from": "cotton"
+    "copy-from": "cotton",
+    "repaired_with": "null"
   },
   {
     "type": "material",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Doing some automated scripts to build faults I encounted a few inconsistencies in materials/repairs that make the generation script annoying to write, caused by not having single source of truth for repairs; you need definition on material and a fitting definition on a tool with repair_item action, some of those are inconsistent; this PR normalizes these materials and their repair kits a bit

#### Describe the solution

##### Biosilicified Chitin
`acidchitin` had identity crisis: misc repair kit could repair it, but it couldn't be repaired as it has no repaired_with, but then items with multiple materials put NO_REPAIR to stop being able to repair them.
Misc repair kit can no longer repair it, items which had multiple mats defined are set to only acidchitin
Some base game pet armor was already not repairable, others were made unrepairable by deleting extra materials
I left the DinoMod stuff alone as I have no clue what's the deal with pet armor there, but they were able to and still can be repaired due to having extra leather in material array

##### Thermoresin / Epoxy
Have no repair tool for them but defined repaired_with - the repaired_with was removed

##### Various "Quilted &lt;Foo&gt;"
These materials are used to hack in extra layers - they use copy_from and copy repaired_with field even though they have no tool to repair them, repairs_with is overwritten with null instead

##### alien_liquid
Had blood defined in the material but the feeding kit (it's repair kit) requires water, the material repaired_with was set to water

##### Coal, charcoal
Had repairs_with removed (and they have no tool to repair anyway)

##### Hyrogen cell material
Had repairs_with mc_steel_chunk, but it has no tool to repair anyway (nor I think makes sense to), this field was replaced with null

##### Chitin molt
Unused material

##### Aftershock - clearcrete
No repair tool but repaired_with defined to "scrap", this was removed

##### Magiclysm - magical_material
No tool to repair but repaired_with copy-from'ed cotton, this was overriden

#### Describe alternatives you've considered

#### Testing

Don't think any user facing effects should appear, except (some) base game acidchitin-based pet armor not being repairable

#### Additional context
