### PR TITLE
Refactor, consolidate, improve plant harvest funcs

### DIFF
--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -3178,7 +3178,7 @@
     "broken_symbol": "*",
     "broken_color": "light_blue",
     "damage_modifier": 120,
-    "bonus": 7,
+    "bonus": 5,
     "power": "-700 W",
     "durability": 200,
     "description": "An automatic reaper.  Use the vehicle controls to turn it on or off.  When on, it will cut down plants that it travels over.  It should be placed in front of any plows in the vehicle for efficient operation.  It does not include cargo space of its own so you need install a cargo space of some kind elsewhere in the vehicle.",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3633,7 +3633,7 @@ void harvest_activity_actor::finish( player_activity &act, Character &who )
         here.ter_set( target, here.get_ter_transforms_into( target ) );
     }
 
-    iexamine::practice_survival_while_foraging( who );
+    iexamine::practice_survival_while_gathering_from_plants( who, 0 );
 }
 
 void harvest_activity_actor::serialize( JsonOut &jsout ) const
@@ -5915,7 +5915,7 @@ void forage_activity_actor::finish( player_activity &act, Character &who )
         add_msg( _( "You didn't find anything." ) );
     }
 
-    iexamine::practice_survival_while_foraging( who );
+    iexamine::practice_survival_while_gathering_from_plants( who, 0 );
 
     act.set_to_null();
 

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -258,7 +258,8 @@ class basecamp
         inline void set_dumping_spot( const tripoint_abs_ms &spot ) {
             dumping_spot = spot;
         }
-        void place_results( const item &result );
+        void place_result( const item &result );
+        void place_results( const std::list<item> &results );
 
         // mission description functions
         void add_available_recipes( mission_data &mission_key, mission_kind kind, const point &dir,
@@ -275,6 +276,10 @@ class basecamp
         /// Returns the description of a camp crafting options. converts fire charges to charcoal,
         /// allows dark crafting
         std::string craft_description( const recipe_id &itm );
+
+        /// Plow, Plant, or Harvest a farm plot, or get info about the operation if npc_ptr is null
+        std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_tgt, farm_ops op,
+                const npc_ptr &comp );
 
         // main mission description collection
         void get_available_missions( mission_data &mission_key );

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -19,6 +19,7 @@ class time_point;
 class vpart_reference;
 struct itype;
 struct tripoint;
+class map;
 
 using seed_tuple = std::tuple<itype_id, std::string, int>;
 
@@ -149,6 +150,7 @@ std::optional<tripoint> getNearFilledGasTank( const tripoint &center, int &fuel_
 
 bool has_keg( const tripoint &pos );
 
+std::list<item> harvest_items( const itype &type, map &here, const tripoint &pos, int skill_level );
 std::list<item> get_harvest_items( const itype &type, int plant_count,
                                    int seed_count, bool byproducts );
 
@@ -163,7 +165,9 @@ itype_id choose_fertilizer( Character &you, const std::string &pname, bool ask_p
 ret_val<void> can_fertilize( Character &you, const tripoint &tile, const itype_id &fertilizer );
 
 // Skill training common functions
-void practice_survival_while_foraging( Character &who );
+/// practice survival skill when doing plant gathering actions
+/// higher ease results in lower skill cap
+void practice_survival_while_gathering_from_plants( Character &who, int ease = 0 );
 
 } // namespace iexamine
 

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -93,15 +93,10 @@ int dice( int number, int sides )
 // 1.3 has a 70% chance of rounding to 1, 30% chance to 2.
 int roll_remainder( double value )
 {
-    double integ;
-    double frac = modf( value, &integ );
-    if( value > 0.0 && value > integ && x_in_y( frac, 1.0 ) ) {
-        integ++;
-    } else if( value < 0.0 && value < integ && x_in_y( -frac, 1.0 ) ) {
-        integ--;
-    }
-
-    return integ;
+    double mag = std::abs( value );
+    double frac = std::modf( mag, &mag );
+    mag += x_in_y( frac, 1.0 );
+    return copysign( mag, value );
 }
 
 // http://www.cse.yorku.ca/~oz/hash.html


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Make plant harvesting more consistent"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While deduplicating the code for harvesting plants I encountered many opportunities for small improvement and refactors and balance adjustment.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
* Move some repeated functionality into helpers
* Change harvest product placement from the ground to the player, or from the player to basecamp storage
* Add messages for more harvest action results
* Produce byproducts from all harvest methods
* Change harvest quantities to be more low and less at high skill, reducing the multiplier from 0 to 10 skill from 7.5 to ~3
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I've been testing in-game and will continue as long as this remains a draft.
`tests/cata_test [rng]`
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
See comments on code.
Replaced the roll_remainder implementation with one I wrote before I found it.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->