### PR TITLE
Rust UI refinements

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3261,8 +3261,6 @@ void Character::do_skill_rust()
 
         const int rust_resist = enchantment_cache->modify_value( enchant_vals::mod::SKILL_RUST_RESIST, 0 );
         if( skill_level_obj.rust( rust_resist, mutation_value( "skill_rust_multiplier" ) ) ) {
-            add_msg_if_player( m_warning,
-                               _( "Your knowledge of %s begins to fade, but your memory banks retain it!" ), aSkill.name() );
             mod_power_level( -bio_memory->power_trigger );
         }
     }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -819,7 +819,8 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
             const SkillLevel &level = you.get_skill_level_object( aSkill->ident() );
             const bool can_train = level.can_train();
             const bool training = level.isTraining();
-            const bool rusty = level.isRusty();
+            const bool skill_gap = level.knowledgeLevel() > level.level();
+            const bool skill_small_gap = level.knowledgeExperience() > level.exercise();
             int exercise = level.knowledgeExperience();
             int level_num = level.knowledgeLevel();
             bool locked = false;
@@ -834,11 +835,13 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                 if( locked ) {
                     cstatus = h_yellow;
                 } else if( !can_train ) {
-                    cstatus = rusty ? h_light_red : h_white;
+                    cstatus = h_white;
                 } else if( exercise >= 100 ) {
                     cstatus = training ? h_pink : h_magenta;
-                } else if( rusty ) {
+                } else if( skill_gap ) {
                     cstatus = training ? h_light_green : h_green;
+                } else if( skill_small_gap ) {
+                    cstatus = training ? h_light_cyan : h_cyan;
                 } else {
                     cstatus = training ? h_light_blue : h_blue;
                 }
@@ -846,8 +849,10 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
             } else {
                 if( locked ) {
                     cstatus = c_yellow;
-                } else if( rusty ) {
+                } else if( skill_gap ) {
                     cstatus = training ? c_light_green : c_green;
+                } else if( skill_small_gap ) {
+                    cstatus = training ? c_light_cyan : c_cyan;
                 } else if( !can_train ) {
                     cstatus = c_white;
                 } else {
@@ -931,9 +936,24 @@ static void draw_skills_info( const catacurses::window &w_info, const Character 
     if( selectedSkill ) {
         const SkillLevel &level = you.get_skill_level_object( selectedSkill->ident() );
         std::string info_text = selectedSkill->description();
-        if( level.isRusty() ) {
-            info_text = string_format( _( "%s\n\nPractical level: %d (%d%%)" ), info_text,
+        float level_gap = 100.0f * std::max( level.knowledgeLevel(), 1 ) / std::max( level.level(), 1 );
+        if( level.knowledgeLevel() == 1 && level.level() == 0 ){
+            level_gap = 150.0f
+        }
+        float learning_bonus = 100.0f * std::max( ( 1.0f + you.get_int() / 40.0f ) - 0.1f * level.exercise() / level.knowledgeExperience(), 1.0f );
+        if( level.knowledgeLevel() > level.level() || level.knowledgeExperience() > level.exercise() ) {
+            info_text = string_format( _( "%s\n\nPractical level: %d (%d%%) " ), info_text,
                                        level.level(), level.exercise() );
+            if( level.knowledgeLevel() > level.level() ) {
+                info_text = string_format( _( "%s| Learning bonus: %f%%" ), info_text,
+                                       level_gap );
+            } else {
+                info_text = string_format( _( "%s| Learning bonus: %f%%" ), info_text,
+                                       learning_bonus );
+            }
+            if( level.isRusty() ) {
+                info_text = string_format( _( "%s\nThis skill will improve easily with practice." ), info_text );
+            }
         }
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, info_text );

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -820,8 +820,8 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
             const bool can_train = level.can_train();
             const bool training = level.isTraining();
             const bool rusty = level.isRusty();
-            int exercise = level.exercise();
-            int level_num = level.level();
+            int exercise = level.knowledgeExperience();
+            int level_num = level.knowledgeLevel();
             bool locked = false;
             if( you.has_active_bionic( bio_cqb ) && is_cqb_skill( aSkill->ident() ) ) {
                 level_num = 5;
@@ -838,7 +838,7 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                 } else if( exercise >= 100 ) {
                     cstatus = training ? h_pink : h_magenta;
                 } else if( rusty ) {
-                    cstatus = training ? h_light_red : h_red;
+                    cstatus = training ? h_light_green : h_green;
                 } else {
                     cstatus = training ? h_light_blue : h_blue;
                 }
@@ -847,7 +847,7 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                 if( locked ) {
                     cstatus = c_yellow;
                 } else if( rusty ) {
-                    cstatus = training ? c_light_red : c_red;
+                    cstatus = training ? c_light_green : c_green;
                 } else if( !can_train ) {
                     cstatus = c_white;
                 } else {
@@ -932,8 +932,8 @@ static void draw_skills_info( const catacurses::window &w_info, const Character 
         const SkillLevel &level = you.get_skill_level_object( selectedSkill->ident() );
         std::string info_text = selectedSkill->description();
         if( level.isRusty() ) {
-            info_text = string_format( _( "%s\n\nKnowledge level: %d (%d%%)" ), info_text,
-                                       level.knowledgeLevel(), level.knowledgeExperience() );
+            info_text = string_format( _( "%s\n\nPractical level: %d (%d%%)" ), info_text,
+                                       level.level(), level.exercise() );
         }
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, info_text );

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -937,19 +937,20 @@ static void draw_skills_info( const catacurses::window &w_info, const Character 
         const SkillLevel &level = you.get_skill_level_object( selectedSkill->ident() );
         std::string info_text = selectedSkill->description();
         float level_gap = 100.0f * std::max( level.knowledgeLevel(), 1 ) / std::max( level.level(), 1 );
-        if( level.knowledgeLevel() == 1 && level.level() == 0 ){
-            level_gap = 150.0f
+        if( level.knowledgeLevel() == 1 && level.level() == 0 ) {
+            level_gap = 150.0f;
         }
-        float learning_bonus = 100.0f * std::max( ( 1.0f + you.get_int() / 40.0f ) - 0.1f * level.exercise() / level.knowledgeExperience(), 1.0f );
+        float learning_bonus = 100.0f * std::max( ( 1.0f + you.get_int() / 40.0f ) - 0.1f *
+                               level.exercise() / level.knowledgeExperience(), 1.0f );
         if( level.knowledgeLevel() > level.level() || level.knowledgeExperience() > level.exercise() ) {
             info_text = string_format( _( "%s\n\nPractical level: %d (%d%%) " ), info_text,
                                        level.level(), level.exercise() );
             if( level.knowledgeLevel() > level.level() ) {
                 info_text = string_format( _( "%s| Learning bonus: %f%%" ), info_text,
-                                       level_gap );
+                                           level_gap );
             } else {
                 info_text = string_format( _( "%s| Learning bonus: %f%%" ), info_text,
-                                       learning_bonus );
+                                           learning_bonus );
             }
             if( level.isRusty() ) {
                 info_text = string_format( _( "%s\nThis skill will improve easily with practice." ), info_text );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The skill rust UI is getting more scrutiny now that more people are being dragged, kicking and screaming, into the century of the fruitbat. There are some elements in there that I just don't like and have wanted to fix for a while. Let's get to it.

#### Describe the solution

1. Change colour of skills to green if knowledge level > skill level. This is to indicate the selected skill is eligible for an xp boost because you _know_ more than you _have tried_ yet.
2. Change default listed level to your knowledge level, not your practical. The things you can do are defined by your knowledge. It's not helpful to show just the practical level in most cases. When you highlight the skill, you can see your skill level as you would have seen knowledge before. **NOTE**: I'd be open to switching this up for combat skills, but UI fixes are not my forte.
3. Remove skill rust warning messages about bionic memory banks. If you're an avid user of this CBM feel free to let me know, but it's my opinion this is now just another unnecessary message spam about rust.

#### Describe alternatives you've considered

I would like to add some information about how much of an XP boost you're getting from your knowledge::skill gap, but right now it is beyond my meager C++ skills on my very sleepy brain.

#### Testing

![image](https://user-images.githubusercontent.com/45136638/233247821-f4a6a817-fecf-4bd3-a47f-1f0e165c853d.png)

All works, but I wouldn't mind having one more kick at the can to display your XP boost before I finish this off.

#### Additional context

Some things I had planned to adjust on the existing rust system when I first made it, but haven't had the skill nor time for myself:

- If you have used a skill in the last 24(?) hours, it should not accumulate rust. This should apply even if you didn't actually use it enough to gain any XP. This change was beyond my code skills at the time, but I do think it is important, especially for skills that can be challenging to train at high levels.
- Related to above, if a skill is "turned off" for XP gain purposes we should still track its use and not rust it if it *would have* gained XP.
- The timer above could be set on a global variable, I wouldn't mind waiting more than 24 hours before the rust timer starts.
- Once those are implemented we should consider bumping up the rust ticker to every 12 hours, so it lags a little more before starting and once it does start it runs more often.

I think these are some very important changes and hope someone can help add them soon.