### PR TITLE
Confirmation before attacking neutral mobs

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -360,9 +360,10 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
                 return false;
             }
 
+            // Ask for confirmation before attacking a neutral creature
             if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
-            !query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
-                	return false;
+                !query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
+                return false;
             }
             you.melee_attack( critter, true );
             if( critter.is_hallucination() ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -361,13 +361,14 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
             }
 
             if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
-                query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
-                you.melee_attack( critter, true );
-                if( critter.is_hallucination() ) {
-                    critter.die( &you );
-                }
-                g->draw_hit_mon( dest_loc, critter, critter.is_dead() );
+            !query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
+                	return false;
             }
+            you.melee_attack( critter, true );
+            if( critter.is_hallucination() ) {
+                critter.die( &you );
+            }
+            g->draw_hit_mon( dest_loc, critter, critter.is_dead() );
             return false;
         } else if( critter.has_flag( MF_IMMOBILE ) || critter.has_effect( effect_harnessed ) ||
                    critter.has_effect( effect_ridden ) ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -360,7 +360,8 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
                 return false;
             }
 
-            if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL && query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
+            if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
+                query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
                 you.melee_attack( critter, true );
                 if( critter.is_hallucination() ) {
                     critter.die( &you );

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -360,11 +360,13 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
                 return false;
             }
 
-            you.melee_attack( critter, true );
-            if( critter.is_hallucination() ) {
-                critter.die( &you );
+            if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL && query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
+                you.melee_attack( critter, true );
+                if( critter.is_hallucination() ) {
+                    critter.die( &you );
+                }
+                g->draw_hit_mon( dest_loc, critter, critter.is_dead() );
             }
-            g->draw_hit_mon( dest_loc, critter, critter.is_dead() );
             return false;
         } else if( critter.has_flag( MF_IMMOBILE ) || critter.has_effect( effect_harnessed ) ||
                    critter.has_effect( effect_ridden ) ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -351,19 +351,23 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
                     return false;
                 }
             }
-            if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
-                g->safe_mode != SAFE_MODE_OFF ) {
-                const std::string msg_safe_mode = press_x( ACTION_TOGGLE_SAFEMODE );
-                add_msg( m_warning,
-                         _( "Not attacking the %1$s -- safe mode is on!  (%2$s to turn it off)" ), critter.name(),
-                         msg_safe_mode );
-                return false;
-            }
-
-            // Ask for confirmation before attacking a neutral creature
-            if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
-                !query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
-                return false;
+            bool safe_mode = ( get_option<bool>( "SAFEMODE" ) ? SAFE_MODE_ON : SAFE_MODE_OFF );
+            if( safe_mode ) {
+                // If safe mode is enabled, only allow attacking neutral creatures when it is inactive
+                if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
+                    g->safe_mode != SAFE_MODE_OFF ) {
+                    const std::string msg_safe_mode = press_x( ACTION_TOGGLE_SAFEMODE );
+                    add_msg( m_warning,
+                             _( "Not attacking the %1$s -- safe mode is on!  (%2$s to turn it off)" ), critter.name(),
+                             msg_safe_mode );
+                    return false;
+                }
+            } else {
+                // If safe mode is disabled, ask for confirmation before attacking a neutral creature
+                if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
+                    !query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
+                    return false;
+                }
             }
             you.melee_attack( critter, true );
             if( critter.is_hallucination() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Confirmation before attacking neutral mobs"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Since movement keys are also used for melee combat by walking into an occupied grid, holding down a movement key to move can result in a character melee attacking unintended targets and possibly drawing the aggression of otherwise neutral creatures. This is especially common in locations occupied by the Exodii faction where a large amount of neutral entities can be found.
Fixes #55442 
Fixes #59021
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added a confirmation prompt which appears when attempting to melee attack a neutral creature by walking into them. This is similar to how attacking neutral NPCs are currently handled. Ranged attacks should be unaffected.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Disable melee attacking when holding down the key and requiring a separate button press.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Confirmation prompt appears correctly when walking into a grids occupied by neutral creatures. Tested with a chicken and an Exodii Quadruped. Walking into hostile creatures, friendly pets and NPCs are unchanged.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->