### PR TITLE
Cowboy profession

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -5364,13 +5364,8 @@
         "entries": [
           { "group": "charged_smart_phone" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          {
-            "item": "sw_619",
-            "ammo-item": "357mag_jhp",
-            "charges": 7,
-            "container-item": "western_holster",
-            "contents-group": "bandolier_cowboy"
-          }
+          { "item": "sw_619", "ammo-item": "357mag_jhp", "charges": 7 },
+          { "item": "western_holster", "contents-group": "bandolier_cowboy" }
         ]
       },
       "male": [ "boxer_shorts" ],

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -324,6 +324,12 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "bandolier_cowboy",
+    "entries": [ { "item": "357mag_jhp", "charges": 18 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "dog_lover_bag",
     "entries": [
       { "item": "rubber_harness_dog" },
@@ -5319,6 +5325,56 @@
         "items": [ "flag_jumpsuit" ],
         "entries": [ { "item": "bikini_top", "variant": "flag_bikini_top" }, { "item": "bikini_bottom", "variant": "flag_bikini_bottom" } ]
       }
+    }
+  },
+  {
+    "type": "profession",
+    "id": "cowboy",
+    "name": "Cowboy",
+    "description": "You liked to spend your days taking care of the horses and cows, searching the perimeter of the ranch in your steed and looking out for anything suspicious, that's why you managed to escape in time when shit hit the fan.",
+    "points": 4,
+    "proficiencies": [ "prof_gunsmithing_basic" ],
+    "skills": [
+      { "level": 2, "name": "survival" },
+      { "level": 2, "name": "gun" },
+      { "level": 2, "name": "pistol" },
+      { "level": 1, "name": "swimming" },
+      { "level": 2, "name": "driving" }
+    ],
+    "pets": [ { "name": "mon_horse", "amount": 1 } ],
+    "items": {
+      "both": {
+        "items": [
+          "leather_belt",
+          "dress_shirt",
+          "jacket_leather",
+          "socks",
+          "cowboy_hat",
+          "wristwatch",
+          "backpack_leather",
+          "horse_tack",
+          "bullwhip",
+          "pockknife",
+          "jeans",
+          "chaps_leather",
+          "gloves_leather",
+          "boots_western",
+          "sunglasses"
+        ],
+        "entries": [
+          { "group": "charged_smart_phone" },
+          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          {
+            "item": "sw_619",
+            "ammo-item": "357mag_jhp",
+            "charges": 7,
+            "container-item": "western_holster",
+            "contents-group": "bandolier_cowboy"
+          }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "sports_bra", "panties" ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
Content "Adds a new profession that starts with a mountable horse: The Cowboy"

#### Purpose of change
We currently lack any profession that starts with a ridable animal (Outside of mods, with the most obvious example being the moose ride from magyclysm), vanilla deserves some love too, we have horses! They are common, domesticated, and reasonable to expect some survivors to escape with one or more...

#### Describe the solution
Adds the new profession, a Cowboy, basically a rancher with some degree of ability to protect itself and a horse.

#### Describe alternatives you've considered
Other animal related professions? But cowboys already fit perfectly for this.

#### Testing
It works! Spawned in game and mounted the horse.

#### Additional context

![imagen](https://user-images.githubusercontent.com/53200489/233540986-cdbaf6d3-bee2-432f-829e-e660d89b7508.png)