### PR TITLE
Set Fixed ordering for skills in info menu, regardless of language chosen

### DIFF
--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -293,7 +293,7 @@
     "companion_combat_rank_factor": 1,
     "companion_survival_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering":  200,
+    "ordering": 200,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -25,7 +25,7 @@
     "companion_survival_rank_factor": 1,
     "companion_industry_rank_factor": 1,
     "display_category": "display_interaction",
-    "ordering":  2500,
+    "ordering": 2500,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -54,7 +54,7 @@
     "name": { "str": "vehicles" },
     "description": "Your skill in operating and steering a vehicle in motion, from cars and boats to helicopters and hot air balloons.  A higher level allows greater control over vehicles at higher speeds, and reduces the penalty of shooting while driving.",
     "display_category": "display_interaction",
-    "ordering":  2700
+    "ordering": 2700
   },
   {
     "type": "skill",

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -303,7 +303,7 @@
     "description": "Your skill in general 'bench science', applying any of a wide range of precision techniques based on your overall understanding of scientific principles.  This is not a research skill, but about using the results of others' research.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering":  1900,
+    "ordering": 1900,
     "companion_skill_practice": [ { "skill": "menial", "weight": 15 } ]
   },
   {

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -6,6 +6,7 @@
     "description": "Your skill in speaking to other people.  Covers ability in boasting, flattery, threats, persuasion, lies, bartering, and other facets of interpersonal communication.  Works best in conjunction with a high level of intelligence.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_interaction",
+    "ordering":  2600,
     "companion_skill_practice": [ { "skill": "recruiting", "weight": 15 }, { "skill": "recruiting", "weight": 70 } ]
   },
   {
@@ -13,7 +14,8 @@
     "id": "computer",
     "name": { "str": "computers" },
     "description": "Your skill in accessing and manipulating computers.  Higher levels can allow a user to navigate complex software systems and even bypass their security.",
-    "display_category": "display_interaction"
+    "display_category": "display_interaction",
+    "ordering":  2400
   },
   {
     "type": "skill",
@@ -23,6 +25,7 @@
     "companion_survival_rank_factor": 1,
     "companion_industry_rank_factor": 1,
     "display_category": "display_interaction",
+    "ordering":  2500,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -32,6 +35,7 @@
     "description": "Your skill in engineering, maintaining and repairing vehicles and other mechanical systems.  This skill covers the craft of items with complex parts, and plays a role in the installation of bionic equipment.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_interaction",
+    "ordering":  2200,
     "companion_skill_practice": [ { "skill": "menial", "weight": 10 }, { "skill": "construction", "weight": 20 } ]
   },
   {
@@ -41,6 +45,7 @@
     "description": "Your skill in manipulating fine devices like security systems, traps, locks and other precision tasks.  This skill does not affect the evasion of traps that are triggered.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_interaction",
+    "ordering":  2300,
     "companion_skill_practice": [ { "skill": "", "weight": 15 }, { "skill": "gathering", "weight": 15 }, { "skill": "trapping", "weight": 80 } ]
   },
   {
@@ -48,7 +53,8 @@
     "id": "driving",
     "name": { "str": "vehicles" },
     "description": "Your skill in operating and steering a vehicle in motion, from cars and boats to helicopters and hot air balloons.  A higher level allows greater control over vehicles at higher speeds, and reduces the penalty of shooting while driving.",
-    "display_category": "display_interaction"
+    "display_category": "display_interaction",
+    "ordering":  2700
   },
   {
     "type": "skill",
@@ -56,6 +62,7 @@
     "name": { "str": "athletics" },
     "description": "Your athletic ability, including swimming endurance and ability to swim with weight.  Athletic skill also improves your overall cardio fitness and stamina.",
     "display_category": "display_interaction",
+    "ordering":  2100,
     "companion_skill_practice": [ { "skill": "", "weight": 5 }, { "skill": "gathering", "weight": 5 }, { "skill": "trapping", "weight": 5 } ]
   },
   {
@@ -65,6 +72,7 @@
     "description": "Your skill in working with raw materials and shaping them into useful objects.  This skill plays an important role in the crafting of many objects.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
+    "ordering":  1700,
     "companion_skill_practice": [
       { "skill": "", "weight": 10 },
       { "skill": "gathering", "weight": 10 },
@@ -80,6 +88,7 @@
     "description": "Your skill in combining food ingredients to make other, tastier food items.  Also includes food preservation and safety, brewing, butchery, and more.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
+    "ordering":  1600,
     "companion_skill_practice": [ { "skill": "menial", "weight": 15 } ]
   },
   {
@@ -89,6 +98,7 @@
     "description": "Your skill in the craft and repair of clothing, bags, blankets and other textiles.  Affects knitting, sewing, stitching, weaving, and nearly anything else involving a needle and thread.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
+    "ordering":  2000,
     "companion_skill_practice": [ { "skill": "menial", "weight": 15 } ]
   },
   {
@@ -98,6 +108,7 @@
     "description": "Your skill in surviving the wilderness, and in crafting various basic survival items.  This also covers your ability to skin and butcher animals for meat and hides.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_crafting",
+    "ordering":  1500,
     "companion_skill_practice": [
       { "skill": "", "weight": 80 },
       { "skill": "gathering", "weight": 80 },
@@ -115,7 +126,8 @@
     "name": { "str": "electronics" },
     "description": "Your skill in dealing with electrical systems, used in the craft and repair of objects with electrical components.  This skill is an important part of installing and managing bionic implants.",
     "companion_industry_rank_factor": 1,
-    "display_category": "display_crafting"
+    "display_category": "display_crafting",
+    "ordering":  1800
   },
   {
     "type": "skill",
@@ -127,6 +139,7 @@
     "companion_combat_rank_factor": 1,
     "companion_survival_rank_factor": 1,
     "display_category": "display_ranged",
+    "ordering":  900,
     "companion_skill_practice": [
       { "skill": "", "weight": 5 },
       { "skill": "gathering", "weight": 5 },
@@ -142,6 +155,7 @@
     "description": "Your overall skill in using bows and firearms.  With higher levels, this general experience increases accuracy with any bows or firearms, but is secondary to practice with the type of ranged weapon in question.",
     "tags": [ "combat_skill" ],
     "display_category": "display_ranged",
+    "ordering":  700,
     "companion_skill_practice": [ { "skill": "gathering", "weight": 60 }, { "skill": "combat", "weight": 5 } ]
   },
   {
@@ -151,7 +165,8 @@
     "description": "Your skill in using heavy weapons like rocket, grenade or missile launchers.  These weapons have a variety of applications and may carry immense destructive power, but they are cumbersome and hard to manage.",
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 30, "base_time": 100, "time_reduction_per_level": 5 },
-    "display_category": "display_ranged"
+    "display_category": "display_ranged",
+    "ordering":  1400
   },
   {
     "type": "skill",
@@ -161,6 +176,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
+    "ordering":  1000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
   },
   {
@@ -171,6 +187,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
+    "ordering":  1200,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 45 } ]
   },
   {
@@ -181,6 +198,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
+    "ordering":  1300,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
   },
   {
@@ -191,6 +209,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
+    "ordering":  1100,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
   },
   {
@@ -200,7 +219,8 @@
     "description": "Your skill in throwing objects over a distance.  Skill increases accuracy, and at higher levels, the range of a throw.",
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 50, "base_time": 220, "time_reduction_per_level": 25 },
-    "display_category": "display_ranged"
+    "display_category": "display_ranged",
+    "ordering":  800
   },
   {
     "type": "skill",
@@ -211,6 +231,7 @@
     "time_to_attack": { "min_time": 50, "base_time": 200, "time_reduction_per_level": 20 },
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
+    "ordering":  100,
     "companion_skill_practice": [
       { "skill": "", "weight": 5 },
       { "skill": "gathering", "weight": 5 },
@@ -228,6 +249,7 @@
     "tags": [ "combat_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
+    "ordering":  300,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -238,6 +260,7 @@
     "tags": [ "combat_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
+    "ordering":  400,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -247,6 +270,7 @@
     "description": "Your ability to dodge an oncoming threat, be it an enemy's attack, a triggered trap, or a falling rock.  This skill is also used in attempts to fall gracefully, and for other acrobatic feats.  The first number shown includes modifiers, and the second does not.",
     "tags": [ "combat_skill" ],
     "display_category": "display_melee",
+    "ordering":  600,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 15 }, { "skill": "combat", "weight": 20 } ]
   },
   {
@@ -257,6 +281,7 @@
     "tags": [ "combat_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
+    "ordering":  500,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -268,6 +293,7 @@
     "companion_combat_rank_factor": 1,
     "companion_survival_rank_factor": 1,
     "display_category": "display_melee",
+    "ordering":  200,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -277,6 +303,7 @@
     "description": "Your skill in general 'bench science', applying any of a wide range of precision techniques based on your overall understanding of scientific principles.  This is not a research skill, but about using the results of others' research.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
+    "ordering":  1900,
     "companion_skill_practice": [ { "skill": "menial", "weight": 15 } ]
   },
   {

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -6,7 +6,7 @@
     "description": "Your skill in speaking to other people.  Covers ability in boasting, flattery, threats, persuasion, lies, bartering, and other facets of interpersonal communication.  Works best in conjunction with a high level of intelligence.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_interaction",
-    "ordering":  2600,
+    "ordering": 2600,
     "companion_skill_practice": [ { "skill": "recruiting", "weight": 15 }, { "skill": "recruiting", "weight": 70 } ]
   },
   {

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -15,7 +15,7 @@
     "name": { "str": "computers" },
     "description": "Your skill in accessing and manipulating computers.  Higher levels can allow a user to navigate complex software systems and even bypass their security.",
     "display_category": "display_interaction",
-    "ordering":  2400
+    "ordering": 2400
   },
   {
     "type": "skill",

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -35,7 +35,7 @@
     "description": "Your skill in engineering, maintaining and repairing vehicles and other mechanical systems.  This skill covers the craft of items with complex parts, and plays a role in the installation of bionic equipment.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_interaction",
-    "ordering":  2200,
+    "ordering": 2200,
     "companion_skill_practice": [ { "skill": "menial", "weight": 10 }, { "skill": "construction", "weight": 20 } ]
   },
   {

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -270,7 +270,7 @@
     "description": "Your ability to dodge an oncoming threat, be it an enemy's attack, a triggered trap, or a falling rock.  This skill is also used in attempts to fall gracefully, and for other acrobatic feats.  The first number shown includes modifiers, and the second does not.",
     "tags": [ "combat_skill" ],
     "display_category": "display_melee",
-    "ordering":  600,
+    "ordering": 600,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 15 }, { "skill": "combat", "weight": 20 } ]
   },
   {

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -45,7 +45,7 @@
     "description": "Your skill in manipulating fine devices like security systems, traps, locks and other precision tasks.  This skill does not affect the evasion of traps that are triggered.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_interaction",
-    "ordering":  2300,
+    "ordering": 2300,
     "companion_skill_practice": [ { "skill": "", "weight": 15 }, { "skill": "gathering", "weight": 15 }, { "skill": "trapping", "weight": 80 } ]
   },
   {

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -6,7 +6,7 @@
     "description": "Your skill in speaking to other people.  Covers ability in boasting, flattery, threats, persuasion, lies, bartering, and other facets of interpersonal communication.  Works best in conjunction with a high level of intelligence.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_interaction",
-    "ordering": 2600,
+    "ordering": 26000,
     "companion_skill_practice": [ { "skill": "recruiting", "weight": 15 }, { "skill": "recruiting", "weight": 70 } ]
   },
   {
@@ -15,7 +15,7 @@
     "name": { "str": "computers" },
     "description": "Your skill in accessing and manipulating computers.  Higher levels can allow a user to navigate complex software systems and even bypass their security.",
     "display_category": "display_interaction",
-    "ordering": 2400
+    "ordering": 24000
   },
   {
     "type": "skill",
@@ -25,7 +25,7 @@
     "companion_survival_rank_factor": 1,
     "companion_industry_rank_factor": 1,
     "display_category": "display_interaction",
-    "ordering": 2500,
+    "ordering": 25000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -35,7 +35,7 @@
     "description": "Your skill in engineering, maintaining and repairing vehicles and other mechanical systems.  This skill covers the craft of items with complex parts, and plays a role in the installation of bionic equipment.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_interaction",
-    "ordering": 2200,
+    "ordering": 22000,
     "companion_skill_practice": [ { "skill": "menial", "weight": 10 }, { "skill": "construction", "weight": 20 } ]
   },
   {
@@ -45,7 +45,7 @@
     "description": "Your skill in manipulating fine devices like security systems, traps, locks and other precision tasks.  This skill does not affect the evasion of traps that are triggered.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_interaction",
-    "ordering": 2300,
+    "ordering": 23000,
     "companion_skill_practice": [ { "skill": "", "weight": 15 }, { "skill": "gathering", "weight": 15 }, { "skill": "trapping", "weight": 80 } ]
   },
   {
@@ -54,7 +54,7 @@
     "name": { "str": "vehicles" },
     "description": "Your skill in operating and steering a vehicle in motion, from cars and boats to helicopters and hot air balloons.  A higher level allows greater control over vehicles at higher speeds, and reduces the penalty of shooting while driving.",
     "display_category": "display_interaction",
-    "ordering": 2700
+    "ordering": 27000
   },
   {
     "type": "skill",
@@ -62,7 +62,7 @@
     "name": { "str": "athletics" },
     "description": "Your athletic ability, including swimming endurance and ability to swim with weight.  Athletic skill also improves your overall cardio fitness and stamina.",
     "display_category": "display_interaction",
-    "ordering": 2100,
+    "ordering": 21000,
     "companion_skill_practice": [ { "skill": "", "weight": 5 }, { "skill": "gathering", "weight": 5 }, { "skill": "trapping", "weight": 5 } ]
   },
   {
@@ -72,7 +72,7 @@
     "description": "Your skill in working with raw materials and shaping them into useful objects.  This skill plays an important role in the crafting of many objects.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering": 1700,
+    "ordering": 17000,
     "companion_skill_practice": [
       { "skill": "", "weight": 10 },
       { "skill": "gathering", "weight": 10 },
@@ -88,7 +88,7 @@
     "description": "Your skill in combining food ingredients to make other, tastier food items.  Also includes food preservation and safety, brewing, butchery, and more.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering": 1600,
+    "ordering": 16000,
     "companion_skill_practice": [ { "skill": "menial", "weight": 15 } ]
   },
   {
@@ -98,7 +98,7 @@
     "description": "Your skill in the craft and repair of clothing, bags, blankets and other textiles.  Affects knitting, sewing, stitching, weaving, and nearly anything else involving a needle and thread.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering": 2000,
+    "ordering": 20000,
     "companion_skill_practice": [ { "skill": "menial", "weight": 15 } ]
   },
   {
@@ -108,7 +108,7 @@
     "description": "Your skill in surviving the wilderness, and in crafting various basic survival items.  This also covers your ability to skin and butcher animals for meat and hides.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering": 1500,
+    "ordering": 15000,
     "companion_skill_practice": [
       { "skill": "", "weight": 80 },
       { "skill": "gathering", "weight": 80 },
@@ -127,7 +127,7 @@
     "description": "Your skill in dealing with electrical systems, used in the craft and repair of objects with electrical components.  This skill is an important part of installing and managing bionic implants.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering": 1800
+    "ordering": 18000
   },
   {
     "type": "skill",
@@ -139,7 +139,7 @@
     "companion_combat_rank_factor": 1,
     "companion_survival_rank_factor": 1,
     "display_category": "display_ranged",
-    "ordering": 900,
+    "ordering": 9000,
     "companion_skill_practice": [
       { "skill": "", "weight": 5 },
       { "skill": "gathering", "weight": 5 },
@@ -155,7 +155,7 @@
     "description": "Your overall skill in using bows and firearms.  With higher levels, this general experience increases accuracy with any bows or firearms, but is secondary to practice with the type of ranged weapon in question.",
     "tags": [ "combat_skill" ],
     "display_category": "display_ranged",
-    "ordering": 700,
+    "ordering": 7000,
     "companion_skill_practice": [ { "skill": "gathering", "weight": 60 }, { "skill": "combat", "weight": 5 } ]
   },
   {
@@ -166,7 +166,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 30, "base_time": 100, "time_reduction_per_level": 5 },
     "display_category": "display_ranged",
-    "ordering": 1400
+    "ordering": 14000
   },
   {
     "type": "skill",
@@ -176,7 +176,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering": 1000,
+    "ordering": 10000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
   },
   {
@@ -187,7 +187,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering": 1200,
+    "ordering": 12000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 45 } ]
   },
   {
@@ -198,7 +198,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering": 1300,
+    "ordering": 13000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
   },
   {
@@ -209,7 +209,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering": 1100,
+    "ordering": 11000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
   },
   {
@@ -220,7 +220,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 50, "base_time": 220, "time_reduction_per_level": 25 },
     "display_category": "display_ranged",
-    "ordering": 800
+    "ordering": 8000
   },
   {
     "type": "skill",
@@ -231,7 +231,7 @@
     "time_to_attack": { "min_time": 50, "base_time": 200, "time_reduction_per_level": 20 },
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering": 100,
+    "ordering": 1000,
     "companion_skill_practice": [
       { "skill": "", "weight": 5 },
       { "skill": "gathering", "weight": 5 },
@@ -249,7 +249,7 @@
     "tags": [ "combat_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering": 300,
+    "ordering": 3000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -260,7 +260,7 @@
     "tags": [ "combat_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering": 400,
+    "ordering": 4000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -270,7 +270,7 @@
     "description": "Your ability to dodge an oncoming threat, be it an enemy's attack, a triggered trap, or a falling rock.  This skill is also used in attempts to fall gracefully, and for other acrobatic feats.  The first number shown includes modifiers, and the second does not.",
     "tags": [ "combat_skill" ],
     "display_category": "display_melee",
-    "ordering": 600,
+    "ordering": 6000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 15 }, { "skill": "combat", "weight": 20 } ]
   },
   {
@@ -281,7 +281,7 @@
     "tags": [ "combat_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering": 500,
+    "ordering": 5000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -293,7 +293,7 @@
     "companion_combat_rank_factor": 1,
     "companion_survival_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering": 200,
+    "ordering": 2000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -303,7 +303,7 @@
     "description": "Your skill in general 'bench science', applying any of a wide range of precision techniques based on your overall understanding of scientific principles.  This is not a research skill, but about using the results of others' research.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering": 1900,
+    "ordering": 19000,
     "companion_skill_practice": [ { "skill": "menial", "weight": 15 } ]
   },
   {
@@ -312,6 +312,7 @@
     "name": { "str": "weapon" },
     "description": "seeing this is a bug",
     "tags": [ "contextual_skill" ],
-    "display_category": "none"
+    "display_category": "none",
+    "ordering": 500000
   }
 ]

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -281,7 +281,7 @@
     "tags": [ "combat_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering":  500,
+    "ordering": 500,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -62,7 +62,7 @@
     "name": { "str": "athletics" },
     "description": "Your athletic ability, including swimming endurance and ability to swim with weight.  Athletic skill also improves your overall cardio fitness and stamina.",
     "display_category": "display_interaction",
-    "ordering":  2100,
+    "ordering": 2100,
     "companion_skill_practice": [ { "skill": "", "weight": 5 }, { "skill": "gathering", "weight": 5 }, { "skill": "trapping", "weight": 5 } ]
   },
   {
@@ -72,7 +72,7 @@
     "description": "Your skill in working with raw materials and shaping them into useful objects.  This skill plays an important role in the crafting of many objects.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering":  1700,
+    "ordering": 1700,
     "companion_skill_practice": [
       { "skill": "", "weight": 10 },
       { "skill": "gathering", "weight": 10 },
@@ -88,7 +88,7 @@
     "description": "Your skill in combining food ingredients to make other, tastier food items.  Also includes food preservation and safety, brewing, butchery, and more.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering":  1600,
+    "ordering": 1600,
     "companion_skill_practice": [ { "skill": "menial", "weight": 15 } ]
   },
   {
@@ -98,7 +98,7 @@
     "description": "Your skill in the craft and repair of clothing, bags, blankets and other textiles.  Affects knitting, sewing, stitching, weaving, and nearly anything else involving a needle and thread.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering":  2000,
+    "ordering": 2000,
     "companion_skill_practice": [ { "skill": "menial", "weight": 15 } ]
   },
   {
@@ -108,7 +108,7 @@
     "description": "Your skill in surviving the wilderness, and in crafting various basic survival items.  This also covers your ability to skin and butcher animals for meat and hides.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering":  1500,
+    "ordering": 1500,
     "companion_skill_practice": [
       { "skill": "", "weight": 80 },
       { "skill": "gathering", "weight": 80 },
@@ -127,7 +127,7 @@
     "description": "Your skill in dealing with electrical systems, used in the craft and repair of objects with electrical components.  This skill is an important part of installing and managing bionic implants.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering":  1800
+    "ordering": 1800
   },
   {
     "type": "skill",
@@ -139,7 +139,7 @@
     "companion_combat_rank_factor": 1,
     "companion_survival_rank_factor": 1,
     "display_category": "display_ranged",
-    "ordering":  900,
+    "ordering": 900,
     "companion_skill_practice": [
       { "skill": "", "weight": 5 },
       { "skill": "gathering", "weight": 5 },
@@ -155,7 +155,7 @@
     "description": "Your overall skill in using bows and firearms.  With higher levels, this general experience increases accuracy with any bows or firearms, but is secondary to practice with the type of ranged weapon in question.",
     "tags": [ "combat_skill" ],
     "display_category": "display_ranged",
-    "ordering":  700,
+    "ordering": 700,
     "companion_skill_practice": [ { "skill": "gathering", "weight": 60 }, { "skill": "combat", "weight": 5 } ]
   },
   {
@@ -166,7 +166,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 30, "base_time": 100, "time_reduction_per_level": 5 },
     "display_category": "display_ranged",
-    "ordering":  1400
+    "ordering": 1400
   },
   {
     "type": "skill",
@@ -176,7 +176,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering":  1000,
+    "ordering": 1000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
   },
   {
@@ -187,7 +187,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering":  1200,
+    "ordering": 1200,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 45 } ]
   },
   {
@@ -198,7 +198,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering":  1300,
+    "ordering": 1300,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
   },
   {
@@ -209,7 +209,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering":  1100,
+    "ordering": 1100,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
   },
   {
@@ -220,7 +220,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 50, "base_time": 220, "time_reduction_per_level": 25 },
     "display_category": "display_ranged",
-    "ordering":  800
+    "ordering": 800
   },
   {
     "type": "skill",
@@ -231,7 +231,7 @@
     "time_to_attack": { "min_time": 50, "base_time": 200, "time_reduction_per_level": 20 },
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering":  100,
+    "ordering": 100,
     "companion_skill_practice": [
       { "skill": "", "weight": 5 },
       { "skill": "gathering", "weight": 5 },
@@ -249,7 +249,7 @@
     "tags": [ "combat_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering":  300,
+    "ordering": 300,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -260,7 +260,7 @@
     "tags": [ "combat_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering":  400,
+    "ordering": 400,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -6,7 +6,7 @@
     "description": "Your skill in speaking to other people.  Covers ability in boasting, flattery, threats, persuasion, lies, bartering, and other facets of interpersonal communication.  Works best in conjunction with a high level of intelligence.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_interaction",
-    "ordering": 26000,
+    "sort_rank": 26000,
     "companion_skill_practice": [ { "skill": "recruiting", "weight": 15 }, { "skill": "recruiting", "weight": 70 } ]
   },
   {
@@ -15,7 +15,7 @@
     "name": { "str": "computers" },
     "description": "Your skill in accessing and manipulating computers.  Higher levels can allow a user to navigate complex software systems and even bypass their security.",
     "display_category": "display_interaction",
-    "ordering": 24000
+    "sort_rank": 24000
   },
   {
     "type": "skill",
@@ -25,7 +25,7 @@
     "companion_survival_rank_factor": 1,
     "companion_industry_rank_factor": 1,
     "display_category": "display_interaction",
-    "ordering": 25000,
+    "sort_rank": 25000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -35,7 +35,7 @@
     "description": "Your skill in engineering, maintaining and repairing vehicles and other mechanical systems.  This skill covers the craft of items with complex parts, and plays a role in the installation of bionic equipment.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_interaction",
-    "ordering": 22000,
+    "sort_rank": 22000,
     "companion_skill_practice": [ { "skill": "menial", "weight": 10 }, { "skill": "construction", "weight": 20 } ]
   },
   {
@@ -45,7 +45,7 @@
     "description": "Your skill in manipulating fine devices like security systems, traps, locks and other precision tasks.  This skill does not affect the evasion of traps that are triggered.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_interaction",
-    "ordering": 23000,
+    "sort_rank": 23000,
     "companion_skill_practice": [ { "skill": "", "weight": 15 }, { "skill": "gathering", "weight": 15 }, { "skill": "trapping", "weight": 80 } ]
   },
   {
@@ -54,7 +54,7 @@
     "name": { "str": "vehicles" },
     "description": "Your skill in operating and steering a vehicle in motion, from cars and boats to helicopters and hot air balloons.  A higher level allows greater control over vehicles at higher speeds, and reduces the penalty of shooting while driving.",
     "display_category": "display_interaction",
-    "ordering": 27000
+    "sort_rank": 27000
   },
   {
     "type": "skill",
@@ -62,7 +62,7 @@
     "name": { "str": "athletics" },
     "description": "Your athletic ability, including swimming endurance and ability to swim with weight.  Athletic skill also improves your overall cardio fitness and stamina.",
     "display_category": "display_interaction",
-    "ordering": 21000,
+    "sort_rank": 21000,
     "companion_skill_practice": [ { "skill": "", "weight": 5 }, { "skill": "gathering", "weight": 5 }, { "skill": "trapping", "weight": 5 } ]
   },
   {
@@ -72,7 +72,7 @@
     "description": "Your skill in working with raw materials and shaping them into useful objects.  This skill plays an important role in the crafting of many objects.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering": 17000,
+    "sort_rank": 17000,
     "companion_skill_practice": [
       { "skill": "", "weight": 10 },
       { "skill": "gathering", "weight": 10 },
@@ -88,7 +88,7 @@
     "description": "Your skill in combining food ingredients to make other, tastier food items.  Also includes food preservation and safety, brewing, butchery, and more.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering": 16000,
+    "sort_rank": 16000,
     "companion_skill_practice": [ { "skill": "menial", "weight": 15 } ]
   },
   {
@@ -98,7 +98,7 @@
     "description": "Your skill in the craft and repair of clothing, bags, blankets and other textiles.  Affects knitting, sewing, stitching, weaving, and nearly anything else involving a needle and thread.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering": 20000,
+    "sort_rank": 20000,
     "companion_skill_practice": [ { "skill": "menial", "weight": 15 } ]
   },
   {
@@ -108,7 +108,7 @@
     "description": "Your skill in surviving the wilderness, and in crafting various basic survival items.  This also covers your ability to skin and butcher animals for meat and hides.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering": 15000,
+    "sort_rank": 15000,
     "companion_skill_practice": [
       { "skill": "", "weight": 80 },
       { "skill": "gathering", "weight": 80 },
@@ -127,7 +127,7 @@
     "description": "Your skill in dealing with electrical systems, used in the craft and repair of objects with electrical components.  This skill is an important part of installing and managing bionic implants.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering": 18000
+    "sort_rank": 18000
   },
   {
     "type": "skill",
@@ -139,7 +139,7 @@
     "companion_combat_rank_factor": 1,
     "companion_survival_rank_factor": 1,
     "display_category": "display_ranged",
-    "ordering": 9000,
+    "sort_rank": 9000,
     "companion_skill_practice": [
       { "skill": "", "weight": 5 },
       { "skill": "gathering", "weight": 5 },
@@ -155,7 +155,7 @@
     "description": "Your overall skill in using bows and firearms.  With higher levels, this general experience increases accuracy with any bows or firearms, but is secondary to practice with the type of ranged weapon in question.",
     "tags": [ "combat_skill" ],
     "display_category": "display_ranged",
-    "ordering": 7000,
+    "sort_rank": 7000,
     "companion_skill_practice": [ { "skill": "gathering", "weight": 60 }, { "skill": "combat", "weight": 5 } ]
   },
   {
@@ -166,7 +166,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 30, "base_time": 100, "time_reduction_per_level": 5 },
     "display_category": "display_ranged",
-    "ordering": 14000
+    "sort_rank": 14000
   },
   {
     "type": "skill",
@@ -176,7 +176,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering": 10000,
+    "sort_rank": 10000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
   },
   {
@@ -187,7 +187,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering": 12000,
+    "sort_rank": 12000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 45 } ]
   },
   {
@@ -198,7 +198,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering": 13000,
+    "sort_rank": 13000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
   },
   {
@@ -209,7 +209,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering": 11000,
+    "sort_rank": 11000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
   },
   {
@@ -220,7 +220,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 50, "base_time": 220, "time_reduction_per_level": 25 },
     "display_category": "display_ranged",
-    "ordering": 8000
+    "sort_rank": 8000
   },
   {
     "type": "skill",
@@ -231,7 +231,7 @@
     "time_to_attack": { "min_time": 50, "base_time": 200, "time_reduction_per_level": 20 },
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering": 1000,
+    "sort_rank": 1000,
     "companion_skill_practice": [
       { "skill": "", "weight": 5 },
       { "skill": "gathering", "weight": 5 },
@@ -249,7 +249,7 @@
     "tags": [ "combat_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering": 3000,
+    "sort_rank": 3000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -260,7 +260,7 @@
     "tags": [ "combat_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering": 4000,
+    "sort_rank": 4000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -270,7 +270,7 @@
     "description": "Your ability to dodge an oncoming threat, be it an enemy's attack, a triggered trap, or a falling rock.  This skill is also used in attempts to fall gracefully, and for other acrobatic feats.  The first number shown includes modifiers, and the second does not.",
     "tags": [ "combat_skill" ],
     "display_category": "display_melee",
-    "ordering": 6000,
+    "sort_rank": 6000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 15 }, { "skill": "combat", "weight": 20 } ]
   },
   {
@@ -281,7 +281,7 @@
     "tags": [ "combat_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering": 5000,
+    "sort_rank": 5000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -293,7 +293,7 @@
     "companion_combat_rank_factor": 1,
     "companion_survival_rank_factor": 1,
     "display_category": "display_melee",
-    "ordering": 2000,
+    "sort_rank": 2000,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
   },
   {
@@ -303,7 +303,7 @@
     "description": "Your skill in general 'bench science', applying any of a wide range of precision techniques based on your overall understanding of scientific principles.  This is not a research skill, but about using the results of others' research.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
-    "ordering": 19000,
+    "sort_rank": 19000,
     "companion_skill_practice": [ { "skill": "menial", "weight": 15 } ]
   },
   {
@@ -313,6 +313,6 @@
     "description": "seeing this is a bug",
     "tags": [ "contextual_skill" ],
     "display_category": "none",
-    "ordering": 500000
+    "sort_rank": 500000
   }
 ]

--- a/data/mods/Aftershock/skills.json
+++ b/data/mods/Aftershock/skills.json
@@ -7,7 +7,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
-    "ordering": 10500,
+    "sort_rank": 10500,
     "companion_skill_practice": [ { "skill": "combat", "weight": 25 } ]
   }
 ]

--- a/data/mods/Aftershock/skills.json
+++ b/data/mods/Aftershock/skills.json
@@ -7,6 +7,7 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
     "display_category": "display_ranged",
+    "ordering": 10500,
     "companion_skill_practice": [ { "skill": "combat", "weight": 25 } ]
   }
 ]

--- a/data/mods/Magiclysm/modinfo.json
+++ b/data/mods/Magiclysm/modinfo.json
@@ -14,6 +14,7 @@
     "id": "spellcraft",
     "name": "spellcraft",
     "display_category": "display_ranged",
+    "sort_rank": 14500,
     "description": "Your skill in the arcane.  Represents magic theory and all that entails.  A higher skill increases how quickly you can learn spells, and decreases their spell failure chance.  You learn this skill by studying books or spells."
   }
 ]

--- a/data/mods/Xedra_Evolved/skills.json
+++ b/data/mods/Xedra_Evolved/skills.json
@@ -8,12 +8,14 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 60, "base_time": 200, "time_reduction_per_level": 14 },
     "display_category": "display_interaction",
+    "ordering": 26500,
     "companion_skill_practice": [ { "skill": "speech", "weight": 1 }, { "skill": "devices", "weight": 1 } ]
   },
   {
     "type": "skill",
     "id": "spellcraft",
     "name": "spellcraft",
+    "ordering": 14500,
     "display_category": "display_ranged",
     "description": "Your skill in the arcane.  Represents magic theory and all that entails.  A higher skill increases how quickly you can learn spells, and decreases their spell failure chance.  You learn this skill by studying books or spells."
   }

--- a/data/mods/Xedra_Evolved/skills.json
+++ b/data/mods/Xedra_Evolved/skills.json
@@ -8,15 +8,15 @@
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 60, "base_time": 200, "time_reduction_per_level": 14 },
     "display_category": "display_interaction",
-    "ordering": 26500,
+    "sort_rank": 26500,
     "companion_skill_practice": [ { "skill": "speech", "weight": 1 }, { "skill": "devices", "weight": 1 } ]
   },
   {
     "type": "skill",
     "id": "spellcraft",
     "name": "spellcraft",
-    "ordering": 14500,
     "display_category": "display_ranged",
+    "sort_rank": 14500,
     "description": "Your skill in the arcane.  Represents magic theory and all that entails.  A higher skill increases how quickly you can learn spells, and decreases their spell failure chance.  You learn this skill by studying books or spells."
   }
 ]

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1579,11 +1579,7 @@ void Character::disp_info( bool customize_character )
 
     const std::vector<const Skill *> player_skill = Skill::get_skills_sorted_by(
     [&]( const Skill & a, const Skill & b ) {
-        skill_displayType_id type_a = a.display_category();
-        skill_displayType_id type_b = b.display_category();
-
-        return localized_compare( std::make_pair( type_a, a.name() ),
-                                  std::make_pair( type_b, b.name() ) );
+            return a.get_ordering() < b.get_ordering();
     } );
 
     std::vector<HeaderSkill> skillslist;

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1579,7 +1579,7 @@ void Character::disp_info( bool customize_character )
 
     const std::vector<const Skill *> player_skill = Skill::get_skills_sorted_by(
     [&]( const Skill & a, const Skill & b ) {
-        return a.get_ordering() < b.get_ordering();
+        return a.get_sort_rank() < b.get_sort_rank();
     } );
 
     std::vector<HeaderSkill> skillslist;

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1579,7 +1579,7 @@ void Character::disp_info( bool customize_character )
 
     const std::vector<const Skill *> player_skill = Skill::get_skills_sorted_by(
     [&]( const Skill & a, const Skill & b ) {
-            return a.get_ordering() < b.get_ordering();
+        return a.get_ordering() < b.get_ordering();
     } );
 
     std::vector<HeaderSkill> skillslist;

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -140,11 +140,11 @@ void Skill::load_skill( const JsonObject &jsobj )
     }
     skill_displayType_id display_type = skill_displayType_id( jsobj.get_string( "display_category" ) );
     Skill sk( ident, name, desc, jsobj.get_tags( "tags" ), display_type );
-    if( jsobj.has_int( "ordering" ) ) {
-        sk._ordering = jsobj.get_int( "ordering" );
+    if( jsobj.has_int( "sort_rank" ) ) {
+        sk._sort_rank = jsobj.get_int( "sort_rank" );
     } else {
-        sk._ordering = 1000000;
-        debugmsg( "skill '%s' missing 'ordering' field.", ident.str() );
+        sk._sort_rank = 1000000;
+        debugmsg( "skill '%s' missing 'sort_rank' field.", ident.str() );
     }
 
     sk._time_to_attack = time_to_attack;

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -78,14 +78,14 @@ bool string_id<Skill>::is_valid() const
 
 Skill::Skill() : Skill( skill_id::NULL_ID(), to_translation( "nothing" ),
                             to_translation( "The zen-most skill there is." ),
-                            std::set<std::string> {}, skill_displayType_id::NULL_ID() )
+                            std::set<std::string> {}, skill_displayType_id::NULL_ID(), 100000000 )
 {
 }
 
 Skill::Skill( const skill_id &ident, const translation &name, const translation &description,
-              const std::set<std::string> &tags, skill_displayType_id display_type )
+              const std::set<std::string> &tags, skill_displayType_id display_type, int ordering )
     : _ident( ident ), _name( name ), _description( description ), _tags( tags ),
-      _display_type( display_type )
+      _display_type( display_type ), _ordering( ordering )
 {
 }
 
@@ -139,7 +139,8 @@ void Skill::load_skill( const JsonObject &jsobj )
         jso_tta.read( "time_reduction_per_level", time_to_attack.time_reduction_per_level );
     }
     skill_displayType_id display_type = skill_displayType_id( jsobj.get_string( "display_category" ) );
-    Skill sk( ident, name, desc, jsobj.get_tags( "tags" ), display_type );
+    int ordering = jsobj.get_int( "ordering", 100000000 );
+    Skill sk( ident, name, desc, jsobj.get_tags( "tags" ), display_type, ordering );
 
     sk._time_to_attack = time_to_attack;
     sk._companion_combat_rank_factor = jsobj.get_int( "companion_combat_rank_factor", 0 );

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -78,14 +78,14 @@ bool string_id<Skill>::is_valid() const
 
 Skill::Skill() : Skill( skill_id::NULL_ID(), to_translation( "nothing" ),
                             to_translation( "The zen-most skill there is." ),
-                            std::set<std::string> {}, skill_displayType_id::NULL_ID(), 100000000 )
+                            std::set<std::string> {}, skill_displayType_id::NULL_ID() )
 {
 }
 
 Skill::Skill( const skill_id &ident, const translation &name, const translation &description,
-              const std::set<std::string> &tags, skill_displayType_id display_type, int ordering )
+              const std::set<std::string> &tags, skill_displayType_id display_type )
     : _ident( ident ), _name( name ), _description( description ), _tags( tags ),
-      _display_type( display_type ), _ordering( ordering )
+      _display_type( display_type )
 {
 }
 
@@ -139,8 +139,13 @@ void Skill::load_skill( const JsonObject &jsobj )
         jso_tta.read( "time_reduction_per_level", time_to_attack.time_reduction_per_level );
     }
     skill_displayType_id display_type = skill_displayType_id( jsobj.get_string( "display_category" ) );
-    int ordering = jsobj.get_int( "ordering", 100000000 );
-    Skill sk( ident, name, desc, jsobj.get_tags( "tags" ), display_type, ordering );
+    Skill sk( ident, name, desc, jsobj.get_tags( "tags" ), display_type );
+    if( jsobj.has_int( "ordering" ) ) {
+        sk._ordering = jsobj.get_int( "ordering" );
+    } else {
+        sk._ordering = 1000000;
+        debugmsg( "skill '%s' missing 'ordering' field.", ident.str() );
+    }
 
     sk._time_to_attack = time_to_attack;
     sk._companion_combat_rank_factor = jsobj.get_int( "companion_combat_rank_factor", 0 );

--- a/src/skill.h
+++ b/src/skill.h
@@ -39,7 +39,7 @@ class Skill
         std::set<std::string> _tags;
         time_info_t _time_to_attack;
         skill_displayType_id _display_type;
-        int _ordering;
+        int _sort_rank;
         std::unordered_map<std::string, int> _companion_skill_practice;
         // these are not real skills, they depend on context
         static std::map<skill_id, Skill> contextual_skills;
@@ -80,8 +80,8 @@ class Skill
         skill_displayType_id display_category() const {
             return _display_type;
         }
-        int get_ordering() const {
-            return _ordering;
+        int get_sort_rank() const {
+            return _sort_rank;
         }
         time_info_t time_to_attack() const {
             return _time_to_attack;

--- a/src/skill.h
+++ b/src/skill.h
@@ -62,7 +62,7 @@ class Skill
 
         Skill();
         Skill( const skill_id &ident, const translation &name, const translation &description,
-               const std::set<std::string> &tags, skill_displayType_id display_type, int ordering );
+               const std::set<std::string> &tags, skill_displayType_id display_type );
 
         const skill_id &ident() const {
             return _ident;

--- a/src/skill.h
+++ b/src/skill.h
@@ -39,6 +39,7 @@ class Skill
         std::set<std::string> _tags;
         time_info_t _time_to_attack;
         skill_displayType_id _display_type;
+        int _ordering;
         std::unordered_map<std::string, int> _companion_skill_practice;
         // these are not real skills, they depend on context
         static std::map<skill_id, Skill> contextual_skills;
@@ -61,7 +62,7 @@ class Skill
 
         Skill();
         Skill( const skill_id &ident, const translation &name, const translation &description,
-               const std::set<std::string> &tags, skill_displayType_id display_type );
+               const std::set<std::string> &tags, skill_displayType_id display_type, int ordering );
 
         const skill_id &ident() const {
             return _ident;
@@ -78,6 +79,9 @@ class Skill
         }
         skill_displayType_id display_category() const {
             return _display_type;
+        }
+        int get_ordering() const {
+            return _ordering;
         }
         time_info_t time_to_attack() const {
             return _time_to_attack;


### PR DESCRIPTION
Adds an ordering value to the skills in skills.json, and uses it to control the order in which the skills appear in the player info menu

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Adds an "ordering" value to each one of the skills inside the skills.json file. It then uses it to set a fixed order to how the skills should be desplayed in the Player Info panel"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #65218
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The ordering value added to each skill in the json file controls the order in which the skills will be displayed, substituting the previous "alphabetical ordering" which led to random results depending on language selected.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I've launched the game and all looked good.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
An image of Before and After:
![Cattura](https://user-images.githubusercontent.com/29839218/233714756-f24e6e08-8ad0-4ba2-b9b1-7ab7bcf803c9.PNG)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->