### PR TITLE
Rebalanced generic zombie drops and bugout bags

### DIFF
--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -123,9 +123,9 @@
     "subtype": "collection",
     "entries": [
       { "group": "bugout_first_aid", "prob": 50 },
-      { "group": "bugout_small_gun", "prob": 90 },
-      { "group": "bugout_food", "prob": 100 },
-      { "group": "bugout_water", "prob": 100 },
+      { "group": "bugout_small_gun", "prob": 45 },
+      { "group": "bugout_food", "prob": 50 },
+      { "group": "bugout_water", "prob": 50 },
       { "group": "bugout_bad_pack", "prob": 100 }
     ]
   },
@@ -138,11 +138,11 @@
     "on_overflow": "spill",
     "entries": [
       { "group": "bugout_first_aid", "prob": 90 },
-      { "group": "bugout_gun", "prob": 100 },
-      { "group": "bugout_food", "prob": 100, "count": [ 1, 2 ] },
-      { "group": "bugout_water", "prob": 100, "count": [ 1, 2 ] },
+      { "group": "bugout_gun", "prob": 50 },
+      { "group": "bugout_food", "prob": 50, "count": [ 1, 2 ] },
+      { "group": "bugout_water", "prob": 50, "count": [ 1, 2 ] },
       { "group": "bugout_extras", "prob": 100, "count": [ 1, 4 ] },
-      { "group": "civilian_armor", "prob": 70 }
+      { "group": "civilian_armor", "prob": 35 }
     ]
   },
   {
@@ -154,12 +154,12 @@
     "on_overflow": "spill",
     "entries": [
       { "group": "bugout_first_aid", "count": 1, "prob": 90 },
-      { "group": "bugout_small_gun", "prob": 100 },
-      { "group": "bugout_long_gun", "prob": 80 },
-      { "group": "bugout_food", "prob": 100, "count": [ 1, 3 ] },
-      { "group": "bugout_water", "prob": 100, "count": [ 1, 3 ] },
+      { "group": "bugout_small_gun", "prob": 50 },
+      { "group": "bugout_long_gun", "prob": 40 },
+      { "group": "bugout_food", "prob": 50, "count": [ 1, 3 ] },
+      { "group": "bugout_water", "prob": 50, "count": [ 1, 3 ] },
       { "group": "bugout_extras", "prob": 100, "count": [ 2, 6 ] },
-      { "group": "civilian_armor", "count": 2, "prob": 70 }
+      { "group": "civilian_armor", "count": 2, "prob": 35 }
     ]
   },
   {

--- a/data/json/monsterdrops/zombie_default.json
+++ b/data/json/monsterdrops/zombie_default.json
@@ -292,9 +292,11 @@
             "prob": 99
           },
           {
-            "collection": [ 
-              { "group": "postman_gear", "damage": [ 1, 4 ] }, { "group": "default_zombie_items_pockets", "prob": 10 }, 
-              { "group": "prof-plumbing_gear", "damage": [ 1, 4 ] }, { "group": "default_zombie_items_pockets", "prob": 10 }
+            "collection": [
+              { "group": "postman_gear", "damage": [ 1, 4 ] },
+              { "group": "default_zombie_items_pockets", "prob": 10 },
+              { "group": "prof-plumbing_gear", "damage": [ 1, 4 ] },
+              { "group": "default_zombie_items_pockets", "prob": 10 }
             ],
             "prob": 1
           }

--- a/data/json/monsterdrops/zombie_default.json
+++ b/data/json/monsterdrops/zombie_default.json
@@ -17,8 +17,8 @@
             "collection": [
               {
                 "distribution": [
-                  { "group": "male_underwear", "prob": 90, "damage": [ 1, 4 ] },
-                  { "item": "union_suit", "prob": 10, "damage": [ 1, 4 ] }
+                  { "group": "male_underwear", "prob": 99, "damage": [ 1, 4 ] },
+                  { "item": "union_suit", "prob": 1, "damage": [ 1, 4 ] }
                 ]
               },
               {
@@ -37,7 +37,7 @@
                     ]
                   },
                   { "item": "suit", "prob": 5, "damage": [ 1, 4 ] },
-                  { "item": "tux", "prob": 5, "damage": [ 1, 4 ] },
+                  { "item": "tux", "prob": 1, "damage": [ 1, 4 ] },
                   { "item": "thawb", "prob": 1, "damage": [ 1, 4 ] },
                   { "item": "cassock", "prob": 1, "damage": [ 1, 4 ] },
                   { "item": "haori", "prob": 1, "damage": [ 1, 4 ] }
@@ -65,9 +65,9 @@
                           {
                             "collection": [
                               {
-                                "distribution": [ { "item": "stockings", "prob": 50, "damage": [ 1, 4 ] }, { "item": "tights", "prob": 50, "damage": [ 1, 4 ] } ]
+                                "distribution": [ { "item": "stockings", "prob": 1, "damage": [ 1, 4 ] }, { "item": "tights", "prob": 5, "damage": [ 1, 4 ] } ]
                               },
-                              { "item": "garter_belt", "prob": 10, "damage": [ 1, 4 ] }
+                              { "item": "garter_belt", "prob": 1, "damage": [ 1, 4 ] }
                             ]
                           },
                           { "group": "socks_unisex", "prob": 50, "damage": [ 1, 4 ] }
@@ -86,7 +86,7 @@
                           { "group": "christmas_dresses", "prob": 50, "damage": [ 1, 4 ], "event": "christmas" },
                           {
                             "collection": [ { "item": "dress_wedding", "damage": [ 1, 4 ] }, { "item": "veil_wedding", "damage": [ 1, 4 ] } ],
-                            "prob": 5
+                            "prob": 1
                           }
                         ]
                       },
@@ -99,7 +99,7 @@
                           { "item": "garter_belt", "prob": 10, "damage": [ 1, 4 ] }
                         ]
                       },
-                      { "item": "long_glove_white", "prob": 20, "damage": [ 1, 4 ] }
+                      { "item": "long_glove_white", "prob": 2, "damage": [ 1, 4 ] }
                     ],
                     "prob": 30
                   }
@@ -114,7 +114,7 @@
           { "item": "helmet_bike", "damage": [ 1, 4 ], "prob": 50 },
           { "group": "clothing_biker", "damage": [ 1, 4 ], "prob": 50 }
         ],
-        "prob": 10
+        "prob": 3
       }
     ]
   },
@@ -159,7 +159,7 @@
     "id": "default_zombie_items_bags_small",
     "entries": [
       { "group": "default_zombie_items_pockets", "prob": 50 },
-      { "item": "vibrator", "prob": 5, "charges-min": 0, "charges-max": 50 },
+      { "item": "vibrator", "prob": 1, "charges-min": 0, "charges-max": 50 },
       { "item": "file", "prob": 10 },
       {
         "distribution": [
@@ -198,15 +198,25 @@
       },
       {
         "distribution": [
+          { "item": "meth", "prob": 5 },
+          { "item": "coke", "prob": 5 },
+          { "item": "lsd", "prob": 2 },
+          { "item": "heroin", "prob": 5 },
+          { "collection": [ { "item": "crackpipe" }, { "item": "crack" } ], "prob": 5 },
+          { "collection": [ { "item": "weed" }, { "item": "pipe_glass", "prob": 50 } ], "prob": 10 },
+          { "distribution": [ { "item": "joint", "prob": 80 }, { "item": "joint_roach", "prob": 20 } ], "prob": 10 }
+        ],
+        "prob": 5
+      },
+      {
+        "distribution": [
           { "item": "cig", "prob": 65, "charges-min": 0, "charges-max": 20 },
           { "item": "chaw", "prob": 5 },
           { "item": "cigar", "prob": 5 },
-          { "group": "pocket_cigar", "prob": 10 },
+          { "group": "pocket_cigar", "prob": 1 },
           { "item": "handrolled_cig", "prob": 10 },
-          { "item": "nic_gum", "prob": 20 },
+          { "item": "nic_gum", "prob": 10 },
           { "item": "ecig", "prob": 15 },
-          { "collection": [ { "item": "weed" }, { "item": "pipe_glass", "prob": 50 } ], "prob": 10 },
-          { "distribution": [ { "item": "joint", "prob": 80 }, { "item": "joint_roach", "prob": 20 } ], "prob": 10 },
           {
             "collection": [
               { "item": "tobacco" },
@@ -214,33 +224,28 @@
             ],
             "prob": 10
           },
-          { "collection": [ { "item": "advanced_ecig" }, { "item": "nicotine_liquid" } ], "prob": 10 },
-          { "collection": [ { "item": "crackpipe" }, { "item": "crack" } ], "prob": 5 }
+          { "collection": [ { "item": "advanced_ecig" }, { "item": "nicotine_liquid" } ], "prob": 10 }
         ],
-        "prob": 50
+        "prob": 15
       },
       {
         "distribution": [
           { "item": "lighter", "prob": 100, "charges": [ 0, 100 ] },
-          { "item": "ref_lighter", "prob": 40, "charges": [ 0, 50 ] },
+          { "item": "ref_lighter", "prob": 20, "charges": [ 0, 50 ] },
           { "item": "matches", "prob": 20, "charges": [ 0, 20 ] },
-          { "item": "small_lighter", "prob": 20, "charges": [ 0, 50 ] },
+          { "item": "small_lighter", "prob": 40, "charges": [ 0, 50 ] },
           {
             "collection": [ { "item": "ref_lighter_butane" }, { "item": "butane_can", "charges": [ 200, 400 ] } ],
-            "prob": 5
+            "prob": 1
           }
         ],
-        "prob": 30
+        "prob": 15
       },
       { "distribution": [ { "item": "gum" }, { "item": "caff_gum" } ], "prob": 30 },
       { "item": "mp3", "prob": 18, "charges-min": 0, "charges-max": 15 },
       { "item": "portable_game", "prob": 10, "charges-min": 0, "charges-max": 50 },
-      { "item": "game_watch", "prob": 10, "damage": [ 1, 4 ], "charges-min": 0, "charges-max": 50 },
+      { "item": "game_watch", "prob": 1, "damage": [ 1, 4 ], "charges-min": 0, "charges-max": 50 },
       { "item": "usb_drive", "prob": 10 },
-      { "item": "meth", "prob": 2 },
-      { "item": "coke", "prob": 2 },
-      { "item": "lsd", "prob": 2 },
-      { "item": "heroin", "prob": 2 },
       { "item": "mobile_memory_card", "prob": 10 },
       { "item": "flyer", "prob": 30 },
       { "item": "multitool", "prob": 5 },
@@ -248,7 +253,7 @@
       { "group": "softdrugs", "prob": 10 },
       { "group": "harddrugs", "prob": 5 },
       { "group": "phones", "prob": 85 },
-      { "group": "vending_food_items", "prob": 50 }
+      { "group": "vending_food_items", "prob": 5 }
     ]
   },
   {
@@ -284,15 +289,14 @@
                 "distribution": [ { "group": "default_zombie_items", "prob": 80 }, { "group": "default_zombie_items_pockets", "prob": 20 } ]
               }
             ],
-            "prob": 96
+            "prob": 99
           },
           {
-            "collection": [ { "group": "postman_gear", "damage": [ 1, 4 ] }, { "group": "default_zombie_items_pockets", "prob": 10 } ],
-            "prob": 2
-          },
-          {
-            "collection": [ { "group": "prof-plumbing_gear", "damage": [ 1, 4 ] }, { "group": "default_zombie_items_pockets", "prob": 10 } ],
-            "prob": 2
+            "collection": [ 
+              { "group": "postman_gear", "damage": [ 1, 4 ] }, { "group": "default_zombie_items_pockets", "prob": 10 }, 
+              { "group": "prof-plumbing_gear", "damage": [ 1, 4 ] }, { "group": "default_zombie_items_pockets", "prob": 10 }
+            ],
+            "prob": 1
           }
         ]
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Category "Balance"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Zombie loot has some real oddities going on, and presently, even vanilla zombies are so loaded that you can easily live off the unspoiled food and drinks they carry, to say nothing of the obscene trading profits you can make pilfering cigarettes and hard drugs off of them.

This is a multi-tiered problem that isn't unique to just zombies, but the zombie_default monsterdrops is as good of a place as any to start making changes.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

* Reduced the probability of union suits on male zombies from 10 to 1. The union suit is considered outmoded to the point of being comical, and should probably be much rarer, however probability requires an integer and it is not currently possible to reduce this to a fraction of a percent.

* Reduced the probability of the tuxedo to 1. This is also too high, as these are rare pieces of formalwear only used at specific events, but again it is not currently possible to make them less common.

* The thawb, cassock, and haori are likewise far too common, but there's not an easy way to make them more rare.

* Reduced the probability of the wedding dress to 1. Ditto about the rarity.

* Reduced the probability of finding stockings, tights, or garter belts on a zombie which was wearing pants to 1, 5, and 1 respectively. Wearing these items under pants is a conceivable possibility (and in some cases tights under pants is a decent way to keep warm), but they were much too common.

* Reduced the probability of the wedding dress and veil to 1. These items are generally something you wear once in your entire life, and even accounting for feral wives making bizarre sartorial decisions, there were way too many of them.

* Reduced long_glove_white's probability from 20 to 2. These are also an exceedingly rare piece of clothing, and are mostly seen as costume pieces.

* Reduced the probability of the biking distribution (helmet_bike and clothing_biker) to 3 from 10. Plenty of people ride two-wheeled vehicles, but most of them are not decked out for riding 24/7. This will make their protective gear a bit harder to find, but it should still be quite readily available in the early game.

* Reduced the probability of finding a vibrator in a small bag from 5 to 1. Most people do not carry sex toys around with them.

* Reduced the probability of the tobacco item distribution from 50 to 16. According to the American Lung Association (https://www.lung.org/research/trends-in-lung-disease/tobacco-trends-brief/overall-tobacco-trends) only 12.6% of Americans are cigarette smokers, with electronic cigarettes coming in at 3.2%. Most smokers tend to carry nicotine products on them, but it's very common to be caught without a pack, thus the common refrain of "Hey can I bum a smoke?" every time you light up in a public area.

* Reduced the probability of cigars in the above item distribution from 5 to 1, as cigar smoking is much less common, and even people who smoke them tend not to carry them around like you would with cigarettes. They're more commonly kept in humidor boxes, or purchased just prior to smoking. I also reduced the prevalence of nicotine gum from 20 to 10 - this is a product which is only used by a percentage of people who are actively trying to quit.

* Moved crack, marijuana, and joints out of the tobacco distribution. Created a new distribution for illicit substances and placed all of these within it, as well as meth, coke, LSD, and heroin.

* The new illicit substance distribution is set to 10 probability, with meth, coke, and crack at 5, lsd and heroin at 2, and marijuana and joints at 20. Drug use is quite common in the united states, however the number of people with a drug abuse disorder is proportionally quite small, and of those, the number which are at any time carrying their drug of choice on their person (especially given the likely supply issues during the cataclysm) would be quite small. Heroin use has been steadily falling since prescription painkillers and fentanyl took over the opioid market. I am ballparking these numbers off of statistics seen here: https://nida.nih.gov/sites/default/files/drugfactsnationwidetrends1.pdf but if anyone wants to make corrections to my math, feel free. Note that prescription drugs are part of a distinct itemgroup.

* Reduced the probability of the lighter/match group from 30 to 15. Plenty of people who are not smokers carry lighters, but as we have reduced the amount of smokers, so too go the lighters.

* Made refillable lighters much less common, from 40 to 20. These items are not rare, but they are far less common than the standard bic lighter.

* Made small lighters more common, at 40. These things are often all you can get at a gas station.

* Reduced the butane lighter refill can's probability to 1. This is generally something you leave at home, not carry around with you.

* Reduced game watches from 10 to 1. These items were a novelty in the 90s, they're practically unheard of today.

* Reduced the probability of vending_food_items to 5 from 50. Most people who are walking around in real life do not have cashews in their pocket, and as it was before this PR, you could live entirely off of unspoiled chips, nuts, and candy that you were taking off of zombies who supposedly died in the middle of a food supply crisis. I think more could be done here - these packages should get ruptured and their contents destroyed by zombie misadventure, but that may be a conversation for another day.

* Reduced the probability of portable games and USB drives to 5. USB drives are becoming less common as online data storage and wireless technology become more accessible, and handheld video games have largely either moved to phones, or are now run on items like the Steamdeck or the Nintendo Switch which people don't take outdoors as often as they did their DS and Game Boys.

* Reduced the number of mail carriers and plumbers. Previously, 2% of all standard zombies were mail carriers, and 2% were plumbers. This has been reduced to .5% for either. The real life United States Postal Service does not employ 2% of the unmutated adult population.

There are snippets suggesting that blob psychosis increased drug and tobacco use, but this loot is also being found on people who died during a months-long calamity that totally disrupted daily life, with collapsing supply chains, martial law, and eventually a total breakdown of society, so at least from March onward, we can probably assume that people in New England would have had a hard time getting drugs. Most of the zombies we encounter have also been dead for a while and probably feral before that, and have likely lost many of the possessions they carried in life. As a result, I have erred on the side of being conservative with drop rates. Players should still find enough crack and heroin lying around to suspect that something might have been wrong even before people started turning into zombies.

On bugout bags:

You have a 1/100 chance of finding a bugout bag on a zombie, and aside from the first aid supplies, these mostly had a 100% chance of giving you a pristine gun (or two!), ammunition for that gun, food, and water, with a very good chance of also including armor.

This PR halves the incidence of food, water, and armor in all types of bugout bags. If someone with a gun died fighting zombies or ferals, then they might have been using that gun and dropped it when they were overwhelmed. If they had food and water, they may have had to use some of it. Armor being present 100% of the time was also an oddity, as normal zombies are never seen wearing it.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Zombies could stand to be a lot stingier with loot in general. As previously stated, in many cases they have been undead for quite some time and no longer pay any attention to their belongings. They walk through bodies of water, fall off rooftops, trample each other, etc. Much more of their stuff could be lost or broken.

I also suspect there's a way to overhaul how drops work to fix the strange prevalence of wedding dresses and other strange items, but it may be out of scope.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Spawned 100 zombies and killed them, resulting in:

1 marijuana (5)
1 bag of chocolate-covered pretzels
3 handheld game systems
3 packs of cigarettes (1-30)
4 USB drives
1 nicotine gum (10)
1 rolling tobacco (20)
1 mailman outfit+mailbag
1 cocaine (8)
1 heroin (4)
1 bag of almonds
4 wedding dress
4 wedding veil
1 bag tortilla chips
1 joint roach
2 hand-rolled cigarette
1 chewing tobacco (20)
0 union suit
0 tuxedo
6 lighter
5 mini lighter
0 refillable lighter
0 butane can
1 bugout bag with a Glock 22 and ammo.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->