### PR TITLE
Add option to hide bionics

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2047,6 +2047,13 @@
   },
   {
     "type": "keybinding",
+    "id": "TOGGLE_SPRITE",
+    "category": "BIONICS",
+    "name": "Toggle sprite",
+    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
     "id": "REFUEL",
     "category": "BIONICS",
     "name": "Open refuel menu",

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -3111,6 +3111,7 @@ void bionic::serialize( JsonOut &json ) const
     if( is_safe_fuel_on() ) {
         json.member( "safe_fuel_threshold", safe_fuel_threshold );
     }
+    json.member( "show_sprite", show_sprite );
 
     if( has_weapon() ) {
         json.member( "weapon", weapon );
@@ -3161,6 +3162,9 @@ void bionic::deserialize( const JsonObject &jo )
     }
     if( jo.has_float( "safe_fuel_threshold" ) ) {
         safe_fuel_threshold = jo.get_float( "safe_fuel_threshold" );
+    }
+    if( jo.has_bool( "show_sprite" ) ) {
+        show_sprite = jo.get_bool( "show_sprite" );
     }
     if( jo.has_array( "bionic_tags" ) ) {
         for( const std::string line : jo.get_array( "bionic_tags" ) ) {

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -245,6 +245,8 @@ struct bionic {
 
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &jo );
+        
+        bool show_sprite = true;
     private:
         // generic bionic specific flags
         cata::flat_set<std::string> bionic_tags;

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -245,7 +245,7 @@ struct bionic {
 
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &jo );
-        
+
         bool show_sprite = true;
     private:
         // generic bionic specific flags

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -246,7 +246,6 @@ struct bionic {
 
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &jo );
-
     private:
         // generic bionic specific flags
         cata::flat_set<std::string> bionic_tags;

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -201,6 +201,7 @@ struct bionic {
         time_duration         charge_timer  = 0_turns;
         char        invlet  = 'a';
         bool        powered = false;
+        bool        show_sprite = true;
         /* An amount of time during which this bionic has been rendered inoperative. */
         time_duration        incapacitated_time;
 
@@ -246,7 +247,6 @@ struct bionic {
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &jo );
 
-        bool show_sprite = true;
     private:
         // generic bionic specific flags
         cata::flat_set<std::string> bionic_tags;

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -274,7 +274,8 @@ static void draw_bionics_titlebar( const catacurses::window &window, avatar *p,
     std::string desc_append = string_format(
                                   _( "[<color_yellow>%s</color>] Reassign, [<color_yellow>%s</color>] Switch tabs, "
                                      "[<color_yellow>%s</color>] Toggle fuel saving mode, [<color_yellow>%s</color>] Toggle sprite visibility, " ),
-                                  ctxt.get_desc( "REASSIGN" ), ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "TOGGLE_SAFE_FUEL" ), ctxt.get_desc( "TOGGLE_SPRITE" ) );
+                                  ctxt.get_desc( "REASSIGN" ), ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "TOGGLE_SAFE_FUEL" ),
+                                  ctxt.get_desc( "TOGGLE_SPRITE" ) );
     desc_append += string_format( _( " [<color_yellow>%s</color>] Sort: %s" ), ctxt.get_desc( "SORT" ),
                                   sort_mode_str( uistate.bionic_sort_mode ) );
     std::string desc;

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -273,8 +273,8 @@ static void draw_bionics_titlebar( const catacurses::window &window, avatar *p,
 
     std::string desc_append = string_format(
                                   _( "[<color_yellow>%s</color>] Reassign, [<color_yellow>%s</color>] Switch tabs, "
-                                     "[<color_yellow>%s</color>] Toggle fuel saving mode, " ),
-                                  ctxt.get_desc( "REASSIGN" ), ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "TOGGLE_SAFE_FUEL" ) );
+                                     "[<color_yellow>%s</color>] Toggle fuel saving mode, [<color_yellow>%s</color>] Toggle sprite visibility, " ),
+                                  ctxt.get_desc( "REASSIGN" ), ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "TOGGLE_SAFE_FUEL" ), ctxt.get_desc( "TOGGLE_SPRITE" ) );
     desc_append += string_format( _( " [<color_yellow>%s</color>] Sort: %s" ), ctxt.get_desc( "SORT" ),
                                   sort_mode_str( uistate.bionic_sort_mode ) );
     std::string desc;
@@ -329,6 +329,9 @@ static std::string build_bionic_poweronly_string( const bionic &bio, avatar *p )
     }
     if( bio.incapacitated_time > 0_turns ) {
         properties.emplace_back( _( "(incapacitated)" ) );
+    }
+    if( !bio.show_sprite ) {
+        properties.emplace_back( _( "(hidden)" ) );
     }
 
     if( bio.is_safe_fuel_on() ) {
@@ -647,6 +650,7 @@ void avatar::power_bionics()
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "TOGGLE_SAFE_FUEL" );
+    ctxt.register_action( "TOGGLE_SPRITE" );
     ctxt.register_action( "SORT" );
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
@@ -845,6 +849,12 @@ void avatar::power_bionics()
                 } else {
                     popup( _( "You can't toggle fuel saving mode on a non-fueled CBM." ) );
                 }
+            }
+        } else if( action == "TOGGLE_SPRITE" ) {
+            auto &bio_list = tab_mode == TAB_ACTIVE ? active : passive;
+            if( !current_bionic_list->empty() ) {
+                tmp = bio_list[cursor];
+                tmp->show_sprite = !tmp->show_sprite;
             }
         } else if( action == "SORT" ) {
             uistate.bionic_sort_mode = pick_sort_mode();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3014,6 +3014,9 @@ std::vector<std::pair<std::string, std::string>> Character::get_overlay_ids() co
 
     // then get bionics
     for( const bionic &bio : *my_bionics ) {
+        if( !bio.show_sprite ) {
+            continue;
+        }
         overlay_id = ( bio.powered ? "active_" : "" ) + bio.id.str();
         order = get_overlay_order_of_mutation( overlay_id );
         mutation_sorting.emplace( order, std::pair<std::string, std::string> { overlay_id, "" } );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add option to hide bionics"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
We currently have the option to hide the visual effects of mutations and equipment, yet the ability to do so for bionics is notably missing.  Adding it would allow for further character customization.
This will fix #62065
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a "hide sprite" toggle to the bionics menu similar to that of mutations and equipment.  Bionic visibility settings are stored with the save file.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Bionics sprites show and hide properly when toggled.  Hidden bionic preferences are saved and loaded properly for each character.  Was able to modify hotkey and hotkey settings persist as they should.  Save files created before this change loaded normally.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->