### PR TITLE
item::in_container can fill up a container with non-charge items

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1146,18 +1146,18 @@ item item::in_its_container( int qty ) const
                          type->default_container_sealed );
 }
 
-item item::in_container( const itype_id &cont, const int qty, const bool sealed ) const
+item item::in_container( const itype_id &cont, int qty, const bool sealed ) const
 {
     if( cont.is_null() ) {
         return *this;
     }
+
+    if( qty <= 0 ) {
+        qty = count();
+    }
     item container( cont, birthday() );
     if( container.is_container() ) {
-        if( count_by_charges() ) {
-            container.fill_with( *this, qty );
-        } else {
-            container.put_in( *this, item_pocket::pocket_type::CONTAINER );
-        }
+        container.fill_with( *this, qty );
         container.invlet = invlet;
         if( sealed ) {
             container.seal();

--- a/src/item.h
+++ b/src/item.h
@@ -917,10 +917,11 @@ class item : public visitable
         /**
          * Returns this item into its default container. If it does not have a default container,
          * returns this. It's intended to be used like \code newitem = newitem.in_its_container();\endcode
+         * qty <= 0 means the current quantity of the item will be used. Any quantity exceeding the capacity
+         * of the container will be ignored.
          */
-        item in_its_container( int qty = INFINITE_CHARGES ) const;
-        item in_container( const itype_id &container_type, int qty = INFINITE_CHARGES,
-                           bool sealed = true ) const;
+        item in_its_container( int qty = 0 ) const;
+        item in_container( const itype_id &container_type, int qty = 0, bool sealed = true ) const;
 
         /**
         * True if item and its contents have any uses.

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -194,7 +194,7 @@ item Single_item_creator::create_single( const time_point &birthday, RecursionLi
     if( modifier ) {
         modifier->modify( tmp, "modifier for " + context() );
     } else {
-        int qty = tmp.charges;
+        int qty = tmp.count();
         if( modifier ) {
             qty = rng( modifier->charges.first, modifier->charges.second );
         } else if( tmp.made_of_from_type( phase_id::LIQUID ) ) {
@@ -207,7 +207,7 @@ item Single_item_creator::create_single( const time_point &birthday, RecursionLi
         tmp.overwrite_relic( artifact->generate_relic( tmp.typeId() ) );
     }
     if( container_item ) {
-        tmp = tmp.in_container( *container_item, tmp.charges, sealed );
+        tmp = tmp.in_container( *container_item, tmp.count(), sealed );
     }
     return tmp;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4803,7 +4803,7 @@ void map::spawn_item( const tripoint &p, const itype_id &type_id, const unsigned
         //let's fail silently if we specify charges for an item that doesn't support it
         new_item.charges = charges;
     }
-    new_item = new_item.in_its_container( new_item.count() );
+    new_item = new_item.in_its_container();
     new_item.set_owner( faction_id( faction ) ); // Set faction to the container as well
     if( ( new_item.made_of( phase_id::LIQUID ) && has_flag( ter_furn_flag::TFLAG_SWIMMABLE, p ) ) ||
         has_flag( ter_furn_flag::TFLAG_DESTROY_ITEM, p ) ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5647,13 +5647,13 @@ void vehicle::place_spawn_items()
                 for( const itype_id &e : spawn.item_ids ) {
                     if( rng_float( 0, 1 ) < spawn_rate ) {
                         item spawn( e );
-                        created.emplace_back( spawn.in_its_container( spawn.count() ) );
+                        created.emplace_back( spawn.in_its_container() );
                     }
                 }
                 for( const std::pair<itype_id, std::string> &e : spawn.variant_ids ) {
                     if( rng_float( 0, 1 ) < spawn_rate ) {
                         item spawn( e.first );
-                        item added = spawn.in_its_container( spawn.count() );
+                        item added = spawn.in_its_container();
                         added.set_itype_variant( e.second );
                         created.push_back( added );
                     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Part of #60885.

#### Describe the solution

Allow filling a container with multiples of a non-charge item, mostly relevant to crafting canned food. Also change the default behavior of `item::in_container` to insert the item as it is instead of completely filling up the container. This is done to a) keep the original behavior of adding only single non-charge items into the container and b) because I think it's more intuitive to use this way. The fixes from #64457 were also made because it was already intended to be used like that even though it worked differently. Consequently those fixes were reverted again.

There might still be cases where this changes behavior, since the test from #64457 doesn't check absolutely all uses of this. Legacy profession definitions for example, because they're legacy and if they cause issues they should be migrated to current standards.

#### Describe alternatives you've considered

Use `std::optional` for qty instead of checking <= 0.

#### Testing

Test added in #64457 still passes.

#### Additional context