### PR TITLE
Tidy assign activity

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -361,7 +361,7 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
     if( !last_target || last_target->is_dead_state() ) {
         who.last_target.reset();
     }
-    who.assign_activity( player_activity( aim_actor ) );
+    who.assign_activity( aim_actor );
 }
 
 void aim_activity_actor::canceled( player_activity &/*act*/, Character &/*who*/ )

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -361,7 +361,7 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
     if( !last_target || last_target->is_dead_state() ) {
         who.last_target.reset();
     }
-    who.assign_activity( player_activity( aim_actor ), false );
+    who.assign_activity( player_activity( aim_actor ) );
 }
 
 void aim_activity_actor::canceled( player_activity &/*act*/, Character &/*who*/ )

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -368,9 +368,9 @@ class read_activity_actor : public activity_actor
         read_activity_actor() = default;
 
         explicit read_activity_actor(
-            int moves, item_location &book, item_location &ereader,
+            time_duration read_time, item_location &book, item_location &ereader,
             bool continuous = false, int learner_id = -1 )
-            : moves_total( moves ), book( book ), ereader( ereader ),
+            : moves_total( to_moves<int>( read_time ) ), book( book ), ereader( ereader ),
               continuous( continuous ), learner_id( learner_id ) {};
 
         activity_id get_type() const override {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1930,7 +1930,7 @@ static bool chop_plank_activity( Character &you, const tripoint_bub_ms &src_loc 
             here.i_rem( src_loc, &i );
             int moves = to_moves<int>( 20_minutes );
             you.add_msg_if_player( _( "You cut the log into planks." ) );
-            you.assign_activity( player_activity( chop_planks_activity_actor( moves ) ) );
+            you.assign_activity( chop_planks_activity_actor( moves ) );
             you.activity.placement = here.getglobal( src_loc );
             return true;
         }
@@ -2379,7 +2379,7 @@ static bool mine_activity( Character &you, const tripoint_bub_ms &src_loc )
 static bool mop_activity( Character &you, const tripoint_bub_ms &src_loc )
 {
     // iuse::mop costs 15 moves per use
-    you.assign_activity( player_activity( mop_activity_actor( 15 ) ) );
+    you.assign_activity( mop_activity_actor( 15 ) );
     you.activity.placement = get_map().getglobal( src_loc );
     return true;
 }
@@ -2397,13 +2397,11 @@ static bool chop_tree_activity( Character &you, const tripoint_bub_ms &src_loc )
     map &here = get_map();
     const ter_id ter = here.ter( src_loc );
     if( here.has_flag( ter_furn_flag::TFLAG_TREE, src_loc ) ) {
-        you.assign_activity( player_activity( chop_tree_activity_actor( moves, item_location( you,
-                                              &best_qual ) ) ) );
+        you.assign_activity( chop_tree_activity_actor( moves, item_location( you, &best_qual ) ) );
         you.activity.placement = here.getglobal( src_loc );
         return true;
     } else if( ter == t_trunk || ter == t_stump ) {
-        you.assign_activity( player_activity( chop_logs_activity_actor( moves, item_location( you,
-                                              &best_qual ) ) ) );
+        you.assign_activity( chop_logs_activity_actor( moves, item_location( you, &best_qual ) ) );
         you.activity.placement = here.getglobal( src_loc );
         return true;
     }
@@ -2858,7 +2856,7 @@ static bool generic_multi_activity_do(
     } else if( reason == do_activity_reason::NEEDS_TILLING &&
                here.has_flag( ter_furn_flag::TFLAG_PLOWABLE, src_loc ) &&
                you.has_quality( qual_DIG, 1 ) && !here.has_furn( src_loc ) ) {
-        you.assign_activity( player_activity( churn_activity_actor( 18000, item_location() ) ) );
+        you.assign_activity( churn_activity_actor( 18000, item_location() ) );
         you.backlog.push_front( player_activity( act_id ) );
         you.activity.placement = src;
         return false;

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1019,10 +1019,8 @@ bool advanced_inventory::move_all_items()
             }
             do_return_entry();
 
-            player_character.assign_activity( player_activity( insert_item_activity_actor(
-                                                  dpane.container,
-                                                  items_to_insert
-                                              ) ) );
+            const insert_item_activity_actor act( dpane.container, items_to_insert );
+            player_character.assign_activity( act );
         }
     } else if( spane.get_area() == AIM_INVENTORY || spane.get_area() == AIM_WORN ) {
         const tripoint placement = darea.off;
@@ -1031,9 +1029,8 @@ bool advanced_inventory::move_all_items()
 
         do_return_entry();
 
-        player_character.assign_activity( player_activity( drop_activity_actor(
-                                              pane_items, placement, force_ground
-                                          ) ) );
+        const drop_activity_actor act( pane_items, placement, force_ground );
+        player_character.assign_activity( act );
     } else if( dpane.get_area() == AIM_INVENTORY ) {
         std::vector<item_location> target_items;
         std::vector<int> quantities;
@@ -1045,12 +1042,8 @@ bool advanced_inventory::move_all_items()
 
         do_return_entry();
 
-        player_character.assign_activity( player_activity( pickup_activity_actor(
-                                              target_items,
-                                              quantities,
-                                              std::optional<tripoint>( player_character.pos() ),
-                                              false
-                                          ) ) );
+        const pickup_activity_actor act( target_items, quantities, player_character.pos(), false );
+        player_character.assign_activity( act );
     } else {
         // Vehicle and map destinations are handled the same.
 
@@ -1067,12 +1060,9 @@ bool advanced_inventory::move_all_items()
 
         do_return_entry();
 
-        player_character.assign_activity( player_activity( move_items_activity_actor(
-                                              target_items,
-                                              quantities,
-                                              dpane.in_vehicle(),
-                                              relative_destination
-                                          ) ) );
+        const move_items_activity_actor act( target_items, quantities, dpane.in_vehicle(),
+                                             relative_destination );
+        player_character.assign_activity( act );
     }
 
     return true;
@@ -1261,27 +1251,20 @@ void advanced_inventory::start_activity(
         }
 
         if( destarea == AIM_WORN ) {
-            player_character.assign_activity( player_activity( wear_activity_actor(
-                                                  target_items,
-                                                  quantities
-                                              ) ) );
+            const wear_activity_actor act( target_items, quantities );
+            player_character.assign_activity( act );
         } else if( destarea == AIM_INVENTORY ) {
-            player_character.assign_activity( player_activity( pickup_activity_actor(
-                                                  target_items,
-                                                  quantities,
-                                                  from_vehicle ? std::nullopt : std::optional<tripoint>( player_character.pos() ),
-                                                  false
-                                              ) ) );
+            const std::optional<tripoint> starting_pos = from_vehicle
+                    ? std::nullopt
+                    : std::optional<tripoint>( player_character.pos() );
+            const pickup_activity_actor act( target_items, quantities, starting_pos, false );
+            player_character.assign_activity( act );
         } else {
             // Stash the destination
             const tripoint relative_destination = squares[destarea].off;
 
-            player_character.assign_activity( player_activity( move_items_activity_actor(
-                                                  target_items,
-                                                  quantities,
-                                                  to_vehicle,
-                                                  relative_destination
-                                              ) ) );
+            const move_items_activity_actor act( target_items, quantities, to_vehicle, relative_destination );
+            player_character.assign_activity( act );
         }
     } else {
         if( !panes[dest].container.get_item() ) {
@@ -1316,10 +1299,8 @@ void advanced_inventory::start_activity(
             }
         }
 
-        player_character.assign_activity( player_activity( insert_item_activity_actor(
-                                              panes[dest].container,
-                                              target_inserts
-                                          ) ) );
+        const insert_item_activity_actor act( panes[dest].container, target_inserts );
+        player_character.assign_activity( act );
     }
 }
 
@@ -1378,7 +1359,8 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
         // make sure advanced inventory is reopened after activity completion.
         do_return_entry();
 
-        player_character.assign_activity( player_activity( wear_activity_actor( { sitem->items.front() }, { amount_to_move } ) ) );
+        const wear_activity_actor act( { sitem->items.front() }, { amount_to_move } );
+        player_character.assign_activity( act );
         // exit so that the activity can be carried out
         exit = true;
 
@@ -1416,9 +1398,8 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
                         remaining_amount -= move_amount;
                     }
 
-                    player_character.assign_activity( player_activity( drop_activity_actor(
-                                                          to_drop, placement, force_ground
-                                                      ) ) );
+                    const drop_activity_actor act( to_drop, placement, force_ground );
+                    player_character.assign_activity( act );
                 }
             }
         }

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -443,7 +443,7 @@ bool avatar::read( item_location &book, item_location ereader )
             add_msg( m_info, _( "%s reads aloud…" ), reader->disp_name() );
         }
 
-        assign_activity( read_activity_actor( to_moves<int>( time_taken ), book, ereader, false ) );
+        assign_activity( read_activity_actor( time_taken, book, ereader, false ) );
         return true;
     }
 
@@ -668,8 +668,7 @@ bool avatar::read( item_location &book, item_location ereader )
         return false;
     }
 
-    assign_activity( read_activity_actor( to_moves<int>( time_taken ), book, ereader, continuous,
-                                          learner_id ) );
+    assign_activity( read_activity_actor( time_taken, book, ereader, continuous, learner_id ) );
 
     return true;
 }

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -443,15 +443,7 @@ bool avatar::read( item_location &book, item_location ereader )
             add_msg( m_info, _( "%s reads aloud…" ), reader->disp_name() );
         }
 
-        assign_activity(
-            player_activity(
-                read_activity_actor(
-                    to_moves<int>( time_taken ),
-                    book,
-                    ereader,
-                    false
-                ) ) );
-
+        assign_activity( read_activity_actor( to_moves<int>( time_taken ), book, ereader, false ) );
         return true;
     }
 
@@ -676,15 +668,8 @@ bool avatar::read( item_location &book, item_location ereader )
         return false;
     }
 
-    assign_activity(
-        player_activity(
-            read_activity_actor(
-                to_moves<int>( time_taken ),
-                book,
-                ereader,
-                continuous,
-                learner_id
-            ) ) );
+    assign_activity( read_activity_actor( to_moves<int>( time_taken ), book, ereader, continuous,
+                                          learner_id ) );
 
     return true;
 }
@@ -2059,7 +2044,7 @@ void avatar::try_to_sleep( const time_duration &dur )
             add_msg_if_player( m_bad, _( "Your soporific inducer doesn't have enough power to operate." ) );
         }
     }
-    assign_activity( player_activity( try_sleep_activity_actor( dur ) ) );
+    assign_activity( try_sleep_activity_actor( dur ) );
 }
 
 bool avatar::query_yn( const std::string &mes ) const

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -843,17 +843,17 @@ void avatar_action::fire_wielded_weapon( avatar &you )
         return;
     }
 
-    you.assign_activity( player_activity( aim_activity_actor::use_wielded() ) );
+    you.assign_activity( aim_activity_actor::use_wielded() );
 }
 
 void avatar_action::fire_ranged_mutation( Character &you, const item &fake_gun )
 {
-    you.assign_activity( player_activity( aim_activity_actor::use_mutation( fake_gun ) ) );
+    you.assign_activity( aim_activity_actor::use_mutation( fake_gun ) );
 }
 
 void avatar_action::fire_ranged_bionic( avatar &you, const item &fake_gun )
 {
-    you.assign_activity( player_activity( aim_activity_actor::use_bionic( fake_gun ) ) );
+    you.assign_activity( aim_activity_actor::use_bionic( fake_gun ) );
 }
 
 void avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret )
@@ -904,7 +904,7 @@ bool avatar_action::eat_here( avatar &you )
         } else {
             here.ter_set( you.pos(), t_grass );
             item food( "underbrush", calendar::turn, 1 );
-            you.assign_activity( player_activity( consume_activity_actor( food ) ) );
+            you.assign_activity( consume_activity_actor( food ) );
             return true;
         }
     }
@@ -915,7 +915,7 @@ bool avatar_action::eat_here( avatar &you )
             return true;
         } else {
             item food( item( "grass", calendar::turn, 1 ) );
-            you.assign_activity( player_activity( consume_activity_actor( food ) ) );
+            you.assign_activity( consume_activity_actor( food ) );
             if( here.ter( you.pos() ) == t_grass_tall ) {
                 here.ter_set( you.pos(), t_grass_long );
             } else if( here.ter( you.pos() ) == t_grass_long ) {
@@ -962,8 +962,8 @@ void avatar_action::eat( avatar &you, const item_location &loc,
         add_msg( _( "Never mind." ) );
         return;
     }
-    you.assign_activity( player_activity( consume_activity_actor( loc, consume_menu_selections,
-                                          consume_menu_selected_items, consume_menu_filter, type ) ) );
+    you.assign_activity( consume_activity_actor( loc, consume_menu_selections,
+                         consume_menu_selected_items, consume_menu_filter, type ) );
     you.last_item = item( *loc ).typeId();
 }
 

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -843,18 +843,17 @@ void avatar_action::fire_wielded_weapon( avatar &you )
         return;
     }
 
-    you.assign_activity( player_activity( aim_activity_actor::use_wielded() ), false );
+    you.assign_activity( player_activity( aim_activity_actor::use_wielded() ) );
 }
 
 void avatar_action::fire_ranged_mutation( Character &you, const item &fake_gun )
 {
-    you.assign_activity( player_activity( aim_activity_actor::use_mutation( fake_gun ) ), false );
+    you.assign_activity( player_activity( aim_activity_actor::use_mutation( fake_gun ) ) );
 }
 
 void avatar_action::fire_ranged_bionic( avatar &you, const item &fake_gun )
 {
-    you.assign_activity(
-        player_activity( aim_activity_actor::use_bionic( fake_gun ) ), false );
+    you.assign_activity( player_activity( aim_activity_actor::use_bionic( fake_gun ) ) );
 }
 
 void avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret )

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1066,8 +1066,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         std::optional<tripoint> target = lockpick_activity_actor::select_location( player_character );
         if( target.has_value() ) {
             add_msg_activate();
-            assign_activity(
-                player_activity( lockpick_activity_actor::use_bionic( here.getabs( *target ) ) ) );
+            assign_activity( lockpick_activity_actor::use_bionic( here.getabs( *target ) ) );
             if( close_bionics_ui ) {
                 *close_bionics_ui = true;
             }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8250,6 +8250,11 @@ void Character::assign_activity( const activity_id &type, int moves, int index, 
     assign_activity( player_activity( type, moves, index, pos, name ) );
 }
 
+void Character::assign_activity( const activity_actor &actor )
+{
+    assign_activity( player_activity( actor ) );
+}
+
 void Character::assign_activity( const player_activity &act )
 {
     bool resuming = false;
@@ -10424,7 +10429,7 @@ bool Character::unload( item_location &loc, bool bypass_activity )
             }
 
         }
-        assign_activity( player_activity( unload_activity_actor( moves, loc ) ) );
+        assign_activity( unload_activity_actor( moves, loc ) );
 
         return true;
     }
@@ -10502,7 +10507,7 @@ bool Character::unload( item_location &loc, bool bypass_activity )
                 // Disassembling ammo belts is easier than assembling them
                 mv /= 2;
             }
-            assign_activity( player_activity( unload_activity_actor( mv, targloc ) ) );
+            assign_activity( unload_activity_actor( mv, targloc ) );
         }
         return true;
 
@@ -11752,7 +11757,7 @@ void Character::use( item_location loc, int pre_obtain_moves, std::string const 
                 moves = pre_obtain_moves;
                 return;
             }
-            u->assign_activity( player_activity( consume_activity_actor( item_location( *u, &used ) ) ) );
+            u->assign_activity( consume_activity_actor( item_location( *u, &used ) ) );
         } else  {
             const time_duration &consume_time = get_consume_time( used );
             moves -= to_moves<int>( consume_time );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8250,10 +8250,10 @@ void Character::assign_activity( const activity_id &type, int moves, int index, 
     assign_activity( player_activity( type, moves, index, pos, name ) );
 }
 
-void Character::assign_activity( const player_activity &act, bool allow_resume )
+void Character::assign_activity( const player_activity &act )
 {
     bool resuming = false;
-    if( allow_resume && !backlog.empty() && backlog.front().can_resume_with( act, *this ) ) {
+    if( !backlog.empty() && backlog.front().can_resume_with( act, *this ) ) {
         resuming = true;
         add_msg_if_player( _( "You resume your task." ) );
         activity = backlog.front();

--- a/src/character.h
+++ b/src/character.h
@@ -2619,6 +2619,8 @@ class Character : public Creature, public visitable
                               const std::string &name = "" );
         /** Assigns activity to player, possibly resuming old activity if it's defined resumable. */
         void assign_activity( const player_activity &act );
+        /** Assigns activity actor to player, possibly resuming old activity if it's defined resumable. */
+        void assign_activity( const activity_actor &actor );
         /** Check if player currently has a given activity */
         bool has_activity( const activity_id &type ) const;
         /** Check if player currently has any of the given activities */

--- a/src/character.h
+++ b/src/character.h
@@ -2617,8 +2617,8 @@ class Character : public Creature, public visitable
         void assign_activity( const activity_id &type, int moves = calendar::INDEFINITELY_LONG,
                               int index = -1, int pos = INT_MIN,
                               const std::string &name = "" );
-        /** Assigns activity to player, possibly resuming old activity if it's similar enough. */
-        void assign_activity( const player_activity &act, bool allow_resume = true );
+        /** Assigns activity to player, possibly resuming old activity if it's defined resumable. */
+        void assign_activity( const player_activity &act );
         /** Check if player currently has a given activity */
         bool has_activity( const activity_id &type ) const;
         /** Check if player currently has any of the given activities */

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -233,7 +233,7 @@ void Character::gunmod_add( item &gun, item &mod )
 
     const int moves = !has_trait( trait_DEBUG_HS ) ? moved_mod.type->gunmod->install_time : 0;
 
-    assign_activity( player_activity( gunmod_add_activity_actor( moves, tool ) ) );
+    assign_activity( gunmod_add_activity_actor( moves, tool ) );
     activity.targets.emplace_back( wielded_gun );
     activity.targets.emplace_back( *this, &moved_mod );
     activity.values.push_back( 0 ); // dummy value
@@ -264,9 +264,7 @@ bool Character::gunmod_remove( item &gun, item &mod )
     // Removing gunmod takes only half as much time as installing it
     const int moves = has_trait( trait_DEBUG_HS ) ? 0 : mod.type->gunmod->install_time / 2;
     item_location gun_loc = item_location( *this, &gun );
-    assign_activity(
-        player_activity(
-            gunmod_remove_activity_actor( moves, gun_loc, static_cast<int>( gunmod_idx ) ) ) );
+    assign_activity( gunmod_remove_activity_actor( moves, gun_loc, static_cast<int>( gunmod_idx ) ) );
     return true;
 }
 

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -446,13 +446,9 @@ void Character::drop( const drop_locations &what, const tripoint &target,
         }
     }
     if( stash ) {
-        assign_activity( player_activity( stash_activity_actor(
-                                              items, placement
-                                          ) ) );
+        assign_activity( stash_activity_actor( items, placement ) );
     } else {
-        assign_activity( player_activity( drop_activity_actor(
-                                              items, placement, /*force_ground=*/false
-                                          ) ) );
+        assign_activity( drop_activity_actor( items, placement, /* force_ground = */ false ) );
     }
 }
 
@@ -470,7 +466,7 @@ void Character::pick_up( const drop_locations &what )
         quantities.emplace_back( dl.second );
     }
 
-    assign_activity( player_activity( pickup_activity_actor( items, quantities, pos(), false ) ) );
+    assign_activity( pickup_activity_actor( items, quantities, pos(), false ) );
 }
 
 invlets_bitset Character::allocated_invlets() const

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -876,7 +876,7 @@ void Character::start_craft( craft_command &command, const std::optional<tripoin
         return;
     }
 
-    assign_activity( player_activity( craft_activity_actor( craft_in_world, command.is_long() ) ) );
+    assign_activity( craft_activity_actor( craft_in_world, command.is_long() ) );
 
     add_msg_player_or_npc(
         pgettext( "in progress craft", "You start working on the %s." ),
@@ -2491,7 +2491,6 @@ bool Character::disassemble( item_location target, bool interactive, bool disass
     }
 
     if( activity.id() != ACT_DISASSEMBLE ) {
-        player_activity new_act;
         // When disassembling items with charges, prompt the player to specify amount
         int num_dis = 1;
         if( obj.count_by_charges() ) {
@@ -2509,13 +2508,9 @@ bool Character::disassemble( item_location target, bool interactive, bool disass
                 num_dis = obj.charges;
             }
         }
-        if( obj.typeId() != itype_disassembly ) {
-            new_act = player_activity( disassemble_activity_actor( r.time_to_craft_moves( *this,
-                                       recipe_time_flag::ignore_proficiencies ) * num_dis ) );
-        } else {
-            new_act = player_activity( disassemble_activity_actor( r.time_to_craft_moves( *this,
-                                       recipe_time_flag::ignore_proficiencies ) * obj.get_making_batch_size() ) );
-        }
+        const int64_t craft_moves = r.time_to_craft_moves( *this, recipe_time_flag::ignore_proficiencies );
+        const int num = obj.typeId() != itype_disassembly ? num_dis : obj.get_making_batch_size();
+        player_activity new_act( disassemble_activity_actor( num * craft_moves ) );
         new_act.targets.emplace_back( std::move( target ) );
 
         // index is used as a bool that indicates if we want recursive uncraft.
@@ -2626,9 +2621,8 @@ void Character::complete_disassemble( item_location target )
             num_dis = obj.charges;
         }
     }
-    player_activity new_act = player_activity( disassemble_activity_actor(
-                                  next_recipe.time_to_craft_moves( *this,
-                                          recipe_time_flag::ignore_proficiencies ) * num_dis ) );
+    int64_t moves = next_recipe.time_to_craft_moves( *this, recipe_time_flag::ignore_proficiencies );
+    player_activity new_act( disassemble_activity_actor( moves * num_dis ) );
     new_act.targets = activity.targets;
     new_act.index = activity.index;
     new_act.position = num_dis;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2539,7 +2539,7 @@ bool Character::disassemble( item_location target, bool interactive, bool disass
 void Character::disassemble_all( bool one_pass )
 {
     // Reset all the activity values
-    assign_activity( player_activity(), true );
+    assign_activity( player_activity() );
 
     bool found_any = false;
     std::vector<item_location> to_disassemble;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9467,7 +9467,7 @@ void game::butcher()
         case BUTCHER_OTHER:
             switch( indexer_index ) {
                 case MULTISALVAGE:
-                    u.assign_activity( player_activity( longsalvage_activity_actor( salvage_tool_index ) ) );
+                    u.assign_activity( longsalvage_activity_actor( salvage_tool_index ) );
                     break;
                 case MULTIBUTCHER:
                     butcher_submenu( corpses );
@@ -9584,7 +9584,7 @@ void game::reload( item_location &loc, bool prompt, bool empty )
         if( extra_moves > 0 ) {
             add_msg( m_warning, _( "You struggle to reload the fouled %s." ), loc->tname() );
         }
-        u.assign_activity( player_activity( reload_activity_actor( std::move( opt ), extra_moves ) ) );
+        u.assign_activity( reload_activity_actor( std::move( opt ), extra_moves ) );
     }
 }
 
@@ -9675,7 +9675,7 @@ void game::reload_weapon( bool try_everything )
         if( turret.can_reload() ) {
             item::reload_option opt = u.select_ammo( turret.base(), true );
             if( opt ) {
-                u.assign_activity( player_activity( reload_activity_actor( std::move( opt ) ) ) );
+                u.assign_activity( reload_activity_actor( std::move( opt ) ) );
             }
         }
         return;
@@ -9956,9 +9956,8 @@ bool game::disable_robot( const tripoint &p )
     const itype_id mon_item_id = critter.type->revert_to_itype;
     if( !mon_item_id.is_empty() &&
         query_yn( _( "Deactivate the %s?" ), critter.name() ) ) {
-
-        u.assign_activity( player_activity( disable_activity_actor( p,
-                                            disable_activity_actor::get_disable_turns(), false ) ) );
+        const disable_activity_actor actor( p, disable_activity_actor::get_disable_turns(), false );
+        u.assign_activity( actor );
         return true;
     }
     // Manhacks are special, they have their own menu here.
@@ -9971,8 +9970,7 @@ bool game::disable_robot( const tripoint &p )
         }
 
         if( choice == 0 ) {
-            u.assign_activity( player_activity( disable_activity_actor( p,
-                                                disable_activity_actor::get_disable_turns(), true ) ) );
+            u.assign_activity( disable_activity_actor( p, disable_activity_actor::get_disable_turns(), true ) );
         }
     }
     return false;
@@ -11169,7 +11167,7 @@ bool game::grabbed_move( const tripoint &dp, const bool via_ramp )
     }
 
     if( u.get_grab_type() == object_type::FURNITURE ) {
-        u.assign_activity( player_activity( move_furniture_activity_actor( dp, via_ramp ) ) );
+        u.assign_activity( move_furniture_activity_actor( dp, via_ramp ) );
         return true;
     }
 
@@ -11851,12 +11849,8 @@ void game::start_hauling( const tripoint &pos )
     // Destination relative to the player
     const tripoint relative_destination{};
 
-    u.assign_activity( player_activity( move_items_activity_actor(
-                                            target_items,
-                                            quantities,
-                                            to_vehicle,
-                                            relative_destination
-                                        ) ) );
+    const move_items_activity_actor actor( target_items, quantities, to_vehicle, relative_destination );
+    u.assign_activity( actor );
 }
 
 std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, bool &rope_ladder,

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1615,9 +1615,7 @@ void game_menus::inv::insert_items( avatar &you, item_location &holster )
     drop_locations holstered_list = game_menus::inv::holster( you, holster );
 
     if( !holstered_list.empty() ) {
-        you.assign_activity(
-            player_activity(
-                insert_item_activity_actor( holster, holstered_list ) ) );
+        you.assign_activity( insert_item_activity_actor( holster, holstered_list ) );
     }
 }
 

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -245,10 +245,7 @@ void gates::open_gate( const tripoint &pos, Character &p )
     const gate_data &gate = gates_data.obj( gid );
 
     p.add_msg_if_player( gate.pull_message );
-    p.assign_activity( player_activity( open_gate_activity_actor(
-                                            gate.moves,
-                                            pos
-                                        ) ) );
+    p.assign_activity( open_gate_activity_actor( gate.moves, pos ) );
 }
 
 // Doors namespace

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1381,8 +1381,7 @@ static void loot()
             player_character.assign_activity( ACT_MOVE_LOOT );
             break;
         case UnloadLoot:
-            player_character.assign_activity(
-                player_activity( unload_loot_activity_actor() ) );
+            player_character.assign_activity( unload_loot_activity_actor() );
             break;
         case FertilizePlots:
             player_character.assign_activity( ACT_FERTILIZE_PLOT );
@@ -2506,8 +2505,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_WORKOUT:
             if( query_yn( _( "Start workout?" ) ) ) {
-                player_character.assign_activity( player_activity( workout_activity_actor(
-                                                      player_character.pos() ) ) );
+                player_character.assign_activity( workout_activity_actor( player_character.pos() ) );
             }
             break;
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1058,7 +1058,7 @@ static void wait()
 
         player_activity new_act( actType, 100 * to_turns<int>( time_to_wait ), 0 );
 
-        player_character.assign_activity( new_act, false );
+        player_character.assign_activity( new_act );
     }
 }
 
@@ -1673,7 +1673,7 @@ bool Character::cast_spell( spell &sp, bool fake_spell,
     if( target ) {
         spell_act.coords.emplace_back( get_map().getabs( *target ) );
     }
-    assign_activity( spell_act, false );
+    assign_activity( spell_act );
     return true;
 }
 

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -365,7 +365,7 @@ bool perform_liquid_transfer( item &liquid, const tripoint *const source_pos,
     map &here = get_map();
     switch( target.dest_opt ) {
         case LD_CONSUME:
-            player_character.assign_activity( player_activity( consume_activity_actor( liquid ) ) );
+            player_character.assign_activity( consume_activity_actor( liquid ) );
             liquid.charges--;
             return true;
         case LD_ITEM: {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1640,7 +1640,7 @@ void iexamine::portable_structure( Character &you, const tripoint &examp )
 
     player_activity new_act = player_activity( tent_deconstruct_activity_actor( to_moves<int>
                               ( 20_minutes ), radius, examp, dropped ) );
-    you.assign_activity( new_act, false );
+    you.assign_activity( new_act );
 }
 
 /**

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1346,7 +1346,7 @@ bool iexamine::try_start_hacking( Character &you, const tripoint &examp )
         return false;
     } else {
         you.use_charges( itype_electrohack, 25 );
-        you.assign_activity( player_activity( hacking_activity_actor() ) );
+        you.assign_activity( hacking_activity_actor() );
         you.activity.placement = get_map().getglobal( examp );
         return true;
     }
@@ -1448,7 +1448,7 @@ void iexamine::rubble( Character &you, const tripoint &examp )
         !query_yn( _( "Clear up that %s?" ), here.furnname( examp ) ) ) {
         return;
     }
-    you.assign_activity( player_activity( clear_rubble_activity_actor( moves ) ) );
+    you.assign_activity( clear_rubble_activity_actor( moves ) );
     you.activity.placement = here.getglobal( examp );
 }
 
@@ -1638,9 +1638,8 @@ void iexamine::portable_structure( Character &you, const tripoint &examp )
         return;
     }
 
-    player_activity new_act = player_activity( tent_deconstruct_activity_actor( to_moves<int>
-                              ( 20_minutes ), radius, examp, dropped ) );
-    you.assign_activity( new_act );
+    tent_deconstruct_activity_actor actor( to_moves<int>( 20_minutes ), radius, examp, dropped );
+    you.assign_activity( actor );
 }
 
 /**
@@ -1777,7 +1776,7 @@ void iexamine::safe( Character &you, const tripoint &examp )
         add_msg( m_info, _( "You can't crack a safe while listening to music!" ) );
         return;
     } else if( query_yn( _( "Attempt to crack the safe?" ) ) ) {
-        you.assign_activity( player_activity( safecracking_activity_actor( examp ) ) );
+        you.assign_activity( safecracking_activity_actor( examp ) );
     }
 }
 
@@ -1858,8 +1857,7 @@ void iexamine::locked_object_pickable( Character &you, const tripoint &examp )
         if( you.get_power_level() >= bio_lockpick->power_activate ) {
             you.mod_power_level( -bio_lockpick->power_activate );
             you.add_msg_if_player( m_info, _( "You activate your %s." ), bio_lockpick->name );
-            you.assign_activity(
-                player_activity( lockpick_activity_actor::use_bionic( here.getabs( examp ) ) ) );
+            you.assign_activity( lockpick_activity_actor::use_bionic( here.getabs( examp ) ) );
             return;
         } else {
             you.add_msg_if_player( m_info, _( "You don't have enough power to activate your %s." ),
@@ -2135,7 +2133,7 @@ bool iexamine_helper::drink_nectar( Character &you )
     if( can_drink_nectar( you ) ) {
         add_msg( _( "You drink some nectar." ) );
         item nectar( "nectar", calendar::turn, 1 );
-        you.assign_activity( player_activity( consume_activity_actor( nectar ) ) );
+        you.assign_activity( consume_activity_actor( nectar ) );
         return true;
     }
 
@@ -2183,7 +2181,7 @@ void iexamine::flower_poppy( Character &you, const tripoint &examp )
         }
         add_msg( _( "You slowly suck up the nectar." ) );
         item poppy( "poppy_nectar", calendar::turn, 1 );
-        you.assign_activity( player_activity( consume_activity_actor( poppy ) ) );
+        you.assign_activity( consume_activity_actor( poppy ) );
         you.mod_fatigue( 20 );
         you.add_effect( effect_pkill2, 7_minutes );
         // Please drink poppy nectar responsibly.
@@ -2328,7 +2326,7 @@ void iexamine::harvest_furn_nectar( Character &you, const tripoint &examp )
     if( !auto_forage && !query_pick( you, examp ) ) {
         return;
     }
-    you.assign_activity( player_activity( harvest_activity_actor( examp, auto_forage ) ) );
+    you.assign_activity( harvest_activity_actor( examp, auto_forage ) );
 }
 
 void iexamine::harvest_furn( Character &you, const tripoint &examp )
@@ -2338,7 +2336,7 @@ void iexamine::harvest_furn( Character &you, const tripoint &examp )
     if( !auto_forage && !query_pick( you, examp ) ) {
         return;
     }
-    you.assign_activity( player_activity( harvest_activity_actor( examp, auto_forage ) ) );
+    you.assign_activity( harvest_activity_actor( examp, auto_forage ) );
 }
 
 void iexamine::harvest_ter_nectar( Character &you, const tripoint &examp )
@@ -2350,7 +2348,7 @@ void iexamine::harvest_ter_nectar( Character &you, const tripoint &examp )
     if( !auto_forage && !query_pick( you, examp ) ) {
         return;
     }
-    you.assign_activity( player_activity( harvest_activity_actor( examp, auto_forage ) ) );
+    you.assign_activity( harvest_activity_actor( examp, auto_forage ) );
 }
 
 void iexamine::harvest_ter( Character &you, const tripoint &examp )
@@ -2361,7 +2359,7 @@ void iexamine::harvest_ter( Character &you, const tripoint &examp )
     if( !auto_forage && !query_pick( you, examp ) ) {
         return;
     }
-    you.assign_activity( player_activity( harvest_activity_actor( examp, auto_forage ) ) );
+    you.assign_activity( harvest_activity_actor( examp, auto_forage ) );
 }
 
 /**
@@ -3682,7 +3680,7 @@ void iexamine::keg( Character &you, const tripoint &examp )
                 if( !you.can_consume_as_is( drink ) ) {
                     return; // They didn't actually drink
                 }
-                you.assign_activity( player_activity( consume_activity_actor( drink ) ) );
+                you.assign_activity( consume_activity_actor( drink ) );
                 drink.charges--;
                 if( drink.charges == 0 ) {
                     add_msg( _( "You squeeze the last drops of %1$s from the %2$s." ),
@@ -3815,7 +3813,7 @@ void iexamine::tree_hickory( Character &you, const tripoint &examp )
         return;
     }
 
-    you.assign_activity( player_activity( harvest_activity_actor( examp, auto_forage ) ) );
+    you.assign_activity( harvest_activity_actor( examp, auto_forage ) );
 }
 
 static item_location maple_tree_sap_container()
@@ -3955,8 +3953,9 @@ void iexamine::tree_maple_tapped( Character &you, const tripoint &examp )
 
         case REMOVE_CONTAINER: {
             Character &player_character = get_player_character();
-            player_character.assign_activity( player_activity( pickup_activity_actor(
-            { item_location( map_cursor( examp ), container ) }, { 0 }, player_character.pos(), false ) ) );
+            const std::vector<item_location> target_items{ item_location( map_cursor( examp ), container ) };
+            const pickup_activity_actor actor( target_items, { 0 }, player_character.pos(), false );
+            player_character.assign_activity( actor );
             return;
         }
 
@@ -4018,7 +4017,7 @@ void iexamine::shrub_wildveggies( Character &you, const tripoint &examp )
     int move_cost = 100000 / ( 2 * you.get_skill_level( skill_survival ) + 5 );
     ///\EFFECT_PER randomly speeds up foraging
     move_cost /= rng( std::max( 4, you.per_cur ), 4 + you.per_cur * 2 );
-    you.assign_activity( player_activity( forage_activity_actor( move_cost ) ) );
+    you.assign_activity( forage_activity_actor( move_cost ) );
     you.activity.placement = here.getglobal( examp );
     you.activity.auto_resume = true;
 }
@@ -4235,8 +4234,8 @@ static void reload_furniture( Character &you, const tripoint &examp, bool allow_
             for( map_stack::iterator itm = items.begin(); itm != items.end(); ) {
                 if( itm->typeId() == ammo_itypeID ) {
                     if( you.can_stash( *itm ) ) {
-                        you.assign_activity( player_activity( pickup_activity_actor(
-                        { item_location( map_cursor( examp ), &*itm ) }, { 0 }, you.pos(), false ) ) );
+                        std::vector<item_location> target_items{ item_location( map_cursor( examp ), &*itm ) };
+                        you.assign_activity( pickup_activity_actor( target_items, { 0 }, you.pos(), false ) );
                         return;
                     } else {
                         // get handling cost before the item reference is invalidated
@@ -6488,7 +6487,7 @@ void iexamine::workbench_internal( Character &you, const tripoint &examp,
                     pgettext( "in progress craft", "You start working on the %s." ),
                     pgettext( "in progress craft", "<npcname> starts working on the %s." ),
                     selected_craft->tname() );
-                you.assign_activity( player_activity( craft_activity_actor( crafts[amenu2.ret], false ) ) );
+                you.assign_activity( craft_activity_actor( crafts[amenu2.ret], false ) );
             }
             break;
         }
@@ -6509,7 +6508,7 @@ void iexamine::workout( Character &you, const tripoint &examp )
         none( you, examp );
         return;
     }
-    you.assign_activity( player_activity( workout_activity_actor( examp ) ) );
+    you.assign_activity( workout_activity_actor( examp ) );
 }
 
 void iexamine::invalid( Character &/*you*/, const tripoint &examp )

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3953,7 +3953,7 @@ bool pickup_selector::wield( int &count )
     if( u.can_wield( *it ).success() ) {
         remove_from_to_use( it );
         add_reopen_activity();
-        u.assign_activity( player_activity( wield_activity_actor( it, charges ) ) );
+        u.assign_activity( wield_activity_actor( it, charges ) );
         return true;
     } else {
         popup_getkey( _( "You can't wield the %s." ), it->display_name() );
@@ -3975,7 +3975,7 @@ bool pickup_selector::wear()
     if( u.can_wear( *items.front() ).success() ) {
         remove_from_to_use( items.front() );
         add_reopen_activity();
-        u.assign_activity( player_activity( wear_activity_actor( items, quantities ) ) );
+        u.assign_activity( wear_activity_actor( items, quantities ) );
         return true;
     } else {
         popup_getkey( _( "You can't wear the %s." ), items.front()->display_name() );
@@ -3986,7 +3986,7 @@ bool pickup_selector::wear()
 
 void pickup_selector::add_reopen_activity()
 {
-    u.assign_activity( player_activity( pickup_menu_activity_actor( where, to_use ) ) );
+    u.assign_activity( pickup_menu_activity_actor( where, to_use ) );
     u.activity.auto_resume = true;
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -954,7 +954,7 @@ std::optional<int> iuse::meditate( Character *p, item *it, bool t, const tripoin
         return std::nullopt;
     }
     if( p->has_trait( trait_SPIRITUAL ) ) {
-        p->assign_activity( player_activity( meditate_activity_actor() ) );
+        p->assign_activity( meditate_activity_actor() );
     } else {
         p->add_msg_if_player( _( "This %s probably meant a lot to someone at one time." ),
                               it->tname() );
@@ -2815,8 +2815,7 @@ std::optional<int> iuse::crowbar( Character *p, item *it, bool, const tripoint &
 
     // previously iuse::hammer
     if( prying->prying_nails ) {
-        p->assign_activity(
-            player_activity( prying_activity_actor( pnt, item_location{*p, it} ) ) );
+        p->assign_activity( prying_activity_actor( pnt, item_location{*p, it} ) );
         return std::nullopt;
     }
 
@@ -2836,8 +2835,7 @@ std::optional<int> iuse::crowbar( Character *p, item *it, bool, const tripoint &
         return std::nullopt;
     }
 
-    p->assign_activity(
-        player_activity( prying_activity_actor( pnt, item_location{*p, it} ) ) );
+    p->assign_activity( prying_activity_actor( pnt, item_location{*p, it} ) );
 
     return std::nullopt;
 }
@@ -2866,7 +2864,7 @@ std::optional<int> iuse::makemound( Character *p, item *it, bool t, const tripoi
     if( here.has_flag( ter_furn_flag::TFLAG_PLOWABLE, pnt ) &&
         !here.has_flag( ter_furn_flag::TFLAG_PLANT, pnt ) ) {
         p->add_msg_if_player( _( "You start churning up the earth here." ) );
-        p->assign_activity( player_activity( churn_activity_actor( 18000, item_location( *p, it ) ) ) );
+        p->assign_activity( churn_activity_actor( 18000, item_location( *p, it ) ) );
         p->activity.placement = here.getglobal( pnt );
         return 1;
     } else {
@@ -2967,7 +2965,7 @@ std::optional<int> iuse::clear_rubble( Character *p, item *it, bool, const tripo
     for( std::size_t i = 0; i < helpersize; i++ ) {
         add_msg( m_info, _( "%s helps with this task…" ), helpers[i]->get_name() );
     }
-    p->assign_activity( player_activity( clear_rubble_activity_actor( moves / bonus ) ) );
+    p->assign_activity( clear_rubble_activity_actor( moves / bonus ) );
     p->activity.placement = get_map().getglobal( pnt );
     return 1;
 }
@@ -3329,10 +3327,8 @@ std::optional<int> iuse::pick_lock( Character *p, item *it, bool, const tripoint
                                      you.get_skill_level( skill_traps ) ) ) * duration_proficiency_factor );
     }
 
-    you.assign_activity(
-        player_activity( lockpick_activity_actor::use_item( to_moves<int>( duration ),
-                         item_location( you, it ),
-                         get_map().getabs( *target ) ) ) );
+    you.assign_activity( lockpick_activity_actor::use_item( to_moves<int>( duration ),
+                         item_location( you, it ), get_map().getabs( *target ) ) );
     return 1;
 }
 
@@ -4726,7 +4722,7 @@ void iuse::cut_log_into_planks( Character &p )
     const int moves = to_moves<int>( 20_minutes );
     p.add_msg_if_player( _( "You cut the log into planks." ) );
 
-    p.assign_activity( player_activity( chop_planks_activity_actor( moves ) ) );
+    p.assign_activity( chop_planks_activity_actor( moves ) );
     p.activity.placement = get_map().getglobal( p.pos() );
 }
 
@@ -4816,7 +4812,7 @@ std::optional<int> iuse::chop_tree( Character *p, item *it, bool t, const tripoi
     for( std::size_t i = 0; i < helpers.size() && i < 3; i++ ) {
         add_msg( m_info, _( "%s helps with this task…" ), helpers[i]->get_name() );
     }
-    p->assign_activity( player_activity( chop_tree_activity_actor( moves, item_location( *p, it ) ) ) );
+    p->assign_activity( chop_tree_activity_actor( moves, item_location( *p, it ) ) );
     p->activity.placement = here.getglobal( pnt );
 
     return 1;
@@ -4858,7 +4854,7 @@ std::optional<int> iuse::chop_logs( Character *p, item *it, bool t, const tripoi
     for( std::size_t i = 0; i < helpers.size() && i < 3; i++ ) {
         add_msg( m_info, _( "%s helps with this task…" ), helpers[i]->get_name() );
     }
-    p->assign_activity( player_activity( chop_logs_activity_actor( moves, item_location( *p, it ) ) ) );
+    p->assign_activity( chop_logs_activity_actor( moves, item_location( *p, it ) ) );
     p->activity.placement = here.getglobal( pnt );
 
     return 1;
@@ -4906,8 +4902,7 @@ std::optional<int> iuse::oxytorch( Character *p, item *it, bool, const tripoint 
         return std::nullopt;
     }
 
-    p->assign_activity(
-        player_activity( oxytorch_activity_actor( pnt, item_location{*p, it} ) ) );
+    p->assign_activity( oxytorch_activity_actor( pnt, item_location{*p, it} ) );
 
     return std::nullopt;
 }
@@ -4950,8 +4945,7 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, bool t, const tripoint
         return std::nullopt;
     }
 
-    p->assign_activity(
-        player_activity( hacksaw_activity_actor( pnt, item_location{*p, it} ) ) );
+    p->assign_activity( hacksaw_activity_actor( pnt, item_location{*p, it} ) );
 
     return std::nullopt;
 }
@@ -4991,7 +4985,7 @@ std::optional<int> iuse::boltcutters( Character *p, item *it, bool, const tripoi
         return std::nullopt;
     }
 
-    p->assign_activity( player_activity( boltcutting_activity_actor( pnt, item_location{*p, it} ) ) );
+    p->assign_activity( boltcutting_activity_actor( pnt, item_location{*p, it} ) );
     return std::nullopt;
 }
 
@@ -5253,7 +5247,7 @@ int iuse::towel_common( Character *p, item *it, bool t )
 
 std::optional<int> iuse::unfold_generic( Character *p, item *it, bool, const tripoint & )
 {
-    p->assign_activity( player_activity( vehicle_unfolding_activity_actor( *it ) ) );
+    p->assign_activity( vehicle_unfolding_activity_actor( *it ) );
     p->i_rem( it );
     return 0;
 }
@@ -8841,7 +8835,7 @@ std::optional<int> iuse::shavekit( Character *p, item *it, bool, const tripoint 
     if( !it->ammo_sufficient( p ) ) {
         p->add_msg_if_player( _( "You need soap to use this." ) );
     } else {
-        p->assign_activity( player_activity( shave_activity_actor() ) );
+        p->assign_activity( shave_activity_actor() );
     }
     return 1;
 }
@@ -8851,7 +8845,7 @@ std::optional<int> iuse::hairkit( Character *p, item *, bool, const tripoint & )
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
-    p->assign_activity( player_activity( haircut_activity_actor() ) );
+    p->assign_activity( haircut_activity_actor() );
     return 1;
 }
 
@@ -9313,7 +9307,7 @@ std::optional<int> iuse::wash_items( Character *p, bool soft_items, bool hard_it
         add_msg( m_info, _( "%s helps with this task…" ), helpers[i]->get_name() );
     }
     // Assign the activity values.
-    p->assign_activity( player_activity( wash_activity_actor( to_clean, required ) ) );
+    p->assign_activity( wash_activity_actor( to_clean, required ) );
 
     return 0;
 }
@@ -9427,7 +9421,7 @@ std::optional<int> iuse::craft( Character *p, item *it, bool, const tripoint & )
         pgettext( "in progress craft", "You start working on the %s." ),
         pgettext( "in progress craft", "<npcname> starts working on the %s." ), craft_name );
     item_location craft_loc = item_location( *p, it );
-    p->assign_activity( player_activity( craft_activity_actor( craft_loc, false ) ) );
+    p->assign_activity( craft_activity_actor( craft_loc, false ) );
 
     return 0;
 }
@@ -9709,8 +9703,7 @@ std::optional<int> iuse::ebooksave( Character *p, item *it, bool t, const tripoi
         return std::nullopt;
     }
 
-    p->assign_activity(
-        player_activity( ebooksave_activity_actor( book, item_location( *p, it ) ) ) );
+    p->assign_activity( ebooksave_activity_actor( book, item_location( *p, it ) ) );
 
     return std::nullopt;
 }
@@ -9832,7 +9825,7 @@ std::optional<int> iuse::binder_add_recipe( Character *p, item *binder, bool, co
     }
 
     bookbinder_copy_activity_actor act( item_location( *p, binder ), recipes[menu.ret]->ident() );
-    p->assign_activity( player_activity( act ) );
+    p->assign_activity( act );
 
     return std::nullopt;
 }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2302,7 +2302,7 @@ std::optional<int> learn_spell_actor::use( Character &p, item &, bool, const tri
         study_spell.values[1] = p.magic->get_spell( spell_id( spells[action] ) ).get_level() + 1;
     }
     study_spell.name = spells[action];
-    p.assign_activity( study_spell, false );
+    p.assign_activity( study_spell );
     return 0;
 }
 
@@ -2374,7 +2374,7 @@ std::optional<int> cast_spell_actor::use( Character &p, item &it, bool, const tr
         // [2]
         cast_spell.values.emplace_back( 0 );
     }
-    p.assign_activity( cast_spell, false );
+    p.assign_activity( cast_spell );
     p.activity.targets.emplace_back( item_location( p, &it ) );
     // Actual handling of charges_to_use is in activity_handlers::spellcasting_finish
     return 0;
@@ -4403,7 +4403,7 @@ std::optional<int> deploy_tent_actor::use( Character &p, item &it, bool, const t
     //checks done start activity:
     player_activity new_act = player_activity( tent_placement_activity_actor( to_moves<int>
                               ( 20_minutes ), direction, radius, it, wall, floor, floor_center, door_closed ) );
-    get_player_character().assign_activity( new_act, false );
+    get_player_character().assign_activity( new_act );
     p.i_rem( &it );
     return 0;
 }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2567,7 +2567,7 @@ std::optional<int> ammobelt_actor::use( Character &p, item &, bool, const tripoi
     item_location loc = p.i_add( mag );
     item::reload_option opt = p.select_ammo( loc, true );
     if( opt ) {
-        p.assign_activity( player_activity( reload_activity_actor( std::move( opt ) ) ) );
+        p.assign_activity( reload_activity_actor( std::move( opt ) ) );
     } else {
         loc.remove_item();
     }
@@ -3290,8 +3290,7 @@ std::optional<int> heal_actor::use( Character &p, item &it, bool, const tripoint
     cost = p.has_proficiency( proficiency_prof_wound_care_expert ) ? cost / 2 : cost;
     cost = p.has_proficiency( proficiency_prof_wound_care ) ? cost / 2 : cost;
 
-    p.assign_activity( player_activity( firstaid_activity_actor( cost, it.tname(),
-                                        patient.getID() ) ) );
+    p.assign_activity( firstaid_activity_actor( cost, it.tname(), patient.getID() ) );
 
     // Player: Only time this item_location gets used in firstaid::finish() is when activating the item's
     // container from the inventory window, so an item_on_person impl is all that is needed.
@@ -4401,9 +4400,9 @@ std::optional<int> deploy_tent_actor::use( Character &p, item &it, bool, const t
     }
 
     //checks done start activity:
-    player_activity new_act = player_activity( tent_placement_activity_actor( to_moves<int>
-                              ( 20_minutes ), direction, radius, it, wall, floor, floor_center, door_closed ) );
-    get_player_character().assign_activity( new_act );
+    tent_placement_activity_actor actor( to_moves<int>( 20_minutes ), direction, radius, it, wall,
+                                         floor, floor_center, door_closed );
+    get_player_character().assign_activity( actor );
     p.i_rem( &it );
     return 0;
 }

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -345,8 +345,7 @@ void play_with( monster &z )
     std::string pet_name = z.get_name();
     Character &player_character = get_player_character();
     const std::string &petstr = z.type->petfood.pet;
-    player_character.assign_activity(
-        player_activity( play_with_pet_activity_actor( pet_name, petstr ) ) );
+    player_character.assign_activity( play_with_pet_activity_actor( pet_name, petstr ) );
 }
 
 void cull( monster &z )
@@ -475,8 +474,7 @@ void milk_source( monster &source_mon )
             source_mon.add_effect( effect_tied, 1_turns, true );
             str_values.emplace_back( "temp_tie" );
         }
-        player_character.assign_activity( player_activity( milk_activity_actor( moves, coords,
-                                          str_values ) ) );
+        player_character.assign_activity( milk_activity_actor( moves, coords, str_values ) );
 
         add_msg( _( "You milk the %s." ), source_mon.get_name() );
     } else {
@@ -499,7 +497,7 @@ void shear_animal( monster &z )
         z.add_effect( effect_tied, 1_turns, true );
     }
 
-    guy.assign_activity( player_activity( shearing_activity_actor( z.pos(), !monster_tied ) ) );
+    guy.assign_activity( shearing_activity_actor( z.pos(), !monster_tied ) );
 }
 
 void remove_battery( monster &z )

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1385,15 +1385,8 @@ void npc::do_npc_read()
         item_location ereader = {};
 
         // NPCs read until they gain a level
-        assign_activity(
-            player_activity(
-                read_activity_actor(
-                    to_moves<int>( time_taken ),
-                    book,
-                    ereader,
-                    true,
-                    getID().get_value()
-                ) ) );
+        read_activity_actor actor( to_moves<int>( time_taken ), book, ereader, true, getID().get_value() );
+        assign_activity( actor );
 
     } else {
         for( const std::string &reason : fail_reasons ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1385,7 +1385,7 @@ void npc::do_npc_read()
         item_location ereader = {};
 
         // NPCs read until they gain a level
-        read_activity_actor actor( to_moves<int>( time_taken ), book, ereader, true, getID().get_value() );
+        read_activity_actor actor( time_taken, book, ereader, true, getID().get_value() );
         assign_activity( actor );
 
     } else {

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -805,9 +805,7 @@ void talk_function::drop_items_in_place( npc &p )
     }
     if( !to_drop.empty() ) {
         // spawn a activity for the npc to drop the specified items
-        p.assign_activity( player_activity( drop_activity_actor(
-                                                to_drop, tripoint_zero, false
-                                            ) ) );
+        p.assign_activity( drop_activity_actor( to_drop, tripoint_zero, false ) );
         p.say( "<acknowledged>" );
     } else {
         p.say( _( "I don't have anything to drop off." ) );
@@ -1161,11 +1159,10 @@ void talk_function::start_training_gen( Character &teacher, std::vector<Characte
             return;
         }
     }
-    player_activity tact = player_activity( ACT_TRAIN_TEACHER, to_moves<int>( time ),
-                                            teacher.getID().get_value(), 0, name );
+    const int teacher_id = teacher.getID().get_value();
+    player_activity tact( ACT_TRAIN_TEACHER, to_moves<int>( time ), teacher_id, 0, name );
     for( Character *student : students ) {
-        player_activity act = player_activity( ACT_TRAIN, to_moves<int>( time ),
-                                               teacher.getID().get_value(), 0, name );
+        player_activity act( ACT_TRAIN, to_moves<int>( time ), teacher_id, 0, name );
         act.values.push_back( expert_multiplier );
         student->assign_activity( act );
         tact.values.push_back( student->getID().get_value() );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1722,7 +1722,7 @@ static bool try_travel_to_destination( avatar &player_character, const tripoint_
     }
     if( query_yn( confirm_msg ) ) {
         if( driving ) {
-            player_character.assign_activity( player_activity( autodrive_activity_actor() ) );
+            player_character.assign_activity( autodrive_activity_actor() );
         } else {
             player_character.reset_move_mode();
             player_character.assign_activity( ACT_TRAVELLING );

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -411,8 +411,8 @@ void Pickup::autopickup( const tripoint &p )
         target_items.push_back( selected.first );
         quantities.push_back( it->count_by_charges() ? it->charges : 0 );
     }
-    pickup_activity_actor actor = pickup_activity_actor( target_items, quantities, player.pos(), true );
-    player.assign_activity( player_activity( actor ) );
+    pickup_activity_actor actor( target_items, quantities, player.pos(), true );
+    player.assign_activity( actor );
 
     // Auto pickup will need to auto resume since there can be several of them on the stack.
     player.activity.auto_resume = true;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1578,7 +1578,7 @@ void vehicle::build_bike_rack_menu( veh_menu &menu, int part )
         .skip_locked_check()
         .on_submit( [this, rackable] {
             bikerack_racking_activity_actor rack( *this, *rackable.veh, rackable.racks );
-            get_player_character().assign_activity( player_activity( rack ), false );
+            get_player_character().assign_activity( player_activity( rack ) );
         } );
 
         has_rack_actions = true;
@@ -1590,7 +1590,7 @@ void vehicle::build_bike_rack_menu( veh_menu &menu, int part )
         .skip_locked_check()
         .on_submit( [this, unrackable] {
             bikerack_unracking_activity_actor unrack( *this, unrackable.parts, unrackable.racks );
-            get_player_character().assign_activity( player_activity( unrack ), false );
+            get_player_character().assign_activity( player_activity( unrack ) );
         } );
 
         has_rack_actions = true;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1578,7 +1578,7 @@ void vehicle::build_bike_rack_menu( veh_menu &menu, int part )
         .skip_locked_check()
         .on_submit( [this, rackable] {
             bikerack_racking_activity_actor rack( *this, *rackable.veh, rackable.racks );
-            get_player_character().assign_activity( player_activity( rack ) );
+            get_player_character().assign_activity( rack );
         } );
 
         has_rack_actions = true;
@@ -1590,7 +1590,7 @@ void vehicle::build_bike_rack_menu( veh_menu &menu, int part )
         .skip_locked_check()
         .on_submit( [this, unrackable] {
             bikerack_unracking_activity_actor unrack( *this, unrackable.parts, unrackable.racks );
-            get_player_character().assign_activity( player_activity( unrack ) );
+            get_player_character().assign_activity( unrack );
         } );
 
         has_rack_actions = true;
@@ -1770,7 +1770,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
             const int moves = to_moves<int>( 6000_seconds / skill );
             const tripoint target = global_square_location().raw() + coord_translate( parts[0].mount );
             const hotwire_car_activity_actor hotwire_act( moves, target );
-            get_player_character().assign_activity( player_activity( hotwire_act ) );
+            get_player_character().assign_activity( hotwire_act );
         } );
 
         if( !is_alarm_on ) {
@@ -1924,7 +1924,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
             if( opt )
             {
                 reload_activity_actor reload_act( std::move( opt ) );
-                get_player_character().assign_activity( player_activity( reload_act ) );
+                get_player_character().assign_activity( reload_act );
             }
         } );
     }
@@ -2066,7 +2066,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
                 item_location base_loc( vehicle_cursor( *this, vp_tank_idx ), &vp_tank.base );
                 item_location water_loc( base_loc, &vp_tank.base.only_item() );
                 const consume_activity_actor consume_act( water_loc );
-                get_player_character().assign_activity( player_activity( consume_act ) );
+                get_player_character().assign_activity( consume_act );
             } );
         }
     }
@@ -2216,7 +2216,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         .hotkey( "FOLD_VEHICLE" )
         .on_submit( [this] {
             vehicle_folding_activity_actor folding_act( *this );
-            get_avatar().assign_activity( player_activity( folding_act ) );
+            get_avatar().assign_activity( folding_act );
         } );
     }
 }

--- a/tests/activity_scheduling_helper.cpp
+++ b/tests/activity_scheduling_helper.cpp
@@ -20,12 +20,11 @@ void activity_schedule::setup( avatar &guy ) const
     // Start our task, for however long the schedule says.
     // This may be longer than the interval, which means that we
     // never finish this task
-    if( actor ) {
-        guy.assign_activity( player_activity( *actor ), false );
-    } else {
-        guy.assign_activity( player_activity( act, calendar::INDEFINITELY_LONG, -1, INT_MIN,
-                                              "" ), false );
-    }
+    guy.assign_activity( player_activity() ); // disallow resuming
+    const player_activity p_act = actor
+                                  ? player_activity( *actor )
+                                  : player_activity( act, calendar::INDEFINITELY_LONG, -1, INT_MIN, "" );
+    guy.assign_activity( p_act );
 }
 
 void activity_schedule::do_turn( avatar &guy ) const

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -102,7 +102,7 @@ TEST_CASE( "zone unloading ammo belts", "[zones][items][ammo_belt][activities][u
         if( move_act ) {
             dummy.assign_activity( player_activity( ACT_MOVE_LOOT ) );
         } else {
-            dummy.assign_activity( player_activity( unload_loot_activity_actor() ) );
+            dummy.assign_activity( unload_loot_activity_actor() );
         }
         CAPTURE( dummy.activity.id() );
         process_activity( dummy );

--- a/tests/firstaid_test.cpp
+++ b/tests/firstaid_test.cpp
@@ -55,8 +55,7 @@ TEST_CASE( "avatar does healing", "[activity][firstaid][avatar]" )
     GIVEN( "avatar has a damaged right arm" ) {
         dummy.apply_damage( nullptr, right_arm, 20 );
         WHEN( "avatar bandages self" ) {
-            dummy.assign_activity( player_activity( firstaid_activity_actor( moves, bandages->tname(),
-                                                    dummy.getID() ) ) );
+            dummy.assign_activity( firstaid_activity_actor( moves, bandages->tname(), dummy.getID() ) );
             dummy.activity.targets.emplace_back( bandages );
             dummy.activity.str_values.emplace_back( right_arm.id().c_str() );
             process_activity( dummy );
@@ -69,8 +68,7 @@ TEST_CASE( "avatar does healing", "[activity][firstaid][avatar]" )
     GIVEN( "avatar has a damaged right arm" ) {
         dummy.apply_damage( nullptr, right_arm, 20 );
         WHEN( "avatar bandages self and is interrupted before finishing" ) {
-            dummy.assign_activity( player_activity( firstaid_activity_actor( moves, bandages->tname(),
-                                                    dummy.getID() ) ) );
+            dummy.assign_activity( firstaid_activity_actor( moves, bandages->tname(), dummy.getID() ) );
             dummy.activity.targets.emplace_back( bandages );
             dummy.activity.str_values.emplace_back( right_arm.id().c_str() );
             process_activity_interrupt( dummy, moves / 2 );
@@ -83,8 +81,7 @@ TEST_CASE( "avatar does healing", "[activity][firstaid][avatar]" )
     GIVEN( "npc has a damaged right arm" ) {
         dunsel.apply_damage( nullptr, right_arm, 20 );
         WHEN( "avatar bandages npc" ) {
-            dummy.assign_activity( player_activity( firstaid_activity_actor( moves, bandages->tname(),
-                                                    dunsel.getID() ) ) );
+            dummy.assign_activity( firstaid_activity_actor( moves, bandages->tname(), dunsel.getID() ) );
             dummy.activity.targets.emplace_back( bandages );
             dummy.activity.str_values.emplace_back( right_arm.id().c_str() );
             process_activity( dummy );

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -257,8 +257,8 @@ static void pick_up_from_feet( Character &you, const std::string &id )
     REQUIRE( found );
 
     you.moves = 100;
-    you.assign_activity( player_activity( pickup_activity_actor( { item_location( map_cursor( you.pos() ), found ) }, { 0 },
-                                          you.pos(), false ) ) );
+    const std::vector<item_location> target_items = { item_location( map_cursor( you.pos() ), found ) };
+    you.assign_activity( pickup_activity_actor( target_items, { 0 }, you.pos(), false ) );
     you.activity.do_turn( you );
 
     REQUIRE( items.size() == size_before - 1 );

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -1824,8 +1824,7 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
     item_location obj1( map_cursor( u.pos() ), &m.add_item_or_charges( u.pos(), rigid_obj ) );
     item_location obj2( map_cursor( u.pos() ), &m.add_item_or_charges( u.pos(), soft_obj ) );
     pickup_activity_actor act_actor( { obj1, obj2 }, { 1, 1 }, u.pos(), autopickup );
-    player_activity act( act_actor );
-    u.assign_activity( act );
+    u.assign_activity( act_actor );
 
     item_location pack;
     if( wear ) {
@@ -2054,8 +2053,7 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
             REQUIRE( obj3->charges == 300 );
             u.cancel_activity();
             pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos(), autopickup );
-            player_activity new_act( new_actor );
-            u.assign_activity( new_act );
+            u.assign_activity( new_actor );
             THEN( ( soft_nested ? "pickup most, nested empty" : "pickup all, overflow into nested" ) ) {
                 if( soft_nested ) {
                     test_pickup_autoinsert_results( u, wear, c, 61, 239, 0, true );
@@ -2086,8 +2084,7 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
             REQUIRE( obj3->charges == 300 );
             u.cancel_activity();
             pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos(), autopickup );
-            player_activity new_act( new_actor );
-            u.assign_activity( new_act );
+            u.assign_activity( new_actor );
             THEN( "pickup most, nested empty" ) {
                 if( soft_nested ) {
                     test_pickup_autoinsert_results( u, wear, c, 61, 239, 0, true );
@@ -2119,8 +2116,7 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
             REQUIRE( obj3->charges == 300 );
             u.cancel_activity();
             pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos(), autopickup );
-            player_activity new_act( new_actor );
-            u.assign_activity( new_act );
+            u.assign_activity( new_actor );
             THEN( "pickup most, nested empty" ) {
                 if( soft_nested ) {
                     test_pickup_autoinsert_results( u, wear, c, 61, 239, 0, true );

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -576,7 +576,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
     auto setup_activity = [&dummy]( const item_location & torch ) -> void {
         boltcutting_activity_actor act{tripoint_zero, torch};
         act.testing = true;
-        dummy.assign_activity( player_activity( act ) );
+        dummy.assign_activity( act );
     };
 
     SECTION( "boltcut start checks" ) {
@@ -840,7 +840,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
     auto setup_activity = [&dummy]( const item_location & torch ) -> void {
         hacksaw_activity_actor act{tripoint_zero, torch};
         act.testing = true;
-        dummy.assign_activity( player_activity( act ) );
+        dummy.assign_activity( act );
     };
 
     SECTION( "hacksaw start checks" ) {
@@ -1106,7 +1106,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
     auto setup_activity = [&dummy]( const item_location & torch ) -> void {
         oxytorch_activity_actor act{tripoint_zero, torch};
         act.testing = true;
-        dummy.assign_activity( player_activity( act ) );
+        dummy.assign_activity( act );
     };
 
     SECTION( "oxytorch start checks" ) {
@@ -1370,7 +1370,7 @@ TEST_CASE( "prying", "[activity][prying]" )
     const tripoint &target = tripoint_zero ) -> void {
         prying_activity_actor act{target, tool};
         act.testing = true;
-        dummy.assign_activity( player_activity( act ) );
+        dummy.assign_activity( act );
     };
 
     SECTION( "prying time tests" ) {

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -454,11 +454,7 @@ TEST_CASE( "reading a book for skill", "[reading][book][skill]" )
             SkillLevel &avatarskill = dummy.get_skill_level_object( bkalpha_islot->skill );
 
             for( int i = 0; i < 100; ++i ) {
-                read_activity_actor::read_book(
-                    *dummy.as_character(),
-                    bkalpha_islot,
-                    avatarskill,
-                    1.0 );
+                read_activity_actor::read_book( *dummy.as_character(), bkalpha_islot, avatarskill, 1.0 );
             }
 
             THEN( "gained a skill level" ) {
@@ -493,14 +489,8 @@ TEST_CASE( "reading a book with an ebook reader", "[reading][book][ereader]" )
         THEN( "player can read the book" ) {
 
             item_location booklc{dummy, &book};
-
-            dummy.activity = player_activity(
-                                 read_activity_actor(
-                                     to_moves<int>( dummy.time_to_read( *booklc, dummy ) ),
-                                     booklc,
-                                     ereader,
-                                     true
-                                 ) );
+            read_activity_actor actor( dummy.time_to_read( *booklc, dummy ), booklc, ereader, true );
+            dummy.activity = player_activity( actor );
 
             dummy.activity.start_or_resume( dummy, false );
             REQUIRE( dummy.activity.id() == ACT_READ );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -147,7 +147,7 @@ struct damage_preset {
 
 static void complete_activity( Character &u, const activity_actor &act )
 {
-    u.assign_activity( player_activity( act ) );
+    u.assign_activity( act );
     while( !u.activity.is_null() ) {
         u.set_moves( u.get_speed() );
         u.activity.do_turn( u );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Tidy signatures so calling assign_activity isn't awkwardly long

#### Describe the solution

https://github.com/CleverRaven/Cataclysm-DDA/commit/c49e37f013a5fbd970e690921022d5abe84e8926 Removes `allow_resume` parameter from the function - all activities that specified "false" already do specify `no_resume` in their json definition so player_activity::can_resume_with will return false anyway making it effectively a noop. It appears the only place where it somewhat has an effect that mattered was in a test and only seems to be there to stop resuming, just clearing activity with a null one should work for that

https://github.com/CleverRaven/Cataclysm-DDA/commit/568aa76de8f85798b7364dd4c3c579c00599018e Unwraps the ""new"" activity_actors into their own overload so they don't need to be wrapped in player_activity at every call site

https://github.com/CleverRaven/Cataclysm-DDA/commit/7afa062d9671d2b8a04b9cf6a9593b5b58bb9bc0 Small cleanup - all callers want to give read_activity_actor a time_duration but it only accepts moves, fixes that

#### Describe alternatives you've considered

#### Testing

Tests should catch a bunch of activities, most changes are just syntax though

#### Additional context
