### PR TITLE
Fixes the Kel-Tec SUB2000’s folding nonsense.

### DIFF
--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -574,7 +574,6 @@
     "dispersion": 180,
     "durability": 7,
     "min_cycle_recoil": 450,
-    "barrel_volume": "250 ml",
     "built_in_mods": [ "sub2000_folding_mechanism" ],
     "valid_mod_locations": [
       [ "accessories", 4 ],

--- a/data/json/items/gunmod/stock.json
+++ b/data/json/items/gunmod/stock.json
@@ -379,7 +379,7 @@
       "moves": 300
     },
     "handling_modifier": -10,
-    "flags": [ "FOLDED_STOCK" ]
+    "//": "This mod shouldn’t get a folding stock flag. The deployed version of this mod adds extra length to the base gun item, which this folded version removes to simulate the greatly shorter length of the sub2000 when collapsed. Adding a folding stock flag will remove another 20 cm from the base gun, making it only 19 cm long."
   },
   {
     "id": "m26_mass_stock",


### PR DESCRIPTION
#### Summary
Bugfixes "fixes #65092, straitens out the Kel-Tec SUB 2000’s folding properties."
#### Purpose of change
The Kel-Tec SUB2000 had a glitch with its folding mechanism that resulted in a bazaar dual-folding cycle, where folding the gun would bring it down to 39 cm in length, unfolding it would extend it to 54 cm, and unfolding it again (yes, you could unfold it again) would bring it to its proper length of 74 cm. This was due to the "folding_stock" flag being present in the json for the folded version of the SUB2000’s integral folding mechanism. On account of how the SUB2000 works in game, with the base gun being 39 cm long (the exact length it is meant to be when folded), the integral mod adding 35 cm in length and bringing it up to its proper overall length of 74 cm, and the mod’s folded configuration simply deducting the added length to bring the weapon back down to 39 cm, the game was trying to additionally factor in an added 20 cm length reduction provided by the flag.
The weapon also had a barrel sawing issue that would reduce the length of the gun, even when it was folded, resulting in a 19-cm-long PCC. This latter point didn’t make sense on account of the fact that, when folded, the SUB2000 has its barrel lying flat against the buttstock in a manner that wouldn’t reduce the gun’s length, even if the barrel was completely hacked off. In addition, I suspect that you can’t saw down the barrel and retain the folding capability, as it would hack off the bit of the barrel designed to lock with the buttstock.
#### Describe the solution
I removed the flag from the mod, adding in a comment to explain why it shouldn’t be re-added in the future, and removed the JSON entry that allowed the SUB2000 to have its barrel sawn.
#### Describe alternatives you've considered
Keeping the adorable teeny tiny 19 cm long carbine and pretending that there isn’t an issue.
#### Testing
I hopped into a game with the changes loaded in and inspected the SUB2000 to ensure that the issues were fixed.
#### Additional context
Consult #65092, where this issue was first brought to light.
