### PR TITLE
Add clang-tidy check looking for opportunities to convert functions to use string_view

### DIFF
--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -311,7 +311,7 @@ void bodygraph_display::draw_borders()
     bh_borders.draw_border( w_border, c_white );
 
     const int first_win_width = partlist_width;
-    auto center_txt_start = [&first_win_width]( const std::string & txt ) {
+    auto center_txt_start = [&first_win_width]( const std::string_view txt ) {
         return 2 + first_win_width + ( BPGRAPH_MAXCOLS / 2 - utf8_width( txt, true ) / 2 );
     };
 

--- a/src/cata_io.h
+++ b/src/cata_io.h
@@ -404,7 +404,7 @@ class JsonObjectOutputArchive
          */
         /*@{*/
         template<typename T>
-        bool io( const std::string &name, const T &value ) {
+        bool io( const std::string_view name, const T &value ) {
             stream.member( name );
             io::detail::has_archive_tag<T>::write( stream, value );
             return false;

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1322,7 +1322,7 @@ void conditional_t::set_compare_num( const JsonObject &jo, const std::string_vie
     }
 }
 
-void conditional_t::set_math( const JsonObject &jo, const std::string &member )
+void conditional_t::set_math( const JsonObject &jo, const std::string_view member )
 {
     eoc_math math;
     math.from_json( jo, member );
@@ -2581,7 +2581,7 @@ void talk_effect_fun_t::set_arithmetic( const JsonObject &jo, const std::string_
     }
 }
 
-void talk_effect_fun_t::set_math( const JsonObject &jo, const std::string &member )
+void talk_effect_fun_t::set_math( const JsonObject &jo, const std::string_view member )
 {
     eoc_math math;
     math.from_json( jo, member );

--- a/src/condition.h
+++ b/src/condition.h
@@ -190,7 +190,7 @@ struct conditional_t {
         void set_can_see( bool is_npc = false );
         void set_compare_string( const JsonObject &jo, const std::string &member );
         void set_compare_num( const JsonObject &jo, std::string_view member );
-        void set_math( const JsonObject &jo, const std::string &member );
+        void set_math( const JsonObject &jo, std::string_view member );
         template<class J>
         static std::function<double( dialogue const & )> get_get_dbl( J const &jo );
         static std::function<double( dialogue const & )> get_get_dbl( const std::string &value,

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -102,7 +102,7 @@ struct talk_effect_fun_t {
         void set_add_faction_trust( const JsonObject &jo, const std::string &member );
         void set_lose_faction_trust( const JsonObject &jo, const std::string &member );
         void set_arithmetic( const JsonObject &jo, std::string_view member, bool no_result );
-        void set_math( const JsonObject &jo, const std::string &member );
+        void set_math( const JsonObject &jo, std::string_view member );
         void set_set_string_var( const JsonObject &jo, const std::string &member );
         void set_custom_light_level( const JsonObject &jo, const std::string &member );
         void set_spawn_monster( const JsonObject &jo, const std::string &member, bool is_npc );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1608,7 +1608,7 @@ tripoint item::get_var( const std::string &name, const tripoint &default_value )
     }
     std::vector<std::string> values = string_split( it->second, ',' );
     cata_assert( values.size() == 3 );
-    auto convert_or_error = []( const std::string & s ) {
+    auto convert_or_error = []( const std::string_view s ) {
         ret_val<int> result = try_parse_integer<int>( s, false );
         if( result.success() ) {
             return result.value();

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5751,7 +5751,7 @@ static void init_memory_card_with_random_stuff( item &it )
     }
 }
 
-static int get_quality_from_string( const std::string &s )
+static int get_quality_from_string( const std::string_view s )
 {
     const ret_val<int> try_quality = try_parse_integer<int>( s, false );
     if( try_quality.success() ) {

--- a/src/json.h
+++ b/src/json.h
@@ -827,7 +827,7 @@ class JsonOut
             write( io::enum_to_string<E>( value ) );
         }
 
-        void write_as_string( const std::string &s ) {
+        void write_as_string( const std::string_view s ) {
             write( s );
         }
 

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -603,7 +603,7 @@ void map_data_common_t::load_symbol( const JsonObject &jo, const std::string &co
     if( has_color && has_bgcolor ) {
         jo.throw_error( "Found both color and bgcolor, only one of these is allowed." );
     } else if( has_color ) {
-        load_season_array( jo, "color", context, color_, []( const std::string & str ) {
+        load_season_array( jo, "color", context, color_, []( const std::string_view str ) {
             // has to use a lambda because of default params
             return color_from_string( str );
         } );

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1445,7 +1445,8 @@ std::string word_rewrap( const std::string &in, int width, const uint32_t split 
     return o;
 }
 
-void draw_tab( const catacurses::window &w, int iOffsetX, const std::string &sText, bool bSelected )
+void draw_tab( const catacurses::window &w, int iOffsetX, const std::string_view sText,
+               bool bSelected )
 {
     int iOffsetXRight = iOffsetX + utf8_width( sText, true ) + 1;
 

--- a/src/output.h
+++ b/src/output.h
@@ -758,7 +758,7 @@ std::string get_labeled_bar( double val, int width, const std::string &label,
  */
 std::string get_labeled_bar( double val, int width, const std::string &label, char c );
 
-void draw_tab( const catacurses::window &w, int iOffsetX, const std::string &sText,
+void draw_tab( const catacurses::window &w, int iOffsetX, std::string_view sText,
                bool bSelected );
 inclusive_rectangle<point> draw_subtab( const catacurses::window &w, int iOffsetX,
                                         const std::string &sText, bool bSelected,

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -168,7 +168,7 @@ std::vector<const recipe *> recipe_subset::recent() const
 }
 
 std::vector<const recipe *> recipe_subset::search(
-    const std::string &txt, const search_type key,
+    const std::string_view txt, const search_type key,
     const std::function<void( size_t, size_t )> &progress_callback ) const
 {
     auto predicate = [&]( const recipe * r ) {
@@ -304,7 +304,7 @@ recipe_subset::recipe_subset( const recipe_subset &src, const std::vector<const 
 }
 
 recipe_subset recipe_subset::reduce(
-    const std::string &txt, const search_type key,
+    const std::string_view txt, const search_type key,
     const std::function<void( size_t, size_t )> &progress_callback ) const
 {
     return recipe_subset( *this, search( txt, key, progress_callback ) );

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -165,11 +165,11 @@ class recipe_subset
 
         /** Find recipes matching query (left anchored partial matches are supported) */
         std::vector<const recipe *> search(
-            const std::string &txt, search_type key = search_type::name,
+            std::string_view txt, search_type key = search_type::name,
             const std::function<void( size_t, size_t )> &progress_callback = {} ) const;
         /** Find recipes matching query and return a new recipe_subset */
         recipe_subset reduce(
-            const std::string &txt, search_type key = search_type::name,
+            std::string_view txt, search_type key = search_type::name,
             const std::function<void( size_t, size_t )> &progress_callback = {} ) const;
         /** Set intersection between recipe_subsets */
         recipe_subset intersection( const recipe_subset &subset ) const;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4714,7 +4714,7 @@ void stats_tracker::deserialize( const JsonObject &jo )
 namespace
 {
 
-void _write_rle_terrain( JsonOut &jsout, std::string const &ter, int num )
+void _write_rle_terrain( JsonOut &jsout, const std::string_view ter, int num )
 {
     jsout.start_array();
     jsout.write( ter );

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -205,7 +205,7 @@ class uistatedata
 
         // nice little convenience function for serializing an array, regardless of amount. :^)
         template<typename T>
-        void serialize_array( JsonOut &json, const std::string &name, T &data ) const {
+        void serialize_array( JsonOut &json, const std::string_view name, T &data ) const {
             json.member( name );
             json.start_array();
             for( const auto &d : data ) {

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -4,7 +4,7 @@
 #include "cata_catch.h"
 #include "output.h"
 
-static void test_remove_color_tags( const std::string &original, const std::string &expected )
+static void test_remove_color_tags( const std::string_view original, const std::string &expected )
 {
     CHECK( remove_color_tags( original ) == expected );
 }

--- a/tools/clang-tidy-plugin/CMakeLists.txt
+++ b/tools/clang-tidy-plugin/CMakeLists.txt
@@ -40,6 +40,7 @@ set(CataAnalyzerSrc
         UseNamedPointConstantsCheck.cpp
         UsePointApisCheck.cpp
         UsePointArithmeticCheck.cpp
+        UseStringViewCheck.cpp
         UTF8ToLowerUpperCheck.cpp
         Utils.cpp
         XYCheck.cpp)

--- a/tools/clang-tidy-plugin/CataTidyModule.cpp
+++ b/tools/clang-tidy-plugin/CataTidyModule.cpp
@@ -36,6 +36,7 @@
 #include "UseNamedPointConstantsCheck.h"
 #include "UsePointApisCheck.h"
 #include "UsePointArithmeticCheck.h"
+#include "UseStringViewCheck.h"
 #include "UTF8ToLowerUpperCheck.h"
 #include "XYCheck.h"
 
@@ -105,6 +106,7 @@ class CataModule : public ClangTidyModule
                 "cata-use-named-point-constants" );
             CheckFactories.registerCheck<UsePointApisCheck>( "cata-use-point-apis" );
             CheckFactories.registerCheck<UsePointArithmeticCheck>( "cata-use-point-arithmetic" );
+            CheckFactories.registerCheck<UseStringViewCheck>( "cata-use-string_view" );
             CheckFactories.registerCheck<UTF8ToLowerUpperCheck>( "cata-utf8-no-to-lower-to-upper" );
             CheckFactories.registerCheck<XYCheck>( "cata-xy" );
         }

--- a/tools/clang-tidy-plugin/UseStringViewCheck.cpp
+++ b/tools/clang-tidy-plugin/UseStringViewCheck.cpp
@@ -1,0 +1,244 @@
+#include "UseStringViewCheck.h"
+
+#include <algorithm>
+#include <clang/AST/ASTContext.h>
+#include <clang/AST/Decl.h>
+#include <clang/AST/DeclBase.h>
+#include <clang/AST/DeclTemplate.h>
+#include <clang/AST/Expr.h>
+#include <clang/AST/ExprCXX.h>
+#include <clang/AST/Type.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/ASTMatchers/ASTMatchersInternal.h>
+#include <clang/Basic/Diagnostic.h>
+#include <clang/Basic/DiagnosticIDs.h>
+#include <clang/Basic/LLVM.h>
+#include <clang/Basic/SourceLocation.h>
+#include <clang/Lex/Lexer.h>
+#include <climits>
+#include <llvm/ADT/Twine.h>
+#include <llvm/Support/Casting.h>
+#include <string>
+
+#include "Utils.h"
+#include "clang/Basic/OperatorKinds.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::cata
+{
+
+static auto isConstStringRef()
+{
+    using namespace clang::ast_matchers;
+    return qualType(
+               hasCanonicalType(
+                   references(
+                       qualType(
+                           allOf(
+                               isConstQualified(),
+                               hasDeclaration(
+                                   namedDecl( hasAnyName( "std::string", "std::basic_string" ) )
+                               )
+                           )
+                       )
+                   )
+               )
+           );
+}
+
+static auto refToStringRefParam()
+{
+    return declRefExpr( to( parmVarDecl( hasType( isConstStringRef() ) ).bind( "param" ) ) );
+}
+
+void UseStringViewCheck::registerMatchers( MatchFinder *Finder )
+{
+    Finder->addMatcher(
+        functionDecl(
+            hasAnyParameter( parmVarDecl( hasType( isConstStringRef() ) ).bind( "param" ) )
+        ).bind( "function" ),
+        this
+    );
+    // This looks for passing a string as a parameter to a function taking a
+    // const string&
+    Finder->addMatcher(
+        callExpr(
+            forEachArgumentWithParamType(
+                refToStringRefParam(),
+                isConstStringRef()
+            ),
+            callee( functionDecl().bind( "callee" ) )
+        ),
+        this
+    );
+    // This looks for passing a string to a function of dependent type, so we
+    // can't know if it's safe to transform
+    Finder->addMatcher(
+        callExpr(
+            hasAnyArgument( refToStringRefParam() ),
+            isTypeDependent()
+        ).bind( "badExpr" ),
+        this
+    );
+    // This looks for passing a string to a constructor taking a const string&
+    Finder->addMatcher(
+        cxxConstructExpr(
+            forEachArgumentWithParamType(
+                refToStringRefParam(),
+                isConstStringRef()
+            ),
+            hasDeclaration( functionDecl().bind( "callee" ) )
+        ),
+        this
+    );
+    // This looks for passing a string to a dependent constructor
+    Finder->addMatcher(
+        cxxUnresolvedConstructExpr( hasAnyArgument( refToStringRefParam() ) ).bind( "badExpr" ),
+        this
+    );
+    // This looks for calling a member function on a string
+    Finder->addMatcher(
+        cxxMemberCallExpr(
+            on( refToStringRefParam() ),
+            hasDeclaration( functionDecl().bind( "callee" ) )
+        ).bind( "membercall" ),
+        this
+    );
+    // This looks for binding a string to a const& member variable
+    Finder->addMatcher(
+        cxxCtorInitializer(
+            withInitializer( refToStringRefParam() ),
+            forField( fieldDecl( hasType( isConstStringRef() ) ).bind( "field" ) )
+        ),
+        this
+    );
+    // This looks fo a different structure that happens in constructor
+    // templates sometimes
+    // `-CXXConstructorDecl A10<T> 'void (const std::string &, const T &)'
+    //   |-CXXCtorInitializer 'A10b'
+    //   | `-ParenListExpr 'NULL TYPE'
+    //   |   `-DeclRefExpr 'const std::string' lvalue ParmVar 's' 'const std::string &'
+    // Strangely the CXXCtorInitializer level doesn't seem to appear in the
+    // parent structure for matchers, so we can't actually match the field
+    // being initialized.
+    Finder->addMatcher(
+        declRefExpr(
+            refToStringRefParam(),
+            hasParent( parenListExpr( hasParent( cxxConstructorDecl() ) ) )
+        ).bind( "badExpr" ),
+        this
+    );
+    // This looks for returning the parameter
+    Finder->addMatcher(
+        returnStmt( hasReturnValue( refToStringRefParam().bind( "badExpr" ) ) ),
+        this
+    );
+    // This looks for taking the address of the parameter
+    Finder->addMatcher(
+        unaryOperator(
+            hasOperatorName( "&" ),
+            hasUnaryOperand( refToStringRefParam().bind( "badExpr" ) )
+        ),
+        this
+    );
+}
+
+void UseStringViewCheck::check( const MatchFinder::MatchResult &Result )
+{
+    const ParmVarDecl *Param = Result.Nodes.getNodeAs<ParmVarDecl>( "param" );
+    const FunctionDecl *Callee = Result.Nodes.getNodeAs<FunctionDecl>( "callee" );
+    const Expr *BadExpr = Result.Nodes.getNodeAs<Expr>( "badExpr" );
+    const FieldDecl *Field = Result.Nodes.getNodeAs<FieldDecl>( "field" );
+    if( Callee || Field || BadExpr ) {
+        // This means we should abort our attempt to rewrite the containing
+        // function
+        if( Result.Nodes.getNodeAs<CXXMemberCallExpr>( "membercall" ) ) {
+            if( const CXXMethodDecl *MethodCallee = dyn_cast<CXXMethodDecl>( Callee ) ) {
+                if( !MethodCallee->getDeclName().isIdentifier() ||
+                    MethodCallee->getName() != "c_str" ) {
+                    // ...with the exception of calls to member functions other
+                    // than c_str, since those should continue to work on
+                    // string_view.
+                    return;
+                }
+            }
+        }
+        auto func_it = function_from_param_.find( Param );
+        if( func_it != function_from_param_.end() ) {
+            found_defns_.erase( func_it->second->getFirstDecl() );
+        }
+        return;
+    }
+
+    const FunctionDecl *Func = Result.Nodes.getNodeAs<FunctionDecl>( "function" );
+
+    if( !Param || !Func ) {
+        return;
+    }
+
+    if( Func->isTemplateInstantiation() ) {
+        return;
+    }
+
+    if( Func->isImplicit() ) {
+        return;
+    }
+
+    if( const CXXMethodDecl *Method = dyn_cast<CXXMethodDecl>( Func ) ) {
+        if( Method->isVirtual() ) {
+            return;
+        }
+    }
+
+    function_from_param_.emplace( Param, Func );
+
+    std::string DeclarationReplacementText = "std::string_view";
+    if( !Param->getName().empty() ) {
+        DeclarationReplacementText += " ";
+        DeclarationReplacementText += Param->getName();
+    }
+
+    const bool IsDefinition = Func->getDefinition() == Func;
+    if( IsDefinition ) {
+        // Save the replacement info for later use if we encounter the
+        // definition later
+        found_defns_.emplace(
+            Func->getFirstDecl(),
+            FoundStringViewDefn{ Param, Func, DeclarationReplacementText } );
+        return;
+    } else {
+        // Save the replacement info for later use if we encounter the
+        // definition later
+        found_decls_.emplace(
+            Func->getFirstDecl(),
+            FoundStringViewDecl{ Param->getSourceRange(), DeclarationReplacementText } );
+        return;
+    }
+}
+
+void UseStringViewCheck::onEndOfTranslationUnit()
+{
+    for( const std::pair<const FunctionDecl *const, FoundStringViewDefn> &p : found_defns_ ) {
+        const ParmVarDecl *Param = p.second.param;
+        const FunctionDecl *Func = p.second.func;
+        // Go back and collect all the previously saved FixIts for declarations of
+        // this function
+        std::vector<FixItHint> fixits;
+
+        auto prior_matches = found_decls_.equal_range( Func->getFirstDecl() );
+        for( auto it = prior_matches.first; it != prior_matches.second; ++it ) {
+            const FoundStringViewDecl &prior = it->second;
+            fixits.push_back( FixItHint::CreateReplacement( prior.range, prior.text ) );
+        }
+
+        const std::string DefinitionReplacementText = "const " + p.second.text;
+        diag( Param->getBeginLoc(), "Parameter %0 of %1 can be std::string_view." )
+                << Param << Func <<
+                FixItHint::CreateReplacement( Param->getSourceRange(), DefinitionReplacementText )
+                << fixits;
+    }
+}
+
+} // namespace clang::tidy::cata

--- a/tools/clang-tidy-plugin/UseStringViewCheck.h
+++ b/tools/clang-tidy-plugin/UseStringViewCheck.h
@@ -1,0 +1,50 @@
+#ifndef CATA_TOOLS_CLANG_TIDY_PLUGIN_USESTRINGVIEWCHECK_H
+#define CATA_TOOLS_CLANG_TIDY_PLUGIN_USESTRINGVIEWCHECK_H
+
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <llvm/ADT/StringRef.h>
+
+#include "ClangTidy.h"
+#include "ClangTidyCheck.h"
+
+namespace clang
+{
+
+namespace tidy
+{
+class ClangTidyContext;
+
+namespace cata
+{
+
+struct FoundStringViewDecl {
+    SourceRange range;
+    std::string text;
+};
+
+struct FoundStringViewDefn {
+    const ParmVarDecl *param;
+    const FunctionDecl *func;
+    std::string text;
+};
+
+class UseStringViewCheck : public ClangTidyCheck
+{
+    public:
+        UseStringViewCheck( StringRef Name, ClangTidyContext *Context )
+            : ClangTidyCheck( Name, Context ) {}
+        void registerMatchers( ast_matchers::MatchFinder *Finder ) override;
+        void check( const ast_matchers::MatchFinder::MatchResult &Result ) override;
+        void onEndOfTranslationUnit() override;
+
+    private:
+        std::unordered_multimap<const FunctionDecl *, FoundStringViewDecl> found_decls_;
+        std::unordered_map<const FunctionDecl *, FoundStringViewDefn> found_defns_;
+        std::unordered_map<const ParmVarDecl *, const FunctionDecl *> function_from_param_;
+};
+
+} // namespace cata
+} // namespace tidy
+} // namespace clang
+
+#endif // CATA_TOOLS_CLANG_TIDY_PLUGIN_USESTRINGVIEWCHECK_H

--- a/tools/clang-tidy-plugin/test/use-string_view.cpp
+++ b/tools/clang-tidy-plugin/test/use-string_view.cpp
@@ -1,0 +1,154 @@
+// RUN: %check_clang_tidy %s cata-use-string_view %t -- -plugins=%cata_plugin -- -isystem %cata_include
+
+namespace std
+{
+
+template<class T>
+struct allocator;
+
+template<class CharT>
+class char_traits;
+
+template <
+    class CharT,
+    class Traits = std::char_traits<CharT>,
+    class Allocator = std::allocator<CharT>
+    > class basic_string
+{
+    public:
+        unsigned size() const;
+        const char *c_str() const;
+};
+
+typedef basic_string<char> string;
+
+}
+
+// Should change both declaration and definition when both are present, and
+// retain their respective parameter names.
+
+void f0( const std::string & );
+// CHECK-FIXES: void f0( std::string_view );
+
+void f0( const std::string &s )
+// CHECK-MESSAGES: warning: Parameter 's' of 'f0' can be std::string_view. [cata-use-string_view]
+// CHECK-FIXES: void f0( const std::string_view s )
+{
+}
+
+// Should not change declarations without a definition
+void f1( const std::string &s );
+
+// Should not change declarations where the string is passed as a string to
+// another function
+void f2( const std::string &s )
+{
+    f1( s );
+}
+
+// Template functions should only generate a single replacement
+template<typename T>
+void f3( const std::string &s, const T & )
+// CHECK-MESSAGES: warning: Parameter 's' of 'f3' can be std::string_view. [cata-use-string_view]
+// CHECK-FIXES: void f3( const std::string_view s, const T & )
+{
+}
+
+void f3a( const std::string &s )
+{
+    f3( s, 0 );
+    f3( s, true );
+}
+
+struct A4 {
+    std::string s4;
+
+    A4( const std::string &s ) : s4( s ) {}
+};
+
+// Should not change declarations where the string has .c_str() called on it.
+void f5( const std::string &s )
+{
+    s.c_str();
+}
+
+// But should change declarations where the string has other member functions
+// called on it.
+void f6( const std::string &s )
+// CHECK-MESSAGES: warning: Parameter 's' of 'f6' can be std::string_view. [cata-use-string_view]
+// CHECK-FIXES: void f6( const std::string_view s )
+{
+    s.size();
+}
+
+// Don't change when initializing a const reference member.
+struct A7 {
+    const std::string &s7;
+
+    A7( const std::string &s ) : s7( s ) {}
+};
+
+// Don't change when a template function calling another template function
+template<typename T>
+void f8( const T &t, const std::string &s )
+{
+    f3( s, t );
+}
+
+// Don't change when passing to a constructor of a class template
+template<typename T>
+struct A9 {
+    A9( const std::string & );
+};
+
+template<typename T>
+void f9( const std::string &s )
+{
+    static_cast<void>( A9<T>( s ) );
+}
+
+// Don't change when passing to a base class constructor
+struct A10b {
+    A10b( const std::string & );
+};
+
+template<typename T>
+struct A10 : A10b {
+    A10( const std::string &s, const T & ) : A10b( s ) {}
+};
+
+// Don't change when passing to an argument of a member function whose type is
+// taken from a class template parameter via a typedef (imitating
+// std::unordered_map::find).
+template<typename T>
+struct A11 {
+    using type = T;
+    void m11( const type & );
+};
+
+struct A11b {
+    template<typename T>
+    void m11b( const std::string &s, const T & ) {
+        a.m11( s );
+    }
+
+    A11<std::string> a;
+};
+
+// Don't change when returning the value
+template<typename T>
+T f12( const std::string &s )
+{
+    return s;
+}
+
+// Don't change virtual functions
+struct A13 {
+    virtual void m13( const std::string & ) {}
+};
+
+// Don't change if address taken
+const std::string *f14( const std::string &s )
+{
+    return &s;
+}

--- a/tools/llama/clang_tidy.sh
+++ b/tools/llama/clang_tidy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This is a helper script intended to assist with running clang-tidy on Amazon
+# Lambda via llama.  This can dramatically accelerate clang-tidy runs,
+# something which can otherwise be quite slow!
+
+set -eu
+
+if [ $# -ge 1 ]
+then
+    file_regex="$1"
+else
+    file_regex='.'
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+top_dir="$(dirname "$script_dir")"
+
+list_of_files=$(grep '"file": "' build/compile_commands.json | \
+    sed "s+.*$PWD/++;s+\"$++" | \
+    egrep "$file_regex")
+
+plugin_lib="$top_dir/build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so"
+plugin_opt=
+if [ -r "$plugin_lib" ]
+then
+    plugin_opt="-plugins=$plugin_lib"
+fi
+
+printf '%s\n' "$list_of_files" | \
+    llama xargs -logs -j 10 gcc \
+        clang-tidy -quiet ${plugin_opt:+"$plugin_opt"} \
+        -export-fixes='{{.O (printf "fixes/%s" .Line)}}' '{{.I .Line}}'


### PR DESCRIPTION
#### Summary
Infrastructure "Add clang-tidy check looking for opportunities to convert functions to use string_view"

#### Purpose of change
Code modernization and simplification.

The primary goals of `std::string_view` are:
* One function can take any contiguous character range type, such as `std::string` or `const char*` (but also potentially more) rather than having to keep separate overloads.
* Passing something other than a `std::string` to such a function should never require an allocation (previously, passing a `const char*` would require an allocation).
* `std::string_view` is a simpler type, so it is easier for compilers to optimize around.

The biggest disadvantages are:
* The contained string may not be nul-terminated, so it requires conversion to a `std::string` before calling `c_str` and passing to any C-style API that expects nul-terminated strings.
* It makes accidentally creating a `string_view` which is a dangling reference to some once-allocated-but-now-freed characters rather too easy.

The latter disadvantage is mitigated somewhat by a `clang-tidy` check we were already running.  But a rule of thumb reviewers should bear in mind is that it's always risky to return a `string_view` from a function.

#### Describe the solution
Add a `clang-tidy` check looking for opportunities to convert functions to use `string_view`.

This check looks for functions that currently have `const std::string &` parameters which could have those parameters changed to use `std::string_view` instead.

It tried to be relatively conservative in what it changes, so that the majority of changed functions should continue to compile and function correctly (although there certainly remain some corner cases where it can run into trouble).

Here are (most of) the reasons a parameter might not be converted to `string_view`:

- If we do not see the function definition.
- If the parameter is passed to another function as a `const string &`.
- If the parameter is passed to a function with dependent type.
- If the parameter is passed to an unresolved constructor.
- If the function is a template instantiation.
- If the function is implicitly generated by the compiler.
- If the parameter is used to initialize a string class member.
- If the parameter is bound to a string reference.
- If `c_str()` is called on the parameter.
- If the parameter is returned from the function as a string.
- If the function is virtual.
- If the address of the parameter is taken.

#### Describe alternatives you've considered
I could have weakened some of the constraints and done more manual conversion of functions, but I think this is a good start.

#### Testing
Unit tests.  clang-tidy.

#### Additional context
This is the last of my personal to-do list of updates we wanted to urgently take to take advantage of C++17.  I plan to move onto other things now.