### PR TITLE
Install gettext on pull translations workflow

### DIFF
--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -9,6 +9,8 @@ jobs:
     if: github.repository == 'CleverRaven/Cataclysm-DDA'
     runs-on: ubuntu-22.04
     steps:
+      - name: install gettext tools
+        run: sudo apt-get install gettext
       - name: "Install Transifex CLI"
         run: |
           curl -sL https://github.com/transifex/cli/releases/download/v1.6.4/tx-linux-amd64.tar.gz | sudo tar zxvf - -C /usr/bin tx


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I added use of `msgattrib` to the pull-translations workflow, but it wasn't installed.  See [this run](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4770318589/jobs/8481469571), for example.

#### Describe the solution
Install `gettext` on the runner before other steps.

#### Describe alternatives you've considered
None.

#### Testing
Will be tested next time the workflow runs.

#### Additional context