### PR TITLE
Split clang-tidy workflow into two parts

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -39,12 +39,20 @@ jobs:
     needs: skip-duplicates
     if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
 
+    strategy:
+      fail-fast: true
+      matrix:
+        # To make the run finish in the run time limit, we split it up into two
+        # parts: the src directory and everything else
+        subset: [ 'src', 'other' ]
+
     runs-on: ubuntu-20.04
     env:
         CMAKE: 1
         CLANG: clang++-12
         COMPILER: clang++-12
         CATA_CLANG_TIDY: plugin
+        CATA_CLANG_TIDY_SUBSET: ${{ matrix.subset }}
         TILES: 1
         SOUND: 1
         RELEASE: 1

--- a/build-scripts/clang-tidy.sh
+++ b/build-scripts/clang-tidy.sh
@@ -121,6 +121,19 @@ else
     fi
 fi
 
+printf "Subset to analyze: '%s'\n" "$CATA_CLANG_TIDY_SUBSET"
+
+# We might need to analyze only a subset of the files if they have been split
+# into multiple jobs for efficiency
+case "$CATA_CLANG_TIDY_SUBSET" in
+    ( src )
+        tidyable_cpp_files=$(printf '%s\n' "$tidyable_cpp_files" | grep '/src/')
+        ;;
+    ( other )
+        tidyable_cpp_files=$(printf '%s\n' "$tidyable_cpp_files" | grep -v '/src/')
+        ;;
+esac
+
 function analyze_files_in_random_order
 {
     if [ -n "$1" ]


### PR DESCRIPTION
#### Summary
Infrastructure "Brief description"

#### Purpose of change
The full clang-tidy run takes too long when it has to run on everything, and causes false failures on PR CI.

#### Describe the solution
Split it into one part for src and one for everything else.

#### Describe alternatives you've considered
I borrowed this idea from #64699 which implemented it differently.  I prefer to have more logic in shell scripts and less in GitHub workflows.

#### Testing
I checked by running the build script locally, but it can only really be tested on CI because I can't reproduce everything.

#### Additional context
Thanks to @BrettDong for the idea of how to achieve this.