### PR TITLE
Abstracts are now abstract

### DIFF
--- a/data/json/items/generic/skulls.json
+++ b/data/json/items/generic/skulls.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "GENERIC",
-    "id": "skull_abstract",
+    "abstract": "skull_abstract",
     "name": { "str": "abstract skull" },
     "description": "This is a dummy item.  If you see it something went wrong.",
     "flags": [ "TRADER_AVOID" ],

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -41,7 +41,7 @@
     "flags": [ "SMELLS", "HEARS", "SEES", "SWIMS", "GRABS", "ARTHROPOD_BLOOD", "QUEEN", "PATH_AVOID_DANGER_1" ]
   },
   {
-    "id": "mon_fish_tiny",
+    "abstract": "mon_fish_tiny",
     "type": "MONSTER",
     "name": { "str_sp": "tiny fish" },
     "//": "a default fish type - does not appear in-game",
@@ -71,7 +71,7 @@
     "flags": [ "FISHABLE", "SEES", "SMELLS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
   },
   {
-    "id": "mon_fish_small",
+    "abstract": "mon_fish_small",
     "type": "MONSTER",
     "name": { "str_sp": "small fish" },
     "//": "a default fish type - does not appear in-game",
@@ -102,7 +102,7 @@
     "flags": [ "FISHABLE", "SEES", "SMELLS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
   },
   {
-    "id": "mon_fish_medium",
+    "abstract": "mon_fish_medium",
     "type": "MONSTER",
     "description": "A medium fish.",
     "default_faction": "fish",
@@ -133,7 +133,7 @@
     "flags": [ "FISHABLE", "SEES", "SMELLS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
   },
   {
-    "id": "mon_fish_large",
+    "abstract": "mon_fish_large",
     "type": "MONSTER",
     "description": "A large fish.",
     "default_faction": "fish",
@@ -164,7 +164,7 @@
     "flags": [ "FISHABLE", "SEES", "SMELLS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
   },
   {
-    "id": "mon_fish_huge",
+    "abstract": "mon_fish_huge",
     "type": "MONSTER",
     "description": "A huge fish.",
     "default_faction": "fish",
@@ -195,7 +195,7 @@
     "flags": [ "FISHABLE", "SEES", "SMELLS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
   },
   {
-    "id": "mon_fry",
+    "abstract": "mon_fry",
     "type": "MONSTER",
     "name": { "str_sp": "fish fry" },
     "//": "a default fish type - does not appear in-game",

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "mon_larva_abstract",
+    "abstract": "mon_larva_abstract",
     "type": "MONSTER",
     "name": { "str": "larva", "str_pl": "larvae" },
     "description": "A fake monster.  If you're seeing this something went wrong.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Some of the abstract items weren't properly made abstracts (half of which due to my negligence) so I decided to clean that up. Mainly because it annoyed me they showed up on HHG, honestly.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changes the affected items and monsters to abstracts.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I wanted to give it to ``human`` and ``child`` as well but abstracts can't revive so this breaks mapgen-spawned corpses
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->