### PR TITLE
fix Free Merchant guard gear groups

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/generic_class_definitions.json
+++ b/data/json/npcs/refugee_center/surface_staff/generic_class_definitions.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "item_group",
-    "id": "FREE_MERCH_GUARD_wield_phase1",
+    "id": "NC_FREE_MERCH_GUARD_wield_phase1",
     "//": "Initially the free mechant guards indoors stick to melee weapons, as most of these folks aren't trained to use guns.",
     "subtype": "distribution",
     "entries": [
@@ -53,6 +53,8 @@
     "id": "NC_FREE_MERCH_GUARD",
     "name": { "str": "Guard" },
     "job_description": "I'm on a guard shift.",
+    "weapon_override": "NC_FREE_MERCH_GUARD_wield_phase1",
+    "worn_override": "NC_FREE_MERCH_GUARD_worn_phase1",
     "traits": [
       { "group": "NPC_starting_traits" },
       { "group": "Appearance_demographics" },


### PR DESCRIPTION
#### Summary
Bugfixes "fix Free Merchant guard gear groups"

#### Purpose of change

fix broken content

#### Describe the solution

This section of code was used as a template to build the Great Library faction in #65194 , where @MNG-cataclysm correctly noticed that it was broken. This PR fixes that.

#### Describe alternatives you've considered

Do nothing

#### Testing

Game loads no errors, guards spawn and look right

<img width="1038" alt="Screenshot 2023-04-23 at 6 58 20 PM" src="https://user-images.githubusercontent.com/26608431/233871898-e0202017-0035-4242-ac0f-935068224bb7.png">


#### Additional context

The github history isn't clear to me, but it appears to me that this content was intended to be used instead of generic NPC gear