### PR TITLE
Fix UPS powered guns with non integer kJ energy consumption

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8752,12 +8752,9 @@ units::energy Character::consume_ups( units::energy qty, const int radius )
 
     // UPS from inventory
     if( qty != 0_kJ ) {
-        int qty_kj = units::to_kilojoule( qty );
         std::vector<const item *> ups_items = all_items_with_flag( flag_IS_UPS );
         for( const item *i : ups_items ) {
-            int consumed = const_cast<item *>( i )->ammo_consume( qty_kj, tripoint_zero, nullptr );
-            qty_kj -= consumed;
-            qty -= units::from_kilojoule( consumed );
+            qty -= const_cast<item *>( i )->energy_consume( qty, tripoint_zero, nullptr );
         }
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5762,7 +5762,6 @@ std::list<item> map::use_charges( const tripoint &origin, const int range,
 units::energy map::consume_ups( const tripoint &origin, const int range, units::energy qty )
 {
     const units::energy wanted_qty = qty;
-    int qty_kj = units::to_kilojoule( qty );
 
     // populate a grid of spots that can be reached
     std::vector<tripoint> reachable_pts;
@@ -5774,8 +5773,8 @@ units::energy map::consume_ups( const tripoint &origin, const int range, units::
             map_stack items = i_at( p );
             for( item &elem : items ) {
                 if( elem.has_flag( flag_IS_UPS ) ) {
-                    qty_kj -=  elem.ammo_consume( qty_kj, p, nullptr );
-                    if( qty_kj == 0 ) {
+                    qty -=  elem.energy_consume( qty, p, nullptr );
+                    if( qty <= 0_J ) {
                         break;
                     }
                 }
@@ -5783,7 +5782,7 @@ units::energy map::consume_ups( const tripoint &origin, const int range, units::
         }
     }
 
-    return wanted_qty - units::from_kilojoule( qty_kj );
+    return wanted_qty - qty;
 }
 
 std::list<std::pair<tripoint, item *> > map::get_rc_items( const tripoint &p )


### PR DESCRIPTION


#### Summary
Bugfixes "Fix UPS powered guns with non integer kJ energy consumption"

#### Purpose of change

Fix #65257


#### Describe the solution

UPS consumption used ammo_consume() which does not have extra handling for non integer energy consumption.
Now it uses energy_consume() instead.

#### Describe alternatives you've considered

#### Testing

Fired XM-P plasma rifle with effective emitter (4.5 kJ consumption). It works and consumes 5 kJ per shot.

#### Additional context
