### PR TITLE
Add 'bearable protein rations' and recipe for them

### DIFF
--- a/data/json/items/comestibles/protein.json
+++ b/data/json/items/comestibles/protein.json
@@ -76,6 +76,26 @@
     "vitamins": [ [ "calcium", 30 ], [ "iron", 30 ], [ "vitC", 30 ], [ "bad_food", 5 ] ]
   },
   {
+    "id": "bearable_protein_ration",
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "name": { "str": "bearable protein ration" },
+    "//": "Inspired by, but not based on, a true story",
+    "description": "A standard protein ration from an evac shelter, made significantly more bearable by sweetening it. Despite your efforts, the texture of the meal could not be saved.",
+    "weight": "160 g",
+    "volume": "230 ml",
+    "price": 500,
+    "price_postapoc": 60,
+    "flags": [ "EDIBLE_FROZEN" ],
+    "fun": -1,
+    "quench": -5,
+    "material": [ "fruit", "veggy" ],
+    "symbol": "%",
+    "color": "green",
+    "calories": 430,
+    "vitamins": [ [ "calcium", 35 ], [ "iron", 35 ], [ "vitC", 35 ] ]
+  },
+  {
     "id": "protein_shake",
     "copy-from": "protein_drink",
     "type": "COMESTIBLE",

--- a/data/json/recipes/food/other.json
+++ b/data/json/recipes/food/other.json
@@ -136,10 +136,19 @@
     "skill_used": "cooking",
     "time": "15 s",
     "autolearn": true,
-    "components": [ 
-		[ [ "protein_bar_evac", 1 ] ],
-		[ [ "honey_bottled", 3 ], [ "honey_glassed", 1 ], [ "sugar", 10 ], [ "sugar_fried", 1 ], [ "chocolate", 1 ], [ "syrup", 2 ], [ "coffee_syrup", 2 ], [ "beet_syrup", 2 ] ]
-	]
+    "components": [
+      [ [ "protein_bar_evac", 1 ] ],
+      [
+        [ "honey_bottled", 3 ],
+        [ "honey_glassed", 1 ],
+        [ "sugar", 10 ],
+        [ "sugar_fried", 1 ],
+        [ "chocolate", 1 ],
+        [ "syrup", 2 ],
+        [ "coffee_syrup", 2 ],
+        [ "beet_syrup", 2 ]
+      ]
+    ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/food/other.json
+++ b/data/json/recipes/food/other.json
@@ -130,6 +130,20 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
+    "result": "bearable_protein_ration",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_OTHER",
+    "skill_used": "cooking",
+    "time": "15 s",
+    "autolearn": true,
+    "components": [ 
+		[ [ "protein_bar_evac", 1 ] ],
+		[ [ "honey_bottled", 3 ], [ "honey_glassed", 1 ], [ "sugar", 10 ], [ "sugar_fried", 1 ], [ "chocolate", 1 ], [ "syrup", 2 ], [ "coffee_syrup", 2 ], [ "beet_syrup", 2 ] ]
+	]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "result": "gelatin_fresh",
     "byproducts": [ [ "formic_acid" ], [ "ruined_chunks" ] ],
     "result_mult": 12,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add 'bearable protein rations' and the recipe to make them"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Protein rations are described as tasting horrible and having an enjoyment modifier to match. However, at this time there are no recipes to make them more palatable - in a survival scenario, even just the basic concept of drizzling some honey onto it salvaged from a kitchen would likely improve the taste if not the texture.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added a new item, the "bearable protein ration," made quickly and easily by combining protein rations and one of several sweetening ingredients, including both forms of honey, sugar, caramel, maple/coffee/beet syrup, etc. This marginally increases the amount of kcal per charge in most cases, save for caramel, which is the most efficient for kcal/volume, but more expensive than simply using sugar.

In the current version, the enjoyment and quench reductions are mitigated (from -5/-9 to -1/-5, respectively) but not removed, and the 'gross food' effect is taken off, as it is now - as the name says - bearable to eat.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Creating multiple variants of the 'bearable' version, including one which was faster, easier and cheaper to make but wouldn't rot and would have a reduced effect, and a second version which was more expensive in both time and materials while also having a spoil timer in exchange for actually reaching a morale-positive enjoyment level. This option was ultimately simplified for a single version, as the chosen ingredients usually have very long to indefinite shelf lives.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

The game boots and loads into worlds without any errors, and the bearable protein ration is craftable immediately at game start, as pouring some honey or sprinkling some sugar in a protein ration is probably not difficult enough to require any skill at food handling.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->