### PR TITLE
math_parser/eoc: migrate arith. weather to math

### DIFF
--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -1144,22 +1144,22 @@
       {
         "text": "Temperature is 21.",
         "topic": "TALK_DONE",
-        "condition": { "compare_num": [ { "weather": "temperature" }, "=", { "const": 21 } ] }
+        "condition": { "math": [ "fahrenheit( weather('temperature') )", "==", "21" ] }
       },
       {
         "text": "Windpower is 15.",
         "topic": "TALK_DONE",
-        "condition": { "compare_num": [ { "weather": "windpower" }, "=", { "const": 15 } ] }
+        "condition": { "math": [ "weather('windpower')", "==", "15" ] }
       },
       {
         "text": "Humidity is 16.",
         "topic": "TALK_DONE",
-        "condition": { "compare_num": [ { "weather": "humidity" }, "=", { "const": 16 } ] }
+        "condition": { "math": [ "weather('humidity')", "==", "16" ] }
       },
       {
         "text": "Pressure is 17.",
         "topic": "TALK_DONE",
-        "condition": { "compare_num": [ { "weather": "pressure" }, "=", { "const": 17 } ] }
+        "condition": { "math": [ "weather('pressure')", "==", "17" ] }
       },
       {
         "text": "Pos_x is 18.",
@@ -1404,22 +1404,22 @@
       {
         "text": "Sets temperature to 2.",
         "topic": "TALK_DONE",
-        "effect": { "arithmetic": [ { "weather": "temperature" }, "=", { "const": 2 } ] }
+        "effect": { "math": [ "weather('temperature')", "=", "from_fahrenheit( 2 )" ] }
       },
       {
         "text": "Sets windpower to 3.",
         "topic": "TALK_DONE",
-        "effect": { "arithmetic": [ { "weather": "windpower" }, "=", { "const": 3 } ] }
+        "effect": { "math": [ "weather('windpower')", "=", "3" ] }
       },
       {
         "text": "Sets humidity to 4.",
         "topic": "TALK_DONE",
-        "effect": { "arithmetic": [ { "weather": "humidity" }, "=", { "const": 4 } ] }
+        "effect": { "math": [ "weather('humidity')", "=", "4" ] }
       },
       {
         "text": "Sets pressure to 5.",
         "topic": "TALK_DONE",
-        "effect": { "arithmetic": [ { "weather": "pressure" }, "=", { "const": 5 } ] }
+        "effect": { "math": [ "weather('pressure')", "=", "5" ] }
       },
       {
         "text": "Sets base strength to 6.",

--- a/data/json/weather_type.json
+++ b/data/json/weather_type.json
@@ -262,12 +262,13 @@
     "rains": false,
     "sound_category": "silent",
     "priority": 20,
-    "required_weathers": [ "clear", "sunny" ],
+    "required_weathers": [ "clear", "sunny", "fog" ],
     "condition": {
       "and": [
         { "math": [ "weather('windpower')", "<", "12" ] },
         { "math": [ "weather('windpower')", ">", "0" ] },
-        { "math": [ "dew_point_factor", "<", "5" ] }
+        { "math": [ "dew_point_factor(celsius(weather('temperature')))", "<=", "2.5" ] },
+        { "math": [ "weather('humidity')", "<", "90" ] }
       ]
     }
   },
@@ -288,32 +289,34 @@
     "rains": false,
     "sound_category": "silent",
     "priority": 20,
-    "required_weathers": [ "mist" ],
+    "required_weathers": [ "clear", "sunny", "mist" ],
     "condition": {
       "and": [
         { "math": [ "weather('windpower')", "<", "12" ] },
         { "math": [ "weather('windpower')", ">", "0" ] },
-        { "math": [ "dew_point_factor", "<=", "2.5" ] }
+        { "math": [ "dew_point_factor(celsius(weather('temperature')))", "<=", "2.5" ] }
       ]
     }
   },
   {
-    "type": "effect_on_condition",
-    "id": "EOC_DEW_POINT_FACTOR",
-    "recurrence": [ "15 minutes", "30 minutes" ],
-    "//": "First and second math calculate the dew point, the third calculate how close the weather to the point it can form a fog",
-    "//2": "dew_point_factor is a difference between actual temperature and the dew point.  the closer it gets to zero, the bigger probability to cause a mist or dew, starting somewhere from 2,5 centigrade or 5 fahrenheit, to zero",
-    "effect": [
-      {
-        "math": [
-          "dprhx",
-          "=",
-          "log ( weather('humidity') / 100 ) + 17.625 * weather('temperature') / ( 516.2 + weather('temperature') )"
-        ]
-      },
-      { "math": [ "dew_point", "=", "516.2 * dprhx / ( 17.625 - dprhx )" ] },
-      { "math": [ "dew_point_factor", "=", "weather('temperature') - ( dew_point )" ] }
-    ]
+    "type": "jmath_function",
+    "id": "dprhx",
+    "num_args": 1,
+    "return": "log(weather('humidity') / 100) + 17.625 * _0 / (243.04 + _0)"
+  },
+  {
+    "type": "jmath_function",
+    "id": "dew_point",
+    "num_args": 1,
+    "//": "Eq. (8) from https://doi.org/10.1175/BAMS-86-2-225; _0 is temperature in Celsius",
+    "return": "243.04 * dprhx(_0) / (17.625 - dprhx(_0))"
+  },
+  {
+    "type": "jmath_function",
+    "id": "dew_point_factor",
+    "num_args": 1,
+    "//": "the closer this difference gets to zero, the bigger the probability for fog to occur, starting at around 2.5 Celsius",
+    "return": "abs( _0 - dew_point(_0) )"
   },
   {
     "id": "early_portal_storm",

--- a/data/json/weather_type.json
+++ b/data/json/weather_type.json
@@ -16,11 +16,7 @@
     "sound_category": "sunny",
     "priority": 10,
     "condition": {
-      "and": [
-        "is_day",
-        { "compare_num": [ { "weather": "pressure" }, ">=", { "const": 1020 } ] },
-        { "compare_num": [ { "weather": "humidity" }, "<", { "const": 70 } ] }
-      ]
+      "and": [ "is_day", { "math": [ "weather('pressure')", ">=", "1020" ] }, { "math": [ "weather('humidity')", "<", "70" ] } ]
     }
   },
   {
@@ -40,12 +36,7 @@
     "rains": false,
     "sound_category": "cloudy",
     "priority": 20,
-    "condition": {
-      "and": [
-        { "compare_num": [ { "weather": "humidity" }, ">=", { "const": 40 } ] },
-        { "compare_num": [ { "weather": "pressure" }, "<", { "const": 1010 } ] }
-      ]
-    }
+    "condition": { "and": [ { "math": [ "weather('humidity')", ">=", "40" ] }, { "math": [ "weather('pressure')", "<", "1010" ] } ] }
   },
   {
     "id": "light_drizzle",
@@ -67,12 +58,7 @@
     "sound_category": "drizzle",
     "required_weathers": [ "cloudy" ],
     "priority": 30,
-    "condition": {
-      "or": [
-        { "compare_num": [ { "weather": "humidity" }, ">=", { "const": 96 } ] },
-        { "compare_num": [ { "weather": "pressure" }, "<", { "const": 1003 } ] }
-      ]
-    }
+    "condition": { "or": [ { "math": [ "weather('humidity')", ">=", "96" ] }, { "math": [ "weather('pressure')", "<", "1003" ] } ] }
   },
   {
     "id": "drizzle",
@@ -94,12 +80,7 @@
     "sound_category": "drizzle",
     "required_weathers": [ "light_drizzle" ],
     "priority": 40,
-    "condition": {
-      "or": [
-        { "compare_num": [ { "weather": "humidity" }, ">=", { "const": 97 } ] },
-        { "compare_num": [ { "weather": "pressure" }, "<", { "const": 1000 } ] }
-      ]
-    }
+    "condition": { "or": [ { "math": [ "weather('humidity')", ">=", "97" ] }, { "math": [ "weather('pressure')", "<", "1000" ] } ] }
   },
   {
     "id": "rain",
@@ -121,12 +102,7 @@
     "sound_category": "rainy",
     "required_weathers": [ "light_drizzle", "drizzle" ],
     "priority": 50,
-    "condition": {
-      "or": [
-        { "compare_num": [ { "weather": "humidity" }, ">=", { "const": 98 } ] },
-        { "compare_num": [ { "weather": "pressure" }, "<", { "const": 993 } ] }
-      ]
-    }
+    "condition": { "or": [ { "math": [ "weather('humidity')", ">=", "98" ] }, { "math": [ "weather('pressure')", "<", "993" ] } ] }
   },
   {
     "id": "rainstorm",
@@ -149,8 +125,8 @@
     "priority": 60,
     "condition": {
       "and": [
-        { "compare_num": [ { "weather": "temperature" }, ">=", { "const": 33 } ] },
-        { "compare_num": [ { "weather": "windpower" }, ">=", { "const": 15 } ] }
+        { "math": [ "weather('temperature')", ">=", "from_fahrenheit( 33 )" ] },
+        { "math": [ "weather('windpower')", ">=", "15" ] }
       ]
     }
   },
@@ -174,7 +150,7 @@
     "sound_category": "thunder",
     "required_weathers": [ "rain" ],
     "priority": 70,
-    "condition": { "compare_num": [ { "weather": "pressure" }, "<", { "const": 996 } ] }
+    "condition": { "math": [ "weather('pressure')", "<", "996" ] }
   },
   {
     "id": "lightning",
@@ -196,7 +172,7 @@
     "sound_category": "thunder",
     "required_weathers": [ "thunder" ],
     "priority": 80,
-    "condition": { "compare_num": [ { "weather": "pressure" }, "<", { "const": 990 } ] }
+    "condition": { "math": [ "weather('pressure')", "<", "990" ] }
   },
   {
     "id": "flurries",
@@ -218,7 +194,7 @@
     "sound_category": "flurries",
     "required_weathers": [ "flurries" ],
     "priority": 90,
-    "condition": { "compare_num": [ { "weather": "temperature" }, "<", { "const": 33 } ] }
+    "condition": { "math": [ "weather('temperature')", "<", "from_fahrenheit( 33 )" ] }
   },
   {
     "id": "snowing",
@@ -240,7 +216,7 @@
     "sound_category": "snow",
     "required_weathers": [ "rain", "thunder", "lightning" ],
     "priority": 100,
-    "condition": { "compare_num": [ { "weather": "temperature" }, "<", { "const": 33 } ] }
+    "condition": { "math": [ "weather('temperature')", "<", "from_fahrenheit( 33 )" ] }
   },
   {
     "id": "snowstorm",
@@ -264,8 +240,8 @@
     "priority": 110,
     "condition": {
       "and": [
-        { "compare_num": [ { "weather": "temperature" }, "<", { "const": 33 } ] },
-        { "compare_num": [ { "weather": "windpower" }, ">=", { "const": 15 } ] }
+        { "math": [ "weather('temperature')", "<", "from_fahrenheit( 33 )" ] },
+        { "math": [ "weather('windpower')", ">=", "15" ] }
       ]
     }
   },
@@ -289,8 +265,8 @@
     "required_weathers": [ "clear", "sunny" ],
     "condition": {
       "and": [
-        { "math": [ "u_val( 'weather:windpower' )", "<", "12" ] },
-        { "math": [ "u_val( 'weather:windpower' )", ">", "0" ] },
+        { "math": [ "weather('windpower')", "<", "12" ] },
+        { "math": [ "weather('windpower')", ">", "0" ] },
         { "math": [ "dew_point_factor", "<", "5" ] }
       ]
     }
@@ -315,8 +291,8 @@
     "required_weathers": [ "mist" ],
     "condition": {
       "and": [
-        { "math": [ "u_val( 'weather:windpower' )", "<", "12" ] },
-        { "math": [ "u_val( 'weather:windpower' )", ">", "0" ] },
+        { "math": [ "weather('windpower')", "<", "12" ] },
+        { "math": [ "weather('windpower')", ">", "0" ] },
         { "math": [ "dew_point_factor", "<=", "2.5" ] }
       ]
     }
@@ -332,11 +308,11 @@
         "math": [
           "dprhx",
           "=",
-          "log ( u_val( 'weather:humidity' ) / 100 ) + 17.625 * u_val( 'weather:temperature' ) / ( 469.5 + u_val( 'weather:temperature' ) )"
+          "log ( weather('humidity') / 100 ) + 17.625 * weather('temperature') / ( 516.2 + weather('temperature') )"
         ]
       },
-      { "math": [ "dew_point", "=", "469.5 * dprhx / ( 17.625 - dprhx )" ] },
-      { "math": [ "dew_point_factor", "=", "u_val('weather: temperature') - ( dew_point )" ] }
+      { "math": [ "dew_point", "=", "516.2 * dprhx / ( 17.625 - dprhx )" ] },
+      { "math": [ "dew_point_factor", "=", "weather('temperature') - ( dew_point )" ] }
     ]
   },
   {

--- a/data/mods/aftershock_exoplanet/weather_type.json
+++ b/data/mods/aftershock_exoplanet/weather_type.json
@@ -19,12 +19,7 @@
     "sun_multiplier": 0.3,
     "required_weathers": [ "cloudy" ],
     "priority": 30,
-    "condition": {
-      "or": [
-        { "compare_num": [ { "weather": "humidity" }, ">=", { "const": 97 } ] },
-        { "compare_num": [ { "weather": "pressure" }, "<", { "const": 1000 } ] }
-      ]
-    }
+    "condition": { "or": [ { "math": [ "weather('humidity')", ">=", "97" ] }, { "math": [ "weather('pressure')", "<", "1000" ] } ] }
   },
   {
     "id": "afs_whiteout",
@@ -46,7 +41,7 @@
     "sun_multiplier": 0.15,
     "required_weathers": [ "cloudy", "afs_flurries" ],
     "priority": 40,
-    "condition": { "and": [ "is_day", { "compare_num": [ { "weather": "windpower" }, ">=", { "const": 20 } ] } ] }
+    "condition": { "and": [ "is_day", { "math": [ "weather('windpower')", ">=", "20" ] } ] }
   },
   {
     "id": "afs_snowing",
@@ -68,12 +63,7 @@
     "sun_multiplier": 0.2,
     "required_weathers": [ "afs_flurries", "afs_whiteout" ],
     "priority": 50,
-    "condition": {
-      "or": [
-        { "compare_num": [ { "weather": "humidity" }, ">=", { "const": 98 } ] },
-        { "compare_num": [ { "weather": "pressure" }, "<", { "const": 993 } ] }
-      ]
-    }
+    "condition": { "or": [ { "math": [ "weather('humidity')", ">=", "98" ] }, { "math": [ "weather('pressure')", "<", "993" ] } ] }
   },
   {
     "id": "afs_thunder",
@@ -95,7 +85,7 @@
     "sun_multiplier": 0.01,
     "required_weathers": [ "afs_snowing" ],
     "priority": 60,
-    "condition": { "compare_num": [ { "weather": "pressure" }, "<", { "const": 990 } ] }
+    "condition": { "math": [ "weather('pressure')", "<", "990" ] }
   },
   {
     "id": "afs_lightning",
@@ -117,6 +107,6 @@
     "sun_multiplier": 0.01,
     "required_weathers": [ "afs_thunder" ],
     "priority": 70,
-    "condition": { "compare_num": [ { "weather": "pressure" }, "<", { "const": 980 } ] }
+    "condition": { "math": [ "weather('pressure')", "<", "980" ] }
   }
 ]

--- a/data/mods/desert_region/weather/weather_eoc.json
+++ b/data/mods/desert_region/weather/weather_eoc.json
@@ -159,11 +159,9 @@
     "id": "EOC_DUST_WIND",
     "recurrence": [ "10 seconds", "30 seconds" ],
     "global": true,
-    "condition": {
-      "and": [ { "compare_num": [ { "weather": "windpower" }, "<=", { "const": 60 } ] }, { "is_weather": "early_dust_storm" } ]
-    },
+    "condition": { "and": [ { "math": [ "weather('windpower')", "<=", "60" ] }, { "is_weather": "early_dust_storm" } ] },
     "deactivate_condition": { "not": { "is_weather": "early_dust_storm" } },
-    "effect": [ { "arithmetic": [ { "weather": "windpower" }, "+=", { "const": 3 } ] }, { "u_message": "WIND", "type": "bad" } ]
+    "effect": [ { "math": [ "weather('windpower')", "+=", "3" ] }, { "u_message": "WIND", "type": "bad" } ]
   },
   {
     "type": "effect_on_condition",
@@ -179,8 +177,8 @@
     "id": "EOC_DUST_WIND_STRONG",
     "recurrence": [ "10 seconds", "30 seconds" ],
     "global": true,
-    "condition": { "and": [ { "compare_num": [ { "weather": "windpower" }, "<=", { "const": 120 } ] }, { "is_weather": "dust_storm" } ] },
+    "condition": { "and": [ { "math": [ "weather('windpower')", "<=", "120" ] }, { "is_weather": "dust_storm" } ] },
     "deactivate_condition": { "not": { "is_weather": "dust_storm" } },
-    "effect": [ { "arithmetic": [ { "weather": "windpower" }, "+=", { "const": 4 } ] }, { "u_message": "WIND", "type": "bad" } ]
+    "effect": [ { "math": [ "weather('windpower')", "+=", "4" ] }, { "u_message": "WIND", "type": "bad" } ]
   }
 ]

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1266,10 +1266,6 @@ Example | Description
 `"faction_trust": "free_merchants"` | The trust the faction has for the player (see [FACTIONS.md](FACTIONS.md)) for details.
 `"faction_like": "free_merchants"` | How much the faction likes the player (see [FACTIONS.md](FACTIONS.md)) for details.
 `"faction_respect": "free_merchants"` | How much the faction respects the player(see [FACTIONS.md](FACTIONS.md)) for details.
-`"weather": "temperature"` | Current temperature.
-`"weather": "windpower"` | Current windpower.
-`"weather": "humidity"` | Current humidity.
-`"weather": "pressure"` | Current pressure.
 `"u_val": "strength"` | Player character's strength. Can be read but not written to. Replace `"strength"` with `"dexterity"`, `"intelligence"`, or `"perception"` to get such values.
 `"u_val": "strength_base"` | Player character's strength. Replace `"strength_base"` with `"dexterity_base"`, `"intelligence_base"`, or `"perception_base"` to get such values.
 `"u_val": "strength_bonus"` | Player character's current strength bonus. Replace `"strength_bonus"` with `"dexterity_bonus"`, `"intelligence_bonus"`, or `"perception_bonus"` to get such values.
@@ -1417,6 +1413,7 @@ This section is a work in progress as functions are ported from `arithmetic` to 
 |----------|------|--------|-------|-------------|
 | pain     |  ✅  |   ✅   | u, n  | Return or set pain<br/> Example:<br/>`{ "math": [ "n_pain()", "=", "u_pain() + 9000" ] }`|
 | skill    |  ✅  |   ✅   | u, n  | Return or set skill level<br/> Example:<br/>`"condition": { "math": [ "u_skill('driving')", ">=", "5"] }`|
+| weather  |  ✅  |   ✅   | N/A<br/>(global)  | Return or set a weather aspect<br/><br/>Aspect must be one of:<br/>`temperature` (in Kelvin),<br/>`humidity` (as percentage),<br/>`pressure` (in millibar),<br/>`windpower` (in mph).<br/><br/>Temperature conversion functions are available: `celsius()`, `fahrenheit()`, `from_celsius()`, and `from_fahrenheit()`.<br/><br/>Examples:<br/>`{ "math": [ "weather('temperature')", "<", "from_fahrenheit( 33 )" ] }`<br/>`{ "math": [ "fahrenheit( weather('temperature') )", "==", "21" ] }`|
 
 
 ##### u_val shim
@@ -1447,7 +1444,6 @@ Most of the values from [arithmetic](#list-of-values-that-can-be-read-andor-writ
 More examples:
 ```JSON
     { "math": [ "u_val('age')" ] },
-    { "math": [ "u_val('weather: temperature')" ] },
     { "math": [ "u_val('time: 1 d')" ] },
     { "math": [ "u_val('proficiency', 'proficiency_id: prof_test', 'format: percent')" ] }
 ```

--- a/doc/WEATHER_TYPE.md
+++ b/doc/WEATHER_TYPE.md
@@ -48,6 +48,6 @@ Each weather type is a type of weather that occurs, and what causes it. The only
     "rains": true,
     "required_weathers": [ "thunder" ],
     "priority": 80,
-    "condition": { "not": { "is_pressure": 990 } }
+    "condition": { "math": [ "weather('pressure')", "<", "990" ] }
   }
 ]

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1470,25 +1470,6 @@ std::function<double( dialogue & )> conditional_t::get_get_dbl( J const &jo )
         return [max_value]( dialogue const & ) {
             return rng( 0, max_value );
         };
-    } else if( jo.has_member( "weather" ) ) {
-        std::string weather_aspect = jo.get_string( "weather" );
-        if( weather_aspect == "temperature" ) {
-            return []( dialogue const & ) {
-                return static_cast<int>( units::to_fahrenheit( get_weather().weather_precise->temperature ) );
-            };
-        } else if( weather_aspect == "windpower" ) {
-            return []( dialogue const & ) {
-                return static_cast<int>( get_weather().weather_precise->windpower );
-            };
-        } else if( weather_aspect == "humidity" ) {
-            return []( dialogue const & ) {
-                return static_cast<int>( get_weather().weather_precise->humidity );
-            };
-        } else if( weather_aspect == "pressure" ) {
-            return []( dialogue const & ) {
-                return static_cast<int>( get_weather().weather_precise->pressure );
-            };
-        }
     } else if( jo.has_member( "faction_trust" ) ) {
         str_or_var name = get_str_or_var( jo.get_member( "faction_trust" ), "faction_trust" );
         return [name]( dialogue const & d ) {
@@ -2114,31 +2095,6 @@ conditional_t::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part> &m
         };
     } else if( jo.has_member( "rand" ) ) {
         jo.throw_error( "can not alter the random number generator, silly!  In " + jo.str() );
-    } else if( jo.has_member( "weather" ) ) {
-        std::string weather_aspect = jo.get_string( "weather" );
-        if( weather_aspect == "temperature" ) {
-            return [min, max]( dialogue & d, double input ) {
-                const int new_temperature = handle_min_max( d, input, min, max );
-                get_weather().weather_precise->temperature = units::from_fahrenheit( new_temperature );
-                get_weather().temperature = units::from_fahrenheit( new_temperature );
-                get_weather().clear_temp_cache();
-            };
-        } else if( weather_aspect == "windpower" ) {
-            return [min, max]( dialogue & d, double input ) {
-                get_weather().weather_precise->windpower = handle_min_max( d, input, min, max );
-                get_weather().clear_temp_cache();
-            };
-        } else if( weather_aspect == "humidity" ) {
-            return [min, max]( dialogue & d, double input ) {
-                get_weather().weather_precise->humidity = handle_min_max( d, input, min, max );
-                get_weather().clear_temp_cache();
-            };
-        } else if( weather_aspect == "pressure" ) {
-            return [min, max]( dialogue & d, double input ) {
-                get_weather().weather_precise->pressure = handle_min_max( d, input, min, max );
-                get_weather().clear_temp_cache();
-            };
-        }
     } else if( jo.has_member( "faction_trust" ) ) {
         str_or_var name = get_str_or_var( jo.get_member( "faction_trust" ), "faction_trust" );
         return [name, min, max]( dialogue & d, double input ) {

--- a/src/condition.h
+++ b/src/condition.h
@@ -46,7 +46,7 @@ const std::unordered_set<std::string> complex_conds = { {
         "days_since_cataclysm", "is_season", "mission_goal", "u_has_var", "npc_has_var",
         "u_has_skill", "npc_has_skill", "u_know_recipe", "u_compare_var", "npc_compare_var",
         "u_compare_time_since_var", "npc_compare_time_since_var", "is_weather", "mod_is_loaded", "one_in_chance", "x_in_y_chance",
-        "is_temperature", "is_windpower", "is_humidity", "is_pressure", "u_is_height", "npc_is_height",
+        "u_is_height", "npc_is_height",
         "u_has_worn_with_flag", "npc_has_worn_with_flag", "u_has_wielded_with_flag", "npc_has_wielded_with_flag",
         "u_has_pain", "npc_has_pain", "u_has_power", "npc_has_power", "u_has_focus", "npc_has_focus", "u_has_morale",
         "npc_has_morale", "u_is_on_terrain", "npc_is_on_terrain", "u_is_in_field", "npc_is_in_field", "compare_int",

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -8,6 +8,8 @@
 #include "dialogue.h"
 #include "math_parser_shim.h"
 #include "mission.h"
+#include "units.h"
+#include "weather.h"
 
 namespace
 {
@@ -79,4 +81,61 @@ std::function<void( dialogue &, double )> skill_ass( char scope,
     return [beta = is_beta( scope ), sid = skill_id( params[0] )]( dialogue const & d, double val ) {
         return d.actor( beta )->set_skill_level( sid, val );
     };
+}
+
+std::function<double( dialogue & )> weather_eval( char /* scope */,
+        std::vector<std::string> const &params )
+{
+    if( params[0] == "temperature" ) {
+        return []( dialogue const & ) {
+            return units::to_kelvin( get_weather().weather_precise->temperature );
+        };
+    }
+    if( params[0] == "windpower" ) {
+        return []( dialogue const & ) {
+            return get_weather().weather_precise->windpower;
+        };
+    }
+    if( params[0] == "humidity" ) {
+        return []( dialogue const & ) {
+            return get_weather().weather_precise->humidity;
+        };
+    }
+    if( params[0] == "pressure" ) {
+        return []( dialogue const & ) {
+            return get_weather().weather_precise->pressure;
+        };
+    }
+    throw std::invalid_argument( "Unknown weather aspect " + params[0] );
+}
+
+std::function<void( dialogue &, double )> weather_ass( char /* scope */,
+        std::vector<std::string> const &params )
+{
+    if( params[0] == "temperature" ) {
+        return []( dialogue const &, double val ) {
+            get_weather().weather_precise->temperature = units::from_kelvin( val );
+            get_weather().temperature = units::from_kelvin( val );
+            get_weather().clear_temp_cache();
+        };
+    }
+    if( params[0] == "windpower" ) {
+        return []( dialogue const &, double val ) {
+            get_weather().weather_precise->windpower = val;
+            get_weather().clear_temp_cache();
+        };
+    }
+    if( params[0] == "humidity" ) {
+        return []( dialogue const &, double val ) {
+            get_weather().weather_precise->humidity = val;
+            get_weather().clear_temp_cache();
+        };
+    }
+    if( params[0] == "pressure" ) {
+        return []( dialogue const &, double val ) {
+            get_weather().weather_precise->pressure = val;
+            get_weather().clear_temp_cache();
+        };
+    }
+    throw std::invalid_argument( "Unknown weather aspect " + params[0] );
 }

--- a/src/math_parser_diag.h
+++ b/src/math_parser_diag.h
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <functional>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -54,16 +55,23 @@ std::function<double( dialogue & )> skill_eval( char scope,
 std::function<void( dialogue &, double )> skill_ass( char scope,
         std::vector<std::string> const &params );
 
-inline std::array<dialogue_func_eval, 3> const dialogue_eval_f{
+std::function<double( dialogue & )> weather_eval( char /* scope */,
+        std::vector<std::string> const &params );
+std::function<void( dialogue &, double )> weather_ass( char /* scope */,
+        std::vector<std::string> const &params );
+
+inline std::array<dialogue_func_eval, 4> const dialogue_eval_f{
     dialogue_func_eval{ "val", "un", -1, u_val },
     dialogue_func_eval{ "pain", "un", 0, pain_eval },
     dialogue_func_eval{ "skill", "un", 1, skill_eval },
+    dialogue_func_eval{ "weather", "g", 1, weather_eval },
 };
 
-inline std::array<dialogue_func_ass, 3> const dialogue_assign_f{
+inline std::array<dialogue_func_ass, 4> const dialogue_assign_f{
     dialogue_func_ass{ "val", "un", -1, u_val_ass },
     dialogue_func_ass{ "pain", "un", 0, pain_ass },
     dialogue_func_ass{ "skill", "un", 1, skill_ass },
+    dialogue_func_ass{ "weather", "g", 1, weather_ass },
 };
 
 #endif // CATA_SRC_MATH_PARSER_DIAG_H

--- a/src/math_parser_func.h
+++ b/src/math_parser_func.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "rng.h"
+#include "units.h"
 
 struct math_func {
     std::string_view symbol;
@@ -115,7 +116,27 @@ constexpr double test_( std::vector<double> const &/* params */ )
     return 42;
 }
 
-constexpr std::array<math_func, 16> functions{
+inline double celsius_from_kelvin( std::vector<double> const &params )
+{
+    return units::to_celsius( units::from_kelvin( params[0] ) );
+}
+
+inline double fahrenheit_from_kelvin( std::vector<double> const &params )
+{
+    return units::to_fahrenheit( units::from_kelvin( params[0] ) );
+}
+
+inline double celsius_to_kelvin( std::vector<double> const &params )
+{
+    return units::to_kelvin( units::from_celsius( params[0] ) );
+}
+
+inline double fahrenheit_to_kelvin( std::vector<double> const &params )
+{
+    return units::to_kelvin( units::from_fahrenheit( params[0] ) );
+}
+
+constexpr std::array<math_func, 20> functions{
     math_func{ "abs", 1, abs },
     math_func{ "max", -1, max },
     math_func{ "min", -1, min },
@@ -132,6 +153,10 @@ constexpr std::array<math_func, 16> functions{
     math_func{ "cos", 1, cos },
     math_func{ "tan", 1, tan },
     math_func{ "_test_", 0, test_ },
+    math_func{ "celsius", 1, celsius_from_kelvin },
+    math_func{ "fahrenheit", 1, fahrenheit_from_kelvin },
+    math_func{ "from_celsius", 1, celsius_to_kelvin },
+    math_func{ "from_fahrenheit", 1, fahrenheit_to_kelvin },
 };
 
 namespace math_constants

--- a/tests/monster_vision_test.cpp
+++ b/tests/monster_vision_test.cpp
@@ -26,7 +26,7 @@ TEST_CASE( "monsters shouldn't see through floors", "[vision]" )
     restore_on_out_of_scope<bool> restore_fov_3d( fov_3d );
     fov_3d = true;
     calendar::turn = midday;
-    clear_map();
+    clear_map( -2, 1 );
     monster &upper = spawn_and_clear( { 5, 5, 0 }, true );
     monster &adjacent = spawn_and_clear( { 5, 6, 0 }, true );
     monster &distant = spawn_and_clear( { 5, 3, 0 }, true );

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -1139,6 +1139,7 @@ TEST_CASE( "npc_compare_int", "[npc_talk]" )
     dialogue d;
     npc &beta = prep_test( d );
     Character &player_character = get_avatar();
+    clear_avatar();
 
     player_character.str_cur = 4;
     player_character.dex_cur = 4;

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -136,6 +136,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     const tripoint spot( 60, 60, 0 );
     dummy.setpos( spot );
     dummy.clear_values();
+    dummy.magic = pimpl<known_magic>();
 }
 
 void arm_shooter( npc &shooter, const std::string &gun_type,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Port another `arithmetic` function to `math`. `weather` was used recently for #64954 and it's a small enough target.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Move the code from `arithmetic` to `math`.
Use Kelvin for temperature to match internal representation.
Add temperature conversion functions.

Fix the calculations and conditions for fog/mist: ported from EOC to `jmath_function`. Added reference for the formula we used and re-converted it to Celsius. Fixed the conditions for mist to better match reality.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Continuing to use Fahrenheit: Temperature is internally already Kelvin so it makes more sense to expose it to EOCs in the same unit. Weather aspects use a mixed bag of undocumented metric and non-metric units atm and I'd rather port them all to SI if possible.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Existing test unit.

Both mist and fog still occur in game. Mist/fog no longer occur by default on a fresh game simply because `dew_point_factor` hasn't been calculated yet.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I promised I'd do this for #64954 but I got sidetracked IRL. Better late than never though.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->