### PR TITLE
Fix some clang-tidy and MSVC errors/warnings

### DIFF
--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -106,7 +106,7 @@ static damage_info_order::info_disp read_info_disp( const std::string &s )
     }
 }
 
-void damage_type::load( const JsonObject &jo, const std::string & )
+void damage_type::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
     optional( jo, was_loaded, "skill", skill, skill_id::NULL_ID() );
@@ -141,7 +141,7 @@ void damage_type::load( const JsonObject &jo, const std::string & )
 
     if( jo.has_array( "derived_from" ) ) {
         JsonArray ja = jo.get_array( "derived_from" );
-        derived_from = { damage_type_id( ja.get_string( 0 ) ), ja.get_float( 1 ) };
+        derived_from = { damage_type_id( ja.get_string( 0 ) ), static_cast<float>( ja.get_float( 1 ) ) };
     }
 
     for( JsonValue jv : jo.get_array( "onhit_eocs" ) ) {
@@ -164,7 +164,7 @@ void damage_type::check()
 }
 
 void damage_info_order::damage_info_order_entry::load( const JsonObject &jo,
-        const std::string &member )
+        std::string_view member )
 {
     if( jo.has_object( member ) || jo.has_int( member ) ) {
         if( jo.has_int( member ) ) {
@@ -178,7 +178,7 @@ void damage_info_order::damage_info_order_entry::load( const JsonObject &jo,
     }
 }
 
-void damage_info_order::load( const JsonObject &jo, const std::string & )
+void damage_info_order::load( const JsonObject &jo, std::string_view )
 {
     dmg_type = damage_type_id( id.c_str() );
     bionic_info.load( jo, "bionic_info" );

--- a/src/damage.h
+++ b/src/damage.h
@@ -48,7 +48,7 @@ struct damage_type {
     static void load_damage_types( const JsonObject &jo, const std::string &src );
     static void reset();
     static void check();
-    void load( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view );
     static const std::vector<damage_type> &get_all();
 };
 
@@ -69,7 +69,7 @@ struct damage_info_order {
     struct damage_info_order_entry {
         int order = -1;
         bool show_type = false;
-        void load( const JsonObject &jo, const std::string &member );
+        void load( const JsonObject &jo, std::string_view member );
     };
     damage_info_order_id id;
     damage_type_id dmg_type = damage_type_id::NULL_ID();
@@ -86,7 +86,7 @@ struct damage_info_order {
     static void reset();
     static void finalize_all();
     void finalize();
-    void load( const JsonObject &jo, const std::string &src );
+    void load( const JsonObject &jo, std::string_view src );
     static const std::vector<damage_info_order> &get_all();
     static const std::vector<damage_info_order> &get_all( info_type sort_by );
 };

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -91,7 +91,7 @@ struct talk_effect_fun_t {
         void set_npc_goal( const JsonObject &jo, std::string_view member, bool is_npc = false );
         void set_destination( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_revert_location( const JsonObject &jo, const std::string_view &member );
-        void set_guard_pos( const JsonObject &jo, const std::string &member, bool is_npc = false );
+        void set_guard_pos( const JsonObject &jo, const std::string_view &member, bool is_npc = false );
         void set_bulk_trade_accept( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_npc_gets_item( bool to_use );
         void set_add_mission( const JsonObject &jo, const std::string &member );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -131,7 +131,6 @@ static const damage_type_id damage_bash( "bash" );
 static const damage_type_id damage_bullet( "bullet" );
 static const damage_type_id damage_cut( "cut" );
 static const damage_type_id damage_heat( "heat" );
-static const damage_type_id damage_stab( "stab" );
 
 static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_cig( "cig" );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -68,8 +68,6 @@ static const ammotype ammo_NULL( "NULL" );
 
 static const damage_type_id damage_bash( "bash" );
 static const damage_type_id damage_bullet( "bullet" );
-static const damage_type_id damage_cut( "cut" );
-static const damage_type_id damage_stab( "stab" );
 
 static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
 static const gun_mode_id gun_mode_MELEE( "MELEE" );
@@ -233,7 +231,7 @@ void Item_factory::finalize_pre( itype &obj )
             if( iter != obj.melee_proportional.end() ) {
                 dt.second *= iter->second;
                 // For maintaining legacy behaviour (when melee damage used ints)
-                std::floor( dt.second );
+                dt.second = std::floor( dt.second );
             }
         }
     }
@@ -244,13 +242,13 @@ void Item_factory::finalize_pre( itype &obj )
             if( iter != obj.melee_relative.end() ) {
                 dt.second += iter->second;
                 // For maintaining legacy behaviour (when melee damage used ints)
-                std::floor( dt.second );
+                dt.second = std::floor( dt.second );
             }
         }
     }
 
     if( obj.has_flag( flag_STAB ) ) {
-        debugmsg( "The \"STAB\" flag used on %s is obsolete. Add a \"stab\" value in the \"melee_damage\" object instead.",
+        debugmsg( "The \"STAB\" flag used on %s is obsolete, add a \"stab\" value in the \"melee_damage\" object instead.",
                   obj.id.c_str() );
     }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3105,7 +3105,7 @@ void talk_effect_fun_t::set_npc_goal( const JsonObject &jo, const std::string_vi
     };
 }
 
-void talk_effect_fun_t::set_guard_pos( const JsonObject &jo, const std::string &member,
+void talk_effect_fun_t::set_guard_pos( const JsonObject &jo, const std::string_view &member,
                                        bool is_npc )
 {
     std::optional<var_info> target_var = read_var_info( jo.get_object( member ) );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3945,9 +3945,9 @@ void Creature::load( const JsonObject &jsin )
         jsin.read( "armor_bonus", armor_bonus );
     } else {
         // Legacy load conversion, remove after 0.H releases
-        int bash_bonus = 0;
-        int cut_bonus = 0;
-        int bullet_bonus = 0;
+        float bash_bonus = 0;
+        float cut_bonus = 0;
+        float bullet_bonus = 0;
         jsin.read( "armor_bash_bonus", bash_bonus );
         jsin.read( "armor_cut_bonus", cut_bonus );
         jsin.read( "armor_bullet_bonus", bullet_bonus );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -89,7 +89,6 @@ static const std::string part_location_onroof( "on_roof" );
 static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 
 static const ammotype ammo_battery( "battery" );
-static const ammotype ammo_plutonium( "plutonium" );
 
 static const bionic_id bio_jointservo( "bio_jointservo" );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix clang tidy errors from https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4793923402/jobs/8526853909
<details>
  <summary>Also MSVC warnings</summary>

  ```js
Build started...
1>------ Build started: Project: Cataclysm-lib-vcpkg-static, Configuration: Release x64 ------
1>Generating "version.h"...
1>VERSION defined as "0.G-1594-gbcbed05d34"
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\utility(186,54): warning C4244: 'initializing': conversion from '_Ty' to '_Ty2', possible loss of data
1>        with
1>        [
1>            _Ty=double
1>        ]
1>        and
1>        [
1>            _Ty2=float
1>        ]
1>C:\projects\Cataclysm-DDA\src\damage.cpp(144): message : see reference to function template instantiation 'std::pair<damage_type_id,float>::pair<damage_type_id,double,0>(_Other1 &&,_Other2 &&) noexcept' being compiled
1>        with
1>        [
1>            _Other1=damage_type_id,
1>            _Other2=double
1>        ]
1>C:\projects\Cataclysm-DDA\src\damage.cpp(144): message : see reference to function template instantiation 'std::pair<damage_type_id,float>::pair<damage_type_id,double,0>(_Other1 &&,_Other2 &&) noexcept' being compiled
1>        with
1>        [
1>            _Other1=damage_type_id,
1>            _Other2=double
1>        ]

1>C:\projects\Cataclysm-DDA\src\item_factory.cpp(236,27): warning C4834: discarding return value of function with 'nodiscard' attribute
1>C:\projects\Cataclysm-DDA\src\item_factory.cpp(247,27): warning C4834: discarding return value of function with 'nodiscard' attribute

1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\utility(186,54): warning C4244: 'initializing': conversion from 'int' to '_Ty2', possible loss of data
1>        with
1>        [
1>            _Ty2=float
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xmemory(674): message : see reference to function template instantiation 'std::pair<const damage_type_id,float>::pair<const CachedType&,int&,0>(_Other1,_Other2) noexcept' being compiled
1>        with
1>        [
1>            _Other1=const CachedType &,
1>            _Other2=int &
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xmemory(681): message : see reference to function template instantiation 'std::pair<const damage_type_id,float>::pair<const CachedType&,int&,0>(_Other1,_Other2) noexcept' being compiled
1>        with
1>        [
1>            _Other1=const CachedType &,
1>            _Other2=int &
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xtree(804): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,const CachedType&,int&>(_Alloc &,_Objty *const ,const CachedType &,int &)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<std::_Tree_node<std::pair<const damage_type_id,float>,std::_Default_allocator_traits<std::allocator<std::pair<const damage_type_id,float>>>::void_pointer>>,
1>            _Ty=std::pair<const damage_type_id,float>,
1>            _Objty=std::pair<const damage_type_id,float>
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xtree(805): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,const CachedType&,int&>(_Alloc &,_Objty *const ,const CachedType &,int &)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<std::_Tree_node<std::pair<const damage_type_id,float>,std::_Default_allocator_traits<std::allocator<std::pair<const damage_type_id,float>>>::void_pointer>>,
1>            _Ty=std::pair<const damage_type_id,float>,
1>            _Objty=std::pair<const damage_type_id,float>
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xtree(999): message : see reference to function template instantiation 'std::_Tree_temp_node<std::allocator<std::_Tree_node<std::pair<const damage_type_id,float>,std::_Default_allocator_traits<_Alloc>::void_pointer>>>::_Tree_temp_node<const CachedType&,int&>(_Alnode &,std::_Tree_node<std::pair<const damage_type_id,float>,std::_Default_allocator_traits<_Alloc>::void_pointer> *,const CachedType &,int &)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<std::pair<const damage_type_id,float>>,
1>            _Alnode=std::allocator<std::_Tree_node<std::pair<const damage_type_id,float>,std::_Default_allocator_traits<std::allocator<std::pair<const damage_type_id,float>>>::void_pointer>>
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xtree(1012): message : see reference to function template instantiation 'std::_Tree_temp_node<std::allocator<std::_Tree_node<std::pair<const damage_type_id,float>,std::_Default_allocator_traits<_Alloc>::void_pointer>>>::_Tree_temp_node<const CachedType&,int&>(_Alnode &,std::_Tree_node<std::pair<const damage_type_id,float>,std::_Default_allocator_traits<_Alloc>::void_pointer> *,const CachedType &,int &)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<std::pair<const damage_type_id,float>>,
1>            _Alnode=std::allocator<std::_Tree_node<std::pair<const damage_type_id,float>,std::_Default_allocator_traits<std::allocator<std::pair<const damage_type_id,float>>>::void_pointer>>
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xtree(1036): message : see reference to function template instantiation 'std::pair<std::_Tree_node<std::pair<const damage_type_id,float>,std::_Default_allocator_traits<_Alloc>::void_pointer> *,bool> std::_Tree<std::_Tmap_traits<_Kty,_Ty,_Pr,_Alloc,false>>::_Emplace<const CachedType&,int&>(const CachedType &,int &)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<std::pair<const damage_type_id,float>>,
1>            _Kty=damage_type_id,
1>            _Ty=float,
1>            _Pr=std::less<damage_type_id>
1>        ]
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xtree(1037): message : see reference to function template instantiation 'std::pair<std::_Tree_node<std::pair<const damage_type_id,float>,std::_Default_allocator_traits<_Alloc>::void_pointer> *,bool> std::_Tree<std::_Tmap_traits<_Kty,_Ty,_Pr,_Alloc,false>>::_Emplace<const CachedType&,int&>(const CachedType &,int &)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<std::pair<const damage_type_id,float>>,
1>            _Kty=damage_type_id,
1>            _Ty=float,
1>            _Pr=std::less<damage_type_id>
1>        ]
1>C:\projects\Cataclysm-DDA\src\savegame_json.cpp(3955): message : see reference to function template instantiation 'std::pair<std::_Tree_iterator<std::_Tree_val<std::_Tree_simple_types<std::pair<const damage_type_id,float>>>>,bool> std::_Tree<std::_Tmap_traits<_Kty,_Ty,_Pr,_Alloc,false>>::emplace<const CachedType&,int&>(const CachedType &,int &)' being compiled
1>        with
1>        [
1>            _Kty=damage_type_id,
1>            _Ty=float,
1>            _Pr=std::less<damage_type_id>,
1>            _Alloc=std::allocator<std::pair<const damage_type_id,float>>
1>        ]
1>C:\projects\Cataclysm-DDA\src\savegame_json.cpp(3955): message : see reference to function template instantiation 'std::pair<std::_Tree_iterator<std::_Tree_val<std::_Tree_simple_types<std::pair<const damage_type_id,float>>>>,bool> std::_Tree<std::_Tmap_traits<_Kty,_Ty,_Pr,_Alloc,false>>::emplace<const CachedType&,int&>(const CachedType &,int &)' being compiled
1>        with
1>        [
1>            _Kty=damage_type_id,
1>            _Ty=float,
1>            _Pr=std::less<damage_type_id>,
1>            _Alloc=std::allocator<std::pair<const damage_type_id,float>>
1>        ]
========== Build: 3 succeeded, 0 failed, 1 up-to-date, 0 skipped ==========

  ```

</details>


#### Describe the solution

Use string_view where analyzer says so
Remove unused statics
Don't discard return value of std::floor
Use the right types to squelch MSVC template warnings

#### Describe alternatives you've considered

#### Testing

#### Additional context
