### PR TITLE
Do not cancel clang-tidy run when a subset finishes

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -40,7 +40,7 @@ jobs:
     if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         # To make the run finish in the run time limit, we split it up into two
         # parts: the src directory and everything else


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
When working on #65223 I noticed that the recent change to divide clang-tidy run into two subsets has caused the `src` subset to always be canceled because the `tests` run is finished earlier. This prevents all warnings to be reported, and unlike the build matrix, the two subsets are checking different sources so they should be all completed IMO.

#### Describe the solution
Do not cancel clang-tidy runs when one subset finishes.

#### Describe alternatives you've considered
Not doing it.

#### Testing
Tested in #65223 and the two subsets finished without interruption.

#### Additional context
