### PR TITLE
Updated Phase Immersion Suit

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1466,7 +1466,8 @@
       "PADDED",
       "USE_UPS",
       "NO_UNLOAD",
-      "COMBAT_TOGGLEABLE"
+      "COMBAT_TOGGLEABLE",
+      "UNBREAKABLE_MELEE"
     ],
     "relic_data": { "passive_effects": [ { "id": "ench_climate_control_all" } ] },
     "armor": [

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1577,7 +1577,8 @@
       "PADDED",
       "USE_UPS",
       "NO_UNLOAD",
-      "COMBAT_TOGGLEABLE"
+      "COMBAT_TOGGLEABLE",
+      "UNBREAKABLE_MELEE"
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Prevented melee from breaking the Phase Immersion Suit"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Recent overhauls to other exoskeletons have added the UNBREAKABLE_MELEE tag to address the inherent issue of compromising protection around you entire body if you punch things a lot. Given that the Phase Immersion Suit is the only exoskeleton without such a property, it seemed appropriate to round things off unless someone has a compelling reason not to.

I considered the angle that the Phase Immersion Suit is more for environmental protection than combat and thus not strictly meant for melee, but the RM13 has the same flag and similar immunities, so there is precedent. Unlike other, HAZMAT-type suits, of course, this clothing is reinforced by several rigid components such as layered carbide and carbon steel.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Simply added the same flag that the other exoskeletons have.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Remove UNBREAKABLE_MELEE from the exoskeletons if we want to go the route of assuming that damaging the hands of such armor can compromise its overall properties. Either that or overhauling the entire system so that armor like this can have its immunities “segmented” or somesuch. That seems like a whole different issue I’m not qualified to handle.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

N/A

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

N/A


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->