### PR TITLE
Carpet Armor

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -32,6 +32,76 @@
     "melee_damage": { "bash": 8 }
   },
   {
+    "id": "carpet_armguards",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "pair of carpet arm guards", "str_pl": "pairs of carpet arm guards" },
+    "description": "Small squares of carpet rolled around your upper and lower arms.  Armor of the truly desperate or crafty.",
+    "weight": "1360 g",
+    "//": "The weight assumes four squares of carpet of about 25cm x 20cm.",
+    "volume": "3 L",
+    "price": 20,
+    "price_postapoc": 10,
+    "to_hit": 1,
+    "material": [ "plastic", "carpet_pilling" ],
+    "symbol": "[",
+    "looks_like": "arm_warmers",
+    "color": "red",
+    "warmth": 10,
+    "material_thickness": 4,
+    "environmental_protection": 1,
+    "flags": [ "OUTER", "BLOCK_WHILE_WORN", "NO_REPAIR" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "carpet_pilling", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "covers": [ "arm_l", "arm_r" ],
+        "encumbrance": 10,
+        "coverage": 90,
+        "cover_ranged": 95,
+        "cover_vitals": 70,
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_upper_r", "arm_upper_l" ]
+      }
+    ]
+  },
+  {
+    "id": "carpet_bracers",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "pair of carpet bracers", "str_pl": "pairs of carpet bracers" },
+    "description": "Small squares of carpet rolled around your lower arms.  The bare minimum to hopefully stop a bite or two.",
+    "weight": "680 g",
+    "//": "The weight assumes two squares of carpet of about 25cm x 20cm.",
+    "volume": "2 L",
+    "price": 10,
+    "price_postapoc": 5,
+    "to_hit": 1,
+    "material": [ "plastic", "carpet_pilling" ],
+    "symbol": "[",
+    "looks_like": "arm_warmers",
+    "color": "red",
+    "warmth": 10,
+    "material_thickness": 4,
+    "environmental_protection": 1,
+    "flags": [ "OUTER", "BLOCK_WHILE_WORN", "NO_REPAIR" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "carpet_pilling", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "covers": [ "arm_l", "arm_r" ],
+        "encumbrance": 10,
+        "coverage": 90,
+        "cover_ranged": 95,
+        "cover_vitals": 70,
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
+      }
+    ]
+  },
+  {
     "id": "armguard_chitin",
     "type": "ARMOR",
     "category": "armor",

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -58,7 +58,7 @@
           { "type": "carpet_pilling", "covered_by_mat": 100, "thickness": 3.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 10,
+        "encumbrance": 5,
         "coverage": 90,
         "cover_ranged": 95,
         "cover_vitals": 70,
@@ -93,7 +93,7 @@
           { "type": "carpet_pilling", "covered_by_mat": 100, "thickness": 3.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 10,
+        "encumbrance": 3,
         "coverage": 90,
         "cover_ranged": 95,
         "cover_vitals": 70,

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -31,6 +31,76 @@
     "melee_damage": { "bash": 8 }
   },
   {
+    "id": "carpet_legguards",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "pair of carpet leg guards", "str_pl": "pairs of carpet leg guards" },
+    "description": "Small squares of carpet rolled around your shins and thighs.  Perfect for wading through the local furniture store.",
+    "weight": "2040 g",
+    "//": "The weight assumes four squares of carpet of about 25cm x 30cm.",
+    "volume": "3 L",
+    "price": 20,
+    "price_postapoc": 10,
+    "to_hit": 1,
+    "material": [ "plastic", "carpet_pilling" ],
+    "symbol": "[",
+    "looks_like": "leg_warmers",
+    "color": "red",
+    "warmth": 10,
+    "material_thickness": 4,
+    "environmental_protection": 1,
+    "flags": [ "OUTER", "NO_REPAIR" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "carpet_pilling", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "encumbrance": 10,
+        "coverage": 90,
+        "cover_ranged": 95,
+        "cover_vitals": 70,
+        "specifically_covers": [ "leg_lower_r", "leg_lower_l", "leg_upper_r", "leg_upper_l" ]
+      }
+    ]
+  },
+  {
+    "id": "carpet_greaves",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "pair of carpet greaves", "str_pl": "pairs of carpet greaves" },
+    "description": "Small squares of carpet rolled around your shins.  These might protect you from the corner of a table.",
+    "weight": "1020 g",
+    "//": "The weight assumes two squares of carpet of about 25cm x 30cm.",
+    "volume": "2 L",
+    "price": 20,
+    "price_postapoc": 10,
+    "to_hit": 1,
+    "material": [ "plastic", "carpet_pilling" ],
+    "symbol": "[",
+    "looks_like": "leg_warmers",
+    "color": "red",
+    "warmth": 10,
+    "material_thickness": 4,
+    "environmental_protection": 1,
+    "flags": [ "OUTER", "NO_REPAIR" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "carpet_pilling", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "encumbrance": 10,
+        "coverage": 90,
+        "cover_ranged": 95,
+        "cover_vitals": 70,
+        "specifically_covers": [ "leg_lower_r", "leg_lower_l" ]
+      }
+    ]
+  },
+  {
     "id": "legguard_chitin",
     "type": "ARMOR",
     "category": "armor",

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -57,7 +57,7 @@
           { "type": "carpet_pilling", "covered_by_mat": 100, "thickness": 3.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
-        "encumbrance": 10,
+        "encumbrance": 5,
         "coverage": 90,
         "cover_ranged": 95,
         "cover_vitals": 70,
@@ -92,7 +92,7 @@
           { "type": "carpet_pilling", "covered_by_mat": 100, "thickness": 3.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
-        "encumbrance": 10,
+        "encumbrance": 3,
         "coverage": 90,
         "cover_ranged": 95,
         "cover_vitals": 70,

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -262,6 +262,62 @@
     "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
+    "id": "carpet_cuirass",
+    "type": "ARMOR",
+    "name": { "str": "carpet cuirass", "str_pl": "carpet cuirasses" },
+    "description": "A rectangular length of tough carpet with a hole cut out for your head and tied around the waist.  It's decently protective for its weight and quite the fashion statement.",
+    "weight": "7000 g",
+    "//": "Assuming roughly 1m^2 at a density of 1.4 lbs/ft^2",
+    "volume": "9250 ml",
+    "price": 120,
+    "price_postapoc": 50,
+    "material": [ "plastic", "carpet_pilling" ],
+    "symbol": "[",
+    "looks_like": "tunic_rag",
+    "color": "red",
+    "longest_side": "60 cm",
+    "warmth": 15,
+    "material_thickness": 4,
+    "flags": [ "OUTER", "NO_REPAIR" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "carpet_pilling", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "encumbrance": 10,
+        "coverage": 85,
+        "cover_ranged": 95,
+        "cover_vitals": 70,
+        "covers": [ "torso" ]
+      },
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "carpet_pilling", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "encumbrance": 5,
+        "coverage": 85,
+        "cover_ranged": 95,
+        "cover_vitals": 70,
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ]
+      },
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "carpet_pilling", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "encumbrance": 5,
+        "coverage": 85,
+        "cover_ranged": 95,
+        "cover_vitals": 70,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
+      }
+    ]
+  },
+  {
     "id": "armor_lorica",
     "type": "ARMOR",
     "name": { "str_sp": "lorica segmentata" },

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -266,7 +266,7 @@
     "type": "ARMOR",
     "name": { "str": "carpet cuirass", "str_pl": "carpet cuirasses" },
     "description": "A rectangular length of tough carpet with a hole cut out for your head and tied around the waist.  It's decently protective for its weight and quite the fashion statement.",
-    "weight": "7000 g",
+    "weight": "6800 g",
     "//": "Assuming roughly 1m^2 at a density of 1.4 lbs/ft^2",
     "volume": "9250 ml",
     "price": 120,

--- a/data/json/items/resources/home_improvement.json
+++ b/data/json/items/resources/home_improvement.json
@@ -117,10 +117,10 @@
     "color": "red",
     "description": "A roll of red carpet.",
     "material": [ "cotton" ],
-    "volume": "1750 ml",
-    "weight": "45 g",
-    "ammo_type": "NULL",
-    "count": 5
+    "volume": "7500 ml",
+    "weight": "6800 g",
+    "//": "Assuming roughly 1m^2 at a density of 1.4 lbs/ft^2",
+    "ammo_type": "NULL"
   },
   {
     "type": "AMMO",
@@ -133,10 +133,10 @@
     "color": "green",
     "description": "A roll of green carpet.",
     "material": [ "cotton" ],
-    "volume": "1750 ml",
-    "weight": "45 g",
-    "ammo_type": "NULL",
-    "count": 5
+    "volume": "7500 ml",
+    "weight": "6800 g",
+    "//": "Assuming roughly 1m^2 at a density of 1.4 lbs/ft^2",
+    "ammo_type": "NULL"
   },
   {
     "type": "AMMO",
@@ -149,10 +149,10 @@
     "color": "yellow",
     "description": "A roll of yellow carpet.",
     "material": [ "cotton" ],
-    "volume": "1750 ml",
-    "weight": "45 g",
-    "ammo_type": "NULL",
-    "count": 5
+    "volume": "7500 ml",
+    "weight": "6800 g",
+    "//": "Assuming roughly 1m^2 at a density of 1.4 lbs/ft^2",
+    "ammo_type": "NULL"
   },
   {
     "type": "AMMO",
@@ -165,10 +165,10 @@
     "color": "magenta",
     "description": "A roll of purple carpet.",
     "material": [ "cotton" ],
-    "volume": "1750 ml",
-    "weight": "45 g",
-    "ammo_type": "NULL",
-    "count": 5
+    "volume": "7500 ml",
+    "weight": "6800 g",
+    "//": "Assuming roughly 1m^2 at a density of 1.4 lbs/ft^2",
+    "ammo_type": "NULL"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/resources/tailoring.json
+++ b/data/json/items/resources/tailoring.json
@@ -122,6 +122,21 @@
     "material": [ "nomex" ]
   },
   {
+    "id": "scrap_carpet",
+    "type": "GENERIC",
+    "category": "other",
+    "name": { "str_sp": "scraps of carpet" },
+    "description": "A misshapen section of loose carpet.  Not useful for much on its own and can be discarded.",
+    "weight": "500 g",
+    "volume": "500 ml",
+    "price": 1,
+    "price_postapoc": 1,
+    "material": [ "carpet_pilling", "plastic" ],
+    "symbol": "=",
+    "color": "dark_gray",
+    "flags": [ "NO_SALVAGE" ]
+  },
+  {
     "type": "GENERIC",
     "id": "fur",
     "symbol": ",",

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -2009,6 +2009,14 @@
   },
   {
     "type": "material",
+    "//": "The dense part of carpet pilling, technically made from synthetic fabric but not sewn into flat sheets.  Only a separate material to lower ballistic resistance.",
+    "id": "carpet_pilling",
+    "name": "Carpet Pilling",
+    "copy-from": "nylon",
+    "resist": { "bash": 1, "cut": 1, "acid": 6, "heat": 2, "bullet": 1 }
+  },
+  {
+    "type": "material",
     "id": "unobtanium",
     "//": "this isn't supposed to be a super impressive material, just impossible to repair",
     "name": "Strange Metal",

--- a/data/json/recipes/armor/arms.json
+++ b/data/json/recipes/armor/arms.json
@@ -221,6 +221,48 @@
     "tools": [ [ [ "swage", -1 ] ] ]
   },
   {
+    "result": "carpet_armguards",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_ARMS",
+    "skill_used": "fabrication",
+    "time": "15 m",
+    "autolearn": true,
+    "byproducts": [ [ "scrap_carpet", 10 ] ],
+    "components": [
+      [
+        [ "y_carpet", 1 ],
+        [ "r_carpet", 1 ],
+        [ "p_carpet", 1 ],
+        [ "g_carpet", 1 ]
+      ],
+      [ [ "cordage", 4, "LIST" ], [ "duct_tape", 50 ] ]
+    ],
+    "qualities": [ { "id": "CUT", "level": 2 } ]
+  },
+  {
+    "result": "carpet_bracers",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_ARMS",
+    "skill_used": "fabrication",
+    "time": "15 m",
+    "autolearn": true,
+    "byproducts": [ [ "scrap_carpet", 12 ] ],
+    "components": [
+      [
+        [ "y_carpet", 1 ],
+        [ "r_carpet", 1 ],
+        [ "p_carpet", 1 ],
+        [ "g_carpet", 1 ]
+      ],
+      [ [ "cordage", 2, "LIST" ], [ "duct_tape", 25 ] ]
+    ],
+    "qualities": [ { "id": "CUT", "level": 2 } ]
+  },
+  {
     "result": "armguard_metal",
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",

--- a/data/json/recipes/armor/arms.json
+++ b/data/json/recipes/armor/arms.json
@@ -231,12 +231,7 @@
     "autolearn": true,
     "byproducts": [ [ "scrap_carpet", 10 ] ],
     "components": [
-      [
-        [ "y_carpet", 1 ],
-        [ "r_carpet", 1 ],
-        [ "p_carpet", 1 ],
-        [ "g_carpet", 1 ]
-      ],
+      [ [ "y_carpet", 1 ], [ "r_carpet", 1 ], [ "p_carpet", 1 ], [ "g_carpet", 1 ] ],
       [ [ "cordage", 4, "LIST" ], [ "duct_tape", 50 ] ]
     ],
     "qualities": [ { "id": "CUT", "level": 2 } ]
@@ -252,12 +247,7 @@
     "autolearn": true,
     "byproducts": [ [ "scrap_carpet", 12 ] ],
     "components": [
-      [
-        [ "y_carpet", 1 ],
-        [ "r_carpet", 1 ],
-        [ "p_carpet", 1 ],
-        [ "g_carpet", 1 ]
-      ],
+      [ [ "y_carpet", 1 ], [ "r_carpet", 1 ], [ "p_carpet", 1 ], [ "g_carpet", 1 ] ],
       [ [ "cordage", 2, "LIST" ], [ "duct_tape", 25 ] ]
     ],
     "qualities": [ { "id": "CUT", "level": 2 } ]

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -457,6 +457,48 @@
     "tools": [ [ [ "swage", -1 ] ] ]
   },
   {
+    "result": "carpet_legguards",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_LEGS",
+    "skill_used": "fabrication",
+    "time": "15 m",
+    "autolearn": true,
+    "byproducts": [ [ "scrap_carpet", 8 ] ],
+    "components": [
+      [
+        [ "y_carpet", 1 ],
+        [ "r_carpet", 1 ],
+        [ "p_carpet", 1 ],
+        [ "g_carpet", 1 ]
+      ],
+      [ [ "cordage", 4, "LIST" ], [ "duct_tape", 50 ] ]
+    ],
+    "qualities": [ { "id": "CUT", "level": 2 } ]
+  },
+  {
+    "result": "carpet_greaves",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_LEGS",
+    "skill_used": "fabrication",
+    "time": "15 m",
+    "autolearn": true,
+    "byproducts": [ [ "scrap_carpet", 10 ] ],
+    "components": [
+      [
+        [ "y_carpet", 1 ],
+        [ "r_carpet", 1 ],
+        [ "p_carpet", 1 ],
+        [ "g_carpet", 1 ]
+      ],
+      [ [ "cordage", 2, "LIST" ], [ "duct_tape", 25 ] ]
+    ],
+    "qualities": [ { "id": "CUT", "level": 2 } ]
+  },
+  {
     "result": "legguard_metal_sheets",
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -467,12 +467,7 @@
     "autolearn": true,
     "byproducts": [ [ "scrap_carpet", 8 ] ],
     "components": [
-      [
-        [ "y_carpet", 1 ],
-        [ "r_carpet", 1 ],
-        [ "p_carpet", 1 ],
-        [ "g_carpet", 1 ]
-      ],
+      [ [ "y_carpet", 1 ], [ "r_carpet", 1 ], [ "p_carpet", 1 ], [ "g_carpet", 1 ] ],
       [ [ "cordage", 4, "LIST" ], [ "duct_tape", 50 ] ]
     ],
     "qualities": [ { "id": "CUT", "level": 2 } ]
@@ -488,12 +483,7 @@
     "autolearn": true,
     "byproducts": [ [ "scrap_carpet", 10 ] ],
     "components": [
-      [
-        [ "y_carpet", 1 ],
-        [ "r_carpet", 1 ],
-        [ "p_carpet", 1 ],
-        [ "g_carpet", 1 ]
-      ],
+      [ [ "y_carpet", 1 ], [ "r_carpet", 1 ], [ "p_carpet", 1 ], [ "g_carpet", 1 ] ],
       [ [ "cordage", 2, "LIST" ], [ "duct_tape", 25 ] ]
     ],
     "qualities": [ { "id": "CUT", "level": 2 } ]

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -170,6 +170,26 @@
     "proficiencies": [ { "proficiency": "prof_closures" } ]
   },
   {
+    "result": "carpet_cuirass",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "fabrication",
+    "time": "10 m",
+    "autolearn": true,
+    "components": [
+      [
+        [ "y_carpet", 1 ],
+        [ "r_carpet", 1 ],
+        [ "p_carpet", 1 ],
+        [ "g_carpet", 1 ]
+      ],
+      [ [ "cordage", 8, "LIST" ], [ "duct_tape", 200 ] ]
+    ],
+    "qualities": [ { "id": "CUT", "level": 2 } ]
+  },
+  {
     "result": "chestguard_metal_sheets",
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -179,12 +179,7 @@
     "time": "10 m",
     "autolearn": true,
     "components": [
-      [
-        [ "y_carpet", 1 ],
-        [ "r_carpet", 1 ],
-        [ "p_carpet", 1 ],
-        [ "g_carpet", 1 ]
-      ],
+      [ [ "y_carpet", 1 ], [ "r_carpet", 1 ], [ "p_carpet", 1 ], [ "g_carpet", 1 ] ],
       [ [ "cordage", 8, "LIST" ], [ "duct_tape", 200 ] ]
     ],
     "qualities": [ { "id": "CUT", "level": 2 } ]


### PR DESCRIPTION

#### Summary
Content "Add carpet armor"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

More junky armor for the early game MacGyver wannabe.

#### Describe the solution

Adds carpet armor. 1mm plastic (the backing of most residential carpets is relatively thin polypropylene) and 3mm of a new carpet pilling material based off the synthetic fabric material. Carpet pilling in reality is often longer but the full fluffy length wouldn't provide protection, so I only measured the very dense bit when compressed as much as I could. Measured against the carpets in my house in real life. "Carpet Pilling" as a material was only added as a sorta variant on synthetic fabric to nerf the ballistic damage. It's densely thick but not layered... layers. 

This was something of a judgement call; I don't have any great sources but if I used the default synth fabric values the carpet armor would have a ballistic defense of 11, and I doubt a single layer of residential carpet can stop .22 LR in its tracks. Carpet pilling is otherwise identical to synthetic fabric except with a ballistic resist of 1, so the final defensive values are 5/5/5 cut/bash/ballistic.

The crafting recipes are super simple; this is meant to be terrible emergency armor, hence minimal tools needed and a fab requirement of 0. Fittingly, the coverage is only 85% on the cuirass since it's not particularly shaped to you well. Encumbrance is fairly middling; it's light and does bend but it's still bulky and stiff.

Also comes with arm guards, leg guards, as well as stripped down bracers and greaves.

Relatedly, this fixes the weight and volume of the carpet item, which previously was only 45g and 0.35L for an entire square meter of carpet (since only one "carpet" item was needed to cover a floor). The new values for one "carpet" item is 6800g and 7500ml which is mid-range for carpet weight for a square meter of carpet.

There's also a carpet scraps item added solely for conservation of mass with the arm and leg guards. It's just a byproduct and otherwise useless.

#### Describe alternatives you've considered

Variants to differentiate house carpet from industrial carpet, but I couldn't be bothered. Defensive values are assuming house carpet.

Different armors for the different colored carpet, but that seemed a bit much.

#### Testing

Made sure the game ran and the recipes worked and the items existed.

#### Additional context

This essentially acts as a much lighter, easier to craft, but less covering and protective version of the sheet metal armor in terms of being easily-made early junky armor. Also the idea is not wholly unique to me; though I can't remember which book it was, I got the idea from a different survival novel I read sometime years ago.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->