### PR TITLE
math_parser: force classic locale before parsing

### DIFF
--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -5,6 +5,7 @@
 #include <cerrno>
 #include <cstddef>
 #include <cstdlib>
+#include <locale>
 #include <memory>
 #include <optional>
 #include <stack>
@@ -210,6 +211,10 @@ class math_exp::math_exp_impl
             if( str.empty() ) {
                 return false;
             }
+            std::locale const &oldloc = std::locale::global( std::locale::classic() );
+            on_out_of_scope reset_loc( [&oldloc]() {
+                std::locale::global( oldloc );
+            } );
             try {
                 _parse( str, assignment );
             } catch( std::invalid_argument const &ex ) {

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -1,6 +1,7 @@
 #include "cata_catch.h"
 
 #include <cmath>
+#include <locale>
 
 #include "avatar.h"
 #include "dialogue.h"
@@ -98,6 +99,20 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
     CHECK( std::isinf( testexp.eval( d ) ) );
     CHECK( testexp.parse( "-1 ^ 0.5" ) );
     CHECK( std::isnan( testexp.eval( d ) ) );
+
+    // locale-independent decimal point
+    std::locale const &oldloc = std::locale();
+    on_out_of_scope reset_loc( [&oldloc]() {
+        std::locale::global( oldloc );
+    } );
+    try {
+        std::locale::global( std::locale( "de_DE.UTF-8" ) );
+    } catch( std::runtime_error &e ) {
+        WARN( "couldn't set locale for math_parser test: " << e.what() );
+    }
+    CAPTURE( std::setlocale( LC_ALL, nullptr ), std::locale().name() );
+    CHECK( testexp.parse( "2 * 1.5" ) );
+    CHECK( testexp.eval( d ) == Approx( 3 ) );
 
     // failed validation
     // NOLINTNEXTLINE(readability-function-cognitive-complexity): false positive


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Parsing numbers in the `math_parser` uses the current locale and it shouldn't.

* Fixes #65351
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Set locale to `C` before parsing.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
`std::from_chars()` for doubles is not supported by our current target compilers

`std::stringstream()` needs a temp string allocation until C++23. I'll still have to use this if the current solution doesn't work everywhere. https://github.com/andrei8l/Cataclysm-DDA/commit/2090f6241a64a34000781809aded231d9d4d55fd might actually be a cleaner solution.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Test unit.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Wait for all tests to pass, preferably without the warning.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->