### PR TITLE
Fix clang-tidy workflow failure

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -15,6 +15,9 @@ on:
     - '**.hpp'
     - '**/CMakeLists.txt'
     - '**/Makefile'
+    - 'build-scripts/clang-tidy.sh'
+    - 'build-scripts/clang-tidy-wrapper.sh'
+    - 'build-scripts/get_affected_files.py'
     - '.github/workflows/clang-tidy.yml'
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
@@ -34,7 +37,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           cancel_others: 'true'
-          paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", ".github/workflows/clang-tidy.yml" ]'
+          paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/clang-tidy.sh", "build-scripts/clang-tidy-wrapper.sh", "build-scripts/get_affected_files.py", ".github/workflows/clang-tidy.yml" ]'
   build:
     needs: skip-duplicates
     if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
@@ -91,5 +94,10 @@ jobs:
       run: bash ./build-scripts/clang-tidy.sh
     - name: show most time consuming checks
       if: always()
-      run: |
-        jq -n 'reduce(inputs.profile | to_entries[]) as {$key,$value} ({}; .[$key] += $value) | with_entries(select(.key|contains(".wall"))) | to_entries | sort_by(.value) | reverse | .[0:10] | from_entries' clang-tidy-trace/*.json
+      run: | # the folder may not exist if there is no file to analyze
+        if [ -d clang-tidy-trace ]
+        then
+          jq -n 'reduce(inputs.profile | to_entries[]) as {$key,$value} ({}; .[$key] += $value) | with_entries(select(.key|contains(".wall"))) | to_entries | sort_by(.value) | reverse | .[0:10] | from_entries' clang-tidy-trace/*.json
+        else
+          echo "clang-tidy-trace folder not found."
+        fi

--- a/build-scripts/clang-tidy.sh
+++ b/build-scripts/clang-tidy.sh
@@ -124,13 +124,16 @@ fi
 printf "Subset to analyze: '%s'\n" "$CATA_CLANG_TIDY_SUBSET"
 
 # We might need to analyze only a subset of the files if they have been split
-# into multiple jobs for efficiency
+# into multiple jobs for efficiency. The paths from `compile_commands.json` can
+# be absolute but the paths from `get_affected_files.py` are relative, so both
+# formats are matched. Exit code 1 from grep (meaning no match) is ignored in
+# case one subset contains no file to analyze.
 case "$CATA_CLANG_TIDY_SUBSET" in
     ( src )
-        tidyable_cpp_files=$(printf '%s\n' "$tidyable_cpp_files" | grep '/src/')
+        tidyable_cpp_files=$(printf '%s\n' "$tidyable_cpp_files" | grep -E '(^|/)src/' || [[ $? == 1 ]])
         ;;
     ( other )
-        tidyable_cpp_files=$(printf '%s\n' "$tidyable_cpp_files" | grep -v '/src/')
+        tidyable_cpp_files=$(printf '%s\n' "$tidyable_cpp_files" | grep -Ev '(^|/)src/' || [[ $? == 1 ]])
         ;;
 esac
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
According to https://github.com/CleverRaven/Cataclysm-DDA/pull/65272#discussion_r1176334742 the clang-tidy failures encountered [here](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4789780565/jobs/8518061193?pr=65109), [here](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4787792131/jobs/8513519115?pr=65291), and [here](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4827077848/jobs/8599496522?pr=65352) are probably due to `grep` failing when there is no match.

I also noticed that [this `other` run](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4827077848/jobs/8599496619?pr=65352) checked two files when the corresponding PR only changed one source file in the `test` directory, and according to [this line](https://github.com/CleverRaven/Cataclysm-DDA/blob/0b9b1fa700787f65a85773824dffaad161503849/build-scripts/get_affected_files.py#L76) and [this line](https://github.com/CleverRaven/Cataclysm-DDA/blob/0b9b1fa700787f65a85773824dffaad161503849/build-scripts/get_affected_files.py#L94), `get_affected_files.py` returns relative paths that do not have a slash at the beginning, whereas the regex in `clang-tidy.sh` always tries to match a slash at the beginning. So my theory is that the regexes in `clang-tidy.sh` only matched absolute paths generated from `compile_commands.json` when build files are changed but not relative paths from `get_affected_files.py` when only source files are changed, so for PRs that changes only source files, the regex matches nothing and all changed files are analyzed in the `other` run.

#### Describe the solution
Ignore exit code 1 from grep and match aboslute and relative paths. Also make changes to relevant build script files trigger the clang-tidy workflow and avoid failing the run if no clang-tidy trace file is generated (which presumably is because there is no file to analyze).

#### Describe alternatives you've considered

#### Testing
Tested by imitating source file only change (https://github.com/CleverRaven/Cataclysm-DDA/pull/65354/commits/3a58719597a4e059695942283f2a6eaed0c3073a):

[`src` run](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4831122660/jobs/8608153102):

The changed `src/achievement.cpp` was analyzed in the `src` run instead of the `other` run.

[`other` run](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4831122660/jobs/8608153256):

The `other` run succeeded because there is no file to analyze, and did not fail due to `grep` not finding any match, and the time consumption printing script did not fail due to missing clang-tidy trace folder.

Tested full clang-tidy run due to changed build files:

[`src` run](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4831308962/jobs/8608587155?pr=65354):

The run completed and the reported warnings are unrelated.

[`other` run](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4831308962/jobs/8608587291?pr=65354)

The run completed.

#### Additional context
Thanks to @BrettDong for pointing to the potential failing reason.