### PR TITLE
Rebalance magiclysm's mage armor spell to also scale with intelligence

### DIFF
--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -959,7 +959,7 @@
     "category": "armor",
     "copy-from": "armor_lightplate",
     "name": { "str_sp": "mage armor" },
-    "description": "A summoned magic armor.  It gets shinier and sturdier with each spell level.",
+    "description": "A summoned magic armor. It gets shinier and sturdier with each spell level and is affected by your intelligence.",
     "weight": "1 g",
     "material": [ "concentrated_mana" ],
     "warmth": 0,

--- a/data/mods/Magiclysm/items/item_enchants.json
+++ b/data/mods/Magiclysm/items/item_enchants.json
@@ -23,27 +23,57 @@
     "has": "WORN",
     "condition": "ALWAYS",
     "name": { "str": "magic armor" },
-    "description": "This armor is made better as your spell level improves.",
+    "description": "This magical armor improves with your intelligence and the spell's level.",
     "values": [
       {
         "value": "ARMOR_BASH",
-        "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": -1 } ] }
+        "add": {
+          "arithmetic": [
+            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": -1 } ] },
+            "+",
+            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": -1 } ] }
+          ]
+        }
       },
       {
         "value": "ARMOR_CUT",
-        "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": -1 } ] }
+        "add": {
+          "arithmetic": [
+            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": -1 } ] },
+            "+",
+            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": -1 } ] }
+          ]
+        }
       },
       {
         "value": "ARMOR_STAB",
-        "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": -1 } ] }
+        "add": {
+          "arithmetic": [
+            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": -1 } ] },
+            "+",
+            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": -1 } ] }
+          ]
+        }
       },
       {
         "value": "ARMOR_BULLET",
-        "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": -1 } ] }
+        "add": {
+          "arithmetic": [
+            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": -1 } ] },
+            "+",
+            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": -1 } ] }
+          ]
+        }
       },
       {
         "value": "LUMINATION",
-        "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": 3 } ] }
+        "add": {
+          "arithmetic": [
+            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": 3 } ] },
+            "+",
+            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": 3 } ] }
+          ]
+        }
       }
     ]
   }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Originally the spell was worded to scale with both spell level and intelligence, now it does so. See https://github.com/CleverRaven/Cataclysm-DDA/pull/64405

#### Describe the solution
Modifies the enchant JSON to use the proper arithmetic. The scaling can be additionally adjusted as desired.

#### Describe alternatives you've considered
Leaving as is (scaling only by spell level)

#### Testing
New JSON tested using debugging tools with a high-int low spell level character.

#### Additional context
None