### PR TITLE
Make vehicle prototypes use generic_factory

### DIFF
--- a/data/json/vehicles/vehicles.json
+++ b/data/json/vehicles/vehicles.json
@@ -1,17 +1,9 @@
 [
   {
-    "id": "custom",
-    "type": "vehicle",
-    "name": "custom",
-    "//": "Don't remove this vehicle definition!",
-    "blueprint": [ "H" ],
-    "parts": [ { "x": 0, "y": 0, "part": "frame_vertical_2" } ]
-  },
-  {
     "id": "none",
     "type": "vehicle",
-    "name": "custom_empty",
-    "//": "Don't remove this vehicle definition!",
+    "name": "empty prototype",
+    "//": "don't remove, used for initializing empty vehicle prototype",
     "blueprint": [ "H" ],
     "parts": [  ]
   }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -135,8 +135,6 @@ static const mtype_id mon_generator( "mon_generator" );
 static const trait_id trait_ASTHMA( "ASTHMA" );
 static const trait_id trait_NONE( "NONE" );
 
-static const vproto_id vehicle_prototype_custom( "custom" );
-
 #if defined(TILES)
 #include "sdl_wrappers.h"
 #endif
@@ -2465,7 +2463,7 @@ static void debug_menu_spawn_vehicle()
         // Vector of name, id so that we can sort by name
         std::vector<std::pair<std::string, vproto_id>> veh_strings;
         for( const vehicle_prototype &proto : vehicles::get_all_prototypes() ) {
-            if( proto.id != vehicle_prototype_custom ) {
+            if( !proto.parts.empty() ) {
                 veh_strings.emplace_back( proto.name.translated(), proto.id );
             }
         }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2464,11 +2464,10 @@ static void debug_menu_spawn_vehicle()
     } else {
         // Vector of name, id so that we can sort by name
         std::vector<std::pair<std::string, vproto_id>> veh_strings;
-        for( auto &elem : vehicle_prototype::get_all() ) {
-            if( elem == vehicle_prototype_custom ) {
-                continue;
+        for( const vehicle_prototype &proto : vehicles::get_all_prototypes() ) {
+            if( proto.id != vehicle_prototype_custom ) {
+                veh_strings.emplace_back( proto.name.translated(), proto.id );
             }
-            veh_strings.emplace_back( elem->name.translated(), elem );
         }
         std::sort( veh_strings.begin(), veh_strings.end(), localized_compare );
         uilist veh_menu;

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -298,9 +298,9 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
             "Max velocity (mph)", "Safe velocity (mph)", "Acceleration (mph/turn)",
             "Aerodynamics coeff", "Rolling coeff", "Static Drag", "Offroad %"
         };
-        auto dump = [&rows]( const vproto_id & obj ) {
-            vehicle veh_empty( get_map(), obj, 0, 0 );
-            vehicle veh_fueled( get_map(), obj, 100, 0 );
+        auto dump = [&rows]( const vehicle_prototype & obj ) {
+            vehicle veh_empty( get_map(), obj.id, 0, 0 );
+            vehicle veh_fueled( get_map(), obj.id, 100, 0 );
 
             std::vector<std::string> r;
             r.push_back( veh_empty.name );
@@ -316,7 +316,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
                                          veh_fueled.k_traction( veh_fueled.wheel_area() ) ) ) );
             rows.push_back( r );
         };
-        for( auto &e : vehicle_prototype::get_all() ) {
+        for( const vehicle_prototype &e : vehicles::get_all_prototypes() ) {
             dump( e );
         }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -309,7 +309,7 @@ void DynamicDataLoader::initialize()
     add( "vehicle_part",  &vpart_info::load );
     add( "vehicle_part_category",  &vpart_category::load );
     add( "vehicle_part_migration", &vpart_migration::load );
-    add( "vehicle",  &vehicle_prototype::load );
+    add( "vehicle", &vehicles::load_prototype );
     add( "vehicle_group",  &VehicleGroup::load );
     add( "vehicle_placement",  &VehiclePlacement::load );
     add( "vehicle_spawn",  &VehicleSpawn::load );
@@ -643,7 +643,7 @@ void DynamicDataLoader::unload_data()
     VehicleGroup::reset();
     VehiclePlacement::reset();
     VehicleSpawn::reset();
-    vehicle_prototype::reset();
+    vehicles::reset_prototypes();
     vitamin::reset();
     vpart_info::reset();
     vpart_category::reset();
@@ -713,7 +713,7 @@ void DynamicDataLoader::finalize_loaded_data( loading_ui &ui )
             { _( "Cities" ), &city::finalize },
             { _( "Start locations" ), &start_locations::finalize_all },
             { _( "Vehicle part migrations" ), &vpart_migration::finalize },
-            { _( "Vehicle prototypes" ), &vehicle_prototype::finalize },
+            { _( "Vehicle prototypes" ), &vehicles::finalize_prototypes },
             { _( "Mapgen weights" ), &calculate_mapgen_weights },
             { _( "Mapgen parameters" ), &overmap_specials::finalize_mapgen_parameters },
             { _( "Behaviors" ), &behavior::finalize },

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1377,8 +1377,8 @@ void Item_factory::finalize_item_blacklist()
             return r.result() == candidate->first;
         } );
     }
-    for( vproto_id &vid : vehicle_prototype::get_all() ) {
-        vehicle_prototype &prototype = const_cast<vehicle_prototype &>( vid.obj() );
+    for( const vehicle_prototype &const_prototype : vehicles::get_all_prototypes() ) {
+        vehicle_prototype &prototype = const_cast<vehicle_prototype &>( const_prototype );
         for( vehicle_item_spawn &vis : prototype.item_spawns ) {
             auto &vec = vis.item_ids;
             const auto iter = std::remove_if( vec.begin(), vec.end(), item_is_blacklisted );
@@ -1480,8 +1480,8 @@ void Item_factory::finalize_item_blacklist()
             }
         }
     }
-    for( vproto_id &vid : vehicle_prototype::get_all() ) {
-        vehicle_prototype &prototype = const_cast<vehicle_prototype &>( vid.obj() );
+    for( const vehicle_prototype &const_prototype : vehicles::get_all_prototypes() ) {
+        vehicle_prototype &prototype = const_cast<vehicle_prototype &>( const_prototype );
         for( vehicle_item_spawn &vis : prototype.item_spawns ) {
             for( itype_id &type_to_spawn : vis.item_ids ) {
                 std::map<itype_id, std::vector<migration>>::iterator replacement =

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -18,6 +18,7 @@
 #include "debug.h"
 #include "flag.h"
 #include "game_constants.h"
+#include "generic_factory.h"
 #include "init.h"
 #include "item.h"
 #include "item_factory.h"
@@ -39,6 +40,11 @@
 
 class npc;
 
+namespace
+{
+generic_factory<vehicle_prototype> vehicle_prototype_factory( "vehicle", "id" );
+} // namespace
+
 static const ammotype ammo_battery( "battery" );
 
 static const itype_id itype_null( "null" );
@@ -49,8 +55,6 @@ static const quality_id qual_LIFT( "LIFT" );
 static const skill_id skill_launcher( "launcher" );
 
 static const vpart_id vpart_turret_generic( "turret_generic" );
-
-static std::unordered_map<vproto_id, vehicle_prototype> vtypes;
 
 // GENERAL GUIDELINES
 // To determine mount position for parts (dx, dy), check this scheme:
@@ -1315,49 +1319,38 @@ time_duration vpart_info::get_unfolding_time() const
 template<>
 const vehicle_prototype &string_id<vehicle_prototype>::obj() const
 {
-    const auto iter = vtypes.find( *this );
-    if( iter == vtypes.end() ) {
-        debugmsg( "invalid vehicle prototype id %s", c_str() );
-        static const vehicle_prototype dummy;
-        return dummy;
-    }
-    return iter->second;
+    return vehicle_prototype_factory.obj( *this );
 }
 
 /** @relates string_id */
 template<>
 bool string_id<vehicle_prototype>::is_valid() const
 {
-    return vtypes.count( *this ) > 0;
+    return vehicle_prototype_factory.is_valid( *this );
 }
 
-vehicle_prototype::vehicle_prototype() = default;
-vehicle_prototype::vehicle_prototype( vehicle_prototype && ) noexcept = default;
-vehicle_prototype::~vehicle_prototype() = default;
+void vehicles::load_prototype( const JsonObject &jo, const std::string &src )
+{
+    vehicle_prototype_factory.load( jo, src );
+}
 
-vehicle_prototype &vehicle_prototype::operator=( vehicle_prototype &&
-                                               ) noexcept( string_is_noexcept ) = default;
+const std::vector<vehicle_prototype> &vehicles::get_all_prototypes()
+{
+    return vehicle_prototype_factory.get_all();
+}
+
+void vehicles::reset_prototypes()
+{
+    vehicle_prototype_factory.reset();
+}
 
 /**
  *Caches a vehicle definition from a JsonObject to be loaded after itypes is initialized.
  */
-void vehicle_prototype::load( const JsonObject &jo )
+void vehicle_prototype::load( const JsonObject &jo, std::string_view src )
 {
-    vproto_id vid = vproto_id( jo.get_string( "id" ) );
-    vehicle_prototype &vproto = vtypes[ vid ];
-    // If there are already parts defined, this vehicle prototype overrides an existing one.
-    // If the json contains a name, it means a completely new prototype (replacing the
-    // original one), therefore the old data has to be cleared.
-    // If the json does not contain a name (the prototype would have no name), it means appending
-    // to the existing prototype (the parts are not cleared).
-    if( !vproto.parts.empty() && jo.has_string( "name" ) ) {
-        vproto = vehicle_prototype();
-    }
-    if( vproto.parts.empty() ) {
-        jo.get_member( "name" ).read( vproto.name );
-    }
-
-    vgroups[ vgroup_id( vid.str() ) ].add_vehicle( vid, 100 );
+    vgroups[vgroup_id( id.str() )].add_vehicle( id, 100 );
+    mandatory( jo, was_loaded, "name", name );
 
     const auto add_part_obj = [&]( const JsonObject & part, point pos ) {
         part_def pt;
@@ -1370,7 +1363,7 @@ void vehicle_prototype::load( const JsonObject &jo )
         assign( part, "fuel", pt.fuel, true );
         assign( part, "tools", pt.tools, true );
 
-        vproto.parts.push_back( pt );
+        parts.emplace_back( pt );
     };
 
     const auto add_part_string = [&]( const std::string & part, point pos ) {
@@ -1378,7 +1371,7 @@ void vehicle_prototype::load( const JsonObject &jo )
         pt.pos = pos;
         std::tie( pt.part, pt.variant ) = get_vpart_id_variant( part );
 
-        vproto.parts.push_back( pt );
+        parts.emplace_back( pt );
     };
 
     if( jo.has_member( "blueprint" ) ) {
@@ -1412,7 +1405,7 @@ void vehicle_prototype::load( const JsonObject &jo )
         next_spawn.chance = spawn_info.get_int( "chance" );
         if( next_spawn.chance <= 0 || next_spawn.chance > 100 ) {
             debugmsg( "Invalid spawn chance in %s (%d, %d): %d%%",
-                      vproto.name, next_spawn.pos.x, next_spawn.pos.y, next_spawn.chance );
+                      name, next_spawn.pos.x, next_spawn.pos.y, next_spawn.chance );
         }
 
         // constrain both with_magazine and with_ammo to [0-100]
@@ -1442,7 +1435,7 @@ void vehicle_prototype::load( const JsonObject &jo )
         } else if( spawn_info.has_string( "item_groups" ) ) {
             next_spawn.item_groups.emplace_back( spawn_info.get_string( "item_groups" ) );
         }
-        vproto.item_spawns.push_back( std::move( next_spawn ) );
+        item_spawns.push_back( std::move( next_spawn ) );
     }
 
     for( JsonObject jzi : jo.get_array( "zones" ) ) {
@@ -1457,33 +1450,30 @@ void vehicle_prototype::load( const JsonObject &jo )
         if( jzi.has_string( "filter" ) ) {
             filter = jzi.get_string( "filter" );
         }
-        vproto.zone_defs.emplace_back( zone_def{ zone_type, name, filter, pt } );
+        zone_defs.emplace_back( zone_def{ zone_type, name, filter, pt } );
     }
-}
-
-void vehicle_prototype::reset()
-{
-    vtypes.clear();
 }
 
 /**
  *Works through cached vehicle definitions and creates vehicle objects from them.
  */
-void vehicle_prototype::finalize()
+void vehicles::finalize_prototypes()
 {
-    for( auto &[id, proto] : vtypes ) {
+    vehicle_prototype_factory.finalize();
+    for( const vehicle_prototype &const_proto : vehicles::get_all_prototypes() ) {
+        vehicle_prototype &proto = const_cast<vehicle_prototype &>( const_proto );
         std::unordered_set<point> cargo_spots;
 
         // Calls the default constructor to create an empty vehicle. Calling the constructor with
         // the type as parameter would make it look up the type in the map and copy the
         // (non-existing) blueprint.
-        proto.blueprint = std::make_unique<vehicle>();
+        proto.blueprint = make_shared_fast<vehicle>();
         vehicle &blueprint = *proto.blueprint;
-        blueprint.type = id;
+        blueprint.type = proto.id;
         blueprint.name = proto.name.translated();
 
         blueprint.suspend_refresh();
-        for( part_def &pt : proto.parts ) {
+        for( vehicle_prototype::part_def &pt : proto.parts ) {
             if( const vpart_migration *migration = vpart_migration::find_migration( pt.part ) ) {
                 debugmsg( "veh prototype '%s' needs fixing, part '%s' is migrated to '%s'",
                           proto.name, pt.part.str(), migration->part_id_new.str() );
@@ -1491,7 +1481,7 @@ void vehicle_prototype::finalize()
             }
 
             if( !pt.part.is_valid() ) {
-                debugmsg( "unknown vehicle part %s in %s", pt.part.c_str(), id.c_str() );
+                debugmsg( "unknown vehicle part %s in %s", pt.part.c_str(), proto.id.str() );
                 continue;
             }
 
@@ -1528,15 +1518,15 @@ void vehicle_prototype::finalize()
             if( !base->gun ) {
                 if( pt.with_ammo ) {
                     debugmsg( "init_vehicles: non-turret %s with ammo in %s", pt.part.c_str(),
-                              id.c_str() );
+                              proto.id.str() );
                 }
                 if( !pt.ammo_types.empty() ) {
                     debugmsg( "init_vehicles: non-turret %s with ammo_types in %s",
-                              pt.part.c_str(), id.c_str() );
+                              pt.part.c_str(), proto.id.str() );
                 }
                 if( pt.ammo_qty.first > 0 || pt.ammo_qty.second > 0 ) {
                     debugmsg( "init_vehicles: non-turret %s with ammo_qty in %s",
-                              pt.part.c_str(), id.c_str() );
+                              pt.part.c_str(), proto.id.str() );
                 }
 
             } else {
@@ -1544,7 +1534,7 @@ void vehicle_prototype::finalize()
                     const itype *ammo = item::find_type( e );
                     if( !ammo->ammo || !base->gun->ammo.count( ammo->ammo->type ) ) {
                         debugmsg( "init_vehicles: turret %s has invalid ammo_type %s in %s",
-                                  pt.part.c_str(), e.c_str(), id.c_str() );
+                                  pt.part.c_str(), e.c_str(), proto.id.str() );
                     }
                 }
                 if( pt.ammo_types.empty() && !base->gun->ammo.empty() ) {
@@ -1555,12 +1545,12 @@ void vehicle_prototype::finalize()
             if( type_can_contain( *base, pt.fuel ) || base->magazine ) {
                 if( !item::type_is_defined( pt.fuel ) ) {
                     debugmsg( "init_vehicles: tank %s specified invalid fuel in %s",
-                              pt.part.c_str(), id.c_str() );
+                              pt.part.c_str(), proto.id.str() );
                 }
             } else {
                 if( !pt.fuel.is_null() ) {
                     debugmsg( "init_vehicles: non-fuel store part %s with fuel in %s",
-                              pt.part.c_str(), id.c_str() );
+                              pt.part.c_str(), proto.id.str() );
                 }
             }
 
@@ -1577,26 +1567,16 @@ void vehicle_prototype::finalize()
             }
             for( auto &j : i.item_ids ) {
                 if( !item::type_is_defined( j ) ) {
-                    debugmsg( "unknown item %s in spawn list of %s", j.c_str(), id.c_str() );
+                    debugmsg( "unknown item %s in spawn list of %s", j.c_str(), proto.id.str() );
                 }
             }
             for( auto &j : i.item_groups ) {
                 if( !item_group::group_is_defined( j ) ) {
-                    debugmsg( "unknown item group %s in spawn list of %s", j.c_str(), id.c_str() );
+                    debugmsg( "unknown item group %s in spawn list of %s", j.c_str(), proto.id.str() );
                 }
             }
         }
     }
-}
-
-std::vector<vproto_id> vehicle_prototype::get_all()
-{
-    std::vector<vproto_id> result;
-    result.reserve( vtypes.size() );
-    for( auto &vp : vtypes ) {
-        result.push_back( vp.first );
-    }
-    return result;
 }
 
 static std::vector<vpart_category> vpart_categories_all;

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1344,10 +1344,7 @@ void vehicles::reset_prototypes()
     vehicle_prototype_factory.reset();
 }
 
-/**
- *Caches a vehicle definition from a JsonObject to be loaded after itypes is initialized.
- */
-void vehicle_prototype::load( const JsonObject &jo, std::string_view src )
+void vehicle_prototype::load( const JsonObject &jo, std::string_view )
 {
     vgroups[vgroup_id( id.str() )].add_vehicle( id, 100 );
     mandatory( jo, was_loaded, "name", name );

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -29,6 +29,16 @@ class JsonObject;
 class Character;
 class vehicle;
 
+template <typename T> class generic_factory;
+
+namespace vehicles
+{
+void load_prototype( const JsonObject &jo, const std::string &src );
+void reset_prototypes();
+void finalize_prototypes();
+const std::vector<vehicle_prototype> &get_all_prototypes();
+} // namespace vehicles
+
 // bitmask backing store of -certain- vpart_info.flags, ones that
 // won't be going away, are involved in core functionality, and are checked frequently
 enum vpart_bitflags : int {
@@ -516,42 +526,36 @@ struct vehicle_item_spawn {
  * is a nullptr. Creating a new vehicle copies the blueprint vehicle.
  */
 struct vehicle_prototype {
-    struct part_def {
-        point pos;
-        vpart_id part;
-        std::string variant;
-        int with_ammo = 0;
-        std::set<itype_id> ammo_types;
-        std::pair<int, int> ammo_qty = { -1, -1 };
-        itype_id fuel = itype_id::NULL_ID();
-        std::vector<itype_id> tools;
-    };
+        struct part_def {
+            point pos;
+            vpart_id part;
+            std::string variant;
+            int with_ammo = 0;
+            std::set<itype_id> ammo_types;
+            std::pair<int, int> ammo_qty = { -1, -1 };
+            itype_id fuel = itype_id::NULL_ID();
+            std::vector<itype_id> tools;
+        };
 
-    struct zone_def {
-        zone_type_id zone_type;
-        std::string name;
-        std::string filter;
-        point pt;
-    };
+        struct zone_def {
+            zone_type_id zone_type;
+            std::string name;
+            std::string filter;
+            point pt;
+        };
 
-    vehicle_prototype();
-    vehicle_prototype( vehicle_prototype && ) noexcept;
-    ~vehicle_prototype();
+        vproto_id id;
+        translation name;
+        std::vector<part_def> parts;
+        std::vector<vehicle_item_spawn> item_spawns;
+        std::vector<zone_def> zone_defs;
 
-    vehicle_prototype &operator=( vehicle_prototype && ) noexcept( string_is_noexcept );
+        shared_ptr_fast<vehicle> blueprint;
 
-    translation name;
-    std::vector<part_def> parts;
-    std::vector<vehicle_item_spawn> item_spawns;
-    std::vector<zone_def> zone_defs;
-
-    std::unique_ptr<vehicle> blueprint;
-
-    static void load( const JsonObject &jo );
-    static void reset();
-    static void finalize();
-
-    static std::vector<vproto_id> get_all();
+        void load( const JsonObject &jo, std::string_view src );
+    private:
+        bool was_loaded = false; // used by generic_factory
+        friend class generic_factory<vehicle_prototype>;
 };
 
 /**


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Want to extend them a bit, but the code is a bit aged, this makes the initial port to generic_factory

#### Describe the solution

Some minor changes are made;
1 unused vehicle prototype is deleted even though comment says not to ( you're not my mom! )
Some unusual behavior listed in the comment is removed; sloppy python script shows no current vehicle json has undefined or empty "name" field (out of tree mods can use copy-from after this patch instead)
https://github.com/CleverRaven/Cataclysm-DDA/blob/5dec49381252c95e448f48e6b9c2aca947707365/src/veh_type.cpp#L1348-L1352

#### Describe alternatives you've considered

#### Testing

Test suite passes
Moving until mapgen spawns vehicles and spawning vehicles via debug menu works

#### Additional context
