### PR TITLE
Obsoleted nonsensical professions

### DIFF
--- a/data/json/obsoletion/obsolete_professions.json
+++ b/data/json/obsoletion/obsolete_professions.json
@@ -1,46 +1,6 @@
 [
   {
     "type": "profession",
-    "id": "jr_survivalist",
-    "name": "Survivalist Jr.",
-    "description": "Your parents were crazy preppers who thought some \"Cataclysm\" was coming, and insisted on preparing you for it.  Turns out they were right.  You didn't get a chance to thank them.  The only thing you can do for them now is what they always hoped you would do in the dark days ahead: survive.",
-    "points": 3,
-    "skills": [
-      { "level": 1, "name": "survival" },
-      { "level": 1, "name": "fabrication" },
-      { "level": 1, "name": "firstaid" },
-      { "level": 1, "name": "traps" }
-    ],
-    "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_lockpicking" ],
-    "items": {
-      "both": {
-        "items": [
-          "jacket_light",
-          "pants_cargo",
-          "socks",
-          "boots",
-          "knit_scarf",
-          "backpack",
-          "granola",
-          "water_clean",
-          "scissors",
-          "magnifying_glass",
-          "wristwatch",
-          "whistle"
-        ],
-        "entries": [
-          { "group": "charged_cell_phone" },
-          { "group": "full_1st_aid" },
-          { "group": "charged_flashlight" },
-          { "item": "tshirt", "variant": "generic_tshirt" }
-        ]
-      },
-      "male": [ "briefs" ],
-      "female": [ "boy_shorts" ]
-    }
-  },
-  {
-    "type": "profession",
     "id": "senior",
     "name": "Senior Citizen",
     "description": "You haven't seen this much blood since the war.  The whole world's gone crazy!  They ate your grandkids!  But dagnabbit, you'll make them all pay for what they've done.",

--- a/data/json/obsoletion/obsolete_professions.json
+++ b/data/json/obsoletion/obsolete_professions.json
@@ -1,0 +1,58 @@
+[
+  {
+    "type": "profession",
+    "id": "jr_survivalist",
+    "name": "Survivalist Jr.",
+    "description": "Your parents were crazy preppers who thought some \"Cataclysm\" was coming, and insisted on preparing you for it.  Turns out they were right.  You didn't get a chance to thank them.  The only thing you can do for them now is what they always hoped you would do in the dark days ahead: survive.",
+    "points": 3,
+    "skills": [
+      { "level": 1, "name": "survival" },
+      { "level": 1, "name": "fabrication" },
+      { "level": 1, "name": "firstaid" },
+      { "level": 1, "name": "traps" }
+    ],
+    "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_lockpicking" ],
+    "items": {
+      "both": {
+        "items": [
+          "jacket_light",
+          "pants_cargo",
+          "socks",
+          "boots",
+          "knit_scarf",
+          "backpack",
+          "granola",
+          "water_clean",
+          "scissors",
+          "magnifying_glass",
+          "wristwatch",
+          "whistle"
+        ],
+        "entries": [
+          { "group": "charged_cell_phone" },
+          { "group": "full_1st_aid" },
+          { "group": "charged_flashlight" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
+      },
+      "male": [ "briefs" ],
+      "female": [ "boy_shorts" ]
+    }
+  },
+  {
+    "type": "profession",
+    "id": "senior",
+    "name": "Senior Citizen",
+    "description": "You haven't seen this much blood since the war.  The whole world's gone crazy!  They ate your grandkids!  But dagnabbit, you'll make them all pay for what they've done.",
+    "proficiencies": [ "prof_knitting" ],
+    "points": 0,
+    "items": {
+      "both": {
+        "items": [ "tobacco", "pipe_tobacco", "socks", "dress_shoes", "knit_scarf", "bellyband", "dentures" ],
+        "entries": [ { "group": "charged_ref_lighter" }, { "item": "cane", "custom-flags": [ "auto_wield" ] } ]
+      },
+      "male": [ "briefs", "dress_shirt", "pants_checkered", "pocketwatch" ],
+      "female": [ "panties", "bra", "dress", "fanny", "gold_watch" ]
+    }
+  }
+]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3048,22 +3048,7 @@
     },
     "missions": [ "MISSION_LOST_SUB" ]
   },
-  {
-    "type": "profession",
-    "id": "senior",
-    "name": "Senior Citizen",
-    "description": "You haven't seen this much blood since the war.  The whole world's gone crazy!  They ate your grandkids!  But dagnabbit, you'll make them all pay for what they've done.",
-    "proficiencies": [ "prof_knitting" ],
-    "points": 0,
-    "items": {
-      "both": {
-        "items": [ "tobacco", "pipe_tobacco", "socks", "dress_shoes", "knit_scarf", "bellyband", "dentures" ],
-        "entries": [ { "group": "charged_ref_lighter" }, { "item": "cane", "custom-flags": [ "auto_wield" ] } ]
-      },
-      "male": [ "briefs", "dress_shirt", "pants_checkered", "pocketwatch" ],
-      "female": [ "panties", "bra", "dress", "fanny", "gold_watch" ]
-    }
-  },
+
   {
     "type": "profession",
     "id": "otaku",
@@ -4053,46 +4038,6 @@
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "charged_matches" },
-          { "item": "tshirt", "variant": "generic_tshirt" }
-        ]
-      },
-      "male": [ "briefs" ],
-      "female": [ "boy_shorts" ]
-    }
-  },
-  {
-    "type": "profession",
-    "id": "jr_survivalist",
-    "name": "Survivalist Jr.",
-    "description": "Your parents were crazy preppers who thought some \"Cataclysm\" was coming, and insisted on preparing you for it.  Turns out they were right.  You didn't get a chance to thank them.  The only thing you can do for them now is what they always hoped you would do in the dark days ahead: survive.",
-    "points": 3,
-    "skills": [
-      { "level": 1, "name": "survival" },
-      { "level": 1, "name": "fabrication" },
-      { "level": 1, "name": "firstaid" },
-      { "level": 1, "name": "traps" }
-    ],
-    "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_lockpicking" ],
-    "items": {
-      "both": {
-        "items": [
-          "jacket_light",
-          "pants_cargo",
-          "socks",
-          "boots",
-          "knit_scarf",
-          "backpack",
-          "granola",
-          "water_clean",
-          "scissors",
-          "magnifying_glass",
-          "wristwatch",
-          "whistle"
-        ],
-        "entries": [
-          { "group": "charged_cell_phone" },
-          { "group": "full_1st_aid" },
-          { "group": "charged_flashlight" },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
       },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4046,6 +4046,46 @@
   },
   {
     "type": "profession",
+    "id": "jr_survivalist",
+    "name": "Survivalist Jr.",
+    "description": "Your parents were crazy preppers who thought some \"Cataclysm\" was coming, and insisted on preparing you for it.  Turns out they were right.  You didn't get a chance to thank them.  The only thing you can do for them now is what they always hoped you would do in the dark days ahead: survive.",
+    "points": 3,
+    "skills": [
+      { "level": 1, "name": "survival" },
+      { "level": 1, "name": "fabrication" },
+      { "level": 1, "name": "firstaid" },
+      { "level": 1, "name": "traps" }
+    ],
+    "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_lockpicking" ],
+    "items": {
+      "both": {
+        "items": [
+          "jacket_light",
+          "pants_cargo",
+          "socks",
+          "boots",
+          "knit_scarf",
+          "backpack",
+          "granola",
+          "water_clean",
+          "scissors",
+          "magnifying_glass",
+          "wristwatch",
+          "whistle"
+        ],
+        "entries": [
+          { "group": "charged_cell_phone" },
+          { "group": "full_1st_aid" },
+          { "group": "charged_flashlight" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
+      },
+      "male": [ "briefs" ],
+      "female": [ "boy_shorts" ]
+    }
+  },
+  {
+    "type": "profession",
     "id": "dodgeball_player",
     "name": "Dodgeball Player",
     "description": "In dodgeball, failing to dodge meant taking a ball to the head and being out of the game.  In the Cataclysm, it means getting eaten by monsters.  Don't slip up.",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3048,7 +3048,6 @@
     },
     "missions": [ "MISSION_LOST_SUB" ]
   },
-
   {
     "type": "profession",
     "id": "otaku",


### PR DESCRIPTION
#### Summary
Content "Obsoleted Senior Citizen"

#### Purpose of change
Being a "Senior Citizen" usually means [being 60 or 65 higher](https://www.elizz.com/wellness/what-age-is-considered-elderly/#:~:text=The%20term%20%E2%80%9Csenior%20citizen%E2%80%9D%20typically,age%20of%2060%20or%2065.), but the game only allows you to be 55 yrs old. Fairly weird and nonsensical.

#### Describe the solution
Obsoleted the profession

#### Describe alternatives you've considered
- Keep the profession
- Buff the age limit, but have to add things which involve "Old man's health becoming deteriorated", and this solution is pretty simple

#### Testing
Loaded the save. Worked properly

#### Additional context
Just Google "How old would someone be considered senior?"