### PR TITLE
Fix calculation for inserting into nested containers

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3902,8 +3902,8 @@ void insert_item_activity_actor::finish( player_activity &act, Character &who )
     if( holstered_item.first ) {
         item &it = *holstered_item.first;
         if( !it.count_by_charges() ) {
-            if( holster->can_contain_directly( it ).success() && ( all_pockets_rigid ||
-                    holster.parents_can_contain_recursive( &it ) ) ) {
+            if( holster->can_contain_directly( it ).success() &&
+                holster.parents_can_contain_recursive( &it ) ) {
 
                 success = holster->put_in( it, item_pocket::pocket_type::CONTAINER,
                                            /*unseal_pockets=*/true ).success();
@@ -3918,8 +3918,7 @@ void insert_item_activity_actor::finish( player_activity &act, Character &who )
 
             }
         } else {
-            int charges = all_pockets_rigid ? holstered_item.second : std::min( holstered_item.second,
-                          holster.max_charges_by_parent_recursive( it ) );
+            int charges = std::min( holstered_item.second, holster.max_charges_by_parent_recursive( it ) );
 
             if( charges > 0 && holster->can_contain_partial_directly( it ) ) {
                 int result = holster->fill_with( it, charges,

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2367,24 +2367,18 @@ void outfit::add_stash( Character &guy, const item &newit, int &remaining_charge
             if( pocke == nullptr ) {
                 continue;
             }
-            if( pocke->rigid() ) {
-                // Rigid container allow to fill unconditionally till volume limit
-                // because do not depend on the capacity of the parent's pocket.
-                filled_count = pocke->fill_with( newit, guy, remaining_charges, false, false );
-            } else {
-                int max_contain_value = pocke->remaining_capacity_for_item( newit );
-                const item_location parent_data = pocket_data_ptr.parent;
+            int max_contain_value = pocke->remaining_capacity_for_item( newit );
+            const item_location parent_data = pocket_data_ptr.parent;
 
-                if( parent_data.has_parent() ) {
-                    if( parent_data.parents_can_contain_recursive( &temp_it ) ) {
-                        max_contain_value = parent_data.max_charges_by_parent_recursive( temp_it );
-                    } else {
-                        max_contain_value = 0;
-                    }
+            if( parent_data.has_parent() ) {
+                if( parent_data.parents_can_contain_recursive( &temp_it ) ) {
+                    max_contain_value = parent_data.max_charges_by_parent_recursive( temp_it );
+                } else {
+                    max_contain_value = 0;
                 }
-                const int charges = std::min( max_contain_value, remaining_charges ) ;
-                filled_count = pocke->fill_with( newit, guy, charges, false, false );
             }
+            const int charges = std::min( max_contain_value, remaining_charges ) ;
+            filled_count = pocke->fill_with( newit, guy, charges, false, false );
             num_contained += filled_count;
             remaining_charges -= filled_count;
         }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -833,8 +833,7 @@ bool inventory_holster_preset::is_shown( const item_location &contained ) const
     if( contained->is_bucket_nonempty() ) {
         return false;
     }
-    if( !holster->all_pockets_rigid() &&
-        !holster.parents_can_contain_recursive( &item_copy ) ) {
+    if( !holster.parents_can_contain_recursive( &item_copy ) ) {
         return false;
     }
     return true;

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -865,6 +865,7 @@ bool item_location::parents_can_contain_recursive( item *it ) const
     //item_location class cannot return current pocket so use first pocket for innermost container
     //Only used for weight and volume multipliers
     const item_pocket *current_pocket = get_item()->get_all_standard_pockets().front();
+    const pocket_data *current_pocket_data = current_pocket->get_pocket_data();
 
     //Repeat until top-most container reached
     while( current_location.has_parent() ) {
@@ -877,18 +878,19 @@ bool item_location::parents_can_contain_recursive( item *it ) const
         }
 
         //Multiply weight and volume multipliers for each container
-        it_weight = it_weight * current_pocket->data->weight_multiplier;
-        it_volume = it_volume * current_pocket->data->volume_multiplier;
-        it_length = it_length * std::cbrt( current_pocket->data->volume_multiplier );
+        it_weight = it_weight * current_pocket_data->weight_multiplier;
+        it_volume = it_volume * current_pocket_data->volume_multiplier;
+        it_length = it_length * std::cbrt( current_pocket_data->volume_multiplier );
 
         if( it_weight > parent_pocket->remaining_weight() ||
             it_volume > parent_pocket->remaining_volume() ||
-            it_length > parent_pocket->data->max_item_length ) {
+            it_length > parent_pocket->get_pocket_data()->max_item_length ) {
             return false;
         }
 
         //Move up one level of containers
         current_pocket = parent_pocket;
+        current_pocket_data = current_pocket->get_pocket_data();
         current_location = current_location.parent_item();
     }
     return true;
@@ -908,27 +910,36 @@ int item_location::max_charges_by_parent_recursive( const item &it ) const
     //item_location class cannot return current pocket so use first pocket for innermost container
     //Only used for weight and volume multipliers
     const item_pocket *current_pocket = get_item()->get_all_standard_pockets().front();
+    const pocket_data *current_pocket_data = current_pocket->get_pocket_data();
 
     //Repeat until top-most container reached
     while( current_location.has_parent() ) {
         //Multiply weight and volume multipliers for each container
-        weight_multiplier = weight_multiplier * current_pocket->data->weight_multiplier;
-        volume_multiplier = volume_multiplier * current_pocket->data->volume_multiplier;
+        weight_multiplier = weight_multiplier * current_pocket_data->weight_multiplier;
+        volume_multiplier = volume_multiplier * current_pocket_data->volume_multiplier;
         //Inserting into rigid pockets will not affect parent volume so stop keeping track
         if( current_pocket->rigid() ) {
             volume_multiplier = 0.0f;
         };
 
-        //Calculate effective remaining weight and volume for current parent
-        units::mass temp_weight = weight_capacity() / weight_multiplier;
-        units::volume temp_volume = volume_capacity() / volume_multiplier;
-        //Find the most restrictive weight/volume to determine maximum charges
-        //Weight or volume multiplier of zero means parent containers are no longer affected so stop keeping track
-        max_weight = ( weight_multiplier > 0 ) ? std::min( max_weight, temp_weight ) : max_weight;
-        max_volume = ( volume_multiplier > 0 ) ? std::min( max_volume, temp_volume ) : max_volume;
+        //Weight multiplier of zero means parent containers are no longer affected so stop keeping track
+        if( weight_multiplier > 0 ) {
+            //Calculate effective remaining weight for current parent
+            units::mass temp_weight = weight_capacity() / weight_multiplier;
+            //Find the most restrictive weight to determine maximum charges
+            max_weight = std::min( max_weight, temp_weight );
+        }
+        //Volume multiplier of zero means parent containers are no longer affected so stop keeping track
+        if( volume_multiplier > 0 ) {
+            //Calculate effective remaining volume for current parent
+            units::volume temp_volume = volume_capacity() / volume_multiplier;
+            //Find the most restrictive volume to determine maximum charges
+            max_volume = std::min( max_volume, temp_volume );
+        }
 
         //Move up one level of containers
         current_pocket = current_location.parent_pocket();
+        current_pocket_data = current_pocket->get_pocket_data();
         current_location = current_location.parent_item();
     }
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -900,7 +900,6 @@ int item_location::max_charges_by_parent_recursive( const item &it ) const
         return item::INFINITE_CHARGES;
     }
 
-    item_pocket *parent_pocket;
     float weight_multiplier = 1.0f;
     float volume_multiplier = 1.0f;
     units::mass max_weight = 1000_kilogram;
@@ -912,8 +911,6 @@ int item_location::max_charges_by_parent_recursive( const item &it ) const
 
     //Repeat until top-most container reached
     while( current_location.has_parent() ) {
-        parent_pocket = current_location.parent_pocket();
-
         //Multiply weight and volume multipliers for each container
         weight_multiplier = weight_multiplier * current_pocket->data->weight_multiplier;
         volume_multiplier = volume_multiplier * current_pocket->data->volume_multiplier;
@@ -923,15 +920,15 @@ int item_location::max_charges_by_parent_recursive( const item &it ) const
         };
 
         //Calculate effective remaining weight and volume for current parent
-        units::mass temp_weight = parent_pocket->remaining_weight() / weight_multiplier;
-        units::volume temp_volume = parent_pocket->remaining_volume() / volume_multiplier;
+        units::mass temp_weight = weight_capacity() / weight_multiplier;
+        units::volume temp_volume = volume_capacity() / volume_multiplier;
         //Find the most restrictive weight/volume to determine maximum charges
         //Weight or volume multiplier of zero means parent containers are no longer affected so stop keeping track
         max_weight = ( weight_multiplier > 0 ) ? std::min( max_weight, temp_weight ) : max_weight;
         max_volume = ( volume_multiplier > 0 ) ? std::min( max_volume, temp_volume ) : max_volume;
 
         //Move up one level of containers
-        current_pocket = parent_pocket;
+        current_pocket = current_location.parent_pocket();
         current_location = current_location.parent_item();
     }
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -857,18 +857,39 @@ bool item_location::has_parent() const
 
 bool item_location::parents_can_contain_recursive( item *it ) const
 {
-    if( !has_parent() ) {
-        return true;
+    item_pocket *parent_pocket;
+    units::mass it_weight = it->weight();
+    units::volume it_volume = it->volume();
+    units::length it_length = it->length();
+    item_location current_location = *this;
+    //item_location class cannot return current pocket so use first pocket for innermost container
+    //only used for weight and volume multipliers
+    const item_pocket *current_pocket = get_item()->get_all_standard_pockets().front();
+
+    //Repeat until top-most container reached
+    while ( current_location.has_parent() ) {
+    	parent_pocket = current_location.parent_pocket();
+    	
+    	//Ignore volume and length after innermost rigid container
+    	if ( current_pocket->rigid() ) {
+    		it_volume = 0_ml;
+    		it_length = 0_mm;
+    	}
+    	
+    	//Multiply weight and volume multipliers for each container
+    	it_weight = it_weight * current_pocket->data->weight_multiplier;
+    	it_volume = it_volume * current_pocket->data->volume_multiplier;
+    	it_length = it_length * std::cbrt( current_pocket->data->volume_multiplier );
+    	
+        if ( it_weight > parent_pocket->remaining_weight() ) { return false; }
+        if ( it_volume > parent_pocket->remaining_volume() ) { return false; }
+        if ( it_length > parent_pocket->data->max_item_length ) { return false; }
+        	
+        //Move up one level of containers
+        current_pocket = parent_pocket;
+        current_location = current_location.parent_item();
     }
-
-    item_location parent = parent_item();
-    item_pocket *pocket = parent_pocket();
-
-    if( pocket->can_contain( *it ).success() ) {
-        return parent.parents_can_contain_recursive( it );
-    }
-
-    return false;
+    return true;
 }
 
 int item_location::max_charges_by_parent_recursive( const item &it ) const

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -867,24 +867,26 @@ bool item_location::parents_can_contain_recursive( item *it ) const
     const item_pocket *current_pocket = get_item()->get_all_standard_pockets().front();
 
     //Repeat until top-most container reached
-    while ( current_location.has_parent() ) {
-    	parent_pocket = current_location.parent_pocket();
-    	
-    	//Ignore volume and length after innermost rigid container
-    	if ( current_pocket->rigid() ) {
-    		it_volume = 0_ml;
-    		it_length = 0_mm;
-    	}
-    	
-    	//Multiply weight and volume multipliers for each container
-    	it_weight = it_weight * current_pocket->data->weight_multiplier;
-    	it_volume = it_volume * current_pocket->data->volume_multiplier;
-    	it_length = it_length * std::cbrt( current_pocket->data->volume_multiplier );
-    	
-        if ( it_weight > parent_pocket->remaining_weight() ) { return false; }
-        if ( it_volume > parent_pocket->remaining_volume() ) { return false; }
-        if ( it_length > parent_pocket->data->max_item_length ) { return false; }
-        	
+    while( current_location.has_parent() ) {
+        parent_pocket = current_location.parent_pocket();
+
+        //Ignore volume and length after innermost rigid container
+        if( current_pocket->rigid() ) {
+            it_volume = 0_ml;
+            it_length = 0_mm;
+        }
+
+        //Multiply weight and volume multipliers for each container
+        it_weight = it_weight * current_pocket->data->weight_multiplier;
+        it_volume = it_volume * current_pocket->data->volume_multiplier;
+        it_length = it_length * std::cbrt( current_pocket->data->volume_multiplier );
+
+        if( it_weight > parent_pocket->remaining_weight() ||
+            it_volume > parent_pocket->remaining_volume() ||
+            it_length > parent_pocket->data->max_item_length ) {
+            return false;
+        }
+
         //Move up one level of containers
         current_pocket = parent_pocket;
         current_location = current_location.parent_item();
@@ -897,7 +899,7 @@ int item_location::max_charges_by_parent_recursive( const item &it ) const
     if( !has_parent() ) {
         return item::INFINITE_CHARGES;
     }
-    
+
     item_pocket *parent_pocket;
     float weight_multiplier = 1.0f;
     float volume_multiplier = 1.0f;
@@ -909,28 +911,30 @@ int item_location::max_charges_by_parent_recursive( const item &it ) const
     const item_pocket *current_pocket = get_item()->get_all_standard_pockets().front();
 
     //Repeat until top-most container reached
-    while ( current_location.has_parent() ) {
-    	parent_pocket = current_location.parent_pocket();
-    	
-    	//Multiply weight and volume multipliers for each container
-    	weight_multiplier = weight_multiplier * current_pocket->data->weight_multiplier;
-    	volume_multiplier = volume_multiplier * current_pocket->data->volume_multiplier;
-    	//Inserting into rigid pockets will not affect parent volume so stop keeping track
-    	if ( current_pocket->rigid() ) { volume_multiplier = 0.0f; };
-    	
-    	//Calculate effective remaining weight and volume for current parent
-    	units::mass temp_weight = parent_pocket->remaining_weight() / weight_multiplier;
-    	units::volume temp_volume = parent_pocket->remaining_volume() / volume_multiplier;
-    	//Find the most restrictive weight/volume to determine maximum charges
-    	//Weight or volume multiplier of zero means parent containers are no longer affected so stop keeping track
-    	max_weight = ( weight_multiplier > 0 ) ? std::min( max_weight, temp_weight ) : max_weight;
-    	max_volume = ( volume_multiplier > 0 ) ? std::min( max_volume, temp_volume ) : max_volume;
-    	
+    while( current_location.has_parent() ) {
+        parent_pocket = current_location.parent_pocket();
+
+        //Multiply weight and volume multipliers for each container
+        weight_multiplier = weight_multiplier * current_pocket->data->weight_multiplier;
+        volume_multiplier = volume_multiplier * current_pocket->data->volume_multiplier;
+        //Inserting into rigid pockets will not affect parent volume so stop keeping track
+        if( current_pocket->rigid() ) {
+            volume_multiplier = 0.0f;
+        };
+
+        //Calculate effective remaining weight and volume for current parent
+        units::mass temp_weight = parent_pocket->remaining_weight() / weight_multiplier;
+        units::volume temp_volume = parent_pocket->remaining_volume() / volume_multiplier;
+        //Find the most restrictive weight/volume to determine maximum charges
+        //Weight or volume multiplier of zero means parent containers are no longer affected so stop keeping track
+        max_weight = ( weight_multiplier > 0 ) ? std::min( max_weight, temp_weight ) : max_weight;
+        max_volume = ( volume_multiplier > 0 ) ? std::min( max_volume, temp_volume ) : max_volume;
+
         //Move up one level of containers
         current_pocket = parent_pocket;
         current_location = current_location.parent_item();
     }
-    
+
     int charges = std::min( it.charges_per_weight( max_weight ), it.charges_per_volume( max_volume ) );
     return charges;
 }

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -399,11 +399,12 @@ class item_pocket
 
         // should the name of this pocket be used as a description
         bool name_as_description = false; // NOLINT(cata-serialize)
+        
+        const pocket_data *data = nullptr; // NOLINT(cata-serialize)
     private:
         // the type of pocket, saved to json
         pocket_type _saved_type = pocket_type::LAST; // NOLINT(cata-serialize)
         bool _saved_sealed = false; // NOLINT(cata-serialize)
-        const pocket_data *data = nullptr; // NOLINT(cata-serialize)
         // the items inside the pocket
         std::list<item> contents;
         bool _sealed = false;

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -399,7 +399,6 @@ class item_pocket
 
         // should the name of this pocket be used as a description
         bool name_as_description = false; // NOLINT(cata-serialize)
-        
         const pocket_data *data = nullptr; // NOLINT(cata-serialize)
     private:
         // the type of pocket, saved to json

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -399,11 +399,11 @@ class item_pocket
 
         // should the name of this pocket be used as a description
         bool name_as_description = false; // NOLINT(cata-serialize)
-        const pocket_data *data = nullptr; // NOLINT(cata-serialize)
     private:
         // the type of pocket, saved to json
         pocket_type _saved_type = pocket_type::LAST; // NOLINT(cata-serialize)
         bool _saved_sealed = false; // NOLINT(cata-serialize)
+        const pocket_data *data = nullptr; // NOLINT(cata-serialize)
         // the items inside the pocket
         std::list<item> contents;
         bool _sealed = false;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix calculation for inserting into nested containers"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When trying to determine if an object will fit into a nested container, the function "parents_can_contain_recursive" is used.  It operates by checking if each of the parent containers "can_contain" an item.  This has 2 issues:

- Parent containers do not respect weight and volume multipliers of child containers.  This was reproduced by attempting to insert a pot helmet into a greater storage ring (Magiclysm) inside an armbag pouch.  The multipliers of the storage ring should allow the pot helmet to fit, but it is not the case
- Rigid containers ignore the weight capacity of parents.  The Insert menu of a metal tank (2L) inside a gallon-sized zipper bag would show a steel chain as an option, but this actually overloads the zipper bag and attempting it will result in an "aborting" message.

For objects with charges, the sister function "max_charges_by_parent_recursive" is used which exhibit similar issues.  Inserting oranges into a greater dimensional bag (Magiclysm) nested in an armband pouch, only one orange can be inserted at a time up to a maximum of 2.  The correct number of oranges that should fit is 6 and they should all be inserted on the first attempt.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Made new calculations for the functions "parents_can_contain_recursive" and "max_charges_by_parent_recursive" which keeps track of weight, volume and length changes in items as they are modified by the weight / volume multiplier of each nested container.  It will continue to check weight capacity even after encountering a rigid container.  Code is commented for clarity.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tests were performed by attempting to reproduce the aforementioned issues using their respective test scenarios as described above.  None of the issues were able to be reproduced.  Also tested various other use cases and so far no anomalies were encountered.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
These fixes target both the list of items displayed on the insert menu, and the actual act of inserting the item into the nested container.  The "pick all items" action do not use these functions and should show results consistent with older behavior.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->