### PR TITLE
appliance recipes update + home improvement backround

### DIFF
--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -629,6 +629,16 @@
   },
   {
     "type": "profession",
+    "subtype": "hobby",
+    "id": "home_improvement",
+    "name": "Home Improvement",
+    "points": 2,
+    "description": "You'd fix up any holes and appliances in your own home with nothing but your two hands and some elbow grease.  You did it to save money on repairmen, but now it seems you'll do it to save your life.",
+    "skills": [ { "level": 2, "name": "fabrication" }, { "level": 1, "name": "mechanics" }, { "level": 1, "name": "electronics" } ],
+    "proficiencies": [ "prof_carpentry_basic", "prof_appliance_repair" ]
+  },
+  {
+    "type": "profession",
     "id": "fishing",
     "subtype": "hobby",
     "name": "Fishing",

--- a/data/json/recipes/recipe_appliance.json
+++ b/data/json/recipes/recipe_appliance.json
@@ -7,7 +7,10 @@
     "subcategory": "CSC_APPLIANCE_UTILITY",
     "copy-from": "minifridge",
     "skills_required": [ "fabrication", 4 ],
-    "proficiencies": [ { "proficiency": "prof_plasticworking", "required": false, "time_multiplier": 1.1, "learning_time_multiplier": 0.1 } ],
+    "proficiencies": [
+      { "proficiency": "prof_plasticworking", "required": false, "time_multiplier": 1.1, "learning_time_multiplier": 0.1 },
+      { "proficiency": "prof_appliance_repair", "required": false, "skill_penalty": 0 }
+    ],
     "qualities": [
       { "id": "HAMMER", "level": 2 },
       { "id": "SAW_M", "level": 1 },
@@ -36,7 +39,10 @@
     "subcategory": "CSC_APPLIANCE_UTILITY",
     "copy-from": "minifreezer",
     "skills_required": [ "fabrication", 4 ],
-    "proficiencies": [ { "proficiency": "prof_plasticworking", "required": false, "time_multiplier": 1.1, "learning_time_multiplier": 0.1 } ],
+    "proficiencies": [
+      { "proficiency": "prof_plasticworking", "required": false, "time_multiplier": 1.1, "learning_time_multiplier": 0.1 },
+      { "proficiency": "prof_appliance_repair", "required": false, "skill_penalty": 0 }
+    ],
     "qualities": [
       { "id": "HAMMER", "level": 2 },
       { "id": "SAW_M", "level": 1 },
@@ -69,6 +75,7 @@
     "category": "CC_APPLIANCE",
     "subcategory": "CSC_APPLIANCE_LIGHTING",
     "skills_required": [ [ "fabrication", 1 ] ],
+    "proficiencies": [ { "proficiency": "prof_appliance_repair" } ],
     "using": [ [ "soldering_standard", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
@@ -92,6 +99,7 @@
     "category": "CC_APPLIANCE",
     "subcategory": "CSC_APPLIANCE_LIGHTING",
     "skills_required": [ [ "fabrication", 1 ] ],
+    "proficiencies": [ { "proficiency": "prof_appliance_repair" } ],
     "using": [ [ "soldering_standard", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
@@ -117,7 +125,7 @@
     "skills_required": [ [ "electronics", 2 ] ],
     "using": [ [ "soldering_standard", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" }, { "proficiency": "prof_appliance_repair" } ],
     "components": [ [ [ "frame", 1 ] ], [ [ "recharge_station", 1 ] ] ]
   },
   {
@@ -134,7 +142,7 @@
     "skills_required": [ [ "electronics", 1 ] ],
     "using": [ [ "soldering_standard", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" }, { "proficiency": "prof_appliance_repair" } ],
     "components": [ [ [ "frame_wood", 1 ] ], [ [ "battery_charger", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -259,6 +259,7 @@
     "autolearn": true,
     "using": [ [ "welding_standard", 5 ], [ "steel_standard", 2 ] ],
     "proficiencies": [
+      { "proficiency": "prof_appliance_repair" },
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_welding_basic", "skill_penalty": 0.5 },
       { "proficiency": "prof_welding" }
@@ -290,6 +291,7 @@
     "autolearn": true,
     "using": [ [ "welding_standard", 10 ], [ "steel_standard", 4 ] ],
     "proficiencies": [
+      { "proficiency": "prof_appliance_repair" },
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_welding_basic", "skill_penalty": 0.5 },
       { "proficiency": "prof_welding" }

--- a/data/json/recipes/recipe_vehicle.json
+++ b/data/json/recipes/recipe_vehicle.json
@@ -359,7 +359,10 @@
     "autolearn": false,
     "book_learn": [ [ "textbook_mechanics", 5 ], [ "manual_mechanics", 5 ], [ "textbook_fabrication", 5 ] ],
     "using": [ [ "welding_standard", 50 ] ],
-    "proficiencies": [ { "proficiency": "prof_plasticworking", "required": false, "time_multiplier": 1.1, "learning_time_multiplier": 0.1 } ],
+    "proficiencies": [
+      { "proficiency": "prof_plasticworking", "required": false, "time_multiplier": 1.1, "learning_time_multiplier": 0.1 },
+      { "proficiency": "prof_appliance_repair" }
+    ],
     "qualities": [
       { "id": "HAMMER", "level": 2 },
       { "id": "SAW_M", "level": 1 },
@@ -427,7 +430,10 @@
     "activity_level": "MODERATE_EXERCISE",
     "copy-from": "minifreezer",
     "skills_required": [ "fabrication", 4 ],
-    "proficiencies": [ { "proficiency": "prof_plasticworking", "required": false, "time_multiplier": 1.1, "learning_time_multiplier": 0.1 } ],
+    "proficiencies": [
+      { "proficiency": "prof_plasticworking", "required": false, "time_multiplier": 1.1, "learning_time_multiplier": 0.1 },
+      { "proficiency": "prof_appliance_repair" }
+    ],
     "qualities": [
       { "id": "HAMMER", "level": 2 },
       { "id": "SAW_M", "level": 1 },


### PR DESCRIPTION
#### Summary
Content "Added missing proficiency to appliance crafts & introduced new background with said proficiency"

#### Purpose of change

The only crafts that use the proficiency `general appliance repair` are the oven and those four ammonia machines. This feels like an oversight so I added the proficiency to the other appliances. To go along with this I added a hobby that starts with it, inspired by the way my father renovated his home by himself.

#### Describe the solution

added `general appliance repair` to:

- The fridge and minifridge
- The freezer and minifreezer
- Standing lamp
- Floodlight
- The space heater (both large and small)
- The recharging station locker
- The battery recharger

#### Describe alternatives you've considered

The background could be removed if it's unnecessary
