### PR TITLE
math_parser: add support for JSON-defined functions

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -73,6 +73,23 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_jmath_test",
+    "effect": [ { "math": [ "blorgy", "=", "jmath_test_blorg(1, 2)" ] } ]
+  },
+  {
+    "type": "jmath_function",
+    "id": "jmath_test_blorg",
+    "num_args": 2,
+    "return": "_0 + jmath_test_blorg2( _1 )"
+  },
+  {
+    "type": "jmath_function",
+    "id": "jmath_test_blorg2",
+    "num_args": 1,
+    "return": "_0 * 3"
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_mess_pass",
     "effect": { "math": [ "weighted_var", "=", "1" ] }
   },

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1452,5 +1452,29 @@ More examples:
     { "math": [ "u_val('time: 1 d')" ] },
     { "math": [ "u_val('proficiency', 'proficiency_id: prof_test', 'format: percent')" ] }
 ```
+#### Math functions defined in JSON
+Math functions can be defined in JSON like this
+```JSON
+  {
+    "type": "jmath_function",
+    "id": "my_math_function",
+    "num_args": 2,
+    "return": "_0 * 2 + rand(_1)"
+  },
+```
+where `_0`, `_1`, etc are positional parameters.
+
+These functions can then be used like regular math functions, for example:
+```JSON
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_do_something",
+    "effect": [ { "math": [ "secret_value", "=", "my_math_function( u_pain(), 500)" ] } ]
+  },
+```
+so `_0` takes the value of `u_pain()` and `_1` takes the value 500 inside `my_math_function()`
+
+Function composition is also supported and the functions can be defined and used in any order.
+
 #### Assignment target
 An assignment target can be either a scoped [variable name](#variables) or a scoped [dialogue function](#dialogue-functions).

--- a/lang/string_extractor/parser.py
+++ b/lang/string_extractor/parser.py
@@ -152,6 +152,7 @@ parsers = {
     "item_category": parse_item_category,
     "item_blacklist": dummy_parser,
     "item_group": dummy_parser,
+    "jmath_function": dummy_parser,
     "json_flag": parse_json_flag,
     "keybinding": parse_keybinding,
     "limb_score": parse_limb_score,

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -337,6 +337,13 @@ void write_var_value( var_type type, const std::string &name, talker *talk, dial
     }
 }
 
+void write_var_value( var_type type, const std::string &name, talker *talk, dialogue *d,
+                      double value )
+{
+    // NOLINTNEXTLINE(cata-translate-string-literal)
+    write_var_value( type, name, talk, d, string_format( "%g", value ) );
+}
+
 static bodypart_id get_bp_from_str( const std::string &ctxt )
 {
     bodypart_id bid = bodypart_str_id::NULL_ID();
@@ -2082,9 +2089,7 @@ conditional_t::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part> &m
         jo.allow_omitted_members();
         return [min, max]( dialogue & d, double input ) {
             write_var_value( var_type::global, "temp_var", d.actor( false ), &d,
-                             std::to_string( handle_min_max( d,
-                                             input, min,
-                                             max ) ) );
+                             handle_min_max( d, input, min, max ) );
         };
     } else if( jo.has_member( "const" ) ) {
         jo.throw_error( "attempted to alter a constant value in " + jo.str() );
@@ -2225,8 +2230,7 @@ conditional_t::get_set_dbl( const J &jo, const std::optional<dbl_or_var_part> &m
             }
             return [is_npc, var_name, type, min, max]( dialogue & d, double input ) {
                 write_var_value( type, var_name, d.actor( is_npc ), &d,
-                                 // NOLINTNEXTLINE(cata-translate-string-literal)
-                                 string_format( "%g", handle_min_max( d, input, min, max ) ) );
+                                 handle_min_max( d, input, min, max ) );
             };
         } else if( checked_value == "time_since_var" ) {
             // This is a strange thing to want to adjust. But we allow it nevertheless.

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -58,6 +58,31 @@ static const efftype_id effect_currently_busy( "currently_busy" );
 
 static const json_character_flag json_flag_MUTATION_THRESHOLD( "MUTATION_THRESHOLD" );
 
+namespace
+{
+struct deferred_math {
+    std::string str;
+    bool assignment;
+    std::shared_ptr<math_exp> exp;
+
+    deferred_math( std::string_view str_, bool ass_ ) : str( str_ ), assignment( ass_ ),
+        exp( std::make_shared<math_exp>() ) {}
+};
+
+std::queue<deferred_math> &get_deferred_math()
+{
+    static std::queue<deferred_math> dfr_math;
+    return dfr_math;
+}
+
+std::shared_ptr<math_exp> &defer_math( std::string_view str, bool ass )
+{
+    get_deferred_math().emplace( str, ass );
+    return get_deferred_math().back().exp;
+}
+
+} // namespace
+
 std::string get_talk_varname( const JsonObject &jo, const std::string &member,
                               bool check_value, dbl_or_var &default_val )
 {
@@ -347,6 +372,16 @@ void read_condition( const JsonObject &jo, const std::string &member_name,
         };
     } else {
         jo.throw_error_at( member_name, "invalid condition syntax" );
+    }
+}
+
+void finalize_conditions()
+{
+    std::queue<deferred_math> &dfr = get_deferred_math();
+    while( !dfr.empty() ) {
+        deferred_math &math = dfr.front();
+        math.exp->parse( math.str, math.assignment );
+        dfr.pop();
     }
 }
 
@@ -2629,7 +2664,7 @@ void eoc_math::from_json( const JsonObject &jo, std::string_view member )
             jo.throw_error( "Invalid unary operator in " + jo.str() );
         }
     } else if( objects.size() == 3 ) {
-        rhs.parse( objects.get_string( 2 ), false );
+        rhs = defer_math( objects.get_string( 2 ), false );
         if( oper == "=" ) {
             action = oper::assign;
         } else if( oper == "+=" ) {
@@ -2659,9 +2694,9 @@ void eoc_math::from_json( const JsonObject &jo, std::string_view member )
         }
     }
     bool const lhs_assign = action >= oper::assign && action <= oper::decrease;
-    lhs.parse( objects.get_string( 0 ), lhs_assign );
+    lhs = defer_math( objects.get_string( 0 ), lhs_assign );
     if( action >= oper::plus_assign && action <= oper::decrease ) {
-        mhs.parse( objects.get_string( 0 ), false );
+        mhs = defer_math( objects.get_string( 0 ), false );
     }
 }
 
@@ -2669,43 +2704,43 @@ double eoc_math::act( dialogue &d ) const
 {
     switch( action ) {
         case oper::ret:
-            return lhs.eval( d );
+            return lhs->eval( d );
         case oper::assign:
-            lhs.assign( d, rhs.eval( d ) );
+            lhs->assign( d, rhs->eval( d ) );
             break;
         case oper::plus_assign:
-            lhs.assign( d, mhs.eval( d ) + rhs.eval( d ) );
+            lhs->assign( d, mhs->eval( d ) + rhs->eval( d ) );
             break;
         case oper::minus_assign:
-            lhs.assign( d, mhs.eval( d ) - rhs.eval( d ) );
+            lhs->assign( d, mhs->eval( d ) - rhs->eval( d ) );
             break;
         case oper::mult_assign:
-            lhs.assign( d, mhs.eval( d ) * rhs.eval( d ) );
+            lhs->assign( d, mhs->eval( d ) * rhs->eval( d ) );
             break;
         case oper::div_assign:
-            lhs.assign( d, mhs.eval( d ) / rhs.eval( d ) );
+            lhs->assign( d, mhs->eval( d ) / rhs->eval( d ) );
             break;
         case oper::mod_assign:
-            lhs.assign( d, std::fmod( mhs.eval( d ), rhs.eval( d ) ) );
+            lhs->assign( d, std::fmod( mhs->eval( d ), rhs->eval( d ) ) );
             break;
         case oper::increase:
-            lhs.assign( d, mhs.eval( d ) + 1 );
+            lhs->assign( d, mhs->eval( d ) + 1 );
             break;
         case oper::decrease:
-            lhs.assign( d, mhs.eval( d ) - 1 );
+            lhs->assign( d, mhs->eval( d ) - 1 );
             break;
         case oper::equal:
-            return float_equals( lhs.eval( d ), rhs.eval( d ) );
+            return static_cast<double>( float_equals( lhs->eval( d ), rhs->eval( d ) ) );
         case oper::not_equal:
-            return !float_equals( lhs.eval( d ), rhs.eval( d ) );
+            return static_cast<double>( !float_equals( lhs->eval( d ), rhs->eval( d ) ) );
         case oper::less:
-            return lhs.eval( d ) < rhs.eval( d );
+            return lhs->eval( d ) < rhs->eval( d );
         case oper::equal_or_less:
-            return lhs.eval( d ) <= rhs.eval( d );
+            return lhs->eval( d ) <= rhs->eval( d );
         case oper::greater:
-            return lhs.eval( d ) > rhs.eval( d );
+            return lhs->eval( d ) > rhs->eval( d );
         case oper::equal_or_greater:
-            return lhs.eval( d ) >= rhs.eval( d );
+            return lhs->eval( d ) >= rhs->eval( d );
         default:
             debugmsg( "unknown eoc math operator %d", action );
     }

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2653,15 +2653,14 @@ void eoc_math::from_json( const JsonObject &jo, std::string_view member )
 
     if( objects.size() == 1 ) {
         action = oper::ret;
-    }
-
-    if( objects.size() == 2 ) {
+    } else if( objects.size() == 2 ) {
         if( oper == "++" ) {
             action = oper::increase;
         } else if( oper == "--" ) {
             action = oper::decrease;
         } else {
             jo.throw_error( "Invalid unary operator in " + jo.str() );
+            return;
         }
     } else if( objects.size() == 3 ) {
         rhs = defer_math( objects.get_string( 2 ), false );
@@ -2691,6 +2690,7 @@ void eoc_math::from_json( const JsonObject &jo, std::string_view member )
             action = oper::equal_or_greater;
         } else {
             jo.throw_error( "Invalid binary operator in " + jo.str() );
+            return;
         }
     }
     bool const lhs_assign = action >= oper::assign && action <= oper::decrease;
@@ -2741,6 +2741,7 @@ double eoc_math::act( dialogue &d ) const
             return lhs->eval( d ) > rhs->eval( d );
         case oper::equal_or_greater:
             return lhs->eval( d ) >= rhs->eval( d );
+        case oper::invalid:
         default:
             debugmsg( "unknown eoc math operator %d", action );
     }

--- a/src/condition.h
+++ b/src/condition.h
@@ -72,6 +72,8 @@ tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, dialogue con
 var_info read_var_info( const JsonObject &jo );
 void write_var_value( var_type type, const std::string &name, talker *talk, dialogue *d,
                       const std::string &value );
+void write_var_value( var_type type, const std::string &name, talker *talk, dialogue *d,
+                      double value );
 std::string get_talk_varname( const JsonObject &jo, const std::string &member,
                               bool check_value, dbl_or_var &default_val );
 std::string get_talk_var_basename( const JsonObject &jo, const std::string &member,

--- a/src/condition.h
+++ b/src/condition.h
@@ -80,6 +80,8 @@ std::string get_talk_var_basename( const JsonObject &jo, const std::string &memb
 void read_condition( const JsonObject &jo, const std::string &member_name,
                      std::function<bool( dialogue & )> &condition, bool default_val );
 
+void finalize_conditions();
+
 /**
  * A condition for a response spoken by the player.
  * This struct only adds the constructors which will load the data from json

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -162,11 +162,13 @@ struct eoc_math {
         equal_or_less,
         greater,
         equal_or_greater,
+
+        invalid,
     };
     std::shared_ptr<math_exp> lhs;
     std::shared_ptr<math_exp> mhs;
     std::shared_ptr<math_exp> rhs;
-    eoc_math::oper action;
+    eoc_math::oper action = oper::invalid;
 
     void from_json( const JsonObject &jo, std::string_view member );
     double act( dialogue &d ) const;

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -163,9 +163,9 @@ struct eoc_math {
         greater,
         equal_or_greater,
     };
-    math_exp lhs;
-    math_exp mhs;
-    math_exp rhs;
+    std::shared_ptr<math_exp> lhs;
+    std::shared_ptr<math_exp> mhs;
+    std::shared_ptr<math_exp> rhs;
     eoc_math::oper action;
 
     void from_json( const JsonObject &jo, std::string_view member );

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -62,6 +62,7 @@
 #include "martialarts.h"
 #include "material.h"
 #include "mission.h"
+#include "math_parser_jmath.h"
 #include "mod_tileset.h"
 #include "monfaction.h"
 #include "mongroup.h"
@@ -246,6 +247,7 @@ void DynamicDataLoader::initialize()
     add( "EXTERNAL_OPTION", &load_external_option );
     add( "option_slider", &option_slider::load_option_sliders );
     add( "json_flag", &json_flag::load_all );
+    add( "jmath_function", &jmath_func::load_func );
     add( "connect_group", &connect_group::load );
     add( "fault", &fault::load_fault );
     add( "relic_procgen_data", &relic_procgen_data::load_relic_procgen_data );
@@ -579,6 +581,7 @@ void DynamicDataLoader::unload_data()
     harvest_list::reset();
     item_category::reset();
     item_controller->reset();
+    jmath_func::reset();
     json_flag::reset();
     connect_group::reset();
     limb_score::reset();
@@ -712,6 +715,7 @@ void DynamicDataLoader::finalize_loaded_data( loading_ui &ui )
             { _( "Overmap specials" ), &overmap_specials::finalize },
             { _( "Overmap locations" ), &overmap_locations::finalize },
             { _( "Cities" ), &city::finalize },
+            { _( "Math functions" ), &jmath_func::finalize },
             { _( "Math expressions" ), &finalize_conditions },
             { _( "Start locations" ), &start_locations::finalize_all },
             { _( "Vehicle part migrations" ), &vpart_migration::finalize },

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -25,6 +25,7 @@
 #include "city.h"
 #include "clothing_mod.h"
 #include "clzones.h"
+#include "condition.h"
 #include "construction.h"
 #include "construction_category.h"
 #include "construction_group.h"
@@ -711,6 +712,7 @@ void DynamicDataLoader::finalize_loaded_data( loading_ui &ui )
             { _( "Overmap specials" ), &overmap_specials::finalize },
             { _( "Overmap locations" ), &overmap_locations::finalize },
             { _( "Cities" ), &city::finalize },
+            { _( "Math expressions" ), &finalize_conditions },
             { _( "Start locations" ), &start_locations::finalize_all },
             { _( "Vehicle part migrations" ), &vpart_migration::finalize },
             { _( "Vehicle prototypes" ), &vehicles::finalize_prototypes },

--- a/src/math_parser_func.h
+++ b/src/math_parser_func.h
@@ -14,7 +14,7 @@
 struct math_func {
     std::string_view symbol;
     int num_params;
-    using f_t = double ( * )( std::vector<double> & );
+    using f_t = double ( * )( std::vector<double> const & );
     f_t f;
 };
 using pmath_func = math_func const *;
@@ -25,12 +25,12 @@ struct math_const {
 };
 using pmath_const = math_const const *;
 
-inline double abs( std::vector<double> &params )
+inline double abs( std::vector<double> const &params )
 {
     return std::abs( params[0] );
 }
 
-inline double max( std::vector<double> &params )
+inline double max( std::vector<double> const &params )
 {
     if( params.empty() ) {
         return 0;
@@ -38,7 +38,7 @@ inline double max( std::vector<double> &params )
     return *std::max_element( params.begin(), params.end() );
 }
 
-inline double min( std::vector<double> &params )
+inline double min( std::vector<double> const &params )
 {
     if( params.empty() ) {
         return 0;
@@ -46,42 +46,42 @@ inline double min( std::vector<double> &params )
     return *std::min_element( params.begin(), params.end() );
 }
 
-inline double math_rng( std::vector<double> &params )
+inline double math_rng( std::vector<double> const &params )
 {
     return rng_float( params[0], params[1] );
 }
 
-inline double rand( std::vector<double> &params )
+inline double rand( std::vector<double> const &params )
 {
     return rng( 0, static_cast<int>( std::round( params[0] ) ) );
 }
 
-inline double sqrt( std::vector<double> &params )
+inline double sqrt( std::vector<double> const &params )
 {
     return std::sqrt( params[0] );
 }
 
-inline double log( std::vector<double> &params )
+inline double log( std::vector<double> const &params )
 {
     return std::log( params[0] );
 }
 
-inline double sin( std::vector<double> &params )
+inline double sin( std::vector<double> const &params )
 {
     return std::sin( params[0] );
 }
 
-inline double cos( std::vector<double> &params )
+inline double cos( std::vector<double> const &params )
 {
     return std::cos( params[0] );
 }
 
-inline double tan( std::vector<double> &params )
+inline double tan( std::vector<double> const &params )
 {
     return std::tan( params[0] );
 }
 
-inline double clamp( std::vector<double> &params )
+inline double clamp( std::vector<double> const &params )
 {
     if( params[2] < params[1] ) {
         debugmsg( "clamp called with hi < lo (%f < %f)", params[2], params[1] );
@@ -90,27 +90,27 @@ inline double clamp( std::vector<double> &params )
     return std::clamp( params[0], params[1], params[2] );
 }
 
-inline double floor( std::vector<double> &params )
+inline double floor( std::vector<double> const &params )
 {
     return std::floor( params[0] );
 }
 
-inline double ceil( std::vector<double> &params )
+inline double ceil( std::vector<double> const &params )
 {
     return std::ceil( params[0] );
 }
 
-inline double trunc( std::vector<double> &params )
+inline double trunc( std::vector<double> const &params )
 {
     return std::trunc( params[0] );
 }
 
-inline double round( std::vector<double> &params )
+inline double round( std::vector<double> const &params )
 {
     return std::round( params[0] );
 }
 
-constexpr double test_( std::vector<double> &/* params */ )
+constexpr double test_( std::vector<double> const &/* params */ )
 {
     return 42;
 }

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -68,6 +68,15 @@ struct func {
     std::vector<thingie> params;
     math_func::f_t f{};
 };
+struct func_jmath {
+    explicit func_jmath( std::vector<thingie> &&params_, jmath_func_id const &id_ );
+
+    double eval( dialogue &d ) const;
+
+    std::vector<thingie> params;
+    jmath_func_id id;
+};
+
 struct func_diag_eval {
     using eval_f = std::function<double( dialogue & )>;
     explicit func_diag_eval( eval_f &&f_ ) : f( f_ ) {}
@@ -118,7 +127,7 @@ struct thingie {
     constexpr double eval( dialogue &d ) const;
 
     using impl_t =
-        std::variant<double, std::string, oper, func, func_diag_eval, func_diag_ass, var>;
+        std::variant<double, std::string, oper, func, func_jmath, func_diag_eval, func_diag_ass, var>;
     impl_t data;
 };
 
@@ -151,7 +160,7 @@ constexpr double thingie::eval( dialogue &d ) const
 }
 
 using op_t =
-    std::variant<pbin_op, punary_op, pmath_func, scoped_diag_eval, scoped_diag_ass, paren>;
+    std::variant<pbin_op, punary_op, pmath_func, jmath_func_id, scoped_diag_eval, scoped_diag_ass, paren>;
 
 constexpr bool operator>( op_t const &lhs, binary_op const &rhs )
 {

--- a/src/math_parser_jmath.cpp
+++ b/src/math_parser_jmath.cpp
@@ -1,0 +1,77 @@
+#include "math_parser_jmath.h"
+
+#include <string>
+#include <string_view>
+
+#include "condition.h"
+#include "dialogue.h"
+#include "generic_factory.h"
+#include "math_parser.h"
+
+namespace
+{
+generic_factory<jmath_func> &get_all_jmath_func()
+{
+    static generic_factory<jmath_func> jmath_func_factory( "jmath_function" );
+    return jmath_func_factory;
+}
+} // namespace
+
+/** @relates string_id */
+template <>
+jmath_func const &string_id<jmath_func>::obj() const
+{
+    return get_all_jmath_func().obj( *this );
+}
+
+/** @relates string_id */
+template <>
+bool string_id<jmath_func>::is_valid() const
+{
+    return get_all_jmath_func().is_valid( *this );
+}
+
+void jmath_func::reset()
+{
+    get_all_jmath_func().reset();
+}
+
+std::vector<jmath_func> const &jmath_func::get_all()
+{
+    return get_all_jmath_func().get_all();
+}
+
+void jmath_func::load_func( const JsonObject &jo, std::string const &src )
+{
+    get_all_jmath_func().load( jo, src );
+}
+
+void jmath_func::load( JsonObject const &jo, const std::string_view /*src*/ )
+{
+    optional( jo, was_loaded, "num_args", num_params );
+    optional( jo, was_loaded, "return", _str );
+}
+
+void jmath_func::finalize()
+{
+    for( jmath_func const &jmf : jmath_func::get_all() ) {
+        jmf._exp.parse( jmf._str );
+        jmf._str.clear();
+    }
+}
+
+double jmath_func::eval( dialogue &d ) const
+{
+    return _exp.eval( d );
+}
+
+double jmath_func::eval( dialogue &d, std::vector<double> const &params ) const
+{
+    dialogue d_next( d );
+    for( std::vector<double>::size_type i = 0; i < params.size(); i++ ) {
+        write_var_value( var_type::context, "npctalk_var_" + std::to_string( i ),
+                         nullptr, &d_next, params[i] );
+    }
+
+    return eval( d_next );
+}

--- a/src/math_parser_jmath.h
+++ b/src/math_parser_jmath.h
@@ -1,0 +1,32 @@
+#ifndef CATA_SRC_MATH_PARSER_JMATH_H
+#define CATA_SRC_MATH_PARSER_JMATH_H
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "math_parser.h"
+#include "type_id.h"
+
+class JsonObject;
+struct dialogue;
+
+struct jmath_func {
+    jmath_func_id id;
+    bool was_loaded = false;
+    int num_params{};
+
+    double eval( dialogue &d ) const;
+    double eval( dialogue &d, std::vector<double> const &params ) const;
+
+    void load( const JsonObject &jo, std::string_view src );
+    static void load_func( const JsonObject &jo, std::string const &src );
+    static void finalize();
+    static void reset();
+    static const std::vector<jmath_func> &get_all();
+
+    mutable std::string _str;
+    mutable math_exp _exp;
+};
+
+#endif // CATA_SRC_MATH_PARSER_JMATH_H

--- a/src/type_id.h
+++ b/src/type_id.h
@@ -298,6 +298,9 @@ using flag_id = string_id<json_flag>;
 
 using json_character_flag = string_id<json_flag>;
 
+struct jmath_func;
+using jmath_func_id = string_id<jmath_func>;
+
 class widget;
 using widget_id = string_id<widget>;
 

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -17,6 +17,8 @@ effect_on_condition_EOC_TEST_TRANSFORM_LINE( "EOC_TEST_TRANSFORM_LINE" );
 static const effect_on_condition_id
 effect_on_condition_EOC_TEST_TRANSFORM_RADIUS( "EOC_TEST_TRANSFORM_RADIUS" );
 static const effect_on_condition_id
+effect_on_condition_EOC_jmath_test( "EOC_jmath_test" );
+static const effect_on_condition_id
 effect_on_condition_EOC_math_diag_assign( "EOC_math_diag_assign" );
 static const effect_on_condition_id effect_on_condition_EOC_math_duration( "EOC_math_duration" );
 static const effect_on_condition_id
@@ -129,6 +131,16 @@ TEST_CASE( "EOC_math_integration", "[eoc][math_parser]" )
     get_avatar().set_stamina( 0 );
     effect_on_condition_EOC_math_weighted_list->activate( d );
     CHECK( std::stod( globvars.get_global_value( "npctalk_var_weighted_var" ) ) == Approx( 1 ) );
+}
+
+TEST_CASE( "EOC_jmath", "[eoc][math_parser]" )
+{
+    global_variables &globvars = get_globals();
+    globvars.clear_global_values();
+    REQUIRE( globvars.get_global_value( "npctalk_var_blorgy" ).empty() );
+    dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
+    effect_on_condition_EOC_jmath_test->activate( d );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_blorgy" ) ) == Approx( 7 ) );
 }
 
 TEST_CASE( "EOC_transform_radius", "[eoc][timed_event]" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add support for JSON defined math functions so that calculations can be easily reused. There is already a potential use case in the dew point calculation that currently uses a global EOC to update the value.

~~* Depends on #65307 and the first commit is that PR squashed~~

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Math functions are defined like this:
```JSON
  {
    "type": "jmath_function",
    "id": "my_math_function",
    "num_args": 2,
    "return": "_0 * 2 + _1"
  },
```
_where `_0`, `_1`, etc are positional parameters (similar to `$1`, `$2`, etc in shell scripts)_
and can be used like regular math functions
```JSON
  {
    "type": "effect_on_condition",
    "id": "EOC_do_something",
    "effect": [ { "math": [ "secret_value", "=", "my_math_function( u_pain(), 500)" ] } ]
  },
```
_so `_0` takes the value of `u_pain()` and `_1` takes the value `500` inside `my_math_function()`_

Functions can be defined and used in any order thanks to deferred parsing.
Function composition with `jmath_function` is also supported, of course.

#### Describe the solution
Defer parsing math to finalization step.
Add the bits and bobs needed to load and use JSON-defined math functions.

TODO:
- [x] documentation: just copy-pasted the text above

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Test unit

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->