### PR TITLE
Make `f`iring action UX more pleasant

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -94,6 +94,7 @@ static const efftype_id effect_happy( "happy" );
 static const efftype_id effect_irradiated( "irradiated" );
 static const efftype_id effect_onfire( "onfire" );
 static const efftype_id effect_pkill( "pkill" );
+static const efftype_id effect_relax_gas( "relax_gas" );
 static const efftype_id effect_sad( "sad" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_sleep_deprived( "sleep_deprived" );
@@ -857,6 +858,21 @@ void avatar::vomit()
         add_msg( m_warning, _( "You retched, but your stomach is empty." ) );
     }
     Character::vomit();
+}
+
+bool avatar::try_break_relax_gas( const std::string &msg_success, const std::string &msg_failure )
+{
+    const effect &pacify = get_effect( effect_relax_gas, body_part_mouth );
+    if( pacify.is_null() ) {
+        return true;
+    } else if( one_in( pacify.get_intensity() ) ) {
+        add_msg( m_good, msg_success );
+        return true;
+    } else {
+        mod_moves( std::max( 0, pacify.get_intensity() * 10 + rng( -30, 30 ) ) );
+        add_msg( m_bad, msg_failure );
+        return false;
+    }
 }
 
 nc_color avatar::basic_symbol_color() const

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -239,6 +239,10 @@ class avatar : public Character
         object_type get_grab_type() const;
         /** Handles player vomiting effects */
         void vomit();
+        // if avatar is affected by relax_gas this rolls chance to overcome it at cost of moves
+        // prints messages for success/failure
+        // @return true if no relax_gas effect or rng roll to ignore it was successful
+        bool try_break_relax_gas( const std::string &msg_success, const std::string &msg_failure );
         void add_pain_msg( int val, const bodypart_id &bp ) const;
         /**
          * Try to steal an item from the NPC's inventory. May result in fail attempt, when NPC not notices you,

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -77,7 +77,6 @@ static const move_mode_id move_mode_prone( "prone" );
 
 static const skill_id skill_swimming( "swimming" );
 
-static const trait_id trait_BRAWLER( "BRAWLER" );
 static const trait_id trait_GRAZER( "GRAZER" );
 static const trait_id trait_RUMINANT( "RUMINANT" );
 static const trait_id trait_SHELL2( "SHELL2" );
@@ -761,66 +760,6 @@ bool avatar_action::can_fire_weapon( avatar &you, const map &m, const item &weap
     return false;
 }
 
-/**
- * Checks if the turret is valid and if the player meets certain conditions for manually firing it.
- * @param turret Turret to check.
- * @return True if all conditions are true, otherwise false.
- */
-static bool can_fire_turret( avatar &you, const map &m, const turret_data &turret )
-{
-    const item &weapon = *turret.base();
-    if( !weapon.is_gun() ) {
-        debugmsg( "Expected turret base to be a gun." );
-        return false;
-    }
-
-    if( you.has_trait( trait_BRAWLER ) ) {
-        add_msg( m_bad, _( "You refuse to use the %s." ), turret.name() );
-        return false;
-    }
-
-    switch( turret.query() ) {
-        case turret_data::status::no_ammo:
-            add_msg( m_bad, _( "The %s is out of ammo." ), turret.name() );
-            return false;
-
-        case turret_data::status::no_power:
-            add_msg( m_bad, _( "The %s is not powered." ), turret.name() );
-            return false;
-
-        case turret_data::status::ready:
-            break;
-
-        default:
-            debugmsg( "Unknown turret status" );
-            return false;
-    }
-
-    if( you.has_effect( effect_relax_gas ) ) {
-        if( one_in( 5 ) ) {
-            add_msg( m_good, _( "Your eyes steel, and you aim your weapon!" ) );
-        } else {
-            you.moves -= rng( 2, 5 ) * 10;
-            add_msg( m_bad, _( "You are too pacified to aim the turret…" ) );
-            return false;
-        }
-    }
-
-    std::vector<std::string> messages;
-
-    for( const std::pair<const gun_mode_id, gun_mode> &mode_map : weapon.gun_all_modes() ) {
-        bool can_use_mode = gunmode_checks_common( you, m, messages, mode_map.second );
-        if( can_use_mode ) {
-            return true;
-        }
-    }
-
-    for( const std::string &message : messages ) {
-        add_msg( m_info, message );
-    }
-    return false;
-}
-
 void avatar_action::fire_wielded_weapon( avatar &you )
 {
     const item_location weapon = you.get_wielded_item();
@@ -856,12 +795,52 @@ void avatar_action::fire_ranged_bionic( avatar &you, const item &fake_gun )
     you.assign_activity( aim_activity_actor::use_bionic( fake_gun ) );
 }
 
-void avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret )
+bool avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret )
 {
-    if( !can_fire_turret( you, m, turret ) ) {
-        return;
+    if( !turret.base()->is_gun() ) {
+        debugmsg( "Expected turret base to be a gun." );
+        return false;
     }
 
+    switch( turret.query() ) {
+        case turret_data::status::no_ammo:
+            add_msg( m_bad, _( "The %s is out of ammo." ), turret.name() );
+            return false;
+        case turret_data::status::no_power:
+            add_msg( m_bad, _( "The %s is not powered." ), turret.name() );
+            return false;
+        case turret_data::status::ready:
+            break;
+        default:
+            debugmsg( "Unknown turret status" );
+            return false;
+    }
+
+    if( you.has_effect( effect_relax_gas ) ) {
+        if( one_in( 5 ) ) {
+            add_msg( m_good, _( "Your eyes steel, and you aim your weapon!" ) );
+        } else {
+            you.mod_moves( - rng( 20, 50 ) );
+            add_msg( m_bad, _( "You are too pacified to aim the turret…" ) );
+            return false;
+        }
+    }
+
+    // check if any gun modes are usable
+    std::vector<std::string> messages;
+    const std::map<gun_mode_id, gun_mode> gunmodes = turret.base()->gun_all_modes();
+    if( !std::any_of( gunmodes.begin(), gunmodes.end(),
+    [&you, &m, &messages]( const std::pair<const gun_mode_id, gun_mode> &p ) {
+    return gunmode_checks_common( you, m, messages, p.second );
+    } ) ) {
+        // no gunmode is usable, dump reason messages why not
+        for( const std::string &msg : messages ) {
+            add_msg( m_bad, msg );
+        }
+        return false;
+    }
+
+    // all checks passed - start aiming
     g->temp_exit_fullscreen();
     target_handler::trajectory trajectory = target_handler::mode_turret_manual( you, turret );
 
@@ -869,6 +848,7 @@ void avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret
         turret.fire( you, trajectory.back() );
     }
     g->reenter_fullscreen();
+    return true;
 }
 
 void avatar_action::mend( avatar &you, item_location loc )

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -66,7 +66,6 @@ static const efftype_id effect_hunger_engorged( "hunger_engorged" );
 static const efftype_id effect_incorporeal( "incorporeal" );
 static const efftype_id effect_onfire( "onfire" );
 static const efftype_id effect_pet( "pet" );
-static const efftype_id effect_relax_gas( "relax_gas" );
 static const efftype_id effect_ridden( "ridden" );
 static const efftype_id effect_stunned( "stunned" );
 static const efftype_id effect_winded( "winded" );
@@ -341,14 +340,9 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
                 you.clear_destination();
                 return false;
             }
-            if( you.has_effect( effect_relax_gas ) ) {
-                if( one_in( 8 ) ) {
-                    add_msg( m_good, _( "Your willpower asserts itself, and so do you!" ) );
-                } else {
-                    you.moves -= rng( 2, 8 ) * 10;
-                    add_msg( m_bad, _( "You're too pacified to strike anything…" ) );
-                    return false;
-                }
+            if( !you.try_break_relax_gas( _( "Your willpower asserts itself, and so do you!" ),
+                                          _( "You're too pacified to strike anything…" ) ) ) {
+                return false;
             }
             if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
                 g->safe_mode != SAFE_MODE_OFF ) {
@@ -733,14 +727,9 @@ bool avatar_action::can_fire_weapon( avatar &you, const map &m, const item &weap
         return false;
     }
 
-    if( you.has_effect( effect_relax_gas ) ) {
-        if( one_in( 5 ) ) {
-            add_msg( m_good, _( "Your eyes steel, and you raise your weapon!" ) );
-        } else {
-            you.moves -= rng( 2, 5 ) * 10;
-            add_msg( m_bad, _( "You can't fire your weapon, it's too heavy…" ) );
-            return false;
-        }
+    if( !you.try_break_relax_gas( _( "Your eyes steel, and you raise your weapon!" ),
+                                  _( "You can't fire your weapon, it's too heavy…" ) ) ) {
+        return false;
     }
 
     std::vector<std::string> messages;
@@ -814,16 +803,6 @@ bool avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret
         default:
             debugmsg( "Unknown turret status" );
             return false;
-    }
-
-    if( you.has_effect( effect_relax_gas ) ) {
-        if( one_in( 5 ) ) {
-            add_msg( m_good, _( "Your eyes steel, and you aim your weapon!" ) );
-        } else {
-            you.mod_moves( - rng( 20, 50 ) );
-            add_msg( m_bad, _( "You are too pacified to aim the turret…" ) );
-            return false;
-        }
     }
 
     // check if any gun modes are usable
@@ -1015,14 +994,9 @@ void avatar_action::plthrow( avatar &you, item_location loc,
         return;
     }
 
-    if( you.has_effect( effect_relax_gas ) ) {
-        if( one_in( 5 ) ) {
-            add_msg( m_good, _( "You concentrate mightily, and your body obeys!" ) );
-        } else {
-            you.moves -= rng( 2, 5 ) * 10;
-            add_msg( m_bad, _( "You can't muster up the effort to throw anything…" ) );
-            return;
-        }
+    if( !you.try_break_relax_gas( _( "You concentrate mightily, and your body obeys!" ),
+                                  _( "You can't muster up the effort to throw anything…" ) ) ) {
+        return;
     }
     // if you're wearing the item you need to be able to take it off
     if( you.is_worn( *orig ) ) {

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -69,8 +69,9 @@ void fire_ranged_bionic( avatar &you, const item &fake_gun );
  * Checks if the player can manually (with their 2 hands, not via vehicle controls)
  * fire a turret and then starts interactive aiming.
  * Assumes that the turret is on player position.
+ * @return true if attempt to fire was successful (aim then cancel is also considered success)
  */
-void fire_turret_manual( avatar &you, map &m, turret_data &turret );
+bool fire_turret_manual( avatar &you, map &m, turret_data &turret );
 
 // Throw an item  't'
 void plthrow( avatar &you, item_location loc,

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1498,8 +1498,9 @@ static void fire()
                 add_msg( m_bad, _( "You refuse to use the turret." ) );
                 return;
             }
-            avatar_action::fire_turret_manual( player_character, here, turret );
-            return;
+            if( avatar_action::fire_turret_manual( player_character, here, turret ) ) {
+                return;
+            }
         }
 
         if( vp.part_with_feature( "CONTROLS", true ) ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -120,7 +120,6 @@ static const damage_type_id damage_cut( "cut" );
 static const efftype_id effect_alarm_clock( "alarm_clock" );
 static const efftype_id effect_incorporeal( "incorporeal" );
 static const efftype_id effect_laserlocked( "laserlocked" );
-static const efftype_id effect_relax_gas( "relax_gas" );
 static const efftype_id effect_stunned( "stunned" );
 
 static const flag_id json_flag_MOP( "MOP" );
@@ -1487,6 +1486,11 @@ static void fire()
     avatar &player_character = get_avatar();
     map &here = get_map();
 
+    if( player_character.try_break_relax_gas( _( "Your willpower asserts itself, and so do you!" ),
+            _( "You're too pacified to strike anything…" ) ) ) {
+        return;
+    }
+
     // Use vehicle turret or draw a pistol from a holster if unarmed
     if( !player_character.is_armed() ) {
 
@@ -1533,17 +1537,7 @@ static void fire()
     if( weapon->is_gun() && !weapon->gun_current_mode().melee() ) {
         avatar_action::fire_wielded_weapon( player_character );
     } else if( weapon->current_reach_range( player_character ) > 1 ) {
-        if( player_character.has_effect( effect_relax_gas ) ) {
-            if( one_in( 8 ) ) {
-                add_msg( m_good, _( "Your willpower asserts itself, and so do you!" ) );
-                reach_attack( player_character );
-            } else {
-                player_character.moves -= rng( 2, 8 ) * 10;
-                add_msg( m_bad, _( "You're too pacified to strike anything…" ) );
-            }
-        } else {
-            reach_attack( player_character );
-        }
+        reach_attack( player_character );
     }
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Streamline `f`iring shortcut:

Pressing `f` while holding a melee weapon on a turret will now try to fire turret instead of doing nothing
Pressing `f` while holding a melee weapon will offer to draw from a holster instead of doing nothing
(Melee weapons above mean non-reach ones, reach ones should behave the same)


#### Describe the solution

The current code will not let you shoot a turret if you're holding something like a knife, forcing the player to hassle with "why doesn't it work", unwield, shoot, wield. Holding a melee weapon and pressing `f` won't offer drawing from holsters either, this PR fixes it so if any action is available - it is offered to the player instead of bailing out doing nothing.

The PR reorganizes code slightly - consolidates and changes function return type to get success flag, centralizes relax_gas handling in an avatar function, rejiggles BRAWLER trait handling a bit as there were more checks than needed, the function now flows linearly;
try break relax gas effect
try melee weapon reach attack
if BRAWLER trait is on bail out
try firing wielded gun
try firing manned turret
try firing controls turret
offer holster draw

Relax gas was also handled wildly with places having seemingly random amount of moves subtracted per attempting a break - this is now dependent on effect's intensity instead

Not quite happy with the gas and BRAWLER handling but one of them is an ugly hack that subtracts avatar moves in functions which are called/commented as "check_something...()" and the other is a dirty pointbuy hack anyway so it'll have to do for now

Holster draw seems a bit wonky too as it appears to offer holster selection and then the drawing specific item rather than drawing specific item directly, but probably separate PR for that

#### Describe alternatives you've considered

#### Testing

Mostly a ui change - has to be manually tested

#### Additional context
