### PR TITLE
Remove unused static (clear clang-tidy error)

### DIFF
--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -35,7 +35,6 @@ static const itype_id fuel_type_battery( "battery" );
 static const itype_id fuel_type_none( "null" );
 
 static const itype_id itype_battery( "battery" );
-static const itype_id itype_muscle( "muscle" );
 
 /*-----------------------------------------------------------------------------
  *                              VEHICLE_PART


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4841733707/jobs/8628429605#step:7:1770

#### Describe the solution

Remove unused variable

#### Describe alternatives you've considered

#### Testing

clang tidy test should pass

#### Additional context
