### PR TITLE
npctrade: un-hardcode trade price formulas

### DIFF
--- a/data/json/npctrade.json
+++ b/data/json/npctrade.json
@@ -1,0 +1,46 @@
+[
+  {
+    "type": "jmath_function",
+    "id": "skill_adjustment",
+    "num_args": 1,
+    "//": "6th-degree polynomial fit for {{-5,1/2},{-4,1/1.65},{-3,1/1.3},{-2,1/1.15},{-1,1/1.05},{0,1},{1,1.05},{2,1.15},{3,1.3},{4,1.65},{5,2}}",
+    "return": "1.00342 + 0.0361699*_0 - 0.00316488*_0^2 + 0.00770736*_0^3 + 0.000952084*_0^4 - 0.000125351*_0^5 - 0.0000172177*_0^6"
+  },
+  {
+    "type": "jmath_function",
+    "id": "skill_adjustment_clamped",
+    "num_args": 1,
+    "return": "skill_adjustment(clamp(_0, -5, 5))"
+  },
+  {
+    "type": "jmath_function",
+    "id": "int_adjustment",
+    "num_args": 1,
+    "//": "exponential fit for {{-20, 0.5}, {0, 1}, {20, 2}}",
+    "return": "e^(0.0346574*clamp(_0, -19, 19))"
+  },
+  {
+    "type": "jmath_function",
+    "id": "npctrade_u_sell_adj",
+    "num_args": 1,
+    "return": "1 - _0"
+  },
+  {
+    "type": "jmath_function",
+    "id": "npctrade_u_sell",
+    "num_args": 0,
+    "return": "npctrade_u_sell_adj(0.25 / (skill_adjustment_clamped(u_skill('speech') - n_skill('speech')) * int_adjustment(u_val('intelligence') - n_val('intelligence'))))"
+  },
+  {
+    "type": "jmath_function",
+    "id": "npctrade_u_buy_adj",
+    "num_args": 1,
+    "return": "1 + _0"
+  },
+  {
+    "type": "jmath_function",
+    "id": "npctrade_u_buy",
+    "num_args": 0,
+    "return": "npctrade_u_buy_adj(0.25 * skill_adjustment_clamped(n_skill('speech') - u_skill('speech')) * int_adjustment(n_val('intelligence') - u_val('intelligence')))"
+  }
+]

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -871,6 +871,7 @@
     "weight": "500 g",
     "volume": "100 ml",
     "longest_side": "10 cm",
+    "price": 100,
     "material": [ "steel" ],
     "symbol": ";",
     "color": "light_gray",

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -591,12 +591,3 @@ bool SkillLevelMap::has_same_levels_as( const SkillLevelMap &other ) const
     }
     return true;
 }
-
-// Actually take the difference in social skill between the two parties involved
-// Caps at 200% when you are 5 levels ahead, int comparison is handled in npctalk.cpp
-double price_adjustment( int barter_skill )
-{
-    int const skill = std::min( 5, std::abs( barter_skill ) );
-    double const val = 0.045 * std::pow( skill, 2 ) - 0.025 * skill + 1;
-    return barter_skill >= 0 ? val : 1 / val;
-}

--- a/src/skill.h
+++ b/src/skill.h
@@ -289,6 +289,4 @@ class SkillDisplayType
         }
 };
 
-double price_adjustment( int );
-
 #endif // CATA_SRC_SKILL_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
* Move the trading price formulas from #57706 and #58119 to JSON, using jmath functions
~~* Depends on #65379 and will not compile without it~~

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Move the calculations to `jmath_function`s.

Instead of quadratic and linear best fits with branches for skill and int adjustments respectively, use a 6th-degree polynomial and an exponential fit.

TODO:
- [ ] document, somewhere

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The polynomial and exponential functions are implementation details. The important bits are that the adjustment doubles/halves at 5 points of skill difference and again at 20 points of intelligence difference and there's a smooth curve in between, as described in #57706 and #58119. Instead of scary functions, I could have used:
- quadratic for skill and linear for intelligence (current hardcoded formulas): these need ternary operators for symmetry and I don't want to implement them at the moment (or ever)
- cubic for skill: the error is too high near the edges
- 4th or 5th degree polynomial: just as scary as a 6th degree but with worse fit so why not 6th?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Prices should be very similar before and after. Check at the extremes of skill/int difference and middle values too. They won't be exactly the same due to the different fits, but should be within a couple of cents for almost all items.

The `[trade]` test suite should still pass.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
The fits were calculated by WolframAlpha:
[skill adjustment](https://www.wolframalpha.com/input?i=polynomial+fit+%7B%7B-5%2C1%2F2%7D%2C%7B-4%2C1%2F1.65%7D%2C%7B-3%2C1%2F1.3%7D%2C%7B-2%2C1%2F1.15%7D%2C%7B-1%2C+1%2F1.05%7D%2C+%7B0%2C1%7D%2C%7B1%2C1.05%7D%2C%7B2%2C1.15%7D%2C%7B3%2C1.3%7D%2C%7B4%2C1.65%7D%2C%7B5%2C2%7D%7D+degree+6)
[int adjustment](https://www.wolframalpha.com/input?i=exponential+fit&assumption=%7B%22C%22%2C+%22exponential+fit%22%7D+-%3E+%7B%22Calculator%22%7D&assumption=%7B%22F%22%2C+%22ExponentialFitCalculator%22%2C+%22data2%22%7D+-%3E%22%7B%7B-20%2C+0.5%7D%2C+%7B0%2C+1%7D%2C+%7B20%2C+2%7D%7D%22)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->