### PR TITLE
Horse Blinders

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -215,6 +215,12 @@
   },
   {
     "type": "effect_type",
+    "id": "monster_blinders",
+    "name": [ "Has Blinders" ],
+    "desc": [ "AI tag used for critters wearing blinders.  This is a bug if you have it." ]
+  },
+  {
+    "type": "effect_type",
     "id": "monster_saddled",
     "name": [ "Has Saddle" ],
     "desc": [ "AI tag used for critters wearing a saddle.  This is a bug if you have it." ]

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -416,6 +416,10 @@
     "info": "This gear is equipped with an accurate hygrometer (which is used to measure humidity)."
   },
   {
+    "id": "BLINDERS",
+    "type": "json_flag"
+  },
+  {
     "id": "BURNOUT",
     "type": "json_flag",
     "//": "You can visually inspect how much it is burned out (candle, torch)."

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -2184,7 +2184,7 @@
     "id": "farm_supply_riding_gear",
     "type": "item_group",
     "subtype": "collection",
-    "items": [ { "item": "horse_tack" }, { "item": "saddlebag" } ]
+    "items": [ { "item": "horse_tack" }, { "item": "saddlebag" }, { "item": "horse_blinders" } ]
   },
   {
     "id": "farm_supply_floor_surprises",

--- a/data/json/items/tool/pets.json
+++ b/data/json/items/tool/pets.json
@@ -128,7 +128,7 @@
   {
     "id": "horse_blinders",
     "type": "TOOL",
-    "name": { "str": "horse blinders" },
+    "name": { "str_sp": "horse blinders" },
     "description": "A simple hood with angled leather cups situated over two eye-holes. This contraption goes over the head of a horse, the leather cups preventing the horse from seeing behind it and to the sides.",
     "weight": "800 g",
     "volume": "1 L",

--- a/data/json/items/tool/pets.json
+++ b/data/json/items/tool/pets.json
@@ -129,7 +129,7 @@
     "id": "horse_blinders",
     "type": "TOOL",
     "name": { "str_sp": "horse blinders" },
-    "description": "A simple hood with angled leather cups situated over two eye-holes. This contraption goes over the head of a horse, the leather cups preventing the horse from seeing behind it and to the sides.",
+    "description": "A simple hood with angled leather cups situated over two eye-holes.  This contraption goes over the head of a horse, the leather cups preventing the horse from seeing behind it and to the sides.",
     "weight": "800 g",
     "volume": "1 L",
     "price": 0,

--- a/data/json/items/tool/pets.json
+++ b/data/json/items/tool/pets.json
@@ -126,6 +126,22 @@
     "melee_damage": { "bash": 5 }
   },
   {
+    "id": "horse_blinders",
+    "type": "TOOL",
+    "name": { "str": "horse blinders" },
+    "description": "A simple hood with angled leather cups situated over two eye-holes. This contraption goes over the head of a horse, the leather cups preventing the horse from seeing behind it and to the sides.",
+    "weight": "800 g",
+    "volume": "1 L",
+    "price": 0,
+    "price_postapoc": 1000,
+    "to_hit": -1,
+    "material": [ "leather" ],
+    "symbol": "B",
+    "color": "yellow",
+    "flags": [ "BLINDERS" ],
+    "melee_damage": { "bash": 1 }
+  },
+  {
     "//": "https://primeusascales.com/product/sls-single-animal-livestock-scales/",
     "id": "livestock_scale",
     "type": "TOOL",

--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -527,6 +527,26 @@
     "components": [ [ [ "leather", 30 ], [ "tanned_hide", 5 ], [ "fur", 30 ], [ "tanned_pelt", 5 ] ], [ [ "wire", 2 ] ] ]
   },
   {
+    "result": "horse_blinders",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "skills_required": [ "fabrication", 2 ],
+    "time": "3 h",
+    "reversible": true,
+    "proficiencies": [
+      { "proficiency": "prof_closures" },
+      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_leatherworking" }
+    ],
+    "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
+    "using": [ [ "sewing_standard", 50 ], [ "cordage", 1 ] ],
+    "components": [ [ [ "leather", 20 ], [ "tanned_hide", 1 ], [ "fur", 20 ], [ "tanned_pelt", 1 ] ], [ [ "wire", 2 ] ] ]
+  },
+  {
     "result": "jack",
     "type": "recipe",
     "activity_level": "BRISK_EXERCISE",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -246,6 +246,7 @@ static const efftype_id effect_masked_scent( "masked_scent" );
 static const efftype_id effect_melatonin( "melatonin" );
 static const efftype_id effect_mending( "mending" );
 static const efftype_id effect_meth( "meth" );
+static const efftype_id effect_monster_blinders( "monster_blinders" );
 static const efftype_id effect_monster_saddled( "monster_saddled" );
 static const efftype_id effect_mute( "mute" );
 static const efftype_id effect_narcosis( "narcosis" );
@@ -1467,7 +1468,9 @@ bool Character::check_mount_will_move( const tripoint &dest_loc )
     if( mounted_creature && mounted_creature->type->has_fear_trigger( mon_trigger::HOSTILE_CLOSE ) ) {
         for( const monster &critter : g->all_monsters() ) {
             Attitude att = critter.attitude_to( *this );
-            if( att == Attitude::HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= 15 &&
+            const bool blinders = mounted_creature->has_effect( effect_monster_blinders );
+            int fear_distance = blinders ? 12 : 15;
+            if( att == Attitude::HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= fear_distance &&
                 rl_dist( dest_loc, critter.pos() ) < rl_dist( pos(), critter.pos() ) ) {
                 add_msg_if_player( _( "You fail to budge your %s!" ), mounted_creature->get_name() );
                 return false;
@@ -1494,13 +1497,15 @@ bool Character::check_mount_is_spooked()
     if( mounted_creature && mounted_creature->type->has_fear_trigger( mon_trigger::HOSTILE_CLOSE ) ) {
         const creature_size mount_size = mounted_creature->get_size();
         const bool saddled = mounted_creature->has_effect( effect_monster_saddled );
+        const bool blinders = mounted_creature->has_effect( effect_monster_blinders );
         const bool combat_mount = mounted_creature->has_flag( MF_COMBAT_MOUNT );
         for( const monster &critter : g->all_monsters() ) {
             double chance = 1.0;
+            int spook_distance = blinders ? 7 : 10;
             Attitude att = critter.attitude_to( *this );
             // actually too close now - horse might spook.
-            if( att == Attitude::HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= 10 ) {
-                chance += 10 - rl_dist( pos(), critter.pos() );
+            if( att == Attitude::HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= spook_distance ) {
+                chance += spook_distance - rl_dist( pos(), critter.pos() );
                 if( critter.get_size() >= mount_size ) {
                     chance *= 2;
                 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1517,7 +1517,8 @@ bool Character::check_mount_is_spooked()
                 if( saddled ) {
                     chance /= 2;
                 }
-                if( combat_mount ) {
+                // don't double dip with combat mounts and blinders
+                if( !blinders && combat_mount ) {
                     chance /= 2;
                 }
                 chance = std::max( 1.0, chance );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1470,7 +1470,8 @@ bool Character::check_mount_will_move( const tripoint &dest_loc )
             Attitude att = critter.attitude_to( *this );
             const bool blinders = mounted_creature->has_effect( effect_monster_blinders );
             int fear_distance = blinders ? 12 : 15;
-            if( att == Attitude::HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= fear_distance &&
+            if( att == Attitude::HOSTILE && sees( critter ) &&
+                rl_dist( pos(), critter.pos() ) <= fear_distance &&
                 rl_dist( dest_loc, critter.pos() ) < rl_dist( pos(), critter.pos() ) ) {
                 add_msg_if_player( _( "You fail to budge your %s!" ), mounted_creature->get_name() );
                 return false;
@@ -1504,7 +1505,8 @@ bool Character::check_mount_is_spooked()
             int spook_distance = blinders ? 7 : 10;
             Attitude att = critter.attitude_to( *this );
             // actually too close now - horse might spook.
-            if( att == Attitude::HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= spook_distance ) {
+            if( att == Attitude::HOSTILE && sees( critter ) &&
+                rl_dist( pos(), critter.pos() ) <= spook_distance ) {
                 chance += spook_distance - rl_dist( pos(), critter.pos() );
                 if( critter.get_size() >= mount_size ) {
                     chance *= 2;

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -43,6 +43,7 @@ const flag_id flag_BIPOD( "BIPOD" );
 const flag_id flag_BIRD( "BIRD" );
 const flag_id flag_BLED( "BLED" );
 const flag_id flag_BLIND( "BLIND" );
+const flag_id flag_BLINDERS( "BLINDERS" );
 const flag_id flag_BLOCK_WHILE_WORN( "BLOCK_WHILE_WORN" );
 const flag_id flag_BOMB( "BOMB" );
 const flag_id flag_BRASS_CATCHER( "BRASS_CATCHER" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -53,6 +53,7 @@ extern const flag_id flag_BIPOD;
 extern const flag_id flag_BIRD;
 extern const flag_id flag_BLED;
 extern const flag_id flag_BLIND;
+extern const flag_id flag_BLINDERS;
 extern const flag_id flag_BLOCK_WHILE_WORN;
 extern const flag_id flag_BOMB;
 extern const flag_id flag_BRASS_CATCHER;

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -724,7 +724,8 @@ bool monexamine::pet_menu( monster &z )
         if( player_character.get_skill_level( skill_survival ) >= 1 ) {
             amenu.addentry( attach_blinders, true, 'h', _( "Attach blinders to %s" ), pet_name );
         } else {
-            amenu.addentry( attach_blinders, false, 'h', _( "You don't know how to attach blinders to %s" ), pet_name );
+            amenu.addentry( attach_blinders, false, 'h', _( "You don't know how to attach blinders to %s" ),
+                            pet_name );
         }
     }
     if( z.has_flag( MF_PET_MOUNTABLE ) && z.has_effect( effect_monster_blinders ) ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2613,6 +2613,7 @@ void monster::die( Creature *nkiller )
     if( death_drops ) {
         // Drop items stored in optionals
         move_special_item_to_inv( tack_item );
+        move_special_item_to_inv( blinders_item );
         move_special_item_to_inv( armor_item );
         move_special_item_to_inv( storage_item );
         move_special_item_to_inv( tied_item );
@@ -3116,6 +3117,9 @@ units::mass monster::get_carried_weight() const
     units::mass total_weight = 0_gram;
     if( tack_item ) {
         total_weight += tack_item->weight();
+    }
+    if( blinders_item ) {
+        total_weight += blinders_item->weight();
     }
     if( storage_item ) {
         total_weight += storage_item->weight();

--- a/src/monster.h
+++ b/src/monster.h
@@ -505,6 +505,7 @@ class monster : public Creature
         character_id dragged_foe_id; // id of character being dragged by the monster
         cata::value_ptr<item> tied_item; // item used to tie the monster
         cata::value_ptr<item> tack_item; // item representing saddle and reins and such
+        cata::value_ptr<item> blinders_item; // item reducing the range a mount gets scared at
         cata::value_ptr<item> armor_item; // item of armor the monster may be wearing
         cata::value_ptr<item> storage_item; // storage item for monster carrying items
         cata::value_ptr<item> battery_item; // item to power mechs

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2597,6 +2597,12 @@ void monster::load( const JsonObject &data )
         newitem.deserialize( tack_item_json );
         tack_item = cata::make_value<item>( newitem );
     }
+    if( data.has_object( "blinders_item" ) ) {
+        JsonValue blinders_item_json = data.get_member( "blinders_item" );
+        item newitem;
+        newitem.deserialize( blinders_item_json );
+        blinders_item = cata::make_value<item>( newitem );
+    }
     if( data.has_object( "armor_item" ) ) {
         JsonValue armor_item_json = data.get_member( "armor_item" );
         item newitem;
@@ -2760,6 +2766,9 @@ void monster::store( JsonOut &json ) const
     }
     if( tack_item ) {
         json.member( "tack_item", *tack_item );
+    }
+    if( blinders_item ) {
+        json.member( "blinders_item", *blinders_item );
     }
     if( armor_item ) {
         json.member( "armor_item", *armor_item );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Added 'Horse Blinders', an attachable for your mount that lets them get a bit closer without getting scared"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The idea here is to make mounted combat more doable by letting the player ride up closer to the enemy. As mentioned in https://github.com/CleverRaven/Cataclysm-DDA/pull/64977, horses are skittish, so you simply won't be able to take non-warhorses up to a zombie for a sword-fight.

Blinders reduce the "scare" range from 10 tiles to 7, which is still a respectable risk-zone, but enable mounted archers to take potshots at zombies. Any closer and they risk getting thrown off still. Additionally, for non-trained mounts, the "no budge" range reduces from 15 to 12 tiles.

Blinders should never remove horses being scared, as the horse still needs to be able to see in front of them to move without tripping on a rock and exploding into a billion lego pieces. The reduced range is simply an abstraction for the comfort of peripherals being blocked, since we're dealing with a 360 degree view here.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Added a 'Horse Blinders' item, which can be attached to a mount provided you have at least one point in the survival skill.
- The blinders effect lets you take an untrained mount to a minimum of 12 (down from 15) tiles from an enemy before it starts refusing to budge.
- The blinders effect lets reduces the range at which a mount starts rolling for being scared to 7 (down from 10) tiles.
- Blinders can be crafted, the recipe being learned at the same place horse tacks are learned, or from having 3 tailoring and 2 fabrication at character creation.
- Additionally, blinders have been added to the farm riding supply loot pool.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Not implementing blinders at all, but where's the fun in that?
- Making blinders make the mount not scared at all, at the cost of slowed movement. Discarded because a slow and blind mount sounds like a terrible idea.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Spawned in a mount and blinders.
- Tested that attaching and removing blinders works.
- Tested that saving and loading the blinders works.
- Tested that the range for scaring and budging works.
- Tested that crafting works.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->