### PR TITLE
[Bombastic Perks] Recycler

### DIFF
--- a/data/mods/BombasticPerks/perkdata/recycler.json
+++ b/data/mods/BombasticPerks/perkdata/recycler.json
@@ -1,29 +1,25 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_queue_can_finder",
-    "effect": [
-      { "queue_eocs": "EOC_can_hunting", "time_in_future": [ "35 minutes", "120 minutes" ] },
-      { "u_message": "You start hunting for cans" },
-      { "arithmetic": [ { "u_val": "var", "var_name": "looking_for_cans" }, "=", { "const": 1 } ] }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_deque_can_finder",
-    "effect": [
-      { "u_message": "You stop looking for cans" },
-      { "arithmetic": [ { "u_val": "var", "var_name": "looking_for_cans" }, "=", { "const": 0 } ] }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_can_hunting",
-    "condition": { "compare_num": [ { "u_val": "var", "var_name": "looking_for_cans" }, ">", { "const": 0 } ] },
+    "//": "only 50% chance to happen each time",
+    "//2": "Processing effect",
+    "condition": { "math": [ "rng(0, 1.0)", ">", "0.5" ] },
     "effect": [
-      { "queue_eocs": "EOC_can_hunting", "time_in_future": [ "35 minutes", "120 minutes" ] },
       { "u_message": "Someone left a perfectly good can of soda on the ground!" },
       { "u_spawn_item": "groce_softdrink", "use_item_group": true }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_can_finder_on",
+    "//": "Activation effect",
+    "effect": [ { "u_message": "You start hunting for cans" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_can_finder_off",
+    "//": "Deactivation effect",
+    "effect": [ { "u_message": "You stop looking for cans" } ]
   }
 ]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -604,9 +604,7 @@
             {
               "or": [
                 { "compare_num": [ { "u_val": "var", "var_name": "no_prerecs" }, ">", { "const": 0 } ] },
-                {
-                  "or": [ { "u_has_skill": { "skill": "survival", "level": 4 } } ]
-                }
+                { "or": [ { "u_has_skill": { "skill": "survival", "level": 4 } } ] }
               ]
             },
             { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] }

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -93,6 +93,11 @@
         "topic": "TALK_PERK_MENU_TUCK_AND_ROLL"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_recycler" } },
+        "text": "Gain [<trait_name:perk_recycler>]",
+        "topic": "TALK_PERK_MENU_RECYCLER"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_tingly" } },
         "text": "Gain [<trait_name:perk_tingly>]",
         "topic": "TALK_PERK_MENU_TINGLY"
@@ -577,6 +582,40 @@
         "failure_topic": "TALK_PERK_MENU_FAIL",
         "effect": [
           { "u_add_trait": "perk_tuck_and_roll" },
+          {
+            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
+          }
+        ]
+      },
+      { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_PERK_MENU_RECYCLER",
+    "dynamic_line": "<trait_name:perk_recycler>: \"<trait_description:perk_recycler>\"\nRequires survival 4.",
+    "responses": [
+      {
+        "text": "Select Perk.",
+        "topic": "TALK_PERK_MENU_MAIN",
+        "condition": {
+          "and": [
+            {
+              "or": [
+                { "compare_num": [ { "u_val": "var", "var_name": "no_prerecs" }, ">", { "const": 0 } ] },
+                {
+                  "or": [ { "u_has_skill": { "skill": "survival", "level": 4 } } ]
+                }
+              ]
+            },
+            { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] }
+          ]
+        },
+        "failure_explanation": "Requirements Not Met",
+        "failure_topic": "TALK_PERK_MENU_FAIL",
+        "effect": [
+          { "u_add_trait": "perk_recycler" },
           {
             "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
           }

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -232,8 +232,11 @@
     "description": "Even with no one around you feel obligated to clean up the streets.  You find full cans of soda in the weirdest places.",
     "category": [ "perk" ],
     "active": true,
-    "activated_eocs": [ "EOC_queue_can_finder" ],
-    "deactivated_eocs": [ "EOC_deque_can_finder" ]
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_can_finder_on" ],
+    "deactivated_eocs": [ "EOC_can_finder_off" ],
+    "processed_eocs": [ "EOC_can_hunting" ],
+    "time": 24000
   },
   {
     "type": "mutation",

--- a/doc/MUTATIONS.md
+++ b/doc/MUTATIONS.md
@@ -235,6 +235,7 @@ Note that **all new traits that can be obtained through mutation must be purifia
       }
     ]
   ],
+  "activated_is_setup": true,                 // If this is true the bellow activated EOC runs then the mutation turns on for processing every turn. If this is false the below "activated_eocs" will run and then the mod will turn itself off.
   "activated_eocs": [ "eoc_id_1" ],           // List of effect_on_conditions that attempt to activate when this mutation is successfully activated.
   "processed_eocs": [ "eoc_id_1" ],           // List of effect_on_conditions that attempt to activate every time (defined above) units of time. Time of 0 means every turn it processes.
   "deactivated_eocs": [ "eoc_id_1" ],         // List of effect_on_conditions that attempt to activate when this mutation is successfully deactivated.

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -794,7 +794,8 @@ void Character::activate_mutation( const trait_id &mut )
                 debugmsg( "Must use an activation eoc for a mutation activation.  If you don't want the effect_on_condition to happen on its own (without the mutation being activated), remove the recurrence min and max.  Otherwise, create a non-recurring effect_on_condition for this mutation with its condition and effects, then have a recurring one queue it." );
             }
         }
-        tdata.powered = false;
+        // if the activation EOCs are not just setup for processing then turn the mutation off
+        tdata.powered = mut->activated_is_setup;
     }
 
     if( mdata.transform ) {

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -343,6 +343,8 @@ struct mutation_branch {
         std::map<mtype_id, int> moncams;
         /** effect_on_conditions triggered when this mutation activates */
         std::vector<effect_on_condition_id> activated_eocs;
+        // if the above activated eocs should be run without turning on the mutation
+        bool activated_is_setup = false;
         /** effect_on_conditions triggered while this mutation is active */
         std::vector<effect_on_condition_id> processed_eocs;
         /** effect_on_conditions triggered when this mutation deactivates */

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -494,6 +494,8 @@ void mutation_branch::load( const JsonObject &jo, const std::string &src )
         deactivated_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
     }
 
+    optional( jo, was_loaded, "activated_is_setup", activated_is_setup, false );
+
     int enchant_num = 0;
     for( JsonValue jv : jo.get_array( "enchantments" ) ) {
         std::string enchant_name = "INLINE_ENCH_" + raw_name + "_" + std::to_string( enchant_num++ );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Adds the recycler perk"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Recycler never worked this adds the infrastructure for it. There was some weirdness with mutation activated EOCs
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
New bool for mutations "activated_is_setup" this means that the activated EOCs run and then the perk activates, instead of replacing turning on the mutation.

Added the stuff for recycler.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Works in game 👍 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->