### PR TITLE
Refactor index_of_part, tidy vehicle functions

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5621,7 +5621,7 @@ void game::control_vehicle()
         const bool controls_ok = controls_idx >= 0; // controls available to "drive"
         const bool reins_ok = reins_idx >= 0 // reins + animal available to "drive"
                               && veh->has_engine_type( fuel_type_animal, false )
-                              && veh->has_harnessed_animal();
+                              && veh->get_harnessed_animal();
         if( veh->player_in_control( u ) ) {
             // player already "driving" - offer ways to leave
             if( controls_ok ) {

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -16,8 +16,6 @@
 #include "vpart_position.h"
 #include "vpart_range.h"
 
-static const efftype_id effect_harnessed( "harnessed" );
-
 bool game::grabbed_veh_move( const tripoint &dp )
 {
     const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.pos() + u.grab_point );
@@ -32,14 +30,11 @@ bool game::grabbed_veh_move( const tripoint &dp )
         return false;
     }
     const int grabbed_part = grabbed_vehicle_vp->part_index();
-    for( const vpart_reference &vpr : grabbed_vehicle->get_all_parts() ) {
-        monster *mon = grabbed_vehicle->get_monster( vpr.part_index() );
-        if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
-            add_msg( m_info, _( "You cannot move this vehicle whilst your %s is harnessed!" ),
-                     mon->get_name() );
-            u.grab( object_type::NONE );
-            return false;
-        }
+    if( monster *mon = grabbed_vehicle->get_harnessed_animal() ) {
+        add_msg( m_info, _( "You cannot move this vehicle whilst your %s is harnessed!" ),
+                 mon->get_name() );
+        u.grab( object_type::NONE );
+        return false;
     }
     const vehicle *veh_under_player = veh_pointer_or_null( m.veh_at( u.pos() ) );
     if( grabbed_vehicle == veh_under_player ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -469,7 +469,7 @@ static void pldrive( const tripoint &p )
         const bool has_animal_controls = veh->part_with_feature( vp.mount, "CONTROL_ANIMAL", true ) >= 0;
         const bool has_controls = veh->part_with_feature( vp.mount, "CONTROLS", true ) >= 0;
         const bool has_animal = veh->has_engine_type( fuel_type_animal, false ) &&
-                                veh->has_harnessed_animal();
+                                veh->get_harnessed_animal();
         if( !has_controls && !has_animal_controls ) {
             add_msg( m_info, _( "You can't drive the vehicle from here.  You need controls!" ) );
             player_character.controlling_vehicle = false;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -894,20 +894,22 @@ void monster::move()
     if( friendly > 0 ) {
         --friendly;
     }
-
-    // don't move if a passenger in a moving vehicle
-    optional_vpart_position vp = here.veh_at( pos() );
-    bool harness_part = static_cast<bool>( here.veh_at( pos() ).part_with_feature( "ANIMAL_CTRL",
-                                           true ) );
-    if( vp && ( ( friendly != 0 && vp->vehicle().is_moving() &&
-                  vp->vehicle().get_monster( vp->part_index() ) ) ||
-                // Don't move if harnessed, even if vehicle is stationary
-                has_effect( effect_harnessed ) ) ) {
-        moves = 0;
-        return;
-        // If harnessed monster finds itself moved from the harness point, the harness probably broke!
-    } else if( !harness_part && has_effect( effect_harnessed ) ) {
-        remove_effect( effect_harnessed );
+    const optional_vpart_position ovp = here.veh_at( pos() );
+    if( has_effect( effect_harnessed ) ) {
+        if( !ovp.part_with_feature( "ANIMAL_CTRL", true ) ) {
+            remove_effect( effect_harnessed ); // the harness part probably broke
+        } else {
+            moves = 0;
+            return; // don't move if harnessed
+        }
+    }
+    const std::optional<vpart_reference> vp_boardable = ovp.part_with_feature( "BOARDABLE", true );
+    if( vp_boardable && friendly != 0 ) {
+        const vehicle &veh = vp_boardable->vehicle();
+        if( veh.is_moving() && veh.get_monster( vp_boardable->part_index() ) ) {
+            moves = 0;
+            return; // don't move if friendly and passenger in a moving vehicle
+        }
     }
     // Set attitude to attitude to our current target
     monster_attitude current_attitude = attitude( nullptr );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -41,6 +41,8 @@ class npc;
 
 static const ammotype ammo_battery( "battery" );
 
+static const itype_id fuel_type_animal( "animal" );
+
 static const itype_id itype_null( "null" );
 
 static const quality_id qual_JACK( "JACK" );
@@ -999,6 +1001,15 @@ void vpart_info::check()
         }
         if( part.has_flag( VPFLAG_ENABLED_DRAINS_EPOWER ) && part.epower == 0_W ) {
             debugmsg( "%s is set to drain epower, but has epower == 0", part.id.c_str() );
+        }
+        if( part.has_flag( VPFLAG_ENGINE ) ) {
+            if( part.power != 0_W && part.fuel_type == fuel_type_animal ) {
+                debugmsg( "engine part '%s' powered by '%s' can't define non-zero 'power'",
+                          part.id.c_str(), part.fuel_type.str() );
+            } else if( part.power == 0_W && part.fuel_type != fuel_type_animal ) {
+                debugmsg( "engine part '%s' powered by '%s' must define non zero 'power'",
+                          part.id.c_str(), part.fuel_type.str() );
+            }
         }
         // Parts with non-zero epower must have a flag that affects epower usage
         static const std::vector<std::string> handled = {{

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -493,9 +493,6 @@ class vpart_info
         int z_order = 0;
         // Display order in vehicle interact display
         int list_order = 0;
-
-        /** Legacy parts don't specify installation requirements */
-        bool legacy = true;
 };
 
 struct vehicle_item_spawn {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2959,25 +2959,14 @@ int vehicle::part_at( const point &dp ) const
     return -1;
 }
 
-/**
- * Given a vehicle part which is inside of this vehicle, returns the index of
- * that part. This exists solely because activities relating to vehicle editing
- * require the index of the vehicle part to be passed around.
- * @param part The part to find.
- * @param check_removed Check whether this part can be removed
- * @return The part index, -1 if it is not part of this vehicle.
- */
-int vehicle::index_of_part( const vehicle_part *const part, const bool check_removed ) const
+int vehicle::index_of_part( const vehicle_part *part, bool include_removed ) const
 {
-    if( part != nullptr ) {
-        for( const vpart_reference &vp : get_all_parts() ) {
-            const vehicle_part &next_part = vp.part();
-            if( !check_removed && next_part.removed ) {
-                continue;
-            }
-            if( part->id == next_part.id && part->mount == vp.mount() ) {
-                return vp.part_index();
-            }
+    if( !part || ( !include_removed && part->removed ) ) {
+        return -1;
+    }
+    for( size_t i = 0; i < parts.size(); i++ ) {
+        if( &parts[i] == part ) {
+            return static_cast<int>( i );
         }
     }
     return -1;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1220,8 +1220,9 @@ class vehicle
                                bool below_roof = true, bool roof = true ) const;
         int roof_at_part( int p ) const;
 
-        // Given a part, finds its index in the vehicle
-        int index_of_part( const vehicle_part *part, bool check_removed = false ) const;
+        // Finds index of a given vehicle_part in parts vector, compared by address
+        // @return index or -1 if part is nullptr, not found or removed and include_removed is false.
+        int index_of_part( const vehicle_part *part, bool include_removed = false ) const;
 
         // get symbol for map
         char part_sym( int p, bool exact = false, bool include_fake = true ) const;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1703,7 +1703,6 @@ class vehicle
         vehicle_stack get_items( int part );
         std::vector<item> &get_tools( vehicle_part &vp );
         const std::vector<item> &get_tools( const vehicle_part &vp ) const;
-        void dump_items_from_part( size_t index );
 
         // Generates starting items in the car, should only be called when placed on the map
         void place_spawn_items();
@@ -1845,8 +1844,6 @@ class vehicle
         // @returns true if succeeded
         bool restore_folded_parts( const item &it );
 
-        //handles locked vehicles interaction
-        bool interact_vehicle_locked();
         //true if an alarm part is installed on the vehicle
         bool has_security_working() const;
         /**
@@ -2008,7 +2005,7 @@ class vehicle
         vehicle_part &part( int part_num );
         const vehicle_part &part( int part_num ) const;
         // get the parent part of a fake part or return part_num otherwise
-        int get_non_fake_part( int part_num );
+        int get_non_fake_part( int part_num ) const;
         // Updates active state on all fake_mounts based on whether they can fill a gap
         // map.cpp calls this in displace_vehicle
         void update_active_fakes();

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1888,7 +1888,7 @@ class vehicle
         //true if an engine exists with specified type
         //If enabled true, this engine must be enabled to return true
         bool has_engine_type( const itype_id &ft, bool enabled ) const;
-        bool has_harnessed_animal() const;
+        monster *get_harnessed_animal() const;
         //true if an engine exists without the specified type
         //If enabled true, this engine must be enabled to return true
         bool has_engine_type_not( const itype_id &ft, bool enabled ) const;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Cleans up a few parts of vehicles code

#### Describe the solution

Refactors `index_of_part` - previously the function comment lied what it does; instead of searching for part "which is inside the vehicle" it instead searched for any part that had same id and mount, it also didn't allow using it with fake parts, this PR changes it - the part searched for must be in the parts vector so the comparison is now done by pointer address, and indexes of fake parts can now be found using this function.

Minor stuff;
Removes vpower fallback to vp.base.engine_displacement() * 373_W value - engines now must define power in json ( now checked in vpart_info::check() )
Changes a couple functions ( has_harnessed_animal -> get_harnessed_animal, index_of_part ) to make them reusable in more places
Removes unused variable (vpart_info::legacy) and a cargo dump function with low chance for reuse, only remotely viable use case is when folding and even that is on the chopping block
Tidy steering code - a bunch of cases all leading to return, inlines and moves variable definitions closer/tighter scope to where they are used

#### Describe alternatives you've considered

#### Testing

Tests are running via some of this stuff, most changes were also playtested as part of a bigger change that this is a slice of

#### Additional context
