### PR TITLE
Change anvil volume from 4L to 24L

### DIFF
--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -5,7 +5,7 @@
     "name": { "str": "anvil" },
     "description": "An enormously heavy block of oddly-shaped steel with a chisel-like projection set into the corner.  It's used in most metalworking fabrication recipes.",
     "weight": "54000 g",
-    "volume": "4 L",
+    "volume": "24 L",
     "price": 100000,
     "price_postapoc": 2000,
     "to_hit": -5,

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -782,7 +782,6 @@
       "glowstick_lit",
       "lye",
       "walnut",
-      "anvil",
       "chaps_leather",
       "hardtack_pudding",
       "recipe_serum",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Change anvil volume to a reasonable 24L"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Anvil was 4L and 54kg. This is 13.5kg/L, which is heavier than a solid cube of lead of the same volume. 

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
This anvilmaker (https://www.oldworldanvils.com/anvil-dimensions) lists three styles of anvils with its measurements and the 110lb versions measure out to a cube volume of roughly 19.8L, 23.2L, and 27.8L. Calculations for the three respective styles, converted into mL:

![image](https://user-images.githubusercontent.com/4686046/235499757-943d8b80-6898-4fc8-86a2-c3cd268094f2.png)

For a nice even number and considering the small weight difference between 54kg and 110lb, I decided on 24L for the final number for anvil volume.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->I thought about making anvils lighter, but that might mean changing its recipe.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Minor JSON change.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->