### PR TITLE
Fix recipe lang parser expecting result field

### DIFF
--- a/lang/string_extractor/parsers/recipe.py
+++ b/lang/string_extractor/parsers/recipe.py
@@ -1,6 +1,16 @@
 from ..write_text import write_text
 
 
+def result_hint(json):
+    hint = json.get("result", json.get("result_eocs", None))
+    if type(hint) is list:
+        hint = ", ".join(hint)
+    if hint is None:
+        raise Exception("no result hint for recipe translation,"
+                        " needs 'result' or 'result_eocs' defined")
+    return hint
+
+
 def parse_recipe(json, origin):
     if "book_learn" in json and type(json["book_learn"]) is dict:
         for book in json["book_learn"]:
@@ -10,8 +20,8 @@ def parse_recipe(json, origin):
     if "description" in json:
         write_text(json["description"], origin,
                    comment="Description of recipe crafting \"{}\""
-                   .format(json["result"]))
+                   .format(result_hint(json)))
     if "blueprint_name" in json:
         write_text(json["blueprint_name"], origin,
                    comment="Blueprint name of recipe crafting \"{}\""
-                   .format(json["result"]))
+                   .format(result_hint(json)))


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4855005599/jobs/8653048632?pr=65030

Fix recipe translation expecting `result` field for recipes

#### Describe the solution

Take `result` if available, fallback to comma separated `result_eocs` or raise exception if both fail

#### Describe alternatives you've considered

#### Testing

Applied linked PR diff, appeared to be picking up the result_eocs field

#### Additional context
