### PR TITLE
added missing proficiencies to the modular kitchen station

### DIFF
--- a/data/json/vehicleparts/modular_tools.json
+++ b/data/json/vehicleparts/modular_tools.json
@@ -36,6 +36,11 @@
     "subcategory": "CSC_ELECTRONIC_PARTS",
     "skill_used": "mechanics",
     "skills_required": [ "electronics", 3 ],
+    "proficiencies": [
+      { "proficiency": "prof_metalworking" },
+      { "proficiency": "prof_welding_basic", "skill_penalty": 0.5 },
+      { "proficiency": "prof_appliance_repair" }
+    ],
     "difficulty": 3,
     "time": "1 h",
     "autolearn": true,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

the new modular kitchen added in #64682 uses welding tools but doesn't have any proficiencies needed in it's craft.

#### Describe the solution

added `principles of metalworking` and `principles of welding` to the recipe. I also added `general appliance repair` because I missed it in my previous PR

#### Describe alternatives you've considered

If there's a reason why it doesn't have these proficiencies let me know, I can close this.

