### PR TITLE
Obsolete NO_QUICKDRAW flag

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -443,11 +443,6 @@
     "//": "Item can never be used with a CVD machine."
   },
   {
-    "id": "NO_QUICKDRAW",
-    "type": "json_flag",
-    "//": "Don't offer to draw items from this holster when the fire key is pressed whilst the player's hands are empty."
-  },
-  {
     "id": "NO_REPAIR",
     "type": "json_flag",
     "//": "Prevents repairing of this item even if otherwise suitable tools exist.",

--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -25,7 +25,7 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Attach what to belt loop?", "holster_msg": "You clip your %s to your %s" },
-    "flags": [ "BELTED", "OVERSIZE", "NO_QUICKDRAW", "WATER_FRIENDLY" ],
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [
       {
         "encumbrance": [ 2, 5 ],
@@ -313,7 +313,7 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Store tool or blade", "holster_msg": "You put your %1$s in your %2$s" },
-    "flags": [ "BELTED", "OVERSIZE", "NO_QUICKDRAW", "WATER_FRIENDLY" ],
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [ { "encumbrance": [ 2, 12 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
     "melee_damage": { "bash": 5 }
   },
@@ -392,7 +392,7 @@
     "description": "A pair of leather suspenders with a holster placed near the stomach.",
     "copy-from": "suspenders_leather",
     "use_action": { "type": "holster", "holster_prompt": "Store tool or blade", "holster_msg": "You put your %1$s in your %2$s" },
-    "flags": [ "BELTED", "WATER_FRIENDLY", "NO_QUICKDRAW" ],
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
     "pocket_data": [
       {
         "magazine_well": "350 ml",

--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -25,7 +25,7 @@
       }
     ],
     "use_action": { "type": "holster" },
-    "flags": [ "BELTED", "OVERSIZE", "NO_QUICKDRAW" ],
+    "flags": [ "BELTED", "OVERSIZE" ],
     "armor": [ { "encumbrance": [ 3, 15 ], "coverage": 10, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
   },
   {

--- a/data/mods/Aftershock/items/armor/exosuit/exosuit_storage.json
+++ b/data/mods/Aftershock/items/armor/exosuit/exosuit_storage.json
@@ -11,7 +11,7 @@
     "weight": "500 g",
     "volume": "2 L",
     "material": [ "qt_steel" ],
-    "flags": [ "WATER_FRIENDLY", "NO_QUICKDRAW", "BELTED", "EXO_LARGE_GADGET" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "EXO_LARGE_GADGET" ]
   },
   {
     "id": "exo_melee_storage",

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -433,7 +433,7 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Store tool or blade", "holster_msg": "You put your %1$s in your %2$s" },
-    "flags": [ "BELTED", "NO_QUICKDRAW", "WATER_FRIENDLY" ],
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
     "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
     "melee_damage": { "bash": 5 }
   },
@@ -511,7 +511,7 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Store tool or blade", "holster_msg": "You put your %1$s in your %2$s" },
-    "flags": [ "BELTED", "NO_QUICKDRAW", "WATER_FRIENDLY" ],
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
     "armor": [ { "encumbrance": [ 2, 12 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
     "melee_damage": { "bash": 5 }
   },
@@ -672,7 +672,7 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Store tool or blade", "holster_msg": "You put your %1$s in your %2$s" },
-    "flags": [ "BELTED", "NO_QUICKDRAW", "WATER_FRIENDLY" ],
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
     "armor": [ { "encumbrance": 5, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
     "melee_damage": { "bash": 5 }
   },

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -355,7 +355,6 @@ Some armor flags, such as `WATCH` and `ALARMCLOCK` are compatible with other ite
 - ```INTEGRATED``` This item represents a part of you granted by mutations or bionics.  It will always fit, cannot be unequipped (aside from losing the source), and won't drop on death, but otherwise behaves like normal armor with regards to function, encumbrance, layer conflicts and so on.
 - ```NORMAL``` Items worn like normal clothing. This is assumed as default.
 - ```NO_TAKEOFF``` Item with that flag can't be taken off.
-- ```NO_QUICKDRAW``` Don't offer to draw items from this holster when the fire key is pressed whilst the players hands are empty
 - ```NO_WEAR_EFFECT``` This gear doesn't provide any effects when worn (most jewelry).
 - ```ONLY_ONE``` You can wear only one.
 - ```OUTER```  Outer garment layer.

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1905,8 +1905,7 @@ void outfit::fire_options( Character &guy, std::vector<std::string> &options,
             return it.is_gun();
         } );
 
-        if( !guns.empty() && clothing.type->can_use( "holster" ) &&
-            !clothing.has_flag( flag_NO_QUICKDRAW ) ) {
+        if( !guns.empty() && clothing.type->can_use( "holster" ) ) {
             //~ draw (first) gun contained in holster
             //~ %1$s: weapon name, %2$s: container name, %3$d: remaining ammo count
             options.push_back( string_format( pgettext( "holster", "%1$s from %2$s (%3$d)" ),

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -206,7 +206,6 @@ const flag_id flag_NO_DROP( "NO_DROP" );
 const flag_id flag_NO_INGEST( "NO_INGEST" );
 const flag_id flag_NO_PACKED( "NO_PACKED" );
 const flag_id flag_NO_PARASITES( "NO_PARASITES" );
-const flag_id flag_NO_QUICKDRAW( "NO_QUICKDRAW" );
 const flag_id flag_NO_RELOAD( "NO_RELOAD" );
 const flag_id flag_NO_REPAIR( "NO_REPAIR" );
 const flag_id flag_NO_SALVAGE( "NO_SALVAGE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -213,7 +213,6 @@ extern const flag_id flag_NO_DROP;
 extern const flag_id flag_NO_INGEST;
 extern const flag_id flag_NO_PACKED;
 extern const flag_id flag_NO_PARASITES;
-extern const flag_id flag_NO_QUICKDRAW;
 extern const flag_id flag_NO_RELOAD;
 extern const flag_id flag_NO_REPAIR;
 extern const flag_id flag_NO_SALVAGE;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Remove an ancient flag

#### Describe the solution

The flag prevents guns inside containers marked with the flag from appearing in drawing from holsters menu and there doesn't appear to be a cohesive reason for it, especially when some of the flagged containers are in fact holsters designed for guns

#### Describe alternatives you've considered

#### Testing

Spawn a back holster, put a gun in it, empty hands and press `f` - nothing happens
Apply patch, repeat - the gun should be offered for drawing

#### Additional context
