### PR TITLE
Prevent mission marker from being cutoff in the overmap

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1260,8 +1260,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         geometry->rect( renderer, clipRect, SDL_Color() );
     }
 
-    point s;
-    get_window_tile_counts( width, height, s.x, s.y );
+    const point s = get_window_tile_counts( point( width, height ) );
 
     init_light();
     map &here = get_map();
@@ -1755,15 +1754,29 @@ void cata_tiles::draw_minimap( const point &dest, const tripoint &center, int wi
     minimap->draw( SDL_Rect{ dest.x, dest.y, width, height }, center );
 }
 
-void cata_tiles::get_window_tile_counts( const int width, const int height, int &columns,
-        int &rows ) const
+point cata_tiles::get_window_tile_counts( const point &size ) const
 {
     if( is_isometric() ) {
-        columns = std::ceil( static_cast<double>( width ) / tile_width ) * 2 + 4;
-        rows = std::ceil( static_cast<double>( height ) / ( tile_width / 2.0 - 1 ) ) * 2 + 4;
+        const int columns = divide_round_up( size.x, tile_width ) * 2 + 4;
+        const int rows = divide_round_up( size.y * 2, tile_width - 2 ) * 2 + 4;
+        return point( columns, rows );
     } else {
-        columns = std::ceil( static_cast<double>( width ) / tile_width );
-        rows = std::ceil( static_cast<double>( height ) / tile_height );
+        const int columns = divide_round_up( size.x, tile_width );
+        const int rows = divide_round_up( size.y, tile_height );
+        return point( columns, rows );
+    }
+}
+
+point cata_tiles::get_window_full_tile_counts( const point &size ) const
+{
+    if( is_isometric() ) {
+        const int columns = divide_round_down( size.x, tile_width ) * 2 + 4;
+        const int rows = divide_round_down( size.y * 2, tile_width - 2 ) * 2 + 4;
+        return point( columns, rows );
+    } else {
+        const int columns = divide_round_down( size.x, tile_width );
+        const int rows = divide_round_down( size.y, tile_height );
+        return point( columns, rows );
     }
 }
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -405,8 +405,10 @@ class cata_tiles
         void draw_minimap( const point &dest, const tripoint &center, int width, int height );
 
     protected:
-        /** How many rows and columns of tiles fit into given dimensions **/
-        void get_window_tile_counts( int width, int height, int &columns, int &rows ) const;
+        /** How many rows and columns of tiles fit into given dimensions, fully or partially shown **/
+        point get_window_tile_counts( const point &size ) const;
+        /** How many rows and columns of tiles can be fully shown in the given dimensions **/
+        point get_window_full_tile_counts( const point &size ) const;
 
         std::optional<tile_lookup_res> find_tile_with_season( const std::string &id ) const;
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -846,8 +846,8 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         geometry->rect( renderer, clipRect, SDL_Color() );
     }
 
-    point s;
-    get_window_tile_counts( width, height, s.x, s.y );
+    const point s = get_window_tile_counts( point( width, height ) );
+    const point full_s = get_window_full_tile_counts( point( width, height ) );
 
     op = point( dest.x * fontwidth, dest.y * fontheight );
     // Rounding up to include incomplete tiles at the bottom/right edges
@@ -864,6 +864,9 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     const tripoint_abs_omt corner_NW = center_abs_omt - point( max_col / 2, max_row / 2 );
     const tripoint_abs_omt corner_SE = corner_NW + point( max_col - 1, max_row - 1 );
     const inclusive_cuboid<tripoint> overmap_area( corner_NW.raw(), corner_SE.raw() );
+    // Area of fully shown tiles
+    const tripoint_abs_omt full_corner_SE = corner_NW + full_s + point_north_west;
+    const inclusive_cuboid<tripoint> full_om_tile_area( corner_NW.raw(), full_corner_SE.raw() );
     // Debug vision allows seeing everything
     const bool has_debug_vision = you.has_trait( trait_DEBUG_NIGHTVISION );
     // sight_points is hoisted for speed reasons.
@@ -1052,11 +1055,9 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             }
         }
 
-        // reduce the area where the map cursor is drawn so it doesn't get cut off
-        inclusive_cuboid<tripoint> map_cursor_area = overmap_area;
-        map_cursor_area.p_max.y--;
+        // only draw in full tiles so it doesn't get cut off
         const std::optional<std::pair<tripoint_abs_omt, std::string>> mission_arrow =
-                    get_mission_arrow( map_cursor_area, center_abs_omt );
+                    get_mission_arrow( full_om_tile_area, center_abs_omt );
         if( mission_arrow ) {
             draw_from_id_string( mission_arrow->second, global_omt_to_draw_position( mission_arrow->first ), 0,
                                  0, lit_level::LIT, false );


### PR DESCRIPTION
#### Summary
Bugfixes "Prevent mission marker from being cutoff in the overmap"

#### Purpose of change
When the mission marker is drawn at the right edge of the overmap and the tiles on the edge are only partially shown, the mission marker is cut off and sometimes hard to see. When the marker is drawn at the bottom edge, it is drawn at the second-to-last tile, but that did not take into account the case where the last tile is fully drawn.

#### Describe the solution
Show the mission marker at the last full tile in the right or bottom instead.

#### Describe alternatives you've considered
Skip the tiles code and draw the marker at exactly the edge of the UI?

#### Testing
Before:
![image](https://user-images.githubusercontent.com/11890223/235615692-f8438da1-99f0-4a17-9290-208322274563.png)
![image](https://user-images.githubusercontent.com/11890223/235615728-8d63dfc0-db0a-40b3-88cc-15a07f6ee0d5.png)

After:
![image](https://user-images.githubusercontent.com/11890223/235611653-b01a7c98-8ffb-4896-a991-0eddae272f29.png)

#### Additional context
