### PR TITLE
Floor craft difficulty at 1 to avoid zero'ing out player's calculated skill

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -997,9 +997,10 @@ float Character::get_recipe_weighted_skill_average( const recipe &making ) const
     // The primary required skill counts extra compared to the secondary skills, before factoring in the
     // weight added by the required level.
     const float weighted_skill_average =
-        ( ( 2.0f * making.difficulty * get_skill_level( making.skill_used ) ) + secondary_skill_total ) /
+        ( ( 2.0f * std::max( making.difficulty,
+                             1 ) * get_skill_level( making.skill_used ) ) + secondary_skill_total ) /
         // No DBZ
-        std::max( 1.f, ( 2.0f * making.difficulty + secondary_difficulty ) );
+        std::max( 1.f, ( 2.0f * std::max( making.difficulty, 1 ) + secondary_difficulty ) );
     add_msg_debug( debugmode::DF_CRAFTING, "Weighted skill average: %g", weighted_skill_average );
 
     float total_skill_modifiers = 0.0f;

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -724,10 +724,10 @@ TEST_CASE( "crafting_failure_rates_match_calculated", "[crafting][random]" )
     const recipe_id armor_qt_lightplate( "armor_qt_lightplate_test_no_tools" );
 
     // Skill zero recipes
-    test_chances_for( makeshift_crowbar, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f );
-    test_chances_for( meat_cooked, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f );
-    test_chances_for( club_wooden_large, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f );
-    test_chances_for( nailboard, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f, 50.f );
+    test_chances_for( makeshift_crowbar, 50.f, 50.f, 50.f, 50.f, 21.19f, 21.19f, 2.28f );
+    test_chances_for( meat_cooked, 50.f, 50.f, 50.f, 50.f, 21.19f, 21.19f, 2.28f );
+    test_chances_for( club_wooden_large, 50.f, 50.f, 50.f, 50.f, 21.19f, 21.19f, 2.28f );
+    test_chances_for( nailboard, 50.f, 50.f, 50.f, 50.f, 21.19f, 21.19f, 2.28f );
     // Recipes requring various degrees of skill and proficiencies
     test_chances_for( cudgel, 82.5, 72.f, 50.f, 50.f, 21.f, 21.f, 2.25 );
     test_chances_for( pumpkin_muffins, 92.5, 82.f, 67.f, 50.f, 43.f, 21.f, 2.25 );


### PR DESCRIPTION
#### Summary
Bugfixes "Difficulty 0 recipes are no longer arbitrarily difficult"

#### Purpose of change
![image](https://user-images.githubusercontent.com/84619419/235643233-e290d71d-1000-4b4e-a9cf-f70f2b0f0d0a.png)
![image](https://user-images.githubusercontent.com/84619419/235643279-1a82eaea-fa6d-4712-96bb-215dcdb2f9ed.png)

* Fixes #64241

#### Describe the solution
Make the player's skill not count as 0 just because the difficulty is 0


#### Describe alternatives you've considered


#### Testing
All tests were carried out by a 8/8/8/8 character with no impairments, using recipes that used no proficiencies or secondary skills.

test recipe (my skill / skill required)
% minor fail chance before --> % minor fail chance after
% catastrophic fail chance before --> % catastrophic fail chance after

clean water (skill 1/0)
50.00 --> 21.19
9.12 --> 0.07

clean water (skill **10**/0)
50.00 --> 0.00
9.12 --> 0.00

sock mitts (skill 0/0)
50.00 --> 50.00
9.12 --> 9.12

baked beans (skill 1/1)
50.00 --> 50.00
0.98 --> 0.98

gloves (skill 0/1)
71.61 --> 71.61
19.57 --> 19.57

As we can see, the only scenario in which this affects the failure chance is when being overskilled for difficulty 0 recipes.

#### Additional context

@anothersimulacrum @I-am-Erk 
Since this is your child, it only seems appropriate to let you know.