### PR TITLE
enable and disable mutations EOCs

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -146,12 +146,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_activate_mutation_test",
-    "effect": [ { "u_deactivate_trait": {"context_val": "this" } } ]
+    "effect": [ { "u_deactivate_trait": { "context_val": "this" } } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_mark_mutation_test",
-    "effect": [ { "math": [ "test_val", "=", "1" ] }, { "set_string_var": { "context_val": "this" }, "target_var": {"global_val": "context_test"}} ]
+    "effect": [
+      { "math": [ "test_val", "=", "1" ] },
+      { "set_string_var": { "context_val": "this" }, "target_var": { "global_val": "context_test" } }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -140,6 +140,21 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_activate_mutation_to_start_test",
+    "effect": [ { "u_activate_trait": "process_mutation" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_activate_mutation_test",
+    "effect": [ { "u_deactivate_trait": {"context_val": "this" } } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_mark_mutation_test",
+    "effect": [ { "math": [ "test_val", "=", "1" ] }, { "set_string_var": { "context_val": "this" }, "target_var": {"global_val": "context_test"}} ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_math_test_nested_context",
     "effect": [ { "math": [ "_nested_simple", "=", "7" ] }, { "math": [ "nested_simple_global", "=", "_nested_simple" ] } ]
   },

--- a/data/mods/TEST_DATA/mutations.json
+++ b/data/mods/TEST_DATA/mutations.json
@@ -337,6 +337,28 @@
   },
   {
     "type": "mutation",
+    "id": "process_mutation",
+    "name": { "str": "Tests processing and using mutation EOCs" },
+    "points": 1,
+    "valid": true,
+    "description": "Tests processing and using mutation EOCs",
+    "activated_eocs": [ "EOC_activate_mutation_test" ],
+    "deactivated_eocs": [ "EOC_mark_mutation_test" ]
+  },
+  {
+    "type": "mutation",
+    "id": "process_mutation_two",
+    "name": { "str": "Tests processing and using mutation EOCs" },
+    "points": 1,
+    "valid": true,
+    "description": "Tests processing and using mutation EOCs",
+    "activated_eocs": [ "EOC_mark_mutation_test" ],
+    "processed_eocs": [ "EOC_mark_mutation_test" ],
+    "deactivated_eocs": [ "EOC_mark_mutation_test" ],
+    "activated_is_setup": true
+  },
+  {
+    "type": "mutation",
     "id": "TEST_REMOVAL_0",
     "name": { "str": "Removal test zeroth (non-purifiable)" },
     "points": 1,

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -146,3 +146,11 @@ uses_debug_menu | | { "debug_menu_option", `debug_menu_index` }, |
 u_var_changed | | { "var", `string` }, { "value", `string` }, |
 vehicle_moves | | { "avatar_on_board", `bool` }, { "avatar_is_driving", `bool` }, { "avatar_remote_control", `bool` }, { "is_flying_aircraft", `bool` }, { "is_floating_watercraft", `bool` }, { "is_on_rails", `bool` }, { "is_falling", `bool` }, { "is_sinking", `bool` }, { "is_skidding", `bool` }, { "velocity", `int` }, // vehicle current velocity, mph * 100 { "z", `int` }, |
 
+## Context Variables For Other EOCs
+Other EOCs have some variables as well that they have access to, they are as follows:
+
+EOC            | Context Variables |
+--------------------- | ----------- |
+mutation: "activated_eocs" | { "this", `mutation_id` }
+mutation: "processed_eocs" | { "this", `mutation_id` }
+mutation: "deactivated_eocs" | { "this", `mutation_id` }

--- a/doc/MUTATIONS.md
+++ b/doc/MUTATIONS.md
@@ -297,6 +297,10 @@ These fields are optional, but are very frequently used in mutations and their c
 
 There are many, many optional fields present for mutations to let them do all sorts of things. You can see them documented above.
 
+### EOC details
+
+Mutations support EOC on activate, deactivate and for processing. As well for each of those the EOC has access to the context variable `this` which is the ID of the mutation itself.
+
 ### Sample trait: Example Sleep
 
 ```json

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -814,6 +814,8 @@ Effect | Description
 `u_add_trait, npc_add_trait: `string or [variable object](#variable-object) | Your character or the NPC will gain the trait.
 `u_lose_effect, npc_lose_effect: `string or [variable object](#variable-object) | Your character or the NPC will lose the effect if they have it.
 `u_lose_trait, npc_lose_trait: `string or [variable object](#variable-object) | Your character or the NPC will lose the trait.
+`u_activate_trait, npc_activate_trait: `string or [variable object](#variable-object) | Your character or the NPC will activate the trait.
+`u_deactivate_trait, npc_deactivate_trait: `string or [variable object](#variable-object) | Your character or the NPC will deactivate the trait.
 `u_learn_martial_art, npc_learn_martial_art: `string or [variable object](#variable-object) | Your character or the NPC will learn the martial art style.
 `u_forget_martial_art, npc_forget_martial_art: `string or [variable object](#variable-object) | Your character or the NPC will forget the martial art style.
 `u_add_var, npc_add_var`: `var_name, type: type_str`, `context: context_str`, either `value: value_str` or `time: true` or `possible_values: string_array` | Your character or the NPC will store `value_str` as a variable that can be later retrieved by `u_has_var` or `npc_has_var`.  `npc_add_var` can be used to store arbitrary local variables, and `u_add_var` can be used to store arbitrary "global" variables, and should be used in preference to setting effects.  If `time` is used instead of `value_str`, then the current turn of the game is stored. If `possible_values` is used one of the values given at random will be used.

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -33,6 +33,8 @@ struct talk_effect_fun_t {
         void set_remove_effect( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_add_trait( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_remove_trait( const JsonObject &jo, const std::string &member, bool is_npc = false );
+        void set_activate_trait( const JsonObject &jo, const std::string &member, bool is_npc = false );
+        void set_deactivate_trait( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_learn_martial_art( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_forget_martial_art( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_mutate( const JsonObject &jo, const std::string &member, bool is_npc = false );

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -788,6 +788,7 @@ void Character::activate_mutation( const trait_id &mut )
     if( !mut->activated_eocs.empty() ) {
         for( const effect_on_condition_id &eoc : mut->activated_eocs ) {
             dialogue d( get_talker_for( *this ), nullptr );
+            d.set_value( "npctalk_var_this", mut.str() );
             if( eoc->type == eoc_type::ACTIVATION ) {
                 eoc->activate( d );
             } else {
@@ -946,6 +947,7 @@ void Character::deactivate_mutation( const trait_id &mut )
 
     for( const effect_on_condition_id &eoc : mut->deactivated_eocs ) {
         dialogue d( get_talker_for( *this ), nullptr );
+        d.set_value( "npctalk_var_this", mut.str() );
         if( eoc->type == eoc_type::ACTIVATION ) {
             eoc->activate( d );
         } else {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2470,6 +2470,25 @@ void talk_effect_fun_t::set_add_trait( const JsonObject &jo, const std::string &
     };
 }
 
+void talk_effect_fun_t::set_activate_trait( const JsonObject &jo, const std::string &member,
+        bool is_npc )
+{
+    str_or_var new_trait = get_str_or_var( jo.get_member( member ), member, true );
+    function = [is_npc, new_trait]( dialogue const & d ) {
+        d.actor( is_npc )->activate_mutation( trait_id( new_trait.evaluate( d ) ) );
+    };
+}
+
+
+void talk_effect_fun_t::set_deactivate_trait( const JsonObject &jo, const std::string &member,
+        bool is_npc )
+{
+    str_or_var new_trait = get_str_or_var( jo.get_member( member ), member, true );
+    function = [is_npc, new_trait]( dialogue const & d ) {
+        d.actor( is_npc )->deactivate_mutation( trait_id( new_trait.evaluate( d ) ) );
+    };
+}
+
 void talk_effect_fun_t::set_remove_trait( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
@@ -4874,7 +4893,15 @@ void talk_effect_t::parse_sub_effect( const JsonObject &jo )
         subeffect_fun.set_remove_trait( jo, "u_lose_trait" );
     } else if( jo.has_member( "npc_lose_trait" ) ) {
         subeffect_fun.set_remove_trait( jo, "npc_lose_trait", is_npc );
-    } else if( jo.has_member( "u_mutate" ) || jo.has_array( "u_mutate" ) ) {
+    } else if( jo.has_member( "u_deactivate_trait" ) ) {
+        subeffect_fun.set_deactivate_trait( jo, "u_deactivate_trait" );
+    } else if( jo.has_member( "npc_deactivate_trait" ) ) {
+        subeffect_fun.set_deactivate_trait( jo, "npc_deactivate_trait", is_npc );
+    } else if( jo.has_member( "u_activate_trait" ) ) {
+        subeffect_fun.set_activate_trait( jo, "u_activate_trait" );
+    } else if( jo.has_member( "npc_activate_trait" ) ) {
+        subeffect_fun.set_activate_trait( jo, "npc_activate_trait", is_npc );
+    } else if( jo.has_member( "u_mutate" ) ) {
         subeffect_fun.set_mutate( jo, "u_mutate" );
     } else if( jo.has_member( "npc_mutate" ) || jo.has_array( "npc_mutate" ) ) {
         subeffect_fun.set_mutate( jo, "npc_mutate", is_npc );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -282,6 +282,7 @@ void suffer::mutation_power( Character &you, const trait_id &mut_id )
         // if you haven't deactivated then run the EOC
         for( const effect_on_condition_id &eoc : mut_id->processed_eocs ) {
             dialogue d( get_talker_for( you ), nullptr );
+            d.set_value( "npctalk_var_this", mut_id.str() );
             if( eoc->type == eoc_type::ACTIVATION ) {
                 eoc->activate( d );
             } else {

--- a/src/talker.h
+++ b/src/talker.h
@@ -206,6 +206,8 @@ class talker
         virtual void mutate_category( const mutation_category_id &, const bool & ) {}
         virtual void set_mutation( const trait_id & ) {}
         virtual void unset_mutation( const trait_id & ) {}
+        virtual void activate_mutation( const trait_id & ) {}
+        virtual void deactivate_mutation( const trait_id & ) {}
         virtual void set_fatigue( int ) {};
         virtual bool has_flag( const json_character_flag & ) const {
             return false;

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -246,6 +246,16 @@ void talker_character::unset_mutation( const trait_id &old_trait )
     me_chr->unset_mutation( old_trait );
 }
 
+void talker_character::activate_mutation( const trait_id &trait )
+{
+    me_chr->activate_mutation( trait );
+}
+
+void talker_character::deactivate_mutation( const trait_id &trait )
+{
+    me_chr->deactivate_mutation( trait );
+}
+
 bool talker_character_const::has_flag( const json_character_flag &trait_flag_to_check ) const
 {
     return me_chr_const->has_flag( trait_flag_to_check );

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -192,6 +192,8 @@ class talker_character: public talker_cloner<talker_character, talker_character_
         void mutate_category( const mutation_category_id &mut_cat, const bool &use_vitamins ) override;
         void set_mutation( const trait_id &new_trait ) override;
         void unset_mutation( const trait_id &old_trait ) override;
+        void activate_mutation( const trait_id &trait ) override;
+        void deactivate_mutation( const trait_id &trait ) override;
         void set_skill_level( const skill_id &skill, int value ) override;
         void learn_recipe( const recipe_id &recipe_to_learn ) override;
         void forget_recipe( const recipe_id &recipe_to_forget ) override;

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -14,11 +14,11 @@ static const activity_id ACT_ADD_VARIABLE_COMPLETE( "ACT_ADD_VARIABLE_COMPLETE" 
 static const activity_id ACT_ADD_VARIABLE_DURING( "ACT_ADD_VARIABLE_DURING" );
 
 static const effect_on_condition_id
-effect_on_condition_EOC_activate_mutation_to_start_test( "EOC_activate_mutation_to_start_test" );
-static const effect_on_condition_id
 effect_on_condition_EOC_TEST_TRANSFORM_LINE( "EOC_TEST_TRANSFORM_LINE" );
 static const effect_on_condition_id
 effect_on_condition_EOC_TEST_TRANSFORM_RADIUS( "EOC_TEST_TRANSFORM_RADIUS" );
+static const effect_on_condition_id
+effect_on_condition_EOC_activate_mutation_to_start_test( "EOC_activate_mutation_to_start_test" );
 static const effect_on_condition_id
 effect_on_condition_EOC_jmath_test( "EOC_jmath_test" );
 static const effect_on_condition_id
@@ -274,7 +274,7 @@ TEST_CASE( "EOC_option_test", "[eoc][math_parser]" )
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
 
-    
+
     globvars.clear_global_values();
 
     REQUIRE( globvars.get_global_value( "npctalk_var_key1" ).empty() );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -4,6 +4,7 @@
 #include "effect_on_condition.h"
 #include "game.h"
 #include "map_helpers.h"
+#include "mutation.h"
 #include "timed_event.h"
 #include "player_helpers.h"
 #include "point.h"
@@ -12,6 +13,8 @@
 static const activity_id ACT_ADD_VARIABLE_COMPLETE( "ACT_ADD_VARIABLE_COMPLETE" );
 static const activity_id ACT_ADD_VARIABLE_DURING( "ACT_ADD_VARIABLE_DURING" );
 
+static const effect_on_condition_id
+effect_on_condition_EOC_activate_mutation_to_start_test( "EOC_activate_mutation_to_start_test" );
 static const effect_on_condition_id
 effect_on_condition_EOC_TEST_TRANSFORM_LINE( "EOC_TEST_TRANSFORM_LINE" );
 static const effect_on_condition_id
@@ -57,6 +60,10 @@ static const mtype_id mon_zombie( "mon_zombie" );
 static const recipe_id recipe_cattail_jelly( "cattail_jelly" );
 
 static const skill_id skill_survival( "survival" );
+
+static const trait_id trait_process_mutation( "process_mutation" );
+static const trait_id trait_process_mutation_two( "process_mutation_two" );
+
 
 namespace
 {
@@ -258,6 +265,7 @@ TEST_CASE( "EOC_context_test", "[eoc][math_parser]" )
     CHECK( d.get_value( "npctalk_var_simple" ).empty() );
 }
 
+
 TEST_CASE( "EOC_option_test", "[eoc][math_parser]" )
 {
     clear_avatar();
@@ -265,6 +273,8 @@ TEST_CASE( "EOC_option_test", "[eoc][math_parser]" )
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
+
+    
     globvars.clear_global_values();
 
     REQUIRE( globvars.get_global_value( "npctalk_var_key1" ).empty() );
@@ -310,7 +320,47 @@ TEST_CASE( "EOC_math_armor", "[eoc][math_parser]" )
     CHECK( std::stod( globvars.get_global_value( "npctalk_var_key1" ) ) == Approx( 4 ) );
     CHECK( std::stod( globvars.get_global_value( "npctalk_var_key2" ) ) == Approx( 9 ) );
     CHECK( std::stod( globvars.get_global_value( "npctalk_var_key3" ) ) == Approx( 0 ) );
+}
 
+TEST_CASE( "EOC_mutation_test", "[eoc][mutations]" )
+{
+    clear_avatar();
+    clear_map();
+
+    dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
+    global_variables &globvars = get_globals();
+
+    avatar &me = get_avatar();
+
+    // test activation
+    globvars.clear_global_values();
+    me.toggle_trait( trait_process_mutation_two );
+    me.activate_mutation( trait_process_mutation_two );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_test_val" ) ) == Approx(
+               1 ) );
+    CHECK( globvars.get_global_value( "npctalk_var_context_test" ) == "process_mutation_two" );
+
+    // test process
+    globvars.clear_global_values();
+    me.suffer();
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_test_val" ) ) == Approx(
+               1 ) );
+    CHECK( globvars.get_global_value( "npctalk_var_context_test" ) == "process_mutation_two" );
+
+    // test deactivate
+    globvars.clear_global_values();
+    me.deactivate_mutation( trait_process_mutation_two );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_test_val" ) ) == Approx(
+               1 ) );
+    CHECK( globvars.get_global_value( "npctalk_var_context_test" ) == "process_mutation_two" );
+
+    // more complex test
+    globvars.clear_global_values();
+    me.toggle_trait( trait_process_mutation );
+    effect_on_condition_EOC_activate_mutation_to_start_test->activate( d );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_test_val" ) ) == Approx(
+               1 ) );
+    CHECK( globvars.get_global_value( "npctalk_var_context_test" ) == "process_mutation" );
 }
 
 TEST_CASE( "EOC_activity_ongoing", "[eoc][timed_event]" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Added enable and disable mutation EOCs"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Fund, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Something people desired, adds mutation enable and disable EOC. Also all Mutation EOCs now have acces to _this a context variable with the current mutation id stored in it.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added the new u_activate_trait and u_deactivate_trait stuff
and
the storage of _this
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
added robust unit tests
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Documentation is included
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->