### PR TITLE
Fix calories for raw-->cooked foods

### DIFF
--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -766,11 +766,12 @@ std::vector<item> recipe::create_results( int batch, item_components *used ) con
                               is_reversible();
         bool is_food_no_override = temp.is_food() && !temp.has_flag( flag_NUTRIENT_OVERRIDE );
         bool set_components = used && ( is_uncraftable || is_food_no_override );
+        bool is_cooked = hot_result() || removes_raw();
         if( set_components ) {
-            batch_comps = used->split( batch, i );
+            batch_comps = used->split( batch, i, is_cooked );
         }
         for( int j = 0; j < result_mult; j++ ) {
-            item_components mult_comps = batch_comps.split( result_mult, j );
+            item_components mult_comps = batch_comps.split( result_mult, j, is_cooked );
             std::vector<item> newits = create_result( set_components, temp.is_food(), &mult_comps );
 
             for( const item &it : newits ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Cooking raw food once again improves their calories"

#### Purpose of change
* Fixes #60665

#### Describe the solution
Copy logic from overload of recipe::create_results, actually pass the resulting value to item_components::split so it will set the `COOKED` flag. 

#### Describe alternatives you've considered


#### Testing
Compiled, cooked some raw food ingame that *does not have* cooks_like, made sure the calories changed both in the examine menu and as reported by debug's stomach contents (**just in case**). For example, the porkbellies used in the linked issue were giving 975 even after cooking. They now give 1300 after cooking, as expected.

#### Additional context
item::debug_info only reports the *type*'s flags(therefore, default only) it seems? This is.... not ideal.