### PR TITLE
Fix crash: dangling pointer to faction

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2996,6 +2996,7 @@ void npc::die( Creature *nkiller )
                 }
             }
             my_fac->remove_member( getID() );
+            my_fac = nullptr;
         }
     }
     dead = true;


### PR DESCRIPTION
#### Summary

Bugfixes "Fix crash when monster attacks a dead NPC"

#### Purpose of change

Fixes #65440

#### Describe the solution

Clear the dangling pointer. ~Note: I am not sure if this fix is ok because the faction may still exist if it is a templated base faction~

Edit: this forgets which faction the NPC was from even if the faction still exists afterwards (has other members or is a templated base faction)

#### Describe alternatives you've considered

move `fac->remove_member( getID() )` to  `game::cleanup_dead()`

https://github.com/CleverRaven/Cataclysm-DDA/blob/d53bbbeae0455f9de1a871c5a47e0503047caa41/src/game.cpp#L4615-L4619

#### Testing

I have spawned a dozen NPCs, removed all their items to avoid triggering #65451 and watched them be devoured by a hoard of zombies -> no crash