### PR TITLE
Make watermelon seeds craftable

### DIFF
--- a/data/json/recipes/food/seed.json
+++ b/data/json/recipes/food/seed.json
@@ -29,6 +29,13 @@
     "charges": 12
   },
   {
+    "result": "seed_watermelon",
+    "type": "recipe",
+    "copy-from": "seed_extraction_cutting",
+    "components": [ [ [ "watermelon", 1 ] ] ],
+    "charges": 12
+  },
+  {
     "result": "seed_cucumber",
     "type": "recipe",
     "copy-from": "seed_extraction_cutting",


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

It appears #56285 forgot to make watermelon seeds craftable

#### Describe the solution

Add a recipe

#### Describe alternatives you've considered

1. More than 12 seeds per watermelon?
2. Craft seeds from watermelon_wedge instead of watermelon?

#### Testing

Tried crafting watermelon seeds -> it works

<!-- 
#### Additional context

Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->