### PR TITLE
Backport to 0.G: Fix crash: dangling pointer to faction

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2994,6 +2994,7 @@ void npc::die( Creature *nkiller )
                 }
             }
             my_fac->remove_member( getID() );
+            my_fac = nullptr;
         }
     }
     dead = true;


### PR DESCRIPTION
#### Summary

Bugfixes "Fix crash when monster attacks a dead NPC"

#### Purpose of change

this is a backport of #65442
original bug: #65440
<!-- 
#### Describe the solution

How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

#### Describe alternatives you've considered

Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I have already tested the patch in #65442

<!-- 
#### Additional context

Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->