### PR TITLE
Allow dead trees to be harvested for their branches (once per tree)

### DIFF
--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -547,6 +547,10 @@
     "color": "brown",
     "move_cost": 0,
     "coverage": 80,
+    "examine_action": "harvest_ter",
+    "//": "gives a maximum of ~15L and ~8.5kg of wood between sticks and twigs",
+    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn", "winter" ], "id": "tree_dead_harv" } ],
+    "transforms_into": "t_tree_very_dead",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT" ],
     "bash": {
       "str_min": 70,
@@ -555,6 +559,28 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 15, 30 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_tree_very_dead",
+    "//": "we must avoid copy-from here so that the dead tree cannot regrow and be harvested again",
+    "name": "dead tree",
+    "looks_like": "t_tree_dead",
+    "description": "An indiscernible tree that has withered away due to weather, fire, or otherworldly causes.  Someone or something has broken most of its dead branches, leaving little but its gnarled trunk.",
+    "symbol": "7",
+    "color": "brown",
+    "move_cost": 0,
+    "coverage": 80,
+    "examine_action": "harvested_plant",
+    "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT" ],
+    "bash": {
+      "str_min": 70,
+      "str_max": 140,
+      "sound": "crunch!",
+      "sound_fail": "whack!",
+      "ter_set": "t_dirt",
+      "items": [ { "item": "stick_long", "count": [ 2, 6 ] }, { "item": "splinter", "count": [ 10, 20 ] } ]
     }
   },
   {

--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -223,6 +223,11 @@
     "entries": [ { "drop": "birchbark", "base_num": [ 2, 8 ] } ]
   },
   {
+    "id": "tree_dead_harv",
+    "type": "harvest",
+    "entries": [ { "drop": "stick", "base_num": [ 2, 5 ] }, { "drop": "twig", "base_num": [ 6, 20 ] } ]
+  },
+  {
     "id": "pine_harv",
     "type": "harvest",
     "entries": [


### PR DESCRIPTION
#### Summary
Content "Dead trees can be harvested for wood(once per tree)"

#### Purpose of change
I have recently been roped into playing innawoods. One of the things that has struck me the most is the utter dearth of small pieces of wood in forests. Fully-grown trees themselves cannot give sticks or twigs in *any** way, despite being the nominal source of that wood. The survivor is relegated to running around forests searching bushes and bashing apart every shrubbery and young tree for smaller pieces of firewood/construction materials. This is not ideal.

*(Unless you somehow hit them with 80+ bashing damage, and then the tree trunk somehow transforms into long sticks, which break into normal sticks. Which is a pretty big "wtf?" but consistent across every tree type. Who is going around hitting trees with superman strength anyway?)

#### Describe the solution
Implement a new harvest and give it to dead trees. Add a new terrain called `t_tree_very_dead` which harvested dead trees transform into. Very dead trees cannot transform into being less dead (and thus, cannot be harvested a second time, *ever*.)

#### Describe alternatives you've considered
I considered adding small amounts of sticks/twigs (much smaller than this harvest) to *all* tree harvests. But that might be annoying when harvesting for fruits, and I'd also have to look into some traditional coppicing practices to figure out *just how much* you could take off a tree each season without killing it. But if the tree is already dead, we don't care!

#### Testing
Loaded my changes locally. Used debug to spawn a large square of dead trees. Harvested some of them, confirmed the results against what I had entered into json. Teleported out and advanced season, then teleported back. Dead trees remained dead, very dead trees remained very dead. Advanced season again, teleported out and back again, confirmed again all trees retained their relative deadness.

Turned on autoforage. Moved by trees. Character did not autoforage. Sticks are not food, so this is more or less desired behavior.

#### Additional context
This may make manual foraging in forests *slightly* more tedious, as dead trees are now a valid examinable tile. However, they are still pretty rare - the 60 billion other tree types are still going to be causing you annoyance regardless.