### PR TITLE
Fix a crash due to stale pointer in mon_visible

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4613,6 +4613,7 @@ void game::cleanup_dead()
     if( npc_is_dead ) {
         for( auto it = critter_tracker->active_npc.begin(); it != critter_tracker->active_npc.end(); ) {
             if( ( *it )->is_dead() ) {
+                get_avatar().get_mon_visible().remove_npc( ( *it ).get() );
                 remove_npc_follower( ( *it )->getID() );
                 overmap_buffer.remove_npc( ( *it )->getID() );
                 it = critter_tracker->active_npc.erase( it );


### PR DESCRIPTION
#### Summary

Bugfixes "Fix a crash related to NPC death"

#### Purpose of change

Fixes #65451

#### Describe the solution

Remove the pointer to npc from mon_visible before it becomes stale.

<!--
#### Describe alternatives you've considered

 Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tried to trigger the bug. Got no crash.

#### Additional context

Thanks to @mqrause for pointing me in the right direction. Note to self: backport to 0.G