### PR TITLE
math_parser: evaluate variables in diag. functions

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -188,6 +188,14 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_math_diag_w_vars",
+    "effect": [
+      { "set_string_var": "survival", "target_var": { "global_val": "myskill" } },
+      { "math": [ "myskill_math", "=", "u_skill(myskill)" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_jmath_test",
     "effect": [ { "math": [ "blorgy", "=", "jmath_test_blorg(1, 2)" ] } ]
   },

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1429,13 +1429,15 @@ Dialogue functions take single-quoted strings as arguments and can return or man
 
 This section is a work in progress as functions are ported from `arithmetic` to `math`.
 
+_function arguments are either `s`trings or `v`[ariables](#variables)_
+
 | Function | Eval | Assign |Scopes | Description |
 |----------|------|--------|-------|-------------|
-| armor    |  ✅   |   ❌  | u, n  | Return the numerical value for a characters armor on a body part, for a damage type.<br/> Example:<br/>`"condition": { "math": [ "u_armor('bash', 'torso')", ">=", "5"] }`|  
-| game_option   |  ✅  |   ❌   | N/A<br/>(global)  | Return the numerical value of a game option<br/> Example:<br/>`"condition": { "math": [ "game_option('NPC_SPAWNTIME')", ">=", "5"] }`|
-| pain     |  ✅  |   ✅   | u, n  | Return or set pain<br/> Example:<br/>`{ "math": [ "n_pain()", "=", "u_pain() + 9000" ] }`|
-| skill    |  ✅  |   ✅   | u, n  | Return or set skill level<br/> Example:<br/>`"condition": { "math": [ "u_skill('driving')", ">=", "5"] }`|
-| weather  |  ✅  |   ✅   | N/A<br/>(global)  | Return or set a weather aspect<br/><br/>Aspect must be one of:<br/>`temperature` (in Kelvin),<br/>`humidity` (as percentage),<br/>`pressure` (in millibar),<br/>`windpower` (in mph).<br/><br/>Temperature conversion functions are available: `celsius()`, `fahrenheit()`, `from_celsius()`, and `from_fahrenheit()`.<br/><br/>Examples:<br/>`{ "math": [ "weather('temperature')", "<", "from_fahrenheit( 33 )" ] }`<br/>`{ "math": [ "fahrenheit( weather('temperature') )", "==", "21" ] }`|
+| armor(`s`/`v`,`s`/`v`)    |  ✅   |   ❌  | u, n  | Return the numerical value for a characters armor on a body part, for a damage type.<br/> Example:<br/>`"condition": { "math": [ "u_armor('bash', 'torso')", ">=", "5"] }`<br/>`"condition": { "math": [ "u_armor(u_dmgtype, u_bp)", ">=", "5"] }`|  
+| game_option(`s`)   |  ✅  |   ❌   | N/A<br/>(global)  | Return the numerical value of a game option<br/> Example:<br/>`"condition": { "math": [ "game_option('NPC_SPAWNTIME')", ">=", "5"] }`|
+| pain()     |  ✅  |   ✅   | u, n  | Return or set pain<br/> Example:<br/>`{ "math": [ "n_pain()", "=", "u_pain() + 9000" ] }`|
+| skill(`s`/`v`)    |  ✅  |   ✅   | u, n  | Return or set skill level<br/> Example:<br/>`"condition": { "math": [ "u_skill('driving')", ">=", "5"] }`<br/>`"condition": { "math": [ "u_skill(someskill)", ">=", "5"] }`|
+| weather(`s`)  |  ✅  |   ✅   | N/A<br/>(global)  | Return or set a weather aspect<br/><br/>Aspect must be one of:<br/>`temperature` (in Kelvin),<br/>`humidity` (as percentage),<br/>`pressure` (in millibar),<br/>`windpower` (in mph).<br/><br/>Temperature conversion functions are available: `celsius()`, `fahrenheit()`, `from_celsius()`, and `from_fahrenheit()`.<br/><br/>Examples:<br/>`{ "math": [ "weather('temperature')", "<", "from_fahrenheit( 33 )" ] }`<br/>`{ "math": [ "fahrenheit( weather('temperature') )", "==", "21" ] }`|
 
 ##### u_val shim
 There is a `val()` shim available that can cover the missing arithmetic functions from `u_val` and `npc_val`:

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -667,4 +667,12 @@ T aggregate( const std::vector<T> &values, aggregate_type agg_func )
     }
 }
 
+// overload pattern for std::variant from https://en.cppreference.com/w/cpp/utility/variant/visit
+template <class... Ts>
+struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+template <class... Ts>
+explicit overloaded( Ts... ) -> overloaded<Ts...>;
+
 #endif // CATA_SRC_CATA_UTILITY_H

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -4,10 +4,10 @@
 #include <string>
 #include <vector>
 
+#include "cata_utility.h"
 #include "condition.h"
 #include "dialogue.h"
 #include "math_parser_shim.h"
-#include "mission.h"
 #include "options.h"
 #include "units.h"
 #include "weather.h"
@@ -26,8 +26,43 @@ bool is_beta( char scope )
 }
 } // namespace
 
+std::string diag_value::str() const
+{
+    return std::string{ sv() };
+}
+
+std::string_view diag_value::sv() const
+{
+    return std::visit( overloaded{
+        []( std::string const & v ) -> std::string const &
+        {
+            return v;
+        },
+        []( var_info const & /* v */ ) -> std::string const &
+        {
+            throw std::invalid_argument( "Variables are not supported in this context" );
+        },
+    },
+    data );
+}
+
+std::string diag_value::eval( dialogue const &d ) const
+{
+    return std::visit( overloaded{
+        []( std::string const & v )
+        {
+            return v;
+        },
+        [&d]( var_info const & v )
+        {
+            return read_var_value( v, d );
+        },
+    },
+    data );
+}
+
 std::function<double( dialogue & )> u_val( char scope,
-        std::vector<std::string> const &params )
+        std::vector<diag_value> const &params )
 {
     kwargs_shim const shim( params, scope );
     try {
@@ -41,7 +76,7 @@ std::function<double( dialogue & )> u_val( char scope,
 }
 
 std::function<void( dialogue &, double )> u_val_ass( char scope,
-        std::vector<std::string> const &params )
+        std::vector<diag_value> const &params )
 {
     kwargs_shim const shim( params, scope );
     try {
@@ -53,25 +88,25 @@ std::function<void( dialogue &, double )> u_val_ass( char scope,
 }
 
 std::function<double( dialogue & )> option_eval( char /* scope */,
-        std::vector<std::string> const &params )
+        std::vector<diag_value> const &params )
 {
-    return[option = params[0]]( dialogue const & ) {
+    return[option = params[0].str()]( dialogue const & ) {
         return get_option<float>( option );
     };
 }
 
 std::function<double( dialogue & )> armor_eval( char scope,
-        std::vector<std::string> const &params )
+        std::vector<diag_value> const &params )
 {
     return[type = params[0], bpid = params[1], beta = is_beta( scope )]( dialogue const & d ) {
-        damage_type_id dt( type );
-        bodypart_id bp( bpid );
+        damage_type_id dt( type.eval( d ) );
+        bodypart_id bp( bpid.eval( d ) );
         return d.actor( beta )->armor_at( dt, bp );
     };
 }
 
 std::function<double( dialogue & )> pain_eval( char scope,
-        std::vector<std::string> const &/* params */ )
+        std::vector<diag_value> const &/* params */ )
 {
     return [beta = is_beta( scope )]( dialogue const & d ) {
         return d.actor( beta )->pain_cur();
@@ -79,7 +114,7 @@ std::function<double( dialogue & )> pain_eval( char scope,
 }
 
 std::function<void( dialogue &, double )> pain_ass( char scope,
-        std::vector<std::string> const &/* params */ )
+        std::vector<diag_value> const &/* params */ )
 {
     return [beta = is_beta( scope )]( dialogue const & d, double val ) {
         d.actor( beta )->set_pain( val );
@@ -87,23 +122,23 @@ std::function<void( dialogue &, double )> pain_ass( char scope,
 }
 
 std::function<double( dialogue & )> skill_eval( char scope,
-        std::vector<std::string> const &params )
+        std::vector<diag_value> const &params )
 {
-    return [beta = is_beta( scope ), sid = skill_id( params[0] )]( dialogue const & d ) {
-        return d.actor( beta )->get_skill_level( sid );
+    return [beta = is_beta( scope ), sid = params[0] ]( dialogue const & d ) {
+        return d.actor( beta )->get_skill_level( skill_id( sid.eval( d ) ) );
     };
 }
 
 std::function<void( dialogue &, double )> skill_ass( char scope,
-        std::vector<std::string> const &params )
+        std::vector<diag_value> const &params )
 {
-    return [beta = is_beta( scope ), sid = skill_id( params[0] )]( dialogue const & d, double val ) {
-        return d.actor( beta )->set_skill_level( sid, val );
+    return [beta = is_beta( scope ), sid = params[0] ]( dialogue const & d, double val ) {
+        return d.actor( beta )->set_skill_level( skill_id( sid.eval( d ) ), val );
     };
 }
 
 std::function<double( dialogue & )> weather_eval( char /* scope */,
-        std::vector<std::string> const &params )
+        std::vector<diag_value> const &params )
 {
     if( params[0] == "temperature" ) {
         return []( dialogue const & ) {
@@ -125,11 +160,11 @@ std::function<double( dialogue & )> weather_eval( char /* scope */,
             return get_weather().weather_precise->pressure;
         };
     }
-    throw std::invalid_argument( "Unknown weather aspect " + params[0] );
+    throw std::invalid_argument( "Unknown weather aspect " + params[0].str() );
 }
 
 std::function<void( dialogue &, double )> weather_ass( char /* scope */,
-        std::vector<std::string> const &params )
+        std::vector<diag_value> const &params )
 {
     if( params[0] == "temperature" ) {
         return []( dialogue const &, double val ) {
@@ -156,5 +191,5 @@ std::function<void( dialogue &, double )> weather_ass( char /* scope */,
             get_weather().clear_temp_cache();
         };
     }
-    throw std::invalid_argument( "Unknown weather aspect " + params[0] );
+    throw std::invalid_argument( "Unknown weather aspect " + params[0].str() );
 }

--- a/src/math_parser_diag.h
+++ b/src/math_parser_diag.h
@@ -5,7 +5,10 @@
 #include <functional>
 #include <string>
 #include <string_view>
+#include <variant>
 #include <vector>
+
+#include "dialogue_helpers.h"
 
 struct dialogue;
 struct dialogue_func {
@@ -16,9 +19,23 @@ struct dialogue_func {
     int num_params{};
 };
 
+struct diag_value {
+    std::string_view sv() const;
+    std::string str() const;
+    std::string eval( dialogue const &d ) const;
+
+    using impl_t = std::variant<std::string, var_info>;
+    impl_t data;
+};
+
+constexpr bool operator==( diag_value const &lhs, std::string_view rhs )
+{
+    return std::holds_alternative<std::string>( lhs.data ) && std::get<std::string>( lhs.data ) == rhs;
+}
+
 struct dialogue_func_eval : dialogue_func {
     using f_t = std::function<double( dialogue & )> ( * )( char scope,
-                std::vector<std::string> const & );
+                std::vector<diag_value> const & );
 
     dialogue_func_eval( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
         : dialogue_func( s_, sc_, n_ ), f( f_ ) {}
@@ -28,7 +45,7 @@ struct dialogue_func_eval : dialogue_func {
 
 struct dialogue_func_ass : dialogue_func {
     using f_t = std::function<void( dialogue &, double )> ( * )( char scope,
-                std::vector<std::string> const & );
+                std::vector<diag_value> const & );
 
     dialogue_func_ass( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
         : dialogue_func( s_, sc_, n_ ), f( f_ ) {}
@@ -40,31 +57,31 @@ using pdiag_func_eval = dialogue_func_eval const *;
 using pdiag_func_ass = dialogue_func_ass const *;
 
 std::function<double( dialogue & )> u_val( char scope,
-        std::vector<std::string> const &params );
+        std::vector<diag_value> const &params );
 std::function<void( dialogue &, double )> u_val_ass( char scope,
-        std::vector<std::string> const &params );
+        std::vector<diag_value> const &params );
 
 std::function<double( dialogue & )> option_eval( char scope,
-        std::vector<std::string> const &params );
+        std::vector<diag_value> const &params );
 
 std::function<double( dialogue & )> armor_eval( char scope,
-        std::vector<std::string> const &params );
+        std::vector<diag_value> const &params );
 
 std::function<double( dialogue & )> pain_eval( char scope,
-        std::vector<std::string> const &/* params */ );
+        std::vector<diag_value> const &/* params */ );
 
 std::function<void( dialogue &, double )> pain_ass( char scope,
-        std::vector<std::string> const &/* params */ );
+        std::vector<diag_value> const &/* params */ );
 
 std::function<double( dialogue & )> skill_eval( char scope,
-        std::vector<std::string> const &params );
+        std::vector<diag_value> const &params );
 std::function<void( dialogue &, double )> skill_ass( char scope,
-        std::vector<std::string> const &params );
+        std::vector<diag_value> const &params );
 
 std::function<double( dialogue & )> weather_eval( char /* scope */,
-        std::vector<std::string> const &params );
+        std::vector<diag_value> const &params );
 std::function<void( dialogue &, double )> weather_ass( char /* scope */,
-        std::vector<std::string> const &params );
+        std::vector<diag_value> const &params );
 
 inline std::array<dialogue_func_eval, 6> const dialogue_eval_f{
     dialogue_func_eval{ "val", "un", -1, u_val },

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -8,6 +8,7 @@
 #include <variant>
 #include <vector>
 
+#include "cata_utility.h"
 #include "debug.h"
 #include "dialogue_helpers.h"
 #include "math_parser_diag.h"
@@ -131,13 +132,6 @@ struct thingie {
     impl_t data;
 };
 
-// overload pattern from https://en.cppreference.com/w/cpp/utility/variant/visit
-template <class... Ts>
-struct overloaded : Ts... {
-    using Ts::operator()...;
-};
-template <class... Ts>
-explicit overloaded( Ts... ) -> overloaded<Ts...>;
 constexpr double thingie::eval( dialogue &d ) const
 {
     return std::visit( overloaded{

--- a/src/math_parser_shim.cpp
+++ b/src/math_parser_shim.cpp
@@ -1,18 +1,18 @@
 #include "math_parser_shim.h"
+#include "math_parser_diag.h"
 #include "math_parser_func.h"
 
 #include <map>
 #include <string_view>
 
-#include "condition.h"
 #include "json_loader.h"
 #include "string_formatter.h"
 
-kwargs_shim::kwargs_shim( std::vector<std::string> const &tokens, char scope )
+kwargs_shim::kwargs_shim( std::vector<diag_value> const &tokens, char scope )
 {
     bool positional = false;
-    for( std::string_view const token : tokens ) {
-        std::vector<std::string_view> parts = tokenize( token, ":", false );
+    for( diag_value const &token : tokens ) {
+        std::vector<std::string_view> parts = tokenize( token.sv(), ":", false );
         if( parts.size() == 1 && !positional ) {
             kwargs.emplace(
                 // NOLINTNEXTLINE(cata-translate-string-literal): not a user-visible string
@@ -22,7 +22,7 @@ kwargs_shim::kwargs_shim( std::vector<std::string> const &tokens, char scope )
         } else if( parts.size() == 2 ) {
             kwargs.emplace( parts[0], parts[1] );
         } else {
-            debugmsg( "Too many parts in token %.*s", token.size(), token.data() );
+            debugmsg( "Too many parts in token %s", token.sv() );
         }
     }
 }

--- a/src/math_parser_shim.h
+++ b/src/math_parser_shim.h
@@ -6,14 +6,16 @@
 #include <string>
 #include <string_view>
 
-#include "json.h"
+#include "flexbuffer_json.h"
+
+struct diag_value;
 
 // temporary shim that pretends to be a JsonObject for the purpose of reusing code between the new
 // "math" and the old "arithmetic"/"compare_num"/"u_val"
 class kwargs_shim
 {
     public:
-        explicit kwargs_shim( std::vector<std::string> const &tokens, char scope );
+        explicit kwargs_shim( std::vector<diag_value> const &tokens, char scope );
 
         std::string get_string( std::string_view key ) const;
         double get_float( std::string_view key, double def = 0 ) const;

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -22,6 +22,8 @@ static const effect_on_condition_id
 effect_on_condition_EOC_math_armor( "EOC_math_armor" );
 static const effect_on_condition_id
 effect_on_condition_EOC_math_diag_assign( "EOC_math_diag_assign" );
+static const effect_on_condition_id
+effect_on_condition_EOC_math_diag_w_vars( "EOC_math_diag_w_vars" );
 static const effect_on_condition_id effect_on_condition_EOC_math_duration( "EOC_math_duration" );
 static const effect_on_condition_id
 effect_on_condition_EOC_math_switch_math( "EOC_math_switch_math" );
@@ -51,6 +53,8 @@ effect_on_condition_EOC_stored_condition_test( "EOC_stored_condition_test" );
 static const effect_on_condition_id effect_on_condition_EOC_teleport_test( "EOC_teleport_test" );
 
 static const mtype_id mon_zombie( "mon_zombie" );
+
+static const skill_id skill_survival( "survival" );
 namespace
 {
 void complete_activity( Character &u )
@@ -158,6 +162,19 @@ TEST_CASE( "EOC_jmath", "[eoc][math_parser]" )
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     effect_on_condition_EOC_jmath_test->activate( d );
     CHECK( std::stod( globvars.get_global_value( "npctalk_var_blorgy" ) ) == Approx( 7 ) );
+}
+
+TEST_CASE( "EOC_diag_with_vars", "[eoc][math_parser]" )
+{
+    global_variables &globvars = get_globals();
+    globvars.clear_global_values();
+    REQUIRE( globvars.get_global_value( "npctalk_var_myskill_math" ).empty() );
+    dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
+    effect_on_condition_EOC_math_diag_w_vars->activate( d );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_myskill_math" ) ) == Approx( 0 ) );
+    get_avatar().set_skill_level( skill_survival, 3 );
+    effect_on_condition_EOC_math_diag_w_vars->activate( d );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_myskill_math" ) ) == Approx( 3 ) );
 }
 
 TEST_CASE( "EOC_transform_radius", "[eoc][timed_event]" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allow dialogue functions in `math` to evaluate their parameters from dialogue variables.

* Needed for #65465 to fully port the skill_level functions.

So something like

```JSON
"condition": { "u_has_skill": { "skill": { "global_val": "myvar" }, "level": 5 } },
```
can be fully ported to
```JSON
"condition": { "math": [ "u_skill(myvar)", ">=", "5" ] }
```
where `myvar` gets evaluated inside `u_skill`.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Expand the math parser to include this use case

TODO:
 - [x] figure out validation: ez pz; I was overthinking it

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Third party parser

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
New test units

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
~~This includes a tiny bit of code from #65465 so that the tests work.~~

~~This will stay in draft until #65298 and #65465 get merged to spare myself some conflict resolution.~~

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->