### PR TITLE
Fix crash when installing vehicle parts on empty square

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -874,7 +874,7 @@ bool veh_interact::update_part_requirements()
     nmsg += res.second;
 
     ret_val<void> can_mount = veh->can_mount(
-                                  veh->part( cpart ).mount, sel_vpart_info->get_id() );
+                                  dd.rotate( 2 ), sel_vpart_info->get_id() );
     if( !can_mount.success() ) {
         ok = false;
         nmsg += _( "<color_white>Cannot install due to:</color>\n> " ) + colorize( can_mount.str(),

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -874,7 +874,7 @@ bool veh_interact::update_part_requirements()
     nmsg += res.second;
 
     ret_val<void> can_mount = veh->can_mount(
-                                  dd.rotate( 2 ), sel_vpart_info->get_id() );
+                                  -dd, sel_vpart_info->get_id() );
     if( !can_mount.success() ) {
         ok = false;
         nmsg += _( "<color_white>Cannot install due to:</color>\n> " ) + colorize( can_mount.str(),


### PR DESCRIPTION
#### Summary
Bugfixes "Fix crash when installing vehicle parts on empty square"

#### Purpose of change
* Fixes #65470

Wow, cpart is not always a valid reference to determine a part location. So it's really not a good idea. (The additional crash seems to occur reliably after installing and then removing a part on an empty space, although on my very first try it crashed the moment I opened the install menu. In any case we need to not pass bad data)

#### Describe the solution
Let's use dd (rotated twice) like the entire rest of veh_interact does

#### Describe alternatives you've considered


#### Testing
Compiled it, mucked around with vehicles for a bit, couldn't reproduce crash and could always install vehicle parts when I should be able to.

#### Additional context
