### PR TITLE
Make copy-from copy terrain/furniture examine actions

### DIFF
--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1378,13 +1378,15 @@ void init_mapdata()
 void map_data_common_t::load( const JsonObject &jo, const std::string & )
 {
     if( jo.has_string( "examine_action" ) ) {
+        examine_actor = nullptr;
         examine_func = iexamine_functions_from_string( jo.get_string( "examine_action" ) );
     } else if( jo.has_object( "examine_action" ) ) {
         JsonObject data = jo.get_object( "examine_action" );
         examine_actor = iexamine_actor_from_jsobj( data );
         examine_actor->load( data );
         examine_func = iexamine_functions_from_string( "invalid" );
-    } else {
+    } else if( !was_loaded ) {
+        examine_actor = nullptr;
         examine_func = iexamine_functions_from_string( "none" );
     }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Make copy-from copy terrain/furniture examine actions"

#### Purpose of change
Copy-from did not copy terrain/furniture examine actions, so gas pumps selected via a gas pump terminal (`f_gas_pump_a` copied from `f_gas_pump`) could not be examined for fuel.

#### Describe the solution
Do not reset exmaine actor/func if the object was already loaded.

#### Describe alternatives you've considered

#### Testing
Selected a gas pump via gas pump terminal, examined the gas pump, and was able to use it for fuel instead of being greeted with a message saying that it is firmly sealed.

#### Additional context
