### PR TITLE
Fix unvisited member reporting from global destructors in atexit.

### DIFF
--- a/src/flexbuffer_json.cpp
+++ b/src/flexbuffer_json.cpp
@@ -1,5 +1,6 @@
 #include "flexbuffer_json.h"
 
+#include <atomic>
 #include <cstring>
 #include <istream>
 #include <optional>
@@ -7,6 +8,16 @@
 #include "cata_unreachable.h"
 #include "filesystem.h"
 #include "json.h"
+
+namespace
+{
+std::atomic_bool report_unvisited_members{true};
+} // namespace
+
+bool Json::globally_report_unvisited_members( bool do_report )
+{
+    return report_unvisited_members.exchange( do_report );
+}
 
 const std::string &Json::flexbuffer_type_to_string( flexbuffers::Type t )
 {
@@ -240,7 +251,8 @@ bool JsonValue::read( std::string &s, bool throw_on_error ) const
 
 void JsonObject::report_unvisited() const
 {
-    if( !std::uncaught_exceptions() && !visited_fields_bitset_.all() ) {
+#ifndef CATA_IN_TOOL
+    if( !std::uncaught_exceptions() && report_unvisited_members && !visited_fields_bitset_.all() ) {
         std::vector<size_t> skipped_members;
         skipped_members.reserve( visited_fields_bitset_.size() );
         tiny_bitset::block_t *bits = visited_fields_bitset_.bits();
@@ -270,6 +282,7 @@ void JsonObject::report_unvisited() const
         error_skipped_members( skipped_members );
         visited_fields_bitset_.set_all();
     }
+#endif
 }
 
 void JsonObject::error_no_member( const std::string_view member ) const

--- a/src/flexbuffer_json.h
+++ b/src/flexbuffer_json.h
@@ -101,6 +101,9 @@ class Json
 
         static const std::string &flexbuffer_type_to_string( flexbuffers::Type t );
 
+        // Atomically sets whether Json destructors report unvisited members or not. Returns the prior value.
+        static bool globally_report_unvisited_members( bool do_report );
+
     protected:
         Json( std::shared_ptr<parsed_flexbuffer> root, flexbuffer json ) : root_{ std::move( root ) },
             json_ { json } {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -610,6 +610,11 @@ int main( int argc, const char *argv[] )
     reset_floating_point_mode();
     flatbuffers::ClassicLocale::Get();
 
+    on_out_of_scope json_member_reporting_guard{ [] {
+            // Disable reporting unvisited members if stack unwinding leaves main early.
+            Json::globally_report_unvisited_members( false );
+        } };
+
 #if defined(_WIN32) and defined(TILES)
     const HANDLE std_output { GetStdHandle( STD_OUTPUT_HANDLE ) }, std_error { GetStdHandle( STD_ERROR_HANDLE ) };
     if( std_output != INVALID_HANDLE_VALUE and std_error != INVALID_HANDLE_VALUE ) {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -291,6 +291,10 @@ CATCH_REGISTER_LISTENER( CataListener )
 int main( int argc, const char *argv[] )
 {
     reset_floating_point_mode();
+    on_out_of_scope json_member_reporting_guard{ [] {
+            // Disable reporting unvisited members if stack unwinding leaves main early.
+            Json::globally_report_unvisited_members( false );
+        } };
     Catch::Session session;
 
     std::vector<const char *> arg_vec( argv, argv + argc );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When globals get destructed in atexit, `std::uncaught_exceptions` returns false. This means the fix from #65363 is insufficient depending on the situation, such as, in test suites when loading initial game data and there's a units error.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I googled but couldn't find another way to detect if we're post-main. So just set up a sentinel guard variable that when destructed or unwound will disable reporting json member errors.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- :fire:
- Not really an alterative, but potentially could dismiss the guard on 'normal' shutdowns to catch places where things aren't cleaned up appropriately. But I'm not sure if we care so much in those cases.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Replicated the error from https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4884099474/jobs/8717107644?pr=65474 locally, validated that with my fix the spam is fixed but the error is still reported.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->