### PR TITLE
Backport to 0.G: Fix a crash due to stale pointer in mon_visible

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4311,6 +4311,7 @@ void game::cleanup_dead()
     if( npc_is_dead ) {
         for( auto it = critter_tracker->active_npc.begin(); it != critter_tracker->active_npc.end(); ) {
             if( ( *it )->is_dead() ) {
+                get_avatar().get_mon_visible().remove_npc( ( *it ).get() );
                 remove_npc_follower( ( *it )->getID() );
                 overmap_buffer.remove_npc( ( *it )->getID() );
                 it = critter_tracker->active_npc.erase( it );


### PR DESCRIPTION
#### Summary

Bugfixes "Fix a crash related to NPC death"

#### Purpose of change

Fixes #65451
Backports #65466

#### Describe the solution

See #65466

<!-- 
#### Describe alternatives you've considered

Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I have already confirmed this patch fixes the bug while testing #65466

<!-- 
#### Additional context

Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->