### PR TITLE
Fix infinite recursion when trying to drain battery

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8710,7 +8710,8 @@ units::energy Character::consume_ups( units::energy qty, const int radius )
     if( qty != 0_kJ ) {
         std::vector<const item *> ups_items = all_items_with_flag( flag_IS_UPS );
         for( const item *i : ups_items ) {
-            qty -= const_cast<item *>( i )->energy_consume( qty, tripoint_zero, nullptr );
+            units::energy available = i->energy_remaining( nullptr );
+            qty -= const_cast<item *>( i )->energy_consume( available, tripoint_zero, nullptr );
         }
     }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8710,8 +8710,7 @@ units::energy Character::consume_ups( units::energy qty, const int radius )
     if( qty != 0_kJ ) {
         std::vector<const item *> ups_items = all_items_with_flag( flag_IS_UPS );
         for( const item *i : ups_items ) {
-            units::energy available = i->energy_remaining( nullptr );
-            qty -= const_cast<item *>( i )->energy_consume( available, tripoint_zero, nullptr );
+            qty -= const_cast<item *>( i )->energy_consume( qty, tripoint_zero, nullptr );
         }
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10441,7 +10441,8 @@ units::energy item::energy_consume( units::energy qty, const tripoint &pos, Char
     // If consumption is not integer kJ we need to consume one extra battery charge to "round up".
     // Should happen only if battery powered and energy per shot is not integer kJ.
     if( qty > 0_kJ && is_battery() ) {
-        qty -= energy_consume( 1_kJ, pos, carrier );
+        int consumed_kj = contents.ammo_consume( 1, pos );
+        qty -= units::from_kilojoule( consumed_kj );
     }
 
     return wanted_energy - qty;

--- a/tests/ammo_test.cpp
+++ b/tests/ammo_test.cpp
@@ -241,6 +241,8 @@ TEST_CASE( "battery energy test", "[ammo][energy][item]" )
     }
 
     SECTION( "Non-integer drain from battery" ) {
+        // Battery charge is in chunks of kj. Non integer kj drain is rounded up.
+        // 4.5 kJ drain becomes 5 kJ drain
         REQUIRE( test_battery.energy_remaining( nullptr ) == 300_kJ );
         units::energy consumed = test_battery.energy_consume( 4500_J, tripoint_zero, nullptr );
         CHECK( test_battery.energy_remaining( nullptr ) == 295_kJ );

--- a/tests/ammo_test.cpp
+++ b/tests/ammo_test.cpp
@@ -5,6 +5,7 @@
 #include "damage.h"
 #include "item.h"
 #include "type_id.h"
+#include "units.h"
 
 static const ammotype ammo_762( "762" );
 static const ammotype ammo_9mm( "9mm" );
@@ -218,5 +219,47 @@ TEST_CASE( "barrel test", "[ammo][weapon]" )
         item base_gun( "test_glock_super_long" );
         CHECK( base_gun.gun_damage( itype_test_100mm_ammo_relative ).total_damage() == 66 );
     }
+}
+
+TEST_CASE( "battery energy test", "[ammo][energy][item]" )
+{
+    item test_battery( "medium_battery_cell" );
+    test_battery.ammo_set( test_battery.ammo_default(), 300 );
+
+    SECTION( "Integer drain from battery" ) {
+        REQUIRE( test_battery.energy_remaining( nullptr ) == 300_kJ );
+        units::energy consumed = test_battery.energy_consume( 200_kJ, tripoint_zero, nullptr );
+        CHECK( test_battery.energy_remaining( nullptr ) == 100_kJ );
+        CHECK( consumed == 200_kJ );
+    }
+
+    SECTION( "Integer over-drain from battery" ) {
+        REQUIRE( test_battery.energy_remaining( nullptr ) == 300_kJ );
+        units::energy consumed = test_battery.energy_consume( 400_kJ, tripoint_zero, nullptr );
+        CHECK( test_battery.energy_remaining( nullptr ) == 0_kJ );
+        CHECK( consumed == 300_kJ );
+    }
+
+    SECTION( "Non-integer drain from battery" ) {
+        REQUIRE( test_battery.energy_remaining( nullptr ) == 300_kJ );
+        units::energy consumed = test_battery.energy_consume( 4500_J, tripoint_zero, nullptr );
+        CHECK( test_battery.energy_remaining( nullptr ) == 295_kJ );
+        CHECK( consumed == 5_kJ );
+    }
+
+    SECTION( "Non-integer over-drain from battery" ) {
+        REQUIRE( test_battery.energy_remaining( nullptr ) == 300_kJ );
+        units::energy consumed = test_battery.energy_consume( 500500_J, tripoint_zero, nullptr );
+        CHECK( test_battery.energy_remaining( nullptr ) == 0_kJ );
+        CHECK( consumed == 300_kJ );
+    }
+
+    SECTION( "zero drain from battery" ) {
+        REQUIRE( test_battery.energy_remaining( nullptr ) == 300_kJ );
+        units::energy consumed = test_battery.energy_consume( 0_J, tripoint_zero, nullptr );
+        CHECK( test_battery.energy_remaining( nullptr ) == 300_kJ );
+        CHECK( consumed == 0_kJ );
+    }
+
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix infinite recursion when trying to drain battery"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Fix #65485
Fix #65407

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Battery energy consumption didn't handle attempt at overdraining very elegantly. It ended in infinite recursion where it tried to squeeze more energy from the battery that had no more energy.
It no longer has that problem.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Tested the attached save.
Made some unit tests.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->