### PR TITLE
Create a context variable with tile location during weather checking.  To be used for portal storms centers

### DIFF
--- a/doc/WEATHER_TYPE.md
+++ b/doc/WEATHER_TYPE.md
@@ -24,7 +24,7 @@ Each weather type is a type of weather that occurs, and what causes it. The only
 | `duration_min`       | Optional, the lower bound on the amount of time this weather can last. Defaults to 5 minutes.    |
 | `duration_max`       | Optional, the upper bound on the amount of time this weather can last. Defaults to 5 minutes.    |
 | `weather_animation`  | Optional, Information controlling weather animations.  Members: factor, color and glyph          |
-| `condition`          | A dialog condition to determine if this weather is happening.  See Dialogue conditions section of [NPCs](NPCs.md) |
+| `condition`          | A dialog condition to determine if this weather is happening.  See Dialogue conditions section of [NPCs](NPCs.md) A context variable of `weather_location` contains the location of the current tile checking its weather.  This can be used to have weather be based on location. |
 | `priority`           | An integer.  If the condition of multiple weather types are true the one with higher priority wins. |
 | `required_weathers`  | A string array of possible weathers, it is at this point in the loop. i.e. rain can only happen if the conditions for clouds light drizzle or drizzle are present.  Required weathers need to have lower load orders to be. |
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1472,7 +1472,7 @@ void Character::burn_fuel( bionic &bio )
     if( energy_gain == 0_J && solar_powered && !g->is_sheltered( pos() ) ) {
         // Some sort of solar source
 
-        const weather_type_id &wtype = current_weather( pos() );
+        const weather_type_id &wtype = current_weather( get_location() );
         float intensity = incident_sun_irradiance( wtype, calendar::turn ); // W/m2
 
         if( !result.connected_solar.empty() ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1093,7 +1093,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         weather_manager &weather = get_weather();
         const units::temperature player_local_temp = weather.get_temperature( player_character.pos() );
         const int windpower = get_local_windpower( weather.windspeed + vehwindspeed,
-                              cur_om_ter, pos(), weather.winddirection, g->is_sheltered( pos() ) );
+                              cur_om_ter, get_location(), weather.winddirection, g->is_sheltered( pos() ) );
         add_msg_if_player( m_info, _( "Temperature: %s." ), print_temperature( player_local_temp ) );
         const w_point weatherPoint = *weather.weather_precise;
         add_msg_if_player( m_info, _( "Relative Humidity: %s." ),
@@ -1514,7 +1514,7 @@ void Character::burn_fuel( bionic &bio )
         }
         weather_manager &weather = get_weather();
         const int windpower = get_local_windpower( weather.windspeed + vehwindspeed,
-                              overmap_buffer.ter( global_omt_location() ), pos(), weather.winddirection,
+                              overmap_buffer.ter( global_omt_location() ), get_location(), weather.winddirection,
                               g->is_sheltered( pos() ) );
         energy_gain = 1_kJ * windpower;
     }

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -423,7 +423,7 @@ void Character::update_bodytemp()
     const oter_id &cur_om_ter = overmap_buffer.ter( global_omt_location() );
     bool sheltered = g->is_sheltered( pos() );
     int bp_windpower = get_local_windpower( weather_man.windspeed + vehwindspeed, cur_om_ter,
-                                            pos(), weather_man.winddirection, sheltered );
+                                            get_location(), weather_man.winddirection, sheltered );
     // Let's cache this not to check it for every bodyparts
     const bool has_bark = has_trait( trait_BARK );
     const bool has_sleep = has_effect( effect_sleep );

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1249,7 +1249,7 @@ static std::string get_string_from_input( const JsonArray &objects, int index )
 {
     if( objects.has_string( index ) ) {
         std::string type = objects.get_string( index );
-        if( type == "u" || type == "npc" || type == "weather" ) {
+        if( type == "u" || type == "npc" ) {
             return type;
         }
     }
@@ -1293,8 +1293,8 @@ static tripoint_abs_ms get_tripoint_from_string( const std::string &type, dialog
     } else if( type.find( "party_" ) == 0 ) {
         var_info var = var_info( var_type::party, type.substr( 7, type.size() - 7 ) );
         return get_tripoint_from_var( var, d );
-    } else if( type == "weather" ) {
-        var_info var = var_info( var_type::global, "weather" );
+    } else if( type.find( "context_" ) == 0 ) {
+        var_info var = var_info( var_type::context, type.substr( 7, type.size() - 7 ) );
         return get_tripoint_from_var( var, d );
     }
     return tripoint_abs_ms();

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1249,7 +1249,7 @@ static std::string get_string_from_input( const JsonArray &objects, int index )
 {
     if( objects.has_string( index ) ) {
         std::string type = objects.get_string( index );
-        if( type == "u" || type == "npc" || type == "weather") {
+        if( type == "u" || type == "npc" || type == "weather" ) {
             return type;
         }
     }
@@ -1293,8 +1293,8 @@ static tripoint_abs_ms get_tripoint_from_string( const std::string &type, dialog
     } else if( type.find( "party_" ) == 0 ) {
         var_info var = var_info( var_type::party, type.substr( 7, type.size() - 7 ) );
         return get_tripoint_from_var( var, d );
-    } else if (type == "weather") {
-        var_info var = var_info(var_type::global, "weather");
+    } else if( type == "weather" ) {
+        var_info var = var_info( var_type::global, "weather" );
         return get_tripoint_from_var( var, d );
     }
     return tripoint_abs_ms();

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1249,7 +1249,7 @@ static std::string get_string_from_input( const JsonArray &objects, int index )
 {
     if( objects.has_string( index ) ) {
         std::string type = objects.get_string( index );
-        if( type == "u" || type == "npc" ) {
+        if( type == "u" || type == "npc" || type == "weather") {
             return type;
         }
     }
@@ -1292,6 +1292,9 @@ static tripoint_abs_ms get_tripoint_from_string( const std::string &type, dialog
         return get_tripoint_from_var( var, d );
     } else if( type.find( "party_" ) == 0 ) {
         var_info var = var_info( var_type::party, type.substr( 7, type.size() - 7 ) );
+        return get_tripoint_from_var( var, d );
+    } else if (type == "weather") {
+        var_info var = var_info(var_type::global, "weather");
         return get_tripoint_from_var( var, d );
     }
     return tripoint_abs_ms();

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1784,7 +1784,7 @@ std::pair<std::string, nc_color> display::wind_text_color( const Character &u )
     const oter_id &cur_om_ter = overmap_buffer.ter( u.global_omt_location() );
     weather_manager &weather = get_weather();
     double windpower = get_local_windpower( weather.windspeed, cur_om_ter,
-                                            u.pos(), weather.winddirection, g->is_sheltered( u.pos() ) );
+                                            u.get_location(), weather.winddirection, g->is_sheltered( u.pos() ) );
 
     // Wind descriptor followed by a directional arrow
     const std::string wind_text = get_wind_desc( windpower ) + " " + get_wind_arrow(

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2202,7 +2202,7 @@ void iexamine::flower_poppy( Character &you, const tripoint &examp )
     }
 
     weather_sum recentWeather = sum_conditions( calendar::turn - 10_minutes, calendar::turn,
-                                you.pos() );
+                                you.get_location() );
 
     // If it has been raining recently, then this event is twice less likely.
     if( ( ( recentWeather.rain_amount > 1 ) ? one_in( 6 ) : one_in( 3 ) ) && resist < 5 ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8950,11 +8950,12 @@ std::optional<int> iuse::lux_meter( Character *p, item *it, bool, const tripoint
 
 std::optional<int> iuse::dbg_lux_meter( Character *p, item *, bool, const tripoint &pos )
 {
-    const float incident_light = incident_sunlight( current_weather( pos ), calendar::turn );
+    map& here = get_map();
+    const float incident_light = incident_sunlight( current_weather( here.getglobal( pos ) ), calendar::turn );
     const float nat_light = g->natural_light_level( pos.z );
     const float sunlight = sun_light_at( calendar::turn );
     const float sun_irrad = sun_irradiance( calendar::turn );
-    const float incident_irrad = incident_sun_irradiance( current_weather( pos ), calendar::turn );
+    const float incident_irrad = incident_sun_irradiance( current_weather( here.getglobal( pos ) ), calendar::turn );
     p->add_msg_if_player( m_neutral,
                           _( "Incident light: %.1f\nNatural light: %.1f\nSunlight: %.1f\nSun irradiance: %.1f\nIncident irradiance %.1f" ),
                           incident_light, nat_light, sunlight, sun_irrad, incident_irrad );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8905,7 +8905,7 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, bool, const tripo
         }
         const oter_id &cur_om_ter = overmap_buffer.ter( p->global_omt_location() );
         const int windpower = get_local_windpower( weather.windspeed + vehwindspeed, cur_om_ter,
-                              p->pos(), weather.winddirection, g->is_sheltered( p->pos() ) );
+                              p->get_location(), weather.winddirection, g->is_sheltered( p->pos() ) );
 
         p->add_msg_if_player( m_neutral, _( "Wind Speed: %.1f %s." ),
                               convert_velocity( windpower * 100, VU_WIND ),
@@ -8950,12 +8950,14 @@ std::optional<int> iuse::lux_meter( Character *p, item *it, bool, const tripoint
 
 std::optional<int> iuse::dbg_lux_meter( Character *p, item *, bool, const tripoint &pos )
 {
-    map& here = get_map();
-    const float incident_light = incident_sunlight( current_weather( here.getglobal( pos ) ), calendar::turn );
+    map &here = get_map();
+    const float incident_light = incident_sunlight( current_weather( here.getglobal( pos ) ),
+                                 calendar::turn );
     const float nat_light = g->natural_light_level( pos.z );
     const float sunlight = sun_light_at( calendar::turn );
     const float sun_irrad = sun_irradiance( calendar::turn );
-    const float incident_irrad = incident_sun_irradiance( current_weather( here.getglobal( pos ) ), calendar::turn );
+    const float incident_irrad = incident_sun_irradiance( current_weather( here.getglobal( pos ) ),
+                                 calendar::turn );
     p->add_msg_if_player( m_neutral,
                           _( "Incident light: %.1f\nNatural light: %.1f\nSunlight: %.1f\nSun irradiance: %.1f\nIncident irradiance %.1f" ),
                           incident_light, nat_light, sunlight, sun_irrad, incident_irrad );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7815,7 +7815,7 @@ void map::fill_funnels( const tripoint &p, const time_point &since )
         }
     }
     if( biggest_container != items.end() ) {
-        retroactively_fill_from_funnel( *biggest_container, tr, since, calendar::turn, getabs( p ) );
+        retroactively_fill_from_funnel( *biggest_container, tr, since, calendar::turn, getglobal( p ) );
     }
 }
 

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -267,7 +267,8 @@ void map::spread_gas( field_entry &cur, const tripoint &p, int percent_spread,
     const bool sheltered = g->is_sheltered( p );
     weather_manager &weather = get_weather();
     const int winddirection = weather.winddirection;
-    const int windpower = get_local_windpower( weather.windspeed, om_ter, p, winddirection,
+    const int windpower = get_local_windpower( weather.windspeed, om_ter, tripoint_abs_ms( p ),
+                          winddirection,
                           sheltered );
 
     const int current_intensity = cur.get_field_intensity();
@@ -926,7 +927,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
     bool sheltered = g->is_sheltered( p );
     weather_manager &weather = get_weather();
     int winddirection = weather.winddirection;
-    int windpower = get_local_windpower( weather.windspeed, om_ter, p, winddirection,
+    int windpower = get_local_windpower( weather.windspeed, om_ter, tripoint_abs_ms( p ), winddirection,
                                          sheltered );
     const ter_t &ter = map_tile.get_ter_t();
     const furn_t &frn = map_tile.get_furn_t();

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -235,8 +235,7 @@ weather_type_id get_weather_at_point( const tripoint_abs_omt &pos )
     }
     auto iter = weather_cache.find( pos );
     if( iter == weather_cache.end() ) {
-        // TODO: fix point types
-        const tripoint abs_ms_pos = project_to<coords::ms>( pos ).raw();
+        const tripoint_abs_ms abs_ms_pos = project_to<coords::ms>( pos );
         const weather_generator &wgen = overmap_buffer.get_settings( pos ).weather;
         const auto weather = wgen.get_weather_conditions( abs_ms_pos, calendar::turn, g->get_seed() );
         iter = weather_cache.insert( std::make_pair( pos, weather ) ).first;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4771,7 +4771,7 @@ units::power vehicle::total_wind_epower() const
             continue;
         }
 
-        int windpower = get_local_windpower( weather.windspeed, cur_om_ter, pos,
+        int windpower = get_local_windpower( weather.windspeed, cur_om_ter, here.getglobal( pos ),
                                              weather.winddirection, false );
         if( windpower <= ( weather.windspeed / 10.0 ) ) {
             continue;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4752,7 +4752,7 @@ units::power vehicle::total_solar_epower() const
     }
     // Weather doesn't change much across the area of the vehicle, so just
     // sample it once.
-    weather_type_id wtype = current_weather( global_pos3() );
+    weather_type_id wtype = current_weather( global_square_location() );
     const float intensity = incident_sun_irradiance( wtype, calendar::turn ) / max_sun_irradiance();
     return epower * intensity;
 }
@@ -7434,7 +7434,7 @@ void vehicle::update_time( const time_point &update_to )
     }
     // Get one weather data set per vehicle, they don't differ much across vehicle area
     const weather_sum accum_weather = sum_conditions( update_from, update_to,
-                                      global_square_location().raw() );
+                                      global_square_location() );
     // make some reference objects to use to check for reload
     const item water( "water" );
     const item water_clean( "water_clean" );

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -553,9 +553,7 @@ std::string weather_forecast( const point_abs_sm &abs_sm_pos )
     // int weather_proportions[NUM_WEATHER_TYPES] = {0};
     units::temperature high = 0_K;
     units::temperature low = 1000_K;
-    // TODO: fix point types
-    const tripoint abs_ms_pos =
-        tripoint( project_to<coords::ms>( abs_sm_pos ).raw(), 0 );
+    const tripoint_abs_ms abs_ms_pos(project_to<coords::ms>( abs_sm_pos ),0);
     w_point weatherPoint = *weather.weather_precise;
     // TODO: wind direction and speed
     const time_point last_hour = calendar::turn - ( calendar::turn - calendar::turn_zero ) %
@@ -906,7 +904,7 @@ void weather_manager::update_weather()
     if( weather_id == WEATHER_NULL || calendar::turn >= nextweather ) {
         w_point &w = *weather_precise;
         const weather_generator &weather_gen = get_cur_weather_gen();
-        w = weather_gen.get_weather( player_character.get_location().raw(), calendar::turn,
+        w = weather_gen.get_weather( player_character.get_location(), calendar::turn,
                                      g->get_seed() );
         weather_type_id old_weather = weather_id;
         std::string eternal_weather_option = get_option<std::string>( "ETERNAL_WEATHER" );

--- a/src/weather.h
+++ b/src/weather.h
@@ -147,7 +147,7 @@ int get_local_windpower( int windpower, const oter_id &omter, const tripoint &lo
                          bool sheltered = false );
 weather_sum sum_conditions( const time_point &start,
                             const time_point &end,
-                            const tripoint &location );
+                            const tripoint_abs_ms &location );
 
 /**
  * @param it The container item which is to be filled.
@@ -179,7 +179,7 @@ bool warm_enough_to_plant( const tripoint_abs_omt &pos );
 
 bool is_wind_blocker( const tripoint &location );
 
-weather_type_id current_weather( const tripoint &location,
+weather_type_id current_weather( const tripoint_abs_ms &location,
                                  const time_point &t = calendar::turn );
 
 void glare( const weather_type_id &w );

--- a/src/weather.h
+++ b/src/weather.h
@@ -142,7 +142,7 @@ units::temperature_delta get_local_windchill( units::temperature temperature, do
 int get_local_humidity( double humidity, const weather_type_id &weather, bool sheltered = false );
 
 // Returns windspeed (mph) after being modified by local cover
-int get_local_windpower( int windpower, const oter_id &omter, const tripoint &location,
+int get_local_windpower( int windpower, const oter_id &omter, const tripoint_abs_ms &location,
                          const int &winddirection,
                          bool sheltered = false );
 weather_sum sum_conditions( const time_point &start,
@@ -156,7 +156,7 @@ weather_sum sum_conditions( const time_point &start,
  * @param tr The funnel (trap which acts as a funnel).
  */
 void retroactively_fill_from_funnel( item &it, const trap &tr, const time_point &start,
-                                     const time_point &end, const tripoint &pos );
+                                     const time_point &end, const tripoint_abs_ms &pos );
 
 double funnel_charges_per_turn( double surface_area_mm2, double rain_depth_mm_per_hour );
 
@@ -177,7 +177,7 @@ nc_color get_wind_color( double );
 bool warm_enough_to_plant( const tripoint &pos );
 bool warm_enough_to_plant( const tripoint_abs_omt &pos );
 
-bool is_wind_blocker( const tripoint &location );
+bool is_wind_blocker( const tripoint_bub_ms &location );
 
 weather_type_id current_weather( const tripoint_abs_ms &location,
                                  const time_point &t = calendar::turn );

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -115,7 +115,7 @@ w_point weather_generator::get_weather( const tripoint_abs_ms &location, const t
                                         unsigned seed ) const
 {
     season_effective_time t( real_t );
-    const weather_gen_common common = get_common_data( location.raw(), real_t, seed);
+    const weather_gen_common common = get_common_data( location.raw(), real_t, seed );
 
     const double x( common.x );
     const double y( common.y );
@@ -192,7 +192,7 @@ weather_type_id weather_generator::get_weather_conditions( const w_point &w ) co
     const weather_manager &game_weather = get_weather_const();
     w_point original_weather_precise = *game_weather.weather_precise;
     *game_weather.weather_precise = w;
-
+    write_var_value( var_type::global, "weather", nullptr, w.location.to_string() );
     weather_type_id current_conditions = WEATHER_CLEAR;
     dialogue d( get_talker_for( get_avatar() ), nullptr );
     for( const weather_type_id &type : sorted_weather ) {

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -111,11 +111,11 @@ units::temperature weather_generator::get_weather_temperature(
     return weather_temperature_from_common_data( *this, get_common_data( location, real_t, seed ),
             season_effective_time( real_t ) );
 }
-w_point weather_generator::get_weather( const tripoint &location, const time_point &real_t,
+w_point weather_generator::get_weather( const tripoint_abs_ms &location, const time_point &real_t,
                                         unsigned seed ) const
 {
     season_effective_time t( real_t );
-    const weather_gen_common common = get_common_data( location, real_t, seed );
+    const weather_gen_common common = get_common_data( location.raw(), real_t, seed);
 
     const double x( common.x );
     const double y( common.y );
@@ -172,13 +172,13 @@ w_point weather_generator::get_weather( const tripoint &location, const time_poi
         }
     }
     std::string wind_desc = get_wind_desc( W );
-    return w_point{ T, H, P, W, wind_desc, current_winddir, t };
+    return w_point{ T, H, P, W, wind_desc, current_winddir, t, location };
 }
 
 weather_type_id weather_generator::get_weather_conditions( const tripoint &location,
         const time_point &t, unsigned seed ) const
 {
-    w_point w( get_weather( location, t, seed ) );
+    w_point w( get_weather( tripoint_abs_ms( location ), t, seed ) );
     weather_type_id wt = get_weather_conditions( w );
     return wt;
 }
@@ -289,7 +289,7 @@ void weather_generator::test_weather( unsigned seed ) const
         const time_point begin = calendar::turn;
         const time_point end = begin + 2 * calendar::year_length();
         for( time_point i = begin; i < end; i += 20_minutes ) {
-            w_point w = get_weather( tripoint_zero, i, seed );
+            w_point w = get_weather( tripoint_abs_ms( tripoint_zero ), i, seed );
             weather_type_id conditions = get_weather_conditions( w );
 
             int year = to_turns<int>( i - calendar::turn_zero ) / to_turns<int>

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -175,10 +175,10 @@ w_point weather_generator::get_weather( const tripoint_abs_ms &location, const t
     return w_point{ T, H, P, W, wind_desc, current_winddir, t, location };
 }
 
-weather_type_id weather_generator::get_weather_conditions( const tripoint &location,
+weather_type_id weather_generator::get_weather_conditions( const tripoint_abs_ms &location,
         const time_point &t, unsigned seed ) const
 {
-    w_point w( get_weather( tripoint_abs_ms( location ), t, seed ) );
+    w_point w( get_weather( location, t, seed ) );
     weather_type_id wt = get_weather_conditions( w );
     return wt;
 }

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -192,9 +192,10 @@ weather_type_id weather_generator::get_weather_conditions( const w_point &w ) co
     const weather_manager &game_weather = get_weather_const();
     w_point original_weather_precise = *game_weather.weather_precise;
     *game_weather.weather_precise = w;
-    write_var_value( var_type::global, "weather", nullptr, w.location.to_string() );
+    std::unordered_map<std::string, std::string> context;
+    context["npctalk_var_weather_location"] = w.location.to_string();
     weather_type_id current_conditions = WEATHER_CLEAR;
-    dialogue d( get_talker_for( get_avatar() ), nullptr );
+    dialogue d( get_talker_for( get_avatar() ), nullptr, context );
     for( const weather_type_id &type : sorted_weather ) {
         bool required_weather = type->required_weathers.empty();
         if( !required_weather ) {

--- a/src/weather_gen.h
+++ b/src/weather_gen.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "calendar.h"
+#include "coordinates.h"
 #include "type_id.h"
 #include "units.h"
 
@@ -21,6 +22,7 @@ struct w_point {
     std::string wind_desc;
     int winddirection = 0;
     season_effective_time time;
+    tripoint_abs_ms location;
 };
 
 class weather_generator
@@ -58,7 +60,7 @@ class weather_generator
          * by the @ref map). You can use @ref map::getabs to get an absolute position from a
          * relative position (relative to the map you called getabs on).
          */
-        w_point get_weather( const tripoint &, const time_point &, unsigned ) const;
+        w_point get_weather( const tripoint_abs_ms &, const time_point &, unsigned ) const;
         weather_type_id get_weather_conditions( const tripoint &, const time_point &, unsigned seed ) const;
         weather_type_id get_weather_conditions( const w_point & ) const;
         int get_wind_direction( season_type ) const;

--- a/src/weather_gen.h
+++ b/src/weather_gen.h
@@ -61,7 +61,7 @@ class weather_generator
          * relative position (relative to the map you called getabs on).
          */
         w_point get_weather( const tripoint_abs_ms &, const time_point &, unsigned ) const;
-        weather_type_id get_weather_conditions( const tripoint &, const time_point &, unsigned seed ) const;
+        weather_type_id get_weather_conditions( const tripoint_abs_ms &, const time_point &, unsigned seed ) const;
         weather_type_id get_weather_conditions( const w_point & ) const;
         int get_wind_direction( season_type ) const;
         int convert_winddir( int ) const;

--- a/src/weather_gen.h
+++ b/src/weather_gen.h
@@ -61,7 +61,8 @@ class weather_generator
          * relative position (relative to the map you called getabs on).
          */
         w_point get_weather( const tripoint_abs_ms &, const time_point &, unsigned ) const;
-        weather_type_id get_weather_conditions( const tripoint_abs_ms &, const time_point &, unsigned seed ) const;
+        weather_type_id get_weather_conditions( const tripoint_abs_ms &, const time_point &,
+                                                unsigned seed ) const;
         weather_type_id get_weather_conditions( const w_point & ) const;
         int get_wind_direction( season_type ) const;
         int convert_winddir( int ) const;

--- a/tests/weather_test.cpp
+++ b/tests/weather_test.cpp
@@ -71,7 +71,7 @@ static year_of_weather_data collect_weather_data( unsigned seed )
 
     // Collect generated weather data for a single year.
     for( time_point i = begin ; i < end ; i += 1_minutes ) {
-        w_point w = wgen.get_weather( tripoint_zero, i, seed );
+        w_point w = wgen.get_weather( tripoint_abs_ms( tripoint_zero ), i, seed );
         int day = to_days<int>( time_past_new_year( i ) );
         int minute = to_minutes<int>( time_past_midnight( i ) );
         result.temperature[day][minute] = units::to_fahrenheit( w.temperature );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allow weather condition checking to have access to the current tile location so weather can change based on location.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a context variable during weather checking with the location of the current tile.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Used this json. It makes early portal storms have a center based on player and the storm only extends 100 tiles.
```
  {
    "id": "early_portal_storm",
    "type": "weather_type",
    "name": "Early Portal Storm",
    "color": "light_red",
    "map_color": "light_red",
    "sym": "o",
    "ranged_penalty": 0,
    "sight_penalty": 1.0,
    "light_modifier": -5,
    "sun_multiplier": 0.8,
    "sound_attn": 0,
    "dangerous": true,
    "precip": "none",
    "rains": false,
    "debug_cause_eoc": "EOC_CAUSE_EARLY_PORTAL_STORM",
    "debug_leave_eoc": "EOC_CANCEL_PORTAL_STORM",
    "tiles_animation": "weather_portal_storm",
    "weather_animation": { "factor": 0.01, "color": "red", "sym": "*" },
    "sound_category": "portal_storm",
    "priority": 120,
    "condition": {
      "and": [
        { "compare_num": [ { "global_val": "var", "var_name": "cause_early_portal_storm" }, "=", { "const": 1 } ] },
        {
          "compare_num": [ { "distance": [ { "context_val": "weather_location" }, { "global_val": "portal_storm_center" } ] }, "<=", { "const": 100 } ]
        }
      ]
    }
  },
  {
    "type": "effect_on_condition",
    "id": "EOC_CAUSE_EARLY_PORTAL_STORM",
    "global": true,
    "//": "This sets up all the variables for the start of an early portal storm.",
    "condition": {
      "not": {
        "or": [
          { "is_weather": "portal_storm" },
          { "is_weather": "early_portal_storm" },
          { "compare_num": [ { "global_val": "var", "var_name": "cause_portal_storm" }, "=", { "const": 1 } ] },
          { "compare_num": [ { "global_val": "var", "var_name": "cause_early_portal_storm" }, "=", { "const": 1 } ] }
        ]
      }
    },
    "effect": [
      { "u_location_variable": { "global_val": "portal_storm_center" } },
      { "arithmetic": [ { "global_val": "var", "var_name": "cause_early_portal_storm" }, "=", { "const": 1 } ] },
      "next_weather",
      { "queue_eocs": "EOC_CAUSE_PORTAL_STORM", "time_in_future": [ "2 minutes", "20 minutes" ] },
      {
        "u_message": "You suddenly register a buzzing in your senses.  It's getting louder, and your head starts to throb.  Something is coming.",
        "type": "bad",
        "popup": true
      }
    ]
  },
  {
    "type": "effect_on_condition",
    "id": "EOC_PORTAL_STORM_CHECK",
    "//": "Normally weather is only checked every 5 minutes or so, since your distance to the storm center can change quickly we want to test much more often.",
    "recurrence": [ "5 seconds", "10 seconds" ],
    "global": true,
    "condition": { "or": [ { "math": [ "cause_early_portal_storm", "==", "1" ] }, { "math": [ "cause_portal_storm", "==", "1" ] } ] },
    "deactivate_condition": { "and": [ { "math": [ "cause_early_portal_storm", "!=", "1" ] }, { "math": [ "cause_portal_storm", "!=", "1" ] } ] },
    "effect": "next_weather"
  },
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->