### PR TITLE
update and modernize lsurvivor_armor

### DIFF
--- a/data/json/items/armor/bespoke_armor/cuttingroom.json
+++ b/data/json/items/armor/bespoke_armor/cuttingroom.json
@@ -319,7 +319,7 @@
           { "type": "cotton", "covered_by_mat": 100, "thickness": 0.15 },
           { "type": "kevlar", "covered_by_mat": 95, "thickness": 3.3 }
         ],
-        "encumbrance": [ 4, 5 ]
+        "encumbrance": [ 4, 5 ],
         "coverage": 100,
         "cover_vitals": 70,
         "covers": [ "torso" ]
@@ -330,7 +330,7 @@
           { "type": "cotton", "covered_by_mat": 100, "thickness": 0.15 },
           { "type": "kevlar", "covered_by_mat": 90, "thickness": 2.2 }
         ],
-        "encumbrance": [ 4, 5 ]
+        "encumbrance": [ 4, 5 ],
         "coverage": 100,
         "cover_vitals": 30,
         "covers": [ "arm_l", "arm_r" ]

--- a/data/json/items/armor/bespoke_armor/cuttingroom.json
+++ b/data/json/items/armor/bespoke_armor/cuttingroom.json
@@ -302,29 +302,94 @@
     "id": "lsurvivor_armor",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "light survivor body armor" },
-    "description": "Lightweight, custom-built body armor made from Kevlar and tough fabric.  Mostly waterproof.",
+    "name": { "str": "light handmade body armor" },
+    "description": "Custom-made armor that combines a level II vest with a combat shirt and adds extra padding to the arms for safety.  Fairly lightweight and ergonomic and has numerous pockets for storage.",
     "weight": "3000 g",
     "volume": "6 L",
     "price": 60000,
     "price_postapoc": 4000,
-    "material": [ "kevlar", "cotton" ],
+    "material": [ "kevlar", "cotton", "nylon" ],
     "symbol": "[",
-    "looks_like": "lsurvivor_suit",
+    "looks_like": "combat_shirt",
     "color": "green",
-    "pocket_data": [
-      { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "3 kg", "moves": 80 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "3 kg", "moves": 80 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 80 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 80 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.55 },
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 0.15 },
+          { "type": "kevlar", "covered_by_mat": 95, "thickness": 3.3 }
+        ],
+        "encumbrance": [ 4, 5 ]
+        "coverage": 100,
+        "cover_vitals": 70,
+        "covers": [ "torso" ]
+      },
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.15 },
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 0.15 },
+          { "type": "kevlar", "covered_by_mat": 90, "thickness": 2.2 }
+        ],
+        "encumbrance": [ 4, 5 ]
+        "coverage": 100,
+        "cover_vitals": 30,
+        "covers": [ "arm_l", "arm_r" ]
+      }
     ],
-    "warmth": 15,
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "description": "Shoulder pouch.",
+        "max_contains_volume": "500 ml",
+        "max_contains_weight": "1 kg",
+        "max_item_length": "13 cm",
+        "moves": 120
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "description": "Shoulder pouch.",
+        "max_contains_volume": "500 ml",
+        "max_contains_weight": "1 kg",
+        "max_item_length": "13 cm",
+        "moves": 120
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "description": "Reinforced pen pouch.",
+        "max_contains_volume": "10 ml",
+        "max_contains_weight": "150 g",
+        "max_item_length": "13 cm",
+        "moves": 120
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "description": "Front torso pouch.",
+        "max_contains_volume": "250 ml",
+        "max_contains_weight": "500 g",
+        "max_item_length": "13 cm",
+        "moves": 150
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "description": "Front torso pouch.",
+        "max_contains_volume": "250 ml",
+        "max_contains_weight": "500 g",
+        "max_item_length": "13 cm",
+        "moves": 150
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "description": "Lower back pouch.",
+        "max_contains_volume": "1000 ml",
+        "max_contains_weight": "2500 g",
+        "max_item_length": "18 cm",
+        "moves": 250
+      }
+    ],
+    "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
-    "armor": [ { "encumbrance": [ 8, 16 ], "coverage": 95, "covers": [ "torso" ] } ]
+    "flags": [ "STURDY" ]
   },
   {
     "id": "xl_lsurvivor_armor",

--- a/data/json/items/armor/bespoke_armor/cuttingroom.json
+++ b/data/json/items/armor/bespoke_armor/cuttingroom.json
@@ -302,7 +302,7 @@
     "id": "lsurvivor_armor",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "light handmade body armor" },
+    "name": { "str": "mercenary body armor" },
     "description": "Custom-made armor that combines a level II vest with a combat shirt and adds extra padding to the arms for safety.  Fairly lightweight and ergonomic and has numerous pockets for storage.",
     "weight": "3000 g",
     "volume": "6 L",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -1109,86 +1109,74 @@
     "subcategory": "CSC_ARMOR_TORSO",
     "skill_used": "tailor",
     "difficulty": 5,
-    "skills_required": [ "fabrication", 6 ],
-    "time": "14 h 45 m",
+    "time": "5 h 15 m",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 60 ], [ "fabric_standard_nostretch", 15 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 30 ] ],
     "qualities": [ { "id": "FABRIC_CUT", "level": 2 } ],
     "components": [
-      [ [ "coat_rain", 1 ] ],
+      [ [ "combat_shirt", 1 ] ],
       [
         [ "tacvest", 1 ],
         [ "legrig", 1 ],
         [ "vest", 1 ],
         [ "tool_belt", 1 ],
-        [ "ragpouch", 2 ],
         [ "leather_pouch", 2 ],
         [ "dump_pouch", 1 ],
         [ "purse", 1 ],
         [ "fanny", 1 ]
       ],
-      [ [ "duct_tape", 150 ] ],
-      [
-        [ "kevlar", 1 ],
-        [ "ballistic_vest_light", 1 ],
-        [ "ballistic_vest_esapi", 1 ],
-        [ "sheet_kevlar_layered", 16 ]
-      ]
+      [ [ "kevlar", 1 ] ],
+      [ [ "filament_durable", 30, "LIST" ] ]
     ],
-    "proficiencies": [ { "proficiency": "prof_polymerworking" }, { "proficiency": "prof_closures_waterproofing" } ]
+    "proficiencies": [ { "proficiency": "prof_polymerworking" }, { "proficiency": "prof_closures" } ]
   },
   {
     "result": "xs_lsurvivor_armor",
     "type": "recipe",
     "copy-from": "lsurvivor_armor",
-    "time": "14 h 45 m",
-    "using": [ [ "sewing_standard", 45 ], [ "fabric_standard_nostretch", 11 ] ],
+    "time": "7 h 45 m",
+    "using": [ [ "tailoring_kevlar_fabric", 50 ] ],
     "qualities": [ { "id": "FABRIC_CUT", "level": 2 } ],
     "components": [
-      [ [ "coat_rain", 1 ] ],
+      [ [ "combat_shirt", 2 ] ],
       [
         [ "tacvest", 1 ],
         [ "legrig", 1 ],
         [ "vest", 1 ],
         [ "tool_belt", 1 ],
-        [ "ragpouch", 1 ],
-        [ "leather_pouch", 1 ],
-        [ "dump_pouch", 1 ],
-        [ "purse", 1 ],
-        [ "fanny", 1 ]
-      ],
-      [ [ "duct_tape", 113 ] ],
-      [
-        [ "kevlar", 1 ],
-        [ "ballistic_vest_light", 1 ],
-        [ "ballistic_vest_esapi", 1 ],
-        [ "sheet_kevlar_layered", 12 ]
-      ]
-    ]
-  },
-  {
-    "result": "xl_lsurvivor_armor",
-    "type": "recipe",
-    "copy-from": "lsurvivor_armor",
-    "time": "16 h 35 m",
-    "using": [ [ "sewing_standard", 90 ], [ "fabric_standard_nostretch", 22 ] ],
-    "qualities": [ { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [
-      [ [ "coat_rain", 2 ] ],
-      [
-        [ "tacvest", 1 ],
-        [ "legrig", 1 ],
-        [ "vest", 1 ],
-        [ "tool_belt", 1 ],
-        [ "ragpouch", 2 ],
         [ "leather_pouch", 2 ],
         [ "dump_pouch", 1 ],
         [ "purse", 1 ],
         [ "fanny", 1 ]
       ],
-      [ [ "duct_tape", 225 ] ],
-      [ [ "kevlar", 2 ], [ "ballistic_vest_esapi", 2 ], [ "sheet_kevlar_layered", 32 ] ]
-    ]
+      [ [ "kevlar", 1 ] ],
+      [ [ "filament_durable", 60, "LIST" ] ]
+    ],
+    "proficiencies": [ { "proficiency": "prof_polymerworking" }, { "proficiency": "prof_closures" } ]
+  },
+  {
+    "result": "xl_lsurvivor_armor",
+    "type": "recipe",
+    "copy-from": "lsurvivor_armor",
+    "time": "4 h 5 m",
+    "using": [ [ "tailoring_kevlar_fabric", 24 ] ],
+    "qualities": [ { "id": "FABRIC_CUT", "level": 2 } ],
+    "components": [
+      [ [ "combat_shirt", 1 ] ],
+      [
+        [ "tacvest", 1 ],
+        [ "legrig", 1 ],
+        [ "vest", 1 ],
+        [ "tool_belt", 1 ],
+        [ "leather_pouch", 2 ],
+        [ "dump_pouch", 1 ],
+        [ "purse", 1 ],
+        [ "fanny", 1 ]
+      ],
+      [ [ "kevlar", 1 ] ],
+      [ [ "filament_durable", 27, "LIST" ] ]
+    ],
+    "proficiencies": [ { "proficiency": "prof_polymerworking" }, { "proficiency": "prof_closures" } ]
   },
   {
     "result": "ballistic_vest_heavy",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -1131,7 +1131,7 @@
     "proficiencies": [ { "proficiency": "prof_polymerworking" }, { "proficiency": "prof_closures" } ]
   },
   {
-    "result": "xs_lsurvivor_armor",
+    "result": "xl_lsurvivor_armor",
     "type": "recipe",
     "copy-from": "lsurvivor_armor",
     "time": "7 h 45 m",
@@ -1155,7 +1155,7 @@
     "proficiencies": [ { "proficiency": "prof_polymerworking" }, { "proficiency": "prof_closures" } ]
   },
   {
-    "result": "xl_lsurvivor_armor",
+    "result": "xs_lsurvivor_armor",
     "type": "recipe",
     "copy-from": "lsurvivor_armor",
     "time": "4 h 5 m",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "update light survivor body armor"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Light survivor body armor was another one of the weird and old survivor armors but it was bad enough that it was inoffensive and went ignored.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
It is now combination armor made of a combat shirt and a kevlar vest, similar to how the mercenary coat is a combo of an army jacket and a us ballistic vest. It has pockets granting a total of 2.01 liters of storage spread across the arms and torso. Torso coverage for kevlar is 95% and 90% for arms. 3.3mm of kevlar for the torso and 2.2mm for the arms. Also renamed to "light handmade body armor".
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Less coverage - the kevlar vest itself has a little less coverage than that but there are extra kevlar sheet layers to make up the difference. 
Move it out of cuttingroom.
Might still have a few too many pockets for normal layer but I've made them all slow access to make up for their laying space and the pockets are all individually fairly small. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->