### PR TITLE
Making Paramilitary Zombies spawn damaged gear.

### DIFF
--- a/data/json/monsterdrops/zombie_survivor.json
+++ b/data/json/monsterdrops/zombie_survivor.json
@@ -83,19 +83,19 @@
     "id": "mon_zombie_paramilitary_death_drops",
     "magazine": 100,
     "entries": [
-      { "group": "clothing_military" },
-      { "item": "elbow_pads", "prob": 10 },
-      { "item": "knee_pads", "prob": 85 },
-      { "group": "operator_headgear", "prob": 80 },
-      { "item": "gloves_tactical", "prob": 60 },
+      { "group": "clothing_military", "damage": [ 1, 4 ] },
+      { "item": "elbow_pads", "damage": [ 1, 4 ], "prob": 10 },
+      { "item": "knee_pads", "damage": [ 1, 4 ], "prob": 85 },
+      { "group": "operator_headgear", "damage": [ 1, 4 ], "prob": 80 },
+      { "item": "gloves_tactical", "damage": [ 1, 4 ], "prob": 60 },
       { "group": "operator_armaments", "prob": 90 },
-      { "group": "bugout_bag", "prob": 10 },
-      { "group": "clothing_tactical_leg", "prob": 15 },
+      { "group": "bugout_bag", "damage": [ 1, 4 ], "prob": 10 },
+      { "group": "clothing_tactical_leg", "damage": [ 1, 4 ], "prob": 15 },
       {
-        "distribution": [ { "group": "clothing_glasses", "prob": 60 }, { "item": "glasses_bal", "prob": 30 } ],
+        "distribution": [ { "group": "clothing_glasses", "damage": [ 1, 4 ], "prob": 60 }, { "item": "glasses_bal", "damage": [ 1, 4 ], "prob": 30 } ],
         "prob": 90
       },
-      { "group": "clothing_watch", "prob": 5 }
+      { "group": "clothing_watch", "damage": [ 1, 4 ], "prob": 5 }
     ]
   },
   {

--- a/data/json/monsterdrops/zombie_survivor.json
+++ b/data/json/monsterdrops/zombie_survivor.json
@@ -92,7 +92,10 @@
       { "group": "bugout_bag", "damage": [ 1, 4 ], "prob": 10 },
       { "group": "clothing_tactical_leg", "damage": [ 1, 4 ], "prob": 15 },
       {
-        "distribution": [ { "group": "clothing_glasses", "damage": [ 1, 4 ], "prob": 60 }, { "item": "glasses_bal", "damage": [ 1, 4 ], "prob": 30 } ],
+        "distribution": [
+          { "group": "clothing_glasses", "damage": [ 1, 4 ], "prob": 60 },
+          { "item": "glasses_bal", "damage": [ 1, 4 ], "prob": 30 }
+        ],
         "prob": 90
       },
       { "group": "clothing_watch", "damage": [ 1, 4 ], "prob": 5 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The Paramilitary Zombies added in #65372 where spawning with perfect, undamaged clothing and armour.

This pull request makes them spawn with damaged gear like other zombies.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added `"damage": [ 1, 4 ]` to most of the lines in the death drops item group.

I didn't change the settings for `operator_armaments` because that resulted in them spawning damaged rifles as well as damaged holsters and LBE, due to how nested groups work with damage.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I considered making it spawn damaged rifles as well as damaged holsters and LBE, but I had a look at Zombie Cops and they also have pristine holsters and LBE. Or trying to refactor it so that the rifles where in a separate group from the holsters.

I decided to stick to how it was done with Zombie Cops, rather than trying to get too fiddly.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Debug spawned and killed a bunch of zombies with and without this patch.

They spawned roughly the same equipment, but after the patch most of it was damaged.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->