### PR TITLE
Mark as dangerous without needing to list all notes

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1061,7 +1061,7 @@
     "type": "keybinding",
     "id": "MARK_DANGER",
     "category": "OVERMAP_NOTES",
-    "name": "Mark/edit danger",
+    "name": "Mark danger",
     "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
   },
   {
@@ -1082,7 +1082,7 @@
     "type": "keybinding",
     "id": "MARK_DANGER",
     "category": "OVERMAP",
-    "name": "Mark/edit danger",
+    "name": "Mark danger",
     "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
   },
   {

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1061,8 +1061,8 @@
     "type": "keybinding",
     "id": "MARK_DANGER",
     "category": "OVERMAP_NOTES",
-    "name": "Mark as dangerous",
-    "bindings": [ { "input_method": "keyboard_char", "key": "M" }, { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] } ]
+    "name": "Mark/edit danger",
+    "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -1077,6 +1077,13 @@
     "category": "OVERMAP",
     "name": "Create/edit note",
     "bindings": [ { "input_method": "keyboard_char", "key": "N" }, { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "MARK_DANGER",
+    "category": "OVERMAP",
+    "name": "Mark/edit danger",
+    "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1876,9 +1876,13 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
             if( overmap_buffer.has_note( curs ) && query_yn( _( "Really delete note?" ) ) ) {
                 overmap_buffer.delete_note( curs );
             }
-        } else if ( action == "MARK_DANGER" ) {
-            // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
-            if( query_yn( _( "Mark area as dangerous ( to avoid on auto move paths? ) This will create a note if none exists already." ) ) ) { //TODO: better handling when a note or dangerous area exists; this is a bit clunky still
+        } else if( action == "MARK_DANGER" ) {
+            if( overmap_buffer.is_marked_dangerous( curs ) &&
+                query_yn( _( "Remove dangerous mark?" ) ) ) {
+                overmap_buffer.mark_note_dangerous( curs, 0,
+                                                    false );// NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
+            } else if( query_yn(
+                           _( "Mark area as dangerous ( to avoid on auto move paths? )  This will create a note if none exists already." ) ) ) {
                 if( !overmap_buffer.has_note( curs ) ) {
                     create_note( curs );
                 }
@@ -1886,17 +1890,14 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
                 // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
                 const std::string popupmsg = _( "Danger radius in overmap squares? ( 0-20 )" );
                 int amount = string_input_popup()
-                                .title( popupmsg )
-                                .width( 20 )
-                                .text( "0" )
-                                .only_digits( true )
-                                .query_int();
+                             .title( popupmsg )
+                             .width( 20 )
+                             .text( "0" )
+                             .only_digits( true )
+                             .query_int();
                 if( amount > -1 && amount <= max_amount ) {
                     overmap_buffer.mark_note_dangerous( curs, amount, true );
                 }
-            } else if( overmap_buffer.is_marked_dangerous( curs ) &&
-                        query_yn( _( "Remove dangerous mark?" ) ) ) {
-                overmap_buffer.mark_note_dangerous( curs, 0, false );
             }
         } else if( action == "LIST_NOTES" ) {
             const point_abs_omt p = draw_notes( curs );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1876,7 +1876,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
             if( overmap_buffer.has_note( curs ) && query_yn( _( "Really delete note?" ) ) ) {
                 overmap_buffer.delete_note( curs );
             }
-        } else if ( action == "MARK_DANGER" ) {
+        } else if ( action == "MARK_DANGER" ) { //TODO: does not actually add danger, just the menus
             // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
             if( query_yn( _( "Mark area as dangerous ( to avoid on auto move paths? )" ) ) ) {
                 const int max_amount = 20;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -411,8 +411,12 @@ class map_notes_callback : public uilist_callback
                     return true;
                 }
                 if( action == "MARK_DANGER" ) {
+                    if( overmap_buffer.is_marked_dangerous( note_location() ) &&
+                        query_yn( _( "Remove dangerous mark?" ) ) ) {
+                        overmap_buffer.mark_note_dangerous( note_location(), 0, false );
+                    }
                     // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
-                    if( query_yn( _( "Mark area as dangerous ( to avoid on auto move paths? )" ) ) ) {
+                    else if( query_yn( _( "Mark area as dangerous ( to avoid on auto move paths? )" ) ) ) {
                         const int max_amount = 20;
                         // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
                         const std::string popupmsg = _( "Danger radius in overmap squares? ( 0-20 )" );
@@ -427,9 +431,6 @@ class map_notes_callback : public uilist_callback
                             menu->ret = UILIST_MAP_NOTE_EDITED;
                             return true;
                         }
-                    } else if( overmap_buffer.is_marked_dangerous( note_location() ) &&
-                               query_yn( _( "Remove dangerous mark?" ) ) ) {
-                        overmap_buffer.mark_note_dangerous( note_location(), 0, false );
                     }
                 }
             }
@@ -1880,9 +1881,11 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
             if( overmap_buffer.is_marked_dangerous( curs ) &&
                 query_yn( _( "Remove dangerous mark?" ) ) ) {
                 overmap_buffer.mark_note_dangerous( curs, 0,
-                                                    false );// NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
-            } else if( query_yn(
-                           _( "Mark area as dangerous ( to avoid on auto move paths? )  This will create a note if none exists already." ) ) ) {
+                                                    false );
+            } else if( ( overmap_buffer.is_marked_dangerous( curs ) &&
+                         query_yn( _( "Edit dangerous mark?" ) ) ) || ( !overmap_buffer.is_marked_dangerous( curs ) &&
+                                 // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
+                                 query_yn( _( "Mark area as dangerous ( to avoid on auto move paths?  This will create a note if none exists already )" ) ) ) ) {
                 if( !overmap_buffer.has_note( curs ) ) {
                     create_note( curs );
                 }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1188,6 +1188,7 @@ static void draw_om_sidebar(
         print_hint( "SEARCH" );
         print_hint( "CREATE_NOTE" );
         print_hint( "DELETE_NOTE" );
+        print_hint( "MARK_DANGER" );
         print_hint( "LIST_NOTES" );
         print_hint( "MISSIONS" );
         print_hint( "TOGGLE_MAP_NOTES", uistate.overmap_show_map_notes ? c_pink : c_magenta );
@@ -1793,6 +1794,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
     ictxt.register_action( "CENTER" );
     ictxt.register_action( "CREATE_NOTE" );
     ictxt.register_action( "DELETE_NOTE" );
+    ictxt.register_action( "MARK_DANGER" );
     ictxt.register_action( "SEARCH" );
     ictxt.register_action( "LIST_NOTES" );
     ictxt.register_action( "TOGGLE_MAP_NOTES" );
@@ -1873,6 +1875,27 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
         } else if( action == "DELETE_NOTE" ) {
             if( overmap_buffer.has_note( curs ) && query_yn( _( "Really delete note?" ) ) ) {
                 overmap_buffer.delete_note( curs );
+            }
+        } else if ( action == "MARK_DANGER" ) {
+            // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
+            if( query_yn( _( "Mark area as dangerous ( to avoid on auto move paths? )" ) ) ) {
+                const int max_amount = 20;
+                // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
+                const std::string popupmsg = _( "Danger radius in overmap squares? ( 0-20 )" );
+                int amount = string_input_popup()
+                                .title( popupmsg )
+                                .width( 20 )
+                                .text( "0" )
+                                .only_digits( true )
+                                .query_int();
+                if( amount > -1 && amount <= max_amount ) {
+                    overmap_buffer.mark_note_dangerous( note_location(), amount, true );
+                    menu->ret = UILIST_MAP_NOTE_EDITED;
+                    return true;
+                }
+            } else if( overmap_buffer.is_marked_dangerous( note_location() ) &&
+                        query_yn( _( "Remove dangerous mark?" ) ) ) {
+                overmap_buffer.mark_note_dangerous( note_location(), 0, false );
             }
         } else if( action == "LIST_NOTES" ) {
             const point_abs_omt p = draw_notes( curs );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1876,9 +1876,12 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
             if( overmap_buffer.has_note( curs ) && query_yn( _( "Really delete note?" ) ) ) {
                 overmap_buffer.delete_note( curs );
             }
-        } else if ( action == "MARK_DANGER" ) { //TODO: does not actually add danger, just the menus
+        } else if ( action == "MARK_DANGER" ) {
             // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
-            if( query_yn( _( "Mark area as dangerous ( to avoid on auto move paths? )" ) ) ) {
+            if( query_yn( _( "Mark area as dangerous ( to avoid on auto move paths? ) This will create a note if none exists already." ) ) ) { //TODO: better handling when a note or dangerous area exists; this is a bit clunky still
+                if( !overmap_buffer.has_note( curs ) ) {
+                    create_note( curs );
+                }
                 const int max_amount = 20;
                 // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
                 const std::string popupmsg = _( "Danger radius in overmap squares? ( 0-20 )" );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -416,7 +416,11 @@ class map_notes_callback : public uilist_callback
                         overmap_buffer.mark_note_dangerous( note_location(), 0, false );
                     }
                     // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
-                    else if( query_yn( _( "Mark area as dangerous ( to avoid on auto move paths? )" ) ) ) {
+                    else if( ( overmap_buffer.is_marked_dangerous( note_location() ) &&
+                               query_yn( _( "Edit dangerous mark?" ) ) ) ||
+                             ( !overmap_buffer.is_marked_dangerous( note_location() ) &&
+                               // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
+                               query_yn( _( "Mark area as dangerous ( to avoid on auto move paths?  This will create a note if none exists already )" ) ) ) ) {
                         const int max_amount = 20;
                         // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
                         const std::string popupmsg = _( "Danger radius in overmap squares? ( 0-20 )" );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1889,13 +1889,11 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
                                 .only_digits( true )
                                 .query_int();
                 if( amount > -1 && amount <= max_amount ) {
-                    overmap_buffer.mark_note_dangerous( note_location(), amount, true );
-                    menu->ret = UILIST_MAP_NOTE_EDITED;
-                    return true;
+                    overmap_buffer.mark_note_dangerous( curs, amount, true );
                 }
-            } else if( overmap_buffer.is_marked_dangerous( note_location() ) &&
+            } else if( overmap_buffer.is_marked_dangerous( curs ) &&
                         query_yn( _( "Remove dangerous mark?" ) ) ) {
-                overmap_buffer.mark_note_dangerous( note_location(), 0, false );
+                overmap_buffer.mark_note_dangerous( curs, 0, false );
             }
         } else if( action == "LIST_NOTES" ) {
             const point_abs_omt p = draw_notes( curs );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Adds the 'Mark as dangerous' keybinding to the overmap"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Makes marking dangerous areas more streamlined instead of going through an additional menu
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Copies code from the method used in the overmap notes menu, with additional adjustments for consistency between the two methods.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Knowing what I'm doing
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
You can mark dangerous areas on tiles with or without a note already set, and edit or remove the mark just as easily. Default keybinding appears and works as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
First actual C++ contribution, will need review.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->