### PR TITLE
Apply exodii faction ownership to the exodii's safehouse stores

### DIFF
--- a/data/json/mapgen/exodii/exo_safehouse.json
+++ b/data/json/mapgen/exodii/exo_safehouse.json
@@ -6,6 +6,7 @@
     "weight": 100,
     "method": "json",
     "object": {
+      "faction_owner": [ { "id": "exodii", "x": [ 5, 17 ], "y": [ 5, 18 ] } ],
       "rows": [
         "        .........       ",
         "     ....,,,,,,,....    ",
@@ -73,6 +74,7 @@
     "weight": 100,
     "method": "json",
     "object": {
+      "faction_owner": [ { "id": "exodii", "x": [ 5, 17 ], "y": [ 5, 18 ] } ],
       "fill_ter": "t_junk_floor",
       "rows": [
         "vvvvvvvvvvvvvvvvvvvvvvvv",
@@ -110,6 +112,7 @@
     "weight": 100,
     "method": "json",
     "object": {
+      "faction_owner": [ { "id": "exodii", "x": [ 5, 17 ], "y": [ 5, 18 ] } ],
       "fill_ter": "t_tile_flat_roof",
       "rows": [
         "vvvvvvvvvvvvvvvvvvvvvvvv",


### PR DESCRIPTION
#### Summary
Bugfixes "Exodii will now properly be mad at you if you steal all their resources from stone barns"

#### Purpose of change
You could just run around the place stealing whatever you want, including the enormous ingots, their guns, their ammo, everything. (Rubik's massive overmap special has faction ownership applied already so that didn't need any changes)

* Closes #63729

#### Describe the solution
Actually apply faction ownership. More specifically, I draw a single bounding box to define faction ownership over the mapgen's area, corresponding to this image:
![image](https://user-images.githubusercontent.com/84619419/236619486-03c750ce-0259-4908-8baf-e5952b9a8c0b.png)


#### Describe alternatives you've considered
The crates should have explosives with anti-tamper fuses :)

#### Testing
Loaded locally, debug spawned multiple levels of the exodii safehouse and confirmed the items spawned within the crates would be properly marked for ownership.
![image](https://user-images.githubusercontent.com/84619419/236619195-fa7e4816-bddb-4f51-8f6e-db810be6a8ac.png)


#### Additional context
The exodii automatons still can't do anything about your theft, but I think that's... ok given their relative intelligence? Definitely out of scope. Only Rubik, Luliya, and any other *actual NPC* of the exodii faction should be able to confront you.

You can also still do things like deconstruct/smash the furniture without the automatons caring but that is again, a much bigger issue.