### PR TITLE
[CR] Modify do_turn to update NPC morale when player morale is updated

### DIFF
--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -689,10 +689,16 @@ bool do_turn()
 
     if( calendar::once_every( 1_minutes ) ) {
         u.update_morale();
+        for( npc &guy : g->all_npcs() ) {
+            guy.update_morale();
+        }
     }
 
     if( calendar::once_every( 9_turns ) ) {
         u.check_and_recover_morale();
+        for( npc &guy : g->all_npcs() ) {
+            guy.check_and_recover_morale();
+        }
     }
 
     if( !u.is_deaf() ) {

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -691,14 +691,12 @@ bool do_turn()
         u.update_morale();
         for( npc &guy : g->all_npcs() ) {
             guy.update_morale();
+            guy.check_and_recover_morale();
         }
     }
 
     if( calendar::once_every( 9_turns ) ) {
         u.check_and_recover_morale();
-        for( npc &guy : g->all_npcs() ) {
-            guy.check_and_recover_morale();
-        }
     }
 
     if( !u.is_deaf() ) {


### PR DESCRIPTION
#### Summary
Bugfixes "NPC morale modifiers now updates regularly instead of being permanently applied"

#### Purpose of change
* Fixes #65492

#### Describe the solution
Find all NPCs, apply morale functions on them same as the player.

#### Describe alternatives you've considered

#### Testing
Compiled, loaded save from linked issue and checked NPC morale. Checked at various intervals, confirmed negative morale disappeared over time and all positive effects disappeared after 3 hours. Reloaded, confirmed all morale effects disappeared after 3 hours even without intermittent checking (i.e. they were NPC at the whole time before performing the body switch)

#### Additional context
Is do_turn really the place to be doing this? It's the main game loop, and where player morale is already being processed but... it feels kind of wrong?

This runs pretty infrequently so I wouldn't imagine it would cause performance problems, but modifying do_turn is pretty scary to me. 