### PR TITLE
Initial Implementation Of Replacable Limbs

### DIFF
--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -110,6 +110,98 @@
     "sub_parts": [ "torso_upper", "torso_neck", "torso_lower", "torso_hanging_front", "torso_hanging_back", "torso_waist" ]
   },
   {
+    "id": "big_head",
+    "type": "body_part",
+    "name": "big head",
+    "accusative": { "ctxt": "bodypart_accusative", "str": "head" },
+    "heading": "big head",
+    "heading_multiple": "big heads",
+    "hp_bar_ui_text": "HEAD",
+    "encumbrance_text": "Dodging and blocking is hampered.",
+    "encumbrance_threshold": 10,
+    "main_part": "big_head",
+    "connected_to": "big_head",
+    "opposite_part": "big_head",
+    "limb_type": "head",
+    "limb_scores": [ [ "reaction", 0.3 ] ],
+    "is_vital": true,
+    "hit_size": 4,
+    "hit_difficulty": 1.2,
+    "side": "both",
+    "grabbing_effect": "grabbing_head",
+    "stylish_bonus": 3,
+    "hot_morale_mod": 2,
+    "cold_morale_mod": 2,
+    "fire_warmth_bonus": 150,
+    "squeamish_penalty": 7,
+    "base_hp": 60,
+    "drench_capacity": 700,
+    "smash_message": "You smash the %s with a firm headbutt.",
+    "smash_efficiency": 0.25,
+    "bionic_slots": 18,
+    "flags": [ "LIMB_UPPER" ],
+    "sub_parts": [ "head_forehead", "head_crown", "head_nape", "head_throat", "head_ear_r", "head_ear_l" ],
+    "encumbrance_per_weight": [
+      { "weight": "1 mg", "encumbrance": 1 },
+      { "weight": "300 g", "encumbrance": 4 },
+      { "weight": "800 g", "encumbrance": 8 },
+      { "weight": "1300 g", "encumbrance": 20 },
+      { "weight": "1600 g", "encumbrance": 30 },
+      { "weight": "2200 g", "encumbrance": 50 },
+      { "weight": "5600 g", "encumbrance": 80 },
+      { "weight": "10000 g", "encumbrance": 160 }
+    ],
+    "effects_on_hit": [
+      {
+        "id": "bleed",
+        "dmg_type": "cut",
+        "dmg_threshold": 5,
+        "dmg_scale_increment": 2,
+        "duration": 60,
+        "duration_dmg_scaling": 30,
+        "max_duration": 960
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "stab",
+        "dmg_threshold": 1,
+        "dmg_scale_increment": 1.5,
+        "duration": 60,
+        "duration_dmg_scaling": 60,
+        "max_duration": 1200
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "bullet",
+        "dmg_threshold": 1,
+        "dmg_scale_increment": 1,
+        "duration": 60,
+        "duration_dmg_scaling": 60
+      },
+      {
+        "id": "stunned",
+        "dmg_type": "bash",
+        "dmg_threshold": 10,
+        "dmg_scale_increment": 5,
+        "chance": 10,
+        "chance_dmg_scaling": 10,
+        "duration": 1,
+        "duration_dmg_scaling": 0.5,
+        "max_duration": 4
+      },
+      {
+        "id": "stunned",
+        "dmg_threshold": 30,
+        "dmg_scale_increment": 10,
+        "chance": 10,
+        "chance_dmg_scaling": 10,
+        "duration": 1,
+        "duration_dmg_scaling": 0.5,
+        "max_duration": 4
+      }
+    ]
+  },
+  {
     "id": "head",
     "type": "body_part",
     "name": "head",

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -25,10 +25,7 @@
     "type": "enchantment",
     "id": "ENCH_DEBUG_BIG_HEAD",
     "condition": "ALWAYS",
-    "modified_bodyparts": [
-      { "lose": "head" },
-      { "gain": "big_head" }
-    ]
+    "modified_bodyparts": [ { "lose": "head" }, { "gain": "big_head" } ]
   },
   {
     "type": "enchantment",

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -23,6 +23,15 @@
   },
   {
     "type": "enchantment",
+    "id": "ENCH_DEBUG_BIG_HEAD",
+    "condition": "ALWAYS",
+    "modified_bodyparts": [
+      { "lose": "head" },
+      { "gain": "big_head" }
+    ]
+  },
+  {
+    "type": "enchantment",
     "id": "RM13",
     "condition": "ACTIVE",
     "values": [

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8156,6 +8156,16 @@
   },
   {
     "type": "mutation",
+    "id": "DEBUG_BIG_HEAD",
+    "name": { "str": "Debug Big Head" },
+    "points": 99,
+    "valid": false,
+    "description": "They said college what make me smart, this is a lot to lug around!",
+    "enchantments": [ "ENCH_DEBUG_BIG_HEAD" ],
+    "debug": true
+  },
+  {
+    "type": "mutation",
     "id": "DEBUG_NIGHTVISION",
     "name": { "str": "Debug Night Vision" },
     "points": 99,

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1992,7 +1992,7 @@ bool Creature::has_part( const bodypart_id &id ) const
 
 bodypart *Creature::get_part( const bodypart_id &id )
 {
-    auto found = body.find( id.id() );
+    auto found = body.find( get_part_id( id ).id() );
     if( found == body.end() ) {
         debugmsg( "Could not find bodypart %s in %s's body", id.id().c_str(), get_name() );
         return nullptr;
@@ -2002,7 +2002,7 @@ bodypart *Creature::get_part( const bodypart_id &id )
 
 const bodypart *Creature::get_part( const bodypart_id &id ) const
 {
-    auto found = body.find( id.id() );
+    auto found = body.find( get_part_id( id ).id() );
     if( found == body.end() ) {
         debugmsg( "Could not find bodypart %s in %s's body", id.id().c_str(), get_name() );
         return nullptr;
@@ -2043,6 +2043,38 @@ static void set_part_helper( Creature &c, const bodypart_id &id,
     if( part ) {
         ( part->*set )( val );
     }
+}
+
+const bodypart_id Creature::get_part_id( const bodypart_id &id ) const
+{
+    auto found = body.find( id.id() );
+    if( found == body.end() ) {
+        // try to find an equivalent part in the body map
+        for( auto &bp : body ) {
+            if( id->part_side == bp.first->part_side &&
+                id->primary_limb_type() == bp.first->primary_limb_type() ) {
+                return bp.first;
+            }
+        }
+
+        // try to find the next best thing
+        std::pair<bodypart_id, float> best = { body_part_bp_null, 0.0 };
+        for( auto &bp : body ) {
+            for( const auto &mp : bp.first->limbtypes ) {
+                // if the secondary limb type matches and is better than the current
+                if( mp.first == id->primary_limb_type() && mp.second > best.second ) {
+                    best = { bp.first, mp.second };
+                }
+            }
+        }
+
+        if( best.first == body_part_bp_null ) {
+            debugmsg( "Could not find equivalent bodypart id %s in %s's body", id.id().c_str(), get_name() );
+        }
+
+        return best.first;
+    }
+    return found->first;
 }
 
 int Creature::get_part_hp_cur( const bodypart_id &id ) const
@@ -2281,7 +2313,7 @@ bodypart_id Creature::get_random_body_part( bool main ) const
     return main ? part->main_part.id() : part;
 }
 
-static void sort_body_parts( std::vector<bodypart_id> &bps )
+static void sort_body_parts( std::vector<bodypart_id> &bps, const Creature *c )
 {
     // We want to dynamically sort the parts based on their connections as
     // defined in json.
@@ -2293,7 +2325,7 @@ static void sort_body_parts( std::vector<bodypart_id> &bps )
     std::unordered_map<bodypart_id, cata::flat_set<bodypart_id>> parts_connected_to;
     bodypart_id root_part;
     for( const bodypart_id &bp : bps ) {
-        bodypart_id conn = bp->connected_to;
+        bodypart_id conn = c->get_part_id( bp->connected_to );
         if( conn == bp ) {
             root_part = bp;
         } else {
@@ -2326,7 +2358,7 @@ static void sort_body_parts( std::vector<bodypart_id> &bps )
         parts_with_no_connections.erase( last );
         unaccounted_parts.erase( bp );
         topo_sorted_parts.push_back( bp );
-        bodypart_id conn = bp->connected_to;
+        bodypart_id conn = c->get_part_id( bp->connected_to );
         if( conn == bp ) {
             break;
         }
@@ -2410,7 +2442,7 @@ std::vector<bodypart_id> Creature::get_all_body_parts( get_body_part_flags flags
     }
 
     if( flags & get_body_part_flags::sorted ) {
-        sort_body_parts( all_bps );
+        sort_body_parts( all_bps, this );
     }
 
     return  all_bps;
@@ -2448,7 +2480,7 @@ std::vector<bodypart_id> Creature::get_all_body_parts_of_type(
     }
 
     if( flags & get_body_part_flags::sorted ) {
-        sort_body_parts( bodyparts );
+        sort_body_parts( bodyparts, this );
     }
 
     return bodyparts;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2045,7 +2045,7 @@ static void set_part_helper( Creature &c, const bodypart_id &id,
     }
 }
 
-const bodypart_id Creature::get_part_id( const bodypart_id &id ) const
+bodypart_id Creature::get_part_id( const bodypart_id &id ) const
 {
     auto found = body.find( id.id() );
     if( found == body.end() ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2050,7 +2050,7 @@ const bodypart_id Creature::get_part_id( const bodypart_id &id ) const
     auto found = body.find( id.id() );
     if( found == body.end() ) {
         // try to find an equivalent part in the body map
-        for( auto &bp : body ) {
+        for( const auto &bp : body ) {
             if( id->part_side == bp.first->part_side &&
                 id->primary_limb_type() == bp.first->primary_limb_type() ) {
                 return bp.first;
@@ -2059,7 +2059,7 @@ const bodypart_id Creature::get_part_id( const bodypart_id &id ) const
 
         // try to find the next best thing
         std::pair<bodypart_id, float> best = { body_part_bp_null, 0.0 };
-        for( auto &bp : body ) {
+        for( const auto &bp : body ) {
             for( const auto &mp : bp.first->limbtypes ) {
                 // if the secondary limb type matches and is better than the current
                 if( mp.first == id->primary_limb_type() && mp.second > best.second ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2050,7 +2050,7 @@ bodypart_id Creature::get_part_id( const bodypart_id &id ) const
     auto found = body.find( id.id() );
     if( found == body.end() ) {
         // try to find an equivalent part in the body map
-        for( const auto &bp : body ) {
+        for( const std::pair<const bodypart_str_id, bodypart> &bp : body ) {
             if( id->part_side == bp.first->part_side &&
                 id->primary_limb_type() == bp.first->primary_limb_type() ) {
                 return bp.first;
@@ -2059,8 +2059,8 @@ bodypart_id Creature::get_part_id( const bodypart_id &id ) const
 
         // try to find the next best thing
         std::pair<bodypart_id, float> best = { body_part_bp_null, 0.0 };
-        for( const auto &bp : body ) {
-            for( const auto &mp : bp.first->limbtypes ) {
+        for( const std::pair<const bodypart_str_id, bodypart> &bp : body ) {
+            for( const std::pair<const body_part_type::type, float> &mp : bp.first->limbtypes ) {
                 // if the secondary limb type matches and is better than the current
                 if( mp.first == id->primary_limb_type() && mp.second > best.second ) {
                     // give an inflated bonus if the part sides match

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2063,7 +2063,9 @@ const bodypart_id Creature::get_part_id( const bodypart_id &id ) const
             for( const auto &mp : bp.first->limbtypes ) {
                 // if the secondary limb type matches and is better than the current
                 if( mp.first == id->primary_limb_type() && mp.second > best.second ) {
-                    best = { bp.first, mp.second };
+                    // give an inflated bonus if the part sides match
+                    float bonus = id->part_side == bp.first->part_side ? 1.0 : 0.0;
+                    best = { bp.first, mp.second + bonus };
                 }
             }
         }

--- a/src/creature.h
+++ b/src/creature.h
@@ -766,6 +766,9 @@ class Creature : public viewer
         bodypart *get_part( const bodypart_id &id );
         const bodypart *get_part( const bodypart_id &id ) const;
 
+        // get the body part id that matches for the character
+        const bodypart_id get_part_id( const bodypart_id &id ) const;
+
         int get_part_hp_cur( const bodypart_id &id ) const;
         int get_part_hp_max( const bodypart_id &id ) const;
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -767,7 +767,7 @@ class Creature : public viewer
         const bodypart *get_part( const bodypart_id &id ) const;
 
         // get the body part id that matches for the character
-        const bodypart_id get_part_id( const bodypart_id &id ) const;
+        bodypart_id get_part_id( const bodypart_id &id ) const;
 
         int get_part_hp_cur( const bodypart_id &id ) const;
         int get_part_hp_max( const bodypart_id &id ) const;

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -705,7 +705,11 @@ void widget::set_default_var_range( const avatar &ava )
         case widget_var::bp_hp:
             // HP for body part
             _var_min = 0;
-            _var_max = ava.get_part_hp_max( only_bp() );
+            if( ava.has_part( only_bp() ) ) {
+                _var_max = ava.get_part_hp_max( only_bp() );
+            } else {
+                _var_max = 0;
+            }
             break;
         case widget_var::bp_encumb:
             _var_min = 0;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#51294
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
When a creature's body is checked for an id, the game will attempt to find the next best thing if it doesn't have the exact request.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added big head mode, this probably breaks a pile of things still needs testing.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
The primary benefit of this system is it solves most of our problems while letting any individual system do more accurate simulation later on. However, for now, things should still for the most part make some sense. As an example if you were to step in acid and that should deal damage hard coded to the "FOOT_L" and "FOOT_R" well this will try to find the thing you are using as feet and damage it in its place.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->