### PR TITLE
[Magiclysm] Small tweaks for mage armor and mage blade

### DIFF
--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -959,7 +959,7 @@
     "category": "armor",
     "copy-from": "armor_lightplate",
     "name": { "str_sp": "mage armor" },
-    "description": "A summoned magic armor.  It gets shinier and sturdier with each spell level.",
+    "description": "A summoned magic armor. It gets shinier and sturdier with each spell level and is affected by your intelligence.",
     "weight": "1 g",
     "material": [ "concentrated_mana" ],
     "warmth": 0,

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -959,7 +959,7 @@
     "category": "armor",
     "copy-from": "armor_lightplate",
     "name": { "str_sp": "mage armor" },
-    "description": "A summoned magic armor. It gets shinier and sturdier with each spell level and is affected by your intelligence.",
+    "description": "A summoned magic armor.  It gets shinier and sturdier with each spell level and is affected by your intelligence.",
     "weight": "1 g",
     "material": [ "concentrated_mana" ],
     "warmth": 0,

--- a/data/mods/Magiclysm/items/item_enchants.json
+++ b/data/mods/Magiclysm/items/item_enchants.json
@@ -4,7 +4,7 @@
     "id": "ench_longsword_holy",
     "has": "WIELD",
     "condition": "ALWAYS",
-    "name": { "str": "magical blade" },
+    "name": { "str": "Magic blade" },
     "description": "The damage done and light emitted by this sword increase with intelligence.",
     "values": [
       {
@@ -30,7 +30,7 @@
     "id": "ench_armor_spirit",
     "has": "WORN",
     "condition": "ALWAYS",
-    "name": { "str": "magic armor" },
+    "name": { "str": "Magic armor" },
     "description": "This magical armor improves with your intelligence and the spell's level.",
     "values": [
       {

--- a/data/mods/Magiclysm/items/item_enchants.json
+++ b/data/mods/Magiclysm/items/item_enchants.json
@@ -23,27 +23,57 @@
     "has": "WORN",
     "condition": "ALWAYS",
     "name": { "str": "magic armor" },
-    "description": "This armor is made better as your spell level improves.",
+    "description": "This magical armor improves with your intelligence and the spell's level.",
     "values": [
       {
         "value": "ARMOR_BASH",
-        "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": -1 } ] }
+        "add": {
+          "arithmetic": [
+            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": -1 } ] },
+            "+",
+            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": -1 } ] }
+          ]
+        }
       },
       {
         "value": "ARMOR_CUT",
-        "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": -1 } ] }
+        "add": {
+          "arithmetic": [
+            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": -1 } ] },
+            "+",
+            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": -1 } ] }
+          ]
+        }
       },
       {
         "value": "ARMOR_STAB",
-        "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": -1 } ] }
+        "add": {
+          "arithmetic": [
+            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": -1 } ] },
+            "+",
+            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": -1 } ] }
+          ]
+        }
       },
       {
         "value": "ARMOR_BULLET",
-        "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": -1 } ] }
+        "add": {
+          "arithmetic": [
+            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": -1 } ] },
+            "+",
+            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": -1 } ] }
+          ]
+        }
       },
       {
         "value": "LUMINATION",
-        "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "spirit_armor" }, "*", { "const": 3 } ] }
+        "add": {
+          "arithmetic": [
+            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": 3 } ] },
+            "+",
+            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": 3 } ] }
+          ]
+        }
       }
     ]
   }

--- a/data/mods/Magiclysm/items/item_enchants.json
+++ b/data/mods/Magiclysm/items/item_enchants.json
@@ -7,10 +7,21 @@
     "name": { "str": "magical blade" },
     "description": "The damage done and light emitted by this sword increase with intelligence.",
     "values": [
-      { "value": "ITEM_DAMAGE_CUT", "add": { "math": [ "u_val('spell_level', 'spell: holy_blade')+u_val('intelligence')" ] } },
+      {
+        "value": "ITEM_DAMAGE_CUT",
+        "add": {
+          "math": [
+            "(u_val('intelligence') * 2) + (u_val('spell_level', 'spell: holy_blade') + u_val('spell_level', 'spell: holy_blade_plus'))"
+          ]
+        }
+      },
       {
         "value": "LUMINATION",
-        "add": { "math": [ "u_val('spell_level', 'spell: holy_blade')+u_val('intelligence')", "*", "3" ] }
+        "add": {
+          "math": [
+            "((u_val('intelligence') * 2) + (u_val('spell_level', 'spell: holy_blade') + u_val('spell_level', 'spell: holy_blade_plus'))) * 3"
+          ]
+        }
       }
     ]
   },
@@ -24,23 +35,43 @@
     "values": [
       {
         "value": "ARMOR_BASH",
-        "add": { "math": [ "u_val('spell_level', 'spell: armor_spirit')+u_val('intelligence')", "*", "-1" ] }
+        "add": {
+          "math": [
+            "((u_val('intelligence') * 1.5) + (u_val('spell_level', 'spell: spirit_armor') + u_val('spell_level', 'spell: spirit_armor_plus')) * 0.5) * -1"
+          ]
+        }
       },
       {
         "value": "ARMOR_CUT",
-        "add": { "math": [ "u_val('spell_level', 'spell: armor_spirit')+u_val('intelligence')", "*", "-1" ] }
+        "add": {
+          "math": [
+            "((u_val('intelligence') * 1.5) + (u_val('spell_level', 'spell: spirit_armor') + u_val('spell_level', 'spell: spirit_armor_plus')) * 0.5) * -1"
+          ]
+        }
       },
       {
         "value": "ARMOR_STAB",
-        "add": { "math": [ "u_val('spell_level', 'spell: armor_spirit')+u_val('intelligence')", "*", "-1" ] }
+        "add": {
+          "math": [
+            "((u_val('intelligence') * 1.5) + (u_val('spell_level', 'spell: spirit_armor') + u_val('spell_level', 'spell: spirit_armor_plus')) * 0.5) * -1"
+          ]
+        }
       },
       {
         "value": "ARMOR_BULLET",
-        "add": { "math": [ "u_val('spell_level', 'spell: armor_spirit')+u_val('intelligence')", "*", "-1" ] }
+        "add": {
+          "math": [
+            "((u_val('intelligence') * 1.5) + (u_val('spell_level', 'spell: spirit_armor') + u_val('spell_level', 'spell: spirit_armor_plus')) * 0.5) * -1"
+          ]
+        }
       },
       {
         "value": "LUMINATION",
-        "add": { "math": [ "u_val('spell_level', 'spell: armor_spirit')+u_val('intelligence')", "*", "3" ] }
+        "add": {
+          "math": [
+            "((u_val('intelligence') * 1.5) + (u_val('spell_level', 'spell: spirit_armor') + u_val('spell_level', 'spell: spirit_armor_plus')) * 0.5) * 3"
+          ]
+        }
       }
     ]
   }

--- a/data/mods/Magiclysm/items/item_enchants.json
+++ b/data/mods/Magiclysm/items/item_enchants.json
@@ -7,13 +7,10 @@
     "name": { "str": "magical blade" },
     "description": "The damage done and light emitted by this sword increase with intelligence.",
     "values": [
-      {
-        "value": "ITEM_DAMAGE_CUT",
-        "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "holy_blade" }, "+", { "u_val": "intelligence" } ] }
-      },
+      { "value": "ITEM_DAMAGE_CUT", "add": { "math": [ "u_val('spell_level', 'spell: holy_blade')+u_val('intelligence')" ] } },
       {
         "value": "LUMINATION",
-        "add": { "arithmetic": [ { "u_val": "spell_level", "spell": "holy_blade" }, "+", { "u_val": "intelligence" } ] }
+        "add": { "math": [ "u_val('spell_level', 'spell: holy_blade')+u_val('intelligence')", "*", "3" ] }
       }
     ]
   },
@@ -27,53 +24,23 @@
     "values": [
       {
         "value": "ARMOR_BASH",
-        "add": {
-          "arithmetic": [
-            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": -1 } ] },
-            "+",
-            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": -1 } ] }
-          ]
-        }
+        "add": { "math": [ "u_val('spell_level', 'spell: armor_spirit')+u_val('intelligence')", "*", "-1" ] }
       },
       {
         "value": "ARMOR_CUT",
-        "add": {
-          "arithmetic": [
-            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": -1 } ] },
-            "+",
-            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": -1 } ] }
-          ]
-        }
+        "add": { "math": [ "u_val('spell_level', 'spell: armor_spirit')+u_val('intelligence')", "*", "-1" ] }
       },
       {
         "value": "ARMOR_STAB",
-        "add": {
-          "arithmetic": [
-            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": -1 } ] },
-            "+",
-            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": -1 } ] }
-          ]
-        }
+        "add": { "math": [ "u_val('spell_level', 'spell: armor_spirit')+u_val('intelligence')", "*", "-1" ] }
       },
       {
         "value": "ARMOR_BULLET",
-        "add": {
-          "arithmetic": [
-            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": -1 } ] },
-            "+",
-            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": -1 } ] }
-          ]
-        }
+        "add": { "math": [ "u_val('spell_level', 'spell: armor_spirit')+u_val('intelligence')", "*", "-1" ] }
       },
       {
         "value": "LUMINATION",
-        "add": {
-          "arithmetic": [
-            { "arithmetic": [ { "u_val": "spell_level", "spell": "armor_spirit" }, "*", { "const": 3 } ] },
-            "+",
-            { "arithmetic": [ { "u_val": "intelligence" }, "*", { "const": 3 } ] }
-          ]
-        }
+        "add": { "math": [ "u_val('spell_level', 'spell: armor_spirit')+u_val('intelligence')", "*", "3" ] }
       }
     ]
   }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Author of #65356 did some job, but they do not respond, and afterwards i found a need to make another changes here and there
Closes #65356
#### Describe the solution
Magic blade gives additional cut damage bonus, which is equal of the player's double intelligent stat, and the sum of holy_blade and holy_blade_plus spell levels (player with int 10 and holy_blade lvl 10 deals additional [ (10*2) + 10 = ] 30 cut damage with sword)
Magic armor gives additional physical armor bonus, which is equal of the player's one and a half intelligent stat, and the half sum of spirit_armor and spirit_armor_plus spell levels (player with int 10 and spirit_armor lvl 10 has additional [ (10 * 1.5) + (10 * 0.5) = ] 20 armor)
#### Testing
Tested against debug monster, looks good, but lack of UI to show the damage is kinda sad