### PR TITLE
Improve EOC error reporting

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2762,7 +2762,7 @@ double eoc_math::act( dialogue &d ) const
             return lhs->eval( d ) >= rhs->eval( d );
         case oper::invalid:
         default:
-            debugmsg( "unknown eoc math operator %d", action );
+            debugmsg( "unknown eoc math operator %d %s", action, d.get_callstack() );
     }
 
     return 0;

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -230,8 +230,8 @@ struct dialogue {
 
         const std::unordered_map<std::string, std::string> &get_context() const;
         const std::unordered_map<std::string, std::function<bool( dialogue & )>> &get_conditionals() const;
-        void amend_callstack( std::string value );
-        const std::string get_callstack() const;
+        void amend_callstack( const std::string &value );
+        std::string get_callstack() const;
     private:
         /**
          * The talker that speaks (almost certainly representing the avatar, ie get_avatar() )

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -230,6 +230,8 @@ struct dialogue {
 
         const std::unordered_map<std::string, std::string> &get_context() const;
         const std::unordered_map<std::string, std::function<bool( dialogue & )>> &get_conditionals() const;
+        void amend_callstack( std::string value );
+        const std::string get_callstack() const;
     private:
         /**
          * The talker that speaks (almost certainly representing the avatar, ie get_avatar() )

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -58,11 +58,11 @@ std::string str_or_var::evaluate( dialogue const &d ) const
             var_name = var_name.substr( 12 );
         }
         debugmsg( "No default value provided for str_or_var_part while encountering unused "
-                  "variable %s.  Add a \"default_str\" member to prevent this.",
-                  var_name );
+                  "variable %s.  Add a \"default_str\" member to prevent this. %s",
+                  var_name, d.get_callstack() );
         return "";
     }
-    debugmsg( "No valid value for str_or_var_part." );
+    debugmsg( "No valid value for str_or_var_part. %s", d.get_callstack() );
     return "";
 }
 
@@ -84,8 +84,8 @@ double dbl_or_var_part::evaluate( dialogue &d ) const
             var_name = var_name.substr( 12 );
         }
         debugmsg( "No default value provided for dbl_or_var_part while encountering unused "
-                  "variable %s.  Add a \"default\" member to prevent this.",
-                  var_name );
+                  "variable %s.  Add a \"default\" member to prevent this. %s",
+                  var_name, d.get_callstack() );
         return 0;
     }
     if( arithmetic_val.has_value() ) {
@@ -95,13 +95,13 @@ double dbl_or_var_part::evaluate( dialogue &d ) const
         if( !val.empty() ) {
             return std::stof( val );
         }
-        debugmsg( "No valid arithmetic value for dbl_or_var_part." );
+        debugmsg( "No valid arithmetic value for dbl_or_var_part. %s", d.get_callstack() );
         return 0;
     }
     if( math_val ) {
         return math_val->act( d );
     }
-    debugmsg( "No valid value for dbl_or_var_part." );
+    debugmsg( "No valid value for dbl_or_var_part. %s", d.get_callstack() );
     return 0;
 }
 
@@ -133,8 +133,8 @@ time_duration duration_or_var_part::evaluate( dialogue &d ) const
             var_name = var_name.substr( 12 );
         }
         debugmsg( "No default value provided for duration_or_var_part while encountering unused "
-                  "variable %s.  Add a \"default\" member to prevent this.",
-                  var_name );
+                  "variable %s.  Add a \"default\" member to prevent this. %s",
+                  var_name, d.get_callstack() );
         return 0_seconds;
     }
     if( arithmetic_val.has_value() ) {
@@ -146,13 +146,13 @@ time_duration duration_or_var_part::evaluate( dialogue &d ) const
             ret_val = time_duration::from_turns( std::stoi( val ) );
             return ret_val;
         }
-        debugmsg( "No valid arithmetic value for duration_or_var_part." );
+        debugmsg( "No valid arithmetic value for duration_or_var_part. %s", d.get_callstack() );
         return 0_seconds;
     }
     if( math_val ) {
         return time_duration::from_turns( math_val->act( d ) );
     }
-    debugmsg( "No valid value for duration_or_var_part." );
+    debugmsg( "No valid value for duration_or_var_part. %s", d.get_callstack() );
     return 0_seconds;
 }
 

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -58,11 +58,11 @@ std::string str_or_var::evaluate( dialogue const &d ) const
             var_name = var_name.substr( 12 );
         }
         debugmsg( "No default value provided for str_or_var_part while encountering unused "
-                  "variable %s.  Add a \"default_str\" member to prevent this. %s",
+                  "variable %s.  Add a \"default_str\" member to prevent this.  %s",
                   var_name, d.get_callstack() );
         return "";
     }
-    debugmsg( "No valid value for str_or_var_part. %s", d.get_callstack() );
+    debugmsg( "No valid value for str_or_var_part.  %s", d.get_callstack() );
     return "";
 }
 
@@ -84,7 +84,7 @@ double dbl_or_var_part::evaluate( dialogue &d ) const
             var_name = var_name.substr( 12 );
         }
         debugmsg( "No default value provided for dbl_or_var_part while encountering unused "
-                  "variable %s.  Add a \"default\" member to prevent this. %s",
+                  "variable %s.  Add a \"default\" member to prevent this.  %s",
                   var_name, d.get_callstack() );
         return 0;
     }
@@ -95,13 +95,13 @@ double dbl_or_var_part::evaluate( dialogue &d ) const
         if( !val.empty() ) {
             return std::stof( val );
         }
-        debugmsg( "No valid arithmetic value for dbl_or_var_part. %s", d.get_callstack() );
+        debugmsg( "No valid arithmetic value for dbl_or_var_part.  %s", d.get_callstack() );
         return 0;
     }
     if( math_val ) {
         return math_val->act( d );
     }
-    debugmsg( "No valid value for dbl_or_var_part. %s", d.get_callstack() );
+    debugmsg( "No valid value for dbl_or_var_part.  %s", d.get_callstack() );
     return 0;
 }
 
@@ -133,7 +133,7 @@ time_duration duration_or_var_part::evaluate( dialogue &d ) const
             var_name = var_name.substr( 12 );
         }
         debugmsg( "No default value provided for duration_or_var_part while encountering unused "
-                  "variable %s.  Add a \"default\" member to prevent this. %s",
+                  "variable %s.  Add a \"default\" member to prevent this.  %s",
                   var_name, d.get_callstack() );
         return 0_seconds;
     }
@@ -146,13 +146,13 @@ time_duration duration_or_var_part::evaluate( dialogue &d ) const
             ret_val = time_duration::from_turns( std::stoi( val ) );
             return ret_val;
         }
-        debugmsg( "No valid arithmetic value for duration_or_var_part. %s", d.get_callstack() );
+        debugmsg( "No valid arithmetic value for duration_or_var_part.  %s", d.get_callstack() );
         return 0_seconds;
     }
     if( math_val ) {
         return time_duration::from_turns( math_val->act( d ) );
     }
-    debugmsg( "No valid value for duration_or_var_part. %s", d.get_callstack() );
+    debugmsg( "No valid value for duration_or_var_part.  %s", d.get_callstack() );
     return 0_seconds;
 }
 

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -285,10 +285,9 @@ void effect_on_conditions::process_reactivate()
 
 bool effect_on_condition::activate( dialogue &d ) const
 {
-    // each version needs a copy of the dialogue to pass down
-
     bool retval = false;
-
+    d.amend_callstack( string_format( "EOC: %s", id.c_str() ) );
+    // each version needs a copy of the dialogue to pass down
     dialogue d_eoc( d );
     if( !has_condition || condition( d_eoc ) ) {
         true_effect.apply( d_eoc );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1726,6 +1726,7 @@ void spell_effect::effect_on_condition( const spell &sp, Creature &caster, const
         }
         Creature *victim = creatures.creature_at<Creature>( potential_target );
         dialogue d( victim ? get_talker_for( victim ) : nullptr, get_talker_for( caster ) );
+        d.amend_callstack( string_format( "Spell: %s Caster: %s", sp.id().c_str(), caster.disp_name() ) );
         effect_on_condition_id eoc = effect_on_condition_id( sp.effect_data() );
         if( eoc->type == eoc_type::ACTIVATION ) {
             eoc->activate( d );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1960,16 +1960,16 @@ const std::unordered_map<std::string, std::function<bool( dialogue & )>>
     return conditionals;
 }
 
-void dialogue::amend_callstack( std::string value )
+void dialogue::amend_callstack( const std::string &value )
 {
-    if( context["callstack"].size() > 0 ) {
+    if( !context["callstack"].empty() ) {
         context["callstack"] += " \\ " + value;
     } else {
         context["callstack"] = value;
     }
 }
 
-const std::string dialogue::get_callstack() const
+std::string dialogue::get_callstack() const
 {
     if( context.count( "callstack" ) != 0 ) {
         return "Callstack: " + context.find( "callstack" )->second;
@@ -1980,17 +1980,17 @@ const std::string dialogue::get_callstack() const
 talker *dialogue::actor( const bool is_beta ) const
 {
     if( !has_beta && !has_alpha ) {
-        debugmsg( "Attempted to use a dialogue with no actors! %s", get_callstack() );
+        debugmsg( "Attempted to use a dialogue with no actors!  %s", get_callstack() );
     }
     if( is_beta && !has_beta ) {
-        debugmsg( "Tried to use an invalid beta talker. %s", get_callstack() );
+        debugmsg( "Tried to use an invalid beta talker.  %s", get_callstack() );
         // Try to avoid a crash by using the alpha if it exists
         if( has_alpha ) {
             return alpha.get();
         }
     }
     if( !is_beta && !has_alpha ) {
-        debugmsg( "Tried to use an invalid alpha talker. %s", get_callstack() );
+        debugmsg( "Tried to use an invalid alpha talker.  %s", get_callstack() );
         // Try to avoid a crash by using the beta if it exists
         if( has_beta ) {
             return beta.get();
@@ -2008,7 +2008,7 @@ dialogue::dialogue( const dialogue &d ) : has_beta( d.has_beta ), has_alpha( d.h
         beta = d.actor( true )->clone();
     }
     if( !has_alpha && !has_beta ) {
-        debugmsg( "Constructed a dialogue with no actors! %s", get_callstack() );
+        debugmsg( "Constructed a dialogue with no actors!  %s", get_callstack() );
     }
     context = d.get_context();
     conditionals = d.get_conditionals();
@@ -2028,7 +2028,7 @@ dialogue::dialogue( std::unique_ptr<talker> alpha_in,
         beta = std::move( beta_in );
     }
     if( !has_alpha && !has_beta ) {
-        debugmsg( "Constructed a dialogue with no actors! %s", get_callstack() );
+        debugmsg( "Constructed a dialogue with no actors!  %s", get_callstack() );
     }
 
     context = ctx;
@@ -3789,12 +3789,12 @@ void talk_effect_fun_t::set_cast_spell( const JsonObject &jo, const std::string_
     function = [is_npc, fake, targeted, true_eocs, false_eocs]( dialogue const & d ) {
         Creature *caster = d.actor( is_npc )->get_creature();
         if( !caster ) {
-            debugmsg( "No valid caster for spell. %s", d.get_callstack() );
+            debugmsg( "No valid caster for spell.  %s", d.get_callstack() );
             run_eoc_vector( false_eocs, d );
             return;
         } else {
             if( !fake.is_valid() ) {
-                debugmsg( "%s is not a valid spell. %s", fake.id.c_str(), d.get_callstack() );
+                debugmsg( "%s is not a valid spell.  %s", fake.id.c_str(), d.get_callstack() );
                 run_eoc_vector( false_eocs, d );
                 return;
             }
@@ -4138,7 +4138,7 @@ void talk_effect_fun_t::set_queue_eocs( const JsonObject &jo, const std::string_
                 // If the target is a monster or item and the eoc is non global it won't be queued and will silently "fail"
                 // this is so monster attacks against other monsters won't give error messages.
             } else {
-                debugmsg( "Cannot queue a non activation effect_on_condition. %s", d.get_callstack() );
+                debugmsg( "Cannot queue a non activation effect_on_condition.  %s", d.get_callstack() );
             }
         }
     };
@@ -4178,7 +4178,7 @@ void talk_effect_fun_t::set_queue_eoc_with( const JsonObject &jo, const std::str
             // If the target is a monster or item and the eoc is non global it won't be queued and will silently "fail"
             // this is so monster attacks against other monsters won't give error messages.
         } else {
-            debugmsg( "Cannot queue a non activation effect_on_condition. %s", d.get_callstack() );
+            debugmsg( "Cannot queue a non activation effect_on_condition.  %s", d.get_callstack() );
         }
     };
 }
@@ -4267,7 +4267,7 @@ void talk_effect_fun_t::set_roll_remainder( const JsonObject &jo,
                     not_had.push_back( cur_string.evaluate( d ) );
                 }
             } else {
-                debugmsg( "Invalid roll remainder type. %s", d.get_callstack() );
+                debugmsg( "Invalid roll remainder type.  %s", d.get_callstack() );
             }
         }
         if( !not_had.empty() ) {
@@ -4291,7 +4291,7 @@ void talk_effect_fun_t::set_roll_remainder( const JsonObject &jo,
                 d.actor( is_npc )->learn_recipe( recipe );
                 name = recipe->result_name();
             } else {
-                debugmsg( "Invalid roll remainder type. %s", d.get_callstack() );
+                debugmsg( "Invalid roll remainder type.  %s", d.get_callstack() );
             }
             std::string cur_message = message.evaluate( d );
             if( !cur_message.empty() ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1960,20 +1960,37 @@ const std::unordered_map<std::string, std::function<bool( dialogue & )>>
     return conditionals;
 }
 
+void dialogue::amend_callstack( std::string value )
+{
+    if( context["callstack"].size() > 0 ) {
+        context["callstack"] += " \\ " + value;
+    } else {
+        context["callstack"] = value;
+    }
+}
+
+const std::string dialogue::get_callstack() const
+{
+    if( context.count( "callstack" ) != 0 ) {
+        return "Callstack: " + context.find( "callstack" )->second;
+    }
+    return "";
+}
+
 talker *dialogue::actor( const bool is_beta ) const
 {
     if( !has_beta && !has_alpha ) {
-        debugmsg( "Attempted to use a dialogue with no actors!" );
+        debugmsg( "Attempted to use a dialogue with no actors! %s", get_callstack() );
     }
     if( is_beta && !has_beta ) {
-        debugmsg( "Tried to use an invalid beta talker." );
+        debugmsg( "Tried to use an invalid beta talker. %s", get_callstack() );
         // Try to avoid a crash by using the alpha if it exists
         if( has_alpha ) {
             return alpha.get();
         }
     }
     if( !is_beta && !has_alpha ) {
-        debugmsg( "Tried to use an invalid alpha talker." );
+        debugmsg( "Tried to use an invalid alpha talker. %s", get_callstack() );
         // Try to avoid a crash by using the beta if it exists
         if( has_beta ) {
             return beta.get();
@@ -1991,9 +2008,8 @@ dialogue::dialogue( const dialogue &d ) : has_beta( d.has_beta ), has_alpha( d.h
         beta = d.actor( true )->clone();
     }
     if( !has_alpha && !has_beta ) {
-        debugmsg( "Constructed a dialogue with no actors!" );
+        debugmsg( "Constructed a dialogue with no actors! %s", get_callstack() );
     }
-
     context = d.get_context();
     conditionals = d.get_conditionals();
 }
@@ -2012,7 +2028,7 @@ dialogue::dialogue( std::unique_ptr<talker> alpha_in,
         beta = std::move( beta_in );
     }
     if( !has_alpha && !has_beta ) {
-        debugmsg( "Constructed a dialogue with no actors!" );
+        debugmsg( "Constructed a dialogue with no actors! %s", get_callstack() );
     }
 
     context = ctx;
@@ -3773,9 +3789,15 @@ void talk_effect_fun_t::set_cast_spell( const JsonObject &jo, const std::string_
     function = [is_npc, fake, targeted, true_eocs, false_eocs]( dialogue const & d ) {
         Creature *caster = d.actor( is_npc )->get_creature();
         if( !caster ) {
-            debugmsg( "No valid caster for spell." );
+            debugmsg( "No valid caster for spell. %s", d.get_callstack() );
             run_eoc_vector( false_eocs, d );
+            return;
         } else {
+            if( !fake.is_valid() ) {
+                debugmsg( "%s is not a valid spell. %s", fake.id.c_str(), d.get_callstack() );
+                run_eoc_vector( false_eocs, d );
+                return;
+            }
             spell sp = fake.get_spell( *caster, 0 );
             if( targeted ) {
                 if( std::optional<tripoint> target = sp.select_target( caster ) ) {
@@ -4003,8 +4025,8 @@ void talk_effect_fun_t::set_run_eocs( const JsonObject &jo, const std::string_vi
         jo.throw_error( "Invalid input for run_eocs" );
     }
     function = [eocs]( dialogue const & d ) {
-        dialogue newDialog( d );
         for( const effect_on_condition_id &eoc : eocs ) {
+            dialogue newDialog( d );
             eoc->activate( newDialog );
         }
     };
@@ -4084,7 +4106,7 @@ void talk_effect_fun_t::set_run_npc_eocs( const JsonObject &jo,
                             dialogue newDialog( get_talker_for( npc ), nullptr, d.get_conditionals(), d.get_context() );
                             eoc->activate( newDialog );
                         } else {
-                            debugmsg( "Tried to use invalid npc: %s", target.evaluate( d ) );
+                            debugmsg( "Tried to use invalid npc: %s. %s", target.evaluate( d ), d.get_callstack() );
                         }
                     }
                 }
@@ -4116,7 +4138,7 @@ void talk_effect_fun_t::set_queue_eocs( const JsonObject &jo, const std::string_
                 // If the target is a monster or item and the eoc is non global it won't be queued and will silently "fail"
                 // this is so monster attacks against other monsters won't give error messages.
             } else {
-                debugmsg( "Cannot queue a non activation effect_on_condition." );
+                debugmsg( "Cannot queue a non activation effect_on_condition. %s", d.get_callstack() );
             }
         }
     };
@@ -4156,7 +4178,7 @@ void talk_effect_fun_t::set_queue_eoc_with( const JsonObject &jo, const std::str
             // If the target is a monster or item and the eoc is non global it won't be queued and will silently "fail"
             // this is so monster attacks against other monsters won't give error messages.
         } else {
-            debugmsg( "Cannot queue a non activation effect_on_condition." );
+            debugmsg( "Cannot queue a non activation effect_on_condition. %s", d.get_callstack() );
         }
     };
 }
@@ -4245,7 +4267,7 @@ void talk_effect_fun_t::set_roll_remainder( const JsonObject &jo,
                     not_had.push_back( cur_string.evaluate( d ) );
                 }
             } else {
-                debugmsg( "Invalid roll remainder type." );
+                debugmsg( "Invalid roll remainder type. %s", d.get_callstack() );
             }
         }
         if( !not_had.empty() ) {
@@ -4269,7 +4291,7 @@ void talk_effect_fun_t::set_roll_remainder( const JsonObject &jo,
                 d.actor( is_npc )->learn_recipe( recipe );
                 name = recipe->result_name();
             } else {
-                debugmsg( "Invalid roll remainder type." );
+                debugmsg( "Invalid roll remainder type. %s", d.get_callstack() );
             }
             std::string cur_message = message.evaluate( d );
             if( !cur_message.empty() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
EOC errors are hard to debug.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added check if a called spell exists to report if doesn't.
Added a new callstack to tell you what EOCs/spells have been called to bring you to your error.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Used this json
```
{
    "type": "effect_on_condition",
    "id": "TEST",
    "effect": {
      "run_eocs": [
        {
          "id": "TEST2",
          "effect": [
            {
              "run_eocs": [
                { "id": "eoc_fake", "effect": [ { "u_cast_spell": { "id": "fake", "hit_self": true } } ] },
                { "id": "eoc_fake2", "effect": [ { "u_cast_spell": { "id": "fake_also", "hit_self": true } } ] }
              ]
            }
          ]
        }
      ]
    }
  }
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->