### PR TITLE
Show playtime when choosing a character to load

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3356,6 +3356,11 @@ bool game::save()
             world_generator->last_character_name = u.name;
             world_generator->save_last_world_info();
             world_generator->active_world->add_save( save_t::from_save_id( u.get_save_id() ) );
+            write_to_file( PATH_INFO::world_base_save_path_path() / ( base64_encode(
+            u.get_save_id() ) + ".pt" ), [&total_time_played]( std::ostream & fout ) {
+                fout.imbue( std::locale::classic() );
+                fout << total_time_played.count();
+            } );
             return true;
         }
     } catch( std::ios::failure & ) {

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -1044,9 +1044,29 @@ bool main_menu::load_game( std::string const &worldname, save_t const &savegame 
     return false;
 }
 
+static std::optional<std::chrono::seconds> get_playtime_from_save( const WORLD *world,
+        const save_t &save )
+{
+    cata_path playtime_file = world->folder_path_path() / ( save.base_path() + ".pt" );
+    std::optional<std::chrono::seconds> pt_seconds;
+    if( file_exist( playtime_file ) ) {
+        read_from_file( playtime_file, [&pt_seconds]( std::istream & fin ) {
+            if( fin.eof() ) {
+                return;
+            }
+            std::chrono::seconds::rep dur_seconds = 0;
+            fin.imbue( std::locale::classic() );
+            fin >> dur_seconds;
+            pt_seconds = std::chrono::seconds( dur_seconds );
+        } );
+    }
+    return pt_seconds;
+}
+
 bool main_menu::load_character_tab( const std::string &worldname )
 {
-    savegames = world_generator->get_world( worldname )->world_saves;
+    WORLD *cur_world = world_generator->get_world( worldname );
+    savegames = cur_world->world_saves;
     if( MAP_SHARING::isSharing() ) {
         auto new_end = std::remove_if( savegames.begin(), savegames.end(), []( const save_t &str ) {
             return str.decoded_name() != MAP_SHARING::getUsername();
@@ -1065,7 +1085,19 @@ bool main_menu::load_character_tab( const std::string &worldname )
     mmenu.border_color = c_white;
     int opt_val = 0;
     for( const save_t &s : savegames ) {
-        mmenu.entries.emplace_back( opt_val++, true, MENU_AUTOASSIGN, s.decoded_name() );
+        std::optional<std::chrono::seconds> playtime = get_playtime_from_save( cur_world, s );
+        std::string save_str = s.decoded_name();
+        if( playtime ) {
+            int padding = std::max( 16 - utf8_width( save_str ), 0 ) + 2;
+            std::chrono::seconds::rep tmp_sec = playtime->count();
+            int pt_sec = static_cast<int>( tmp_sec % 60 );
+            int pt_min = static_cast<int>( tmp_sec % 3600 ) / 60;
+            int pt_hrs = static_cast<int>( tmp_sec / 3600 );
+            save_str = string_format( "%s%s<color_c_light_blue>[%02d:%02d:%02d]</color>",
+                                      save_str, std::string( padding, ' ' ), pt_hrs, pt_min,
+                                      static_cast<int>( pt_sec ) );
+        }
+        mmenu.entries.emplace_back( opt_val++, true, MENU_AUTOASSIGN, save_str );
     }
     mmenu.entries.emplace_back( opt_val, true, 'q', _( "<- Back to Main Menu" ), c_yellow, c_yellow );
     mmenu.query();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I like the idea of seeing how much time I've invested in a save when I go to load the game:

![Screenshot from 2023-05-06 22-20-56](https://user-images.githubusercontent.com/12537966/236654302-aa640ae0-7a21-408a-a6f4-324f840ea9cc.png)

#### Describe the solution
Using the meta stats implemented by jbytheway in #41223, because why reinvent the wheel :P

The current total playtime is written to a new file when saving the game, which gets read when choosing a character to load. This means that the playtime won't display for existing characters until they save the game again, which will then display the correct playtime.

#### Describe alternatives you've considered
The real way to do this would be to selectively load the stats tracker for each character and use the event bus to obtain the total playtime, but as far as I can tell it would require a lot of new special handling just for this one use case.

#### Testing
Works with super long names and double-width characters:

![Screenshot from 2023-05-06 22-18-25](https://user-images.githubusercontent.com/12537966/236654275-21c5742d-10c3-440b-a033-41688aad2dd2.png)

#### Additional context
