### PR TITLE
Pockets overflow into their parent pockets if possible

### DIFF
--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1992,10 +1992,10 @@ void outfit::best_pocket( Character &guy, const item &it, const item *avoid,
     }
 }
 
-void outfit::overflow( const tripoint &pos )
+void outfit::overflow( Character &guy )
 {
-    for( item &clothing : worn ) {
-        clothing.overflow( pos );
+    for( item_location &clothing : top_items_loc( guy ) ) {
+        clothing.overflow();
     }
 }
 

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -195,7 +195,7 @@ class outfit
         void best_pocket( Character &guy, const item &it, const item *avoid,
                           std::pair<item_location, item_pocket *> &current_best,
                           bool ignore_settings = false );
-        void overflow( const tripoint &pos );
+        void overflow( Character &guy );
         void holster_opts( std::vector<dispose_option> &opts, item_location obj, Character &guy );
         void get_eligible_containers_for_crafting( std::vector<const item *> &conts ) const;
         // convenient way to call on_takeoff for all clothing. does not actually delete them, call clear() to do that

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -517,8 +517,11 @@ void Character::drop_invalid_inventory()
         add_msg_if_player( m_bad, _( "Liquid from your inventory has leaked onto the ground." ) );
     }
 
-    weapon.overflow( pos() );
-    worn.overflow( pos() );
+    item_location weap = get_wielded_item();
+    if( weap ) {
+        weap.overflow();
+    }
+    worn.overflow( *this );
 
     cache_inventory_is_valid = true;
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9753,9 +9753,9 @@ bool item::spill_open_pockets( Character &guy, const item *avoid )
     return contents.spill_open_pockets( guy, avoid );
 }
 
-void item::overflow( const tripoint &pos )
+void item::overflow( const tripoint &pos, item_location loc )
 {
-    contents.overflow( pos );
+    contents.overflow( pos, loc );
 }
 
 book_proficiency_bonuses item::get_book_proficiency_bonuses() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9753,7 +9753,7 @@ bool item::spill_open_pockets( Character &guy, const item *avoid )
     return contents.spill_open_pockets( guy, avoid );
 }
 
-void item::overflow( const tripoint &pos, item_location loc )
+void item::overflow( const tripoint &pos, const item_location &loc )
 {
     contents.overflow( pos, loc );
 }

--- a/src/item.h
+++ b/src/item.h
@@ -1633,7 +1633,7 @@ class item : public visitable
         bool spill_contents( const tripoint &pos );
         bool spill_open_pockets( Character &guy, const item *avoid = nullptr );
         // spill items that don't fit in the container
-        void overflow( const tripoint &pos, item_location loc = item_location::nowhere );
+        void overflow( const tripoint &pos, const item_location &loc = item_location::nowhere );
 
         /** Checks if item is a holster and currently capable of storing obj
          *  @param obj object that we want to holster

--- a/src/item.h
+++ b/src/item.h
@@ -1633,7 +1633,7 @@ class item : public visitable
         bool spill_contents( const tripoint &pos );
         bool spill_open_pockets( Character &guy, const item *avoid = nullptr );
         // spill items that don't fit in the container
-        void overflow( const tripoint &pos );
+        void overflow( const tripoint &pos, item_location loc = item_location::nowhere );
 
         /** Checks if item is a holster and currently capable of storing obj
          *  @param obj object that we want to holster

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1132,10 +1132,10 @@ bool item_contents::spill_contents( const tripoint &pos )
     return spilled;
 }
 
-void item_contents::overflow( const tripoint &pos )
+void item_contents::overflow( const tripoint &pos, item_location loc )
 {
     for( item_pocket &pocket : contents ) {
-        pocket.overflow( pos );
+        pocket.overflow( pos, loc );
     }
 }
 

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1132,7 +1132,7 @@ bool item_contents::spill_contents( const tripoint &pos )
     return spilled;
 }
 
-void item_contents::overflow( const tripoint &pos, item_location loc )
+void item_contents::overflow( const tripoint &pos, const item_location &loc )
 {
     for( item_pocket &pocket : contents ) {
         pocket.overflow( pos, loc );

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -262,7 +262,7 @@ class item_contents
         void on_pickup( Character &guy, item *avoid = nullptr );
         bool spill_contents( const tripoint &pos );
         // spill items that don't fit in the container
-        void overflow( const tripoint &pos );
+        void overflow( const tripoint &pos, item_location loc );
         void clear_items();
         // clears all items from magazine type pockets
         void clear_magazines();

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -262,7 +262,7 @@ class item_contents
         void on_pickup( Character &guy, item *avoid = nullptr );
         bool spill_contents( const tripoint &pos );
         // spill items that don't fit in the container
-        void overflow( const tripoint &pos, item_location loc );
+        void overflow( const tripoint &pos, const item_location &loc );
         void clear_items();
         // clears all items from magazine type pockets
         void clear_magazines();

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -957,6 +957,11 @@ bool item_location::eventually_contains( item_location loc ) const
     return false;
 }
 
+void item_location::overflow()
+{
+    get_item()->overflow( position(), *this );
+}
+
 item_location::type item_location::where() const
 {
     return ptr->where();

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -147,6 +147,11 @@ class item_location
          */
         bool eventually_contains( item_location loc ) const;
 
+        /**
+         * Overflow items into parent pockets recursively
+         */
+        void overflow();
+
     private:
         class impl;
 

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1638,7 +1638,27 @@ std::optional<item> item_pocket::remove_item( const item_location &it )
     return remove_item( *it );
 }
 
-void item_pocket::overflow( const tripoint &pos )
+static void move_to_parent_pocket_recursive( const tripoint &pos, item &it, item_location loc )
+{
+    if( loc ) {
+        item_pocket *parent_pocket = loc.parent_pocket();
+        if( parent_pocket && parent_pocket->can_contain( it ).success() ) {
+            add_msg( m_bad, _( "Your %1$s falls into your %2$s." ), it.tname(), loc.parent_item()->tname() );
+            loc.parent_pocket()->insert_item( it );
+            return;
+        }
+        if( loc.where() == item_location::type::container ) {
+            move_to_parent_pocket_recursive( pos, it, loc.parent_item() );
+            return;
+        }
+    }
+
+    map &here = get_map();
+    add_msg( m_bad, _( "Your %s falls to the ground." ), it.tname() );
+    here.add_item_or_charges( pos, it );
+}
+
+void item_pocket::overflow( const tripoint &pos, item_location loc )
 {
     if( is_type( pocket_type::MOD ) || is_type( pocket_type::CORPSE ) ||
         is_type( pocket_type::EBOOK ) ) {
@@ -1651,18 +1671,21 @@ void item_pocket::overflow( const tripoint &pos )
 
     // overflow recursively
     for( item &it : contents ) {
-        it.overflow( pos );
+        if( loc ) {
+            item_location content_loc( loc, &it );
+            content_loc.overflow();
+        } else {
+            it.overflow( pos );
+        }
     }
 
-    map &here = get_map();
     // first remove items that shouldn't be in there anyway
     for( auto iter = contents.begin(); iter != contents.end(); ) {
         ret_val<contain_code> ret_contain = can_contain( *iter );
         if( is_type( pocket_type::MIGRATION ) || ( !ret_contain.success() &&
                 ret_contain.value() != contain_code::ERR_NO_SPACE &&
                 ret_contain.value() != contain_code::ERR_CANNOT_SUPPORT ) ) {
-            add_msg( m_bad, _( "Your %s falls to the ground." ), iter->tname() );
-            here.add_item_or_charges( pos, *iter );
+            move_to_parent_pocket_recursive( pos, *iter, loc );
             iter = contents.erase( iter );
         } else {
             ++iter;
@@ -1691,8 +1714,7 @@ void item_pocket::overflow( const tripoint &pos )
             if( overflow_count > 0 ) {
                 ammo.charges -= overflow_count;
                 item dropped_ammo( ammo.typeId(), ammo.birthday(), overflow_count );
-                add_msg( m_bad, _( "Your %s falls to the ground." ), iter->tname() );
-                here.add_item_or_charges( pos, contents.front() );
+                move_to_parent_pocket_recursive( pos, *iter, loc );
                 total_qty -= overflow_count;
             }
             if( ammo.count() == 0 ) {
@@ -1711,8 +1733,7 @@ void item_pocket::overflow( const tripoint &pos )
             return left.volume() > right.volume();
         } );
         while( remaining_volume() < 0_ml && !contents.empty() ) {
-            add_msg( m_bad, _( "Your %s falls to the ground." ), contents.front().tname() );
-            here.add_item_or_charges( pos, contents.front() );
+            move_to_parent_pocket_recursive( pos, contents.front(), loc );
             contents.pop_front();
         }
     }
@@ -1721,8 +1742,7 @@ void item_pocket::overflow( const tripoint &pos )
             return left.weight() > right.weight();
         } );
         while( remaining_weight() < 0_gram && !contents.empty() ) {
-            add_msg( m_bad, _( "Your %s falls to the ground." ), contents.front().tname() );
-            here.add_item_or_charges( pos, contents.front() );
+            move_to_parent_pocket_recursive( pos, contents.front(), loc );
             contents.pop_front();
         }
     }
@@ -1803,7 +1823,8 @@ void item_pocket::process( map &here, Character *carrier, const tripoint &pos, f
     }
 }
 
-void item_pocket::leak( map &here, Character *carrier, const tripoint &pos, item_pocket *pocke )
+void item_pocket::leak( map &here, Character *carrier, const tripoint &pos,
+                        item_pocket *pocke )
 {
     std::vector<item *> erases;
     for( auto iter = contents.begin(); iter != contents.end(); ) {
@@ -2203,7 +2224,8 @@ std::vector<item_pocket::favorite_settings>::iterator item_pocket::find_preset(
     return iter;
 }
 
-void item_pocket::delete_preset( const std::vector<item_pocket::favorite_settings>::iterator iter )
+void item_pocket::delete_preset( const std::vector<item_pocket::favorite_settings>::iterator
+                                 iter )
 {
     pocket_presets.erase( iter );
     save_presets();

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1638,7 +1638,8 @@ std::optional<item> item_pocket::remove_item( const item_location &it )
     return remove_item( *it );
 }
 
-static void move_to_parent_pocket_recursive( const tripoint &pos, item &it, item_location loc )
+static void move_to_parent_pocket_recursive( const tripoint &pos, item &it,
+        const item_location &loc )
 {
     if( loc ) {
         item_pocket *parent_pocket = loc.parent_pocket();
@@ -1658,7 +1659,7 @@ static void move_to_parent_pocket_recursive( const tripoint &pos, item &it, item
     here.add_item_or_charges( pos, it );
 }
 
-void item_pocket::overflow( const tripoint &pos, item_location loc )
+void item_pocket::overflow( const tripoint &pos, const item_location &loc )
 {
     if( is_type( pocket_type::MOD ) || is_type( pocket_type::CORPSE ) ||
         is_type( pocket_type::EBOOK ) ) {

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -291,7 +291,7 @@ class item_pocket
         std::optional<item> remove_item( const item &it );
         std::optional<item> remove_item( const item_location &it );
         // spills any contents that can't fit into the pocket, largest items first
-        void overflow( const tripoint &pos );
+        void overflow( const tripoint &pos, item_location loc );
         bool spill_contents( const tripoint &pos );
         void on_pickup( Character &guy, item *avoid = nullptr );
         void on_contents_changed();

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -291,7 +291,7 @@ class item_pocket
         std::optional<item> remove_item( const item &it );
         std::optional<item> remove_item( const item_location &it );
         // spills any contents that can't fit into the pocket, largest items first
-        void overflow( const tripoint &pos, item_location loc );
+        void overflow( const tripoint &pos, const item_location &loc );
         bool spill_contents( const tripoint &pos );
         void on_pickup( Character &guy, item *avoid = nullptr );
         void on_contents_changed();

--- a/tests/item_autopickup_test.cpp
+++ b/tests/item_autopickup_test.cpp
@@ -17,7 +17,7 @@ static const itype_id itype_bottle_plastic( "bottle_plastic" );
 static const itype_id itype_bottle_plastic_pill_prescription( "bottle_plastic_pill_prescription" );
 static const itype_id itype_box_cigarette( "box_cigarette" );
 static const itype_id itype_box_small( "box_small" );
-static const itype_id itype_can_food( "can_food" );
+static const itype_id itype_can_medium( "can_medium" );
 static const itype_id itype_can_tuna( "can_tuna" );
 static const itype_id itype_candy2( "candy2" );
 static const itype_id itype_candycigarette( "candycigarette" );
@@ -386,16 +386,16 @@ TEST_CASE( "auto pickup should consider item rigidness and seal", "[autopickup][
     }
     // small tin can (sealed) > canned tuna fish (WL), canned meat
     WHEN( "there is a sealed container on the ground containing items whitelisted in auto-pickup rules" ) {
-        item item_small_tin_can = item( itype_can_food );
+        item item_medium_tin_can = item( itype_can_medium );
         unique_item item_canned_tuna = unique_item( itype_can_tuna, 1, true );
         unique_item item_canned_meat = unique_item( itype_meat_canned, 1, true );
 
         // insert items inside can and seal it
-        item_small_tin_can.force_insert_item( *item_canned_tuna.get(), pocket_type_container );
-        item_small_tin_can.force_insert_item( *item_canned_meat.get(), pocket_type_container );
-        item_small_tin_can.seal();
+        item_medium_tin_can.force_insert_item( *item_canned_tuna.get(), pocket_type_container );
+        item_medium_tin_can.force_insert_item( *item_canned_meat.get(), pocket_type_container );
+        item_medium_tin_can.seal();
 
-        unique_item item_sealed_tuna = unique_item( item_small_tin_can );
+        unique_item item_sealed_tuna = unique_item( item_medium_tin_can );
         REQUIRE( item_sealed_tuna.spawn_item( ground ) );
 
         add_autopickup_rule( item_canned_tuna.get(), true );
@@ -408,17 +408,17 @@ TEST_CASE( "auto pickup should consider item rigidness and seal", "[autopickup][
     }
     // small tin can (sealed) > canned tuna fish (WL), canned meat
     WHEN( "there is a sealed container on the ground containing no whitelisted items" ) {
-        item item_small_tin_can = item( itype_can_food );
+        item item_medium_tin_can = item( itype_can_medium );
         item item_bottle_plastic = item( itype_bottle_plastic );
         unique_item item_canned_tuna = unique_item( itype_can_tuna, 1, true );
         unique_item item_canned_meat = unique_item( itype_meat_canned, 1, true );
 
         // insert items inside can and seal it
-        item_small_tin_can.force_insert_item( *item_canned_tuna.get(), pocket_type_container );
-        item_small_tin_can.force_insert_item( *item_canned_meat.get(), pocket_type_container );
-        item_small_tin_can.seal();
+        item_medium_tin_can.force_insert_item( *item_canned_tuna.get(), pocket_type_container );
+        item_medium_tin_can.force_insert_item( *item_canned_meat.get(), pocket_type_container );
+        item_medium_tin_can.seal();
 
-        unique_item item_sealed_tuna = unique_item( item_small_tin_can );
+        unique_item item_sealed_tuna = unique_item( item_medium_tin_can );
         REQUIRE( item_sealed_tuna.spawn_item( ground ) );
         // autopickup something other than the sealed items
         unique_item item_red_herring = unique_item( item_bottle_plastic );

--- a/tests/item_contents_test.cpp
+++ b/tests/item_contents_test.cpp
@@ -13,7 +13,9 @@
 #include "units.h"
 
 static const itype_id itype_crowbar_pocket_test( "crowbar_pocket_test" );
+static const itype_id itype_jar_glass_sealed( "jar_glass_sealed" );
 static const itype_id itype_log( "log" );
+static const itype_id itype_pickle( "pickle" );
 static const itype_id itype_purse( "purse" );
 
 TEST_CASE( "item_contents" )
@@ -112,4 +114,30 @@ TEST_CASE( "overflow test", "[item]" )
     here.i_clear( origin );
     purse.overflow( origin );
     CHECK( here.i_at( origin ).size() == 1 );
+}
+
+TEST_CASE( "overflow test into parent item", "[item]" )
+{
+    clear_map();
+    tripoint origin{ 60, 60, 0 };
+    item jar( itype_jar_glass_sealed );
+    item pickle( itype_pickle );
+    pickle.force_insert_item( pickle, item_pocket::pocket_type::MIGRATION );
+    jar.put_in( pickle, item_pocket::pocket_type::CONTAINER );
+    int contents_pre = 0;
+    for( item *it : jar.all_items_top() ) {
+        contents_pre += it->count();
+    }
+    REQUIRE( contents_pre == 1 );
+
+    item_location jar_loc( map_cursor( origin ), &jar );
+    jar_loc.overflow();
+    map &here = get_map();
+    CHECK( here.i_at( origin ).size() == 0 );
+
+    int contents_count = 0;
+    for( item *it : jar.all_items_top() ) {
+        contents_count += it->count();
+    }
+    CHECK( contents_count == 2 );
 }

--- a/tests/item_contents_test.cpp
+++ b/tests/item_contents_test.cpp
@@ -133,7 +133,7 @@ TEST_CASE( "overflow test into parent item", "[item]" )
     item_location jar_loc( map_cursor( origin ), &jar );
     jar_loc.overflow();
     map &here = get_map();
-    CHECK( here.i_at( origin ).size() == 0 );
+    CHECK( here.i_at( origin ).empty() );
 
     int contents_count = 0;
     for( item *it : jar.all_items_top() ) {


### PR DESCRIPTION
#### Summary
Features "Pockets overflow into their parent pockets if possible"

#### Purpose of change

More working towards #60885. The migration makes this necessary so your foodstuffs won't be dropped everywhere, even out of sealed containers.

#### Describe the solution

Try to find a parent pocket the can hold the item recursively. Print a message of what moved to where to inform players something unintentional happened.

#### Describe alternatives you've considered

Could move the item to any pocket of the parents or even any pocket on the character (if it's on the character), but this should be a fairly rare occurence anyway, so no need to make it more complex than necessary.
This also doesn't account for possible partial overflow of stacked items, because #60885.

#### Testing

Added a simple test case. Then also tested it using an existing bug (#58808):
1. Spawn golf bag, fast draw holster and expandable baton
2. Wear golf bag
3. Organize it as golf bag > fast draw holster > expandable baton
4. Expand the baton (becomes too big for holster but stays there)
5. Wield golf bag to trigger inventory sanity checks (no to drawing from holster)
6. Baton drops into golf bag instead of the ground

![grafik](https://user-images.githubusercontent.com/38702195/236659230-43288cff-b216-4b6f-aa58-f24d25bff26e.png)

#### Additional context