### PR TITLE
QoL changes in mechanic practice

### DIFF
--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -163,7 +163,8 @@
       { "item": "engineering_makerspace_kit" },
       { "item": "bubblewrap", "count": 2 },
       { "item": "manual_makerspace" },
-      { "item": "screwdriver" }
+      { "item": "screwdriver" },
+      { "item": "wrench_small" }
     ]
   },
   {
@@ -201,7 +202,8 @@
       { "item": "engineering_robotics_kit" },
       { "item": "bubblewrap", "count": 2 },
       { "item": "manual_robotics_kit" },
-      { "item": "screwdriver" }
+      { "item": "screwdriver" },
+      { "item": "wrench_small" }
     ]
   },
   {
@@ -231,7 +233,9 @@
       { "item": "engineering_engine_kit" },
       { "item": "bubblewrap", "count": 2 },
       { "item": "manual_engine_kit" },
-      { "item": "screwdriver" }
+      { "item": "screwdriver" },
+      { "item": "wrench_small" },
+      { "item": "chem_ethanol", "charges-min": 750 }
     ]
   },
   {

--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -234,8 +234,7 @@
       { "item": "bubblewrap", "count": 2 },
       { "item": "manual_engine_kit" },
       { "item": "screwdriver" },
-      { "item": "wrench_small" },
-      { "item": "chem_ethanol", "charges-min": 750 }
+      { "item": "wrench_small" }
     ]
   },
   {

--- a/data/json/recipes/practice/mechanics.json
+++ b/data/json/recipes/practice/mechanics.json
@@ -11,7 +11,7 @@
     "practice_data": { "min_difficulty": 1, "max_difficulty": 1, "skill_limit": 2 },
     "proficiencies": [ { "proficiency": "prof_plumbing", "time_multiplier": 1, "skill_penalty": 0 } ],
     "time": "1 h",
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 2 } ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "//": "You drain the battery charge but the kit can be reused.",
     "tools": [ [ [ "engineering_makerspace_kit", 50 ] ] ],
     "book_learn": [ [ "manual_makerspace", 0 ] ]
@@ -28,7 +28,7 @@
     "practice_data": { "min_difficulty": 0, "max_difficulty": 1, "skill_limit": 1 },
     "proficiencies": [ { "proficiency": "prof_elec_circuits", "time_multiplier": 1, "skill_penalty": 0 } ],
     "time": "1 h",
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 2 } ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "//": "You drain the battery charge but the kit can be reused.",
     "tools": [ [ [ "engineering_robotics_kit", 50 ] ] ],
     "book_learn": [ [ "manual_robotics_kit", 0 ] ]
@@ -45,7 +45,7 @@
     "practice_data": { "min_difficulty": 2, "max_difficulty": 2, "skill_limit": 3 },
     "proficiencies": [ { "proficiency": "prof_basic_engines", "time_multiplier": 1, "skill_penalty": 0 } ],
     "time": "1 h",
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 2 } ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "//": "You drain the battery charge but the kit can be reused.",
     "tools": [ [ [ "engineering_engine_kit", 50 ] ] ],
     "book_learn": [ [ "manual_engine_kit", 0 ] ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
STEM kit (and another) require WRENCH 2, but provide no tool for it. What service it is?
#### Describe the solution
Loot groups for `makerspace kit for STEM`, `stirling engine kit` and `robotics kit for young learners` got small adjustable wrench (small is the only which can fit the box), ~~stirling engine kit also got a bottle with ethanol to power engine~~ got no bottle, because baterries not included
Training recipes now require `WRENCH 1` instead of `WRENCH 2`