### PR TITLE
Audit burn_data for vanilla materials

### DIFF
--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -1055,11 +1055,11 @@
     "bash_dmg_verb": "bruised",
     "cut_dmg_verb": "sliced",
     "vitamins": [ [ "calcium", 1 ], [ "iron", 1.3 ] ],
-    "//": "Copied from chitin",
+    "//": "FIXME if you see me",
     "burn_data": [
-      { "fuel": 0, "smoke": 0, "burn": 0.0001 },
-      { "fuel": 0.2, "smoke": 3, "burn": 0.005, "volume_per_turn": "200 ml" },
-      { "fuel": 0.35, "smoke": 5, "burn": 0.015, "volume_per_turn": "200 ml" }
+      { "fuel": 0, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
+      { "fuel": 0.2, "smoke": 3, "burn": 0.002, "volume_per_turn": "500 ml" },
+      { "fuel": 0.35, "smoke": 5, "burn": 0.004, "volume_per_turn": "1 L" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 1, "bullet": 1 }
@@ -1265,7 +1265,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
-    "//1": "Nylon/polyester react poorly to flame(they melt) but are hard to light. Doesn't break down easily unless exposed to a high-intensity fire.",
+    "//1": "Nylon/polyester reacts poorly to flame (it melts) but is hard to light. Doesn't break down easily unless exposed to a high-intensity fire.",
     "burn_data": [
       { "fuel": 0.05, "smoke": 1, "burn": 0.01 },
       { "fuel": 0.05, "smoke": 2, "burn": 0.03 },
@@ -1980,7 +1980,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
-    "//1": "Nylon reacts poorly to flame(it melts) but is hard to light. Doesn't break down easily unless exposed to a high-intensity fire.",
+    "//1": "Nylon reacts poorly to flame (it melts) but is hard to light. Doesn't break down easily unless exposed to a high-intensity fire.",
     "burn_data": [
       { "fuel": 0.05, "smoke": 1, "burn": 0.01 },
       { "fuel": 0.05, "smoke": 2, "burn": 0.03 },
@@ -2246,13 +2246,12 @@
     "bash_dmg_verb": "squished",
     "cut_dmg_verb": "cut",
     "vitamins": [ [ "iron", 0.1 ] ],
-    "//": "This burn data assumes wheat and chaff. In this form, it burns pretty well.",
+    "//": "This material is used primarily for foodstuffs, and should not provide any significant fuel value.",
     "burn_data": [
-      { "fuel": 0.6, "smoke": 1, "burn": 0.025, "volume_per_turn": "200 ml" },
-      { "fuel": 1.2, "smoke": 1, "burn": 0.05, "volume_per_turn": "825 ml" },
-      { "fuel": 1.8, "smoke": 1, "burn": 0.075 }
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
     ],
-    "burn_products": [ [ "ash", 0.013 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 0, "bullet": 1 }
   },
   {

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -276,6 +276,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap_bronze", 0.5 ] ],
     "resist": { "bash": 4, "cut": 5, "acid": 1, "heat": 2, "bullet": 2 }
   },
   {
@@ -304,6 +305,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap_bronze", 0.5 ] ],
     "resist": { "bash": 5, "cut": 5, "acid": 5, "heat": 2, "bullet": 2 }
   },
   {
@@ -320,6 +322,7 @@
     "repaired_with": "scrap",
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 2 }
   },
   {
@@ -478,6 +481,7 @@
     "dmg_adj": [ "chipped", "scratched", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "cut",
+    "burn_products": [ [ "ceramic_shard", 0.5 ] ],
     "resist": { "bash": 2, "cut": 3, "acid": 6, "heat": 3, "bullet": 2 }
   },
   {
@@ -508,6 +512,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "copper", 0.5 ] ],
     "resist": { "bash": 2, "cut": 3, "acid": 0, "heat": 3, "bullet": 2 }
   },
   {
@@ -724,6 +729,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
     "cut_dmg_verb": "cut",
+    "burn_products": [ [ "ceramic_shard", 0.5 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 4, "heat": 3, "bullet": 1 }
   },
   {
@@ -814,7 +820,7 @@
       { "fuel": 0, "smoke": 0, "burn": 0 },
       { "fuel": 0, "smoke": 0, "burn": 1000, "volume_per_turn": "5000 ml", "//": "More like shattering than melting" }
     ],
-    "burn_products": [ [ "glass_shard", 1 ] ],
+    "burn_products": [ [ "glass_shard", 0.5 ] ],
     "resist": { "bash": 5, "cut": 10, "acid": 10, "heat": 3, "bullet": 9 }
   },
   {
@@ -835,7 +841,7 @@
       { "fuel": 0, "smoke": 0, "burn": 0 },
       { "fuel": 0, "smoke": 0, "burn": 1000, "volume_per_turn": "5000 ml", "//": "More like shattering than melting" }
     ],
-    "burn_products": [ [ "glass_shard", 1 ] ],
+    "burn_products": [ [ "glass_shard", 0.5 ] ],
     "resist": { "bash": 3, "cut": 4, "acid": 10, "heat": 3, "bullet": 3 }
   },
   {
@@ -856,7 +862,7 @@
       { "fuel": 0, "smoke": 0, "burn": 0 },
       { "fuel": 0, "smoke": 0, "burn": 1000, "volume_per_turn": "5000 ml", "//": "More like shattering than melting" }
     ],
-    "burn_products": [ [ "glass_shard", 1 ] ],
+    "burn_products": [ [ "glass_shard", 0.5 ] ],
     "resist": { "bash": 3, "cut": 4, "acid": 10, "heat": 3, "bullet": 3 }
   },
   {
@@ -873,6 +879,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "gold_small", 0.5 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 10, "heat": 3, "bullet": 1 }
   },
   {
@@ -1055,7 +1062,6 @@
     "bash_dmg_verb": "bruised",
     "cut_dmg_verb": "sliced",
     "vitamins": [ [ "calcium", 1 ], [ "iron", 1.3 ] ],
-    "//": "FIXME if you see me",
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
       { "fuel": 0.2, "smoke": 3, "burn": 0.002, "volume_per_turn": "500 ml" },
@@ -1078,6 +1084,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 4, "cut": 4, "acid": 5, "heat": 3, "bullet": 2 }
   },
   {
@@ -1198,6 +1205,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "lead", 0.5 ] ],
     "resist": { "bash": 0, "cut": 0, "acid": 8, "heat": 3, "bullet": 0 }
   },
   {
@@ -1568,6 +1576,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "silver_small", 0.5 ] ],
     "resist": { "bash": 2, "cut": 3, "acid": 10, "heat": 3, "bullet": 2 }
   },
   {
@@ -1584,6 +1593,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "platinum_small", 0.5 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 10, "heat": 3, "bullet": 1 }
   },
   {
@@ -1637,6 +1647,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 4.5 }
   },
   {
@@ -1654,6 +1665,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 7, "cut": 7, "acid": 7, "heat": 3, "bullet": 4.5 }
   },
   {
@@ -1671,6 +1683,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 10, "cut": 10, "acid": 7, "heat": 3, "bullet": 6.5 }
   },
   {
@@ -1688,6 +1701,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 10, "cut": 10, "acid": 7, "heat": 3, "bullet": 6.5 }
   },
   {
@@ -1705,6 +1719,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 11, "cut": 11, "acid": 7, "heat": 3, "bullet": 7.5 }
   },
   {
@@ -1725,6 +1740,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 2 }
   },
   {
@@ -1746,6 +1762,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 4.5 }
   },
   {
@@ -1767,6 +1784,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 7, "cut": 7, "acid": 7, "heat": 3, "bullet": 4.5 }
   },
   {
@@ -1788,6 +1806,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 10, "cut": 10, "acid": 7, "heat": 3, "bullet": 6.5 }
   },
   {
@@ -1809,6 +1828,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 10, "cut": 10, "acid": 7, "heat": 3, "bullet": 6.5 }
   },
   {
@@ -1830,6 +1850,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 11, "cut": 11, "acid": 7, "heat": 3, "bullet": 7.5 }
   },
   {
@@ -1846,6 +1867,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 3 }
   },
   {
@@ -1914,6 +1936,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "burn_products": [ [ "pebble", 0.5 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 8, "heat": 3, "bullet": 3 }
   },
   {

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -20,10 +20,11 @@
     "copy-from": "generic_polymer_resin",
     "//": "This material ID is for plastics that can be reshaped and molded by application of heat and return to their original properties when cooled, and these specific ones are quite hard and durable when in solid state.",
     "salvaged_into": "thermo_resin_chunk",
+    "//1": "Most consumer polymers and plastics receive a UL94 rating for flammability and the lowest UL94 rating is HB, generally considered self-extinguishing. Plastics are flammable but should only contribute significant fuel in intense fires.",
     "burn_data": [
-      { "fuel": 1, "smoke": 2, "burn": 1, "volume_per_turn": "750 ml" },
-      { "fuel": 1, "smoke": 3, "burn": 2 },
-      { "fuel": 1, "smoke": 5, "burn": 5 }
+      { "fuel": 0.1, "smoke": 2, "burn": 0.001 },
+      { "fuel": 0.4, "smoke": 3, "burn": 0.003 },
+      { "fuel": 1, "smoke": 5, "burn": 0.008 }
     ]
   },
   {
@@ -33,10 +34,11 @@
     "copy-from": "generic_polymer_resin",
     "//": "'epoxy' is a general catch-all for strong, brittle polymers that cannot be reshaped with application of heat.  Not all of these are necessarily going to be literally epoxy, but it's close enough.",
     "salvaged_into": "epoxy_chunk",
+    "//1": "Epoxy greatly varies in flammability depending on its curing state, but here we'll assume any item with this material has set epoxy.",
     "burn_data": [
-      { "fuel": 1, "smoke": 2, "burn": 1, "volume_per_turn": "750 ml" },
-      { "fuel": 1, "smoke": 3, "burn": 2 },
-      { "fuel": 1, "smoke": 5, "burn": 5 }
+      { "fuel": 0.1, "smoke": 5, "burn": 0.001 },
+      { "fuel": 0.2, "smoke": 8, "burn": 0.006 },
+      { "fuel": 0.6, "smoke": 15, "burn": 0.02 }
     ]
   },
   {
@@ -113,6 +115,7 @@
       "energy": "15600 kJ",
       "explosion_data": { "chance_hot": 5, "chance_cold": 10, "factor": 0.2, "fiery": true, "size_factor": 0.1 }
     },
+    "//": "Despite being set below the cutoff point for non-flammable liquids, burns quite well. 1L adds about 45 minutes to a fire at the lowest intensity bracket.",
     "burn_data": [
       { "fuel": 150, "smoke": 0, "burn": 1 },
       { "fuel": 300, "smoke": 0, "burn": 2 },
@@ -137,10 +140,11 @@
       "energy": "15600 kJ",
       "explosion_data": { "chance_hot": 5, "chance_cold": 10, "factor": 0.2, "fiery": true, "size_factor": 0.1 }
     },
+    "//1": "Liquid paint, presumably latex-based (primary game use is painting walls). Capable of smothering most fires.",
     "burn_data": [
-      { "fuel": 150, "smoke": 0, "burn": 1 },
-      { "fuel": 300, "smoke": 0, "burn": 2 },
-      { "fuel": 450, "smoke": 0, "burn": 3 }
+      { "fuel": -1, "smoke": 0, "burn": 0.01 },
+      { "fuel": -1, "smoke": 0, "burn": 0.01 },
+      { "fuel": -1, "smoke": 0, "burn": 0.01 }
     ],
     "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 0, "bullet": 0 }
   },
@@ -177,7 +181,6 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
-    "burn_products": [ [ "resin_chunk", 1 ] ],
     "resist": { "bash": 8, "cut": 12, "acid": 20, "heat": 8, "bullet": 10 }
   },
   {
@@ -210,11 +213,13 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "//": "Normal chitin has low but non-zero flammability according to the US NFPA.",
     "burn_data": [
-      { "fuel": 0, "smoke": 0, "burn": 0 },
-      { "fuel": 1, "smoke": 3, "burn": 1, "volume_per_turn": "200 ml" },
-      { "fuel": 1, "smoke": 5, "burn": 3 }
+      { "fuel": 0, "smoke": 0, "burn": 0.0001 },
+      { "fuel": 0.2, "smoke": 3, "burn": 0.005, "volume_per_turn": "200 ml" },
+      { "fuel": 0.35, "smoke": 5, "burn": 0.015, "volume_per_turn": "200 ml" }
     ],
+    "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 2.3, "cut": 3.7, "acid": 16, "heat": 4, "bullet": 1.2 }
   },
   {
@@ -235,10 +240,11 @@
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
     "vitamins": [ [ "calcium", 2 ] ],
+    "//": "There is some historical evidence that animal bones have been used as an *added* combustion fuel by humans, but bones overall are a difficult material to use for this purpose and vary greatly in their suitability. The primary combustive component is in fact marrow and fats trapped inside the bone, not the bone structure itself.",
     "burn_data": [
-      { "fuel": 0, "smoke": 0, "burn": 0 },
-      { "fuel": 0, "smoke": 1, "burn": 1, "volume_per_turn": "250 ml" },
-      { "fuel": 1, "smoke": 1, "burn": 2 }
+      { "fuel": 0, "smoke": 0, "burn": 0.0003 },
+      { "fuel": 0.2, "smoke": 3, "burn": 0.01, "volume_per_turn": "250 ml" },
+      { "fuel": 0.35, "smoke": 5, "burn": 0.02, "volume_per_turn": "250 ml" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 2, "cut": 3, "acid": 7, "heat": 1, "bullet": 1 }
@@ -270,7 +276,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap_bronze", 1 ] ],
     "resist": { "bash": 4, "cut": 5, "acid": 1, "heat": 2, "bullet": 2 }
   },
   {
@@ -299,7 +304,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap_bronze", 1 ] ],
     "resist": { "bash": 5, "cut": 5, "acid": 5, "heat": 2, "bullet": 2 }
   },
   {
@@ -316,7 +320,6 @@
     "repaired_with": "scrap",
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 2 }
   },
   {
@@ -333,7 +336,11 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
-    "burn_data": [ { "fuel": 10, "smoke": 1, "burn": 10 }, { "fuel": 8, "smoke": 1, "burn": 20 }, { "fuel": 5, "smoke": 1, "burn": 50 } ],
+    "burn_data": [
+      { "fuel": 0.6, "smoke": 1, "burn": 0.025, "volume_per_turn": "200 ml" },
+      { "fuel": 1.2, "smoke": 1, "burn": 0.05, "volume_per_turn": "825 ml" },
+      { "fuel": 1.8, "smoke": 1, "burn": 0.075 }
+    ],
     "burn_products": [ [ "ash", 0.013 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 0, "bullet": 1 }
   },
@@ -410,9 +417,9 @@
     "repaired_with": "chitin_piece",
     "salvaged_into": "chitin_piece",
     "burn_data": [
-      { "fuel": 0, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 1, "smoke": 3, "burn": 1 },
-      { "fuel": 1, "smoke": 5, "burn": 4 }
+      { "fuel": 0, "smoke": 0, "burn": 0.0001 },
+      { "fuel": 0.2, "smoke": 3, "burn": 0.005, "volume_per_turn": "200 ml" },
+      { "fuel": 0.35, "smoke": 5, "burn": 0.015, "volume_per_turn": "200 ml" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 2.5, "cut": 4, "acid": 6, "heat": 2.5, "bullet": 1.4 }
@@ -432,9 +439,9 @@
     "cut_dmg_verb": "chipped",
     "chip_resist": 10,
     "burn_data": [
-      { "fuel": 0, "smoke": 2, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 1, "smoke": 4, "burn": 2 },
-      { "fuel": 1, "smoke": 6, "burn": 5 }
+      { "fuel": 0, "smoke": 0, "burn": 0.0001 },
+      { "fuel": 0.2, "smoke": 3, "burn": 0.005, "volume_per_turn": "200 ml" },
+      { "fuel": 0.35, "smoke": 5, "burn": 0.015, "volume_per_turn": "200 ml" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 1.4, "cut": 3, "acid": 4, "heat": 2, "bullet": 0.9 }
@@ -471,7 +478,6 @@
     "dmg_adj": [ "chipped", "scratched", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "cut",
-    "burn_products": [ [ "ceramic_shard", 1 ] ],
     "resist": { "bash": 2, "cut": 3, "acid": 6, "heat": 3, "bullet": 2 }
   },
   {
@@ -502,7 +508,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap_copper", 1 ] ],
     "resist": { "bash": 2, "cut": 3, "acid": 0, "heat": 3, "bullet": 2 }
   },
   {
@@ -523,9 +528,9 @@
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 1, "smoke": 1, "burn": 1 },
-      { "fuel": 1, "smoke": 1, "burn": 2 }
+      { "fuel": 1, "smoke": 1, "burn": 0.02 },
+      { "fuel": 2, "smoke": 1, "burn": 0.04 },
+      { "fuel": 3, "smoke": 1, "burn": 0.06 }
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 3, "heat": 0, "bullet": 1 }
   },
@@ -558,9 +563,9 @@
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "750 ml" },
-      { "fuel": 1, "smoke": 1, "burn": 1 },
-      { "fuel": 1, "smoke": 1, "burn": 2 }
+      { "fuel": 1, "smoke": 1, "burn": 0.02 },
+      { "fuel": 2, "smoke": 1, "burn": 0.04 },
+      { "fuel": 3, "smoke": 1, "burn": 0.06 }
     ],
     "resist": { "bash": 2, "cut": 2.25, "acid": 4, "heat": 0, "bullet": 2 }
   },
@@ -582,9 +587,9 @@
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "750 ml" },
-      { "fuel": 1, "smoke": 1, "burn": 1 },
-      { "fuel": 1, "smoke": 1, "burn": 2 }
+      { "fuel": 1, "smoke": 1, "burn": 0.02 },
+      { "fuel": 2, "smoke": 1, "burn": 0.04 },
+      { "fuel": 3, "smoke": 1, "burn": 0.06 }
     ],
     "resist": { "bash": 2, "cut": 2.5, "acid": 4, "heat": 0, "bullet": 2 }
   },
@@ -650,7 +655,11 @@
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
     "vitamins": [ [ "calcium", 0.5 ], [ "iron", 0.5 ] ],
-    "burn_data": [ { "fuel": 0, "smoke": 1, "burn": 1 }, { "fuel": 1, "smoke": 3, "burn": 2 }, { "fuel": 1, "smoke": 5, "burn": 5 } ],
+    "burn_data": [
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
+    ],
     "resist": { "bash": 0, "cut": 0, "acid": 1, "heat": 1, "bullet": 0 }
   },
   {
@@ -670,10 +679,11 @@
     "bash_dmg_verb": "bruised",
     "cut_dmg_verb": "sliced",
     "vitamins": [ [ "calcium", 0.1 ], [ "iron", 1.3 ] ],
+    "//1": "It's rather difficult to find citeable data on how well arbitrary volumes of human flesh burns, so I've settled for just spitballing it, using wood as a baseline and knowing that cremation takes a lot of fuel. Now it burns less well than wood. So, big improvement. This data was last touched 7 years ago, in a 2016 PR which also cleaned up the fire code. They thought it was crusty and nonsensical at the time. I checked to see what had changed since then. Essentially nothing. So these values never made any sense.",
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "2500 ml" },
-      { "fuel": 2, "smoke": 3, "burn": 2, "volume_per_turn": "10000 ml" },
-      { "fuel": 3, "smoke": 10, "burn": 3 }
+      { "fuel": 0.05, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
+      { "fuel": 0.1, "smoke": 3, "burn": 0.002, "volume_per_turn": "500 ml" },
+      { "fuel": 0.2, "smoke": 10, "burn": 0.004, "volume_per_turn": "1 L" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "soft": true,
@@ -695,10 +705,11 @@
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "2500 ml" },
-      { "fuel": 2, "smoke": 3, "burn": 2, "volume_per_turn": "10000 ml" },
-      { "fuel": 3, "smoke": 10, "burn": 3 }
+      { "fuel": 0.02, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
+      { "fuel": 0.05, "smoke": 2, "burn": 0.002, "volume_per_turn": "500 ml" },
+      { "fuel": 0.1, "smoke": 3, "burn": 0.004, "volume_per_turn": "1 L" }
     ],
+    "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 1, "bullet": 1 }
   },
   {
@@ -713,7 +724,6 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
     "cut_dmg_verb": "cut",
-    "burn_products": [ [ "ceramic_shard", 1 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 4, "heat": 3, "bullet": 1 }
   },
   {
@@ -733,9 +743,9 @@
     "cut_dmg_verb": "cut",
     "vitamins": [ [ "vitC", 2 ] ],
     "burn_data": [
-      { "fuel": 1, "smoke": 2, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 1, "smoke": 1, "burn": 2 },
-      { "fuel": 1, "smoke": 1, "burn": 3 }
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 1, "bullet": 1 }
   },
@@ -756,9 +766,9 @@
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
     "burn_data": [
-      { "fuel": 1, "smoke": 3, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 1, "smoke": 5, "burn": 2 },
-      { "fuel": 1, "smoke": 10, "burn": 4 }
+      { "fuel": 0.6, "smoke": 1, "burn": 0.02 },
+      { "fuel": 1, "smoke": 1, "burn": 0.04 },
+      { "fuel": 1, "smoke": 1, "burn": 0.06 }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 2, "cut": 1.25, "acid": 3, "heat": 1, "bullet": 1 }
@@ -780,9 +790,9 @@
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
     "burn_data": [
-      { "fuel": 1, "smoke": 2, "burn": 1, "volume_per_turn": "750 ml" },
-      { "fuel": 1, "smoke": 3, "burn": 2 },
-      { "fuel": 1, "smoke": 5, "burn": 5 }
+      { "fuel": 0.6, "smoke": 1, "burn": 0.02 },
+      { "fuel": 1, "smoke": 1, "burn": 0.04 },
+      { "fuel": 1, "smoke": 1, "burn": 0.06 }
     ],
     "resist": { "bash": 2, "cut": 2, "acid": 4, "heat": 1, "bullet": 2 }
   },
@@ -863,7 +873,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "gold_small", 1 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 10, "heat": 3, "bullet": 1 }
   },
   {
@@ -883,10 +892,11 @@
     "cut_dmg_verb": "sliced",
     "vitamins": [ [ "calcium", 0.1 ], [ "iron", 1.3 ] ],
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "2500 ml" },
-      { "fuel": 2, "smoke": 3, "burn": 2, "volume_per_turn": "10000 ml" },
-      { "fuel": 3, "smoke": 10, "burn": 3 }
+      { "fuel": 0.05, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
+      { "fuel": 0.1, "smoke": 3, "burn": 0.002, "volume_per_turn": "500 ml" },
+      { "fuel": 0.2, "smoke": 10, "burn": 0.004, "volume_per_turn": "1 L" }
     ],
+    "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "soft": true,
     "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 1, "bullet": 1 }
   },
@@ -906,7 +916,11 @@
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
     "vitamins": [ [ "iron", 0.2 ], [ "vitC", 0.1 ], [ "calcium", 0.1 ] ],
-    "burn_data": [ { "fuel": 1, "smoke": 1, "burn": 1 }, { "fuel": 1, "smoke": 1, "burn": 2 }, { "fuel": 1, "smoke": 1, "burn": 3 } ],
+    "burn_data": [
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
+    ],
     "resist": { "bash": 0, "cut": 0, "acid": 1, "heat": 1, "bullet": 0 }
   },
   {
@@ -923,6 +937,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "//1": "1L adds about 90 minutes to a fire at the lowest intensity bracket.",
     "burn_data": [
       { "fuel": 300, "smoke": 6, "burn": 1 },
       { "fuel": 600, "smoke": 6, "burn": 2 },
@@ -1040,10 +1055,11 @@
     "bash_dmg_verb": "bruised",
     "cut_dmg_verb": "sliced",
     "vitamins": [ [ "calcium", 1 ], [ "iron", 1.3 ] ],
+    "//": "Copied from chitin",
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "2500 ml" },
-      { "fuel": 2, "smoke": 3, "burn": 2, "volume_per_turn": "10000 ml" },
-      { "fuel": 3, "smoke": 10, "burn": 3 }
+      { "fuel": 0, "smoke": 0, "burn": 0.0001 },
+      { "fuel": 0.2, "smoke": 3, "burn": 0.005, "volume_per_turn": "200 ml" },
+      { "fuel": 0.35, "smoke": 5, "burn": 0.015, "volume_per_turn": "200 ml" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 1, "bullet": 1 }
@@ -1062,7 +1078,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 4, "cut": 4, "acid": 5, "heat": 3, "bullet": 2 }
   },
   {
@@ -1080,7 +1095,11 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "smashed",
     "cut_dmg_verb": "cut",
-    "burn_data": [ { "fuel": 1, "smoke": 1, "burn": 1 }, { "fuel": 1, "smoke": 1, "burn": 2 }, { "fuel": 1, "smoke": 1, "burn": 3 } ],
+    "burn_data": [
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
+    ],
     "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 1, "bullet": 1 }
   },
   {
@@ -1099,7 +1118,11 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "smashed",
     "cut_dmg_verb": "cut",
-    "burn_data": [ { "fuel": 1, "smoke": 1, "burn": 1 }, { "fuel": 1, "smoke": 1, "burn": 2 }, { "fuel": 1, "smoke": 1, "burn": 3 } ],
+    "burn_data": [
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
+    ],
     "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 0, "bullet": 0 }
   },
   {
@@ -1175,7 +1198,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "lead", 1 ] ],
     "resist": { "bash": 0, "cut": 0, "acid": 8, "heat": 3, "bullet": 0 }
   },
   {
@@ -1196,9 +1218,9 @@
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
     "burn_data": [
-      { "fuel": 0, "smoke": 0, "burn": 0 },
-      { "fuel": 1, "smoke": 3, "burn": 2, "volume_per_turn": "500 ml" },
-      { "fuel": 1, "smoke": 3, "burn": 2 }
+      { "fuel": 0.05, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
+      { "fuel": 0.1, "smoke": 3, "burn": 0.002, "volume_per_turn": "500 ml" },
+      { "fuel": 0.2, "smoke": 10, "burn": 0.004, "volume_per_turn": "1 L" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 1, "cut": 3, "acid": 4, "heat": 2, "bullet": 2 }
@@ -1219,9 +1241,9 @@
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
     "burn_data": [
-      { "fuel": 0, "smoke": 1, "burn": 1 },
-      { "fuel": 1, "smoke": 3, "burn": 2, "volume_per_turn": "500 ml" },
-      { "fuel": 1, "smoke": 3, "burn": 3 }
+      { "fuel": 0.05, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
+      { "fuel": 0.1, "smoke": 3, "burn": 0.002, "volume_per_turn": "500 ml" },
+      { "fuel": 0.2, "smoke": 10, "burn": 0.004, "volume_per_turn": "1 L" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 2, "cut": 2, "acid": 6, "heat": 1, "bullet": 1 }
@@ -1243,10 +1265,11 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "//1": "Nylon/polyester react poorly to flame(they melt) but are hard to light. Doesn't break down easily unless exposed to a high-intensity fire.",
     "burn_data": [
-      { "fuel": 1, "smoke": 2, "burn": 1, "volume_per_turn": "650 ml" },
-      { "fuel": 1, "smoke": 3, "burn": 3 },
-      { "fuel": 1, "smoke": 5, "burn": 5 }
+      { "fuel": 0.05, "smoke": 1, "burn": 0.01 },
+      { "fuel": 0.05, "smoke": 2, "burn": 0.03 },
+      { "fuel": 0.15, "smoke": 5, "burn": 0.5 }
     ],
     "resist": { "bash": 2, "cut": 2, "acid": 9, "heat": 2, "bullet": 2 }
   },
@@ -1288,10 +1311,11 @@
     "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "//": "Neoprene is considered highly fire-resistant, and it survives much better than most fabrics. Leaving a 1L cube in a small fire for upwards of 20 minutes produces burnt-badly burnt items.",
     "burn_data": [
-      { "fuel": 1, "smoke": 3, "burn": 1, "volume_per_turn": "2500 ml" },
-      { "fuel": 1, "smoke": 3, "burn": 2 },
-      { "fuel": 1, "smoke": 3, "burn": 3 }
+      { "fuel": 0.001, "smoke": 3, "burn": 0.001, "volume_per_turn": "1 ml" },
+      { "fuel": 0.001, "smoke": 3, "burn": 0.002, "volume_per_turn": "5 ml" },
+      { "fuel": 0.003, "smoke": 3, "burn": 0.005 }
     ],
     "resist": { "bash": 2, "cut": 1, "acid": 1, "heat": 2, "bullet": 1 }
   },
@@ -1312,7 +1336,6 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
-    "burn_products": [ [ "nomex", 1 ] ],
     "burn_data": [ { "immune": true }, { "immune": true }, { "immune": true } ],
     "resist": { "bash": 1, "cut": 1, "acid": 5, "heat": 20, "bullet": 1 }
   },
@@ -1368,10 +1391,11 @@
     "repaired_with": "wax",
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "//1": "Basically as flammable as a candle.",
     "burn_data": [
-      { "fuel": 150, "smoke": 0, "burn": 1 },
-      { "fuel": 300, "smoke": 0, "burn": 2 },
-      { "fuel": 450, "smoke": 0, "burn": 3 }
+      { "fuel": 0.1, "smoke": 1, "burn": 0.001 },
+      { "fuel": 0.4, "smoke": 1, "burn": 0.003 },
+      { "fuel": 1, "smoke": 2, "burn": 0.008 }
     ],
     "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 0, "bullet": 0 }
   },
@@ -1390,7 +1414,11 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
-    "burn_data": [ { "fuel": 10, "smoke": 1, "burn": 10 }, { "fuel": 8, "smoke": 1, "burn": 20 }, { "fuel": 5, "smoke": 1, "burn": 50 } ],
+    "burn_data": [
+      { "fuel": 0.6, "smoke": 1, "burn": 0.025, "volume_per_turn": "200 ml" },
+      { "fuel": 1.2, "smoke": 1, "burn": 0.05, "volume_per_turn": "825 ml" },
+      { "fuel": 1.8, "smoke": 1, "burn": 0.075 }
+    ],
     "burn_products": [ [ "ash", 0.013 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 0, "bullet": 1 }
   },
@@ -1407,7 +1435,11 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
-    "burn_data": [ { "fuel": 10, "smoke": 1, "burn": 10 }, { "fuel": 8, "smoke": 1, "burn": 20 }, { "fuel": 5, "smoke": 1, "burn": 50 } ],
+    "burn_data": [
+      { "fuel": 0.6, "smoke": 1, "burn": 0.025, "volume_per_turn": "200 ml" },
+      { "fuel": 1.2, "smoke": 1, "burn": 0.05, "volume_per_turn": "825 ml" },
+      { "fuel": 1.8, "smoke": 1, "burn": 0.075 }
+    ],
     "burn_products": [ [ "ash", 0.013 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 0, "bullet": 1 }
   },
@@ -1427,10 +1459,11 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
+    "//1": "Most consumer polymers and plastics receive a UL94 rating for flammability and the lowest UL94 rating is HB, generally considered self-extinguishing. Plastics are flammable but should only contribute significant fuel in intense fires.",
     "burn_data": [
-      { "fuel": 1, "smoke": 2, "burn": 1, "volume_per_turn": "750 ml" },
-      { "fuel": 1, "smoke": 3, "burn": 2 },
-      { "fuel": 1, "smoke": 5, "burn": 5 }
+      { "fuel": 0.1, "smoke": 2, "burn": 0.001 },
+      { "fuel": 0.4, "smoke": 3, "burn": 0.003 },
+      { "fuel": 1, "smoke": 5, "burn": 0.008 }
     ],
     "resist": { "bash": 2, "cut": 2, "acid": 9, "heat": 1, "bullet": 2 }
   },
@@ -1449,9 +1482,9 @@
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
     "burn_data": [
-      { "fuel": 1, "smoke": 2, "burn": 1, "volume_per_turn": "750 ml" },
-      { "fuel": 1, "smoke": 3, "burn": 2 },
-      { "fuel": 1, "smoke": 5, "burn": 5 }
+      { "fuel": 0.1, "smoke": 2, "burn": 0.001 },
+      { "fuel": 0.4, "smoke": 3, "burn": 0.003 },
+      { "fuel": 1, "smoke": 5, "burn": 0.008 }
     ],
     "resist": { "bash": 0.75, "cut": 0.5, "acid": 9, "heat": 1, "bullet": 0.5 }
   },
@@ -1468,6 +1501,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "//": "This is a highly non-specific material which usually can't be found in any great quantity, so it doesn't really matter what the burn_data is.",
     "burn_data": [
       { "fuel": 10, "smoke": 2, "burn": 10 },
       { "fuel": 10, "smoke": 2, "burn": 10 },
@@ -1534,7 +1568,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "silver_small", 1 ] ],
     "resist": { "bash": 2, "cut": 3, "acid": 10, "heat": 3, "bullet": 2 }
   },
   {
@@ -1551,7 +1584,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "platinum_small", 1 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 10, "heat": 3, "bullet": 1 }
   },
   {
@@ -1605,7 +1637,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 4.5 }
   },
   {
@@ -1623,7 +1654,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 7, "cut": 7, "acid": 7, "heat": 3, "bullet": 4.5 }
   },
   {
@@ -1641,7 +1671,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 10, "cut": 10, "acid": 7, "heat": 3, "bullet": 6.5 }
   },
   {
@@ -1659,7 +1688,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 10, "cut": 10, "acid": 7, "heat": 3, "bullet": 6.5 }
   },
   {
@@ -1677,7 +1705,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 11, "cut": 11, "acid": 7, "heat": 3, "bullet": 7.5 }
   },
   {
@@ -1698,7 +1725,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 2 }
   },
   {
@@ -1720,7 +1746,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 4.5 }
   },
   {
@@ -1742,7 +1767,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 7, "cut": 7, "acid": 7, "heat": 3, "bullet": 4.5 }
   },
   {
@@ -1764,7 +1788,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 10, "cut": 10, "acid": 7, "heat": 3, "bullet": 6.5 }
   },
   {
@@ -1786,7 +1809,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 10, "cut": 10, "acid": 7, "heat": 3, "bullet": 6.5 }
   },
   {
@@ -1808,7 +1830,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 11, "cut": 11, "acid": 7, "heat": 3, "bullet": 7.5 }
   },
   {
@@ -1825,7 +1846,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 3 }
   },
   {
@@ -1841,7 +1861,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "fuel_data": { "energy": "10000 kJ" },
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 3 }
   },
@@ -1858,7 +1877,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "fuel_data": { "energy": "10000 kJ" },
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 3 }
   },
@@ -1876,7 +1894,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "scrap", 1 ] ],
     "fuel_data": {
       "//": "Compressed gaseous hydrogen has 9.2 MJ/L.  This stuff has a very high energy density but is also bulky and explosive.",
       "energy": "4000000 kJ",
@@ -1897,7 +1914,6 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
-    "burn_products": [ [ "pebble", 1 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 8, "heat": 3, "bullet": 3 }
   },
   {
@@ -1912,7 +1928,6 @@
     "dmg_adj": [ "resonating", "cascading", "unravelling", "fractal" ],
     "bash_dmg_verb": "agitated",
     "cut_dmg_verb": "agitated",
-    "burn_products": [ [ "pebble", 1 ] ],
     "resist": { "bash": 160, "cut": 200, "acid": 100, "heat": 100, "bullet": 160 }
   },
   {
@@ -1930,7 +1945,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "alloy_sheet", 1 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 5, "heat": 3, "bullet": 5 }
   },
   {
@@ -1966,10 +1980,11 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "//1": "Nylon reacts poorly to flame(it melts) but is hard to light. Doesn't break down easily unless exposed to a high-intensity fire.",
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "650 ml" },
-      { "fuel": 1, "smoke": 1, "burn": 1 },
-      { "fuel": 1, "smoke": 1, "burn": 2 }
+      { "fuel": 0.05, "smoke": 1, "burn": 0.01 },
+      { "fuel": 0.05, "smoke": 2, "burn": 0.03 },
+      { "fuel": 0.15, "smoke": 5, "burn": 0.5 }
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 9, "heat": 2, "bullet": 3 }
   },
@@ -1997,6 +2012,12 @@
     "id": "carpet_pilling",
     "name": "Carpet Pilling",
     "copy-from": "nylon",
+    "//1": "Carpet, on the other hand, burns pretty well.",
+    "burn_data": [
+      { "fuel": 1, "smoke": 1, "burn": 0.02 },
+      { "fuel": 2, "smoke": 1, "burn": 0.04 },
+      { "fuel": 3, "smoke": 1, "burn": 0.06 }
+    ],
     "resist": { "bash": 1, "cut": 1, "acid": 6, "heat": 2, "bullet": 1 }
   },
   {
@@ -2034,7 +2055,6 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
-    "burn_products": [ [ "tin", 1 ] ],
     "resist": { "bash": 0, "cut": 0, "acid": 2, "heat": 3, "bullet": 0 }
   },
   {
@@ -2055,9 +2075,9 @@
     "cut_dmg_verb": "cut",
     "vitamins": [ [ "calcium", 0.1 ], [ "vitC", 0.5 ] ],
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 2, "smoke": 1, "burn": 2, "volume_per_turn": "2500 ml" },
-      { "fuel": 2, "smoke": 1, "burn": 3 }
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 1, "bullet": 1 }
   },
@@ -2078,9 +2098,9 @@
     "cut_dmg_verb": "cut",
     "vitamins": [ [ "calcium", 0.1 ], [ "vitC", 4 ], [ "iron", 0.1 ] ],
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 2, "smoke": 1, "burn": 2, "volume_per_turn": "2500 ml" },
-      { "fuel": 2, "smoke": 1, "burn": 3 }
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 1, "bullet": 1 }
   },
@@ -2101,9 +2121,9 @@
     "cut_dmg_verb": "cut",
     "vitamins": [ [ "calcium", 0.3 ], [ "vitC", 0.6 ], [ "iron", 0.8 ] ],
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 2, "smoke": 1, "burn": 2, "volume_per_turn": "2500 ml" },
-      { "fuel": 2, "smoke": 1, "burn": 3 }
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 1, "bullet": 1 }
   },
@@ -2124,9 +2144,9 @@
     "cut_dmg_verb": "cut",
     "vitamins": [ [ "calcium", 1.8 ], [ "vitC", 5.2 ], [ "iron", 0.9 ] ],
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 2, "smoke": 1, "burn": 2, "volume_per_turn": "2500 ml" },
-      { "fuel": 2, "smoke": 1, "burn": 3 }
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 1, "bullet": 1 }
   },
@@ -2147,9 +2167,9 @@
     "cut_dmg_verb": "cut",
     "vitamins": [ [ "calcium", 0.3 ], [ "iron", 1 ] ],
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 2, "smoke": 1, "burn": 2, "volume_per_turn": "2500 ml" },
-      { "fuel": 2, "smoke": 1, "burn": 3 }
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 1, "bullet": 1 }
   },
@@ -2170,9 +2190,9 @@
     "cut_dmg_verb": "cut",
     "vitamins": [ [ "calcium", 0.4 ], [ "iron", 4 ] ],
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 2, "smoke": 1, "burn": 2, "volume_per_turn": "2500 ml" },
-      { "fuel": 2, "smoke": 1, "burn": 3 }
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 1, "bullet": 1 }
   },
@@ -2226,7 +2246,13 @@
     "bash_dmg_verb": "squished",
     "cut_dmg_verb": "cut",
     "vitamins": [ [ "iron", 0.1 ] ],
-    "burn_data": [ { "fuel": 1, "smoke": 2, "burn": 1 }, { "fuel": 1, "smoke": 2, "burn": 2 }, { "fuel": 1, "smoke": 1, "burn": 3 } ],
+    "//": "This burn data assumes wheat and chaff. In this form, it burns pretty well.",
+    "burn_data": [
+      { "fuel": 0.6, "smoke": 1, "burn": 0.025, "volume_per_turn": "200 ml" },
+      { "fuel": 1.2, "smoke": 1, "burn": 0.05, "volume_per_turn": "825 ml" },
+      { "fuel": 1.8, "smoke": 1, "burn": 0.075 }
+    ],
+    "burn_products": [ [ "ash", 0.013 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 0, "bullet": 1 }
   },
   {
@@ -2263,6 +2289,11 @@
     "//": "physical density for charcoal estimated to sit at about 0.208 kg/liter, while energy density per kg is slightly lower than pure anthracite coal at 30 MJ/kg.",
     "//1": "208g of charcoal (1 liter) yields 6240 kJ (30MJ x .208), and a single chunk (8mL/1.664g) is worth 50kJ",
     "//2": "density sourced from https://www.aqua-calc.com/page/density-table/substance/charcoal and http://ukrfuel.com/news-physical-properties-of-charcoal-22.html",
+    "burn_data": [
+      { "fuel": 2, "smoke": 1, "burn": 0.1 },
+      { "fuel": 4, "smoke": 1, "burn": 0.2 },
+      { "fuel": 6, "smoke": 1, "burn": 0.3 }
+    ],
     "density": 0.208
   },
   {
@@ -2275,6 +2306,11 @@
     "//1": "Raw density of anthracite is ~1.5g/cm^3 but bulk density is lower at slightly less than 1.0.",
     "//2": "Roughly 5x the energy content of charcoal per liter under that specific bulk density. Fuel data below assumes bulk density.",
     "//3": "Compressed pure anthracite (1.5 g/cm^3 density) would represent about 50 MJ/kg and could eventually be a second material.",
+    "burn_data": [
+      { "fuel": 10, "smoke": 0.1, "burn": 0.1 },
+      { "fuel": 20, "smoke": 0.2, "burn": 0.2 },
+      { "fuel": 30, "smoke": 0.3, "burn": 0.3 }
+    ],
     "fuel_data": { "energy": "31200 kJ" },
     "density": 0.931
   },
@@ -2296,9 +2332,9 @@
     "bash_dmg_verb": "torn",
     "cut_dmg_verb": "cut",
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 1, "smoke": 1, "burn": 2 },
-      { "fuel": 1, "smoke": 1, "burn": 5 }
+      { "fuel": 0.6, "smoke": 1, "burn": 0.025, "volume_per_turn": "200 ml" },
+      { "fuel": 1.2, "smoke": 1, "burn": 0.05, "volume_per_turn": "825 ml" },
+      { "fuel": 1.8, "smoke": 1, "burn": 0.075 }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 4, "heat": 0, "bullet": 1 }
@@ -2358,9 +2394,9 @@
     "cut_dmg_verb": "cut",
     "vitamins": [ [ "vitC", 2 ] ],
     "burn_data": [
-      { "fuel": 1, "smoke": 2, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 1, "smoke": 1, "burn": 2 },
-      { "fuel": 1, "smoke": 1, "burn": 3 }
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 1, "bullet": 1 }
   },
@@ -2381,9 +2417,9 @@
     "cut_dmg_verb": "sliced",
     "vitamins": [ [ "calcium", 0.1 ], [ "iron", 1.3 ] ],
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "2500 ml" },
-      { "fuel": 2, "smoke": 3, "burn": 2, "volume_per_turn": "10000 ml" },
-      { "fuel": 3, "smoke": 10, "burn": 3 }
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 1, "bullet": 1 }
   },
@@ -2402,7 +2438,11 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "smashed",
     "cut_dmg_verb": "cut",
-    "burn_data": [ { "fuel": 1, "smoke": 1, "burn": 1 }, { "fuel": 1, "smoke": 1, "burn": 2 }, { "fuel": 1, "smoke": 1, "burn": 3 } ],
+    "burn_data": [
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
+    ],
     "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 1, "bullet": 1 }
   },
   {
@@ -2422,9 +2462,9 @@
     "cut_dmg_verb": "cut",
     "vitamins": [ [ "calcium", 1.5 ], [ "iron", 0.1 ] ],
     "burn_data": [
-      { "fuel": -100, "smoke": 1, "burn": 1 },
-      { "fuel": -50, "smoke": 2, "burn": 1 },
-      { "fuel": -10, "smoke": 2, "burn": 2 }
+      { "fuel": 0, "smoke": 1, "burn": 0.002 },
+      { "fuel": 0, "smoke": 3, "burn": 0.002 },
+      { "fuel": 0, "smoke": 5, "burn": 0.005 }
     ],
     "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 0, "bullet": 0 }
   },
@@ -2463,7 +2503,6 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
-    "burn_products": [ [ "material_soil", 1 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 0, "heat": 20, "bullet": 1 }
   },
   {
@@ -2558,6 +2597,7 @@
       "energy": "34800 kJ",
       "explosion_data": { "chance_hot": 5, "chance_cold": 1000, "factor": 0.2, "fiery": false, "size_factor": 0.1 }
     },
+    "//": "Historically used as a fuel (blended with other liquids), still burns quite well on its own.",
     "burn_data": [
       { "fuel": 300, "smoke": 0, "burn": 1 },
       { "fuel": 600, "smoke": 0, "burn": 2 },
@@ -2612,9 +2652,9 @@
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
     "burn_data": [
-      { "fuel": 1, "smoke": 3, "burn": 1, "volume_per_turn": "1250 ml" },
-      { "fuel": 1, "smoke": 5, "burn": 2 },
-      { "fuel": 1, "smoke": 10, "burn": 4 }
+      { "fuel": 0.6, "smoke": 1, "burn": 0.02 },
+      { "fuel": 1, "smoke": 1, "burn": 0.04 },
+      { "fuel": 1, "smoke": 1, "burn": 0.06 }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 0.5, "cut": 0.31, "acid": 1, "heat": 1, "bullet": 0.25 }
@@ -2658,9 +2698,9 @@
     "cut_dmg_verb": "chipped",
     "vitamins": [ [ "calcium", 2 ] ],
     "burn_data": [
-      { "fuel": 0, "smoke": 0, "burn": 0 },
-      { "fuel": 0, "smoke": 1, "burn": 1, "volume_per_turn": "250 ml" },
-      { "fuel": 1, "smoke": 1, "burn": 2 }
+      { "fuel": 0, "smoke": 0, "burn": 0.0003 },
+      { "fuel": 0.2, "smoke": 3, "burn": 0.01, "volume_per_turn": "250 ml" },
+      { "fuel": 0.35, "smoke": 5, "burn": 0.02, "volume_per_turn": "250 ml" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 2, "cut": 3, "acid": 7, "heat": 1, "bullet": 1 }


### PR DESCRIPTION
#### Summary
Balance "Most materials now burn at least a little slower than gunpowder"

#### Purpose of change
Pretty much the entirety of our materials' burn_data entries were just copy-pasted (cargo culted) from one contributor to the next.  Most items are consumed by small fires in *seconds*, and the amount of fuel added to the fire would be very high, even for non-combustible materials.

#### Describe the solution
Go through materials.json. Do my best to research the relative flammability of a given material. Add comments. Comments comments comments. Burn everything. Burn it again to be sure. Remove burn_products from a bunch of materials which... literally don't burn and can't produce them.

#### Describe alternatives you've considered
I probably could have done something productive with my time instead...

#### Testing
I created a 1L, 1kg solid debug item and changed its material around before loading in to a preset testing setup and lighting fires then watching how well the objects burned. The testing setup consisted of 2x fire rings and 2x empty grass tiles, each of the 4 burn tiles had 1 tinder on them (required to start the fire) and was lit by a firestarter CBM. The player character was in the center of the burn tiles, which were located at the 7/9/3/1 positions on the numpad. No burn tiles were adjacent as that could skew the results.

For materials whose 'burn curve' varied significantly with the intensity of the fire, tests were repeated with the amount of tinder increased to 10000 units.

I repeated these tests for pretty much every material I modified except the copy-pastes (like the 6 different forms of chitin). For the liquid-expected materials (alcohol, hydrocarbons, etc) I duplicated the debug item into a liquid form and gave it a charges/stack_size of 1

#### Additional context
Wood was largely used a baseline and expressly was not touched.

This is probably going to have some knock-on effects and I have no doubt someone out there will be very upset you can no longer recreate dante's inferno by dropping a match onto a pile of zombie corpses and their loot.

Hats off to rubber for having actually tested their data before implementing. Looks like it works about how you wanted.