### PR TITLE
Mutators for EOCs

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -65,6 +65,18 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_mutator_test",
+    "effect": [
+      { "set_string_var": "mon_zombie", "target_var": { "context_val": "temp" } },
+      { "set_string_var": { "mutator": "mon_faction", "mtype_id": "mon_zombie" }, "target_var": { "global_val": "key1" } },
+      {
+        "set_string_var": { "mutator": "mon_faction", "mtype_id": { "context_val": "temp" } },
+        "target_var": { "global_val": "key2" }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_math_test_context",
     "effect": [
       { "math": [ "_simple", "=", "12" ] },

--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -68,7 +68,10 @@
     "id": "EOC_mutator_test",
     "effect": [
       { "set_string_var": "mon_zombie", "target_var": { "context_val": "temp" } },
-      { "set_string_var": { "mutator": "mon_faction", "mtype_id": "mon_zombie" }, "target_var": { "global_val": "key1" } },
+      {
+        "set_string_var": { "mutator": "mon_faction", "mtype_id": "mon_zombie" },
+        "target_var": { "global_val": "key1" }
+      },
       {
         "set_string_var": { "mutator": "mon_faction", "mtype_id": { "context_val": "temp" } },
         "target_var": { "global_val": "key2" }

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1238,6 +1238,18 @@ Example:
 ]
 ```
 
+### Mutators
+`mutators`: take in an ammount of data and provide you with a relevant string. This can be used to get information about items, monsters, etc. from the id, or other data. Mutators can be used anywhere that a string [variable object](#variable-object) can be used. Mutators take the form:
+```json
+{ "mutator": "MUTATOR_NAME", "REQUIRED_KEY1": "REQUIRED_VALUE1", ..., "REQUIRED_KEYn": "REQUIRED_VALUEn" }
+```
+
+#### List Of Mutators
+Mutator Name | Required Keys | Description
+--- | --- | ---
+`"mon_faction"` | `mtype_id`: String or [variable object](#variable-object). | Returns the faction of the monster with mtype_id.
+
+
 ### Compare Numbers and Arithmetics
 *`arithmetic` and `compare_num` are deprecated in the long term. See [Math](#math) for the replacement.*
 

--- a/src/condition.h
+++ b/src/condition.h
@@ -197,6 +197,8 @@ struct conditional_t {
         void set_compare_num( const JsonObject &jo, std::string_view member );
         void set_math( const JsonObject &jo, std::string_view member );
         template<class J>
+        static std::function<std::string( const dialogue & )> get_get_string( J const &jo );
+        template<class J>
         static std::function<double( dialogue & )> get_get_dbl( J const &jo );
         static std::function<double( dialogue & )> get_get_dbl( const std::string &value,
                 const JsonObject &jo );

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -39,6 +39,9 @@ std::string read_var_value( const var_info &info, const dialogue &d )
 
 std::string str_or_var::evaluate( dialogue const &d ) const
 {
+    if( function.has_value() ) {
+        return function.value()( d );
+    }
     if( str_val.has_value() ) {
         return str_val.value();
     }

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -141,6 +141,7 @@ struct str_or_var {
     std::optional<std::string> str_val;
     std::optional<var_info> var_val;
     std::optional<std::string> default_val;
+    std::optional<std::function<std::string( const dialogue & )>> function;
     std::string evaluate( dialogue const &d ) const;
 };
 

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -33,6 +33,7 @@ static const effect_on_condition_id
 effect_on_condition_EOC_math_var( "EOC_math_var" );
 static const effect_on_condition_id
 effect_on_condition_EOC_math_weighted_list( "EOC_math_weighted_list" );
+static const effect_on_condition_id effect_on_condition_EOC_mutator_test( "EOC_mutator_test" );
 static const effect_on_condition_id effect_on_condition_EOC_run_with_test( "EOC_run_with_test" );
 static const effect_on_condition_id
 effect_on_condition_EOC_run_with_test_expects_fail( "EOC_run_with_test_expects_fail" );
@@ -230,6 +231,22 @@ TEST_CASE( "EOC_context_test", "[eoc][math_parser]" )
 
     // value shouldn't exist in the original dialogue
     CHECK( d.get_value( "npctalk_var_simple" ).empty() );
+}
+
+TEST_CASE( "EOC_mutator_test", "[eoc][math_parser]" )
+{
+    clear_avatar();
+    clear_map();
+
+    dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
+    global_variables &globvars = get_globals();
+    globvars.clear_global_values();
+
+    REQUIRE( globvars.get_global_value( "npctalk_var_key1" ).empty() );
+    REQUIRE( globvars.get_global_value( "npctalk_var_key2" ).empty() );
+    CHECK( effect_on_condition_EOC_mutator_test->activate( d ) );
+    CHECK( globvars.get_global_value( "npctalk_var_key1" ) == "zombie" );
+    CHECK( globvars.get_global_value( "npctalk_var_key2" ) == "zombie" );
 }
 
 TEST_CASE( "EOC_activity_ongoing", "[eoc][timed_event]" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Mutators for strings in EOC"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
With the context variables and events it is possible someone may want to query information about something. The first example is a monsters faction from its mtype_id.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a new possibility for str_or_var to evaluate as a function instead of a variable or string.

Added the get_get_str function which houses all the new mutators.

Added documentation.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Unit tests have been added, but I haven't compiled locally yet.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->