### PR TITLE
Changed Giant Pincer into a piece of integrated armor with qualities and some natural moves, also messed a little with the warmth values of crustacean carapace.

### DIFF
--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -777,7 +777,7 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str_sp": "sclerotin right pincer" },
-    "description": "Useful for the hunt, suitable for maximum efficiency.",
+    "description": "A powerful tool for snatching fish or breaking open shells.",
     "weight": "900 g",
     "volume": "1 L",
     "price": 0,

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -720,7 +720,7 @@
     "material": [ "sclerotin" ],
     "symbol": "x",
     "color": "brown",
-    "warmth": 7,
+    "warmth": 20,
     "environmental_protection": 1,
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "BLOCK_WHILE_WORN", "UNBREAKABLE", "OUTER" ],
     "armor": [
@@ -771,6 +771,35 @@
         "encumbrance": 9
       }
     ]
+  },
+  {
+    "id": "integrated_giant_pincer",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "sclerotin right pincer" },
+    "description": "Useful for the hunt, suitable for maximum efficiency.",
+    "weight": "900 g",
+    "volume": "1 L",
+    "price": 0,
+    "price_postapoc": 0,
+    "material": [ "sclerotin" ],
+    "symbol": ",",
+    "color": "brown",
+    "warmth": 10,
+    "to_hit": 1,
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -4 ], [ "PRY", 1 ], [ "HAMMER", 1 ] ],
+    "environmental_protection": 3,
+    "techniques": [ "BRUTAL", "WBLOCK_2" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "PADDED" ],
+    "armor": [
+      {
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 6.4 } ],
+        "covers": [ "hand_r" ],
+        "coverage": 80,
+        "encumbrance": 30
+      }
+    ],
+    "melee_damage": { "bash": 12, "cut": 3 }
   },
   {
     "id": "integrated_shell",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2834,16 +2834,16 @@
     "leads_to": [ "CRUSTACEAN_CLAW" ],
     "integrated_armor": [ "integrated_carapace" ],
     "wet_protection": [
-      { "part": "head", "ignore": 15 },
-      { "part": "leg_l", "ignore": 20 },
-      { "part": "leg_r", "ignore": 20 },
-      { "part": "foot_l", "ignore": 9 },
-      { "part": "foot_r", "ignore": 9 },
-      { "part": "arm_l", "ignore": 20 },
-      { "part": "arm_r", "ignore": 20 },
-      { "part": "hand_l", "ignore": 9 },
-      { "part": "hand_r", "ignore": 9 },
-      { "part": "torso", "ignore": 34 }
+      { "part": "head", "ignored": 15 },
+      { "part": "leg_l", "ignored": 20 },
+      { "part": "leg_r", "ignored": 20 },
+      { "part": "foot_l", "ignored": 9 },
+      { "part": "foot_r", "ignored": 9 },
+      { "part": "arm_l", "ignored": 20 },
+      { "part": "arm_r", "ignored": 20 },
+      { "part": "hand_l", "ignored": 9 },
+      { "part": "hand_r", "ignored": 9 },
+      { "part": "torso", "ignored": 34 }
     ],
     "passive_mods": { "dex_mod": -2 }
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2834,16 +2834,16 @@
     "leads_to": [ "CRUSTACEAN_CLAW" ],
     "integrated_armor": [ "integrated_carapace" ],
     "wet_protection": [
-      { "part": "head", "ignored": 8 },
-      { "part": "leg_l", "ignored": 16 },
-      { "part": "leg_r", "ignored": 16 },
-      { "part": "foot_l", "ignored": 6 },
-      { "part": "foot_r", "ignored": 6 },
-      { "part": "arm_l", "ignored": 16 },
-      { "part": "arm_r", "ignored": 16 },
-      { "part": "hand_l", "ignored": 6 },
-      { "part": "hand_r", "ignored": 6 },
-      { "part": "torso", "ignored": 20 }
+      { "part": "head", "ignore": 15 },
+      { "part": "leg_l", "ignore": 20 },
+      { "part": "leg_r", "ignore": 20 },
+      { "part": "foot_l", "ignore": 9 },
+      { "part": "foot_r", "ignore": 9 },
+      { "part": "arm_l", "ignore": 20 },
+      { "part": "arm_r", "ignore": 20 },
+      { "part": "hand_l", "ignore": 9 },
+      { "part": "hand_r", "ignore": 9 },
+      { "part": "torso", "ignore": 34 }
     ],
     "passive_mods": { "dex_mod": -2 }
   },
@@ -2901,19 +2901,15 @@
     "points": 0,
     "visibility": 10,
     "ugliness": 9,
-    "cut_dmg_bonus": 3,
-    "bash_dmg_bonus": 6,
-    "butchering_quality": -3,
     "description": "Instead of your right hand, you now have a giant claw resembling ones found on crabs.  It encumbers you greatly, but you can use it in melee combat to deal massive damage.",
-    "encumbrance_always": [ [ "hand_r", 40 ] ],
     "valid": false,
     "cancels": [ "NAILS", "CLAWS", "TALONS", "WEBBED", "ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8" ],
     "prereqs": [ "CRUSTACEAN_CARAPACE" ],
+    "integrated_armor": [ "integrated_giant_pincer" ],
     "threshreq": [ "THRESH_CRUSTACEAN" ],
     "category": [ "CRUSTACEAN" ],
     "restricts_gear": [ "hand_r" ],
-    "types": [ "HANDS" ],
-    "armor": [ { "parts": [ "hand_r" ], "bash": 3, "cut": 3 } ]
+    "types": [ "HANDS" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Changed Giant Pincer into a piece of integrated armor with Prying 1, Hammer 1, Cut 1, and Butchering -4 also decreased its encumbrance from 40 to 30. It also know has the built in moves Parry and Brutal Strike."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

To bring it inline with Sclerotin Claws that are a part of CHITIN3, those also have rapid strike built-in. Changes to warmth modifiers are because you have enough encumbrance already that wearing clothing to add warmth makes you extremely slow and vulnerable. Without this Crustacean mutants get frostbite in around 30 minutes during mildly cold periods.
#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Keeping these the same as they currently are.
#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Spawned in game and mutated myself, walked around and used the claw in combat and to hammer some stuff.
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->