### PR TITLE
Apply different messages per intensity level

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -246,16 +246,18 @@
     ],
     "max_intensity": 4,
     "blood_analysis_description": "Patient has dangerous levels of multiple chemicals in their blood.  Sedation and restraint suggested.",
-    "base_mods": { "speed_mod": [ 10 ], "str_mod": [ 1 ], "stim_amount": [ 1 ], "stim_tick": [ 500 ], "stim_max_val": [ 50 ] },
+    "base_mods": { "speed_mod": [ 10 ], "str_mod": [ 1 ], "stim_amount": [ 1 ], "stim_tick": [ 500 ], "stim_max_val": [ 50 ], "hurt_chance": [ 1 ],
+      "hurt_tick": [ 15000 ], "pain_amount": [ 0 ], "pain_chance": [ 2 ], "pain_tick": [ 400 ], "hurt_amount": [ 1 ] },
     "scaling_mods": {
       "perspiration_amount": [ 6 ],
       "perspiration_min": [ 1 ],
       "perspiration_chance": [ 2 ],
-      "perspiration_tick": [ 1500 ],
+      "perspiration_tick": [ 150 ],
       "pain_amount": [ 10 ],
       "pain_min": [ 1 ],
-      "pain_chance": [ 2 ],
-      "pain_tick": [ 600 ],
+      "hurt_amount": [ 1 ],
+      "pain_tick": [ -100 ],
+      "hurt_tick": [ -4925 ],
       "stim_max_val": [ 400 ]
     }
   },

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -221,7 +221,7 @@
     "//": "Intensity 1 is a standard dosage of the drug.  Further intensities reflect taking pills while the first dose hasn't worn off.  It is not wise to do so.",
     "name": [ "Energized", "Enflamed", "Arythmic", "Tachycardiac" ],
     "apply_message": [
-      [ "These magickal trucker pills have kicked in and you feel great!", "good" ],
+      [ "These magickal trucker pills have kicked in and you feel great!  ", "good" ],
       [
         "You shouldn't have taken this many pills.  Your skin flushes and your nerves feel like they are on fire.",
         "bad"
@@ -244,6 +244,7 @@
       [ "Your heartbeat slows into a somewhat normal rhythm but your skin is still on fire.", "good" ],
       [ "The pain in your chest subsides but your heart is still beating in a concerning fashion.", "good" ]
     ],
+    "rating": "mixed",
     "max_intensity": 4,
     "blood_analysis_description": "Patient has dangerous levels of multiple chemicals in their blood.  Sedation and restraint suggested.",
     "base_mods": { "speed_mod": [ 10 ], "str_mod": [ 1 ], "stim_amount": [ 1 ], "stim_tick": [ 500 ], "stim_max_val": [ 50 ] },

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -246,8 +246,19 @@
     ],
     "max_intensity": 4,
     "blood_analysis_description": "Patient has dangerous levels of multiple chemicals in their blood.  Sedation and restraint suggested.",
-    "base_mods": { "speed_mod": [ 10 ], "str_mod": [ 1 ], "stim_amount": [ 1 ], "stim_tick": [ 500 ], "stim_max_val": [ 50 ], "hurt_chance": [ 1 ],
-      "hurt_tick": [ 15000 ], "pain_amount": [ 0 ], "pain_chance": [ 2 ], "pain_tick": [ 400 ], "hurt_amount": [ 1 ] },
+    "base_mods": {
+      "speed_mod": [ 10 ],
+      "str_mod": [ 1 ],
+      "stim_amount": [ 1 ],
+      "stim_tick": [ 500 ],
+      "stim_max_val": [ 50 ],
+      "hurt_chance": [ 1 ],
+      "hurt_tick": [ 15000 ],
+      "pain_amount": [ 0 ],
+      "pain_chance": [ 2 ],
+      "pain_tick": [ 400 ],
+      "hurt_amount": [ 1 ]
+    },
     "scaling_mods": {
       "perspiration_amount": [ 6 ],
       "perspiration_min": [ 1 ],

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -244,7 +244,6 @@
       [ "Your heartbeat slows into a somewhat normal rhythm but your skin is still on fire.", "good" ],
       [ "The pain in your chest subsides but your heart is still beating in a concerning fashion.", "good" ]
     ],
-    "rating": "mixed",
     "max_intensity": 4,
     "blood_analysis_description": "Patient has dangerous levels of multiple chemicals in their blood.  Sedation and restraint suggested.",
     "base_mods": { "speed_mod": [ 10 ], "str_mod": [ 1 ], "stim_amount": [ 1 ], "stim_tick": [ 500 ], "stim_max_val": [ 50 ] },
@@ -256,15 +255,15 @@
       "pain_amount": [ 10 ],
       "pain_min": [ 1 ],
       "pain_chance": [ 2 ],
-      "pain_tick": [ 6000 ],
-      "stim_max_val": [ 100 ]
+      "pain_tick": [ 600 ],
+      "stim_max_val": [ 400 ]
     }
   },
   {
     "type": "effect_type",
     "id": "cheval_withdrawal",
     "rating": "bad",
-    "blood_analysis_description": "Heightened levels of organosulfur compounds, mercury, and silver.",
+    "blood_analysis_description": "Patient has multiple byproducts in blood stream suggesting extended drug binge.",
     "base_mods": { "speed_mod": [ -15 ], "str_mod": [ -1 ], "stim_amount": [ -1 ], "stim_tick": [ 500 ], "stim_max_val": [ -50 ] }
   },
   {

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -221,7 +221,7 @@
     "//": "Intensity 1 is a standard dosage of the drug.  Further intensities reflect taking pills while the first dose hasn't worn off.  It is not wise to do so.",
     "name": [ "Energized", "Enflamed", "Arythmic", "Tachycardiac" ],
     "apply_message": [
-      [ "These magickal trucker pills have kicked in and you feel great!  ", "good" ],
+      [ "These magickal trucker pills have kicked in and you feel great!", "good" ],
       [
         "You shouldn't have taken this many pills.  Your skin flushes and your nerves feel like they are on fire.",
         "bad"

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -244,7 +244,6 @@
       [ "Your heartbeat slows into a somewhat normal rhythm but your skin is still on fire.", "good" ],
       [ "The pain in your chest subsides but your heart is still beating in a concerning fashion.", "good" ]
     ],
-    "rating": "mixed",
     "max_intensity": 4,
     "blood_analysis_description": "Patient has dangerous levels of multiple chemicals in their blood.  Sedation and restraint suggested.",
     "base_mods": { "speed_mod": [ 10 ], "str_mod": [ 1 ], "stim_amount": [ 1 ], "stim_tick": [ 500 ], "stim_max_val": [ 50 ] },

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -220,7 +220,18 @@
     "id": "cheval_overdose",
     "//": "Intensity 1 is a standard dosage of the drug.  Further intensities reflect taking pills while the first dose hasn't worn off.  It is not wise to do so.",
     "name": [ "Energized", "Enflamed", "Arythmic", "Tachycardiac" ],
-    "apply_message": "These magickal trucker pills have kicked in and you feel great!",
+    "apply_message": [
+      [ "These magickal trucker pills have kicked in and you feel great!  ", "good" ],
+      [
+        "You shouldn't have taken this many pills.  Your skin flushes and your nerves feel like they are on fire.",
+        "bad"
+      ],
+      [ "Your heartbeat doesn't feel normal.  Why on earth did you take more of these pills?", "bad" ],
+      [
+        "This might just be it, the big one.  With no hospital available you're just going to have to ride it straight through Hell.",
+        "bad"
+      ]
+    ],
     "decay_messages": [
       [
         "These magickal trucker pills have worn off and you feel rough.  It might be best to go ahead and sleep through the hangover as best you can.",

--- a/doc/EFFECTS_JSON.md
+++ b/doc/EFFECTS_JSON.md
@@ -164,6 +164,9 @@ if it doesn't exist.
     "rating": "good"        - Defaults to "neutral" if missing
 ```
 This is used for how the messages when the effect is applied and removed are displayed. Also this affects "blood_analysis_description" (see below) field: effects with "good" rating will be colored green, effects with any other rating will be colored red when character conducts a blood analysis through some means.
+
+If [apply_message](#advanced-apply_message) is an array you can't include this entry (it is handled with apply message).
+
 Valid entries are:
 ```C++
 "good"
@@ -180,6 +183,17 @@ Valid entries are:
 If the "apply_message" or "remove_message" fields exist, the respective message will be
 displayed upon the addition or removal of the effect. Note: "apply_message" will only display
 if the effect is being added, not if it is simply incrementing a current effect (so only new bites, etc.).
+
+### advanced apply_message
+```C++
+    "apply_message": [
+        ["Your effect is applied", "good"],
+        ["You took way too much effect", "bad"],
+    ] 
+```
+You can instead of having a string for apply_message and including a [rating](#rating) can do advanced apply_message. This is an array of arrays with each inner array matching up with an intensity level and including the message and rating. This is useful for effects that too much of is a bad thing.
+
+When using an advanced apply_message you can not include a [rating: ""](#rating) entry.
 
 ### Memorial Log
 ```C++

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -502,9 +502,9 @@ void bodygraph_display::prepare_infotext( bool reset_pos )
     info_txt.emplace_back( string_format( "%s:", colorize( _( "Effects" ), c_magenta ) ) );
     for( const effect &eff : info.effects ) {
         if( eff.get_id()->is_show_in_info() ) {
-            effect_rating rt = eff.get_id()->get_rating();
+            game_message_type rt = eff.get_id()->get_rating( eff.get_intensity() );
             info_txt.emplace_back( string_format( "  %s", colorize( eff.disp_name(),
-                                                  rt == e_good ? c_green : rt == e_bad ? c_red : c_yellow ) ) );
+                                                  rt == m_good ? c_green : rt == m_bad ? c_red : c_yellow ) ) );
         }
     }
     info_txt.emplace_back( "--" );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2712,7 +2712,7 @@ void Character::conduct_blood_analysis()
             continue;
         }
         effect_descriptions.emplace_back( elem.first->get_blood_analysis_description() );
-        colors.emplace_back( elem.first->get_rating() == e_good ? c_green : c_red );
+        colors.emplace_back( elem.first->get_rating() == m_good ? c_green : c_red );
     }
 
     const int win_w = 46;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1586,8 +1586,8 @@ void Creature::add_effect( const effect_source &source, const efftype_id &eff_id
         ( *effects )[eff_id][bp] = e;
         if( Character *ch = as_character() ) {
             get_event_bus().send<event_type::character_gains_effect>( ch->getID(), eff_id );
-            if( is_avatar() && !const.load_apply_msgs().empty() ) {
-                add_msg( type.gain_game_message_type(), const.load_apply_msgs() );
+            if( is_avatar() && !type.load_apply_msgs().empty() ) {
+                add_msg( type.gain_game_message_type(), type.load_apply_msgs() );
             }
         }
         on_effect_int_change( eff_id, e.get_intensity(), bp );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1530,10 +1530,10 @@ void Creature::add_effect( const effect_source &source, const efftype_id &eff_id
             if( e.get_int_dur_factor() > 0_turns ) {
                 // Set intensity if value is given
             } else if( intensity > 0 ) {
-                e.set_intensity( intensity );
+                e.set_intensity( intensity, true );
                 // Else intensity uses the type'd step size if it already exists
             } else if( e.get_int_add_val() != 0 ) {
-                e.mod_intensity( e.get_int_add_val() );
+                e.mod_intensity( e.get_int_add_val(), true );
             }
 
             // Bound intensity by [1, max intensity]
@@ -1586,6 +1586,9 @@ void Creature::add_effect( const effect_source &source, const efftype_id &eff_id
         ( *effects )[eff_id][bp] = e;
         if( Character *ch = as_character() ) {
             get_event_bus().send<event_type::character_gains_effect>( ch->getID(), eff_id );
+            if( is_avatar() ) {
+                eff_id->add_apply_msg( e.get_intensity() );
+            }
         }
         on_effect_int_change( eff_id, e.get_intensity(), bp );
         // Perform any effect addition effects.
@@ -1666,7 +1669,8 @@ bool Creature::remove_effect( const efftype_id &eff_id, const bodypart_id &bp )
     if( Character *ch = as_character() ) {
         if( is_avatar() ) {
             if( !type.get_remove_message().empty() ) {
-                add_msg( type.lose_game_message_type(), type.get_remove_message() );
+                add_msg( type.lose_game_message_type( get_effect( eff_id, bp.id() ).get_intensity() ),
+                         type.get_remove_message() );
             }
         }
         get_event_bus().send<event_type::character_loses_effect>( ch->getID(), eff_id );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1586,8 +1586,8 @@ void Creature::add_effect( const effect_source &source, const efftype_id &eff_id
         ( *effects )[eff_id][bp] = e;
         if( Character *ch = as_character() ) {
             get_event_bus().send<event_type::character_gains_effect>( ch->getID(), eff_id );
-            if( is_avatar() && !type.load_apply_msgs().empty() ) {
-                add_msg( type.gain_game_message_type(), type.load_apply_msgs() );
+            if( is_avatar() && !const.load_apply_msgs().empty() ) {
+                add_msg( type.gain_game_message_type(), const.load_apply_msgs() );
             }
         }
         on_effect_int_change( eff_id, e.get_intensity(), bp );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1586,7 +1586,6 @@ void Creature::add_effect( const effect_source &source, const efftype_id &eff_id
         ( *effects )[eff_id][bp] = e;
         if( Character *ch = as_character() ) {
             get_event_bus().send<event_type::character_gains_effect>( ch->getID(), eff_id );
-            }
         }
         on_effect_int_change( eff_id, e.get_intensity(), bp );
         // Perform any effect addition effects.

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1586,8 +1586,6 @@ void Creature::add_effect( const effect_source &source, const efftype_id &eff_id
         ( *effects )[eff_id][bp] = e;
         if( Character *ch = as_character() ) {
             get_event_bus().send<event_type::character_gains_effect>( ch->getID(), eff_id );
-            if( is_avatar() && !type.load_apply_msgs().empty() ) {
-                add_msg( type.gain_game_message_type(), type.load_apply_msgs() );
             }
         }
         on_effect_int_change( eff_id, e.get_intensity(), bp );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1586,8 +1586,8 @@ void Creature::add_effect( const effect_source &source, const efftype_id &eff_id
         ( *effects )[eff_id][bp] = e;
         if( Character *ch = as_character() ) {
             get_event_bus().send<event_type::character_gains_effect>( ch->getID(), eff_id );
-            if( is_avatar() && !type.get_apply_message().empty() ) {
-                add_msg( type.gain_game_message_type(), type.get_apply_message() );
+            if( is_avatar() && !type.load_apply_msgs().empty() ) {
+                add_msg( type.gain_game_message_type(), type.load_apply_msgs() );
             }
         }
         on_effect_int_change( eff_id, e.get_intensity(), bp );

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -1148,7 +1148,10 @@ int effect::set_intensity( int val, bool alert )
     }
 
     val = std::max( std::min( val, eff_type->max_intensity ), 0 );
-    if( val == intensity ) {
+    if( val == intensity 
+        val - 1 < static_cast<int>( eff_type->apply_msgs.size() ) ) {
+        add_msg( eff_type->apply_msgs[ val - 1 ].second,
+                 eff_type->apply_msgs[ val - 1 ].first.translated() );
         // Nothing to change
         return intensity;
     }

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -1148,7 +1148,7 @@ int effect::set_intensity( int val, bool alert )
     }
 
     val = std::max( std::min( val, eff_type->max_intensity ), 0 );
-    if( val == intensity 
+    if( val == intensity
         val - 1 < static_cast<int>( eff_type->apply_msgs.size() ) ) {
         add_msg( eff_type->apply_msgs[ val - 1 ].second,
                  eff_type->apply_msgs[ val - 1 ].first.translated() );

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -549,9 +549,13 @@ bool effect_type::has_flag( const flag_id &flag ) const
     return flags.count( flag );
 }
 
-effect_rating effect_type::get_rating() const
+game_message_type effect_type::get_rating( int intensity ) const
 {
-    return rating;
+    if( apply_msgs.size() < intensity ) {
+        return apply_msgs[intensity - 1].second;
+    } else {
+        return apply_msgs[0].second;
+    }
 }
 
 bool effect_type::use_name_ints() const
@@ -568,36 +572,31 @@ bool effect_type::use_desc_ints( bool reduced ) const
     }
 }
 
-game_message_type effect_type::gain_game_message_type() const
+game_message_type effect_type::lose_game_message_type( int intensity ) const
 {
-    switch( rating ) {
-        case e_good:
-            return m_good;
-        case e_bad:
+    switch( get_rating( intensity ) ) {
+        case m_good:
             return m_bad;
-        case e_neutral:
+        case m_bad:
+            return m_good;
+        case m_neutral:
             return m_neutral;
-        case e_mixed:
+        case m_mixed:
             return m_mixed;
         default:
             // Should never happen
             return m_neutral;
     }
 }
-game_message_type effect_type::lose_game_message_type() const
+void effect_type::add_apply_msg( int intensity ) const
 {
-    switch( rating ) {
-        case e_good:
-            return m_bad;
-        case e_bad:
-            return m_good;
-        case e_neutral:
-            return m_neutral;
-        case e_mixed:
-            return m_mixed;
-        default:
-            // Should never happen
-            return m_neutral;
+    if( intensity - 1 < static_cast<int>( apply_msgs.size() ) ) {
+        add_msg( apply_msgs[intensity - 1].second,
+                 apply_msgs[intensity - 1].first.translated() );
+    } else if( !apply_msgs[0].first.empty() ) {
+        // if the apply message is empty we shouldn't show the message
+        add_msg( apply_msgs[0].second,
+                 apply_msgs[0].first.translated() );
     }
 }
 std::string effect_type::get_apply_memorial_log( const memorial_gender gender ) const
@@ -641,28 +640,37 @@ bool effect_type::load_miss_msgs( const JsonObject &jo, const std::string_view m
     return jo.read( member, miss_msgs );
 }
 
+static std::optional<game_message_type> process_rating( std::string r )
+{
+    if( r == "good" ) {
+        return m_good;
+    } else if( r == "neutral" ) {
+        return m_neutral;
+    } else if( r == "bad" ) {
+        return m_bad;
+    } else if( r == "mixed" ) {
+        return m_mixed;
+    } else {
+        // handle errors for returning nothing above
+        return {};
+    }
+}
+
 // helps load the internal message arrays for decay and apply into the msgs vector
-void load_msg_help( const JsonArray ja,
-                    std::vector<std::pair<translation, game_message_type>> &apply_msgs )
+static void load_msg_help( const JsonArray &ja,
+                           std::vector<std::pair<translation, game_message_type>> &apply_msgs )
 {
     translation msg;
     ja.read( 0, msg );
     std::string r = ja.get_string( 1 );
-    game_message_type rate = m_neutral;
-    if( r == "good" ) {
-        rate = m_good;
-    } else if( r == "neutral" ) {
-        rate = m_neutral;
-    } else if( r == "bad" ) {
-        rate = m_bad;
-    } else if( r == "mixed" ) {
-        rate = m_mixed;
-    } else {
+    std::optional<game_message_type> rate = process_rating( r );
+    if( !rate.has_value() ) {
         ja.throw_error(
             1, string_format( "Unexpected message type \"%s\"; expected \"good\", "
                               "\"neutral\", " "\"bad\", or \"mixed\"", r ) );
+        rate = m_neutral;
     }
-    apply_msgs.emplace_back( msg, rate );
+    apply_msgs.emplace_back( msg, rate.value() );
 }
 
 bool effect_type::load_decay_msgs( const JsonObject &jo, const std::string_view member )
@@ -680,14 +688,19 @@ bool effect_type::load_apply_msgs( const JsonObject &jo, const std::string_view 
 {
     if( jo.has_array( member ) ) {
         JsonArray ja = jo.get_array( member );
-        if( ja.has_string( 0 ) ) {
-            load_msg_help( ja, apply_msgs );
-        } else {
-            for( JsonArray inner : jo.get_array( member ) ) {
-                load_msg_help( inner, apply_msgs );
-            }
+        for( JsonArray inner : jo.get_array( member ) ) {
+            load_msg_help( inner, apply_msgs );
         }
         return true;
+    } else {
+        translation msg;
+        optional( jo, false, member, msg );
+        if( jo.has_string( "rating" ) ) {
+            std::optional<game_message_type> rate = process_rating( jo.get_string( "rating" ) );
+            apply_msgs.emplace_back( msg, rate.value() );
+        } else {
+            apply_msgs.emplace_back( msg, game_message_type::m_neutral );
+        }
     }
     return false;
 }
@@ -1156,14 +1169,7 @@ int effect::set_intensity( int val, bool alert )
         add_msg( eff_type->decay_msgs[ val - 1 ].second,
                  eff_type->decay_msgs[ val - 1 ].first.translated() );
     } else if( alert ) {
-        if( val - 1 < static_cast<int>( eff_type->apply_msgs.size() ) ) {
-            add_msg( eff_type->apply_msgs[val - 1].second,
-                     eff_type->apply_msgs[val - 1].first.translated() );
-        } else {
-            add_msg( eff_type->apply_msgs[0].second,
-                     eff_type->apply_msgs[0].first.translated() );
-        }
-
+        eff_type->add_apply_msg( val );
     }
 
     if( val == 0 && !eff_type->int_decay_remove ) {
@@ -1472,25 +1478,6 @@ void load_effect_type( const JsonObject &jo )
 
     new_etype.part_descs = jo.get_bool( "part_descs", false );
 
-    if( jo.has_member( "rating" ) ) {
-        std::string r = jo.get_string( "rating" );
-        if( r == "good" ) {
-            new_etype.rating = e_good;
-        } else if( r == "neutral" ) {
-            new_etype.rating = e_neutral;
-        } else if( r == "bad" ) {
-            new_etype.rating = e_bad;
-        } else if( r == "mixed" ) {
-            new_etype.rating = e_mixed;
-        } else {
-            jo.throw_error_at(
-                "rating",
-                string_format( "Unexpected rating \"%s\"; expected \"good\", \"neutral\", "
-                               "\"bad\", or \"mixed\"", r ) );
-        }
-    } else {
-        new_etype.rating = e_neutral;
-    }
     jo.read( "remove_message", new_etype.remove_message );
     optional( jo, false, "apply_memorial_log", new_etype.apply_memorial_log,
               text_style_check_reader() );

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -551,7 +551,7 @@ bool effect_type::has_flag( const flag_id &flag ) const
 
 game_message_type effect_type::get_rating( int intensity ) const
 {
-    if( apply_msgs.size() < intensity ) {
+    if( apply_msgs.size() < static_cast<size_t>( intensity ) ) {
         return apply_msgs[intensity - 1].second;
     } else {
         return apply_msgs[0].second;

--- a/src/effect.h
+++ b/src/effect.h
@@ -128,8 +128,6 @@ class effect_type
          *  an effect's "rating" value. */
         game_message_type lose_game_message_type() const;
 
-        /** Returns the message displayed when a new effect is obtained. */
-        std::string get_apply_message() const;
         /** Returns the memorial log added when a new effect is obtained. */
         std::string get_apply_memorial_log( memorial_gender gender ) const;
         /** Returns the message displayed when an effect is removed. */
@@ -151,6 +149,7 @@ class effect_type
         void load_mod_data( const JsonObject &jo );
         bool load_miss_msgs( const JsonObject &jo, std::string_view member );
         bool load_decay_msgs( const JsonObject &jo, std::string_view member );
+        bool load_apply_msgs( const JsonObject &jo, std::string_view member );
 
         /** Verifies data is accurate */
         static void check_consistency();

--- a/src/effect.h
+++ b/src/effect.h
@@ -225,9 +225,10 @@ class effect_type
 
         std::vector<std::pair<translation, game_message_type>> decay_msgs;
 
+        std::vector<std::pair<translation, game_message_type>> apply_msgs;
+
         effect_rating rating = effect_rating::e_neutral;
 
-        translation apply_message;
         std::string apply_memorial_log;
         translation remove_message;
         std::string remove_memorial_log;

--- a/src/effect.h
+++ b/src/effect.h
@@ -29,13 +29,6 @@ class JsonOut;
 /** Handles the large variety of weed messages. */
 void weed_msg( Character &p );
 
-enum effect_rating {
-    e_good,     // The effect is good for the one who has it.
-    e_neutral,  // There is no effect or the effect is very nominal. This is the default.
-    e_bad,      // The effect is bad for the one who has it.
-    e_mixed     // The effect has good and bad parts to the one who has it.
-};
-
 /** @relates string_id */
 template<>
 const effect_type &string_id<effect_type>::obj() const;
@@ -112,7 +105,7 @@ class effect_type
         efftype_id id;
 
         /** Returns if an effect is good or bad for message display. */
-        effect_rating get_rating() const;
+        game_message_type get_rating( int intensity = 1 ) const;
 
         /** Returns true if there is a listed name in the JSON entry for each intensity from
          *  1 to max_intensity. */
@@ -121,12 +114,12 @@ class effect_type
          *  from 1 to max_intensity with the matching reduced value. */
         bool use_desc_ints( bool reduced ) const;
 
-        /** Returns the appropriate game_message_type when a new effect is obtained. This is equal to
-         *  an effect's "rating" value. */
-        game_message_type gain_game_message_type() const;
         /** Returns the appropriate game_message_type when an effect is lost. This is opposite to
          *  an effect's "rating" value. */
-        game_message_type lose_game_message_type() const;
+        game_message_type lose_game_message_type( int intensity = 1 ) const;
+
+        // adds a message to the log for applying an effect
+        void add_apply_msg( int intensity ) const;
 
         /** Returns the memorial log added when a new effect is obtained. */
         std::string get_apply_memorial_log( memorial_gender gender ) const;
@@ -226,8 +219,6 @@ class effect_type
         std::vector<std::pair<translation, game_message_type>> decay_msgs;
 
         std::vector<std::pair<translation, game_message_type>> apply_msgs;
-
-        effect_rating rating = effect_rating::e_neutral;
 
         std::string apply_memorial_log;
         translation remove_message;

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -535,7 +535,7 @@ class ma_buff_effect_type : public effect_type
             int_decay_remove = false;
             name.push_back( buff.name );
             desc.push_back( buff.description );
-            rating = e_good;
+            apply_msgs.emplace_back( no_translation( "" ), m_good );
         }
 };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Apply different messages at different intensity levels"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I want to apply different messages at different intensity levels. Mirroring how decay messages work. Required for #65311 

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I have cargo culted the decay message bool and removed the std:: for apply message.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->