### PR TITLE
Electrolyzing lye for sodium metal

### DIFF
--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -741,10 +741,11 @@
       { "proficiency": "prof_inorganic_chemistry" },
       { "proficiency": "prof_inorganic_chemistry" }
     ],
+    "charges": 200,
     "batch_time_factors": [ 60, 4 ],
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "electrolysis_kit", 500 ] ], [ [ "surface_heat", 0.08, "LIST" ] ] ],
-    "components": [ [ [ "lye_powder", 200 ] ], [ [ "lamp_oil", 125 ] ] ],
+    "components": [ [ [ "lye_powder", 200 ] ], [ [ "lamp_oil", 100 ] ] ],
     "//1": "kerosene is used here because sodium metal needs to be suspended in a mineral oil to prevent it from reacting to air."
   },
   {

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -732,10 +732,10 @@
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_CHEMICALS",
     "skill_used": "chemistry",
-    "difficulty": 1,
+    "difficulty": 4,
     "time": "20 m",
     "//": "placeholder time, will replace this with a fitting value later",
-    "book_learn": [ [ "adv_chemistry", 3 ], [ "textbook_chemistry", 3 ] ],
+    "book_learn": [ [ "adv_chemistry", 4 ], [ "textbook_chemistry", 4 ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry" },
       { "proficiency": "prof_inorganic_chemistry" },
@@ -744,7 +744,7 @@
     "charges": 700,
     "batch_time_factors": [ 60, 4 ],
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "electrolysis_kit", 500 ] ], [ [ "surface_heat", 1, "LIST" ] ] ],
+    "tools": [ [ [ "electrolysis_kit", 100 ] ], [ [ "surface_heat", 1, "LIST" ] ] ],
     "components": [ [ [ "lye_powder", 1129 ] ], [ [ "lamp_oil", 350 ] ] ],
     "//0": "One battery charge is one kJ, one unit of surface_heat is 25 charges, 1129 lye powder is 30 grams, 25 kJ is needed to melt 30 grams of lye.",
     "//1": "kerosene is used here because sodium metal needs to be suspended in a mineral oil to prevent it from reacting to air. It's half of the resulting sodium because the item itself is 50/50."

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -726,26 +726,26 @@
     "charges": 3
   },
   {
-	"type": "recipe",
-	"activity_level": "LIGHT_EXERCISE",
-	"result": "chem_sodium",
-	"category": "CC_CHEM",
-	"subcategory": "CSC_CHEM_CHEMICALS",
-	"skill_used": "chemistry",
-	"difficulty": 1,
-	"time": "20 m",
-	"//": "placeholder time, will replace this with a fitting value later",
-	"book_learn": [ [ "adv_chemistry", 3 ], [ "textbook_chemistry", 3 ] ],
-	"proficiencies": [
-		{ "proficiency": "prof_intro_chemistry" },
-		{ "proficiency": "prof_inorganic_chemistry" },
-		{ "proficiency": "prof_inorganic_chemistry" },
-	],
-	"batch_time_factors": [ 60, 4 ],
-	"qualities": [ { "id": "CHEM", "level": 2 } ],
-	"tools": [ [ [ "electrolysis_kit", 500 ] ], [ [ "surface_heat", 0.094, "LIST" ] ] ],
-	"components": [ [ [ "lye_powder", 200 ] ], [ [ "lamp_oil", 125 ] ] ],
-	"//1": "kerosene is used here because sodium metal needs to be suspended in a mineral oil to prevent it from reacting to air."
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "chem_sodium",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_CHEMICALS",
+    "skill_used": "chemistry",
+    "difficulty": 1,
+    "time": "20 m",
+    "//": "placeholder time, will replace this with a fitting value later",
+    "book_learn": [ [ "adv_chemistry", 3 ], [ "textbook_chemistry", 3 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_intro_chemistry" },
+      { "proficiency": "prof_inorganic_chemistry" },
+      { "proficiency": "prof_inorganic_chemistry" }
+    ],
+    "batch_time_factors": [ 60, 4 ],
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
+    "tools": [ [ [ "electrolysis_kit", 500 ] ], [ [ "surface_heat", 0.08, "LIST" ] ] ],
+    "components": [ [ [ "lye_powder", 200 ] ], [ [ "lamp_oil", 125 ] ] ],
+    "//1": "kerosene is used here because sodium metal needs to be suspended in a mineral oil to prevent it from reacting to air."
   },
   {
     "type": "recipe",

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -741,12 +741,13 @@
       { "proficiency": "prof_inorganic_chemistry" },
       { "proficiency": "prof_inorganic_chemistry" }
     ],
-    "charges": 200,
+    "charges": 700,
     "batch_time_factors": [ 60, 4 ],
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "electrolysis_kit", 500 ] ], [ [ "surface_heat", 0.08, "LIST" ] ] ],
-    "components": [ [ [ "lye_powder", 200 ] ], [ [ "lamp_oil", 100 ] ] ],
-    "//1": "kerosene is used here because sodium metal needs to be suspended in a mineral oil to prevent it from reacting to air."
+    "tools": [ [ [ "electrolysis_kit", 500 ] ], [ [ "surface_heat", 1, "LIST" ] ] ],
+    "components": [ [ [ "lye_powder", 1129 ] ], [ [ "lamp_oil", 350 ] ] ],
+    "//0": "One battery charge is one kJ, one unit of surface_heat is 25 charges, 1129 lye powder is 30 grams, 25 kJ is needed to melt 30 grams of lye.",
+    "//1": "kerosene is used here because sodium metal needs to be suspended in a mineral oil to prevent it from reacting to air. It's half of the resulting sodium because the item itself is 50/50."
   },
   {
     "type": "recipe",

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -743,7 +743,7 @@
     "charges": 700,
     "batch_time_factors": [ 60, 4 ],
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "electrolysis_kit", 216 ] ], [ [ "surface_heat", 1, "LIST" ] ], [ [ "syringe" ] ] ],
+    "tools": [ [ [ "electrolysis_kit", 216 ] ], [ [ "surface_heat", 1, "LIST" ] ], [ [ "syringe", -1 ] ] ],
     "components": [ [ [ "lye_powder", 1129 ] ], [ [ "lamp_oil", 350 ] ] ],
     "//": "One battery charge is one kJ, one unit of surface_heat is 25 charges, 1129 lye powder is 30 grams, 25 kJ is needed to melt 30 grams of lye.",
     "//1": "kerosene is used here because sodium metal needs to be suspended in a mineral oil to prevent it from reacting to air. It's half of the resulting sodium because the item itself is 50/50."

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -733,8 +733,7 @@
     "subcategory": "CSC_CHEM_CHEMICALS",
     "skill_used": "chemistry",
     "difficulty": 4,
-    "time": "20 m",
-    "//": "placeholder time, will replace this with a fitting value later",
+    "time": "60 m",
     "book_learn": [ [ "adv_chemistry", 4 ], [ "textbook_chemistry", 4 ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry" },
@@ -744,9 +743,9 @@
     "charges": 700,
     "batch_time_factors": [ 60, 4 ],
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "electrolysis_kit", 100 ] ], [ [ "surface_heat", 1, "LIST" ] ] ],
+    "tools": [ [ [ "electrolysis_kit", 216 ] ], [ [ "surface_heat", 1, "LIST" ] ], [ [ "syringe" ] ] ],
     "components": [ [ [ "lye_powder", 1129 ] ], [ [ "lamp_oil", 350 ] ] ],
-    "//0": "One battery charge is one kJ, one unit of surface_heat is 25 charges, 1129 lye powder is 30 grams, 25 kJ is needed to melt 30 grams of lye.",
+    "//": "One battery charge is one kJ, one unit of surface_heat is 25 charges, 1129 lye powder is 30 grams, 25 kJ is needed to melt 30 grams of lye.",
     "//1": "kerosene is used here because sodium metal needs to be suspended in a mineral oil to prevent it from reacting to air. It's half of the resulting sodium because the item itself is 50/50."
   },
   {

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -726,6 +726,28 @@
     "charges": 3
   },
   {
+	"type": "recipe",
+	"activity_level": "LIGHT_EXERCISE",
+	"result": "chem_sodium",
+	"category": "CC_CHEM",
+	"subcategory": "CSC_CHEM_CHEMICALS",
+	"skill_used": "chemistry",
+	"difficulty": 1,
+	"time": "20 m",
+	"//": "placeholder time, will replace this with a fitting value later",
+	"book_learn": [ [ "adv_chemistry", 3 ], [ "textbook_chemistry", 3 ] ],
+	"proficiencies": [
+		{ "proficiency": "prof_intro_chemistry" },
+		{ "proficiency": "prof_inorganic_chemistry" },
+		{ "proficiency": "prof_inorganic_chemistry" },
+	],
+	"batch_time_factors": [ 60, 4 ],
+	"qualities": [ { "id": "CHEM", "level": 2 } ],
+	"tools": [ [ [ "electrolysis_kit", 500 ] ], [ [ "surface_heat", 0.094, "LIST" ] ] ],
+	"components": [ [ [ "lye_powder", 200 ] ], [ [ "lamp_oil", 125 ] ] ],
+	"//1": "kerosene is used here because sodium metal needs to be suspended in a mineral oil to prevent it from reacting to air."
+  },
+  {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "heatpack",

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -733,7 +733,7 @@
     "subcategory": "CSC_CHEM_CHEMICALS",
     "skill_used": "chemistry",
     "difficulty": 4,
-    "time": "60 m",
+    "time": "120 m",
     "book_learn": [ [ "adv_chemistry", 4 ], [ "textbook_chemistry", 4 ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry" },
@@ -743,7 +743,7 @@
     "charges": 700,
     "batch_time_factors": [ 60, 4 ],
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "electrolysis_kit", 216 ] ], [ [ "surface_heat", 1, "LIST" ] ], [ [ "syringe", -1 ] ] ],
+    "tools": [ [ [ "electrolysis_kit", 1500 ] ], [ [ "surface_heat", 1, "LIST" ] ], [ [ "syringe", -1 ] ] ],
     "components": [ [ [ "lye_powder", 1129 ] ], [ [ "lamp_oil", 350 ] ] ],
     "//": "One battery charge is one kJ, one unit of surface_heat is 25 charges, 1129 lye powder is 30 grams, 25 kJ is needed to melt 30 grams of lye.",
     "//1": "kerosene is used here because sodium metal needs to be suspended in a mineral oil to prevent it from reacting to air. It's half of the resulting sodium because the item itself is 50/50."

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -738,7 +738,7 @@
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry" },
       { "proficiency": "prof_inorganic_chemistry" },
-      { "proficiency": "prof_inorganic_chemistry" }
+      { "proficiency": "prof_intro_chem_synth" }
     ],
     "charges": 700,
     "batch_time_factors": [ 60, 4 ],


### PR DESCRIPTION
#### Summary
Content "Crafting recipe for Sodium"

#### Purpose of change

A couple days ago I heard a complaint that certain chemicals require lab diving to find, and should have crafting recipes as a substitute. I'm going to start off with an easy one, which is sodium metal. It's only used (at the moment) for crafting lead azide, which is used for making bullet primers. 
Now bullet primers can be crafted without having to go into a lab, your welcome, random guy.

#### Describe the solution

Recipe was added to `recipe_medsandchemicals` The steps are:

- Lye powder is heated to 318 degrees Celsius so it melts ~~(2 kJ needed for 2662 mg of powder, thanks to the devcord for helping me with the math here)~~ Because of how `surface_heat` functions, I've had to increase the size of the recipe to 30 grams of powder which needs about 26 kJ to melt - one unit of `surface_heat` is 25 battery charges
- Electrolysis machine is used to separate the sodium's bond ~~(I haven't figured out how much power it should take yet and I'll do that soon)~~ done
-Sodium is extracted with a syringe and then suspended in kerosene to prevent it from reacting with oxygen. 

~~This PR is still being worked on, I'll do some more work tomorrow.~~ It's finished! wooho!
 
#### Describe alternatives you've considered

There was another way I found that involved a crucible and magnesium powder, but it feels way more difficult and yields less than this method.

#### Testing



#### Additional context
