### PR TITLE
Toggle language to English - Adds instructions for users

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2102,7 +2102,7 @@
   },
   {
     "type": "keybinding",
-    "name": "Toggle language to English",
+    "name": "Toggle language to English (requires global keybind!)",
     "id": "toggle_language_to_en"
   },
   {

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2102,7 +2102,7 @@
   },
   {
     "type": "keybinding",
-    "name": "Toggle language to English (requires global keybind!)",
+    "name": "Toggle language to English (requires global keybind! )",
     "id": "toggle_language_to_en"
   },
   {

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2102,7 +2102,7 @@
   },
   {
     "type": "keybinding",
-    "name": "Toggle language to English (requires global keybind! )",
+    "name": "Toggle language to English (requires global keybind!)",
     "id": "toggle_language_to_en"
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Provides a clear instruction on how to use "Toggle language to English" option correctly"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently, the option "Toggle language to English" is meant to receive a global keybind to work as intended because the keybind is not assigned to any context, thus assigning a local keybind will severely limit the functionality of the option.
User don't have a way to know this, so they will mistakenly assign a local keybind and then will get the impression that my addition is incomplete or poorly made, and I take issue with that.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I've changed the keybind entry from "Toggle language to English" to "Toggle language to English (requires global keybind!)"
This way the keybind will be self-explanatory on how is meant to be used.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I'm making this PR after a user was confused by this option, here's their message:
![Cattura](https://github.com/CleverRaven/Cataclysm-DDA/assets/29839218/f9f7150c-aea9-4d95-b652-7899b1d66367)

That's what happens when a local keybind is assigned, it will work only outside of menus.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->