### PR TITLE
Small improvements to vehicle install part menu

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2371,20 +2371,20 @@ void veh_interact::move_cursor( const point &d, int dstart_at )
             if( has_critter && vp.has_flag( VPFLAG_OBSTACLE ) ) {
                 continue;
             }
-            if( veh->can_mount( vd, vp.get_id() ).success() ) {
-                if( vp.has_flag( VPFLAG_APPLIANCE ) ) {
-                    // exclude "appliances" from vehicle part list
-                    continue;
-                }
-                if( vp.get_id() != vpart_shapes[ vp.name() + vp.base_item.str() ][ 0 ]->get_id() ) {
-                    // only add first shape to install list
-                    continue;
-                }
-                if( can_potentially_install( vp ) ) {
-                    can_mount.push_back( &vp );
-                } else {
-                    req_missing.push_back( &vp );
-                }
+            if( vp.has_flag( "NOINSTALL" ) ) {
+                // exclude parts that should never be installed through install menu
+                continue;
+            }
+            if( vp.has_flag( VPFLAG_APPLIANCE ) ) {
+                // exclude "appliances" from vehicle part list
+                continue;
+            }
+            if( vp.get_id() != vpart_shapes[ vp.name() + vp.base_item.str() ][ 0 ]->get_id() ) {
+                // only add first shape to install list
+                continue;
+            }
+            if( can_potentially_install( vp ) ) {
+                can_mount.push_back( &vp );
             } else {
                 req_missing.push_back( &vp );
             }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1118,6 +1118,7 @@ ret_val<void> vehicle::can_mount( const point &dp, const vpart_id &id ) const
     }
 
     //It also has to be a real part, not the null part
+    //Fallback. This response should never actually be displayed as veh_interact::move_cursor now(May 2023) excludes NOINSTALL parts
     const vpart_info &part = id.obj();
     if( part.has_flag( "NOINSTALL" ) ) {
         return ret_val<void>::make_failure( _( "Part cannot be installed." ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #65553

-Hide appliances in install part menu.

-Hide NOINSTALL parts in install part menu

#### Describe the solution
Eliminated the now-redundant check to see if a vehicle part can be mounted, just dump the whole list, exclude the ones we were always going to exclude, then sort and display them. 

Add a new check to exclude NOINSTALL parts. This hides the "null part" and various jumper cables/cables to connect appliances). These parts were never meant to be installed by the player through this menu, at all. There's a separate NO_INSTALL_PLAYER flag which covers rotors and airbags. The logic for that is handled in veh_interact::update_part_requirements.
#### Describe alternatives you've considered
Could pull that logic out of veh_interact::update_part_requirements :thinking:

#### Testing
Compiled, slapped some frames together and checked it out at various stages (without hammerspace). Null part no longer displays, appliances no longer display, all checks out.

#### Additional context
