### PR TITLE
Open multiple containers in Advanced Inventory Manager

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -150,7 +150,7 @@ advanced_inventory::advanced_inventory()
         { AIM_DRAGGED,   point( 25, 1 ), tripoint_zero,       _( "Grabbed Vehicle" ),    _( "GR" ),  "D", "ITEMS_DRAGGED_CONTAINER", AIM_DRAGGED},
         { AIM_ALL,       point( 22, 3 ), tripoint_zero,       _( "Surrounding area" ),   _( "AL" ),  "A", "ITEMS_AROUND",    AIM_ALL},
         { AIM_CONTAINER, point( 22, 1 ), tripoint_zero,       _( "Container" ),          _( "CN" ),  "C", "ITEMS_CONTAINER", AIM_CONTAINER},
-        { AIM_CONTAINER2, point( 22, 1 ), tripoint_zero,       _( "Container" ),          _( "CN" ),  "C", "ITEMS_CONTAINER", AIM_CONTAINER2},
+        { AIM_CONTAINER2,point( 22, 1 ), tripoint_zero,       _( "Container" ),          _( "CN" ),  "C", "ITEMS_CONTAINER", AIM_CONTAINER2},
         { AIM_WORN,      point( 25, 3 ), tripoint_zero,       _( "Worn Items" ),         _( "WR" ),  "W", "ITEMS_WORN",      AIM_WORN}
     }
 } )
@@ -287,7 +287,7 @@ void advanced_inventory::print_items( const advanced_inventory_pane &pane, bool 
     Character &player_character = get_player_character();
     //print inventory's current and total weight + volumeS
     if( pane.get_area() == AIM_INVENTORY || pane.get_area() == AIM_WORN ||
-    ( ( pane.get_area() == AIM_CONTAINER || pane.get_area() == AIM_CONTAINER2 ) && pane.container ) ) {
+        ( ( pane.get_area() == AIM_CONTAINER || pane.get_area() == AIM_CONTAINER2 ) && pane.container ) ) {
 
         double weight_carried;
         double weight_capacity;
@@ -673,7 +673,8 @@ int advanced_inventory::print_header( advanced_inventory_pane &pane, aim_locatio
         // or highlight container [C] if container mode is active.
         if( squares[data_location].canputitems( pane.get_cur_item_ptr() != nullptr ?
                                                 pane.get_cur_item_ptr()->items.front() : item_location::nowhere ) ||
-        ( area == AIM_CONTAINER && data_location == AIM_CONTAINER ) || ( area == AIM_CONTAINER2 && data_location == AIM_CONTAINER2 ) ) {
+            ( area == AIM_CONTAINER && data_location == AIM_CONTAINER ) || ( area == AIM_CONTAINER2 &&
+                    data_location == AIM_CONTAINER2 ) ) {
 
             bcolor = in_vehicle ? c_light_blue :
                      area == data_location || all_brackets ? c_light_gray : c_dark_gray;
@@ -896,7 +897,8 @@ bool advanced_inventory::move_all_items()
     Character &player_character = get_player_character();
 
     // Check some preconditions to quickly leave the function.
-    if( ( spane.get_area() == AIM_CONTAINER || spane.get_area() == AIM_CONTAINER2 ) && dpane.get_area() == AIM_INVENTORY ) {
+    if( ( spane.get_area() == AIM_CONTAINER || spane.get_area() == AIM_CONTAINER2 ) &&
+        dpane.get_area() == AIM_INVENTORY ) {
         if( spane.container.held_by( player_character ) ) {
             // TODO: Implement this, distributing the contents to other inventory pockets.
             popup( _( "You already have everything in that container." ) );
@@ -1171,16 +1173,18 @@ void advanced_inventory::change_square( aim_location changeSquare,
 {
     // Opening a container, decide which AIM_CONTAINER to use
     if( changeSquare == AIM_CONTAINER ) {
-        if( ( panes[left].get_area() == AIM_CONTAINER || panes[left].get_area() == AIM_CONTAINER2 ) && ( panes[right].get_area() == AIM_CONTAINER || panes[right].get_area() == AIM_CONTAINER2 ) ) {
-    	    // When both panes show containers and a third is opened, replace the current container
-    	    changeSquare = spane.get_area();
-        } else if ( panes[left].get_area() == AIM_CONTAINER || panes[right].get_area() == AIM_CONTAINER ) {
-        	// AIM_CONTAINER already used so opening a second container will use AIM_CONTAINER2
-    	    changeSquare = AIM_CONTAINER2;
-	    }
+        if( ( panes[left].get_area() == AIM_CONTAINER || panes[left].get_area() == AIM_CONTAINER2 ) &&
+            ( panes[right].get_area() == AIM_CONTAINER || panes[right].get_area() == AIM_CONTAINER2 ) ) {
+            // When both panes show containers and a third is opened, replace the current container
+            changeSquare = spane.get_area();
+        } else if( panes[left].get_area() == AIM_CONTAINER || panes[right].get_area() == AIM_CONTAINER ) {
+            // AIM_CONTAINER already used so opening a second container will use AIM_CONTAINER2
+            changeSquare = AIM_CONTAINER2;
+        }
     }
     // Determine behavior if current pane is used.  AIM_CONTAINER should never swap to allow for multi-containers
-    if( ( panes[left].get_area() == changeSquare || panes[right].get_area() == changeSquare ) && ( changeSquare != AIM_CONTAINER && changeSquare != AIM_CONTAINER2 ) ) {
+    if( ( panes[left].get_area() == changeSquare || panes[right].get_area() == changeSquare ) &&
+        ( changeSquare != AIM_CONTAINER && changeSquare != AIM_CONTAINER2 ) ) {
         if( squares[changeSquare].can_store_in_vehicle() && changeSquare != AIM_DRAGGED &&
             spane.get_area() != changeSquare ) {
             // only deal with spane, as you can't _directly_ change dpane
@@ -1198,7 +1202,8 @@ void advanced_inventory::change_square( aim_location changeSquare,
         }
         // we need to check the original area if we can place items in vehicle storage
     } else if( squares[changeSquare].canputitems(
-                   ( changeSquare == AIM_CONTAINER || changeSquare == AIM_CONTAINER2 ) && spane.get_cur_item_ptr() != nullptr ?
+                   ( changeSquare == AIM_CONTAINER || changeSquare == AIM_CONTAINER2 ) &&
+                   spane.get_cur_item_ptr() != nullptr ?
                    spane.get_cur_item_ptr()->items.front() : item_location::nowhere ) ) {
 
         bool in_vehicle_cargo = false;
@@ -1928,8 +1933,8 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     // Map and vehicles have a maximal item count, check that. Inventory does not have this.
     if( destarea != AIM_INVENTORY &&
         destarea != AIM_WORN &&
-    destarea != AIM_CONTAINER &&
-    destarea != AIM_CONTAINER2 ) {
+        destarea != AIM_CONTAINER &&
+        destarea != AIM_CONTAINER2 ) {
         const int cntmax = p.max_size - p.get_item_count();
         // For items counted by charges, adding it adds 0 items if something there stacks with it.
         const bool adds0 = by_charges && std::any_of( panes[dest].items.begin(), panes[dest].items.end(),

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1169,10 +1169,18 @@ void advanced_inventory::redraw_sidebar()
 void advanced_inventory::change_square( aim_location changeSquare,
                                         advanced_inventory_pane &dpane, advanced_inventory_pane &spane )
 {
-    if( changeSquare == AIM_CONTAINER && ( panes[left].get_area() == AIM_CONTAINER || panes[right].get_area() == AIM_CONTAINER ) ) {
-    	changeSquare = AIM_CONTAINER2;
+    // Opening a container, decide which AIM_CONTAINER to use
+    if( changeSquare == AIM_CONTAINER ) {
+        if( ( panes[left].get_area() == AIM_CONTAINER || panes[left].get_area() == AIM_CONTAINER2 ) && ( panes[right].get_area() == AIM_CONTAINER || panes[right].get_area() == AIM_CONTAINER2 ) ) {
+    	    // When both panes show containers and a third is opened, replace the current container
+    	    changeSquare = spane.get_area();
+        } else if ( panes[left].get_area() == AIM_CONTAINER || panes[right].get_area() == AIM_CONTAINER ) {
+        	// AIM_CONTAINER already used so opening a second container will use AIM_CONTAINER2
+    	    changeSquare = AIM_CONTAINER2;
+	    }
     }
-    if( panes[left].get_area() == changeSquare || panes[right].get_area() == changeSquare ) {
+    // Determine behavior if current pane is used.  AIM_CONTAINER should never swap to allow for multi-containers
+    if( ( panes[left].get_area() == changeSquare || panes[right].get_area() == changeSquare ) && ( changeSquare != AIM_CONTAINER && changeSquare != AIM_CONTAINER2 ) ) {
         if( squares[changeSquare].can_store_in_vehicle() && changeSquare != AIM_DRAGGED &&
             spane.get_area() != changeSquare ) {
             // only deal with spane, as you can't _directly_ change dpane

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -150,6 +150,7 @@ advanced_inventory::advanced_inventory()
         { AIM_DRAGGED,   point( 25, 1 ), tripoint_zero,       _( "Grabbed Vehicle" ),    _( "GR" ),  "D", "ITEMS_DRAGGED_CONTAINER", AIM_DRAGGED},
         { AIM_ALL,       point( 22, 3 ), tripoint_zero,       _( "Surrounding area" ),   _( "AL" ),  "A", "ITEMS_AROUND",    AIM_ALL},
         { AIM_CONTAINER, point( 22, 1 ), tripoint_zero,       _( "Container" ),          _( "CN" ),  "C", "ITEMS_CONTAINER", AIM_CONTAINER},
+        { AIM_CONTAINER2, point( 22, 1 ), tripoint_zero,       _( "Container" ),          _( "CN" ),  "C", "ITEMS_CONTAINER", AIM_CONTAINER2},
         { AIM_WORN,      point( 25, 3 ), tripoint_zero,       _( "Worn Items" ),         _( "WR" ),  "W", "ITEMS_WORN",      AIM_WORN}
     }
 } )
@@ -286,13 +287,13 @@ void advanced_inventory::print_items( const advanced_inventory_pane &pane, bool 
     Character &player_character = get_player_character();
     //print inventory's current and total weight + volumeS
     if( pane.get_area() == AIM_INVENTORY || pane.get_area() == AIM_WORN ||
-        ( pane.get_area() == AIM_CONTAINER && pane.container ) ) {
+    ( ( pane.get_area() == AIM_CONTAINER || pane.get_area() == AIM_CONTAINER2 ) && pane.container ) ) {
 
         double weight_carried;
         double weight_capacity;
         units::volume volume_carried;
         units::volume volume_capacity;
-        if( pane.get_area() == AIM_CONTAINER ) {
+        if( pane.get_area() == AIM_CONTAINER || pane.get_area() == AIM_CONTAINER2 ) {
             weight_carried = convert_weight( squares[pane.get_area()].weight );
             weight_capacity = convert_weight( pane.container->get_total_weight_capacity() );
             volume_carried = squares[pane.get_area()].volume;
@@ -329,7 +330,7 @@ void advanced_inventory::print_items( const advanced_inventory_pane &pane, bool 
         } else {
             units::volume maxvolume = 0_ml;
             advanced_inv_area &s = squares[pane.get_area()];
-            if( pane.get_area() == AIM_CONTAINER && pane.container ) {
+            if( ( pane.get_area() == AIM_CONTAINER || pane.get_area() == AIM_CONTAINER2 ) && pane.container ) {
                 maxvolume = pane.container->get_total_capacity();
             } else if( pane.in_vehicle() ) {
                 maxvolume = s.veh->max_volume( s.vstor );
@@ -672,7 +673,7 @@ int advanced_inventory::print_header( advanced_inventory_pane &pane, aim_locatio
         // or highlight container [C] if container mode is active.
         if( squares[data_location].canputitems( pane.get_cur_item_ptr() != nullptr ?
                                                 pane.get_cur_item_ptr()->items.front() : item_location::nowhere ) ||
-            ( area == AIM_CONTAINER && data_location == AIM_CONTAINER ) ) {
+        ( area == AIM_CONTAINER && data_location == AIM_CONTAINER ) || ( area == AIM_CONTAINER2 && data_location == AIM_CONTAINER2 ) ) {
 
             bcolor = in_vehicle ? c_light_blue :
                      area == data_location || all_brackets ? c_light_gray : c_dark_gray;
@@ -895,7 +896,7 @@ bool advanced_inventory::move_all_items()
     Character &player_character = get_player_character();
 
     // Check some preconditions to quickly leave the function.
-    if( spane.get_area() == AIM_CONTAINER && dpane.get_area() == AIM_INVENTORY ) {
+    if( ( spane.get_area() == AIM_CONTAINER || spane.get_area() == AIM_CONTAINER2 ) && dpane.get_area() == AIM_INVENTORY ) {
         if( spane.container.held_by( player_character ) ) {
             // TODO: Implement this, distributing the contents to other inventory pockets.
             popup( _( "You already have everything in that container." ) );
@@ -985,7 +986,7 @@ bool advanced_inventory::move_all_items()
     // Keep a list of favorites separated, only drop non-fav first if they exist.
     std::vector<drop_or_stash_item_info> pane_favs;
     bool filter_buckets = dpane.get_area() == AIM_INVENTORY || dpane.get_area() == AIM_WORN ||
-                          dpane.get_area() == AIM_CONTAINER || dpane.in_vehicle();
+                          dpane.get_area() == AIM_CONTAINER || dpane.get_area() == AIM_CONTAINER2 || dpane.in_vehicle();
 
     std::string skipped_items_message = fill_lists_with_pane_items( player_character, spane, pane_items,
                                         pane_favs, filter_buckets );
@@ -1010,7 +1011,7 @@ bool advanced_inventory::move_all_items()
         add_msg( m_info, skipped_items_message );
     }
 
-    if( dpane.get_area() == AIM_CONTAINER ) {
+    if( dpane.get_area() == AIM_CONTAINER || dpane.get_area() == AIM_CONTAINER2 ) {
         if( dpane.container ) {
             drop_locations items_to_insert;
 
@@ -1165,9 +1166,12 @@ void advanced_inventory::redraw_sidebar()
     refresh_minimap();
 }
 
-void advanced_inventory::change_square( const aim_location changeSquare,
+void advanced_inventory::change_square( aim_location changeSquare,
                                         advanced_inventory_pane &dpane, advanced_inventory_pane &spane )
 {
+    if( changeSquare == AIM_CONTAINER && ( panes[left].get_area() == AIM_CONTAINER || panes[right].get_area() == AIM_CONTAINER ) ) {
+    	changeSquare = AIM_CONTAINER2;
+    }
     if( panes[left].get_area() == changeSquare || panes[right].get_area() == changeSquare ) {
         if( squares[changeSquare].can_store_in_vehicle() && changeSquare != AIM_DRAGGED &&
             spane.get_area() != changeSquare ) {
@@ -1186,15 +1190,15 @@ void advanced_inventory::change_square( const aim_location changeSquare,
         }
         // we need to check the original area if we can place items in vehicle storage
     } else if( squares[changeSquare].canputitems(
-                   changeSquare == AIM_CONTAINER && spane.get_cur_item_ptr() != nullptr ?
+                   ( changeSquare == AIM_CONTAINER || changeSquare == AIM_CONTAINER2 ) && spane.get_cur_item_ptr() != nullptr ?
                    spane.get_cur_item_ptr()->items.front() : item_location::nowhere ) ) {
 
         bool in_vehicle_cargo = false;
-        if( changeSquare == AIM_CONTAINER ) {
+        if( changeSquare == AIM_CONTAINER || changeSquare == AIM_CONTAINER2 ) {
             panes[src].container = spane.get_cur_item_ptr()->items.front();
             dpane.recalc = true;
             // Reset pane's container to null if switching away from it
-        } else if( spane.get_area() == AIM_CONTAINER ) {
+        } else if( spane.get_area() == AIM_CONTAINER || spane.get_area() == AIM_CONTAINER2 ) {
             panes[src].container = item_location::nowhere;
             dpane.recalc = true;
             // auto select vehicle if items exist at said square, or both are empty
@@ -1234,7 +1238,7 @@ void advanced_inventory::start_activity(
 
     Character &player_character = get_player_character();
 
-    if( destarea != AIM_CONTAINER ) {
+    if( destarea != AIM_CONTAINER && destarea != AIM_CONTAINER2 ) {
         // Find target items and quantities thereof for the new activity
         std::vector<item_location> target_items;
         std::vector<int> quantities;
@@ -1350,7 +1354,7 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
     // but are potentially at a different place).
     recalc = true;
     cata_assert( amount_to_move > 0 );
-    if( srcarea == AIM_CONTAINER && destarea == AIM_INVENTORY &&
+    if( ( srcarea == AIM_CONTAINER || srcarea == AIM_CONTAINER2 ) && destarea == AIM_INVENTORY &&
         spane.container.held_by( player_character ) ) {
         popup( _( "The %s is already in your inventory." ), sitem->items.front()->tname() );
 
@@ -1378,7 +1382,7 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
         } else {
             // important if item is worn
             if( player_character.can_drop( *sitem->items.front() ).success() ) {
-                if( destarea == AIM_CONTAINER ) {
+                if( destarea == AIM_CONTAINER || destarea == AIM_CONTAINER2 ) {
                     do_return_entry();
                     start_activity( destarea, srcarea, sitem, amount_to_move, from_vehicle, to_vehicle );
                 } else {
@@ -1916,7 +1920,8 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     // Map and vehicles have a maximal item count, check that. Inventory does not have this.
     if( destarea != AIM_INVENTORY &&
         destarea != AIM_WORN &&
-        destarea != AIM_CONTAINER ) {
+    destarea != AIM_CONTAINER &&
+    destarea != AIM_CONTAINER2 ) {
         const int cntmax = p.max_size - p.get_item_count();
         // For items counted by charges, adding it adds 0 items if something there stacks with it.
         const bool adds0 = by_charges && std::any_of( panes[dest].items.begin(), panes[dest].items.end(),

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -109,6 +109,7 @@ void advanced_inv_area::init()
             }
             break;
         case AIM_CONTAINER:
+        case AIM_CONTAINER2:
             // set container position based on location
             set_container_position();
             // location always valid, actual check is done in canputitems()
@@ -206,7 +207,8 @@ bool advanced_inv_area::is_same( const advanced_inv_area &other ) const
     // e.g. dragged vehicle (to the south) and AIM_SOUTH are the same.
     if( id != AIM_INVENTORY && other.id != AIM_INVENTORY &&
         id != AIM_WORN && other.id != AIM_WORN &&
-        id != AIM_CONTAINER && other.id != AIM_CONTAINER ) {
+    ( id != AIM_CONTAINER && other.id != AIM_CONTAINER ) &&
+    ( id != AIM_CONTAINER2 && other.id != AIM_CONTAINER2 ) ) {
         //     have a vehicle?...     ...do the cargo index and pos match?...    ...at least pos?
         return veh == other.veh ? pos == other.pos && vstor == other.vstor : pos == other.pos;
     }
@@ -218,7 +220,9 @@ bool advanced_inv_area::canputitems( const item_location &container ) const
 {
     bool canputitems = false;
     switch( id ) {
-        case AIM_CONTAINER: {
+        case AIM_CONTAINER:
+        case AIM_CONTAINER2:
+        {
             if( container ) {
                 if( container.get_item()->is_container() ) {
                     canputitems = true;

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -207,8 +207,8 @@ bool advanced_inv_area::is_same( const advanced_inv_area &other ) const
     // e.g. dragged vehicle (to the south) and AIM_SOUTH are the same.
     if( id != AIM_INVENTORY && other.id != AIM_INVENTORY &&
         id != AIM_WORN && other.id != AIM_WORN &&
-    ( id != AIM_CONTAINER && other.id != AIM_CONTAINER ) &&
-    ( id != AIM_CONTAINER2 && other.id != AIM_CONTAINER2 ) ) {
+        ( id != AIM_CONTAINER && other.id != AIM_CONTAINER ) &&
+        ( id != AIM_CONTAINER2 && other.id != AIM_CONTAINER2 ) ) {
         //     have a vehicle?...     ...do the cargo index and pos match?...    ...at least pos?
         return veh == other.veh ? pos == other.pos && vstor == other.vstor : pos == other.pos;
     }
@@ -221,8 +221,7 @@ bool advanced_inv_area::canputitems( const item_location &container ) const
     bool canputitems = false;
     switch( id ) {
         case AIM_CONTAINER:
-        case AIM_CONTAINER2:
-        {
+        case AIM_CONTAINER2: {
             if( container ) {
                 if( container.get_item()->is_container() ) {
                     canputitems = true;

--- a/src/advanced_inv_area.h
+++ b/src/advanced_inv_area.h
@@ -24,6 +24,7 @@ enum aim_location : char {
     AIM_DRAGGED,
     AIM_ALL,
     AIM_CONTAINER,
+    AIM_CONTAINER2,
     AIM_WORN,
     NUM_AIM_LOCATIONS,
     // only useful for AIM_ALL

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -216,7 +216,7 @@ void advanced_inventory_pane::add_items_from_area( advanced_inv_area &square,
         }
 
         u.worn.add_AIM_items_from_area( u, square, *this );
-    } else if( square.id == AIM_CONTAINER ) {
+    } else if( square.id == AIM_CONTAINER || square.id == AIM_CONTAINER2 ) {
         square.volume = 0_ml;
         square.weight = 0_gram;
         if( container ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Open multiple containers in Advanced Inventory Manager"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The Advanced Inventory Manager can open one container, yes.  But what about _second container_?
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
When viewing a container in AIM, pressing the "Select items in container" key will actually open a second container and allow you to transfer items between them.  Moving that ring between your pocketses have never been easier.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Opened various containers including nested ones in both panes of the AIM.  Transferred some items around as well.  No problems so far.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Some hacky solutions are involved, someone familiar with the AIM code might want to take a look just in case.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->