### PR TITLE
Wandering Hordes prefer to wander and recruit in open terrain

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3995,9 +3995,9 @@ void overmap::move_hordes()
             // Only monsters in the open (fields, forests, roads) are eligible to wander
             const oter_id &om_here = ter( project_to<coords::omt>( p ) );
             if( !is_ot_match( "field", om_here, ot_match_type::contains ) ) {
-                if( !is_ot_match( "forest", om_here, ot_match_type::prefix ) ) {
-                    if( !is_ot_match( "swamp", om_here, ot_match_type::prefix ) ) {
-                        if( !is_ot_match( "road", om_here, ot_match_type::contains ) ) {
+                if( !is_ot_match( "road", om_here, ot_match_type::contains ) ) {
+                    if( !is_ot_match( "forest", om_here, ot_match_type::prefix ) ) {
+                        if( !is_ot_match( "swamp", om_here, ot_match_type::prefix ) ) {
                             monster_map_it++;
                             continue;
                         }
@@ -4070,11 +4070,9 @@ void overmap::move_nemesis()
             movement_chance = 1;
         } else if( is_ot_match( "field", walked_into, ot_match_type::contains ) ) {
             movement_chance = 3;
-        } else if( is_ot_match( "forest", walked_into, ot_match_type::prefix ) ) {
-            movement_chance = 6;
-        } else if( is_ot_match( "swamp", walked_into, ot_match_type::prefix ) ) {
-            movement_chance = 6;
-        } else if( is_ot_match( "bridge", walked_into, ot_match_type::prefix ) ) {
+        } else if( is_ot_match( "forest", walked_into, ot_match_type::prefix ) ||
+                   is_ot_match( "swamp", walked_into, ot_match_type::prefix ) ||
+                   is_ot_match( "bridge", walked_into, ot_match_type::prefix ) ) {
             movement_chance = 6;
         } else if( is_ot_match( "river", walked_into, ot_match_type::prefix ) ) {
             movement_chance = 10;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3979,6 +3979,16 @@ void overmap::move_hordes()
                 continue;
             }
 
+            // Only monsters in the open (fields, forests, roads) are eligible to wander
+            const oter_id &om_here = ter( project_to<coords::omt>( p ) );
+            if( is_ot_match( "field", om_here, ot_match_type::contains ) ||
+                is_ot_match( "forest", om_here, ot_match_type::prefix ) ||
+                is_ot_match( "swamp", om_here, ot_match_type::prefix ) ||
+                is_ot_match( "road", om_here, ot_match_type::contains ) ) {
+                monster_map_it++;
+                continue;
+            }
+
             // Check if the monster is a zombie.
             const mtype &type = *this_monster.type;
             if(
@@ -4050,13 +4060,20 @@ void overmap::move_nemesis()
         std::tie( omp, local_sm ) = project_remain<coords::om>( mg.abs_pos );
 
         // Decrease movement chance according to the terrain we're currently on.
+        // Hordes will tend toward roads / open fields and path around specials.
         const oter_id &walked_into = ter( project_to<coords::omt>( local_sm ) );
-        int movement_chance = 1;
-        if( walked_into == oter_forest || walked_into == oter_forest_water ) {
+        int movement_chance = 25;
+        if( is_ot_match( "road", walked_into, ot_match_type::contains ) ) {
+            movement_chance = 1;
+        } else if( is_ot_match( "field", walked_into, ot_match_type::contains ) ) {
             movement_chance = 3;
-        } else if( walked_into == oter_forest_thick ) {
+        } else if( is_ot_match( "forest", walked_into, ot_match_type::prefix ) ) {
             movement_chance = 6;
-        } else if( walked_into == oter_river_center ) {
+        } else if( is_ot_match( "swamp", walked_into, ot_match_type::prefix ) ) {
+            movement_chance = 6;
+        } else if( is_ot_match( "bridge", walked_into, ot_match_type::prefix ) ) {
+            movement_chance = 6;
+        } else if( is_ot_match( "river", walked_into, ot_match_type::prefix ) ) {
             movement_chance = 10;
         }
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3979,16 +3979,6 @@ void overmap::move_hordes()
                 continue;
             }
 
-            // Only monsters in the open (fields, forests, roads) are eligible to wander
-            const oter_id &om_here = ter( project_to<coords::omt>( p ) );
-            if( is_ot_match( "field", om_here, ot_match_type::contains ) ||
-                is_ot_match( "forest", om_here, ot_match_type::prefix ) ||
-                is_ot_match( "swamp", om_here, ot_match_type::prefix ) ||
-                is_ot_match( "road", om_here, ot_match_type::contains ) ) {
-                monster_map_it++;
-                continue;
-            }
-
             // Check if the monster is a zombie.
             const mtype &type = *this_monster.type;
             if(
@@ -4000,6 +3990,19 @@ void overmap::move_hordes()
                 // Don't delete the monster, just increment the iterator.
                 monster_map_it++;
                 continue;
+            }
+
+            // Only monsters in the open (fields, forests, roads) are eligible to wander
+            const oter_id &om_here = ter( project_to<coords::omt>( p ) );
+            if( !is_ot_match( "field", om_here, ot_match_type::contains ) ) {
+                if( !is_ot_match( "forest", om_here, ot_match_type::prefix ) ) {
+                    if( !is_ot_match( "swamp", om_here, ot_match_type::prefix ) ) {
+                        if( !is_ot_match( "road", om_here, ot_match_type::contains ) ) {
+                            monster_map_it++;
+                            continue;
+                        }
+                    }
+                }
             }
 
             // Scan for compatible hordes in this area, selecting the largest.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Wandering Hordes prefer to wander and recruit in open terrain"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

At the moment, wandering hordes move around and recruit zombies almost indiscriminately, mostly ignoring the terrain they are on.

This leads to unrealistic scenarios such as zombies appearing inside empty buildings when they wander in, and zombies that should be inside buildings (such as prison inmates) mysteriously teleporting to the open field when they become part of a horde.

This PR adds a check to a zombie's location before horde recruitment, to check if they are in open terrain before recruitment.  Also the horde move to preference is tweaked to much prefer open terrain (roads and fields) and everything else has a reduced preference.  A horde will still path through difficult terrain in order to reach cities and noises however.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

The first change is a check added to zombie horde recruitment to pass a check, which is;

> Does the overmap terrain this zombie is currently on ;
> contain the string "field" or "road" (to also check for farm field, dirt road)
> be prefixed by "swamp" or "road" (to cover all road types)

If it passes any one of these 4 checks, the zombie becomes eligible for wandering horde recruitment.

The second change is to the wandering horde's movement chance onto an overmap tile algorithm, which is ;

Deleting the old code, and using the more versalite is_ot_match() function to iterate through destination checks,
starting from the most preferred (1) (and common, for least overhead) terrain type to least preferred (25), 

> Does destination overmap tile string contain "road"?  Set preference to 1 if so,
> Does destination overmap tile string contain "field"?  Set preference to 3 if so,
> Is destination overmap tile string prefixed by "forest"/"swamp"/"bridge"?  Set preference to 6 if so,
> Else does the destination tile have the prefix "river"? Set preference to 10 if so.
> All other overmap destinations (which will most likely be a structure or obstacle) will be set to a preference of 25.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Disabling of Horde recruitment from inside Specials testing results.

Walked past a TCL, left the area...  Observed no hordes appearing.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/34361592/00bf285b-4ffe-4a8a-8af2-7e722904712d)

Went back, entered the carpark and agitated some zeds to draw them outside the special into wilderness.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/34361592/c625f70e-fd52-4bf8-b4db-71305a6c03a9)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/34361592/33b2c53a-4a58-4ad6-bfee-4a40fc1f05ff)

Left the area, then checked the map to see if any hordes have appeared.  Success apparent, as the hordes that appeared are only the zombies that were drawn outside the special.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/34361592/01fea793-354f-48d2-902b-3b949ef1204e)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![horde_test1_output](https://github.com/CleverRaven/Cataclysm-DDA/assets/34361592/0d734a20-716a-4dff-a090-8e19445dc632)

I will be doing more testing, as of now it seems to me that a preference of 25 for structures does allow the horde quite a high chance to wander through a house.  I will test with higher values, and may adjust the other preferences accordingly.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->