### PR TITLE
Irradiated Melon Deconstruct fix

### DIFF
--- a/data/json/uncraft/comestibles/fruit.json
+++ b/data/json/uncraft/comestibles/fruit.json
@@ -41,7 +41,7 @@
     "result": "irradiated_melon",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
-    "copy-from": "pineapple"
+    "copy-from": "melon"
   },
   {
     "result": "irradiated_pineapple",


### PR DESCRIPTION
#### Summary
Bugfixes "fix irradiated melon deconstruct"

#### Purpose of change
Irradiated cantaloupe melons were giving pineapple chunks when deconstructed. With this fix, they deconstruct into melon chunks the same as non-irradiated melons do.

#### Describe the solution
change irradiated melon's "copyfrom" in the uncraft folder from "pineapple" to "melon" so it sources from the correct recipe

#### Describe alternatives you've considered
none. cantaloupple is an abomination beyond comprehension and must not be allowed to exist