### PR TITLE
Changing flyer lore

### DIFF
--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -343,7 +343,7 @@
       {
         "id": "flier_83",
         "text": {
-          "str": "This flyer appears to have been hastily photocopied on cheap cartridge paper. It appears to be advertising an event 7 days after the evacuation order was sent out. 'Great Antler Bar & Grill is closing down forever. Come and celebrate the memmeries. fFood will be free. come quick fresh and tender.' There are several grainy photos of an empty restaurant with the windows boarded up, rotting food haphazardly served on the tables in different stages of decomposition. At the bottom of the flier is a blurry photo of a woman, her eyes bloodshot and mouth are disturbingly wide. You can't quite determine whether she is laughing or crying.",
+          "str": "This flyer appears to have been hastily photocopied on cheap cartridge paper. It appears to be advertising an event 7 days after the evacuation order was sent out. 'Great Antler Bar & Grill is closing down forever. Come and celebrate the memmeries. fFood will be free. come quick fresh and tender.' There are several grainy photos of an empty restaurant with the windows boarded up, rotting food haphazardly served on the tables at different stages of decomposition. The bottom of the flier is a blurry photo of a woman, her eyes bloodshot and mouth disturbingly wide. You can't quite determine whether she is laughing or crying.",
           "//NOLINT(cata-text-style)": "intentional format"
         }
       }

--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -341,12 +341,12 @@
         "text": "Foodplace is advertising the \"Big Deal™\" on this flyer.  Plainly worded sentences on the distinct blue-and-magenta colored background try to convince the reader to buy their \"Delicious Food™\" in bulk to save money.  There is a picture showing a sample order at the bottom."
       },
       {
-  "id": "flier_83",
-  "text": {
-    "str": "This flyer appears to have been hastily photocopied on cheap cartridge paper. It appears to be advertising an event 7 days after the evacuation order was sent out. 'Great Antler Bar & Grill is closing down forever. Come and celebrate the memmeries. fFood will be free. come quick fresh and tender.' There are several grainy photos of an empty restaurant with the windows boarded up, with rotting food haphazardly served on the tables in different stages of decomposition. At the bottom of the flier is a blurry photo of a woman, her eyes bloodshot and mouth are disturbingly wide. You can't quite determine whether she is laughing or crying.",
-    "//NOLINT(cata-text-style)": "intentional format"
-  }
-}
+        "id": "flier_83",
+        "text": {
+          "str": "This flyer appears to have been hastily photocopied on cheap cartridge paper. It appears to be advertising an event 7 days after the evacuation order was sent out. 'Great Antler Bar & Grill is closing down forever. Come and celebrate the memmeries. fFood will be free. come quick fresh and tender.' There are several grainy photos of an empty restaurant with the windows boarded up, with rotting food haphazardly served on the tables in different stages of decomposition. At the bottom of the flier is a blurry photo of a woman, her eyes bloodshot and mouth are disturbingly wide. You can't quite determine whether she is laughing or crying.",
+          "//NOLINT(cata-text-style)": "intentional format"
+        }
+      }
     ]
   }
 ]

--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -217,7 +217,7 @@
       },
       {
         "id": "flier_54",
-        "text": "This is a flier for some kind of reality tv show that takes place in New Jersey.  The flier claims that the finale will 'blow your minds', and was to air the day the evacuation order was given."
+        "text": "This is a flier for some kind of reality TV show that takes place in New Jersey.  The flier claims that the finale will 'blow your minds', and was to air the day the evacuation order was given."
       },
       {
         "id": "flier_55",

--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -343,7 +343,7 @@
       {
         "id": "flier_83",
         "text": {
-          "str": "This flyer appears to have been hastily photocopied on cheap cartridge paper. It appears to be advertising an event 7 days after the evacuation order was sent out. 'Great Antler Bar & Grill is closing down forever. Come and celebrate the memmeries. fFood will be free. come quick fresh and tender.' There are several grainy photos of an empty restaurant with the windows boarded up, with rotting food haphazardly served on the tables in different stages of decomposition. At the bottom of the flier is a blurry photo of a woman, her eyes bloodshot and mouth are disturbingly wide. You can't quite determine whether she is laughing or crying.",
+          "str": "This flyer appears to have been hastily photocopied on cheap cartridge paper. It appears to be advertising an event 7 days after the evacuation order was sent out. 'Great Antler Bar & Grill is closing down forever. Come and celebrate the memmeries. fFood will be free. come quick fresh and tender.' There are several grainy photos of an empty restaurant with the windows boarded up, rotting food haphazardly served on the tables in different stages of decomposition. At the bottom of the flier is a blurry photo of a woman, her eyes bloodshot and mouth are disturbingly wide. You can't quite determine whether she is laughing or crying.",
           "//NOLINT(cata-text-style)": "intentional format"
         }
       }

--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -229,7 +229,7 @@
       },
       {
         "id": "flier_57",
-        "text": "This is a public alert from the Center of Disease Control.  Its message, repeated in several languages reads: \"ADVISORY.  Do not attempt to bring infected loved ones or friends to any hospitals, they are being currently overwhelmed due to the volume of incoming patients.  Restain those believed to be infected, and wait for further information at www.cdc.gov.\""
+        "text": "This is a public alert from the Center of Disease Control.  Its message, repeated in several languages reads: \"ADVISORY.  Do not attempt to bring infected loved ones or friends to any hospitals, they are being currently overwhelmed due to the volume of incoming patients.  Restrain those believed to be infected, and wait for further information at www.cdc.gov.\""
       },
       {
         "id": "flier_58",

--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -317,7 +317,7 @@
       {
         "id": "flier_78",
         "text": {
-          "str": "This scrap of paper appears to be an advertisement for a Music Venue dated a few days before the evacuation order. It's printed in a bright neon green paper, with pictures of people dancing manically. It's main headliner features a locally famous DJ.",
+          "str": "This scrap of paper appears to be an advertisement for a Music Venue dated a few days before the evacuation order. It's printed on bright neon green paper, with pictures of people dancing manically. It's main headliner features a locally famous DJ.",
           "//NOLINT(cata-text-style)": "intentional format"
         }
       },

--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -9,7 +9,7 @@
       },
       {
         "id": "flier_2",
-        "text": "This is an advertisement for an personal injury lawyer.  \"Had an accident while working? Botched surgery gone wrong?  Relatives missing after the government investigated them?  There's only one solution to all of this; SUE!\""
+        "text": "This is an advertisement for an personal injury lawyer.  \"Had an accident while working?  Botched surgery gone wrong?  Relatives missing after the government investigated them?  There's only one solution to all of this; SUE!\""
       },
       {
         "id": "flier_3",

--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -9,7 +9,7 @@
       },
       {
         "id": "flier_2",
-        "text": "This is an advertisement for compact bionic modules.  \"Nerve pain?  Depression?  Tardiness?  There's not a problem a compact bionic module can't solve.  Talk to your doctor to find out of CBMs are right for you!\""
+        "text": "This is an advertisement for an insurance lawyer. \"Had an accident while working? Botched surgery gone wrong? Relatives missing after the government investigated them? There's only one solution to all of this; SUE!\""
       },
       {
         "id": "flier_3",
@@ -209,7 +209,7 @@
       },
       {
         "id": "flier_52",
-        "text": "This is a poster advertising a underground bunker.  The poster shows a nuclear bomb wiping out a city while a family huddles safely underground.  There a slogan \"Concerned about enemy attack?  Want to protect your family?  Join the VAULT program today.\" which is written in the middle.  However, there seems to be no information about *how* one might do so."
+        "text": "This is high quality flier, mass produced with photocopying. \"IF YOU ARE STUCK IN THE CITY, DO NOT LEAVE UNTIL NIGHTFALL, *THEY* WILL SEE YOU!\" The flier further discusses how to barricade your apartment, and to duct tape sheets to your windows."
       },
       {
         "id": "flier_53",
@@ -217,7 +217,7 @@
       },
       {
         "id": "flier_54",
-        "text": "This is an old flier for a movie from the 30s.  A tan man with slick black hair and muscles bulging through his off-white suit is clasping a woman to his hip with one hand, and the woman is wearing a black leather dress.  With her hips splayed, she is holding a pistol in one hand and starring directly out of the advert.  The caption reads \"Witness the rebirth of New Noir with 'Jersey Shore Blues'.  Starring Jenifer Languiz as 'Snookie'!\""
+        "text": "This is a flier for some kind of reality tv show that takes place in New Jersey. The flier claims that the finale will 'blow your minds', and was to air the day the evacuation order was given."
       },
       {
         "id": "flier_55",
@@ -229,7 +229,7 @@
       },
       {
         "id": "flier_57",
-        "text": "This is a leaflet about autoclaving procedure.  One sentence catches your attention \"/!\\Always place your tools into an autoclave pouch before autoclaving./!\\\""
+        "text": "This is a public alert from the Center of Disease Control. Its message, repeated in several languages reads: \"ADVISORY. Do not attempt to bring infected loved ones or friends to any hospitals, they are being currently overwhelmed due to the volume of incoming patients. Restain those believed to be infected, and wait for further information at www.cdc.gov.\""
       },
       {
         "id": "flier_58",
@@ -339,7 +339,14 @@
       {
         "id": "flier_82",
         "text": "Foodplace is advertising the \"Big Deal™\" on this flyer.  Plainly worded sentences on the distinct blue-and-magenta colored background try to convince the reader to buy their \"Delicious Food™\" in bulk to save money.  There is a picture showing a sample order at the bottom."
-      }
+      },
+      {
+  "id": "flier_83",
+  "text": {
+    "str": "This flyer appears to have been hastily photocopied on cheap cartridge paper. It appears to be advertising an event 7 days after the evacuation order was sent out. 'Great Antler Bar & Grill is closing down forever. Come and celebrate the memmeries. fFood will be free. come quick fresh and tender.' There are several grainy photos of an empty restaurant with the windows boarded up, with rotting food haphazardly served on the tables in different stages of decomposition. At the bottom of the flier is a blurry photo of a woman, her eyes bloodshot and mouth are disturbingly wide. You can't quite determine whether she is laughing or crying.",
+    "//NOLINT(cata-text-style)": "intentional format"
+  }
+}
     ]
   }
 ]

--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -9,7 +9,7 @@
       },
       {
         "id": "flier_2",
-        "text": "This is an advertisement for an insurance lawyer.  \"Had an accident while working? Botched surgery gone wrong?  Relatives missing after the government investigated them?  There's only one solution to all of this; SUE!\""
+        "text": "This is an advertisement for an personal injury lawyer.  \"Had an accident while working? Botched surgery gone wrong?  Relatives missing after the government investigated them?  There's only one solution to all of this; SUE!\""
       },
       {
         "id": "flier_3",

--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -317,7 +317,7 @@
       {
         "id": "flier_78",
         "text": {
-          "str": "This ancient missing persons poster is faded and torn.  It features a photo of a stern looking woman in her early fifties.  It reads \"Missing Adult - Prof. Amy Takatoshi - Last Seen Thursday, July 12 - Please contact the Boston Police Missing Persons Unit.\"",
+          "str": "This scrap of paper appears to be an advertisement for a Music Venue dated a few days before the evacuation order. It's printed in a bright neon green paper, with pictures of people dancing manically. It's main headliner features a locally famous DJ.",
           "//NOLINT(cata-text-style)": "intentional format"
         }
       },

--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -9,7 +9,7 @@
       },
       {
         "id": "flier_2",
-        "text": "This is an advertisement for an insurance lawyer. \"Had an accident while working? Botched surgery gone wrong? Relatives missing after the government investigated them? There's only one solution to all of this; SUE!\""
+        "text": "This is an advertisement for an insurance lawyer.  \"Had an accident while working? Botched surgery gone wrong?  Relatives missing after the government investigated them?  There's only one solution to all of this; SUE!\""
       },
       {
         "id": "flier_3",
@@ -209,7 +209,7 @@
       },
       {
         "id": "flier_52",
-        "text": "This is high quality flier, mass produced with photocopying. \"IF YOU ARE STUCK IN THE CITY, DO NOT LEAVE UNTIL NIGHTFALL, *THEY* WILL SEE YOU!\" The flier further discusses how to barricade your apartment, and to duct tape sheets to your windows."
+        "text": "This is high quality flier, mass produced with photocopying.  \"IF YOU ARE STUCK IN THE CITY, DO NOT LEAVE UNTIL NIGHTFALL, *THEY* WILL SEE YOU!\" The flier further discusses how to barricade your apartment, and to duct tape sheets to your windows."
       },
       {
         "id": "flier_53",
@@ -217,7 +217,7 @@
       },
       {
         "id": "flier_54",
-        "text": "This is a flier for some kind of reality tv show that takes place in New Jersey. The flier claims that the finale will 'blow your minds', and was to air the day the evacuation order was given."
+        "text": "This is a flier for some kind of reality tv show that takes place in New Jersey.  The flier claims that the finale will 'blow your minds', and was to air the day the evacuation order was given."
       },
       {
         "id": "flier_55",
@@ -229,7 +229,7 @@
       },
       {
         "id": "flier_57",
-        "text": "This is a public alert from the Center of Disease Control. Its message, repeated in several languages reads: \"ADVISORY. Do not attempt to bring infected loved ones or friends to any hospitals, they are being currently overwhelmed due to the volume of incoming patients. Restain those believed to be infected, and wait for further information at www.cdc.gov.\""
+        "text": "This is a public alert from the Center of Disease Control.  Its message, repeated in several languages reads: \"ADVISORY.  Do not attempt to bring infected loved ones or friends to any hospitals, they are being currently overwhelmed due to the volume of incoming patients.  Restain those believed to be infected, and wait for further information at www.cdc.gov.\""
       },
       {
         "id": "flier_58",

--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -343,7 +343,7 @@
       {
         "id": "flier_83",
         "text": {
-          "str": "This flyer appears to have been hastily photocopied on cheap cartridge paper. It appears to be advertising an event 7 days after the evacuation order was sent out. 'Great Antler Bar & Grill is closing down forever. Come and celebrate the memmeries. fFood will be free. come quick fresh and tender.' There are several grainy photos of an empty restaurant with the windows boarded up, rotting food haphazardly served on the tables at different stages of decomposition. The bottom of the flier is a blurry photo of a woman, her eyes bloodshot and mouth disturbingly wide. You can't quite determine whether she is laughing or crying.",
+          "str": "This flier has been hastily photocopied on cheap cartridge paper. It appears to be advertising an event 7 days after the evacuation order was sent out. 'Great Antler Bar & Grill is closing down forever. Come and celebrate the memmeries. fFood will be free. come quick fresh and tender.' There are several grainy photos of an empty restaurant with the windows boarded up, rotting food haphazardly served on the tables at different stages of decomposition. The bottom of the flier is a blurry photo of a woman, her eyes bloodshot and mouth disturbingly wide. You can't quite determine whether she is laughing or crying.",
           "//NOLINT(cata-text-style)": "intentional format"
         }
       }

--- a/data/json/snippets/missing_posters.json
+++ b/data/json/snippets/missing_posters.json
@@ -104,7 +104,7 @@
       {
         "id": "female_8",
         "text": {
-          "str": "This poster seems to be several years old. Even heavily faded, there's still some prominent details left. \n\nCITY OF\nBOSTON\nPOLICE DEPARTMENT\n\nMISSING \n\nThe Boston Police Department's Missing Persons Unit is seeking information on the location of Amy Takatoshi.\n\n[Photograph: A stern looking woman in a lab coat can be seen sitting for a professional photo.]\n\nAmy Takatoshi\n51-year-old Asian Female; 5'5\"; 126 lbs.\nShort Black Hair; No tattoos, beauty mark on right cheek\n\nAmy Takatoshi was last seen on 7/12, wearing a pencil skirt, white button down shirt, tie, and pumps, leaving the Massachusetts Institute of Technology building around at 7 AM.\n\nIf you have any information, please call the Missing Persons Unit at (202) 555-0114.",
+          "str": "This poster seems to be several years old.  Even heavily faded, there's still some prominent details left.\n\nCITY OF\nBOSTON\nPOLICE DEPARTMENT\n\nMISSING\n\nThe Boston Police Department's Missing Persons Unit is seeking information on the location of Amy Takatoshi.\n\n[Photograph: A stern looking woman in a lab coat can be seen sitting for a professional photo.]\n\nAmy Takatoshi\n51-year-old Asian Female; 5'5\"; 126 lbs.\nShort Black Hair; No tattoos, beauty mark on right cheek\n\nAmy Takatoshi was last seen on 7/12, wearing a pencil skirt, white button down shirt, tie, and pumps, leaving the Massachusetts Institute of Technology building around at 7 AM.\n\nIf you have any information, please call the Missing Persons Unit at (202) 555-0114.",
           "//~": "Please replace the fictitious phone number with one of your local equivalent when translating"
         }
       }

--- a/data/json/snippets/missing_posters.json
+++ b/data/json/snippets/missing_posters.json
@@ -104,7 +104,7 @@
       {
         "id": "female_8",
         "text": {
-          "str": "This poster seems to be several years old. Even heavily faded, there's still some prominent details left.\n\nCITY OF\nBOSTON\nPOLICE DEPARTMENT\n\nMISSING \n\nThe Boston Police Department's Missing Persons Unit is seeking information on the location of Amy Takatoshi.\n\n[Photograph: A stern looking woman in a lab coat can be seen sitting for a professional photo.]\n\nAmy Takatoshi\n51-year-old Asian Female; 5'5\"; 126 lbs.\nShort Black Hair; No tattoos, beauty mark on right cheek\n\nAmy Takatoshi was last seen on 7/12, wearing a pencil skirt, white button down shirt, tie, and pumps, leaving the Massachusetts Institute of Technology building around at 7 AM.\n\nIf you have any information, please call the Missing Persons Unit at (202) 555-0114.",
+          "str": "This poster seems to be several years old. Even heavily faded, there's still some prominent details left. \n\nCITY OF\nBOSTON\nPOLICE DEPARTMENT\n\nMISSING \n\nThe Boston Police Department's Missing Persons Unit is seeking information on the location of Amy Takatoshi.\n\n[Photograph: A stern looking woman in a lab coat can be seen sitting for a professional photo.]\n\nAmy Takatoshi\n51-year-old Asian Female; 5'5\"; 126 lbs.\nShort Black Hair; No tattoos, beauty mark on right cheek\n\nAmy Takatoshi was last seen on 7/12, wearing a pencil skirt, white button down shirt, tie, and pumps, leaving the Massachusetts Institute of Technology building around at 7 AM.\n\nIf you have any information, please call the Missing Persons Unit at (202) 555-0114.",
           "//~": "Please replace the fictitious phone number with one of your local equivalent when translating"
         }
       }

--- a/data/json/snippets/missing_posters.json
+++ b/data/json/snippets/missing_posters.json
@@ -41,7 +41,7 @@
       {
         "id": "male_6",
         "text": {
-          "str": "MISSING/ RUNAWAY PERSON\n\nIF YOU HAVE ANY INFORMATION ON JONAH BROWN'S WHEREABOUTS PLEASE CALL ESSEX COUNTY SHERIFF'S DEPARTMENT AT 978-555-6174 OR BY DIALING 911.\n\n[Photograph: a college athlete posing with a basketball for a professional photo.]\n\nJONAH BROWN\n\nMissing From: 2337 Huntz Lane, Lynn, MA\nDate Missing: March 7\nAge: 20\nSex: Male\nHeight: 6'3\"\nEyes: Brown\nHair: Black, Short\nRace: African-American\n\nLast Seen Wearing:\n ● orange & gray puffer coat\n ● red long beanie\n ● black jeans\n ● white running shoes\n ● silver necklace\n\nFor additional information, please see www.where-is-jonah.org.\n\nDON'T HESITATE\nANYONE HAVING INFORMATION SHOULD CONTACT 911 or 1-800-TIPS",
+          "str": "MISSING/RUNAWAY PERSON\n\nIF YOU HAVE ANY INFORMATION ON JONAH BROWN'S WHEREABOUTS PLEASE CALL ESSEX COUNTY SHERIFF'S DEPARTMENT AT 978-555-6174 OR BY DIALING 911.\n\n[Photograph: a college athlete posing with a basketball for a professional photo.]\n\nJONAH BROWN\n\nMissing From: 2337 Huntz Lane, Lynn, MA\nDate Missing: March 7\nAge: 20\nSex: Male\nHeight: 6'3\"\nEyes: Brown\nHair: Black, Short\nRace: African-American\n\nLast Seen Wearing:\n ● orange & gray puffer coat\n ● red long beanie\n ● black jeans\n ● white running shoes\n ● silver necklace\n\nFor additional information, please see www.where-is-jonah.org.\n\nDON'T HESITATE\nANYONE HAVING INFORMATION SHOULD CONTACT 911 or 1-800-TIPS",
           "//~": "Please replace the fictitious phone number with one of your local equivalent when translating"
         }
       },
@@ -78,7 +78,7 @@
       {
         "id": "female_4",
         "text": {
-          "str": "CITY OF\nBOSTON\nPOLICE DEPARTMENT\n\nMissing/ Runaway Person\n\nThe Boston Police Department's Special Victims Unit is seeking information on the location of Cassandra Rose.\n\n[Photograph: a middle-aged woman in heavy makeup posing for a selfie inside a truck.]\n\nCassandra Rose\n43-year-old White Female; 5'9\"; 138 lbs.\nLong Black Hair; Tattoos on neck, right forearm and upper back\n\nCassandra Rose was last seen on 4/6, wearing a camouflage hoodie and gray sweatpants, near Eternal Harvest Baptist Church.  There is concern for Cassandra's welfare.\n\nAnyone with information is asked to call the Boston Police Department Special Victims Unit at (508) 555-4200.",
+          "str": "CITY OF\nBOSTON\nPOLICE DEPARTMENT\n\nMissing/Runaway Person\n\nThe Boston Police Department's Special Victims Unit is seeking information on the location of Cassandra Rose.\n\n[Photograph: a middle-aged woman in heavy makeup posing for a selfie inside a truck.]\n\nCassandra Rose\n43-year-old White Female; 5'9\"; 138 lbs.\nLong Black Hair; Tattoos on neck, right forearm and upper back\n\nCassandra Rose was last seen on 4/6, wearing a camouflage hoodie and gray sweatpants, near Eternal Harvest Baptist Church.  There is concern for Cassandra's welfare.\n\nAnyone with information is asked to call the Boston Police Department Special Victims Unit at (508) 555-4200.",
           "//~": "Please replace the fictitious phone number with one of your local equivalent when translating"
         }
       },
@@ -100,7 +100,14 @@
           "//~": "Please replace the fictitious phone number with one of your local equivalent when translating",
           "//NOLINT(cata-text-style)": "intentional format"
         }
-      }
+      },
+      {
+  "id": "female_8",
+  "text": {
+    "str": "This poster seems to be several years old. Even heavily faded, there's still some prominent details left.\n\nCITY OF\nBOSTON\nPOLICE DEPARTMENT\n\nMISSING \n\nThe Boston Police Department's Missing Persons Unit is seeking information on the location of Amy Takatoshi.\n\n[Photograph: A stern looking woman in a lab coat can be seen sitting for a professional photo.]\n\nAmy Takatoshi\n51-year-old Asian Female; 5'5\"; 126 lbs.\nShort Black Hair; No tattoos, beauty mark on right cheek\n\nAmy Takatoshi was last seen on 7/12, wearing a pencil skirt, white button down shirt, tie, and pumps, leaving the Massachusetts Institute of Technology building around at 7 AM.\n\nIf you have any information, please call the Missing Persons Unit at (202) 555-0114.",
+    "//~": "Please replace the fictitious phone number with one of your local equivalent when translating"
+  }
+}
     ]
   },
   {

--- a/data/json/snippets/missing_posters.json
+++ b/data/json/snippets/missing_posters.json
@@ -102,12 +102,12 @@
         }
       },
       {
-  "id": "female_8",
-  "text": {
-    "str": "This poster seems to be several years old. Even heavily faded, there's still some prominent details left.\n\nCITY OF\nBOSTON\nPOLICE DEPARTMENT\n\nMISSING \n\nThe Boston Police Department's Missing Persons Unit is seeking information on the location of Amy Takatoshi.\n\n[Photograph: A stern looking woman in a lab coat can be seen sitting for a professional photo.]\n\nAmy Takatoshi\n51-year-old Asian Female; 5'5\"; 126 lbs.\nShort Black Hair; No tattoos, beauty mark on right cheek\n\nAmy Takatoshi was last seen on 7/12, wearing a pencil skirt, white button down shirt, tie, and pumps, leaving the Massachusetts Institute of Technology building around at 7 AM.\n\nIf you have any information, please call the Missing Persons Unit at (202) 555-0114.",
-    "//~": "Please replace the fictitious phone number with one of your local equivalent when translating"
-  }
-}
+        "id": "female_8",
+        "text": {
+          "str": "This poster seems to be several years old. Even heavily faded, there's still some prominent details left.\n\nCITY OF\nBOSTON\nPOLICE DEPARTMENT\n\nMISSING \n\nThe Boston Police Department's Missing Persons Unit is seeking information on the location of Amy Takatoshi.\n\n[Photograph: A stern looking woman in a lab coat can be seen sitting for a professional photo.]\n\nAmy Takatoshi\n51-year-old Asian Female; 5'5\"; 126 lbs.\nShort Black Hair; No tattoos, beauty mark on right cheek\n\nAmy Takatoshi was last seen on 7/12, wearing a pencil skirt, white button down shirt, tie, and pumps, leaving the Massachusetts Institute of Technology building around at 7 AM.\n\nIf you have any information, please call the Missing Persons Unit at (202) 555-0114.",
+          "//~": "Please replace the fictitious phone number with one of your local equivalent when translating"
+        }
+      }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Changing flyers to fit with the lore of the game."

#### Purpose of change

There are going to be some more changes soon, if the mods permit it. For now, I've moved the missing person's flyer and remade it into an actual poster, in a similar style to the others. 

#### Describe the solution

I have reformatted and changed the flyer so that it now a missing's person report, rather than a flyer. In it's place, I added a flyer for a music venue featuring a local DJ.

#### Describe alternatives you've considered

There's a few more flyers I wish to change or remove, since some of these are old, and don't reflect the current lore. Here is a few:
-flier_57 "This is a leaflet about autoclaving procedure.  One sentence catches your attention \"/!\\Always place your tools into an autoclave pouch before autoclaving./!\\\" 
This seems like an odd subject to make a flyer for. It seems more better suited as a sign to be placed in hospitals.

-flier_71 "TOO LONG TO PUT HERE" 
This seems better suited as a survivor letter, rather than as a flyer.

-flier_52 "This is a poster advertising a underground bunker.  The poster shows a nuclear bomb wiping out a city while a family huddles safely underground.  There a slogan \"Concerned about enemy attack?  Want to protect your family?  Join the VAULT program today.\" which is written in the middle.  However, there seems to be no information about *how* one might do so."
This is just a fallout reference, but it makes no sense within the context of the game. This should probably be removed.

-flier_2 "This is an advertisement for compact bionic modules.  \"Nerve pain?  Depression?  Tardiness?  There's not a problem a compact bionic module can't solve.  Talk to your doctor to find out of CBMs are right for you!\""
This one I admittedly am not too sure about, but I believe a few others have discussed that the lore about CBMs have changed, and this is a outdated remnant of it. This should be changed to better reflect the lore currently.
#### Testing

Checked to see if they spawned correctly, and they did. 

#### Additional context

More changes may come, depending on what I'm allowed to do. People are also allowed to comment on which flyers they believe are outdated and such, or request to add new ones in, as long as they fit within the lore.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->