### PR TITLE
Extract recipe hints for inline result_eocs

### DIFF
--- a/lang/string_extractor/parsers/recipe.py
+++ b/lang/string_extractor/parsers/recipe.py
@@ -1,14 +1,26 @@
 from ..write_text import write_text
 
 
+def extract_eoc_id(json):
+    if type(json) is str:
+        return json  # eoc id
+    elif type(json) is dict and "id" in json:
+        return json.get("id")  # eoc defined inline
+    else:
+        raise Exception("result_eocs member missing id")
+
+
 def result_hint(json):
     hint = json.get("result", json.get("result_eocs", None))
-    if type(hint) is list:
-        hint = ", ".join(hint)
     if hint is None:
         raise Exception("no result hint for recipe translation,"
                         " needs 'result' or 'result_eocs' defined")
-    return hint
+    if type(hint) is str:
+        return hint
+    elif type(hint) is list:
+        return ", ".join(map(extract_eoc_id, hint))
+    else:
+        raise Exception("recipe's result_eocs has unsupported form")
 
 
 def parse_recipe(json, origin):


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/4926261272/jobs/8801570651?pr=65490

#### Describe the solution

Extract ids from eocs defined inline for translation hint

#### Describe alternatives you've considered

#### Testing

Run string extractor with one of the entries from https://github.com/CleverRaven/Cataclysm-DDA/pull/65490

#### Additional context
