### PR TITLE
Fix crash on installing CBMs

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2788,6 +2788,7 @@ bionic_uid Character::add_bionic( const bionic_id &b, bionic_uid parent_uid )
         }
     }
 
+    invalidate_pseudo_items();
     update_bionic_power_capacity();
 
     calc_encumbrance();
@@ -2800,8 +2801,6 @@ bionic_uid Character::add_bionic( const bionic_id &b, bionic_uid parent_uid )
         recalculate_enchantment_cache();
     }
     effect_on_conditions::process_reactivate( *this );
-
-    invalidate_pseudo_items();
 
     return bio_uid;
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #64036
* Closes #65387
* Closes #65551

#### Describe the solution
Apply the patch provided by @andrei8l in https://github.com/CleverRaven/Cataclysm-DDA/issues/64036#issuecomment-1478879730

#### Describe alternatives you've considered


#### Testing
I compiled from master without this patch and confirmed it crashed in the provided saves. I compiled with the patch and confirmed this prevented the crash. I do not see any issues this could cause and saw no side effects during local testing.

#### Additional context
I probably should have done this earlier but better late than never?