### PR TITLE
Added wooden frame packs.

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -2992,7 +2992,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-		"holster": true,
+        "holster": true,
         "max_contains_volume": "1000 L",
         "max_contains_weight": "150 kg",
         "moves": 300,

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -2945,5 +2945,66 @@
     "armor": [
       { "encumbrance": [ 10, 25 ], "coverage": 60, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] }
     ]
+  },
+  {
+    "id": "frame_pack",
+    "type": "ARMOR",
+    "name": { "str": "pack frame" },
+    "description": "An L-shaped wooden frame with straps to secure a large item to it.",
+    "weight": "5 kg",
+    "volume": "10 L",
+    "price": 800,
+    "price_postapoc": 750,
+    "material": [ "wood" ],
+    "symbol": "[",
+    "looks_like": "backpack",
+    "color": "brown",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+		"holster": true,
+        "max_contains_volume": "100 L",
+        "max_contains_weight": "75 kg",
+        "moves": 300,
+        "min_item_volume": "1 L"
+      }
+    ],
+    "warmth": 5,
+    "material_thickness": 1,
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "armor": [
+      { "encumbrance": [ 10, 50 ], "coverage": 60, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] }
+    ]
+  },
+  {
+    "id": "bigframe_pack",
+    "type": "ARMOR",
+    "name": { "str": "big pack frame" },
+    "description": "A sturdy L-shaped wooden frame with leather straps to secure an oversized item to it. It has straps to wear it on your back.",
+    "weight": "10 kg",
+    "volume": "45 L",
+    "price": 800,
+    "price_postapoc": 750,
+    "material": [ "wood" ],
+    "symbol": "[",
+    "looks_like": "golf_bag",
+    "color": "brown",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+		"holster": true,
+        "max_contains_volume": "1000 L",
+        "max_contains_weight": "150 kg",
+        "moves": 300,
+        "min_item_volume": "1 L",
+		"max_item_length": "180 cm"
+      }
+    ],
+    "warmth": 5,
+    "material_thickness": 1,
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": [
+      { "encumbrance": [ 30, 250 ], "coverage": 70, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] }
+    ]
   }
 ]

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -2962,7 +2962,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-		"holster": true,
+        "holster": true,
         "max_contains_volume": "100 L",
         "max_contains_weight": "75 kg",
         "moves": 300,

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -2997,7 +2997,7 @@
         "max_contains_weight": "150 kg",
         "moves": 300,
         "min_item_volume": "1 L",
-		"max_item_length": "180 cm"
+        "max_item_length": "180 cm"
       }
     ],
     "warmth": 5,

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -2315,9 +2315,7 @@
     "autolearn": true,
     "reversible": true,
     "using": [ [ "strap_large", 3 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_carving" }
-    ],
+    "proficiencies": [ { "proficiency": "prof_carving" } ],
     "components": [ [ [ "2x4", 4 ], [ "stick", 8 ] ] ]
   }
 ]

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -2287,5 +2287,39 @@
       { "proficiency": "prof_carving" }
     ],
     "components": [ [ [ "2x4", 4 ], [ "stick", 8 ] ] ]
+  },
+  {
+    "result": "frame_pack",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 2,
+    "time": "1 h",
+    "autolearn": true,
+    "reversible": true,
+    "using": [ [ "strap_large", 3 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_carving" }
+    ],
+    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ] ]
+  },
+  {
+    "result": "bigframe_pack",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "2 h",
+    "autolearn": true,
+    "reversible": true,
+    "using": [ [ "strap_large", 3 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_carving" }
+    ],
+    "components": [ [ [ "2x4", 4 ], [ "stick", 8 ] ] ]
   }
 ]

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -2300,9 +2300,7 @@
     "autolearn": true,
     "reversible": true,
     "using": [ [ "strap_large", 3 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_carving" }
-    ],
+    "proficiencies": [ { "proficiency": "prof_carving" } ],
     "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary

Content "Added wooden frame packs"


#### Purpose of change

Apart from using your hands or vehicles, there seems to be few ways of transporting over-sized objects and appliances.


#### Describe the solution

The wooden frame packs added are based on a simple premise. An L-shaped wood frame can support an incredibly large amount of weight, and a multitude of leather belts and straps serve to secure the object in question to the frame. Intended objects include oversized appliances, quartered or whole game, or simply large containers to make an unconventional backpack.

#### Describe alternatives you've considered

No alternatives were wholly considered.

#### Testing

I tested the items by spawning them in with debug. No error messages or problems occurred. When testing with combat, the encumbrance seemed to make combat sufficiently difficult. Even with middling (3-5) skills and "average" (8-10) stats, fighting against a regular zombie with a pocket knife still resulted in several injuries. 

#### Additional context

Images of wooden frame packs:
https://www.carryology.com/wp-content/uploads/2015/07/image-17.jpg
https://cdn.shopify.com/s/files/1/0036/2852/products/IMG_9925_2000x.jpg?v=1655140657

Inspiring concept from another game:
https://www.gamersdecide.com/sites/default/files/authors/u171181/outward_best_backpacks_-_mefinos_trade_backpack_-_4.jpg

If there's questions about carrying something as bulky and heavy as a fridge on your back, just look here.
(https://youtu.be/Goy8fdRXisw?t=17)
This concept just adds straps to make it hands-free.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->