### PR TITLE
firemen don't carry flamethrowers jesus

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/gear.json
+++ b/data/json/itemgroups/Clothing_Gear/gear.json
@@ -131,7 +131,7 @@
       [ "jack", 5 ],
       [ "throw_extinguisher", 10 ],
       [ "grapnel", 5 ],
-      { "item": "wearable_light", "prob": 5, "charges-min": 0 },
+      { "item": "wearable_light", "prob": 5, "charges-min": 1 },
       { "group": "tools_toolbox", "prob": 1 },
       { "item": "smoxygen_tank", "prob": 35, "charges-min": 4 },
       { "item": "watercannon", "prob": 10, "charges-min": 0 },

--- a/data/json/itemgroups/Clothing_Gear/gear.json
+++ b/data/json/itemgroups/Clothing_Gear/gear.json
@@ -105,7 +105,6 @@
       { "item": "rx11_stimpack", "prob": 1, "charges-min": 0 },
       [ "flaregun", 5 ],
       [ "signal_flare", 5 ],
-      { "item": "flamethrower", "prob": 1, "charges-min": 0, "charges-max": 500 },
       { "item": "handflare", "prob": 20, "charges": 300 },
       { "item": "heavy_flashlight", "prob": 30, "charges": [ 0, 300 ] },
       { "item": "glowstick", "prob": 10, "charges": 1400 },

--- a/data/json/itemgroups/Clothing_Gear/gear.json
+++ b/data/json/itemgroups/Clothing_Gear/gear.json
@@ -131,7 +131,7 @@
       [ "jack", 5 ],
       [ "throw_extinguisher", 10 ],
       [ "grapnel", 5 ],
-      { "item": "wearable_light", "prob": 5, "charges-min": 1 },
+      { "item": "wearable_light", "prob": 5, "charges-min": 0 },
       { "group": "tools_toolbox", "prob": 1 },
       { "item": "smoxygen_tank", "prob": 35, "charges-min": 4 },
       { "item": "watercannon", "prob": 10, "charges-min": 0 },


### PR DESCRIPTION
#### Summary
None


#### Purpose of change
 
Do I NEED to explain this?
Even if it could be argued that it's meant for making firebreaks to stop wildfires, There are actual tools for that (see: drip torch) and I am frankly sure the firefighters we have ingame are urban ones, not wildfire control.

#### Describe the solution

Removed the line in `fireman_gear` that allows flamethrowers to spawn.

#### Additional context

Yes I know what Fahrenheit 451 is, we already have a reference to that in the RM451.