### PR TITLE
[Innawoods] Overrides to remove a bunch of manmade items from innawoods

### DIFF
--- a/data/mods/innawood/itemgroups/monster_drops_lairs.json
+++ b/data/mods/innawood/itemgroups/monster_drops_lairs.json
@@ -55,5 +55,13 @@
     "id": "hive",
     "subtype": "distribution",
     "entries": [ { "item": "honeycomb", "prob": 10 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wasp_lair",
+    "//": "Override for mx_Trapdoor_spider_den, no loot value but even more warning",
+    "subtype": "distribution",
+    "ammo": 10,
+    "entries": [ { "group": "human_parts", "prob": 1 } ]
   }
 ]

--- a/data/mods/innawood/npcs/classes.json
+++ b/data/mods/innawood/npcs/classes.json
@@ -1,0 +1,55 @@
+[
+  {
+    "type": "npc_class",
+    "id": "NC_SCAVENGER_PREPPER",
+    "name": { "str": "Scavenger" },
+    "job_description": "I'm just trying to survive.",
+    "traits": [
+      { "group": "BG_survival_story_EVACUEE" },
+      { "group": "NPC_starting_traits" },
+      { "group": "Appearance_demographics" },
+      { "trait": "GETS_RANDOM_MISSION_NOMOVE" }
+    ],
+    "//": "Override to erase shopkeep item groups appearing when spawned! A tiny bit safer than overriding all the item groups themevles",
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
+      { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 0, 3 ] } },
+      { "skill": "archery", "bonus": { "rng": [ 0, 3 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_SCAVENGER_MOONSHINER",
+    "name": { "str": "Scavenger" },
+    "job_description": "I'm just trying to survive.",
+    "traits": [
+      { "group": "BG_survival_story_EVACUEE" },
+      { "group": "NPC_starting_traits" },
+      { "group": "Appearance_demographics" },
+      { "trait": "GETS_RANDOM_MISSION_NOMOVE" }
+    ],
+    "//": "Override to erase shopkeep item groups appearing when spawned! A tiny bit safer than overriding all the item groups themevles",
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
+      { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 0, 3 ] } },
+      { "skill": "archery", "bonus": { "rng": [ 0, 3 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_SLAVE",
+    "name": { "str": "Slave" },
+    "job_description": "I've had very bad luck recently.",
+    "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "carry_override": "naked_prisoner",
+    "weapon_override": "naked_prisoner",
+    "//": "Override to erase worn_override so they'll get a full selection of random innawoods NPC clothes (without having to define a new item group)",
+    "skills": [
+      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 4, 2 ] }, { "rng": [ -4, -1 ] } ] } ] } }
+    ]
+  }
+]

--- a/data/mods/innawood/npcs/items_generic.json
+++ b/data/mods/innawood/npcs/items_generic.json
@@ -223,18 +223,18 @@
     "id": "survivor_bashing",
     "//": "Override for hardcoded reference in npc::starting_weapon",
     "type": "item_group",
-    "items": [ [ "cudgel", 1 ], [ "stick_long", 2 ], [ "rock", 5 ] ]
+    "items": [ [ "cudgel", 1 ], [ "stick_long", 2 ], [ "rock", 5 ], [ "q_staff", 1 ] ]
   },
   {
     "id": "survivor_stabbing",
     "//": "Override for hardcoded reference in npc::starting_weapon",
     "type": "item_group",
-    "items": [ [ "pointy_stick", 5 ] ]
+    "items": [ [ "pointy_stick", 5 ], [ "pointy_stick_long", 2 ] ]
   },
   {
     "id": "survivor_cutting",
     "//": "Override for hardcoded reference in npc::starting_weapon",
     "type": "item_group",
-    "items": [ [ "sharp_rock", 5 ] ]
+    "items": [ [ "sharp_rock", 5 ], [ "bone_knife", 2 ] ]
   }
 ]

--- a/data/mods/innawood/npcs/items_generic.json
+++ b/data/mods/innawood/npcs/items_generic.json
@@ -218,5 +218,23 @@
       [ "yeast", 5 ],
       [ "zucchini", 3 ]
     ]
+  },
+  {
+    "id": "survivor_bashing",
+    "//": "Override for hardcoded reference in npc::starting_weapon",
+    "type": "item_group",
+    "items": [ [ "cudgel", 1 ], [ "stick_long", 2 ], [ "rock", 5 ] ]
+  },
+  {
+    "id": "survivor_stabbing",
+    "//": "Override for hardcoded reference in npc::starting_weapon",
+    "type": "item_group",
+    "items": [ [ "pointy_stick", 5 ] ]
+  },
+  {
+    "id": "survivor_cutting",
+    "//": "Override for hardcoded reference in npc::starting_weapon",
+    "type": "item_group",
+    "items": [ [ "sharp_rock", 5 ] ]
   }
 ]


### PR DESCRIPTION
#### Summary
Balance "Removed a bunch of rare cases where inappropriate items could spawn in innawoods"

#### Purpose of change
NPCs could spawn with a "ceiling cthulhu" t-shirt (NC_slave) or other inappropriate items, like rebar spears.

#### Describe the solution
Add a whole bunch of overrides and comments to explain why they're there.

#### Describe alternatives you've considered
Those hardcoded references should probably go away at some point...

#### Testing
Spawned in a bunch of NPCs and other things, cutting down new issues as I found them. Probably spawned 200 NPCs total over 4-5 loads of the game.

#### Additional context
They still spawn with lighters but I'll probably remove that next.

Holy crap a lot of them spawn with flintlocks. I guess this is just due to the way most NPC classes are weighted towards guns, but... that's a lot of guns! Maybe some more work on nulling out classes is due but I don't know what's appropriate, so these changes are the most minimal possible.