### PR TITLE
Remove hardcoded lighter from some starting NPC inventories

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1044,12 +1044,6 @@ void starting_inv( npc &who, const npc_class_id &type )
         return;
     }
 
-    item lighter( "lighter" );
-    // Set lighter ammo
-    if( !lighter.ammo_default().is_null() ) {
-        lighter.ammo_set( lighter.ammo_default(), rng( 10, 100 ) );
-    }
-    res.emplace_back( lighter );
     // If wielding a gun, get some additional ammo for it
     const item_location weapon = who.get_wielded_item();
     if( weapon && weapon->is_gun() ) {


### PR DESCRIPTION
#### Summary
Balance "Removed hardcoded lighter from some starting NPC inventories"

#### Purpose of change
Individual items should not be hardcoded into NPCs' starting inventories. If a lighter is desired we can add it to relevant classes' starting inventories, defined in JSON.

#### Describe the solution
It's time for the lighter to go.

#### Describe alternatives you've considered

#### Testing
Compiled, spawned many many NPCs in innawoods with adjusted spawns from #65591. No lighters.

#### Additional context
The inclusion of this lighter dates all the way back to an original commit by Whales on Oct 25, 2011 at 1621 EDT. https://github.com/CleverRaven/Cataclysm-DDA/commit/e625ed348e6509233ec292badc9bb40c886569fc#diff-a728f9a572846b675ebb3b145e2d41193ed193b9d130cc34f7171c0b8f165004