### PR TITLE
Make makeshift sling not give survival skill

### DIFF
--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -1243,7 +1243,6 @@
     "activity_level": "NO_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_STORAGE",
-    "skill_used": "survival",
     "time": "48 s",
     "reversible": true,
     "autolearn": true,


### PR DESCRIPTION
#### Summary
Balance "Make makeshift sling not give survival skill"

#### Purpose of change
Can someone remind me:
1. Why does folding a blanket make you better at "survival"?
2. How did this survive (no pun intended) for years?

#### Describe the solution
Make it a skill-less craft like soap flakes and makeshift bandages.

#### Describe alternatives you've considered
Leaving as is, for some reason.

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/52408044/5709bbcb-b9a5-4ed9-a157-6d3e4f251047)

#### Additional context
Expect more crafting tweaks soon.