### PR TITLE
Bionic two way radio

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1348,6 +1348,15 @@
     "flags": [ "BIONIC_NPC_USABLE" ]
   },
   {
+    "id": "bio_radio",
+    "type": "bionic",
+    "name": { "str": "Infolink" },
+    "description": "A compact communications device has been built into your ears, enabling you to communicate over radio waves.",
+    "occupied_bodyparts": [ [ "head", 2 ] ],
+    "flags": [ "BIONIC_NPC_USABLE" ],
+    "passive_pseudo_items": [ "fake_radio" ]
+  },
+  {
     "id": "bio_radscrubber",
     "type": "bionic",
     "name": { "str": "Radiation Scrubber System" },

--- a/data/json/itemgroups/bionics.json
+++ b/data/json/itemgroups/bionics.json
@@ -92,7 +92,8 @@
       [ "bio_soporific", 10 ],
       [ "bio_recoil", 10 ],
       [ "bio_ar", 10 ],
-      [ "bio_fitnessband", 10 ]
+      [ "bio_fitnessband", 10 ],
+      [ "bio_radio", 10 ]
     ]
   },
   {
@@ -181,7 +182,8 @@
       [ "bio_weight", 10 ],
       [ "bio_jointservo", 10 ],
       [ "bio_shotgun", 10 ],
-      [ "bio_recoil", 10 ]
+      [ "bio_recoil", 10 ],
+      [ "bio_radio", 10 ]
     ]
   }
 ]

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -779,7 +779,7 @@
     "price": 50000,
     "price_postapoc": 1000,
     "weight": "100 g",
-    "difficulty": 6
+    "difficulty": 4
   },
   {
     "id": "bio_radscrubber",

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -770,6 +770,18 @@
     "difficulty": 4
   },
   {
+    "id": "bio_radio",
+    "copy-from": "bionic_general",
+    "type": "BIONIC_ITEM",
+    "name": { "str": "Infolink CBM" },
+    "looks_like": "bio_int_enhancer",
+    "description": "A wireless communications device that integrates with the ear canal to enable hands-free communication over radio waves.",
+    "price": 50000,
+    "price_postapoc": 1000,
+    "weight": "100 g",
+    "difficulty": 6
+  },
+  {
     "id": "bio_radscrubber",
     "copy-from": "bionic_general_npc_usable",
     "type": "BIONIC_ITEM",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -127,6 +127,13 @@
     "extend": { "flags": [ "FIRESTARTER", "USES_BIONIC_POWER" ] }
   },
   {
+    "id": "fake_radio",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "bionic radio" },
+    "extend": { "flags": [ "TWO_WAY_RADIO", "USES_BIONIC_POWER" ] }
+  }
+  {
     "id": "fake_tire_changer",
     "copy-from": "fake_item",
     "type": "TOOL",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -132,7 +132,7 @@
     "type": "TOOL",
     "name": { "str": "bionic radio" },
     "extend": { "flags": [ "TWO_WAY_RADIO", "USES_BIONIC_POWER" ] }
-  }
+  },
   {
     "id": "fake_tire_changer",
     "copy-from": "fake_item",

--- a/data/json/npcs/exodii/exodii_merchant_itemlist.json
+++ b/data/json/npcs/exodii/exodii_merchant_itemlist.json
@@ -235,7 +235,8 @@
       [ "bio_sunglasses", 10 ],
       [ "bio_meteorologist", 10 ],
       [ "bio_pitch_perfect", 10 ],
-      [ "bio_fitnessband", 10 ]
+      [ "bio_fitnessband", 10 ],
+      [ "bio_radio", 10 ]
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Bionic radio system"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Radio bionic is an obvious inclusion that was mentioned as being desirable by Erk.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This bionic provides two-way radio functionality. Pretty simple, just lets you talk to your npc buddies without carrying a radio on your own.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I initially wanted to give it one-way-radio functionality (like the default "radio" item) but due to a number of factors this was FAR too much effort and hardcoded nonsense to enable what is basically just a flavortext functionality because the standard radio function is simultaneously half-baked and absurdly complicated and it led to all sorts of issues actually trying to implement it in a way that was functional.

I could also not call it "Infolink" as that's explicitly a Deus Ex thing, but I don't think that's a copyrighted term on DX's part and that's basically also what this is.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Installed the bionic. Gave an NPC buddy a two way radio and then traveled some distance. Confirmed I could chat with the NPC through my bionic.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->