### PR TITLE
Abort eat menu activity and cancel activity when NPC somehow has this activity

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2518,8 +2518,15 @@ void activity_handlers::toolmod_add_finish( player_activity *act, Character *you
 }
 
 // This activity opens the menu (it's not meant to queue consumption of items)
-void activity_handlers::eat_menu_do_turn( player_activity *, Character * )
+void activity_handlers::eat_menu_do_turn( player_activity *, Character *you )
 {
+    if( !you->is_avatar() ) {
+        debugmsg( "Character %s somehow opened the eat menu!  Cancelling their activity to prevent infinite loop",
+                  you->name );
+        you->cancel_activity();
+        return;
+    }
+
     avatar &player_character = get_avatar();
     avatar_action::eat_or_use( player_character, game_menus::inv::consume( player_character ) );
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #65555

#### Describe the solution
Since the calling character is getting passed as an argument (but unused) we can just check if the calling character is the player character. Only the player character should ever be able to call this activity, as it opens a menu that interacts only with the player character.

#### Describe alternatives you've considered
Maybe set activity to eat (instead of *eat menu*) for the NPC instead of canceling? But they don't necessarily have anything to eat and it's still unclear why/how they got into this state.

#### Testing
Loaded the save from the linked issue, confirms it produces a debug message (once) and then cancels the NPC's activity. Confirmed the player character could still open and use the eat menu while triggering this function (set a breakpoint to make sure I was using this activity and not one of the other consumption ones)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/0e7ac1a1-468c-4aae-aad7-e5105edbc65c)

Loaded a new world with NPC needs enabled (so the default mod is disabled!) and confirmed NPCs were still able to eat without error.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/e587ef47-4fb0-4717-a363-98a200276396)


#### Additional context
I saw we have similar defensive code in activity_handlers::view_recipe_do_turn already.