### PR TITLE
Allow zones to interact across multiple Z levels

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2699,7 +2699,8 @@ static requirement_check_result generic_multi_activity_check_requirement(
             loot_zone_spots.emplace_back( elem );
             combined_spots.emplace_back( elem );
         }
-        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1, PICKUP_RANGE - 1 ) ) {
+        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1,
+                PICKUP_RANGE - 1 ) ) {
             combined_spots.push_back( elem );
         }
         add_basecamp_storage_to_loot_zone_list( mgr, src_loc, you, loot_zone_spots, combined_spots );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -970,7 +970,7 @@ static bool are_requirements_nearby(
     }
     // use nearby welding rig without needing to drag it or position yourself on the right side of the vehicle.
     if( !found_welder ) {
-        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
+        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1, PICKUP_RANGE - 1) ) {
             const std::optional<vpart_reference> &vp = here.veh_at( elem ).part_with_tool( itype_welder );
 
             if( vp ) {
@@ -2698,7 +2698,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
             loot_zone_spots.emplace_back( elem );
             combined_spots.emplace_back( elem );
         }
-        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
+        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1, PICKUP_RANGE - 1 ) ) {
             combined_spots.push_back( elem );
         }
         add_basecamp_storage_to_loot_zone_list( mgr, src_loc, you, loot_zone_spots, combined_spots );
@@ -2808,7 +2808,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
                         local_src_set.push_back( here.bub_from_abs( elem ) );
                     }
                     std::vector<tripoint_bub_ms> candidates;
-                    for( const tripoint_bub_ms &point_elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
+                    for( const tripoint_bub_ms &point_elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1, PICKUP_RANGE - 1 ) ) {
                         // we don't want to place the components where they could interfere with our ( or someone else's ) construction spots
                         if( !you.sees( point_elem ) || ( std::find( local_src_set.begin(), local_src_set.end(),
                                                          point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -970,7 +970,8 @@ static bool are_requirements_nearby(
     }
     // use nearby welding rig without needing to drag it or position yourself on the right side of the vehicle.
     if( !found_welder ) {
-        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1, PICKUP_RANGE - 1) ) {
+        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1,
+                PICKUP_RANGE - 1 ) ) {
             const std::optional<vpart_reference> &vp = here.veh_at( elem ).part_with_tool( itype_welder );
 
             if( vp ) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2808,7 +2808,8 @@ static requirement_check_result generic_multi_activity_check_requirement(
                         local_src_set.push_back( here.bub_from_abs( elem ) );
                     }
                     std::vector<tripoint_bub_ms> candidates;
-                    for( const tripoint_bub_ms &point_elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1, PICKUP_RANGE - 1 ) ) {
+                    for( const tripoint_bub_ms &point_elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1,
+                            PICKUP_RANGE - 1 ) ) {
                         // we don't want to place the components where they could interfere with our ( or someone else's ) construction spots
                         if( !you.sees( point_elem ) || ( std::find( local_src_set.begin(), local_src_set.end(),
                                                          point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -785,7 +785,7 @@ std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint_ab
 {
     std::unordered_set<tripoint> res;
     map &here = get_map();
-    for( const tripoint &elem : here.points_in_radius( here.getlocal( where ), radius ) ) {
+    for( const tripoint &elem : here.points_in_radius( here.getlocal( where ), radius, radius ) ) {
         const zone_data *zone = get_zone_at( here.getglobal( elem ), true, fac );
         if( zone == nullptr ) {
             continue;
@@ -823,10 +823,8 @@ bool zone_manager::has_near( const zone_type_id &type, const tripoint_abs_ms &wh
 {
     const auto &point_set = get_point_set( type, fac );
     for( const tripoint_abs_ms &point : point_set ) {
-        if( point.z() == where.z() ) {
-            if( square_dist( point, where ) <= range ) {
-                return true;
-            }
+        if( square_dist( point, where ) <= range ) {
+            return true;
         }
     }
 
@@ -926,12 +924,10 @@ std::unordered_set<tripoint_abs_ms> zone_manager::get_near( const zone_type_id &
     std::unordered_set<tripoint_abs_ms> near_point_set;
 
     for( const tripoint_abs_ms &point : point_set ) {
-        if( point.z() == where.z() ) {
-            if( square_dist( point, where ) <= range ) {
-                if( ( type != zone_type_LOOT_CUSTOM && type != zone_type_LOOT_ITEM_GROUP ) ||
-                    ( it != nullptr && custom_loot_has( point, it, type, fac ) ) ) {
-                    near_point_set.insert( point );
-                }
+        if( square_dist( point, where ) <= range ) {
+            if( ( type != zone_type_LOOT_CUSTOM && type != zone_type_LOOT_ITEM_GROUP ) ||
+                ( it != nullptr && custom_loot_has( point, it, type, fac ) ) ) {
+                near_point_set.insert( point );
             }
         }
     }


### PR DESCRIPTION
#### Summary
Features "Allow zones to interact across multiple Z levels"

#### Purpose of change
In the game as it is currently, zones that are created on the same tile can interact just fine; but they cannot interact if the zones are above or below on the Z level. This can allow players to create surface level bases, set mining jobs below and use tools in the attic to perform those tasks, if they are within reach.

#### Describe the solution
By removing a section of checks in `clzones.cpp` to make sure that the zone is on the same z level, it allows them to interact using the basic sorting jobs and stuff like that. The changes to `activity_item_handling.cpp` are required so that Players + NPCs can find their tool zones properly, as it uses it's own logic to find loot zones. Now players can tell NPCs to mine underground with tools from the surface.

#### Describe alternatives you've considered
N/A

#### Testing
- Tested organizing loot from z level 0 to z level -1 and vice-versa. No issues.
- Tested automated jobs, chopping wood using an axe from z level -1 and a tree on z level 0. No issues.
- Tested telling a miner (z level -1) to do a mining job (z level -1), but their tools were on z level 0. No issues; went up the stairs, came back down without a care in the world and got to work.

#### Additional context

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->