### PR TITLE
Add support for running and smashing animations

### DIFF
--- a/doc/TILESET.md
+++ b/doc/TILESET.md
@@ -65,7 +65,22 @@ Sprites can be referenced across tilesheet directories, but they must be stored 
 
 #### Hardcoded IDs
 
-The special ID `unknown` provides a sprite that is displayed when an entity has no other sprite. Other hardcoded IDs also exist, and most of them are referenced in [`src/cata_tiles.cpp`](/src/cata_tiles.cpp). A full list of hardcoded IDs _may_ be present in [`tools/json_tools/generate_overlay_ids.py`](/tools/json_tools/generate_overlay_ids.py) stored as `CPP_IDS` but it's updated manually and may lag behind.
+The special ID `unknown` provides a sprite that is displayed when an entity has no other sprite. Other hardcoded IDs also exist, and most of them are referenced in [`src/cata_tiles.cpp`](/src/cata_tiles.cpp). A full list of hardcoded IDs _may_ be present in [`tools/json_tools/generate_overlay_ids.py`](/tools/json_tools/generate_overlay_ids.py) stored as `CPP_IDS` but it's updated manually and may lag behind. Other IDs may be found below.
+
+Sprinting trail animations (game.cpp):
+`sprint_nw` Player running towards north-west.
+`sprint_n`
+`sprint_ne`
+`sprint_w`
+`sprint_e`
+`sprint_sw`
+`sprint_s`
+`sprint_se`
+
+Bashing animations (handle_action.cpp):
+`bash_complete` Bash results in destruction of target.
+`bash_effective` Bash effective but target not yet destroyed.
+`bash_ineffective` Bash not effective.
 
 #### Complex IDs
 

--- a/doc/TILESET.md
+++ b/doc/TILESET.md
@@ -67,15 +67,15 @@ Sprites can be referenced across tilesheet directories, but they must be stored 
 
 The special ID `unknown` provides a sprite that is displayed when an entity has no other sprite. Other hardcoded IDs also exist, and most of them are referenced in [`src/cata_tiles.cpp`](/src/cata_tiles.cpp). A full list of hardcoded IDs _may_ be present in [`tools/json_tools/generate_overlay_ids.py`](/tools/json_tools/generate_overlay_ids.py) stored as `CPP_IDS` but it's updated manually and may lag behind. Other IDs may be found below.
 
-Sprinting trail animations (game.cpp):
-`sprint_nw` Player running towards north-west.
-`sprint_n`
-`sprint_ne`
-`sprint_w`
-`sprint_e`
-`sprint_sw`
-`sprint_s`
-`sprint_se`
+Running trail animations (game.cpp):
+`run_nw` Player running towards north-west.
+`run_n`
+`run_ne`
+`run_w`
+`run_e`
+`run_sw`
+`run_s`
+`run_se`
 
 Bashing animations (handle_action.cpp):
 `bash_complete` Bash results in destruction of target.

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -4212,6 +4212,8 @@ void cata_tiles::draw_custom_explosion_frame()
             explosion_tile_id = exp_strong;
         } else if( col == c_yellow ) {
             explosion_tile_id = exp_medium;
+        } else if( col == c_black ) {
+            return;
         } else {
             explosion_tile_id = exp_weak;
         }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -4205,6 +4205,7 @@ void cata_tiles::draw_custom_explosion_frame()
 
         const tripoint &p = pr.first;
         std::string explosion_tile_id;
+        // Use target sprite if exist, otherwise col will determine fallback sprite
         if( pr.second.tile_name &&
             find_tile_looks_like( *pr.second.tile_name, TILE_CATEGORY::NONE, "" ) ) {
             explosion_tile_id = *pr.second.tile_name;
@@ -4213,6 +4214,7 @@ void cata_tiles::draw_custom_explosion_frame()
         } else if( col == c_yellow ) {
             explosion_tile_id = exp_medium;
         } else if( col == c_black ) {
+            // c_black results in no fallback sprite
             return;
         } else {
             explosion_tile_id = exp_weak;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10405,7 +10405,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
 
     if( moving ) {
         cata_event_dispatch::avatar_moves( old_abs_pos, u, m );
-        
+
         // Add smoke effect when sprinting
         if( u.is_running() ) {
             std::map<tripoint, nc_color> area_color;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10412,25 +10412,25 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
             area_color[oldpos] = c_black;
             if( u.posy() < oldpos.y ) {
                 if( u.posx() < oldpos.x ) {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_nw" );
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_nw" );
                 } else if( u.posx() == oldpos.x ) {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_n" );
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_n" );
                 } else {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_ne" );
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_ne" );
                 }
             } else if( u.posy() == oldpos.y ) {
                 if( u.posx() < oldpos.x ) {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_w" );
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_w" );
                 } else {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_e" );
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_e" );
                 }
             } else {
                 if( u.posx() < oldpos.x ) {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_sw" );
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_sw" );
                 } else if( u.posx() == oldpos.x ) {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_s" );
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_s" );
                 } else {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_se" );
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_se" );
                 }
             }
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10405,6 +10405,13 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
 
     if( moving ) {
         cata_event_dispatch::avatar_moves( old_abs_pos, u, m );
+        
+        // Add smoke effect when sprinting
+        if( u.is_running() ) {
+            std::map<tripoint, nc_color> area_color;
+            area_color[oldpos] = c_white;
+            explosion_handler::draw_custom_explosion( oldpos, area_color, "fd_smoke" );
+        }
     }
 
     if( furniture_move ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10410,7 +10410,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
         if( u.is_running() ) {
             std::map<tripoint, nc_color> area_color;
             area_color[oldpos] = c_black;
-            explosion_handler::draw_custom_explosion( oldpos, area_color, "fd_smoke" );
+            explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_n" );
         }
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10410,28 +10410,28 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
         if( u.is_running() ) {
             std::map<tripoint, nc_color> area_color;
             area_color[oldpos] = c_black;
-            if( u.posy() < oldpos.y ){
-            	if( u.posx() < oldpos.x ) {
+            if( u.posy() < oldpos.y ) {
+                if( u.posx() < oldpos.x ) {
                     explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_nw" );
-            	} else if( u.posx() == oldpos.x ) {
+                } else if( u.posx() == oldpos.x ) {
                     explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_n" );
-            	} else {
+                } else {
                     explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_ne" );
-            	}
-            } else if( u.posy() == oldpos.y ){
-            	if( u.posx() < oldpos.x ) {
+                }
+            } else if( u.posy() == oldpos.y ) {
+                if( u.posx() < oldpos.x ) {
                     explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_w" );
-            	} else {
+                } else {
                     explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_e" );
-            	}
+                }
             } else {
-            	if( u.posx() < oldpos.x ) {
+                if( u.posx() < oldpos.x ) {
                     explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_sw" );
-            	} else if( u.posx() == oldpos.x ) {
+                } else if( u.posx() == oldpos.x ) {
                     explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_s" );
-            	} else {
+                } else {
                     explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_se" );
-            	}
+                }
             }
         }
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10406,11 +10406,33 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     if( moving ) {
         cata_event_dispatch::avatar_moves( old_abs_pos, u, m );
 
-        // Add smoke effect when sprinting
+        // Add trail animation when sprinting
         if( u.is_running() ) {
             std::map<tripoint, nc_color> area_color;
             area_color[oldpos] = c_black;
-            explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_n" );
+            if( u.posy() < oldpos.y ){
+            	if( u.posx() < oldpos.x ) {
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_nw" );
+            	} else if( u.posx() == oldpos.x ) {
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_n" );
+            	} else {
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_ne" );
+            	}
+            } else if( u.posy() == oldpos.y ){
+            	if( u.posx() < oldpos.x ) {
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_w" );
+            	} else {
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_e" );
+            	}
+            } else {
+            	if( u.posx() < oldpos.x ) {
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_sw" );
+            	} else if( u.posx() == oldpos.x ) {
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_s" );
+            	} else {
+                    explosion_handler::draw_custom_explosion( oldpos, area_color, "sprint_se" );
+            	}
+            }
         }
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10409,7 +10409,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
         // Add smoke effect when sprinting
         if( u.is_running() ) {
             std::map<tripoint, nc_color> area_color;
-            area_color[oldpos] = c_white;
+            area_color[oldpos] = c_black;
             explosion_handler::draw_custom_explosion( oldpos, area_color, "fd_smoke" );
         }
     }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -884,11 +884,11 @@ static void smash()
 
         if( bash_result.success ) {
             std::map<tripoint, nc_color> area_color;
-            area_color[smashp] = c_white;
+            area_color[smashp] = c_black;
             explosion_handler::draw_custom_explosion( smashp, area_color, "fd_smoke" );
         } else if( smashskill >= here.bash_resistance( smashp ) ) {
             std::map<tripoint, nc_color> area_color;
-            area_color[smashp] = c_white;
+            area_color[smashp] = c_black;
             explosion_handler::draw_custom_explosion( smashp, area_color, "crack_glass_center_tall" );
         } else if( one_in( 10 ) ) {
             if( here.has_furn( smashp ) && here.furn( smashp ).obj().bash.str_min != -1 ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -885,7 +885,7 @@ static void smash()
         // Variables for bash animation
         std::map<tripoint, nc_color> anim_area;
         anim_area[smashp] = c_black;
-        
+
         if( bash_result.success ) {
             // Bash results in destruction of target
             explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_complete" );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -882,18 +882,19 @@ static void smash()
         player_character.moves -= move_cost * weary_mult;
         player_character.recoil = MAX_RECOIL;
 
+        // Variables for bash animation
+        std::map<tripoint, nc_color> anim_area;
+        anim_area[smashp] = c_black;
+        
         if( bash_result.success ) {
             // Bash results in destruction of target
-            std::map<tripoint, nc_color> area_color;
-            area_color[smashp] = c_black;
-            explosion_handler::draw_custom_explosion( smashp, area_color, "bash_complete" );
+            explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_complete" );
         } else if( smashskill >= here.bash_resistance( smashp ) ) {
             // Bash effective but target not yet destroyed
-            std::map<tripoint, nc_color> area_color;
-            area_color[smashp] = c_black;
-            explosion_handler::draw_custom_explosion( smashp, area_color, "bash_effective" );
+            explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_effective" );
         } else {
             // Bash not effective
+            explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_ineffective" );
             if( one_in( 10 ) ) {
                 if( here.has_furn( smashp ) && here.furn( smashp ).obj().bash.str_min != -1 ) {
                     // %s is the smashed furniture

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -886,12 +886,12 @@ static void smash()
             // Bash results in destruction of target
             std::map<tripoint, nc_color> area_color;
             area_color[smashp] = c_black;
-            explosion_handler::draw_custom_explosion( smashp, area_color, "fd_smoke" );
+            explosion_handler::draw_custom_explosion( smashp, area_color, "bash_complete" );
         } else if( smashskill >= here.bash_resistance( smashp ) ) {
             // Bash effective but target not yet destroyed
             std::map<tripoint, nc_color> area_color;
             area_color[smashp] = c_black;
-            explosion_handler::draw_custom_explosion( smashp, area_color, "crack_glass_center_tall" );
+            explosion_handler::draw_custom_explosion( smashp, area_color, "bash_effective" );
         } else {
             // Bash not effective
             if( one_in( 10 ) ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -883,20 +883,25 @@ static void smash()
         player_character.recoil = MAX_RECOIL;
 
         if( bash_result.success ) {
+            // Bash results in destruction of target
             std::map<tripoint, nc_color> area_color;
             area_color[smashp] = c_black;
             explosion_handler::draw_custom_explosion( smashp, area_color, "fd_smoke" );
         } else if( smashskill >= here.bash_resistance( smashp ) ) {
+            // Bash effective but target not yet destroyed
             std::map<tripoint, nc_color> area_color;
             area_color[smashp] = c_black;
             explosion_handler::draw_custom_explosion( smashp, area_color, "crack_glass_center_tall" );
-        } else if( one_in( 10 ) ) {
-            if( here.has_furn( smashp ) && here.furn( smashp ).obj().bash.str_min != -1 ) {
-                // %s is the smashed furniture
-                add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), here.furnname( smashp ) );
-            } else {
-                // %s is the smashed terrain
-                add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), here.tername( smashp ) );
+        } else {
+            // Bash not effective
+            if( one_in( 10 ) ) {
+                if( here.has_furn( smashp ) && here.furn( smashp ).obj().bash.str_min != -1 ) {
+                    // %s is the smashed furniture
+                    add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), here.furnname( smashp ) );
+                } else {
+                    // %s is the smashed terrain
+                    add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), here.tername( smashp ) );
+                }
             }
         }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -882,15 +882,21 @@ static void smash()
         player_character.moves -= move_cost * weary_mult;
         player_character.recoil = MAX_RECOIL;
 
-        if( !bash_result.success ) {
-            if( smashskill < here.bash_resistance( smashp ) && one_in( 10 ) ) {
-                if( here.has_furn( smashp ) && here.furn( smashp ).obj().bash.str_min != -1 ) {
-                    // %s is the smashed furniture
-                    add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), here.furnname( smashp ) );
-                } else {
-                    // %s is the smashed terrain
-                    add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), here.tername( smashp ) );
-                }
+        if( bash_result.success ) {
+            std::map<tripoint, nc_color> area_color;
+            area_color[smashp] = c_white;
+            explosion_handler::draw_custom_explosion( smashp, area_color, "fd_smoke" );
+        } else if( smashskill >= here.bash_resistance( smashp ) ) {
+            std::map<tripoint, nc_color> area_color;
+            area_color[smashp] = c_white;
+            explosion_handler::draw_custom_explosion( smashp, area_color, "crack_glass_center_tall" );
+        } else if( one_in( 10 ) ) {
+            if( here.has_furn( smashp ) && here.furn( smashp ).obj().bash.str_min != -1 ) {
+                // %s is the smashed furniture
+                add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), here.furnname( smashp ) );
+            } else {
+                // %s is the smashed terrain
+                add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), here.tername( smashp ) );
             }
         }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add support for running and smashing animations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Certain actions could benefit from some extra animations for improved reactivity.  Sprinting and smashing are some of those.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds new sprite IDs which allow tilesets to assign sprites for a motion trail when a character is running, as well as for various smashing animations.  Sprinting animations are available in 8 directions, while smashing animations come in ineffective smashing, effective smashing, and complete smashing (destruction).

Tileset makers have full control on how these are used.  For example, you could reuse 3 sprites between the 8 sprinting directions, show cracks for effective smashing, and no sprite at all for ineffective smashing.

This modifies the function cata_tiles::draw_custom_explosion_frame, which normally falls back to 3 explosion sprites determined by nc_color if the target sprite is missing.  It now supports nc_black which will result in no fallback image.  This adds some flexibility for more custom animations in the future.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->




#### Testing
The video below shows these animations at work using ChibiUltica as the tileset.  "fd_smoke" is used for both sprinting and smashing destruction, while "crack_glass_center_tall" is used for effective smashing.

https://github.com/CleverRaven/Cataclysm-DDA/assets/129854247/662adaf5-2626-4627-8b01-dffd17c60c7e

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
The new sprite IDs can be found in TILESET.md under Hardcoded IDs.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->