### PR TITLE
fix: isherwoods all share the same outfit

### DIFF
--- a/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
@@ -25,7 +25,7 @@
     ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
+    "worn_override": "NC_Isherwood_male_worn",
     "weapon_override": "NC_ISHERWOOD_rifle",
     "skills": [
       {

--- a/data/json/npcs/isherwood_farm/NPC_Chris_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Chris_Isherwood.json
@@ -20,7 +20,7 @@
     "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" }, { "trait": "NO_BASH" } ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
+    "worn_override": "NC_Isherwood_male_worn",
     "weapon_override": "NC_ISHERWOOD_rifle",
     "skills": [
       {

--- a/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
@@ -25,6 +25,7 @@
     ],
     "common": false,
     "bonus_per": { "one_in": 4 },
+    "worn_override": "NC_Isherwood_female_worn",
     "weapon_override": "NC_ISHERWOOD_rifle",
     "shopkeeper_item_group": "NC_ISHERWOOD_CLAIRE_misc",
     "skills": [

--- a/data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json
@@ -25,7 +25,7 @@
     ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
+    "worn_override": "NC_Isherwood_male_worn",
     "weapon_override": "NC_ISHERWOOD_rifle",
     "shopkeeper_item_group": "NC_ISHERWOOD_EDDIE_misc",
     "skills": [

--- a/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
@@ -25,7 +25,7 @@
     ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
+    "worn_override": "NC_Isherwood_male_worn",
     "weapon_override": "NC_ISHERWOOD_rifle",
     "shopkeeper_item_group": "NC_ISHERWOOD_JACK_misc",
     "skills": [
@@ -43,28 +43,63 @@
   },
   {
     "type": "item_group",
-    "id": "NC_Isherwood_worn",
+    "id": "NC_Isherwood_male_worn",
     "subtype": "collection",
     "entries": [
-      { "item": "backpack_leather" },
+      { "distribution": [ { "item": "backpack_leather" }, { "item": "wicker_backpack" }, { "item": "slingpack" } ] },
+      {
+        "distribution": [
+          { "item": "jacket_light" },
+          { "item": "jacket_leather" },
+          { "item": "trenchcoat" },
+          { "item": "jacket_jean" },
+          { "item": "jacket_flannel" }
+        ]
+      },
       {
         "collection": [ { "item": "3006", "container-item": "ammo_pouch" }, { "item": "3006", "charges": [ 4, 8 ] } ]
       },
       { "item": "3006", "charges": [ 4, 8 ] },
-      { "item": "jeans" },
-      { "item": "tshirt" },
-      { "item": "gloves_fingerless" },
-      { "item": "panties" },
-      { "item": "socks" },
-      { "item": "cowboy_hat" },
-      { "item": "boots" }
-    ],
-    "items": [
-      [ "jacket_light", 20 ],
-      [ "jacket_leather", 20 ],
-      [ "trenchcoat", 20 ],
-      [ "jacket_jean", 20 ],
-      [ "jacket_flannel", 20 ]
+      { "distribution": [ { "item": "boxer_briefs" }, { "item": "boxer_shorts" }, { "item": "briefs" } ] },
+      { "distribution": [ { "item": "tshirt" }, { "item": "undershirt" } ] },
+      { "distribution": [ { "item": "jeans" }, { "item": "pants_cargo" }, { "item": "pants_leather" } ] },
+      { "item": "leather_belt", "prob": 50 },
+      { "item": "gloves_fingerless", "prob": 50 },
+      { "item": "cowboy_hat", "prob": 80 },
+      { "distribution": [ { "item": "boots" }, { "item": "boots_western" } ] },
+      { "item": "socks", "prob": 50 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_Isherwood_female_worn",
+    "subtype": "collection",
+    "entries": [
+      { "distribution": [ { "item": "backpack_leather" }, { "item": "wicker_backpack" }, { "item": "slingpack" } ] },
+      {
+        "distribution": [
+          { "item": "jacket_light" },
+          { "item": "jacket_leather" },
+          { "item": "trenchcoat" },
+          { "item": "jacket_jean" },
+          { "item": "jacket_flannel" }
+        ]
+      },
+      {
+        "collection": [ { "item": "3006", "container-item": "ammo_pouch" }, { "item": "3006", "charges": [ 4, 8 ] } ]
+      },
+      { "item": "3006", "charges": [ 4, 8 ] },
+      {
+        "distribution": [ { "item": "bra" }, { "item": "sports_bra" }, { "item": "camisole" }, { "item": "halter_top" } ]
+      },
+      { "distribution": [ { "item": "panties" }, { "item": "boy_shorts" } ] },
+      { "distribution": [ { "item": "tshirt" }, { "item": "longshirt" }, { "item": "undershirt" } ] },
+      { "distribution": [ { "item": "jeans" }, { "item": "pants_cargo" }, { "item": "pants_leather" } ] },
+      { "item": "leather_belt", "prob": 50 },
+      { "item": "gloves_fingerless", "prob": 50 },
+      { "item": "cowboy_hat", "prob": 80 },
+      { "distribution": [ { "item": "boots" }, { "item": "boots_western" } ] },
+      { "item": "socks", "prob": 50 }
     ]
   },
   {

--- a/data/json/npcs/isherwood_farm/NPC_Jesse_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Jesse_Isherwood.json
@@ -25,7 +25,7 @@
     ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
+    "worn_override": "NC_Isherwood_female_worn",
     "weapon_override": "NC_ISHERWOOD_rifle",
     "skills": [
       {

--- a/data/json/npcs/isherwood_farm/NPC_Lisa_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Lisa_Isherwood.json
@@ -24,7 +24,7 @@
     ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
+    "worn_override": "NC_Isherwood_female_worn",
     "weapon_override": "NC_ISHERWOOD_rifle",
     "skills": [
       {

--- a/data/json/npcs/isherwood_farm/NPC_Luke_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Luke_Isherwood.json
@@ -25,7 +25,7 @@
     ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
+    "worn_override": "NC_Isherwood_male_worn",
     "weapon_override": "NC_ISHERWOOD_rifle",
     "skills": [
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I was inspired by chaosvolt's fix of this same problem
https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2787

I also noticed this back in #62905, you can see in one of the screenshots there carlos was wearing panties. hey I didn't want to judge

anyway split the outfit so there's a female and male version and add a litte variety

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![Screenshot from 2023-05-13 18-04-21](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/b145f54c-51e0-4696-b8f8-3c4e0f7eca72)
![Screenshot from 2023-05-13 18-04-52](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/c44a498b-fef3-4320-9729-2876f4e57c60)
![Screenshot from 2023-05-13 18-05-12](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/ebb5dff2-7f26-4a93-91a7-00df21f0652f)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->