### PR TITLE
Reintroduce light snares

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4191,5 +4191,15 @@
     "desc": [ "You are covered in glowing nether spores!" ],
     "apply_message": "The glowing spores settle on you!",
     "rating": "bad"
+  },
+  {
+    "id": "lightsnare",
+    "type": "effect_type",
+    "name": [ "Snared" ],
+    "desc": [ "For such a tiny creature, you're in a very big pickle." ],
+    "rating": "bad",
+    "show_intensity": false,
+    "//": "Don't multiply speed by 0 or else the effect will never be removed for creatures with 0 damage(e.g. rabbits)",
+    "enchantments": [ { "values": [ { "value": "SPEED", "multiply": 0.01 } ] } ]
   }
 ]

--- a/data/json/itemgroups/activities_hobbies.json
+++ b/data/json/itemgroups/activities_hobbies.json
@@ -435,7 +435,8 @@
       { "distribution": [ { "group": "full_survival_kit" }, { "group": "used_survival_kit" } ], "prob": 30 },
       { "group": "premium_contents", "prob": 3 },
       { "item": "ar_glasses_basic", "prob": 1, "charges-min": 0 },
-      { "item": "ar_glasses_advanced", "prob": 1, "charges-min": 0 }
+      { "item": "ar_glasses_advanced", "prob": 1, "charges-min": 0 },
+      [ "light_snare_kit", 5 ]
     ]
   },
   {

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -215,6 +215,7 @@
       { "item": "tinderbox", "prob": 10, "charges": [ 0, 100 ] },
       [ "lifestraw", 4 ],
       [ "chem_hexamine", 10 ],
+      [ "light_snare_kit", 8 ],
       { "item": "esbit_stove", "prob": 15, "charges": [ 0, 50 ] }
     ]
   },
@@ -613,7 +614,7 @@
       [ "horse_tack", 3 ],
       [ "saddlebag", 5 ],
       [ "lifestraw", 3 ],
-      [ "acetylene_machine", 2 ],
+      [ "light_snare_kit", 3 ],
       { "item": "propane_lantern", "prob": 15, "charges": [ 2000, 3000 ] },
       { "item": "propane_cooker", "prob": 15, "charges": [ 2000, 3000 ] }
     ]

--- a/data/json/items/tool/traps.json
+++ b/data/json/items/tool/traps.json
@@ -31,7 +31,7 @@
     "name": "light snare kit",
     "description": "A simple loop snare, comprising a carefully wound loop of string, two anchor points, and a tool to hammer them in.  It is suitable for immobilizing only small animals.  It has no means of harming its target, as live meat lasts longer.",
     "weight": "2500 g",
-    "volume": "2900 ml",
+    "volume": "3150 ml",
     "longest_side": "80 cm",
     "price": 1500,
     "price_postapoc": 500,

--- a/data/json/items/tool/traps.json
+++ b/data/json/items/tool/traps.json
@@ -26,6 +26,28 @@
     "melee_damage": { "bash": 9, "cut": 1 }
   },
   {
+    "id": "light_snare_kit",
+    "type": "TOOL",
+    "name": "light snare kit",
+    "description": "A simple loop snare, comprising a carefully wound loop of string, two anchor points, and a tool to hammer them in.  It is suitable for immobilizing only small animals.  It has no means of harming its target, as live meat lasts longer.",
+    "weight": "2500 g",
+    "volume": "2900 ml",
+    "longest_side": "80 cm",
+    "price": 1500,
+    "price_postapoc": 500,
+    "material": "wood",
+    "symbol": ";",
+    "color": "brown",
+    "flags": [ "SINGLE_USE" ],
+    "use_action": {
+      "type": "place_trap",
+      "trap": "tr_light_snare",
+      "moves": 150,
+      "practice": 2,
+      "done_message": "You set the snare trap."
+    }
+  },
+  {
     "id": "blade_trap",
     "type": "TOOL",
     "name": { "str": "blade trap" },

--- a/data/json/recipes/tools/tools_primitive.json
+++ b/data/json/recipes/tools/tools_primitive.json
@@ -420,5 +420,33 @@
     "reversible": true,
     "autolearn": true,
     "components": [ [ [ "material_sand", 1 ] ], [ [ "leather", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "light_snare_kit",
+    "//": "Carving notches into the sticks (~15m), looping and knotting the string to sit securely in them (~30m), testing/misc/overhead (~5m)",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "survival",
+    "difficulty": 3,
+    "decomp_learn": 1,
+    "//2": "Pop culture magazine lacks most helpful information, requires inferring and therefore doesn't learn the recipe until survival 2",
+    "book_learn": [
+      [ "mag_survival", 2 ],
+      [ "pocket_survival", 1 ],
+      [ "manual_survival", 1 ],
+      [ "textbook_survival", 1 ],
+      [ "survival_book", 1 ]
+    ],
+    "time": "50 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "proficiencies": [
+      { "proficiency": "prof_carving", "max_experience": "15 m" },
+      { "proficiency": "prof_fibers", "max_experience": "30 m" }
+    ],
+    "reversible": { "time": "5 m" },
+    "autolearn": true,
+    "components": [ [ [ "pointy_stick", 2 ] ], [ [ "rock", 1 ] ], [ [ "string_36", 1 ] ] ]
   }
 ]

--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -163,6 +163,17 @@
   },
   {
     "type": "trap",
+    "id": "tr_light_snare",
+    "name": "light snare trap",
+    "color": "brown",
+    "symbol": "^",
+    "visibility": 1,
+    "avoidance": 8,
+    "difficulty": 0,
+    "action": "snare_light"
+  },
+  {
+    "type": "trap",
     "id": "tr_beartrap",
     "trigger_weight": "200 g",
     "name": "bear trap",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -238,7 +238,6 @@ static const efftype_id effect_incorporeal( "incorporeal" );
 static const efftype_id effect_infected( "infected" );
 static const efftype_id effect_jetinjector( "jetinjector" );
 static const efftype_id effect_lack_sleep( "lack_sleep" );
-static const efftype_id effect_lightsnare( "lightsnare" );
 static const efftype_id effect_lying_down( "lying_down" );
 static const efftype_id effect_masked_scent( "masked_scent" );
 static const efftype_id effect_melatonin( "melatonin" );
@@ -3199,10 +3198,6 @@ void Character::die( Creature *nkiller )
         }
     }
 
-    if( has_effect( effect_lightsnare ) ) {
-        inv->add_item( item( "string_36", calendar::turn_zero ) );
-        inv->add_item( item( "snare_trigger", calendar::turn_zero ) );
-    }
     if( has_effect( effect_heavysnare ) ) {
         inv->add_item( item( "rope_6", calendar::turn_zero ) );
         inv->add_item( item( "snare_trigger", calendar::turn_zero ) );

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -25,7 +25,6 @@ static const flag_id json_flag_GRAB( "GRAB" );
 
 static const itype_id itype_rope_6( "rope_6" );
 static const itype_id itype_snare_trigger( "snare_trigger" );
-static const itype_id itype_string_36( "string_36" );
 
 static const json_character_flag json_flag_DOWNED_RECOVERY( "DOWNED_RECOVERY" );
 
@@ -97,14 +96,11 @@ void Character::try_remove_bear_trap()
 
 void Character::try_remove_lightsnare()
 {
-    map &here = get_map();
     if( is_mounted() ) {
         auto *mon = mounted_creature.get();
         if( x_in_y( mon->type->melee_dice * mon->type->melee_sides, 12 ) ) {
             mon->remove_effect( effect_lightsnare );
             remove_effect( effect_lightsnare );
-            here.spawn_item( pos(), itype_string_36 );
-            here.spawn_item( pos(), itype_snare_trigger );
             add_msg( _( "The %s escapes the light snare!" ), mon->get_name() );
         }
     } else {
@@ -112,10 +108,6 @@ void Character::try_remove_lightsnare()
             remove_effect( effect_lightsnare );
             add_msg_player_or_npc( m_good, _( "You free yourself from the light snare!" ),
                                    _( "<npcname> frees themselves from the light snare!" ) );
-            item string( "string_36", calendar::turn );
-            item snare( "snare_trigger", calendar::turn );
-            here.add_item_or_charges( pos(), string );
-            here.add_item_or_charges( pos(), snare );
         } else {
             add_msg_if_player( m_bad,
                                _( "You try to free yourself from the light snare, but can't get loose!" ) );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2089,8 +2089,6 @@ bool monster::move_effects( bool )
     if( has_effect( effect_lightsnare ) ) {
         if( x_in_y( type->melee_dice * type->melee_sides, 12 ) ) {
             remove_effect( effect_lightsnare );
-            here.spawn_item( pos(), "string_36" );
-            here.spawn_item( pos(), "snare_trigger" );
             if( u_see_me ) {
                 add_msg( _( "The %s escapes the light snare!" ), name() );
             }
@@ -2646,15 +2644,12 @@ void monster::die( Creature *nkiller )
         move_special_item_to_inv( storage_item );
         move_special_item_to_inv( tied_item );
 
-        if( has_effect( effect_lightsnare ) ) {
-            add_item( item( "string_36", calendar::turn_zero ) );
-            add_item( item( "snare_trigger", calendar::turn_zero ) );
-        }
         if( has_effect( effect_heavysnare ) ) {
             add_item( item( "rope_6", calendar::turn_zero ) );
             add_item( item( "snare_trigger", calendar::turn_zero ) );
         }
     }
+
 
     if( death_drops && !no_extra_death_drops ) {
         drop_items_on_death( corpse.get_item() );


### PR DESCRIPTION
#### Summary
Content "Added craftable/findable light snares"

#### Purpose of change
I want to (force) feed the rabbit. The rabbit moves at 160(!!!) speed. I cannot catch the rabbit.

(Snares were removed in the great mod obsoleting of 2020, along with the 'More Survival Tools' mod. They were only moved to the mod because... apparently they had stopped working? I don't think that was a good reason but it happened.)

#### Describe the solution
Dust off some old code, write some new code. Do a bit of housecleaning wherever references to the lightsnare effect could be found. (Heavysnare *was not touched* and still lingers like a disease). Re-add the old item. Re-add the old trap. Redo all the values that don't make sense. Add new crafting recipe from scratch. Add item (commercial pre-made kits) to some appropriate existing item groups.

#### Describe alternatives you've considered
Maybe I'll do heavysnare next...

#### Testing
Youarealreadytamed.jpg
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/dddcfe73-10af-46c2-a2f1-f813d4812593)


#### Additional context
We still have tileset support for the snare trap! That's awesome! (It's been wasted since 2020 but that's the tilesets' problem!)

In the process of adding it to item groups I replaced an existing entry in tools_survival. An acetylene gas machine is NOT a survival tool. 