### PR TITLE
Use tool quality for maple tapping

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -884,7 +884,18 @@
     "price_postapoc": 10,
     "material": [ "steel" ],
     "weight": "11 g",
-    "volume": "50 ml"
+    "volume": "50 ml",
+    "qualities": [ [ "TREE_TAP", 1 ] ]
+  },
+  {
+    "type": "GENERIC",
+    "id": "makeshift_tree_spile",
+    "copy-from": "tree_spile",
+    "color": "brown",
+    "name": { "str": "makeshift tree spile" },
+    "description": "A carved piece of wood which is inserted in a tree crust in order to slowly harvest its sap.  Can be used on a maple tree in between late winter and early spring to harvest maple sap.",
+    "material": [ "wood" ],
+    "qualities": [ [ "TREE_TAP", 1 ] ]
   },
   {
     "type": "GENERIC",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1018,6 +1018,20 @@
   {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
+    "result": "makeshift_tree_spile",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "survival",
+    "difficulty": 2,
+    "time": "10 m",
+    "autolearn": true,
+    "proficiencies": [ { "proficiency": "prof_carving" } ],
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "pointy_stick", 1 ], [ "stick", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
     "result": "brazier",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -60,6 +60,11 @@
   },
   {
     "type": "tool_quality",
+    "id": "TREE_TAP",
+    "name": { "str": "tree tapping" }
+  },
+  {
+    "type": "tool_quality",
     "id": "SMOOTH",
     "name": { "str": "smoothing" }
   },

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3839,8 +3839,10 @@ void iexamine::tree_maple( Character &you, const tripoint &examp )
         return;
     }
 
-    item_location spile_loc = g->inv_map_splice( []( const item & it ) {
-        return it.get_quality_nonrecursive( qual_TREE_TAP ) > 0;
+    map &here = get_map();
+    item_location spile_loc = g->inv_map_splice( [&here]( const item_location & it ) {
+        return it->get_quality_nonrecursive( qual_TREE_TAP ) > 0 &&
+               t_tree_maple_tapped != here.ter( it.position() );
     }, _( "Use which tapping tool?" ), PICKUP_RANGE, _( "You don't have a tapping tool at hand." ) );
 
     item *spile = spile_loc.get_item();
@@ -3850,7 +3852,6 @@ void iexamine::tree_maple( Character &you, const tripoint &examp )
     std::string spile_name = spile->tname();
 
     you.mod_moves( -to_moves<int>( 20_seconds ) );
-    map &here = get_map();
     here.ter_set( examp, t_tree_maple_tapped );
     here.add_item_or_charges( examp, *spile, false );
     spile_loc.remove_item();

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -173,7 +173,6 @@ static const itype_id itype_petrified_eye( "petrified_eye" );
 static const itype_id itype_sheet( "sheet" );
 static const itype_id itype_stick( "stick" );
 static const itype_id itype_string_36( "string_36" );
-static const itype_id itype_tree_spile( "tree_spile" );
 static const itype_id itype_unfinished_cac2( "unfinished_cac2" );
 static const itype_id itype_unfinished_charcoal( "unfinished_charcoal" );
 
@@ -210,6 +209,7 @@ static const quality_id qual_DRILL( "DRILL" );
 static const quality_id qual_HAMMER( "HAMMER" );
 static const quality_id qual_LOCKPICK( "LOCKPICK" );
 static const quality_id qual_PRY( "PRY" );
+static const quality_id qual_TREE_TAP( "TREE_TAP" );
 
 static const requirement_id requirement_data_anesthetic( "anesthetic" );
 static const requirement_id requirement_data_autoclave( "autoclave" );
@@ -3821,45 +3821,49 @@ static item_location maple_tree_sap_container()
     const item maple_sap = item( "maple_sap", calendar::turn_zero );
     return g->inv_map_splice( [&]( const item & it ) {
         return it.get_remaining_capacity_for_liquid( maple_sap, true ) > 0;
-    }, _( "Use which container to collect sap?" ), PICKUP_RANGE );
+    }, _( "Use which container to collect sap?" ), PICKUP_RANGE,
+    _( "You don't have a container at hand." ) );
 }
 
 void iexamine::tree_maple( Character &you, const tripoint &examp )
 {
-    if( !you.has_quality( qual_DRILL ) ) {
+    const inventory &crafting_inv = you.crafting_inventory();
+    if( !crafting_inv.has_quality( qual_DRILL ) ) {
         add_msg( m_info, _( "You need a tool to drill the crust to tap this maple tree." ) );
         return;
     }
 
-    if( !you.has_quality( qual_HAMMER ) ) {
+    if( !crafting_inv.has_quality( qual_HAMMER ) ) {
         add_msg( m_info,
                  _( "You need a tool to hammer the spile into the crust to tap this maple tree." ) );
         return;
     }
 
-    const inventory &crafting_inv = you.crafting_inventory();
+    item_location spile_loc = g->inv_map_splice( []( const item & it ) {
+        return it.get_quality_nonrecursive( qual_TREE_TAP ) > 0;
+    }, _( "Use which tapping tool?" ), PICKUP_RANGE, _( "You don't have a tapping tool at hand." ) );
 
-    if( !crafting_inv.has_amount( itype_tree_spile, 1 ) ) {
-        add_msg( m_info, _( "You need a %s to tap this maple tree." ),
-                 item::nname( itype_tree_spile ) );
+    item *spile = spile_loc.get_item();
+    if( !spile ) {
         return;
     }
-
-    std::vector<item_comp> comps;
-    comps.emplace_back( itype_tree_spile, 1 );
-    you.consume_items( comps, 1, is_crafting_component );
+    std::string spile_name = spile->tname();
 
     you.mod_moves( -to_moves<int>( 20_seconds ) );
     map &here = get_map();
     here.ter_set( examp, t_tree_maple_tapped );
-    add_msg( m_info, _( "You drill the maple tree crust and tap a spile into the prepared hole." ) );
+    here.add_item_or_charges( examp, *spile, false );
+    spile_loc.remove_item();
+    add_msg( m_info, _( "You drill the maple tree crust and tap a %s into the prepared hole." ),
+             spile_name );
 
     item_location cont_loc = maple_tree_sap_container();
 
     item *container = cont_loc.get_item();
     if( container ) {
         here.add_item_or_charges( examp, *container, false );
-        add_msg( m_info, _( "You hang the %s under the spile to collect sap." ), container->tname( 1 ) );
+        add_msg( m_info, _( "You hang the %s under the %s to collect sap." ), container->tname(),
+                 spile_name );
         cont_loc.remove_item();
     } else {
         add_msg( m_info, _( "No container added.  The sap will just spill on the ground." ) );
@@ -3870,14 +3874,14 @@ void iexamine::tree_maple_tapped( Character &you, const tripoint &examp )
 {
     bool has_sap = false;
     item *container = nullptr;
+    item *spile = nullptr;
     int charges = 0;
 
     const std::string maple_sap_name = item::nname( itype_maple_sap );
 
     map &here = get_map();
     map_stack items = here.i_at( examp );
-    if( !items.empty() ) {
-        item &it = items.only_item();
+    for( item &it : items ) {
         if( it.will_spill() || it.is_watertight_container() ) {
             container = &it;
 
@@ -3890,6 +3894,13 @@ void iexamine::tree_maple_tapped( Character &you, const tripoint &examp )
                 return VisitResponse::NEXT;
             } );
         }
+        if( it.get_quality_nonrecursive( qual_TREE_TAP ) > 0 ) {
+            spile = &it;
+        }
+    }
+
+    if( !spile ) {
+        return;
     }
 
     enum options {
@@ -3911,14 +3922,14 @@ void iexamine::tree_maple_tapped( Character &you, const tripoint &examp )
 
     switch( selectmenu.ret ) {
         case REMOVE_TAP: {
-            if( !you.has_quality( qual_HAMMER ) ) {
-                add_msg( m_info, _( "You need a hammering tool to remove the spile from the crust." ) );
+            if( !you.crafting_inventory().has_quality( qual_HAMMER ) ) {
+                add_msg( m_info, _( "You need a hammering tool to remove the %s from the crust." ),
+                         spile->tname() );
                 return;
             }
 
-            item tree_spile( "tree_spile" );
-            add_msg( _( "You remove the %s." ), tree_spile.tname( 1 ) );
-            here.add_item_or_charges( you.pos(), tree_spile );
+            add_msg( _( "You remove the %s." ), spile->tname() );
+            here.add_item_or_charges( you.pos(), *spile );
 
             if( container ) {
                 here.add_item_or_charges( you.pos(), *container );
@@ -3937,7 +3948,8 @@ void iexamine::tree_maple_tapped( Character &you, const tripoint &examp )
             container = cont_loc.get_item();
             if( container ) {
                 here.add_item_or_charges( examp, *container, false );
-                add_msg( m_info, _( "You hang the %s under the spile to collect sap." ), container->tname( 1 ) );
+                you.mod_moves( -you.item_handling_cost( *container ) );
+                add_msg( m_info, _( "You hang the %s under the spile to collect sap." ), container->tname() );
                 cont_loc.remove_item();
             } else {
                 add_msg( m_info, _( "No container added.  The sap will just spill on the ground." ) );
@@ -3952,10 +3964,9 @@ void iexamine::tree_maple_tapped( Character &you, const tripoint &examp )
         }
 
         case REMOVE_CONTAINER: {
-            Character &player_character = get_player_character();
-            const std::vector<item_location> target_items{ item_location( map_cursor( examp ), container ) };
-            const pickup_activity_actor actor( target_items, { 0 }, player_character.pos(), false );
-            player_character.assign_activity( actor );
+            here.add_item_or_charges( you.pos(), *container );
+            you.mod_moves( -you.item_handling_cost( *container ) );
+            here.i_rem( examp, container );
             return;
         }
 


### PR DESCRIPTION
#### Summary
Content "Use tool quality for maple tapping"

#### Purpose of change

Use a new tool quality for maple tapping, instead of the hardcoded itype. This allows for new tree tapping items, this PR also introduces a makeshift tree spile made of wood, and a way to craft it.

Implements #63578.

#### Describe the solution

- Introduce a new tool quality, TREE_TAP
- When examining a maple tree, allow the player to select an item with this quality to use as tap.
- The tap item is then put on the map tile of the tree.
- Removing the tap returns the original item.

I've added some QoL changes as well:
- Take the hammer and drill from crafting inventory instead of player inventory.
- Removing the container puts it on the tile instead of the player picking it up, as this would fail when the player had no room in their inventory. 

#### Describe alternatives you've considered

With regards to the makeshift tree spile: I've used https://bluehillheritagetrust.org/wp-content/uploads/2022/04/Staghorn-Sumac-Spile.pdf as a reference, and created a recipe based on what seemed reasonable. Since I have no real-life experience with maple tapping, I'd be happy to take input on this matter.

#### Testing

Tested adding / removing taps, adding / removing containers.
Tested crafting a makeshift tree spile.
Tested sap production on day 1 of Spring: after a day, 3 units of sap were produced with a makeshift tree spile.

#### Additional context

Tap selection menu:
![2023-05-14_20-12-32](https://github.com/CleverRaven/Cataclysm-DDA/assets/78301810/6586c611-79b1-4589-af86-dbdab7cdfbf5)

Taps are visible on the tree:
![2023-05-14_20-13-55](https://github.com/CleverRaven/Cataclysm-DDA/assets/78301810/33a423be-0dda-46f1-9e06-42c20b17a806)
