### PR TITLE
vehicle_part cleanup

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -596,7 +596,7 @@
     "durability": 120,
     "description": "A power cord sticking out of an appliance.  You need to plug it into a powered grid for the appliance to work properly.",
     "item": "power_cord",
-    "flags": [ "NOINSTALL", "NO_UNINSTALL", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ]
+    "flags": [ "NO_INSTALL_HIDDEN", "NO_UNINSTALL", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ]
   },
   {
     "id": "ap_standing_lamp",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -84,7 +84,7 @@
     "broken_color": "red",
     "durability": 100,
     "item": "null",
-    "flags": [ "NOINSTALL" ],
+    "flags": [ "NO_INSTALL_HIDDEN" ],
     "breaks_into": [  ]
   },
   {
@@ -1158,7 +1158,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "adhesive", 2 ] ] }
     },
-    "flags": [ "MOUNTABLE", "BOARDABLE", "CARGO", "NO_INSTALL_PLAYER", "NO_UNINSTALL" ],
+    "flags": [ "MOUNTABLE", "BOARDABLE", "CARGO", "NO_INSTALL_HIDDEN", "NO_UNINSTALL" ],
     "breaks_into": [ { "item": "plastic_chunk", "count": [ 10, 20 ] } ],
     "damage_reduction": { "bash": 10 }
   },
@@ -1184,7 +1184,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "adhesive_rubber", 2 ], [ "tire_rubber", 2 ] ] }
     },
-    "flags": [ "FLOATS", "VARIABLE_SIZE", "NO_INSTALL_PLAYER", "NO_UNINSTALL" ],
+    "flags": [ "FLOATS", "VARIABLE_SIZE", "NO_INSTALL_HIDDEN", "NO_UNINSTALL" ],
     "breaks_into": [ { "item": "plastic_chunk", "count": [ 10, 20 ] } ],
     "damage_reduction": { "bash": 10 }
   },
@@ -2460,7 +2460,7 @@
     "description": "Thick copper cable with leads on either end.  Attach one end to one vehicle and the other to another, and you can transfer electrical power between the two.",
     "item": "jumper_cable",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NOINSTALL", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
     "breaks_into": [ { "item": "cable", "charges": [ 1, 10 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ]
   },
   {
@@ -2479,7 +2479,7 @@
     "description": "A long orange extension cord for connecting appliances.  Currently plugged in.",
     "item": "extension_cable",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NOINSTALL", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
     "breaks_into": [ { "item": "cable", "charges": [ 1, 10 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ]
   },
   {
@@ -2498,7 +2498,7 @@
     "description": "An extra long 30m orange extension cord for connecting outdoor appliances.  Currently plugged in.",
     "item": "long_extension_cable",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NOINSTALL", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
     "breaks_into": [ { "item": "cable", "charges": [ 1, 10 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ]
   },
   {
@@ -2517,7 +2517,7 @@
     "//": "Epower for POWER_TRANSFER stuff is how much percentage-wise loss there is in transmission",
     "item": "jumper_cable_heavy",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NOINSTALL", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
     "breaks_into": [ { "item": "wire", "count": [ 4, 8 ] }, { "item": "plastic_chunk", "count": [ 4, 8 ] } ]
   },
   {
@@ -2534,7 +2534,7 @@
     "description": "A heavy-duty tow cable, if the other end was attached to another vehicle, it could pull it.",
     "item": "hd_tow_cable",
     "requirements": { "removal": { "time": 500 } },
-    "flags": [ "NOINSTALL", "UNMOUNT_ON_DAMAGE", "TOW_CABLE" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "TOW_CABLE" ],
     "breaks_into": [ { "item": "scrap", "count": [ 4, 8 ] }, { "item": "grip_hook", "count": 1 }, { "item": "cable", "count": [ 1, 4 ] } ]
   },
   {
@@ -2552,7 +2552,7 @@
     "durability": 120,
     "item": "jumper_cable_debug",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NOINSTALL", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
     "breaks_into": [ { "item": "jumper_cable_debug" } ]
   },
   {

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -429,14 +429,16 @@
   },
   {
     "id": "NO_INSTALL_PLAYER",
-    "type": "json_flag"
+    "type": "json_flag",
+    "//": "Part can't be installed by player but visible in install menu (e.g. helicopter rotors)."
+  },
+  {
+    "id": "NO_INSTALL_HIDDEN",
+    "type": "json_flag",
+    "//": "Part can't be installed by player and hidden in install menu (e.g. power cords, inflatable boat parts, summoned vehicle parts)."
   },
   {
     "id": "NO_ROOF_NEEDED",
-    "type": "json_flag"
-  },
-  {
-    "id": "NOINSTALL",
     "type": "json_flag"
   },
   {

--- a/data/mods/Magiclysm/vehicleparts/vehicle_parts.json
+++ b/data/mods/Magiclysm/vehicleparts/vehicle_parts.json
@@ -40,6 +40,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
     },
-    "damage_reduction": { "all": 60 }
+    "damage_reduction": { "all": 60 },
+    "extend": { "flags": [ "NO_INSTALL_HIDDEN" ] }
   }
 ]

--- a/data/mods/Magiclysm/vehicles/summoned_vehicles.json
+++ b/data/mods/Magiclysm/vehicles/summoned_vehicles.json
@@ -61,14 +61,13 @@
     "size": "37500 ml",
     "power": "200 W",
     "location": "structure",
-    "//": "Flagged OBSOLETE to hide from install UI. This should not be interactable nor visible as a vehicle part, its part of a summoned magic 'vehicle'",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 20 ], [ "spellcraft", 1 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },
       "removal": { "skills": [ [ "mechanics", 20 ], [ "spellcraft", 1 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 20 ], [ "spellcraft", 1 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
     },
     "flags": [
-      "OBSOLETE",
+      "NO_INSTALL_HIDDEN",
       "ENGINE",
       "STABLE",
       "E_STARTS_INSTANTLY",

--- a/data/mods/TEST_DATA/appliance.json
+++ b/data/mods/TEST_DATA/appliance.json
@@ -75,7 +75,7 @@
     "durability": 120,
     "description": "A power cord sticking out of an appliance.  You need to plug it in a powered grid for the appliance to work properly.",
     "item": "test_power_cord",
-    "flags": [ "NOINSTALL", "NO_UNINSTALL", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ]
+    "flags": [ "NO_INSTALL_HIDDEN", "NO_UNINSTALL", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ]
   },
   {
     "type": "TOOL",
@@ -103,7 +103,7 @@
     "description": "A long orange extension cord for connecting appliances.  Currently plugged in.",
     "item": "test_extension_cable",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NOINSTALL", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
     "breaks_into": [ { "item": "cable", "charges": [ 1, 10 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ]
   },
   {
@@ -142,7 +142,7 @@
     "description": "A long orange extension cord for connecting appliances.  Currently plugged in.",
     "item": "test_power_cord_25_loss",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NOINSTALL", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "UNMOUNT_ON_MOVE", "POWER_TRANSFER" ],
     "breaks_into": [ { "item": "cable", "charges": [ 1, 10 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ]
   }
 ]

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -1552,8 +1552,8 @@ These flags apply to the `use_action` field, instead of the `flags` field.
 - ```NAILABLE``` Attached with nails.
 - ```NEEDS_BATTERY_MOUNT``` Part with this flag needs to be installed over part with `BATTERY_MOUNT` flag.
 - ```NEEDS_HANDHELD_BATTERY_MOUNT``` Same as `NEEDS_BATTERY_MOUNT`, but for handheld battery mount.
-- ```NOINSTALL``` Cannot be installed.
-- ```NO_INSTALL_PLAYER``` Cannot be installed by a player, but can be installed on vehicles.
+- ```NO_INSTALL_PLAYER``` Part can't be installed by player but visible in install menu (e.g. helicopter rotors).
+- ```NO_INSTALL_HIDDEN``` Part can't be installed by player and hidden in install menu (e.g. power cords, inflatable boat parts, summoned vehicle parts).
 - ```NO_MODIFY_VEHICLE``` Installing a part with this flag on a vehicle will mean that it can no longer be modified. Parts with this flag should not be installable by players.
 - ```NO_UNINSTALL``` Cannot be uninstalled.
 - ```NO_REPAIR``` Cannot be repaired.

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1396,10 +1396,10 @@ void construct::done_vehicle( const tripoint_bub_ms &p, Character & )
         debugmsg( "constructing failed: add_vehicle returned null" );
         return;
     }
-    item base = components.front();
+    const item &base = components.front();
 
     veh->name = name;
-    veh->install_part( point_zero, vpart_from_item( base.typeId() ), std::move( base ) );
+    veh->install_part( point_zero, vpart_from_item( base.typeId() ), item( base ) );
 
     // Update the vehicle cache immediately,
     // or the vehicle will be invisible for the first couple of turns.

--- a/src/flag.h
+++ b/src/flag.h
@@ -417,7 +417,7 @@ class json_flag
         }
 
         /** Requires this flag to be installed on vehicle */
-        std::string requires_flag() const {
+        const std::string &requires_flag() const {
             return requires_flag_;
         }
 

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -393,18 +393,15 @@ bool perform_liquid_transfer( item &liquid, const tripoint *const source_pos,
                                       round_up( to_liter( liquid.charges * stack ), 1 ),
                                       liquid.tname() );
 
-            vehicle_part &tank = veh_interact::select_part( *target.veh, sel, title );
-
-            if( !tank ) {
+            const std::optional<vpart_reference> vpr = veh_interact::select_part( *target.veh, sel, title );
+            if( !vpr ) {
                 return false;
             }
 
-            const vpart_reference vp( *target.veh, target.veh->index_of_part( &tank ) );
-
             if( create_activity() ) {
-                serialize_liquid_target( player_character.activity, vp );
+                serialize_liquid_target( player_character.activity, *vpr );
                 return true;
-            } else if( player_character.pour_into( vp, liquid ) ) {
+            } else if( player_character.pour_into( *vpr, liquid ) ) {
                 // this branch is used in milking and magiclysm butchery blood draining
                 player_character.mod_moves( -1000 ); // consistent with veh_interact::do_refill activity
                 return true;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8108,10 +8108,10 @@ std::optional<int> iuse::tow_attach( Character *p, item *it, bool, const tripoin
             const vpart_id vpid( it->typeId().str() );
             point vcoords = source_vp->mount();
             vehicle_part source_part( vpid, item( *it ) );
-            source_veh->install_part( vcoords, source_part );
+            source_veh->install_part( vcoords, std::move( source_part ) );
             vcoords = target_vp->mount();
             vehicle_part target_part( vpid, item( *it ) );
-            target_veh->install_part( vcoords, target_part );
+            target_veh->install_part( vcoords, std::move( target_part ) );
 
             if( p->has_item( *it ) ) {
                 p->add_msg_if_player( m_good, _( "You link up the %1$s and the %2$s." ),
@@ -8370,7 +8370,7 @@ std::optional<int> iuse::cable_attach( Character *p, item *it, bool, const tripo
             vehicle_part source_part( vpid, item( *it ) );
             source_part.target.first = target_global;
             source_part.target.second = target_veh->global_square_location().raw();
-            source_veh->install_part( vcoords, source_part );
+            source_veh->install_part( vcoords, std::move( source_part ) );
 
             vcoords = target_vp->mount();
             vehicle_part target_part( vpid, item( *it ) );
@@ -8379,7 +8379,7 @@ std::optional<int> iuse::cable_attach( Character *p, item *it, bool, const tripo
                                     it->get_var( "source_z", 0 ) );
             target_part.target.first = source_global;
             target_part.target.second = source_veh->global_square_location().raw();
-            target_veh->install_part( vcoords, target_part );
+            target_veh->install_part( vcoords, std::move( target_part ) );
 
             if( p != nullptr && p->has_item( *it ) ) {
                 p->add_msg_if_player( m_good, _( "You link up the electric systems of the %1$s and the %2$s." ),
@@ -8496,7 +8496,7 @@ std::optional<int> iuse::cord_attach( Character *p, item *it, bool, const tripoi
             vehicle_part source_part( vpid, item( *it ) );
             source_part.target.first = target_global;
             source_part.target.second = target_veh->global_square_location().raw();
-            source_veh->install_part( vcoords, source_part );
+            source_veh->install_part( vcoords, std::move( source_part ) );
 
             vcoords = target_vp->mount();
             vehicle_part target_part( vpid, item( *it ) );
@@ -8505,7 +8505,7 @@ std::optional<int> iuse::cord_attach( Character *p, item *it, bool, const tripoi
                                     it->get_var( "source_z", 0 ) );
             target_part.target.first = source_global;
             target_part.target.second = source_veh->global_square_location().raw();
-            target_veh->install_part( vcoords, target_part );
+            target_veh->install_part( vcoords, std::move( target_part ) );
 
             if( p != nullptr && p->has_item( *it ) ) {
                 p->add_msg_if_player( m_good, _( "You link up the electric systems of the %1$s and the %2$s." ),

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8107,10 +8107,10 @@ std::optional<int> iuse::tow_attach( Character *p, item *it, bool, const tripoin
             }
             const vpart_id vpid( it->typeId().str() );
             point vcoords = source_vp->mount();
-            vehicle_part source_part( vpid, "", vcoords, item( *it ) );
+            vehicle_part source_part( vpid, item( *it ) );
             source_veh->install_part( vcoords, source_part );
             vcoords = target_vp->mount();
-            vehicle_part target_part( vpid, "", vcoords, item( *it ) );
+            vehicle_part target_part( vpid, item( *it ) );
             target_veh->install_part( vcoords, target_part );
 
             if( p->has_item( *it ) ) {
@@ -8367,13 +8367,13 @@ std::optional<int> iuse::cable_attach( Character *p, item *it, bool, const tripo
             const vpart_id vpid( it->typeId().str() );
 
             point vcoords = source_vp->mount();
-            vehicle_part source_part( vpid, "", vcoords, item( *it ) );
+            vehicle_part source_part( vpid, item( *it ) );
             source_part.target.first = target_global;
             source_part.target.second = target_veh->global_square_location().raw();
             source_veh->install_part( vcoords, source_part );
 
             vcoords = target_vp->mount();
-            vehicle_part target_part( vpid, "", vcoords, item( *it ) );
+            vehicle_part target_part( vpid, item( *it ) );
             tripoint source_global( it->get_var( "source_x", 0 ),
                                     it->get_var( "source_y", 0 ),
                                     it->get_var( "source_z", 0 ) );
@@ -8493,13 +8493,13 @@ std::optional<int> iuse::cord_attach( Character *p, item *it, bool, const tripoi
             const vpart_id vpid( it->typeId().str() );
 
             point vcoords = source_vp->mount();
-            vehicle_part source_part( vpid, "", vcoords, item( *it ) );
+            vehicle_part source_part( vpid, item( *it ) );
             source_part.target.first = target_global;
             source_part.target.second = target_veh->global_square_location().raw();
             source_veh->install_part( vcoords, source_part );
 
             vcoords = target_vp->mount();
-            vehicle_part target_part( vpid, "", vcoords, item( *it ) );
+            vehicle_part target_part( vpid, item( *it ) );
             tripoint source_global( it->get_var( "source_x", 0 ),
                                     it->get_var( "source_y", 0 ),
                                     it->get_var( "source_z", 0 ) );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6786,7 +6786,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
                     const point source_point = parts_to_move.front()->mount;
                     for( const vehicle_part *vp : parts_to_move ) {
                         // TODO: change mount points to be tripoint
-                        first_veh->install_part( target_point, *vp );
+                        first_veh->install_part( target_point, vehicle_part( *vp ) );
                     }
 
                     if( !handler_ptr ) {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6785,8 +6785,17 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
                     const point target_point = first_veh_parts.front()->mount;
                     const point source_point = parts_to_move.front()->mount;
                     for( const vehicle_part *vp : parts_to_move ) {
+                        const vpart_info &vpi = vp->info();
                         // TODO: change mount points to be tripoint
-                        first_veh->install_part( target_point, vehicle_part( *vp ) );
+                        const ret_val<void> valid_mount = first_veh->can_mount( target_point, vpi );
+                        if( valid_mount.success() ) {
+                            // make a copy so we don't interfere with veh_to_add->remove_part below
+                            first_veh->install_part( target_point, vehicle_part( *vp ) );
+                        } else {
+                            DebugLog( D_WARNING, DC_ALL )
+                                    << "merging wrecks ignoring part '" << vpi.get_id().str() << "' "
+                                    << "as it would make invalid vehicle: " << valid_mount.str();
+                        }
                     }
 
                     if( !handler_ptr ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -161,8 +161,6 @@ static const ter_str_id ter_t_pwr_sb_switchgear_s( "t_pwr_sb_switchgear_s" );
 static const ter_str_id ter_t_rubble( "t_rubble" );
 static const ter_str_id ter_t_wreckage( "t_wreckage" );
 
-static const vpart_id vpart_turret_mount( "turret_mount" );
-
 static const std::array<std::string, static_cast<size_t>( object_type::NUM_OBJECT_TYPES )>
 obj_type_name = { { "OBJECT_NONE", "OBJECT_ITEM", "OBJECT_ACTOR", "OBJECT_PLAYER",
         "OBJECT_NPC", "OBJECT_MONSTER", "OBJECT_VEHICLE", "OBJECT_TRAP", "OBJECT_FIELD",
@@ -619,16 +617,6 @@ void activity_tracker::deserialize( const JsonObject &jo )
     }
 }
 
-// migration handling of items that used to have charges instead of real items.
-// remove this migration function after 0.F
-static void migrate_item_charges( item &it )
-{
-    if( it.charges != 0 && it.has_pocket_type( item_pocket::pocket_type::MAGAZINE ) ) {
-        it.ammo_set( it.ammo_default(), it.charges );
-        it.charges = 0;
-    }
-}
-
 /**
  * Gather variables for saving. These variables are common to both the avatar and NPCs.
  */
@@ -1068,14 +1056,6 @@ void Character::load( const JsonObject &data )
         const tripoint p( pmap.get_int( "x" ), pmap.get_int( "y" ), pmap.get_int( "z" ) );
         const std::string t = pmap.get_string( "trap" );
         known_traps.insert( trap_map::value_type( p, t ) );
-    }
-
-    // remove after 0.F
-    if( savegame_loading_version < 33 ) {
-        visit_items( []( item * it, item * ) {
-            migrate_item_charges( *it );
-            return VisitResponse::NEXT;
-        } );
     }
 
     JsonArray parray;
@@ -3465,9 +3445,7 @@ void vehicle::deserialize( const JsonObject &data )
     data.read( "is_alarm_on", is_alarm_on );
     data.read( "camera_on", camera_on );
     data.read( "autopilot_on", autopilot_on );
-    if( !data.read( "last_update_turn", last_update ) ) {
-        last_update = calendar::turn;
-    }
+    data.read( "last_update_turn", last_update );
 
     units::angle fdir_angle = units::from_degrees( fdir );
     face.init( fdir_angle );
@@ -3477,24 +3455,15 @@ void vehicle::deserialize( const JsonObject &data )
     std::string temp_old_id;
     data.read( "owner", temp_id );
     data.read( "old_owner", temp_old_id );
-    // for savegames before the change to faction_id for ownership.
-    if( temp_id.empty() ) {
-        owner = faction_id::NULL_ID();
-    } else {
-        owner = faction_id( temp_id );
-    }
-    if( temp_old_id.empty() ) {
-        old_owner = faction_id::NULL_ID();
-    } else {
-        old_owner = faction_id( temp_old_id );
-    }
+    owner = faction_id( temp_id );
+    old_owner = faction_id( temp_old_id );
     data.read( "theft_time", theft_time );
 
     parts.clear();
     for( const JsonValue val : data.get_array( "parts" ) ) {
         vehicle_part part;
         try {
-            val.read( part, true );
+            val.read( part, /* throw_on_error = */ true );
             parts.emplace_back( std::move( part ) );
         } catch( const JsonError &err ) {
             debugmsg( err.what() );
@@ -3522,49 +3491,10 @@ void vehicle::deserialize( const JsonObject &data )
     smart_controller_cfg = std::nullopt;
     data.read( "smart_controller", smart_controller_cfg );
     data.read( "vehicle_noise", vehicle_noise );
-
-    // Need to manually backfill the active item cache since the part loader can't call its vehicle.
-    for( const vpart_reference &vp : get_any_parts( VPFLAG_CARGO ) ) {
-        auto it = vp.part().items.begin();
-        auto end = vp.part().items.end();
-        for( ; it != end; ++it ) {
-            // remove after 0.F
-            if( savegame_loading_version < 33 ) {
-                migrate_item_charges( *it );
-            }
-        }
-    }
-
-    for( const vpart_reference &vp : get_any_parts( "TURRET" ) ) {
-        install_part( vp.mount(), vpart_turret_mount );
-
-        //Forcibly set turrets' targeting mode to manual if no turret control unit is
-        //present on turret's tile on loading save
-        if( !has_part( global_part_pos3( vp.part() ), "TURRET_CONTROLS" ) ) {
-            vp.part().enabled = false;
-        }
-        //Set turret control unit's state equal to turret's targeting mode on loading save
-        for( const vpart_reference &turret_part : get_any_parts( "TURRET_CONTROLS" ) ) {
-            turret_part.part().enabled = vp.part().enabled;
-        }
-    }
-
     data.read( "tags", tags );
     data.read( "labels", labels );
-
-    if( data.has_string( "fuel_remainder" ) ) {
-        data.read( "fuel_remainder", fuel_remainder );
-    } else {
-        // Compatibility with 0.F
-        // It is a small and not important number so just ignore it.
-    }
-
-    if( data.has_string( "fuel_used_last_turn" ) ) {
-        data.read( "fuel_used_last_turn", fuel_used_last_turn );
-    } else {
-        // Compatibility with 0.F
-        // It is a small and not important number so just ignore it.
-    }
+    data.read( "fuel_remainder", fuel_remainder );
+    data.read( "fuel_used_last_turn", fuel_used_last_turn );
 
     refresh();
 
@@ -3591,25 +3521,6 @@ void vehicle::deserialize( const JsonObject &data )
     // that can't be used as it currently stands because it would also
     // make it instantly fire all its turrets upon load.
     of_turn = 0;
-
-    /** Legacy saved games did not store part enabled status within parts */
-    const auto set_legacy_state = [&]( const std::string_view var, const std::string & flag ) {
-        if( data.get_bool( var, false ) ) {
-            for( const vpart_reference &vp : get_any_parts( flag ) ) {
-                vp.part().enabled = true;
-            }
-        }
-    };
-
-    set_legacy_state( "stereo_on", "STEREO" );
-    set_legacy_state( "chimes_on", "CHIMES" );
-    set_legacy_state( "fridge_on", "FRIDGE" );
-    set_legacy_state( "reaper_on", "REAPER" );
-    set_legacy_state( "planter_on", "PLANTER" );
-    set_legacy_state( "recharger_on", "RECHARGE" );
-    set_legacy_state( "scoop_on", "SCOOP" );
-    set_legacy_state( "plow_on", "PLOW" );
-    set_legacy_state( "reactor_on", "REACTOR" );
 }
 
 void vehicle::serialize( JsonOut &json ) const
@@ -5084,10 +4995,6 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                     update_lum_add( p, it );
                 }
                 active_items.add( it, p );
-                if( savegame_loading_version < 33 ) {
-                    // remove after 0.F
-                    migrate_item_charges( it );
-                }
             }
         }
     } else if( member_name == "traps" ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3267,7 +3267,7 @@ void vehicle_part::deserialize( const JsonObject &data )
     if( !pid.is_valid() ) {
         data.throw_error_at( "id", "bad vehicle part" );
     }
-    id = pid;
+    info_ = &pid.obj();
     if( variant.empty() ) {
         data.read( "variant", variant );
     }
@@ -3327,7 +3327,7 @@ void vehicle_part::deserialize( const JsonObject &data )
 void vehicle_part::serialize( JsonOut &json ) const
 {
     json.start_object();
-    json.member( "id", id.str() );
+    json.member( "id", info_->get_id().str() );
     if( !variant.empty() ) {
         json.member( "variant", variant );
     }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3422,7 +3422,7 @@ void veh_interact::complete_vehicle( Character &you )
         case 'o': {
             const bool appliance_removal = static_cast<char>( you.activity.index ) == 'O';
             const bool wall_wire_removal = appliance_removal &&
-                                           veh->part( vehicle_part ).id == vpart_ap_wall_wiring;
+                                           veh->part( vehicle_part ).info().get_id() == vpart_ap_wall_wiring;
             const inventory &inv = you.crafting_inventory();
             if( vehicle_part >= veh->part_count() ) {
                 vehicle_part = veh->get_next_shifted_index( vehicle_part, you );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3295,14 +3295,14 @@ void veh_interact::complete_vehicle( Character &you )
 
             you.invalidate_crafting_inventory();
             cata_assert( you.activity.str_values.size() >= 2 );
-            const std::string &variant_id = you.activity.str_values[1];
-            int partnum = !base.is_null() ? veh->install_part( d, part_id,
-                          std::move( base ), variant_id ) : -1;
+            const int partnum = veh->install_part( d, part_id, std::move( base ) );
             if( partnum < 0 ) {
                 debugmsg( "complete_vehicle install part fails dx=%d dy=%d id=%s",
                           d.x, d.y, part_id.c_str() );
                 break;
             }
+            ::vehicle_part &vp_new = veh->part( partnum );
+            vp_new.variant = you.activity.str_values[1];
 
             // Need map-relative coordinates to compare to output of look_around.
             // Need to call coord_translate() directly since it's a new part.
@@ -3335,7 +3335,7 @@ void veh_interact::complete_vehicle( Character &you )
 
                 units::angle dir = normalize( atan2( delta ) - veh->face.dir() );
 
-                veh->part( partnum ).direction = dir;
+                vp_new.direction = dir;
             }
 
             const tripoint vehp = veh->global_pos3() + tripoint( q, 0 );
@@ -3346,7 +3346,7 @@ void veh_interact::complete_vehicle( Character &you )
             }
 
             you.add_msg_if_player( m_good, _( "You install a %1$s into the %2$s." ),
-                                   veh->part( partnum ).name(), veh->name );
+                                   vp_new.name(), veh->name );
 
             for( const auto &sk : vpinfo.install_skills ) {
                 you.practice( sk.first, veh_utils::calc_xp_gain( vpinfo, sk.first, you ) );

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -56,8 +56,8 @@ class veh_interact
         static player_activity run( vehicle &veh, const point &p );
 
         /** Prompt for a part matching the selector function */
-        static vehicle_part &select_part( const vehicle &veh, const part_selector &sel,
-                                          const std::string &title = std::string() );
+        static std::optional<vpart_reference> select_part( const vehicle &veh, const part_selector &sel,
+                const std::string &title = std::string() );
 
         static void complete_vehicle( Character &you );
 

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -655,10 +655,10 @@ void vpart_info::finalize()
         int mechanics_req = 3 + static_cast<int>( item->weight / 10_kilogram );
         int electronics_req = 0; // calculated below
 
-        // mark turrets with migrated-from or blacklisted items obsolete
+        // if turret base item is migrated-from or blacklisted hide it from install menu
         if( item_id != item_controller->migrate_id( item_id ) ||
             item_is_blacklisted( item->get_id() ) ) {
-            new_part.set_flag( "OBSOLETE" );
+            new_part.set_flag( "NO_INSTALL_HIDDEN" );
         }
 
         if( gun_uses_liquid_ammo( *item ) ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1453,13 +1453,14 @@ void vehicles::finalize_prototypes()
                 continue;
             }
 
-            const int part_idx = blueprint.install_part( pt.pos, pt.part, pt.variant );
+            const int part_idx = blueprint.install_part( pt.pos, pt.part );
             if( part_idx < 0 ) {
                 debugmsg( "init_vehicles: '%s' part '%s'(%d) can't be installed to %d,%d",
                           blueprint.name, pt.part.c_str(),
                           blueprint.part_count(), pt.pos.x, pt.pos.y );
             } else {
                 vehicle_part &vp = blueprint.part( part_idx );
+                vp.variant = pt.variant;
                 for( const itype_id &it : pt.tools ) {
                     blueprint.get_tools( vp ).emplace_back( it, calendar::turn );
                 }

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -142,8 +142,12 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who, const std::str
         vpart_id replacement_id = pt.info().get_id();
         get_map().spawn_items( who.pos(), pt.pieces_for_broken_part() );
         veh.remove_part( part_index );
-        const int partnum = veh.install_part( loc, replacement_id, std::move( base ), variant );
-        veh.part( partnum ).direction = dir;
+        const int partnum = veh.install_part( loc, replacement_id, std::move( base ) );
+        if( partnum >= 0 ) {
+            vehicle_part &vp = veh.part( partnum );
+            vp.direction = dir;
+            vp.variant = variant;
+        }
         veh.part_removal_cleanup();
     } else {
         veh.set_hp( pt, pt.info().durability, true );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1407,7 +1407,9 @@ int vehicle::install_part( const point &dp, const vpart_id &id, const std::strin
     if( !( force || can_mount( dp, id ).success() ) ) {
         return -1;
     }
-    return install_part( dp, vehicle_part( id, variant_id, dp, item( id.obj().base_item ) ) );
+    vehicle_part vp( id, item( id.obj().base_item ) );
+    vp.variant = variant_id;
+    return install_part( dp, vp );
 }
 
 int vehicle::install_part( const point &dp, const vpart_id &id, item &&obj,
@@ -1416,7 +1418,9 @@ int vehicle::install_part( const point &dp, const vpart_id &id, item &&obj,
     if( !( force || can_mount( dp, id ).success() ) ) {
         return -1;
     }
-    return install_part( dp, vehicle_part( id, variant_id, dp, std::move( obj ) ) );
+    vehicle_part vp( id, std::move( obj ) );
+    vp.variant = variant_id;
+    return install_part( dp, std::move( vp ) );
 }
 
 int vehicle::install_part( const point &dp, const vehicle_part &new_part )
@@ -1870,7 +1874,7 @@ bool vehicle::remove_part( const int p, RemovePartHandler &handler )
     if( parts[p].has_flag( vp_flag::animal_flag ) ) {
         item base = parts[p].get_base();
         handler.spawn_animal_from_part( base, part_loc );
-        parts[p].set_base( base );
+        parts[p].set_base( std::move( base ) );
         parts[p].remove_flag( vp_flag::animal_flag );
     }
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -249,9 +249,6 @@ struct vehicle_part {
         vehicle_part( const vpart_id &vp, const std::string &variant_id, const point &dp,
                       item &&obj );
 
-        /** Check this instance is non-null (not default constructed) */
-        explicit operator bool() const;
-
         bool has_flag( const vp_flag flag ) const noexcept {
             const uint32_t flag_as_uint32 = static_cast<uint32_t>( flag );
             return ( flags & flag_as_uint32 ) == flag_as_uint32;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -966,16 +966,17 @@ class vehicle
         bool can_unmount( int p ) const;
         bool can_unmount( int p, std::string &reason ) const;
 
-        // install a new part to vehicle
-        int install_part( const point &dp, const vpart_id &id, const std::string &variant = "",
-                          bool force = false );
+        // install a part of type \p type at mount \p dp
+        // @return installed part index or -1 if can_mount(...) failed
+        int install_part( const point &dp, const vpart_id &type );
 
-        // Install a copy of the given part, skips possibility check
-        int install_part( const point &dp, const vehicle_part &part );
+        // install a part of type \p type at mount \p dp with \p base for base item
+        // @return installed part index or -1 if can_mount(...) failed
+        int install_part( const point &dp, const vpart_id &type, item &&base );
 
-        /** install item specified item to vehicle as a vehicle part */
-        int install_part( const point &dp, const vpart_id &id, item &&obj,
-                          const std::string &variant = "", bool force = false );
+        // install the given part (moving it), skips can_mount check
+        // @return installed part index
+        int install_part( const point &dp, vehicle_part &&vp );
 
         struct rackable_vehicle {
             std::string name;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -970,12 +970,12 @@ class vehicle
         // @return installed part index or -1 if can_mount(...) failed
         int install_part( const point &dp, const vpart_id &type );
 
-        // install a part of type \p type at mount \p dp with \p base for base item
+        // install a part of type \p type at mount \p dp with \p base (std::move -ing it)
         // @return installed part index or -1 if can_mount(...) failed
         int install_part( const point &dp, const vpart_id &type, item &&base );
 
-        // install the given part (moving it), skips can_mount check
-        // @return installed part index
+        // install the given part \p vp (std::move -ing it)
+        // @return installed part index or -1 if can_mount(...) failed
         int install_part( const point &dp, vehicle_part &&vp );
 
         struct rackable_vehicle {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -959,8 +959,12 @@ class vehicle
         // get vpart type info for part number (part at given vector index)
         const vpart_info &part_info( int index, bool include_removed = false ) const;
 
-        // check if certain part can be mounted at certain position (not accounting frame direction)
-        ret_val<void> can_mount( const point &dp, const vpart_id &id ) const;
+        /**
+         * @param dp The coordinate to mount at (in vehicle mount point coords)
+         * @param vpi The part type to check
+         * @return true if the part can be mounted at specified position.
+         */
+        ret_val<void> can_mount( const point &dp, const vpart_info &vpi ) const;
 
         // check if certain part can be unmounted
         bool can_unmount( int p ) const;

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -93,7 +93,7 @@ std::string vehicle::part_id_string( const int p, char &part_mod, bool below_roo
         part_mod = 2;
     }
 
-    return vp.id.str() + ( vp.variant.empty() ?  "" : "_" + vp.variant );
+    return vp.info().get_id().str() + ( vp.variant.empty() ?  "" : "_" + vp.variant );
 }
 
 nc_color vehicle::part_color( const int p, const bool exact, const bool include_fake ) const

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -55,11 +55,6 @@ vehicle_part::vehicle_part( const vpart_id &vp, const std::string &variant_id, c
     }
 }
 
-vehicle_part::operator bool() const
-{
-    return id != vpart_id::NULL_ID();
-}
-
 const item &vehicle_part::get_base() const
 {
     return base;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -549,7 +549,7 @@ void vehicle::connect( const tripoint &source_pos, const tripoint &target_pos )
     vehicle_part source_part( vpid, item( cord ) );
     source_part.target.first = target_global;
     source_part.target.second = target_veh->global_square_location().raw();
-    source_veh->install_part( vcoords, source_part );
+    source_veh->install_part( vcoords, std::move( source_part ) );
 
     vcoords = target_vp->mount();
     vehicle_part target_part( vpid, item( cord ) );
@@ -558,7 +558,7 @@ void vehicle::connect( const tripoint &source_pos, const tripoint &target_pos )
                             cord.get_var( "source_z", 0 ) );
     target_part.target.first = here.getabs( source_global );
     target_part.target.second = source_veh->global_square_location().raw();
-    target_veh->install_part( vcoords, target_part );
+    target_veh->install_part( vcoords, std::move( target_part ) );
 }
 
 double vehicle::engine_cold_factor( const vehicle_part &vp ) const

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2074,11 +2074,12 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
             };
             std::string title = string_format( _( "Purify <color_%s>water</color> in tank" ),
                                                get_all_colors().get_name( itype_water->color ) );
-            vehicle_part &tank = veh_interact::select_part( *this, sel, title );
-            if( !tank )
+            const std::optional<vpart_reference> vpr = veh_interact::select_part( *this, sel, title );
+            if( !vpr )
             {
                 return;
             }
+            vehicle_part &tank = vpr->part();
             int64_t cost = static_cast<int64_t>( itype_water_purifier->charges_to_use() );
             if( fuel_left( itype_battery ) < tank.ammo_remaining() * cost )
             {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -546,13 +546,13 @@ void vehicle::connect( const tripoint &source_pos, const tripoint &target_pos )
     const vpart_id vpid( cord.typeId().str() );
 
     point vcoords = source_vp->mount();
-    vehicle_part source_part( vpid, "", vcoords, item( cord ) );
+    vehicle_part source_part( vpid, item( cord ) );
     source_part.target.first = target_global;
     source_part.target.second = target_veh->global_square_location().raw();
     source_veh->install_part( vcoords, source_part );
 
     vcoords = target_vp->mount();
-    vehicle_part target_part( vpid, "", vcoords, item( cord ) );
+    vehicle_part target_part( vpid, item( cord ) );
     tripoint source_global( cord.get_var( "source_x", 0 ),
                             cord.get_var( "source_y", 0 ),
                             cord.get_var( "source_z", 0 ) );
@@ -1480,12 +1480,12 @@ void vehicle::use_monster_capture( int part, const tripoint &pos )
     }
     item base = item( parts[part].get_base() );
     base.type->invoke( get_avatar(), base, pos );
-    parts[part].set_base( base );
     if( base.has_var( "contained_name" ) ) {
         parts[part].set_flag( vp_flag::animal_flag );
     } else {
         parts[part].remove_flag( vp_flag::animal_flag );
     }
+    parts[part].set_base( std::move( base ) );
     invalidate_mass();
 }
 

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -304,7 +304,7 @@ static void check_part_ammo_capacity( vpart_id part_type, itype_id item_type, am
     CAPTURE( part_type );
     CAPTURE( item_type );
     CAPTURE( ammo_type );
-    vehicle_part test_part( part_type, "", point_zero, item( item_type ) );
+    vehicle_part test_part( part_type, item( item_type ) );
     CHECK( expected_count == test_part.ammo_capacity( ammo_type ) );
 }
 
@@ -319,7 +319,7 @@ TEST_CASE( "verify_vehicle_tank_refill", "[vehicle]" )
 TEST_CASE( "check_capacity_fueltype_handling", "[vehicle]" )
 {
     GIVEN( "tank is empty" ) {
-        vehicle_part vp( vpart_tank_test, "", point_zero, item( itype_metal_tank_test ) );
+        vehicle_part vp( vpart_tank_test, item( itype_metal_tank_test ) );
         REQUIRE( vp.ammo_remaining() == 0 );
         THEN( "ammo_current ammotype is always null" ) {
             CHECK( vp.ammo_current().is_null() );
@@ -333,10 +333,10 @@ TEST_CASE( "check_capacity_fueltype_handling", "[vehicle]" )
     }
 
     GIVEN( "tank is not empty" ) {
-        vehicle_part vp( vpart_tank_test, "", point_zero, item( itype_metal_tank_test ) );
+        vehicle_part vp( vpart_tank_test, item( itype_metal_tank_test ) );
         item tank( itype_metal_tank_test );
         REQUIRE( tank.fill_with( item( itype_water_clean ), 100 ) == 100 );
-        vp.set_base( tank );
+        vp.set_base( std::move( tank ) );
         REQUIRE( vp.ammo_remaining() == 100 );
 
         THEN( "ammo_current is not null" ) {

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -108,13 +108,13 @@ TEST_CASE( "power loss to cables", "[vehicle][power]" )
         const vpart_id vpid( cord.typeId().str() );
 
         point vcoords = source_vp->mount();
-        vehicle_part source_part( vpid, "", vcoords, item( cord ) );
+        vehicle_part source_part( vpid, item( cord ) );
         source_part.target.first = target_global;
         source_part.target.second = target_veh->global_square_location().raw();
         source_veh->install_part( vcoords, source_part );
 
         vcoords = target_vp->mount();
-        vehicle_part target_part( vpid, "", vcoords, item( cord ) );
+        vehicle_part target_part( vpid, item( cord ) );
         tripoint source_global( cord.get_var( "source_x", 0 ),
                                 cord.get_var( "source_y", 0 ),
                                 cord.get_var( "source_z", 0 ) );

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -111,7 +111,7 @@ TEST_CASE( "power loss to cables", "[vehicle][power]" )
         vehicle_part source_part( vpid, item( cord ) );
         source_part.target.first = target_global;
         source_part.target.second = target_veh->global_square_location().raw();
-        source_veh->install_part( vcoords, source_part );
+        source_veh->install_part( vcoords, std::move( source_part ) );
 
         vcoords = target_vp->mount();
         vehicle_part target_part( vpid, item( cord ) );
@@ -120,7 +120,7 @@ TEST_CASE( "power loss to cables", "[vehicle][power]" )
                                 cord.get_var( "source_z", 0 ) );
         target_part.target.first = here.getabs( source_global );
         target_part.target.second = source_veh->global_square_location().raw();
-        target_veh->install_part( vcoords, target_part );
+        target_veh->install_part( vcoords, std::move( target_part ) );
     };
 
     const std::vector<tripoint> placements { { 4, 10, 0 }, { 6, 10, 0 }, { 8, 10, 0 } };

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -448,7 +448,7 @@ static void connect_power_line( const tripoint &src_pos, const tripoint &dst_pos
     vehicle_part source_part( vpid, item( cord ) );
     source_part.target.first = target_global;
     source_part.target.second = target_veh->global_square_location().raw();
-    source_veh->install_part( vcoords, source_part );
+    source_veh->install_part( vcoords, std::move( source_part ) );
 
     vcoords = target_vp->mount();
     vehicle_part target_part( vpid, item( cord ) );
@@ -457,7 +457,7 @@ static void connect_power_line( const tripoint &src_pos, const tripoint &dst_pos
                             cord.get_var( "source_z", 0 ) );
     target_part.target.first = here.getabs( source_global );
     target_part.target.second = source_veh->global_square_location().raw();
-    target_veh->install_part( vcoords, target_part );
+    target_veh->install_part( vcoords, std::move( target_part ) );
 }
 
 TEST_CASE( "power_cable_stretch_disconnect" )

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -226,7 +226,7 @@ static void unfold_and_check( const vehicle_preset &veh_preset, const damage_pre
         item base = vpr.part().get_base();
         base.set_degradation( damage_preset.degradation );
         base.set_damage( damage_preset.damage );
-        vpr.part().set_base( base );
+        vpr.part().set_base( std::move( base ) );
         veh.set_hp( vpr.part(), vpr.info().durability, true );
     }
 
@@ -445,13 +445,13 @@ static void connect_power_line( const tripoint &src_pos, const tripoint &dst_pos
     const vpart_id vpid( cord.typeId().str() );
 
     point vcoords = source_vp->mount();
-    vehicle_part source_part( vpid, "", vcoords, item( cord ) );
+    vehicle_part source_part( vpid, item( cord ) );
     source_part.target.first = target_global;
     source_part.target.second = target_veh->global_square_location().raw();
     source_veh->install_part( vcoords, source_part );
 
     vcoords = target_vp->mount();
-    vehicle_part target_part( vpid, "", vcoords, item( cord ) );
+    vehicle_part target_part( vpid, item( cord ) );
     tripoint source_global( cord.get_var( "source_x", 0 ),
                             cord.get_var( "source_y", 0 ),
                             cord.get_var( "source_z", 0 ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Clean up some vehicle_part related things

#### Describe the solution

A bunch of changes that should clean up various areas related to vehicle_part; prunes constructor or function arguments that can be setter calls, and (hopefully) prevent some invalid vehicle configurations by making all install_part overloads check can_mount.

https://github.com/CleverRaven/Cataclysm-DDA/pull/65675/commits/40f01e46ef2456de526c56269d9104f2aa736d39 Removes operator bool()+default constructed hack and instead uses std::optional for vehicle tank selection function.

https://github.com/CleverRaven/Cataclysm-DDA/pull/65675/commits/15fa4bba16a82b527a60b73364361b2fd58f0daf Prunes vehicle_part constructors and arguments - leaving just the default one and the one taking type id and base item, the other 2 arguments aren't needed to construct a valid vehicle part and most places don't use them. The mount point argument isn't relevant until the part is actually placed by `vehicle::install_part` (which sets it), variant field is both valid when empty and can be set as a normal field at any time, instead of being a constructor argument.

Also removes `id` field making `vehicle_part::info_` field the single source of truth for vehicle part type, this allows replacing caching code from `vehicle_part::info()` with just a pointer dereference.

https://github.com/CleverRaven/Cataclysm-DDA/pull/65675/commits/b60d5ff164669a74671793b5cdd4f733a0ae7370 Prunes parameters from `vehicle::install_part` overloads; variant is a normal field that is both valid empty and can be set at any time and `force` argument that skips a check for what looks to be exclusively to allow power cable installations (more on this later).

https://github.com/CleverRaven/Cataclysm-DDA/pull/65675/commits/5c47680f245fc8bb90e2f74a74334110503c0caa - Makes all install_part overloads check can_mount for valid part mounting, and raise a debugmsg if the check fails (this commit will fail tests).

https://github.com/CleverRaven/Cataclysm-DDA/pull/65675/commits/6f935da37003cc93cace8f4d9f954bdc0d1a6b61 - Refactors \*INSTALL\* flags; as the previously mentioned `force` check was used to skip a failing can_mount case:

Power cords (/jumper cables) actually violate the "rules" of vehicles, they're set to NOINSTALL so can_mount check fails, but then circumvented this via the overload that didn't perform the check, this also violates the check of multiple parts of same type can't be mounted on same tile, (next is speculation:) to get around this the `force` argument was introduced to install_part to skip the check.

This commit cleans up this area;
* `NOINSTALL` flag is removed
* `NO_INSTALL_HIDDEN` will hide the part from install ui.
* `NO_INSTALL_PLAYER` will show in the install ui but won't let the player actually install the part.
Neither flag will block install_part or make can_mount fail and only prevent the UI from showing or allowing to install the part, this allows install_part to install jumper cables from code and still have a can_mount check

POWER_TRANSFER parts specifically are now allowed to stack same ids on same tile in `vehicle::can_mount` checks, while this isn't strictly correct (pretty sure i saw code somewhere that assumes unique ids) this is how it currently works.

Obsolete/migrated, special (mana frames, inflatable boat parts), all kinds of POWER_TRANSFER cables are set to `NO_INSTALL_HIDDEN`.
Helicopter rotors are currently the only parts which have `NO_INSTALL_PLAYER`.

`vehicle::can_mount` is also refactored to cut down on the number of invididual loops and various visual fluff for better ux (example in screenshot).

(This commit will still fail tests - as the wreck merging test still generates invalid vehicles, fixed in next commit)

https://github.com/CleverRaven/Cataclysm-DDA/pull/65675/commits/3d108a5c0f2b874735b99d0d32d0b01293780ef6 Blocks one of the cases where wrecks generate invalid vehicles; parts that would cause a conflict are dropped (quietly, only writing to debug.log), hopefully this will stop wrecks generating double-frames, double-seats and similar weird configurations which sometimes trigger errors when critters hop on them.

At this commit the tests pass

https://github.com/CleverRaven/Cataclysm-DDA/pull/65675/commits/d0305f2bcdf2df9fe3ce0fd5891ffa76eff986c6 Removes old migrations, one migration is installing a turret_mount for any turret that's loaded which causes an error for already-migrated vehicles since install_part raises debug_msg on failure now, but all of the removed migrations should be obsolete anyway.

At this commit existing saves should load without errors (as long as the part setup is valid and not debugmenu'd).

#### Describe alternatives you've considered

#### Testing

Tests should catch most of the changes, playtested the changes a bit

#### Additional context

Likely the only hotspot for install_part is vehicles::finalize_prototypes; but testing with afs, blazemod, magiclysm and xedra,
the time spent in it is almost the same as without this patch, or at least random jitter overwhelmed the difference, in total the finalize method runs in under 200ms or so.

TODO:
May be fix more weird stuff, like parts with "on_roof" location not actually requiring a roof, but that's a change for another pr, seems there's a ton of those; solar panels on various car prototypes, floodlights, turret mounts, emergency lights, security cameras on tractors etc...

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/4019570d-a0a0-40d0-bb36-2180434d01a7)
