### PR TITLE
Running and smashing animations now respect animation settings

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10407,7 +10407,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
         cata_event_dispatch::avatar_moves( old_abs_pos, u, m );
 
         // Add trail animation when sprinting
-        if( u.is_running() ) {
+        if( get_option<bool>( "ANIMATIONS" ) && u.is_running() ) {
             std::map<tripoint, nc_color> area_color;
             area_color[oldpos] = c_black;
             if( u.posy() < oldpos.y ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -888,13 +888,19 @@ static void smash()
 
         if( bash_result.success ) {
             // Bash results in destruction of target
-            explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_complete" );
+            if( get_option<bool>( "ANIMATIONS" ) ) {
+                explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_complete" );
+            }
         } else if( smashskill >= here.bash_resistance( smashp ) ) {
             // Bash effective but target not yet destroyed
-            explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_effective" );
+            if( get_option<bool>( "ANIMATIONS" ) ) {
+                explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_effective" );
+            }
         } else {
             // Bash not effective
-            explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_ineffective" );
+            if( get_option<bool>( "ANIMATIONS" ) ) {
+                explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_ineffective" );
+            }
             if( one_in( 10 ) ) {
                 if( here.has_furn( smashp ) && here.furn( smashp ).obj().bash.str_min != -1 ) {
                     // %s is the smashed furniture


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Running and smashing animations now respect animation settings"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The "Animations" setting has no effect on the running and smashing animations introduced in #65622.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The relevant code now checks for animation settings.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Animation no longer plays when animations are set to false.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->