### PR TITLE
MF_IMMOBILE disallows infinite throw training

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1329,7 +1329,8 @@ dealt_projectile_attack Character::throw_item( const tripoint &target, const ite
         practice( skill_throw, final_xp_mult, MAX_SKILL );
         // TODO: Check target for existence of head
         get_event_bus().send<event_type::character_gets_headshot>( getID() );
-    } else if( dealt_attack.hit_critter != nullptr && missed_by > 0.0f && !critter->has_flag( MF_IMMOBILE ) ) {
+    } else if( dealt_attack.hit_critter != nullptr && missed_by > 0.0f &&
+               !critter->has_flag( MF_IMMOBILE ) ) {
         practice( skill_throw, final_xp_mult / ( 1.0f + missed_by ), MAX_SKILL );
     } else {
         // Pure grindy practice - cap gain at lvl 2

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1325,11 +1325,11 @@ dealt_projectile_attack Character::throw_item( const tripoint &target, const ite
                                            this, nullptr, wp_attack );
 
     const double missed_by = dealt_attack.missed_by;
-    if( missed_by <= 0.1 && dealt_attack.hit_critter != nullptr ) {
+    if( missed_by <= 0.1 && dealt_attack.hit_critter != nullptr && !critter->has_flag( MF_IMMOBILE ) ) {
         practice( skill_throw, final_xp_mult, MAX_SKILL );
         // TODO: Check target for existence of head
         get_event_bus().send<event_type::character_gets_headshot>( getID() );
-    } else if( dealt_attack.hit_critter != nullptr && missed_by > 0.0f ) {
+    } else if( dealt_attack.hit_critter != nullptr && missed_by > 0.0f && !critter->has_flag( MF_IMMOBILE ) ) {
         practice( skill_throw, final_xp_mult / ( 1.0f + missed_by ), MAX_SKILL );
     } else {
         // Pure grindy practice - cap gain at lvl 2


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "stationary monsters don't let you train throwing to high levels"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There was a pretty serious skill training exploit with throwing tons of weak items at a tough stationary monster like a riot turret which brought you to 10 throwing at cost of maybe 30-60 IRL minutes of macroing. A stationary monster shouldn't be really any different than a target painted at a wall in terms of difficulty to hit.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
You now need a moving target to train 4-10. This can be still be literally anything that isn't a totally nonmoving creature so there's still probably room for cheesy easy throwing training somewhere but this should at least help.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->