### PR TITLE
Split caffeine dependence into two hobbies

### DIFF
--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -69,11 +69,20 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "caffiend",
+    "name": "Caffeine Fiend",
+    "description": "Caffeine gave you life and without it you are nothing.  Your dependence upon it was so extreme that you can barely function in its absence and you've done lasting psychological harm to yourself.  You'd better find a steady supply, and fast.",
+    "points": -1,
+    "traits": [ "STIMBOOST", "SLEEPY" ],
+    "addictions": [ { "intensity": 50, "type": "caffeine" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "caffeine_junkie",
     "name": "Caffeine Dependence",
     "description": "Coffee was your faithful companion every morning, and without it you feel like a zombie.  Thanks to all the actual zombies shambling about, getting your caffeine fix will be much harder now.",
     "points": -1,
-    "traits": [ "STIMBOOST" ],
     "addictions": [ { "intensity": 10, "type": "caffeine" } ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "two caffeine addict hobbies"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The basic level of caffeine dependence was pretty tame, representative mostly of an average individual who drinks a few cups a day. Thus it was also pretty silly that they got the stimulant psychosis trait. I wanted to introduce a more severe version that justified the heavier psychological changes.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Removes STIMBOOST from regular caffeine dependence.
Introduce a new hobby with SLEEPY and STIMBOOST + [50] dependence. It is called Caffeine Fiend (isn't the i-before-e rule just so great and perfect!?) 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I wanted to call it "caffiend" but it doesn't translate as well to other languages and the pun might not land as well with non native speakers. So I just called the hobby ID that.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
https://www.youtube.com/watch?v=UR4DzHo5hz8
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->