### PR TITLE
Clear eoc_events in game::setup

### DIFF
--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -474,6 +474,12 @@ void effect_on_conditions::load( const JsonObject &jo, const std::string &src )
     effect_on_condition_factory.load( jo, src );
 }
 
+void eoc_events::clear()
+{
+    has_cached = false;
+    event_EOCs.clear();
+}
+
 void eoc_events::notify( const cata::event &e )
 {
     if( !has_cached ) {

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -31,6 +31,7 @@ class eoc_events : public event_subscriber
 {
     public:
         void notify( const cata::event &e ) override;
+        void clear();
 
     private:
         std::map<event_type, std::vector<effect_on_condition>> event_EOCs;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -775,6 +775,7 @@ void game::setup()
     // reset kill counts
     kill_tracker_ptr->clear();
     achievements_tracker_ptr->clear();
+    eoc_events_ptr->clear();
     // reset follower list
     follower_ids.clear();
     scent.reset();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Stale eocs remain after unloading a game and reloading another one

#### Describe the solution

Clear them

#### Describe alternatives you've considered

#### Testing

Load world with xedra mod, save/quit, load vanilla world - you'll see the error below on load, apply patch, there should be no error

#### Additional context
 DEBUG    : invalid effect_on_condition id "EOC_XE_VARIABLE_INITIALIZATION"

 FUNCTION : obj
 FILE     : C:\projects\Cataclysm-DDA\src\generic_factory.h
 LINE     : 448
 VERSION  : 0.G-1918-ga4f928bb3d
