### PR TITLE
[BombasticPerks] Crafty hands and Chainsmoker traits

### DIFF
--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -122,6 +122,16 @@
         "text": "Gain [<trait_name:perk_popeye>]",
         "topic": "TALK_PERK_MENU_POPEYE"
       },
+      {
+        "condition": { "not": { "u_has_trait": "perk_crafty_hands" } },
+        "text": "Gain [<trait_name:perk_crafty_hands>]",
+        "topic": "TALK_PERK_MENU_CRAFTY_HANDS"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_chainsmoker" } },
+        "text": "Gain [<trait_name:perk_chainsmoker>]",
+        "topic": "TALK_PERK_MENU_CHAINSMOKER"
+      },
       { "text": "Settings", "topic": "TALK_PERK_MENU_CONFIG" },
       { "text": "Quit.", "topic": "TALK_DONE" }
     ]
@@ -737,6 +747,50 @@
         "failure_topic": "TALK_PERK_MENU_FAIL",
         "effect": [
           { "u_add_trait": "perk_popeye" },
+          {
+            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
+          }
+        ]
+      },
+      { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_PERK_MENU_CRAFTY_HANDS",
+    "dynamic_line": "<trait_name:perk_crafty_hands>: \"<trait_description:perk_crafty_hands>\"",
+    "responses": [
+      {
+        "text": "Select Perk.",
+        "topic": "TALK_PERK_MENU_MAIN",
+        "condition": { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] },
+        "failure_explanation": "Requirements Not Met",
+        "failure_topic": "TALK_PERK_MENU_FAIL",
+        "effect": [
+          { "u_add_trait": "perk_crafty_hands" },
+          {
+            "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
+          }
+        ]
+      },
+      { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_PERK_MENU_CHAINSMOKER",
+    "dynamic_line": "<trait_name:perk_chainsmoker>: \"<trait_description:perk_chainsmoker>\"",
+    "responses": [
+      {
+        "text": "Select Perk.",
+        "topic": "TALK_PERK_MENU_MAIN",
+        "condition": { "compare_num": [ { "u_val": "var", "var_name": "num_perks" }, ">", { "const": 0 } ] },
+        "failure_explanation": "Requirements Not Met",
+        "failure_topic": "TALK_PERK_MENU_FAIL",
+        "effect": [
+          { "u_add_trait": "perk_chainsmoker" },
           {
             "arithmetic": [ { "u_val": "var", "var_name": "num_perks" }, "=", { "u_val": "var", "var_name": "num_perks" }, "-", { "const": 1 } ]
           }

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -273,5 +273,26 @@
     "description": "You have a habit of always ducking at the right time.  You have a 5% chance to dodge any incoming attack.",
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "EVASION", "add": 0.05 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_crafty_hands",
+    "name": { "str": "Crafty hands" },
+    "points": 0,
+    "description": "You really like to do stuff with your own hands.  +10% for crafting speed.",
+    "category": [ "perk" ],
+    "crafting_speed_multiplier": 1.1
+  },
+  {
+    "type": "mutation",
+    "id": "perk_chainsmoker",
+    "name": { "str": "Chainsmoker" },
+    "points": 0,
+    "description": "Smoking is bad, but damn its badass.  You deal more damage and shoot faster when you smoke.",
+    "category": [ "perk" ],
+    "enchantments": [
+      { "condition": { "u_has_effect": "cig" }, "values": [ { "value": "MELEE_DAMAGE", "multiply": 0.25 } ] },
+      { "condition": { "u_has_effect": "cig" }, "values": [ { "value": "WEAPON_DISPERSION", "multiply": 0.25 } ] }
+    ]
   }
 ]

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -288,7 +288,7 @@
     "id": "perk_chainsmoker",
     "name": { "str": "Chainsmoker" },
     "points": 0,
-    "description": "Smoking is bad, but damn its badass.  You deal more damage and shoot faster when you smoke.",
+    "description": "Smoking is bad, but damn it's badass.  You deal more damage and shoot more accurately when you smoke.",
     "category": [ "perk" ],
     "enchantments": [
       { "condition": { "u_has_effect": "cig" }, "values": [ { "value": "MELEE_DAMAGE", "multiply": 0.25 } ] },


### PR DESCRIPTION
#### Summary
Mods "[BombasticPerks] Crafty hands and Chainsmoker traits"
#### Purpose of change
🤷 
#### Describe the solution
Two new perks 
Crafty hands simply boost your crafting speed for 10%
Chainsmoker boost your melee and shooting abilities if you have nicotine effect
#### Testing
Both works good, but somehow my character can't take a perk menu. Debugged one looks like it works correctly