### PR TITLE
Urns and memorial items no longer spawn in bookstores

### DIFF
--- a/data/json/itemgroups/books.json
+++ b/data/json/itemgroups/books.json
@@ -572,8 +572,7 @@
       { "item": "vacuum_sealing", "prob": 15 },
       { "item": "baking_book", "prob": 190 },
       { "item": "book_pneumatics", "prob": 8 },
-      { "item": "cookbook_bloodforgood", "prob": 50 },
-      { "group": "memorial_mansion", "prob": 10 }
+      { "item": "cookbook_bloodforgood", "prob": 50 }
     ]
   },
   {

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -359,21 +359,6 @@
   },
   {
     "type": "item_group",
-    "id": "memorial_mansion",
-    "subtype": "collection",
-    "entries": [
-      { "item": "corpse_ash", "prob": 100, "charges-min": 1905, "charges-max": 3969, "container-item": "crystal_urn" },
-      { "item": "photo_album", "prob": 80 },
-      { "item": "bouquet", "prob": 80 },
-      { "item": "candlestick", "prob": 50, "charges-min": 1, "charges-max": 6 },
-      { "group": "liquor_and_spirits", "prob": 60 },
-      { "group": "wines_worthy", "prob": 50 },
-      { "item": "cigar", "prob": 50 },
-      { "group": "jewelry_accessories", "prob": 50 }
-    ]
-  },
-  {
-    "type": "item_group",
     "id": "grave_cremains",
     "subtype": "collection",
     "entries": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Urns and memorial items no longer spawn in bookstores"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Fixes #65450.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Removes the `memorial_mansion` items group, as it was only used for books inside the `mansion_books` group, which only appears in bookstores.

#### Describe alternatives you've considered
Adding `mansion_books` or `memorial_mansion` item groups to mansions somewhere.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Did not do testing yet, but this looks like a straightforward change.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->