### PR TITLE
Only reject air for pathfinding bounds, not pathable tiles without floors

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7089,7 +7089,7 @@ void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tri
         const tripoint tp = { p.xy(), f.z };
         const int tp_cost = move_cost( tp );
         // rejection conditions
-        if( tp_cost < cost_min || tp_cost > cost_max || ( !has_floor_or_support( tp ) && tp != f ) ) {
+        if( tp_cost < cost_min || tp_cost > cost_max || is_open_air( tp ) ) {
             continue;
         }
         // set initial cost for grid point


### PR DESCRIPTION
#### Summary
Bugfixes "Stairs doesn't block pathfinding for some purposes (e.g. crafting pickup range)"

#### Purpose of change
* Fixes #65593

#### Describe the solution
map::has_floor_or_support always returns false if going downwards is a valid move. Going downwards on stairs is a valid move, but not the *only* move. Therefore we need to check something more sane, like map::is_open_air.

There shouldn't be any scenarios where you can go downwards (map::has_floor_or_support returns true) that doesn't also return true for map::is_open_air, **except for** stairs.

#### Describe alternatives you've considered
I originally did this by checking map::passable and then realized that open air is, technically speaking, passable. Soooo that didn't work.

#### Testing
Compiled locally and confirmed I could find crafting components through the stairs. Debugged a new scenario(image below) where I was separated from components by air, confirmed I could not access them.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/a7ea0f64-a483-45c1-87a2-b013cb7629e3)

#### Additional context
map::has_floor_or_support is a very sussy name and a very sussy function.

This bug report came from 0.G so if this fix is acceptable it may be desirable to also backport it.