### PR TITLE
Change difficulty and colors of hard aircraft ferals

### DIFF
--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -956,9 +956,11 @@
     "speed": 90,
     "aggression": 30,
     "morale": 25,
+    "color": "light_blue",
     "melee_dice": 2,
     "melee_dice_sides": 3,
     "dodge": 3,
+    "diff": 4,
     "starting_ammo": { "9mm": 3 },
     "special_attacks": [
       {

--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -426,6 +426,8 @@
     "weight": "120 kg",
     "hp": 150,
     "speed": 110,
+    "color": "white_red",
+    "diff": 5,
     "melee_dice_sides": 6,
     "bleed_rate": 20,
     "grab_strength": 35,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Change colors and difficulty of some of the harder aircraft carrier enemies"

#### Purpose of change
Fixes #64000

Update difficulty of mon_zombie_marine_upgrade and mon_feral_officer
Change color of mon_zombie_marine_upgrade and mon_feral_officer


#### Describe the solution
Modify two different colors of harder aircraft enemies via JSON:
Changes color of mon_zombie_marine_upgrade to red
Changes color of mon_feral_officer to blue

Update difficulty of mon_zombie_marine_upgrade and mon_feral_officer

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Verified the build would work, verified the color changes


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
<img width="316" alt="Screenshot 2023-05-18 at 6 19 00 PM" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/36281130/ce762353-805b-47a1-a293-eba478f1e96e">


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->