### PR TITLE
Lizards shouldn't be Light Sensitive

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6443,7 +6443,7 @@
     "description": "Sunlight makes you uncomfortable.  If you are outdoors and the weather is Sunny, you suffer -1 to all stats.",
     "types": [ "SUNLIGHT" ],
     "changes_to": [ "TROGLO2" ],
-    "category": [ "LIZARD", "BEAST", "INSECT", "SLIME", "SPIDER", "BATRACHIAN", "RAT", "TROGLOBITE" ]
+    "category": [ "BEAST", "INSECT", "SLIME", "SPIDER", "BATRACHIAN", "RAT", "TROGLOBITE" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Balance "Remove Light Sensitive from Lizard mutation path"

#### Purpose of change
While some lizards are shade-dwellers, most don't mind sunlight and indeed amny species like to sunbath. Until we get offshoots (mixed thresholds) I think it doesn't make sense for it to have the trait.

#### Describe the solution
Remove it from the list.

#### Describe alternatives you've considered
Leaving as is.

#### Testing
None needed.

#### Additional context
N/A