### PR TITLE
Fix Large Talons integrated armor not appearing

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3456,17 +3456,13 @@
     "points": 2,
     "visibility": 4,
     "ugliness": 3,
-    "cut_dmg_bonus": 3,
-    "butchering_quality": 4,
+    "integrated_armor": [ "integrated_talons" ],
     "flags": [ "UNARMED_BONUS" ],
     "mixed_effect": true,
-    "restricts_gear": [ "hand_fingers_l", "hand_fingers_r" ],
-    "destroys_gear": true,
     "description": "Your index fingers have grown into huge talons.  After a bit of practice, you find that this does not affect your dexterity, but allows for a deadly unarmed attack.  They also prevent wearing gloves.",
     "types": [ "CLAWS" ],
     "prereqs": [ "NAILS" ],
-    "category": [ "LIZARD", "BIRD", "CHIMERA" ],
-    "allowed_items": [ "ALLOWS_TALONS" ]
+    "category": [ "LIZARD", "BIRD", "CHIMERA" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Bugfixes "Fix Large Talons integrated armor not appearing"

#### Purpose of change
In #65070, due to a copypaste error, I forgot to actually make talons integrated armor.

#### Describe the solution
Change the needed lines.

#### Describe alternatives you've considered
N/A

#### Testing
![изображение](https://github.com/CleverRaven/Cataclysm-DDA/assets/52408044/a77498b8-904e-4998-b301-223a0342e40f)

#### Additional context
Sorry this was my fault. Also, 4th tweak PR today.