### PR TITLE
clang-tidy cata-almost-never-auto

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -66,7 +66,6 @@ readability-*,\
 -bugprone-throw-keyword-missing,\
 -bugprone-unchecked-optional-access,\
 -bugprone-unhandled-exception-at-new,\
--cata-almost-never-auto,\
 -cert-dcl58-cpp,\
 -cert-err33-c,\
 -clang-analyzer-cplusplus.NewDeleteLeaks,\

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -966,7 +966,7 @@ void data_handling_activity_actor::do_turn( player_activity &act, Character &p )
         }
     }
 
-    const auto monster_photos = mc.get_var( "MC_MONSTER_PHOTOS" );
+    const std::string monster_photos = mc.get_var( "MC_MONSTER_PHOTOS" );
     if( !monster_photos.empty() ) {
         downloaded_monster_photos++;
         std::string photos = eink.get_var( "EINK_MONSTER_PHOTOS" );

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -62,8 +62,8 @@ static bool alcohol_diazepam_add( Character &u, int in, bool is_alcohol )
     static time_point last_dia_dream = calendar::turn_zero;
     const bool recent_dream = ( is_alcohol && ( calendar::turn - last_alc_dream < 2_hours ) ) ||
                               ( !is_alcohol && ( calendar::turn - last_dia_dream < 2_hours ) );
-    const auto morale_type = is_alcohol ? MORALE_CRAVING_ALCOHOL :
-                             MORALE_CRAVING_DIAZEPAM;
+    const morale_type morale_type = is_alcohol ? MORALE_CRAVING_ALCOHOL :
+                                    MORALE_CRAVING_DIAZEPAM;
     bool ret = false;
     u.mod_per_bonus( -1 );
     u.mod_int_bonus( -1 );
@@ -121,8 +121,8 @@ static bool crack_coke_add( Character &u, int in, int stim, bool is_crack )
         !is_crack ?
         ( u.in_sleep_state() ? "addict_coke_asleep" : "addict_coke_awake" ) :
         ( u.in_sleep_state() ? "addict_crack_asleep" : "addict_crack_awake" );
-    const auto morale_type = !is_crack ? MORALE_CRAVING_COCAINE :
-                             MORALE_CRAVING_CRACK;
+    const morale_type morale_type = !is_crack ? MORALE_CRAVING_COCAINE :
+                                    MORALE_CRAVING_CRACK;
     bool ret = false;
     auto run_addict_eff = [&ret, &morale_type]( Character & u, int in, bool is_crack,
     const std::string & snippet ) {

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -315,7 +315,7 @@ advanced_inv_area::itemstack advanced_inv_area::i_stacked( T items )
     std::unordered_map<itype_id, std::set<int>> cache;
     // iterate through and create stacks
     for( item &elem : items ) {
-        const auto id = elem.typeId();
+        const itype_id id = elem.typeId();
         auto iter = cache.find( id );
         bool got_stacked = false;
         // cache entry exists

--- a/src/ammo.cpp
+++ b/src/ammo.cpp
@@ -43,7 +43,7 @@ bool string_id<ammunition_type>::is_valid() const
 template<>
 const ammunition_type &string_id<ammunition_type>::obj() const
 {
-    const auto &the_map = all_ammunition_types();
+    const ammo_map_t &the_map = all_ammunition_types();
 
     const auto it = the_map.find( *this );
     if( it != the_map.end() ) {

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -788,7 +788,7 @@ void avatar::power_bionics()
             menu_mode = ACTIVATING;
 
             if( action == "CONFIRM" && !current_bionic_list->empty() ) {
-                auto &bio_list = tab_mode == TAB_ACTIVE ? active : passive;
+                sorted_bionics &bio_list = tab_mode == TAB_ACTIVE ? active : passive;
                 tmp = bio_list[cursor];
             } else {
                 tmp = bionic_by_invlet( ch );
@@ -841,7 +841,7 @@ void avatar::power_bionics()
             // switches between activation and examination
             menu_mode = menu_mode == ACTIVATING ? EXAMINING : ACTIVATING;
         } else if( action == "TOGGLE_SAFE_FUEL" ) {
-            auto &bio_list = tab_mode == TAB_ACTIVE ? active : passive;
+            sorted_bionics &bio_list = tab_mode == TAB_ACTIVE ? active : passive;
             if( !current_bionic_list->empty() ) {
                 tmp = bio_list[cursor];
                 if( !tmp->info().fuel_opts.empty() || tmp->info().is_remote_fueled ) {
@@ -852,7 +852,7 @@ void avatar::power_bionics()
                 }
             }
         } else if( action == "TOGGLE_SPRITE" ) {
-            auto &bio_list = tab_mode == TAB_ACTIVE ? active : passive;
+            sorted_bionics &bio_list = tab_mode == TAB_ACTIVE ? active : passive;
             if( !current_bionic_list->empty() ) {
                 tmp = bio_list[cursor];
                 tmp->show_sprite = !tmp->show_sprite;
@@ -863,7 +863,7 @@ void avatar::power_bionics()
             active = filtered_bionics( *my_bionics, TAB_ACTIVE );
             passive = filtered_bionics( *my_bionics, TAB_PASSIVE );
         } else if( action == "CONFIRM" || action == "ANY_INPUT" ) {
-            auto &bio_list = tab_mode == TAB_ACTIVE ? active : passive;
+            sorted_bionics &bio_list = tab_mode == TAB_ACTIVE ? active : passive;
             if( action == "CONFIRM" && !current_bionic_list->empty() ) {
                 tmp = bio_list[cursor];
             } else {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2481,7 +2481,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             // needs to be defined by the tileset to look good, so we use system clock:
             std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
             auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>( now );
-            auto value = now_ms.time_since_epoch();
+            std::chrono::milliseconds value = now_ms.time_since_epoch();
             // aiming roughly at the standard 60 frames per second:
             int animation_frame = value.count() / 17;
             // offset by log_rand so that everything does not blink at the same time:
@@ -3692,7 +3692,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
                 rot_facing = -1;
             }
             if( rot_facing >= -1 ) {
-                const auto ent_name = m->type->id;
+                const mtype_id ent_name = m->type->id;
                 std::string chosen_id = ent_name.str();
                 if( m->has_effect( effect_ridden ) ) {
                     int pl_under_height = 6;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9621,7 +9621,7 @@ std::vector<std::string> Character::short_description_parts() const
         result.push_back( _( "Wearing: " ) + worn_str );
     }
     const int visibility_cap = 0; // no cap
-    const auto trait_str = visible_mutations( visibility_cap );
+    const std::string trait_str = visible_mutations( visibility_cap );
     if( !trait_str.empty() ) {
         result.push_back( _( "Traits: " ) + trait_str );
     }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1305,7 +1305,7 @@ void Character::modify_morale( item &food, const int nutr )
 
     // Allergy check for food that is ingested (not gum)
     if( !food.has_flag( flag_NO_INGEST ) ) {
-        const auto allergy = allergy_type( food );
+        const morale_type allergy = allergy_type( food );
         if( allergy != MORALE_NULL ) {
             add_msg_if_player( m_bad, _( "Your stomach begins gurgling and you feel bloated and ill." ) );
             add_morale( allergy, -75, -400, 30_minutes, 24_minutes );

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1321,7 +1321,7 @@ void editmap::edit_fld()
             }
             if( field_intensity != fsel_intensity || target_list.size() > 1 ) {
                 for( tripoint &elem : target_list ) {
-                    const auto fid = static_cast<field_type_id>( idx );
+                    const field_type_id fid = static_cast<field_type_id>( idx );
                     field &t_field = here.get_field( elem );
                     field_entry *t_fld = t_field.find_field( fid );
                     int t_intensity = 0;

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -686,7 +686,7 @@ void emp_blast( const tripoint &p )
         monster &critter = *mon_ptr;
         if( critter.has_flag( MF_ELECTRONIC ) ) {
             int deact_chance = 0;
-            const auto mon_item_id = critter.type->revert_to_itype;
+            const itype_id mon_item_id = critter.type->revert_to_itype;
             switch( critter.get_size() ) {
                 case creature_size::tiny:
                     deact_chance = 6;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -4874,7 +4874,7 @@ std::string basecamp::gathering_description()
     // doesn't have perfect knowledge
     std::map<std::string, int> itemnames;
     for( size_t a = 0; a < 6; a++ ) {
-        const auto items = item_group::items_from( itemlist, calendar::turn );
+        const std::vector<item> items = item_group::items_from( itemlist, calendar::turn );
         for( const item &it : items ) {
             itemnames[it.display_name()]++;
         }

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -252,7 +252,7 @@ std::vector<std::string> find_file_if_bfs( const std::string &root_path,
 
         // We could use fs::recursive_directory_iterator maybe
         for_each_dir_entry( path, [&]( const fs::directory_entry & entry ) {
-            const auto full_path = entry.path().generic_u8string();
+            const std::string full_path = entry.path().generic_u8string();
 
             // don't add files ending in '~'.
             if( full_path.back() == '~' ) {

--- a/src/flexbuffer_cache.cpp
+++ b/src/flexbuffer_cache.cpp
@@ -323,8 +323,8 @@ class flexbuffer_disk_cache
             std::error_code ec;
             std::string json_source_path_string = lexically_normal_json_source_path.u8string();
             fs::file_time_type mtime = fs::last_write_time( lexically_normal_json_source_path );
-            auto mtime_ms = std::chrono::duration_cast<std::chrono::milliseconds>
-                            ( mtime.time_since_epoch() ).count();
+            int64_t mtime_ms = std::chrono::duration_cast<std::chrono::milliseconds>
+                               ( mtime.time_since_epoch() ).count();
             if( ec ) {
                 return false;
             }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7988,8 +7988,8 @@ bool game::take_screenshot() const
 
     // build file name: <map_dir>/screenshots/[<character_name>]_<date>.png
     // NOLINTNEXTLINE(cata-translate-string-literal)
-    const auto tmp_file_name = string_format( "[%s]_%s.png", get_player_character().get_name(),
-                               timestamp_now() );
+    const std::string tmp_file_name = string_format( "[%s]_%s.png", get_player_character().get_name(),
+                                      timestamp_now() );
 
     std::string file_name = ensure_valid_file_name( tmp_file_name );
     auto current_file_path = map_directory.str() + file_name;

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -131,7 +131,7 @@ void gate_data::check() const
 
 bool gate_data::is_suitable_wall( const tripoint &pos ) const
 {
-    const auto wid = get_map().ter( pos );
+    const ter_id wid = get_map().ter( pos );
     const auto iter = std::find_if( walls.begin(), walls.end(), [ wid ]( const ter_str_id & wall ) {
         return wall.id() == wid;
     } );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1575,7 +1575,7 @@ void iexamine::deployed_furniture( Character &you, const tripoint &pos )
     }
     you.add_msg_if_player( m_info, _( "You take down the %s." ),
                            here.furn( pos ).obj().name() );
-    const auto furn_item = here.furn( pos ).obj().deployed_item;
+    const itype_id furn_item = here.furn( pos ).obj().deployed_item;
     here.add_item_or_charges( pos, item( furn_item, calendar::turn ) );
     here.furn_set( pos, f_null );
 }
@@ -2703,7 +2703,7 @@ void iexamine::fertilize_plant( Character &you, const tripoint &tile,
     // The plant furniture has the NOITEM token which prevents adding items on that square,
     // spawned items are moved to an adjacent field instead, but the fertilizer token
     // must be on the square of the plant, therefore this hack:
-    const auto old_furn = here.furn( tile );
+    const furn_id old_furn = here.furn( tile );
     here.furn_set( tile, f_null );
     here.spawn_item( tile, itype_fertilizer, 1, 1, calendar::turn );
     here.furn_set( tile, old_furn );
@@ -3300,7 +3300,7 @@ void iexamine::fireplace( Character &you, const tripoint &examp )
             }
             you.add_msg_if_player( m_info, _( "You take down the %s." ),
                                    here.furnname( examp ) );
-            const auto furn_item = here.furn( examp ).obj().deployed_item;
+            const itype_id furn_item = here.furn( examp ).obj().deployed_item;
             here.add_item_or_charges( examp, item( furn_item, calendar::turn ) );
             here.furn_set( examp, f_null );
             return;
@@ -3726,7 +3726,7 @@ bool iexamine::pour_into_keg( const tripoint &pos, item &liquid )
         return false;
     }
     map &here = get_map();
-    const auto keg_name = here.name( pos );
+    const std::string keg_name = here.name( pos );
 
     map_stack stack = here.i_at( pos );
     if( stack.empty() ) {
@@ -4448,7 +4448,7 @@ static int getNearPumpCount( const tripoint &p, fuel_station_fuel_type &fuel_typ
     int result = 0;
     map &here = get_map();
     for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
-        const auto t = here.ter( tmp );
+        const ter_id t = here.ter( tmp );
         if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
             result++;
             fuel_type = FUEL_TYPE_GASOLINE;
@@ -4573,7 +4573,7 @@ std::optional<tripoint> iexamine::getGasPumpByNumber( const tripoint &p, int num
     int k = 0;
     map &here = get_map();
     for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
-        const auto t = here.ter( tmp );
+        const ter_id t = here.ter( tmp );
         if( ( t == ter_t_gas_pump || t == ter_t_gas_pump_a
               || t == ter_t_diesel_pump || t == ter_t_diesel_pump_a ) && number == k++ ) {
             return tmp;
@@ -4641,7 +4641,7 @@ static void turnOnSelectedPump( const tripoint &p, int number, fuel_station_fuel
     int k = 0;
     map &here = get_map();
     for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
-        const auto t = here.ter( tmp );
+        const ter_id t = here.ter( tmp );
         if( fuel_type == FUEL_TYPE_GASOLINE ) {
             if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
                 if( number == k++ ) {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4064,7 +4064,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         def.min_skills.clear();
     }
     for( JsonArray cur : jarr ) {
-        const auto sk = skill_id( cur.get_string( 0 ) );
+        const skill_id sk = skill_id( cur.get_string( 0 ) );
         if( !sk.is_valid() ) {
             jo.throw_error_at( "min_skills", string_format( "invalid skill: %s", sk.c_str() ) );
         }
@@ -5027,7 +5027,7 @@ void item_group::debug_spawn()
         // Spawn items from the group 100 times
         std::map<std::string, int> itemnames;
         for( size_t a = 0; a < 100; a++ ) {
-            const auto items = items_from( groups[index], calendar::turn );
+            const ItemList items = items_from( groups[index], calendar::turn );
             for( const item &it : items ) {
                 itemnames[it.display_name()]++;
             }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7754,7 +7754,7 @@ std::optional<int> iuse::multicooker( Character *p, item *it, bool t, const trip
 
                 /** @EFFECT_FABRICATION >3 allows multicooker upgrade */
                 if( p->get_skill_level( skill_electronics ) >= 4 && p->get_skill_level( skill_fabrication ) >= 4 ) {
-                    const auto upgr = it->get_var( "MULTI_COOK_UPGRADE" );
+                    const std::string upgr = it->get_var( "MULTI_COOK_UPGRADE" );
                     if( upgr.empty() ) {
                         menu.addentry( mc_upgrade, true, 'u', _( "Upgrade multi-cooker" ) );
                     } else {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1995,7 +1995,7 @@ uint8_t map::get_known_rotates_to_f( const tripoint &p,
  */
 const harvest_id &map::get_harvest( const tripoint &pos ) const
 {
-    const auto furn_here = furn( pos );
+    const furn_id furn_here = furn( pos );
     if( !furn_here->has_flag( ter_furn_flag::TFLAG_HARVESTED ) ) {
         const harvest_id &harvest = furn_here->get_harvest();
         if( ! harvest.is_null() ) {
@@ -2003,7 +2003,7 @@ const harvest_id &map::get_harvest( const tripoint &pos ) const
         }
     }
 
-    const auto ter_here = ter( pos );
+    const ter_id ter_here = ter( pos );
     if( ter_here->has_flag( ter_furn_flag::TFLAG_HARVESTED ) ) {
         return harvest_id::NULL_ID();
     }
@@ -2014,7 +2014,7 @@ const harvest_id &map::get_harvest( const tripoint &pos ) const
 const std::set<std::string> &map::get_harvest_names( const tripoint &pos ) const
 {
     static const std::set<std::string> null_harvest_names = {};
-    const auto furn_here = furn( pos );
+    const furn_id furn_here = furn( pos );
     if( furn_here->can_examine( pos ) ) {
         if( furn_here->has_flag( ter_furn_flag::TFLAG_HARVESTED ) ) {
             return null_harvest_names;
@@ -2023,7 +2023,7 @@ const std::set<std::string> &map::get_harvest_names( const tripoint &pos ) const
         return furn_here->get_harvest_names();
     }
 
-    const auto ter_here = ter( pos );
+    const ter_id ter_here = ter( pos );
     if( ter_here->has_flag( ter_furn_flag::TFLAG_HARVESTED ) ) {
         return null_harvest_names;
     }
@@ -3763,7 +3763,7 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
             // HACK: A hack for destroy && !bash_floor
             // We have to check what would we create and cancel if it is what we have now
             tripoint below( p.xy(), p.z - 1 );
-            const auto roof = get_roof( below, false );
+            const ter_id roof = get_roof( below, false );
             if( roof == ter( p ) ) {
                 smash_ter = false;
                 bash = nullptr;
@@ -3921,7 +3921,7 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
             // Take the tent down
             const int rad = tentp->second.obj().bash.collapse_radius;
             for( const tripoint &pt : points_in_radius( tentp->first, rad ) ) {
-                const auto frn = furn( pt );
+                const furn_id frn = furn( pt );
                 if( frn == f_null ) {
                     continue;
                 }
@@ -3981,7 +3981,7 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
 
     if( smash_ter && ter( p ) == t_open_air && zlevels ) {
         tripoint below( p.xy(), p.z - 1 );
-        const auto roof = get_roof( below, params.bash_floor && ter( below ).obj().movecost != 0 );
+        const ter_id roof = get_roof( below, params.bash_floor && ter( below ).obj().movecost != 0 );
         ter_set( p, roof );
     }
 
@@ -6711,7 +6711,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
     if( curr_field.field_count() > 0 ) {
         const field_type_id &fid = curr_field.displayed_field_type();
         const field_entry *fe = curr_field.find_field( fid );
-        const auto field_symbol = fid->get_symbol();
+        const std::string field_symbol = fid->get_symbol();
         if( field_symbol == "&" || fe == nullptr ) {
             // Do nothing, a '&' indicates invisible fields.
         } else if( field_symbol == "*" ) {
@@ -7010,7 +7010,7 @@ int map::obstacle_coverage( const tripoint &loc1, const tripoint &loc2 ) const
         obstaclepos = new_point;
         return false;
     } );
-    if( const auto obstacle_f = furn( obstaclepos ) ) {
+    if( const furn_id obstacle_f = furn( obstaclepos ) ) {
         return obstacle_f->coverage;
     }
     if( const optional_vpart_position vp = veh_at( obstaclepos ) ) {
@@ -7025,7 +7025,7 @@ int map::obstacle_coverage( const tripoint &loc1, const tripoint &loc2 ) const
 
 int map::coverage( const tripoint &p ) const
 {
-    if( const auto obstacle_f = furn( p ) ) {
+    if( const furn_id obstacle_f = furn( p ) ) {
         return obstacle_f->coverage;
     }
     if( const optional_vpart_position vp = veh_at( p ) ) {
@@ -8109,7 +8109,7 @@ void map::actualize( const tripoint &grid )
                 field_ter_locs.push_back( pnt );
             }
 
-            const auto trap_here = tmpsub->get_trap( p );
+            const trap_id trap_here = tmpsub->get_trap( p );
             if( trap_here != tr_null ) {
                 traplocs[trap_here.to_i()].push_back( pnt );
             }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -379,7 +379,7 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
 
     units::angle dir1 = random_direction();
 
-    auto crashed_hull = VehicleGroup_crashed_helicopters->pick();
+    vproto_id crashed_hull = VehicleGroup_crashed_helicopters->pick();
 
     // Create the vehicle so we can rotate it and calculate its bounding box, but don't place it on the map.
     auto veh = std::make_unique<vehicle>( m, crashed_hull, rng( 1, 33 ), 1 );
@@ -2201,7 +2201,8 @@ static bool mx_mayhem( map &m, const tripoint &abs_sub )
 
 static bool mx_casings( map &m, const tripoint &abs_sub )
 {
-    const auto items = item_group::items_from( Item_spawn_data_ammo_casings, calendar::turn );
+    const std::vector<item> items = item_group::items_from( Item_spawn_data_ammo_casings,
+                                    calendar::turn );
 
     switch( rng( 1, 4 ) ) {
         //Pile of random casings in random place
@@ -2215,7 +2216,7 @@ static bool mx_casings( map &m, const tripoint &abs_sub )
             }
             //Spawn random trash in random place
             for( int i = 0; i < rng( 1, 3 ); i++ ) {
-                const auto trash =
+                const std::vector<item> trash =
                     item_group::items_from( Item_spawn_data_map_extra_casings, calendar::turn );
                 const tripoint trash_loc = random_entry( m.points_in_radius( tripoint{ SEEX, SEEY, abs_sub.z },
                                            10 ) );
@@ -2249,7 +2250,7 @@ static bool mx_casings( map &m, const tripoint &abs_sub )
             const tripoint location = { SEEX, SEEY, abs_sub.z };
             //Spawn random trash in random place
             for( int i = 0; i < rng( 1, 3 ); i++ ) {
-                const auto trash =
+                const std::vector<item> trash =
                     item_group::items_from( Item_spawn_data_map_extra_casings, calendar::turn );
                 const tripoint trash_loc = random_entry( m.points_in_radius( location, 10 ) );
                 m.spawn_items( trash_loc, trash );
@@ -2281,7 +2282,7 @@ static bool mx_casings( map &m, const tripoint &abs_sub )
             }
             //Spawn random trash in random place
             for( int i = 0; i < rng( 1, 3 ); i++ ) {
-                const auto trash =
+                const std::vector<item> trash =
                     item_group::items_from( Item_spawn_data_map_extra_casings, calendar::turn );
                 const tripoint trash_loc =
                     random_entry( m.points_in_radius( tripoint{ SEEX, SEEY, abs_sub.z }, 10 ) );
@@ -2301,9 +2302,9 @@ static bool mx_casings( map &m, const tripoint &abs_sub )
         case 4: {
             const tripoint first_loc = { rng( 1, SEEX - 2 ), rng( 1, SEEY - 2 ), abs_sub.z };
             const tripoint second_loc = { rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ), abs_sub.z };
-            const auto first_items =
+            const std::vector<item> first_items =
                 item_group::items_from( Item_spawn_data_ammo_casings, calendar::turn );
-            const auto second_items =
+            const std::vector<item> second_items =
                 item_group::items_from( Item_spawn_data_ammo_casings, calendar::turn );
 
             for( const tripoint &loc : m.points_in_radius( first_loc, rng( 1, 2 ) ) ) {
@@ -2318,7 +2319,7 @@ static bool mx_casings( map &m, const tripoint &abs_sub )
             }
             //Spawn random trash in random place
             for( int i = 0; i < rng( 1, 3 ); i++ ) {
-                const auto trash =
+                const std::vector<item> trash =
                     item_group::items_from( Item_spawn_data_map_extra_casings, calendar::turn );
                 const tripoint trash_loc =
                     random_entry( m.points_in_radius( tripoint{ SEEX, SEEY, abs_sub.z }, 10 ) );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -5650,7 +5650,7 @@ void map::draw_lab( mapgendata &dat )
                         // liquid floors.
                         break;
                     }
-                    auto fluid_type = one_in( 3 ) ? t_sewage : t_water_sh;
+                    ter_id fluid_type = one_in( 3 ) ? t_sewage : t_water_sh;
                     for( int i = 0; i < EAST_EDGE; i++ ) {
                         for( int j = 0; j < SOUTH_EDGE; j++ ) {
                             // We spare some terrain to make it look better visually.
@@ -5677,7 +5677,7 @@ void map::draw_lab( mapgendata &dat )
                         // liquid floors.
                         break;
                     }
-                    auto fluid_type = one_in( 3 ) ? t_sewage : t_water_sh;
+                    ter_id fluid_type = one_in( 3 ) ? t_sewage : t_water_sh;
                     for( int i = 0; i < 2; ++i ) {
                         draw_rough_circle( [this, fluid_type]( const point & p ) {
                             if( t_thconc_floor == ter( p ) || t_strconc_floor == ter( p ) ||
@@ -6574,7 +6574,8 @@ std::vector<item *> map::place_items(
 std::vector<item *> map::put_items_from_loc( const item_group_id &group_id, const tripoint &p,
         const time_point &turn )
 {
-    const auto items = item_group::items_from( group_id, turn, spawn_flags::use_spawn_rate );
+    const std::vector<item> items =
+        item_group::items_from( group_id, turn, spawn_flags::use_spawn_rate );
     return spawn_items( p, items );
 }
 

--- a/src/mapgenformat.cpp
+++ b/src/mapgenformat.cpp
@@ -49,7 +49,7 @@ format_effect<ID>::format_effect( const std::string &chars, std::vector<ID> dets
 template<typename ID>
 ID format_effect<ID>::translate( const char c ) const
 {
-    const auto index = characters.find( c );
+    const size_t index = characters.find( c );
     if( index == std::string::npos ) {
         return ID( 0 );
     }

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -670,7 +670,7 @@ void Messages::dialog::do_filter( const std::string &filter_str )
     bool has_type_filter = false;
     game_message_type filter_type = m_neutral;
     std::string filter_text;
-    const auto colon = filter_str.find( ':' );
+    const size_t colon = filter_str.find( ':' );
     if( colon != std::string::npos ) {
         has_type_filter = msg_type_from_name( filter_type, filter_str.substr( 0, colon ) );
         filter_text = filter_str.substr( colon + 1 );

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -285,7 +285,7 @@ void mission::on_talk_with_npc( const character_id &npc_id )
 mission *mission::reserve_random( const mission_origin origin, const tripoint_abs_omt &p,
                                   const character_id &npc_id )
 {
-    const auto type = mission_type::get_random_id( origin, p );
+    const mission_type_id type = mission_type::get_random_id( origin, p );
     if( type.is_null() ) {
         return nullptr;
     }
@@ -472,7 +472,7 @@ bool mission::is_complete( const character_id &_npc_id ) const
         }
 
         case MGOAL_GO_TO_TYPE: {
-            const auto cur_ter = overmap_buffer.ter( player_character.global_omt_location() );
+            const oter_id cur_ter = overmap_buffer.ter( player_character.global_omt_location() );
             return ( cur_ter->get_type_id() == oter_type_str_id( type->target_id.str() ) );
         }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1512,7 +1512,7 @@ bool mattack::growplants( monster *z )
         return true;
     }
     for( const tripoint &p : here.points_in_radius( z->pos(), 5 ) ) {
-        const auto ter = here.ter( p );
+        const ter_id ter = here.ter( p );
         if( ter != t_tree_young && ter != t_underbrush ) {
             // Skip as soon as possible to avoid all the checks
             continue;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -589,7 +589,7 @@ void monster::plan()
 
     // Friendly monsters here
     // Avoid for hordes of same-faction stuff or it could get expensive
-    const auto actual_faction = friendly == 0 ? faction : STATIC( mfaction_str_id( "player" ) );
+    const mfaction_id actual_faction = friendly == 0 ? faction : STATIC( mfaction_str_id( "player" ) );
     const auto &myfaction_iter = factions.find( actual_faction );
     if( myfaction_iter == factions.end() ) {
         DebugLog( D_ERROR, D_GAME ) << disp_name() << " tried to find faction "

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2470,7 +2470,7 @@ void monster::process_turn()
                 if( zap != pos() ) {
                     explosion_handler::emp_blast( zap ); // Fries electronics due to the intensity of the field
                 }
-                const auto t = here.ter( zap );
+                const ter_id t = here.ter( zap );
                 if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
                     if( one_in( 4 ) ) {
                         explosion_handler::explosion( this, pos(), 40, 0.8, true );

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -1009,7 +1009,7 @@ void player_morale::set_worn( const item &it, bool worn )
     }
 
     if( super_fancy ) {
-        const auto id = it.typeId();
+        const itype_id id = it.typeId();
         const auto iter = super_fancy_items.find( id );
 
         if( iter != super_fancy_items.end() ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1804,7 +1804,7 @@ static std::string assemble_profession_details( const avatar &u, const input_con
     }
 
     // Profession skills
-    const auto prof_skills = sorted_profs[cur_id]->skills();
+    const profession::StartingSkillList prof_skills = sorted_profs[cur_id]->skills();
     assembled += "\n" + colorize( _( "Profession skills:" ), COL_HEADER ) + "\n";
     if( prof_skills.empty() ) {
         assembled += pgettext( "set_profession_skill", "None" ) + std::string( "\n" );
@@ -2222,7 +2222,7 @@ static std::string assemble_hobby_details( const avatar &u, const input_context 
     }
 
     // Background skills
-    const auto prof_skills = sorted_hobbies[cur_id]->skills();
+    const profession::StartingSkillList prof_skills = sorted_hobbies[cur_id]->skills();
     assembled += "\n" + colorize( _( "Background skill experience:" ), COL_HEADER ) + "\n";
     if( prof_skills.empty() ) {
         assembled += pgettext( "set_profession_skill", "None" ) + std::string( "\n" );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5801,7 +5801,7 @@ bool npc::item_whitelisted( const item &it )
         return true;
     }
 
-    const auto to_match = it.tname( 1, false );
+    const std::string to_match = it.tname( 1, false );
     return item_name_whitelisted( to_match );
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3171,8 +3171,8 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
             *world_options.value() :
             OPTIONS;
 
-    auto OPTIONS_OLD = OPTIONS;
-    auto WOPTIONS_OLD = ACTIVE_WORLD_OPTIONS;
+    options_container OPTIONS_OLD = OPTIONS;
+    options_container WOPTIONS_OLD = ACTIVE_WORLD_OPTIONS;
     if( world_generator->active_world == nullptr ) {
         ingame = false;
     }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -160,7 +160,7 @@ std::vector<std::string> foldstring( const std::string &str, int width, const ch
                             tags.pop_back();
                         }
                     } else {
-                        auto tag_end = rawwline.find( '>', tag_pos );
+                        size_t tag_end = rawwline.find( '>', tag_pos );
                         if( tag_end != std::string::npos ) {
                             tags.emplace_back( rawwline.substr( tag_pos, tag_end + 1 - tag_pos ) );
                         }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4231,7 +4231,7 @@ void overmap::place_forest_trails()
         if( !inbounds( p, 1 ) ) {
             return false;
         }
-        const auto current_terrain = ter( tripoint_om_omt( p, 0 ) );
+        const oter_id current_terrain = ter( tripoint_om_omt( p, 0 ) );
         return current_terrain == oter_forest || current_terrain == oter_forest_thick ||
                current_terrain == oter_forest_water;
     };

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -130,7 +130,7 @@ std::tuple<char, nc_color, size_t> get_note_display_info( const std::string_view
         }
 
         // find the first following delimiter
-        const auto end = note.find_first_of( " :;", pos, 3 );
+        const size_t end = note.find_first_of( " :;", pos, 3 );
         if( end == std::string::npos ) {
             return result;
         }
@@ -237,7 +237,8 @@ weather_type_id get_weather_at_point( const tripoint_abs_omt &pos )
     if( iter == weather_cache.end() ) {
         const tripoint_abs_ms abs_ms_pos = project_to<coords::ms>( pos );
         const weather_generator &wgen = overmap_buffer.get_settings( pos ).weather;
-        const auto weather = wgen.get_weather_conditions( abs_ms_pos, calendar::turn, g->get_seed() );
+        const weather_type_id weather = wgen.get_weather_conditions( abs_ms_pos, calendar::turn,
+                                        g->get_seed() );
         iter = weather_cache.insert( std::make_pair( pos, weather ) ).first;
     }
     return iter->second;

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1493,7 +1493,7 @@ std::vector<city_reference> overmapbuffer::get_cities_near( const tripoint_abs_s
         std::transform( om->cities.begin(), om->cities.end(), std::back_inserter( result ),
         [&]( city & element ) {
             const auto rel_pos_city = project_to<coords::sm>( element.pos );
-            const auto abs_pos_city =
+            const tripoint_abs_sm abs_pos_city =
                 tripoint_abs_sm( project_combine( om->pos(), rel_pos_city ), 0 );
             const int distance = rl_dist( abs_pos_city, location );
 
@@ -1538,7 +1538,7 @@ city_reference overmapbuffer::closest_known_city( const tripoint_abs_sm &center 
 
 std::string overmapbuffer::get_description_at( const tripoint_abs_sm &where )
 {
-    const auto oter = ter( project_to<coords::omt>( where ) );
+    const oter_id oter = ter( project_to<coords::omt>( where ) );
     const nc_color ter_color = oter->get_color();
     std::string ter_name = colorize( oter->get_name(), ter_color );
 

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -91,7 +91,7 @@ SDL_Color get_map_color_at( const tripoint &p )
         return curses_color_to_SDL( vp->vehicle().part_color( vp->part_index() ) );
     }
 
-    if( const auto furn_id = here.furn( p ) ) {
+    if( const furn_id furn_id = here.furn( p ) ) {
         return curses_color_to_SDL( furn_id->color() );
     }
 

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -137,7 +137,7 @@ class item_reader : public generic_typed_reader<item_reader>
                 return profession::itypedec( jv.get_string() );
             }
             JsonArray jarr = jv.get_array();
-            const auto id = jarr.get_string( 0 );
+            const std::string id = jarr.get_string( 0 );
             const snippet_id snippet( jarr.get_string( 1 ) );
             return profession::itypedec( id, snippet );
         }

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -404,15 +404,15 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
                 }
             } else if( column == COLUMN_PROXIMITY && ( current_tab[line].category == Categories::SOUND ||
                        !current_tab[line].whitelist ) ) {
-                const auto text = string_input_popup()
-                                  .title( _( "Proximity Distance (0=max view distance)" ) )
-                                  .width( 4 )
-                                  .text( std::to_string( current_tab[line].proximity ) )
-                                  .description( _( "Option: " ) + std::to_string( get_option<int>( "SAFEMODEPROXIMITY" ) ) +
-                                                " " + get_options().get_option( "SAFEMODEPROXIMITY" ).getDefaultText() )
-                                  .max_length( 3 )
-                                  .only_digits( true )
-                                  .query_string();
+                const std::string text = string_input_popup()
+                                         .title( _( "Proximity Distance (0=max view distance)" ) )
+                                         .width( 4 )
+                                         .text( std::to_string( current_tab[line].proximity ) )
+                                         .description( _( "Option: " ) + std::to_string( get_option<int>( "SAFEMODEPROXIMITY" ) ) +
+                                                       " " + get_options().get_option( "SAFEMODEPROXIMITY" ).getDefaultText() )
+                                         .max_length( 3 )
+                                         .only_digits( true )
+                                         .query_string();
                 if( text.empty() ) {
                     current_tab[line].proximity = get_option<int>( "SAFEMODEPROXIMITY" );
                 } else {

--- a/src/simple_pathfinding.cpp
+++ b/src/simple_pathfinding.cpp
@@ -293,7 +293,7 @@ simple_path<tripoint_abs_omt> find_overmap_path( const tripoint_abs_omt &source,
     const point_abs_omt source_point = source.xy();
     constexpr int max_search_count = 100000;
 
-    constexpr auto report_period = std::chrono::milliseconds( 100 );
+    constexpr std::chrono::milliseconds report_period = std::chrono::milliseconds( 100 );
     std::chrono::steady_clock::time_point report_next = std::chrono::steady_clock::now();
     int progress = 0;
     while( !open_set.empty() ) {
@@ -301,7 +301,7 @@ simple_path<tripoint_abs_omt> find_overmap_path( const tripoint_abs_omt &source,
         open_set.pop();
         if( progress++ >= 100 ) { // stagger progress checks to 1 in 100 nodes
             progress = 0;
-            const auto now = std::chrono::steady_clock::now();
+            const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
             if( now > report_next ) { // report progress every `report_period`
                 progress_fn( open_set.size(), known_nodes.size() );
                 report_next = now + report_period;

--- a/src/trait_group.cpp
+++ b/src/trait_group.cpp
@@ -99,7 +99,7 @@ void trait_group::debug_spawn()
         // Spawn traits from the group 100 times
         std::map<std::string, int> traitnames;
         for( size_t a = 0; a < 100; a++ ) {
-            const auto traits = traits_from( groups[index] );
+            const Trait_list traits = traits_from( groups[index] );
             for( const trait_and_var &tr : traits ) {
                 traitnames[tr.name()]++;
             }

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -616,7 +616,7 @@ static std::string get_looks_like( const vpart_info &vpi, const itype &it )
             if( !at->default_ammotype() ) {
                 continue;
             }
-            const auto at_weight = at->default_ammotype()->weight;
+            const units::mass at_weight = at->default_ammotype()->weight;
             if( 15_gram > at_weight && at_weight > 3_gram ) {
                 return true; // detects g80 and coil gun
             }

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1816,7 +1816,7 @@ int worldfactory::show_worldgen_basic( WORLD *world )
         } else if( action == "PICK_MODS" ) {
             show_worldgen_tab_modselection( w_confirmation, world, false );
         } else if( action == "ADVANCED_SETTINGS" ) {
-            auto WOPTIONS_OLD = world->WORLD_OPTIONS;
+            options_manager::options_container WOPTIONS_OLD = world->WORLD_OPTIONS;
             show_worldgen_tab_options( w_confirmation, world, false );
             for( auto &iter : WOPTIONS_OLD ) {
                 if( iter.second != world->WORLD_OPTIONS[iter.first] ) {

--- a/tests/line_test.cpp
+++ b/tests/line_test.cpp
@@ -382,19 +382,23 @@ static void line_to_comparison( const int iterations )
         const int t1 = 0;
         const int t2 = 0;
         int count1 = 0;
-        const auto start1 = std::chrono::high_resolution_clock::now();
+        const std::chrono::high_resolution_clock::time_point start1 =
+            std::chrono::high_resolution_clock::now();
         while( count1 < iterations ) {
             line_to( p12, p22, t1 );
             count1++;
         }
-        const auto end1 = std::chrono::high_resolution_clock::now();
+        const std::chrono::high_resolution_clock::time_point end1 =
+            std::chrono::high_resolution_clock::now();
         int count2 = 0;
-        const auto start2 = std::chrono::high_resolution_clock::now();
+        const std::chrono::high_resolution_clock::time_point start2 =
+            std::chrono::high_resolution_clock::now();
         while( count2 < iterations ) {
             canonical_line_to( p12, p22, t2 );
             count2++;
         }
-        const auto end2 = std::chrono::high_resolution_clock::now();
+        const std::chrono::high_resolution_clock::time_point end2 =
+            std::chrono::high_resolution_clock::now();
 
         if( iterations > 1 ) {
             const long long diff1 =

--- a/tests/make_static_test.cpp
+++ b/tests/make_static_test.cpp
@@ -26,6 +26,7 @@ TEST_CASE( "make_static_macro_test", "[make_static_macro]" )
     // entity with the same address should be returned
     CHECK( &get_static() == &get_static() );
 
+    // NOLINTNEXTLINE(cata-almost-never-auto)
     const auto test11 = STATIC( "test11" );
     static_assert( std::is_same<std::decay_t<decltype( test11 )>, std::string>::value,
                    "type must be std::string" );

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -81,13 +81,15 @@ TEST_CASE( "lru_cache_perf", "[.]" )
 {
     constexpr int max_size = 1000000;
     lru_cache<tripoint, int> symbol_cache;
-    const auto start1 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point start1 =
+        std::chrono::high_resolution_clock::now();
     for( int i = 0; i < 1000000; ++i ) {
         for( int j = -60; j <= 60; ++j ) {
             symbol_cache.insert( max_size, { i, j, 0 }, 1 );
         }
     }
-    const auto end1 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point end1 =
+        std::chrono::high_resolution_clock::now();
     const long long diff1 = std::chrono::duration_cast<std::chrono::microseconds>
                             ( end1 - start1 ).count();
     printf( "completed %d insertions in %lld microseconds.\n", max_size, diff1 );

--- a/tests/reachability_cache_test.cpp
+++ b/tests/reachability_cache_test.cpp
@@ -22,7 +22,7 @@ using namespace map_test_case_common::tiles;
 static const ter_str_id ter_t_brick_wall( "t_brick_wall" );
 static const ter_str_id ter_t_flat_roof( "t_flat_roof" );
 
-static const auto ter_set_flat_roof_above = ter_set( ter_t_flat_roof, tripoint_above );
+static const tile_predicate ter_set_flat_roof_above = ter_set( ter_t_flat_roof, tripoint_above );
 
 static const tile_predicate set_up_tiles_common =
     ifchar( '.', noop ) ||

--- a/tests/shadowcasting_test.cpp
+++ b/tests/shadowcasting_test.cpp
@@ -232,7 +232,8 @@ static void shadowcasting_runoff( const int iterations, const bool test_bresenha
 
     const point offset( 65, 65 );
 
-    const auto start1 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point start1 =
+        std::chrono::high_resolution_clock::now();
     for( int i = 0; i < iterations; i++ ) {
         // First the control algorithm.
         oldCastLight( seen_squares_control, transparency_cache, 0, 1, 1, 0, offset.x, offset.y, 0 );
@@ -247,15 +248,18 @@ static void shadowcasting_runoff( const int iterations, const bool test_bresenha
         oldCastLight( seen_squares_control, transparency_cache, 0, -1, -1, 0, offset.x, offset.y, 0 );
         oldCastLight( seen_squares_control, transparency_cache, -1, 0, 0, -1, offset.x, offset.y, 0 );
     }
-    const auto end1 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point end1 =
+        std::chrono::high_resolution_clock::now();
 
-    const auto start2 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point start2 =
+        std::chrono::high_resolution_clock::now();
     for( int i = 0; i < iterations; i++ ) {
         // Then the current algorithm.
         castLightAll<float, float, sight_calc, sight_check, update_light, accumulate_transparency>(
             seen_squares_experiment, transparency_cache, offset );
     }
-    const auto end2 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point end2 =
+        std::chrono::high_resolution_clock::now();
 
     if( iterations > 1 ) {
         const long long diff1 = std::chrono::duration_cast<std::chrono::microseconds>
@@ -308,22 +312,26 @@ static void shadowcasting_float_quad(
 
     const point offset( 65, 65 );
 
-    const auto start1 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point start1 =
+        std::chrono::high_resolution_clock::now();
     for( int i = 0; i < iterations; i++ ) {
         castLightAll<float, four_quadrants, sight_calc, sight_check, update_light_quadrants,
                      accumulate_transparency>(
                          lit_squares_quad, transparency_cache, offset );
     }
-    const auto end1 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point end1 =
+        std::chrono::high_resolution_clock::now();
 
-    const auto start2 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point start2 =
+        std::chrono::high_resolution_clock::now();
     for( int i = 0; i < iterations; i++ ) {
         // Then the current algorithm.
         castLightAll<float, float, sight_calc, sight_check, update_light,
                      accumulate_transparency>(
                          lit_squares_float, transparency_cache, offset );
     }
-    const auto end2 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point end2 =
+        std::chrono::high_resolution_clock::now();
 
     if( iterations > 1 ) {
         const long long diff1 = std::chrono::duration_cast<std::chrono::microseconds>
@@ -368,12 +376,14 @@ static void do_3d_benchmark(
         floor_caches[z + OVERMAP_DEPTH] = &grids->floor_cache[z + OVERMAP_DEPTH];
     }
 
-    const auto start = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point start =
+        std::chrono::high_resolution_clock::now();
     for( int i = 0; i < iterations; i++ ) {
         cast_zlight<float, sight_calc, sight_check, accumulate_transparency>(
             seen_caches, transparency_caches, floor_caches, origin, 0, 1.0 );
     }
-    const auto end = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point end =
+        std::chrono::high_resolution_clock::now();
 
     if( iterations > 1 ) {
         const long long diff =
@@ -438,13 +448,15 @@ static void shadowcasting_3d_2d( const int iterations )
 
     const tripoint offset( 65, 65, 0 );
 
-    const auto start1 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point start1 =
+        std::chrono::high_resolution_clock::now();
     for( int i = 0; i < iterations; i++ ) {
         // First the control algorithm.
         castLightAll<float, float, sight_calc, sight_check, update_light, accumulate_transparency>(
             seen_squares_control, transparency_cache, offset.xy() );
     }
-    const auto end1 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point end1 =
+        std::chrono::high_resolution_clock::now();
 
     const tripoint origin( offset );
     array_of_grids_of<const float> transparency_caches;
@@ -457,13 +469,15 @@ static void shadowcasting_3d_2d( const int iterations )
         floor_caches[z + OVERMAP_DEPTH] = &floor_cache;
     }
 
-    const auto start2 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point start2 =
+        std::chrono::high_resolution_clock::now();
     for( int i = 0; i < iterations; i++ ) {
         // Then the newer algorithm.
         cast_zlight<float, sight_calc, sight_check, accumulate_transparency>(
             seen_caches, transparency_caches, floor_caches, origin, 0, 1.0 );
     }
-    const auto end2 = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point end2 =
+        std::chrono::high_resolution_clock::now();
 
     if( iterations > 1 ) {
         const long long diff1 =

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -384,16 +384,16 @@ int main( int argc, const char *argv[] )
 
     bool error_during_initialization = debug_has_error_been_observed();
 
-    const auto start = std::chrono::system_clock::now();
+    const std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
     std::time_t start_time = std::chrono::system_clock::to_time_t( start );
     // Leading newline in case there were debug messages during
     // initialization.
     DebugLog( D_INFO, DC_ALL ) << "Starting the actual test at " << std::ctime( &start_time );
     result = session.run();
-    const auto end = std::chrono::system_clock::now();
+    const std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
     std::time_t end_time = std::chrono::system_clock::to_time_t( end );
 
-    auto world_name = world_generator->active_world->world_name;
+    std::string world_name = world_generator->active_world->world_name;
     if( result == 0 || dont_save ) {
         world_generator->delete_world( world_name, true );
     } else {

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -102,7 +102,7 @@ static const time_point day_time = calendar::turn_zero + 9_hours + 30_minutes;
 using namespace map_test_case_common;
 using namespace map_test_case_common::tiles;
 
-auto static const ter_set_flat_roof_above = ter_set( ter_t_flat_roof, tripoint_above );
+static const tile_predicate ter_set_flat_roof_above = ter_set( ter_t_flat_roof, tripoint_above );
 
 static bool spawn_moncam( map_test_case::tile tile )
 {

--- a/tools/repeat_clang_tidy.sh
+++ b/tools/repeat_clang_tidy.sh
@@ -38,7 +38,7 @@ else
 fi
 
 list_of_files=$(grep '"file": "' build/compile_commands.json | \
-    sed "s+.*$PWD/++;s+\"$++" | \
+    sed "s+.*$PWD/++;s+\",\?$++" | \
     sort -u | \
     egrep "$file_regex")
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Enforcement of code style.

#### Describe the solution
In LLVM 16 this check was a lot more effective.  So, it was briefly disabled during the migration.  This fixes all its warnings again, and re-enables it.

#### Describe alternatives you've considered
None.

#### Testing
Run clang-tidy.

#### Additional context