### PR TITLE
A bunch of random item reworks: 6

### DIFF
--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -101,15 +101,17 @@
     "category": "other",
     "name": { "str": "chess set" },
     "description": "A wooden box containing all the pieces needed to play a game of chess.",
-    "weight": "907 g",
-    "volume": "2 L",
-    "price": 7500,
+    "weight": "550 g",
+    "volume": "2400 ml",
+    "longest_side": "30 cm",
+    "price": "16 USD",
     "price_postapoc": 500,
     "material": [ "wood" ],
     "symbol": "?",
     "color": "brown",
     "flags": [ "NO_REPAIR" ],
-    "use_action": [ "PLAY_GAME" ]
+    "use_action": [ "PLAY_GAME" ],
+    "//": "Based on folded volume of https://www.amazon.co.uk/Big-Game-Hunters-Portable-Wooden/dp/B07XVKG4YY/ref=sr_1_6?crid=1N6NEJ01S0U4V&keywords=chess+set&qid=1684582085&sprefix=chess+se%2Caps%2C117&sr=8-6"
   },
   {
     "id": "checkers",

--- a/data/json/items/generic/bedding.json
+++ b/data/json/items/generic/bedding.json
@@ -6,17 +6,18 @@
     "name": { "str": "pillowcase" },
     "looks_like": "pillow",
     "description": "A simple cotton pillowcase.",
-    "weight": "415 g",
-    "volume": "1 L",
-    "price": 0,
+    "weight": "136 g",
+    "volume": "120 ml",
+    "price": 650,
     "price_postapoc": 2,
-    "to_hit": -5,
+    "to_hit": { "grip": "none", "length": "short", "surface": "any", "balance": "clumsy" },
     "material": [ "cotton" ],
     "repairs_like": "tshirt",
     "flags": [ "SLEEP_AID_CONTAINER" ],
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "15 L", "max_contains_weight": "15 kg", "moves": 400 } ],
     "symbol": ")",
-    "color": "white"
+    "color": "white",
+    "//": "Based on https://www.amazon.com/AmazonBasics-Thread-Count-Pillow-Cases/dp/B01MUDQUN9/ref=sr_1_7?crid=2HK7WH8A1GKY5&keywords=pillowcase%2Bcotton&qid=1684589982&sprefix=pillowcase%2Bcotton%2Caps%2C192&sr=8-7&th=1"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/generic/bedding.json
+++ b/data/json/items/generic/bedding.json
@@ -7,7 +7,7 @@
     "looks_like": "pillow",
     "description": "A simple cotton pillowcase.",
     "weight": "136 g",
-    "volume": "120 ml",
+    "volume": "90 ml",
     "price": 650,
     "price_postapoc": 2,
     "to_hit": { "grip": "none", "length": "short", "surface": "any", "balance": "clumsy" },

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -578,7 +578,14 @@
     "flags": [ "SHEATH_KNIFE" ],
     "looks_like": "fork",
     "copy-from": "base_silverware",
-    "melee_damage": { "bash": 2, "stab": 1 }
+    "weight": "130 g",
+    "volume": "800 ml",
+    "//1": "Lower than what the amazon link implies but I refuse to believe it's 1l of volume. 800ml is probably way overkill either way, since it has plenty of empty space that this calculation does not account for.",
+    "longest_side": "23 cm",
+    "price": "9 USD",
+    "to_hit": { "grip": "none", "length": "hand", "surface": "point", "balance": "neutral" },
+    "melee_damage": { "bash": 2, "stab": 1 },
+    "//2": "Based on https://www.amazon.com/Cooking-Light-Wine-Professional-Opener/dp/B081R28ZLP/ref=sr_1_12?crid=1XEV9UEX382A&keywords=corkscrew&qid=1684583858&sprefix=corkscrew%2Caps%2C236&sr=8-12"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -178,7 +178,7 @@
     "weight": "318 g",
     "volume": "475 ml",
     "longest_side": "12 cm",
-    "price": "16 USD",
+    "price": "5 USD",
     "to_hit": { "grip": "solid", "length": "hand", "surface": "any", "balance": "clumsy" },
     "pocket_data": [
       {

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -175,9 +175,14 @@
     "symbol": "u",
     "description": "A ceramic coffee cup with a logo on the side.",
     "copy-from": "base_ceramic_dish",
+    "weight": "318 g",
+    "volume": "475 ml",
+    "longest_side": "12 cm",
+    "price": "16 USD",
+    "to_hit": { "grip": "solid", "length": "hand", "surface": "any", "balance": "clumsy" },
     "pocket_data": [
       {
-        "max_contains_volume": "250 ml",
+        "max_contains_volume": "330 ml",
         "max_contains_weight": "1 kg",
         "watertight": true,
         "open_container": true,
@@ -236,7 +241,8 @@
       },
       { "id": "mug25", "text": "A white ceramic coffee mug.  There's a tiny dinosaur sculpture inside of it." },
       { "id": "mug26", "text": "A white ceramic coffee mug.  It says \"I <3 Massachusetts.\" on the side." }
-    ]
+    ],
+    "//": "Based on https://www.amazon.com/Black-Novelty-Coffee-Homeyes-Ceramic/dp/B0B6CWNKCP/ref=sr_1_51?keywords=ceramic%2Bmug&qid=1684583367&sr=8-51&th=1"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -41,9 +41,10 @@
     "category": "spare_parts",
     "name": { "str": "dish towel" },
     "description": "A dish towel, useful for cleaning hard surfaces.",
-    "weight": "80 g",
-    "volume": "200 ml",
-    "price": 200,
+    "weight": "65600 mg",
+    "volume": "58 ml",
+    "//1": "Calculated from cotton density because if I took exact product dimensions you'd have <2ml of volume BUT no way in hell is the player folding the towel so neatly.",
+    "price": 127,
     "price_postapoc": 20,
     "material": [ "cotton" ],
     "symbol": ",",
@@ -58,7 +59,8 @@
       { "id": "dtowel6", "text": "A dish towel with a floral pattern." },
       { "id": "dtowel7", "text": "A dish towel with a gingham pattern." },
       { "id": "dtowel8", "text": "A dish towel with a cat pattern." }
-    ]
+    ],
+    "//2": "Based on https://www.amazon.com/Zeppoli-Classic-Kitchen-15-Pack-Natural/dp/B01IG8X9E6/ref=sr_1_9?crid=3VWY7NLBYVH2N&keywords=dish%2Btowel&qid=1684589366&sprefix=dish%2Btowel%2Caps%2C256&sr=8-9&th=1"
   },
   {
     "id": "elec_hairtrimmer",

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -42,7 +42,7 @@
     "name": { "str": "dish towel" },
     "description": "A dish towel, useful for cleaning hard surfaces.",
     "weight": "65600 mg",
-    "volume": "58 ml",
+    "volume": "43 ml",
     "//1": "Calculated from cotton density because if I took exact product dimensions you'd have <2ml of volume BUT no way in hell is the player folding the towel so neatly.",
     "price": 127,
     "price_postapoc": 20,

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -4514,7 +4514,8 @@
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
     "time": "6 s",
-    "components": [ [ [ "cotton_patchwork", 1 ] ] ],
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_cotton", 1 ] ], [ [ "scrap_cotton", 26 ] ] ],
     "flags": [ "BLIND_EASY" ]
   },
   {

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -127,7 +127,7 @@
     "result": "corkscrew",
     "time": "6 s",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "scrap", 1 ] ] ]
+    "components": [ [ [ "scrap", 2 ] ] ]
   },
   {
     "result": "cufflinks",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -2187,13 +2187,6 @@
     "components": [ [ [ "ceramic_shard", 1 ] ] ]
   },
   {
-    "result": "ceramic_mug",
-    "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
-    "time": "3 s",
-    "components": [ [ [ "ceramic_shard", 1 ] ] ]
-  },
-  {
     "result": "ceramic_plate",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -550,9 +550,9 @@
     "result": "pillowcase",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
-    "time": "2 m",
-    "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-    "components": [ [ [ "sheet_cotton", 3 ] ], [ [ "zipper_short_plastic", 1 ] ] ]
+    "time": "15 s",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_cotton", 3 ] ], [ [ "zipper_short_plastic", 1 ] ], [ [ "scrap_cotton", 18 ] ] ]
   },
   {
     "result": "blanket",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<details>
<summary>CHESS SET</summary>

- Weight: 907g -> 550g
- Volume: 2l -> 2.4l
- Longest side: N/A -> 30cm
- ``price_preapoc``: 75$ -> 16$

</details>

<details>
<summary>COFFEE MUG</summary>

- Weight: 375g -> 318g
- Volume: 375ml -> 475ml
- Longest side: N/A -> 12cm
- ``price_preapoc``: 12$ -> 5$
- ``to_hit`` values now use modifiers
- Pocket volume: 250ml -> 330ml
- Disassembly removed - single ceramic shard weighs much more than a whole mug

</details>

<details>
<summary>CORKSCREW</summary>

- Weight: 48g -> 130g
- Volume: 25ml -> 800ml (already lower than what the numbers would imply, but probably still overkill, open to editing that)
- Longest side: N/A -> 23cm
- ``price_preapoc``: 1$ -> 9$
- ``to_hit`` values now use modifiers
- Disassembly yield increased to account for weight increase

</details>

<details>
<summary>DISH TOWEL</summary>

- Weight: 80g -> 65.6g
- Volume: 200ml -> 43ml
- ``price_preapoc``: 2$ -> 1.27$
- Disassembly yield edited, now instead of a single patch will yield a sheet and some cotton scrap but will also require a ``CUTTING 2`` tool

</details>

<details>
<summary>PILLOWCASE</summary>

- Weight: 415g -> 136g
- Volume: 1l -> 90ml
- ``price_preapoc``: 0$ -> 6.5$
- ``to_hit`` values now use modifiers
- Disassembly recipe had added cotton scrap to avoid loss of mass
- Disassembly recipe made shorter (2m -> 15s)
- Disassembly now needs ``CUTTING 2``

</details>

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->