### PR TITLE
[Xedra Evolved] Balancing Vampirism

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -135,7 +135,7 @@
     "types": [ "TEETH" ],
     "valid": false,
     "vitamin_rates": [ [ "human_blood_vitamin", 180 ] ],
-    "flags": [ "CANNIBAL" ],
+    "flags": [ "CANNIBAL", "ALBINO" ],
     "attacks": [
       {
         "attack_text_u": "You sink your fangs into %s",
@@ -182,7 +182,7 @@
     "valid": false,
     "vitamins_absorb_multi": [ [ "all", [ [ "human_blood_vitamin", 1.25 ] ] ] ],
     "vitamin_rates": [ [ "human_blood_vitamin", 180 ] ],
-    "flags": [ "CANNIBAL" ],
+    "flags": [ "CANNIBAL", "ALBINO", "DAYFEAR" ],
     "metabolism_modifier": 0.8,
     "stamina_regen_modifier": 0.1
   },
@@ -219,7 +219,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "flags": [ "CANNIBAL" ],
+    "flags": [ "CANNIBAL", "SUNBURN", "DAYFEAR" ],
     "metabolism_modifier": 5,
     "stamina_regen_modifier": 0.1
   },
@@ -232,7 +232,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "flags": [ "CANNIBAL" ],
+    "flags": [ "CANNIBAL", "SUNBURN", "DAYFEAR" ],
     "metabolism_modifier": 5,
     "stamina_regen_modifier": 0.1
   }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -903,7 +903,7 @@ void suffer::in_sunlight( Character &you )
     if( you.has_flag( json_flag_DAYFEAR ) ) {
         you.mod_str_bonus( -2 );
         you.mod_dex_bonus( -2 );
-        you.add_miss_reason( _( "You fear the sunlight!" ), 4 );
+        you.add_miss_reason( _( "You fear the sunlight!" ), 2 );
         you.mod_int_bonus( -2 );
         you.mod_per_bonus( -2 );
     }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -118,6 +118,7 @@ static const itype_id itype_oxygen_tank( "oxygen_tank" );
 static const itype_id itype_smoxygen_tank( "smoxygen_tank" );
 
 static const json_character_flag json_flag_ALBINO( "ALBINO" );
+static const json_character_flag json_flag_DAYFEAR( "DAYFEAR" );
 static const json_character_flag json_flag_GILLS( "GILLS" );
 static const json_character_flag json_flag_GLARE_RESIST( "GLARE_RESIST" );
 static const json_character_flag json_flag_GRAB( "GRAB" );
@@ -898,6 +899,13 @@ void suffer::in_sunlight( Character &you )
         you.add_miss_reason( _( "The sunlight distracts you." ), 1 );
         you.mod_int_bonus( -1 );
         you.mod_per_bonus( -1 );
+    }
+    if( you.has_flag( json_flag_DAYFEAR ) ) {
+        you.mod_str_bonus( -2 );
+        you.mod_dex_bonus( -2 );
+        you.add_miss_reason( _( "You fear the sunlight!" ), 4 );
+        you.mod_int_bonus( -2 );
+        you.mod_per_bonus( -2 );
     }
     if( you.has_trait( trait_TROGLO3 ) ) {
         you.mod_str_bonus( -4 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Balance to Vampirism"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adds some balance to the vampirism process in Xedra Evolved.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds the appropriate flags to vampire stages. Also adds a DAYFEAR flag and adds it where appropriate.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Creating more unique stages of sunburn but sunburn is super complicated already.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->