### PR TITLE
Misc fixes for tests noise, log noise and missed vpart changes

### DIFF
--- a/data/json/vehicleparts/frames.json
+++ b/data/json/vehicleparts/frames.json
@@ -8,6 +8,7 @@
     "description": "A metal framework.  Other vehicle components can be mounted on it, and it can be attached to other frames to increase the vehicle's size.",
     "breaks_into": "ig_vp_frame",
     "symbol": "h",
+    "broken_symbol": "#",
     "symbols": {
       "cover": "^",
       "cross": "c",

--- a/data/mods/Magiclysm/vehicleparts/frames.json
+++ b/data/mods/Magiclysm/vehicleparts/frames.json
@@ -19,9 +19,9 @@
   {
     "id": "folding_orichalcum_frame",
     "type": "vehicle_part",
+    "copy-from": "frame_orichalcum",
     "name": "foldable orichalcum frame",
     "item": "fold_orichalcum_frame",
-    "location": "structure",
     "durability": 250,
     "description": "A light metal framework, designed to fold.  Other vehicle components can be mounted on it.  If all the frames and components of a vehicle are foldable, the vehicle can be folding into a small package and picked up as a normal item.",
     "folded_volume": "5 L",
@@ -31,8 +31,6 @@
       "removal": { "skills": [ [ "mechanics", 2 ], [ "spellcraft", 1 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ], [ "spellcraft", 1 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
     },
-    "flags": [ "INITIAL_PART", "MOUNTABLE" ],
-    "categories": [ "hull" ],
     "damage_reduction": { "all": 12 }
   },
   {

--- a/data/mods/Magiclysm/vehicles/summoned_vehicles.json
+++ b/data/mods/Magiclysm/vehicles/summoned_vehicles.json
@@ -42,12 +42,10 @@
   {
     "type": "vehicle_part",
     "id": "mana_frame",
+    "copy-from": "frame_abstract",
     "name": "mana frame",
-    "symbol": "O",
-    "categories": [ "movement", "hull" ],
+    "breaks_into": "EMPTY_GROUP",
     "color": "magenta",
-    "broken_symbol": "M",
-    "broken_color": "red",
     "damage_modifier": 10,
     "noise_factor": 1,
     "fuel_type": "mana",
@@ -60,12 +58,6 @@
     "description": "A shape of pure mana that can float and carry items.",
     "size": "37500 ml",
     "power": "200 W",
-    "location": "structure",
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 20 ], [ "spellcraft", 1 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },
-      "removal": { "skills": [ [ "mechanics", 20 ], [ "spellcraft", 1 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 20 ], [ "spellcraft", 1 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
-    },
     "flags": [
       "NO_INSTALL_HIDDEN",
       "ENGINE",

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6792,11 +6792,8 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
                         if( valid_mount.success() ) {
                             // make a copy so we don't interfere with veh_to_add->remove_part below
                             first_veh->install_part( target_point, vehicle_part( *vp ) );
-                        } else {
-                            DebugLog( D_WARNING, DC_ALL )
-                                    << "merging wrecks ignoring part '" << vpi.get_id().str() << "' "
-                                    << "as it would make invalid vehicle: " << valid_mount.str();
                         }
+                        // ignore parts that would make invalid vehicle configuration
                     }
 
                     if( !handler_ptr ) {

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -41,6 +41,7 @@ static const skill_id skill_unarmed( "unarmed" );
 static const trait_id trait_TOUGH_FEET( "TOUGH_FEET" );
 
 static constexpr tripoint attacker_location{ 65, 65, 0 };
+static constexpr int test_margin = 75; // 7.5% margin on test outcomes
 
 static void reset_caches( int a_zlev, int t_zlev )
 {
@@ -458,7 +459,7 @@ TEST_CASE( "Grab breaks against weak grabber(s)", "[mattack][grab]" )
         // Single zombie grabbing a starting survivor has about 50% chance to release on a turn
         // Actually higher for non-arm/torso grabs, but bundled works well enough
         INFO( "You should have about 40% chance to break a weak grab every turn as a starting character" );
-        CHECK( success == Approx( 400 ).margin( 50 ) );
+        CHECK( success == Approx( 400 ).margin( test_margin ) );
     }
     SECTION( "Starter character vs 3 weak grabs at the same time" ) {
         // Setup 3v1 test
@@ -489,7 +490,7 @@ TEST_CASE( "Grab breaks against weak grabber(s)", "[mattack][grab]" )
         }
         Messages::clear_messages();
         INFO( "You have about 5% chance to break three weak grabs on a single turn" );
-        CHECK( success == Approx( 50 ).margin( 50 ) );
+        CHECK( success == Approx( 50 ).margin( test_margin ) );
     }
     // Setup lategame character
     you.set_skill_level( skill_unarmed, 8 );
@@ -516,7 +517,7 @@ TEST_CASE( "Grab breaks against weak grabber(s)", "[mattack][grab]" )
         }
         Messages::clear_messages();
         INFO( "100% chance to break a weak grab as a lategame character with grab breaks" );
-        CHECK( success == Approx( 1000 ).margin( 50 ) );
+        CHECK( success == Approx( 1000 ).margin( test_margin ) );
     }
     SECTION( "Lategame character vs 3 weak grabs at the same time" ) {
         // Setup 3v1 test
@@ -547,7 +548,7 @@ TEST_CASE( "Grab breaks against weak grabber(s)", "[mattack][grab]" )
         }
         Messages::clear_messages();
         INFO( "99% chance to break three weak grabs on a single turn" );
-        CHECK( success == Approx( 990 ).margin( 50 ) );
+        CHECK( success == Approx( 990 ).margin( test_margin ) );
     }
 }
 
@@ -596,7 +597,7 @@ TEST_CASE( "Grab breaks against midline grabbers", "[mattack][grab]" )
         }
         Messages::clear_messages();
         INFO( "You should have about 15% chance to break a mid-strength grab every turn as a starting character" );
-        CHECK( success == Approx( 150 ).margin( 50 ) );
+        CHECK( success == Approx( 150 ).margin( test_margin ) );
     }
     SECTION( "Starter character vs 3 mid grabs at the same time" ) {
         // Setup 3v1 test
@@ -627,7 +628,7 @@ TEST_CASE( "Grab breaks against midline grabbers", "[mattack][grab]" )
         }
         Messages::clear_messages();
         INFO( "You have about 5% chance to break three midline grabs on a single turn" );
-        CHECK( success == Approx( 50 ).margin( 50 ) );
+        CHECK( success == Approx( 50 ).margin( test_margin ) );
     }
     // Setup lategame character
     you.set_skill_level( skill_unarmed, 8 );
@@ -654,7 +655,7 @@ TEST_CASE( "Grab breaks against midline grabbers", "[mattack][grab]" )
         }
         Messages::clear_messages();
         INFO( "80% chance to break a midline grab as a lategame character with grab breaks" );
-        CHECK( success == Approx( 800 ).margin( 50 ) );
+        CHECK( success == Approx( 800 ).margin( test_margin ) );
     }
     SECTION( "Lategame character vs 3 mid grabs at the same time" ) {
         // Setup 3v1 test
@@ -685,7 +686,7 @@ TEST_CASE( "Grab breaks against midline grabbers", "[mattack][grab]" )
         }
         Messages::clear_messages();
         INFO( "25% chance to break three mid grabs on a single turn" );
-        CHECK( success == Approx( 250 ).margin( 50 ) );
+        CHECK( success == Approx( 250 ).margin( test_margin ) );
     }
 }
 
@@ -733,7 +734,7 @@ TEST_CASE( "Grab breaks against strong grabbers", "[mattack][grab]" )
         }
         Messages::clear_messages();
         INFO( "You should have about 7,5% chance to break a max-strength grab every turn as a starting character" );
-        CHECK( success == Approx( 75 ).margin( 50 ) );
+        CHECK( success == Approx( 75 ).margin( test_margin ) );
     }
     SECTION( "Starter character vs 3 max-strength grabs at the same time" ) {
         you.clear_effects();
@@ -761,7 +762,7 @@ TEST_CASE( "Grab breaks against strong grabbers", "[mattack][grab]" )
         }
         Messages::clear_messages();
         INFO( "You have about 0% chance to break three max-strength grabs on a single turn" );
-        CHECK( success == Approx( 0 ).margin( 25 ) );
+        CHECK( success == Approx( 0 ).margin( test_margin / 2 ) );
     }
 
     you.set_skill_level( skill_unarmed, 8 );
@@ -787,7 +788,7 @@ TEST_CASE( "Grab breaks against strong grabbers", "[mattack][grab]" )
         }
         Messages::clear_messages();
         INFO( "40% chance to break a max-strength grab as a lategame character with grab breaks" );
-        CHECK( success == Approx( 400 ).margin( 50 ) );
+        CHECK( success == Approx( 400 ).margin( test_margin ) );
     }
     SECTION( "Lategame character vs 3 max-strength grabs at the same time" ) {
         you.clear_effects();
@@ -814,6 +815,6 @@ TEST_CASE( "Grab breaks against strong grabbers", "[mattack][grab]" )
         }
         Messages::clear_messages();
         INFO( "5% chance to break three max-strength grabs on a single turn" );
-        CHECK( success == Approx( 50 ).margin( 50 ) );
+        CHECK( success == Approx( 50 ).margin( test_margin ) );
     }
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Quiets down some test failures
Removes a spammy log message
Adds a few (minor) part changes I missed in cherrypicking

#### Describe the solution

~~Prevents random diseases breaking swim tests by giving DISIMMUNE trait:~~

Adding DISIMMUNE trait somehow [lowers stamina cost for swimming](https://github.com/irwiss/Cataclysm-DDA/actions/runs/5034204802/jobs/9028885921?pr=3#step:16:3220), removed the commit from this PR

---

https://github.com/CleverRaven/Cataclysm-DDA/pull/65765/commits/c3d6da1f24c31c5f8cc7cde3a579b4cd703ce3f5 - Puts the margin in a constexpr at the top and raises all margins from 5% to 7.5% (besides the one case where it's half)
* https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5028205470/jobs/9018641472?pr=65741#step:16:2196
* https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5021235118/jobs/9003671421?pr=65728#step:16:2213
* https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5015831306/jobs/8992440239?pr=65660#step:16:605
* https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5006175005/jobs/8971143566?pr=65681#step:16:320

https://github.com/CleverRaven/Cataclysm-DDA/pull/65765/commits/4b250b2ed51b1ba5b5cf7c88124a6f6976cae5e0 - Squelches log message, didn't realize how spammy it can be if mapgen rng hits the map with some wrecks, the message isn't actionable anyway.

https://github.com/CleverRaven/Cataclysm-DDA/pull/65765/commits/7c74733cfe9d1b9cc758577069df54adc2289431 - A couple more changes I accidentally lost in between cherry picking for #65721, none should be user visible

#### Describe alternatives you've considered

#### Testing

Not sure how to test for less random test failures except hopes and prayers
The parts changes in last commit were tested via part dump similar to #65721

#### Additional context
