### PR TITLE
More scrollbars

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2082,6 +2082,20 @@
   },
   {
     "type": "keybinding",
+    "id": "SCROLL_TRAIT_INFO_UP",
+    "category": "MUTATIONS",
+    "name": "Scroll mutation info up",
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "SCROLL_TRAIT_INFO_DOWN",
+    "category": "MUTATIONS",
+    "name": "Scroll mutation info down",
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
     "id": "APPLY",
     "category": "MEDICAL",
     "name": "Use item",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
- Fixes #65764

#### Describe the solution
Split the trait description into lines and allow scrolling with `<` and `>`.

#### Describe alternatives you've considered

#### Testing
Viewing a long trait description in the character info screen:

![char_menu](https://github.com/CleverRaven/Cataclysm-DDA/assets/12537966/9eaf3d4a-daee-48a0-9af1-523a080b82ca)

Viewing a long trait description in the mutation screen:

![Screenshot from 2023-05-20 17-41-07](https://github.com/CleverRaven/Cataclysm-DDA/assets/12537966/0cc23398-2667-48e2-917b-f0142621ab35)


#### Additional context

Also fixed a small unrelated issue where entering "examine" mode in the mutation menu would display a blank description box until the user selects a different trait.