### PR TITLE
Making red phosphorus doesn't require the matchbox

### DIFF
--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -1355,7 +1355,7 @@
     "time": "10 m",
     "autolearn": true,
     "qualities": [ { "id": "FINE_GRIND", "level": 1 } ],
-    "tools": [ [ [ "matches", 20 ], [ "ref_matches", 20 ] ] ]
+    "components": [ [ [ "match", 20 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change

Fixes #65773.

#### Describe the solution

Change from using the matchbox/matchbook to the matches themselves.

#### Describe alternatives you've considered

N/A

#### Testing

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/99621099/0e956c78-3eb1-4d62-b30d-84e03a6a4106)


#### Additional context

~~Why does the plural not work on matches in the test~~