### PR TITLE
Enable clang-tidy cert-dcl58-cpp

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -66,7 +66,6 @@ readability-*,\
 -bugprone-throw-keyword-missing,\
 -bugprone-unchecked-optional-access,\
 -bugprone-unhandled-exception-at-new,\
--cert-dcl58-cpp,\
 -cert-err33-c,\
 -clang-analyzer-cplusplus.NewDeleteLeaks,\
 -clang-analyzer-cplusplus.StringChecker,\

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -482,18 +482,14 @@ inline auto project_bounds( const coord_point<tripoint, Origin, CoarseScale> &co
 
 } // namespace coords
 
-namespace std
-{
-
 template<typename Point, coords::origin Origin, coords::scale Scale>
-struct hash<coords::coord_point<Point, Origin, Scale>> {
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+struct std::hash<coords::coord_point<Point, Origin, Scale>> {
     std::size_t operator()( const coords::coord_point<Point, Origin, Scale> &p ) const {
         const hash<Point> h{};
         return h( p.raw() );
     }
 };
-
-} // namespace std
 
 /** Typedefs for point types with coordinate mnemonics.
  *

--- a/src/int_id.h
+++ b/src/int_id.h
@@ -119,14 +119,12 @@ class int_id
 };
 
 // Support hashing of int based ids by forwarding the hash of the int.
-namespace std
-{
 template<typename T>
-struct hash< int_id<T> > {
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+struct std::hash<int_id<T>> {
     std::size_t operator()( const int_id<T> &v ) const noexcept {
         return hash<int>()( v.to_i() );
     }
 };
-} // namespace std
 
 #endif // CATA_SRC_INT_ID_H

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -28,17 +28,11 @@ void mapgen_arguments::deserialize( const JsonValue &ji )
     ji.read( map, true );
 }
 
-// NOLINTNEXTLINE(cert-dcl58-cpp)
-namespace std
-{
-
-size_t hash<mapgen_arguments>::operator()( const mapgen_arguments &args ) const noexcept
+size_t std::hash<mapgen_arguments>::operator()( const mapgen_arguments &args ) const noexcept
 {
     cata::range_hash h;
     return h( args.map );
 }
-
-} // namespace std
 
 static const regional_settings dummy_regional_settings;
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -171,16 +171,14 @@ extern template struct pos_dir<tripoint_rel_omt>;
 using om_pos_dir = pos_dir<tripoint_om_omt>;
 using rel_pos_dir = pos_dir<tripoint_rel_omt>;
 
-namespace std
-{
 template<typename Tripoint>
-struct hash<pos_dir<Tripoint>> {
-    size_t operator()( const pos_dir<Tripoint> &p ) const {
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+struct std::hash<pos_dir<Tripoint>> {
+    std::size_t operator()( const pos_dir<Tripoint> &p ) const {
         cata::tuple_hash h;
         return h( std::make_tuple( p.p, p.dir ) );
     }
 };
-} // namespace std
 
 class overmap
 {

--- a/src/string_id.h
+++ b/src/string_id.h
@@ -158,7 +158,7 @@ class string_identity_static
         friend class string_id;
 
         template<typename T>
-        friend struct std::hash;
+        friend struct std::hash; // NOLINT(cert-dcl58-cpp)
 };
 
 /**
@@ -190,7 +190,7 @@ class string_identity_dynamic
         friend class string_id;
 
         template<typename T>
-        friend struct std::hash;
+        friend struct std::hash; // NOLINT(cert-dcl58-cpp)
 };
 
 template<typename T>
@@ -362,16 +362,14 @@ class string_id
 };
 
 // Support hashing of string based ids by forwarding the hash of the string.
-namespace std
-{
 template<typename T>
-struct hash<string_id<T>> {
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+struct std::hash<string_id<T>> {
     std::size_t operator()( const string_id<T> &v ) const noexcept {
         using IdType = decltype( v._id._id );
         return std::hash<IdType>()( v._id._id );
     }
 };
-} // namespace std
 
 /** Lexicographic order comparator for string_ids */
 template<typename T>

--- a/src/vpart_range.h
+++ b/src/vpart_range.h
@@ -79,9 +79,9 @@ class vehicle_part_iterator
         }
 };
 
-namespace std
-{
-template<class T> struct iterator_traits<vehicle_part_iterator<T>> {
+template<class T>
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+struct std::iterator_traits<vehicle_part_iterator<T>> {
     using difference_type = size_t;
     using value_type = vpart_reference;
     // TODO: maybe change into random access iterator? This requires adding
@@ -90,7 +90,6 @@ template<class T> struct iterator_traits<vehicle_part_iterator<T>> {
     using pointer = const vpart_reference *;
     using iterator_category = std::forward_iterator_tag;
 };
-} // namespace std
 
 /**
  * The generic range, it misses the `bool contained(size_t)` function that is


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Static analysis.

This check looks for inappropriately adding to `namespace std`.

#### Describe the solution
Re-enable this check and suppress the false-positives it was producing.

Also refactor some of the template specializations now that I've learnt a better way to write them (without explicitly opening `namespace std`).

The issue regarding these false-positives can be found [here](https://github.com/llvm/llvm-project/issues/45454).  Once that is fixed these suppressions can be removed.

#### Describe alternatives you've considered
Leaving this check disabled until the bug is fixed.

#### Testing
Run clang-tidy.

#### Additional context