### PR TITLE
Make big collapsible drum deployable

### DIFF
--- a/data/json/items/containers/military.json
+++ b/data/json/items/containers/military.json
@@ -274,6 +274,7 @@
     "price": 39500,
     "price_postapoc": 250,
     "//": "todo: replace with some better rubber material",
+    "use_action": { "type": "deploy_furn", "furn_type": "f_432gal_drum_rubber" },
     "material": [ { "type": "rubber", "portion": 9 }, { "type": "steel", "portion": 1 } ],
     "symbol": "0"
   }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I designed a big collapsible drum to be deployable, but forgot to make it actually possible to deploy one
#### Describe the solution
Add `use_action` `deploy_furn` to it
#### Describe alternatives you've considered
Make a recipe to deploy one, maybe even with some attachments to secure it