### PR TITLE
Fix divide by zero in driving offset

### DIFF
--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -240,6 +240,28 @@ constexpr T lerp_clamped( const T &min, const T &max, float t )
     return lerp( min, max, clamp( t, 0.0f, 1.0f ) );
 }
 
+// Inverse of \p lerp, unbounded so it may extrapolate, returns 0.0f if min == max
+// @returns linear factor for interpolating between \p min and \p max to reach \p value
+template<typename T>
+constexpr float inverse_lerp( const T &min, const T &max, const T &value )
+{
+    if( max == min ) {
+        return 0.0f; // avoids a NaN
+    }
+    return ( value - min ) / ( max - min );
+}
+
+// Remaps \p value from range of \p i_min to \p i_max to a range between \p o_min and \p o_max
+// uses unclamped linear interpolation, so output value may be beyond output range if value is
+// outside input range.
+template<typename Tin, typename Tout>
+constexpr Tout linear_remap( const Tin &i_min, const Tin &i_max,
+                             const Tout &o_min, const Tout &o_max, Tin value )
+{
+    const float t = inverse_lerp( i_min, i_max, value );
+    return lerp( o_min, o_max, t );
+}
+
 /**
  * From `points`, finds p1 and p2 such that p1.first < x < p2.first
  * Then linearly interpolates between p1.second and p2.second and returns the result.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1295,14 +1295,7 @@ void game::calc_driving_offset( vehicle *veh )
         offset = veh->face_vec();
         velocity = veh->cruise_velocity;
     }
-    float rel_offset;
-    if( std::fabs( velocity ) < min_offset_vel ) {
-        rel_offset = 0;
-    } else if( std::fabs( velocity ) > max_offset_vel ) {
-        rel_offset = ( velocity > 0 ) ? 1 : -1;
-    } else {
-        rel_offset = ( velocity - min_offset_vel ) / ( max_offset_vel - min_offset_vel );
-    }
+    const float rel_offset = inverse_lerp( min_offset_vel, max_offset_vel, velocity );
     // Squeeze into the corners, by making the offset vector longer,
     // the PC is still in view as long as both offset.x and
     // offset.y are <= 1


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix a state where `game::calc_driving_offset` can get a NaN in rel_offset via division by zero when min_offset_vel == max_offset_vel.

While the state is relatively uncommon (see testing section) it's pretty severe; driving_view_offset ends up with garbage values (close to MAXINT), propagates into avatar's view_offset and calls into map memory with garbage positions.

#### Describe the solution

Add inverse_lerp/linear_remap functions to cata_utility.h
Use inverse_lerp which handles min==max by returning 0
I think a couple other places in codebase could use it but I can't remember where they are right now.

#### Describe alternatives you've considered

#### Testing

Have game running on 1920x1080 resolution, mostly standard settings, load attached save, set game to MSXotto tileset, maximum zoomed-in, control the APC, set speed to 1 t/t and hold arrow right, eventually either a loop will spin forever, oom crash or allocation exception triggers.

Likely not all of above conditions are necessary to reproduce

#### Additional context
[Debug AFS Magiclysm XED.zip](https://github.com/CleverRaven/Cataclysm-DDA/files/11538197/Debug.AFS.Magiclysm.XED.zip)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/f532af5e-abe3-4a0c-b3cc-befb37831860)
