### PR TITLE
Enable clang-tidy check cert-err33-c

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -66,7 +66,6 @@ readability-*,\
 -bugprone-throw-keyword-missing,\
 -bugprone-unchecked-optional-access,\
 -bugprone-unhandled-exception-at-new,\
--cert-err33-c,\
 -clang-analyzer-cplusplus.NewDeleteLeaks,\
 -clang-analyzer-cplusplus.StringChecker,\
 -clang-analyzer-optin.cplusplus.UninitializedObject,\

--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -346,9 +346,11 @@ std::wstring utf8_to_wstr( const std::string &str )
     strip_trailing_nulls( wstr );
     return wstr;
 #else
-    std::size_t sz = std::mbstowcs( nullptr, str.c_str(), 0 ) + 1;
-    std::wstring wstr( sz, '\0' );
-    std::mbstowcs( wstr.data(), str.c_str(), sz );
+    std::size_t sz = std::mbstowcs( nullptr, str.c_str(), 0 );
+    cata_assert( sz != static_cast<size_t>( -1 ) );
+    std::wstring wstr( sz + 1, '\0' );
+    std::size_t converted = std::mbstowcs( wstr.data(), str.c_str(), sz );
+    cata_assert( converted == sz );
     strip_trailing_nulls( wstr );
     return wstr;
 #endif
@@ -363,9 +365,11 @@ std::string wstr_to_utf8( const std::wstring &wstr )
     strip_trailing_nulls( str );
     return str;
 #else
-    std::size_t sz = std::wcstombs( nullptr, wstr.c_str(), 0 ) + 1;
-    std::string str( sz, '\0' );
-    std::wcstombs( str.data(), wstr.c_str(), sz );
+    std::size_t sz = std::wcstombs( nullptr, wstr.c_str(), 0 );
+    cata_assert( sz != static_cast<size_t>( -1 ) );
+    std::string str( sz + 1, '\0' );
+    std::size_t converted = std::wcstombs( str.data(), wstr.c_str(), sz );
+    cata_assert( converted == sz );
     strip_trailing_nulls( str );
     return str;
 #endif

--- a/src/chkjson/chkjson.cpp
+++ b/src/chkjson/chkjson.cpp
@@ -166,11 +166,15 @@ static void load_json_dir( const std::string &dirname )
 
 int main( int, char ** )
 {
-    setlocale( LC_ALL, "" );
+    char *result = setlocale( LC_ALL, "" );
+    if( !result ) {
+        std::cerr << "Failed to set locale\n";
+        return 1;
+    }
     try {
         load_json_dir( "data/json" );
     } catch( const std::exception &err ) {
-        printf( "Error: %s\n", err.what() );
+        std::cerr << "Error: " << err.what() << "\n";
         return 1;
     }
     return 0;

--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -85,8 +85,13 @@ extern "C" {
         std::cerr << log_text.str();
         FILE *file = fopen( crash_log_file.c_str(), "w" );
         if( file ) {
-            fwrite( log_text.str().data(), 1, log_text.str().size(), file );
-            fclose( file );
+            size_t written = fwrite( log_text.str().data(), 1, log_text.str().size(), file );
+            if( written < log_text.str().size() ) {
+                std::cerr << "Error: writing to log file failed: " << strerror( errno ) << "\n";
+            }
+            if( fclose( file ) ) {
+                std::cerr << "Error: closing log file failed: " << strerror( errno ) << "\n";
+            }
         }
 #if defined(__ANDROID__)
         // Create a placeholder dummy file "config/crash.log.prompt"
@@ -105,7 +110,7 @@ extern "C" {
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-        signal( sig, SIG_DFL );
+        static_cast<void>( signal( sig, SIG_DFL ) );
 #pragma GCC diagnostic pop
         const char *msg;
         switch( sig ) {
@@ -134,7 +139,7 @@ extern "C" {
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-        std::signal( SIGABRT, SIG_DFL );
+        static_cast<void>( std::signal( SIGABRT, SIG_DFL ) );
 #pragma GCC diagnostic pop
         abort(); // NOLINT(cata-assert)
     }
@@ -161,7 +166,7 @@ extern "C" {
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-        std::signal( SIGABRT, SIG_DFL );
+        static_cast<void>( std::signal( SIGABRT, SIG_DFL ) );
 #pragma GCC diagnostic pop
         abort(); // NOLINT(cata-assert)
     } catch( ... ) {
@@ -173,7 +178,7 @@ extern "C" {
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-    std::signal( SIGABRT, SIG_DFL );
+    static_cast<void>( std::signal( SIGABRT, SIG_DFL ) );
 #pragma GCC diagnostic pop
     abort(); // NOLINT(cata-assert)
 }
@@ -191,7 +196,10 @@ void init_crash_handlers()
 #endif
          } ) {
 
-        std::signal( sig, signal_handler );
+        sighandler_t previous_handler = std::signal( sig, signal_handler );
+        if( previous_handler == SIG_ERR ) {
+            std::cerr << "Failed to set signal handler for signal " << sig << "\n";
+        }
     }
     std::set_terminate( crash_terminate_handler );
 }

--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -196,7 +196,7 @@ void init_crash_handlers()
 #endif
          } ) {
 
-        sighandler_t previous_handler = std::signal( sig, signal_handler );
+        void ( *previous_handler )( int sig ) = std::signal( sig, signal_handler );
         if( previous_handler == SIG_ERR ) {
             std::cerr << "Failed to set signal handler for signal " << sig << "\n";
         }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3148,7 +3148,7 @@ void debug()
             debugmsg( "Test debugmsg" );
             break;
         case debug_menu_index::CRASH_GAME:
-            raise( SIGSEGV );
+            static_cast<void>( raise( SIGSEGV ) );
             break;
         case debug_menu_index::ACTIVATE_EOC: {
             const std::vector<effect_on_condition> &eocs = effect_on_conditions::get_all();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3463,7 +3463,10 @@ void game::write_memorial_file( std::string sLastWords )
     std::time_t t = std::time( nullptr );
     tm current_time;
     localtime_r( &t, &current_time );
-    std::strftime( buffer, suffix_len, "%Y-%m-%d-%H-%M-%S", &current_time );
+    size_t result = std::strftime( buffer, suffix_len, "%Y-%m-%d-%H-%M-%S", &current_time );
+    if( result == 0 ) {
+        cata_fatal( "Could not construct filename" );
+    }
     memorial_file_path << buffer;
 #endif
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -213,7 +213,9 @@ static void InitSDL()
     //SDL2 has no functionality for INPUT_DELAY, we would have to query it manually, which is expensive
     //SDL2 instead uses the OS's Input Delay.
 
-    atexit( SDL_Quit );
+    if( atexit( SDL_Quit ) ) {
+        debugmsg( "atexit failed to register SDL_Quit" );
+    }
 }
 
 static bool SetupRenderTarget()

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -408,7 +408,10 @@ void worldfactory::init()
             for( auto &origin_file : get_files_from_path( ".", origin_path, false ) ) {
                 std::string filename = origin_file.substr( origin_file.find_last_of( "/\\" ) );
 
-                rename( origin_file.c_str(), ( newworld->folder_path() + filename ).c_str() );
+                if( rename( origin_file.c_str(), ( newworld->folder_path() + filename ).c_str() ) ) {
+                    debugmsg( "Error while moving world files: %s.  World may have been corrupted",
+                              strerror( errno ) );
+                }
             }
             newworld->world_saves = old_world.world_saves;
             newworld->WORLD_OPTIONS = old_world.WORLD_OPTIONS;

--- a/tests/catacharset_test.cpp
+++ b/tests/catacharset_test.cpp
@@ -43,21 +43,25 @@ TEST_CASE( "base64", "[catacharset]" )
 TEST_CASE( "utf8_to_wstr", "[catacharset]" )
 {
     // std::mbstowcs' returning -1 workaround
-    setlocale( LC_ALL, "" );
+    char *result = setlocale( LC_ALL, "" );
+    REQUIRE( result );
     std::string src( u8"Hello, 世界!" );
     std::wstring dest( L"Hello, 世界!" );
     CHECK( utf8_to_wstr( src ) == dest );
-    setlocale( LC_ALL, "C" );
+    result = setlocale( LC_ALL, "C" );
+    REQUIRE( result );
 }
 
 TEST_CASE( "wstr_to_utf8", "[catacharset]" )
 {
     // std::wcstombs' returning -1 workaround
-    setlocale( LC_ALL, "" );
+    char *result = setlocale( LC_ALL, "" );
+    REQUIRE( result );
     std::wstring src( L"Hello, 世界!" );
     std::string dest( u8"Hello, 世界!" );
     CHECK( wstr_to_utf8( src ) == dest );
-    setlocale( LC_ALL, "C" );
+    result = setlocale( LC_ALL, "C" );
+    REQUIRE( result );
 }
 
 TEST_CASE( "localized_compare", "[catacharset]" )

--- a/tests/point_test.cpp
+++ b/tests/point_test.cpp
@@ -146,7 +146,8 @@ TEST_CASE( "point_to_from_string", "[point]" )
             // On platforms where we can't set the locale, don't worry about it
             return;
         }
-        setlocale( LC_ALL, nullptr );
+        char *result = setlocale( LC_ALL, "" );
+        REQUIRE( result );
     }
     CAPTURE( std::locale().name() );
 

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -121,7 +121,7 @@ static bool test_drag(
     if( !valid ) {
         printf( "    { \"%s\": [ %f, %f, %f, %d, %d ] },\n",
                 veh_id.c_str(), c_air, c_rolling, c_water, safe_v, max_v );
-        fflush( stdout );
+        static_cast<void>( fflush( stdout ) );
     }
     return valid;
 }
@@ -129,7 +129,7 @@ static bool test_drag(
 static void print_drag_test_strings( const vproto_id &veh )
 {
     test_drag( veh );
-    fflush( stdout );
+    static_cast<void>( fflush( stdout ) );
 }
 
 static void test_vehicle_drag( std::pair<const vproto_id, std::vector<double>> &veh_drag )

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -354,7 +354,7 @@ static void print_test_strings( const vproto_id &type )
     ss << average_from_stat( find_inner( type, expected_mass, "t_dirt", 5, false, false, true ) );
     ss << " ] }," << std::endl;
     printf( "%s", ss.str().c_str() );
-    fflush( stdout );
+    static_cast<void>( fflush( stdout ) );
 }
 
 static void test_vehicle(

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -2825,7 +2825,8 @@ TEST_CASE( "W_NO_PADDING widget flag", "[widget]" )
     ava.movecounter = 0;
 
     // workaround for mbstowcs to process multibyte utf-8 chars
-    setlocale( LC_ALL, "" );
+    char *result = setlocale( LC_ALL, "" );
+    REQUIRE( result );
 
     SECTION( "without flag" ) {
         const widget_id &wgt = widget_test_layout_nopad_noflag;
@@ -2899,5 +2900,6 @@ TEST_CASE( "W_NO_PADDING widget flag", "[widget]" )
         }
     }
 
-    setlocale( LC_ALL, "C" );
+    result = setlocale( LC_ALL, "C" );
+    REQUIRE( result );
 }

--- a/tools/clang-tidy-plugin/HeaderGuardCheck.cpp
+++ b/tools/clang-tidy-plugin/HeaderGuardCheck.cpp
@@ -1,5 +1,6 @@
 #include "HeaderGuardCheck.h"
 
+#include <iostream>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -309,7 +310,7 @@ class HeaderGuardPPCallbacks : public PPCallbacks
                 const FileInfo &Info = FileInfos.at( FileName );
                 const FileEntry *FE = Info.Entry;
                 if( !FE ) {
-                    fprintf( stderr, "No FileEntry for %s\n", FileName.c_str() );
+                    std::cerr << "No FileEntry for " << FileName << "\n";
                     continue;
                 }
                 FileID FID = SM.translateFile( FE );

--- a/tools/clang-tidy-plugin/UseLocalizedSortingCheck.cpp
+++ b/tools/clang-tidy-plugin/UseLocalizedSortingCheck.cpp
@@ -17,6 +17,7 @@
 #include <clang/Basic/SourceLocation.h>
 #include <clang/Lex/Lexer.h>
 #include <climits>
+#include <iostream>
 #include <llvm/ADT/Twine.h>
 #include <llvm/Support/Casting.h>
 #include <string>
@@ -66,7 +67,7 @@ static bool IsStringish( QualType T )
         const ClassTemplateSpecializationDecl *SpecDecl =
             dyn_cast<ClassTemplateSpecializationDecl>( TTag );
         if( !SpecDecl ) {
-            fprintf( stderr, "Not a spec: %s\n", TTag->getKindName().str().c_str() );
+            std::cerr << "Not a spec: " << TTag->getKindName().str() << "\n";
             return false;
         }
         const TemplateArgumentList &Args = SpecDecl->getTemplateArgs();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
More static analysis.

This check looks for unused return values on a variety of C library functions.

#### Describe the solution
I resolved most of the warnings by printing out some kind of error message in the event that the function failed.

Many of them are low-level things whose failure indicates some sort of serious problem, so the errors are simply printed to `stderr`, because our usual error reporting infrastructure might not be available.

#### Describe alternatives you've considered
Many error-handling solutions are available.

#### Testing
clang-tidy; unit tests.

#### Additional context