### PR TITLE
Update JSON linting to not lie and ignore forbidden files

### DIFF
--- a/msvc-full-features/style-json.ps1
+++ b/msvc-full-features/style-json.ps1
@@ -35,14 +35,15 @@ if ( IsFileLocked( $formatter ) ) {
 
 # Probe for files changed in common "upstream" branches, only style those
 $gitChanged = @( git diff --name-only '*.json' )
-foreach ( $probe in @( 'master', 'origin/master', 'upstream/master', 'fork/master' ) ) {
+foreach ( $probe in @( 'master/data/json', 'master/data/mods', 'origin/master/data/json', 'origin/master/data/mods', 'upstream/master/data/json', 'upstream/master/data/mods', 'fork/master/data/json', 'fork/master/data/mods' ) ) {
 	$mergebase = Invoke-Expression "git merge-base $probe HEAD" 2>&1
 	if ( -not( $? ) ) {
 		continue # skip missing branches
 	}
 	$gitChanged = ( @( $gitChanged ) + @( git diff --name-only $mergebase '*.json' ) ) | Select-Object -Unique
 	if ( -not( $? ) ) {
-		ExitWithError( "Linting JSON skipped: git diff command failed." )
+#		ExitWithError( "Linting JSON skipped: git diff command failed." )
+    Exit 0 # No point spamming "error" messages because a no remote version of a file exists
 	}
 }
 
@@ -73,4 +74,5 @@ $gitChanged | ForEach-Object -Begin { $i = 0 } -Process { $i = $i+1 } {
 	} else {
 		Invoke-Expression "$formatter $_"
 	}
+  Write-Output "JSON linting done"
 } -End $null

--- a/msvc-full-features/style-json.ps1
+++ b/msvc-full-features/style-json.ps1
@@ -42,8 +42,7 @@ foreach ( $probe in @( 'master/data/json', 'master/data/mods', 'origin/master/da
 	}
 	$gitChanged = ( @( $gitChanged ) + @( git diff --name-only $mergebase '*.json' ) ) | Select-Object -Unique
 	if ( -not( $? ) ) {
-#		ExitWithError( "Linting JSON skipped: git diff command failed." )
-    Exit 0 # No point spamming "error" messages because a no remote version of a file exists
+    Exit 0 # No point spamming "error" messages because no remote version of a file exists
 	}
 }
 

--- a/tools/format/format_main.cpp
+++ b/tools/format/format_main.cpp
@@ -99,7 +99,7 @@ int main( int argc, char *argv[] )
             std::ofstream fout( filename, std::ios::binary | std::ios::trunc );
             fout << out.str();
             fout.close();
-            std::cout << color_bad << "Needs linting : " << color_end << filename << std::endl;
+            std::cout << color_bad << "Has been linted : " << color_end << filename << std::endl;
             std::cout << "Please read doc/JSON_STYLE.md" << std::endl;
             exit( EXIT_FAILURE );
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Update the Windows shell script for JSON linting to not process files that are forbidden to change into the formatters format by only processing the data/json and data/mods sub directories rather than the whole project.
- Update the shell script to stop spamming error messages when no remote version of a file exists.
- Report when the task is finished when there where any files to process (rather than having the user wait to see when file count lines stop appearing).
- Change the "error" message from json_formatter to say it changed the file rather than indicated that it just rejected it and it was up to the user to somehow format it manually.
 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Covered above.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Get rid of the references to JSON_STYLE.md. This file is useless in that it doesn't actually tell you what the rules are, just hints at some of them, and you've already found that you have to use the formatter (or the web version of it) to get the formatting to conform to the hidden rules anyway. Didn't do it solely because of the belief that reviewers would force it to be changed back, and so it would be a pointless exercise.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ran the script from VS (set up as per the instructions as they were a few months ago) and had it exit because no files were changed.
Changed a "random" JSON file (data/json/mapgen/basecamps/expansion/modular/farm/version_2/modular_farm_common.json) by adding a blank line in it and ran the script. Verified that the modified text was produced and that the JSON file was changed back.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->