### PR TITLE
Fix electric oil press

### DIFF
--- a/data/json/items/vehicle/utilities.json
+++ b/data/json/items/vehicle/utilities.json
@@ -250,6 +250,7 @@
     "category": "veh_parts",
     "color": "green",
     "symbol": "Y",
+    "ammo": "battery",
     "pocket_data": [
       { "pocket_type": "MAGAZINE_WELL", "flag_restriction": [ "BATTERY_HEAVY" ], "default_magazine": "heavy_battery_cell" }
     ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/65812

#### Describe the solution

Add missing ammo field

#### Describe alternatives you've considered

#### Testing

In the linked issue

#### Additional context
