### PR TITLE
Enable clang-tidy check modernize-use-emplace

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -79,7 +79,6 @@ readability-*,\
 -modernize-pass-by-value,\
 -modernize-return-braced-init-list,\
 -modernize-use-default-member-init,\
--modernize-use-emplace,\
 -modernize-use-nodiscard,\
 -performance-inefficient-vector-operation,\
 -performance-unnecessary-copy-initialization,\

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -876,7 +876,7 @@ void bookbinder_copy_activity_actor::finish( player_activity &act, Character &p 
         std::vector<tool_comp> writing_tools;
         writing_tools.reserve( writing_tools_filter.size() );
         for( const item *tool : writing_tools_filter ) {
-            writing_tools.emplace_back( tool_comp( tool->typeId(), 1 ) );
+            writing_tools.emplace_back( tool->typeId(), 1 );
         }
 
         p.consume_tools( writing_tools, pages );
@@ -6475,7 +6475,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
         // TODO: fix point types
         std::vector<tripoint_abs_ms> src_set;
         for( const tripoint &p : coord_set ) {
-            src_set.emplace_back( tripoint_abs_ms( p ) );
+            src_set.emplace_back( p );
         }
         // sort source tiles by distance
         const auto &src_sorted = get_sorted_tiles_by_distance( abspos, src_set );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1741,7 +1741,7 @@ static bool construction_activity( Character &you, const zone_data * /*zone*/,
     for( const std::vector<tool_comp> &it : built_chosen.requirements->get_tools() ) {
         you.consume_tools( it );
     }
-    you.backlog.push_front( player_activity( activity_to_restore ) );
+    you.backlog.emplace_front( activity_to_restore );
     you.assign_activity( ACT_BUILD );
     you.activity.placement = here.getglobal( src_loc );
     return true;
@@ -1985,7 +1985,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
         // TODO: fix point types
         std::vector<tripoint_abs_ms> src_set;
         for( const tripoint &p : act.coord_set ) {
-            src_set.emplace_back( tripoint_abs_ms( p ) );
+            src_set.emplace_back( p );
         }
         // sort source tiles by distance
         const auto &src_sorted = get_sorted_tiles_by_distance( abspos, src_set );
@@ -2797,7 +2797,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
             return requirement_check_result::SKIP_LOCATION;
         } else {
             if( !check_only ) {
-                you.backlog.push_front( player_activity( act_id ) );
+                you.backlog.emplace_front( act_id );
                 you.assign_activity( ACT_FETCH_REQUIRED );
                 player_activity &act_prev = you.backlog.front();
                 act_prev.str_values.push_back( what_we_need.str() );
@@ -2862,7 +2862,7 @@ static bool generic_multi_activity_do(
                here.has_flag( ter_furn_flag::TFLAG_PLOWABLE, src_loc ) &&
                you.has_quality( qual_DIG, 1 ) && !here.has_furn( src_loc ) ) {
         you.assign_activity( churn_activity_actor( 18000, item_location() ) );
-        you.backlog.push_front( player_activity( act_id ) );
+        you.backlog.emplace_front( act_id );
         you.activity.placement = src;
         return false;
     } else if( reason == do_activity_reason::NEEDS_PLANTING &&
@@ -2881,23 +2881,23 @@ static bool generic_multi_activity_do(
             }
             // TODO: fix point types
             iexamine::plant_seed( you, src_loc.raw(), itype_id( seed ) );
-            you.backlog.push_front( player_activity( act_id ) );
+            you.backlog.emplace_front( act_id );
             return false;
         }
     } else if( reason == do_activity_reason::NEEDS_CHOPPING && you.has_quality( qual_AXE, 1 ) ) {
         if( chop_plank_activity( you, src_loc ) ) {
-            you.backlog.push_front( player_activity( act_id ) );
+            you.backlog.emplace_front( act_id );
             return false;
         }
     } else if( reason == do_activity_reason::NEEDS_BUTCHERING ||
                reason == do_activity_reason::NEEDS_BIG_BUTCHERING ) {
         if( butcher_corpse_activity( you, src_loc, reason ) ) {
-            you.backlog.push_front( player_activity( act_id ) );
+            you.backlog.emplace_front( act_id );
             return false;
         }
     } else if( reason == do_activity_reason::CAN_DO_CONSTRUCTION ) {
         if( here.partial_con_at( src_loc ) ) {
-            you.backlog.push_front( player_activity( act_id ) );
+            you.backlog.emplace_front( act_id );
             you.assign_activity( ACT_BUILD );
             you.activity.placement = src;
             return false;
@@ -2920,11 +2920,11 @@ static bool generic_multi_activity_do(
         }
     } else if( reason == do_activity_reason::NEEDS_TREE_CHOPPING && you.has_quality( qual_AXE, 1 ) ) {
         if( chop_tree_activity( you, src_loc ) ) {
-            you.backlog.push_front( player_activity( act_id ) );
+            you.backlog.emplace_front( act_id );
             return false;
         }
     } else if( reason == do_activity_reason::NEEDS_FISHING && you.has_quality( qual_FISHING_ROD, 1 ) ) {
-        you.backlog.push_front( player_activity( act_id ) );
+        you.backlog.emplace_front( act_id );
         // we don't want to keep repeating the fishing activity, just piggybacking on this functions structure to find requirements.
         you.activity = player_activity();
         item &best_rod = you.best_item_with_quality( qual_FISHING_ROD );
@@ -2937,24 +2937,24 @@ static bool generic_multi_activity_do(
         return false;
     } else if( reason == do_activity_reason::NEEDS_MINING ) {
         // if have enough batteries to continue etc.
-        you.backlog.push_front( player_activity( act_id ) );
+        you.backlog.emplace_front( act_id );
         if( mine_activity( you, src_loc ) ) {
             return false;
         }
     } else if( reason == do_activity_reason::NEEDS_MOP ) {
         if( mop_activity( you, src_loc ) ) {
-            you.backlog.push_front( player_activity( act_id ) );
+            you.backlog.emplace_front( act_id );
             return false;
         }
     } else if( reason == do_activity_reason::NEEDS_VEH_DECONST ) {
         if( vehicle_activity( you, src_loc, you.activity_vehicle_part_index, 'o' ) ) {
-            you.backlog.push_front( player_activity( act_id ) );
+            you.backlog.emplace_front( act_id );
             return false;
         }
         you.activity_vehicle_part_index = -1;
     } else if( reason == do_activity_reason::NEEDS_VEH_REPAIR ) {
         if( vehicle_activity( you, src_loc, you.activity_vehicle_part_index, 'r' ) ) {
-            you.backlog.push_front( player_activity( act_id ) );
+            you.backlog.emplace_front( act_id );
             return false;
         }
 
@@ -2980,7 +2980,7 @@ static bool generic_multi_activity_do(
                     // Keep doing
                     // After assignment of disassemble activity (not multitype anymore)
                     // the backlog will not be nuked in do_player_activity()
-                    you.backlog.emplace_back( player_activity( ACT_MULTIPLE_DIS ) );
+                    you.backlog.emplace_back( ACT_MULTIPLE_DIS );
                     break;
                 }
             }

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -321,14 +321,14 @@ std::vector<std::pair<std::string, std::string>> collect_protection_subvalues(
             const bool display_median, const damage_type_id &type )
 {
     std::vector<std::pair<std::string, std::string>> subvalues;
-    subvalues.emplace_back( std::make_pair( _( "Worst:" ), string_format( "%.2f",
-                                            worst_res.type_resist( type ) ) ) );
+    subvalues.emplace_back( _( "Worst:" ), string_format( "%.2f",
+                            worst_res.type_resist( type ) ) );
     if( display_median ) {
-        subvalues.emplace_back( std::make_pair( _( "Median:" ), string_format( "%.2f",
-                                                median_res.type_resist( type ) ) ) );
+        subvalues.emplace_back( _( "Median:" ), string_format( "%.2f",
+                                median_res.type_resist( type ) ) );
     }
-    subvalues.emplace_back( std::make_pair( _( "Best:" ), string_format( "%.2f",
-                                            best_res.type_resist( type ) ) ) );
+    subvalues.emplace_back( _( "Best:" ), string_format( "%.2f",
+                            best_res.type_resist( type ) ) );
     return subvalues;
 }
 

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -242,10 +242,10 @@ auto_note_manager_gui::auto_note_manager_gui()
             continue;
         }
 
-        char_mapExtraCache.emplace( std::make_pair( extra.id, std::make_pair( extra,
-                                    settings.has_auto_note_enabled( extra.id, true ) ) ) );
-        global_mapExtraCache.emplace( std::make_pair( extra.id, std::make_pair( extra,
-                                      settings.has_auto_note_enabled( extra.id, false ) ) ) );
+        char_mapExtraCache.emplace( extra.id, std::make_pair( extra,
+                                    settings.has_auto_note_enabled( extra.id, true ) ) );
+        global_mapExtraCache.emplace( extra.id, std::make_pair( extra,
+                                      settings.has_auto_note_enabled( extra.id, false ) ) );
 
         if( settings.was_discovered( extra.id ) ) {
             char_displayCache.push_back( extra.id );

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -150,7 +150,7 @@ avatar::avatar()
     show_map_memory = true;
     active_mission = nullptr;
     grab_type = object_type::NONE;
-    calorie_diary.push_front( daily_calories{} );
+    calorie_diary.emplace_front( );
     a_diary = nullptr;
 }
 
@@ -1520,7 +1520,7 @@ void avatar::update_cardio_acc()
 
 void avatar::advance_daily_calories()
 {
-    calorie_diary.push_front( daily_calories{} );
+    calorie_diary.emplace_front( );
     if( calorie_diary.size() > 30 ) {
         calorie_diary.pop_back();
     }

--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -22,7 +22,7 @@ void node_t::add_predicate( const
                             std::function<status_t ( const oracle_t *, const std::string & )> &
                             new_predicate, const std::string &argument, const bool &invert_result )
 {
-    conditions.emplace_back( std::make_tuple( new_predicate, argument, invert_result ) );
+    conditions.emplace_back( new_predicate, argument, invert_result );
 }
 void node_t::set_goal( const std::string &new_goal )
 {
@@ -162,8 +162,8 @@ void node_t::load( const JsonObject &jo, const std::string_view )
         }
         const std::string predicate_argument = predicate_object.get_string( "argument", "" );
         const bool invert_result = predicate_object.get_bool( "invert_result", false );
-        conditions.emplace_back( std::make_tuple( new_predicate->second, predicate_argument,
-                                 invert_result ) );
+        conditions.emplace_back( new_predicate->second, predicate_argument,
+                                 invert_result );
     }
     optional( jo, was_loaded, "goal", _goal );
 }

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1033,7 +1033,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             for( auto it = stack.begin(); it != stack.end(); it++ ) {
                 if( it->weight() < weight_cap &&
                     it->made_of_any( affected_materials ) ) {
-                    affected.emplace_back( std::make_pair( *it, p ) );
+                    affected.emplace_back( *it, p );
                     stack.erase( it );
                     break;
                 }

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -418,12 +418,12 @@ void bodygraph_display::prepare_partlist()
     partlist.clear();
     for( const auto &bgp : id->parts ) {
         for( const bodypart_id &bid : bgp.second.bodyparts ) {
-            partlist.emplace_back( std::make_tuple( bid, static_cast<const sub_body_part_type *>( nullptr ),
-                                                    &bgp.second, u->has_part( bid ) ) );
+            partlist.emplace_back( bid, static_cast<const sub_body_part_type *>( nullptr ),
+                                   &bgp.second, u->has_part( bid ) );
         }
         for( const sub_bodypart_id &sid : bgp.second.sub_bodyparts ) {
             const bodypart_id bid = sid->parent.id();
-            partlist.emplace_back( std::make_tuple( bid, &*sid, &bgp.second, u->has_part( bid ) ) );
+            partlist.emplace_back( bid, &*sid, &bgp.second, u->has_part( bid ) );
         }
     }
     std::sort( partlist.begin(), partlist.end(),
@@ -639,7 +639,7 @@ std::vector<std::string> get_bodygraph_lines( const Character &u,
                 txt.insert( txt.begin(), center_text_pos( txt, 0, width ), ' ' );
                 ret.emplace_back( colorize( txt, c_light_red ) );
             } else {
-                ret.emplace_back( std::string( width, ' ' ) );
+                ret.emplace_back( width, ' ' );
             }
         }
         return ret;

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -319,7 +319,7 @@ plot_options::query_seed_result plot_options::query_seed()
         }
     }
     std::vector<seed_tuple> seed_entries = iexamine::get_seed_entries( seed_inv );
-    seed_entries.emplace( seed_entries.begin(), seed_tuple( itype_null, _( "No seed" ), 0 ) );
+    seed_entries.emplace( seed_entries.begin(), itype_null, _( "No seed" ), 0 );
 
     int seed_index = iexamine::query_seed( seed_entries );
 
@@ -394,8 +394,8 @@ std::string unload_options::get_zone_name_suggestion() const
 std::vector<std::pair<std::string, std::string>> loot_options::get_descriptions() const
 {
     std::vector<std::pair<std::string, std::string>> options;
-    options.emplace_back( std::make_pair( _( "Loot: Custom: " ),
-                                          !mark.empty() ? mark : _( "No filter" ) ) );
+    options.emplace_back( _( "Loot: Custom: " ),
+                          !mark.empty() ? mark : _( "No filter" ) );
 
     return options;
 }
@@ -403,9 +403,9 @@ std::vector<std::pair<std::string, std::string>> loot_options::get_descriptions(
 std::vector<std::pair<std::string, std::string>> unload_options::get_descriptions() const
 {
     std::vector<std::pair<std::string, std::string>> options;
-    options.emplace_back( std::make_pair( _( "Unload: " ),
-                                          string_format( "%s%s%s", mods ? _( "mods " ) : "",  molle ? _( "MOLLE " ) : "",
-                                                  always_unload ? _( "unload all" ) : _( "unload unmatched" ) ) ) );
+    options.emplace_back( _( "Unload: " ),
+                          string_format( "%s%s%s", mods ? _( "mods " ) : "",  molle ? _( "MOLLE " ) : "",
+                                         always_unload ? _( "unload all" ) : _( "unload unmatched" ) ) );
 
     return options;
 }
@@ -484,8 +484,8 @@ std::vector<std::pair<std::string, std::string>> blueprint_options::get_descript
 {
     std::vector<std::pair<std::string, std::string>> options =
                 std::vector<std::pair<std::string, std::string>>();
-    options.emplace_back( std::make_pair( _( "Construct: " ),
-                                          group ? group->name() : _( "No Construction" ) ) );
+    options.emplace_back( _( "Construct: " ),
+                          group ? group->name() : _( "No Construction" ) );
 
     return options;
 }
@@ -494,8 +494,8 @@ std::vector<std::pair<std::string, std::string>> plot_options::get_descriptions(
 {
     auto options = std::vector<std::pair<std::string, std::string>>();
     options.emplace_back(
-        std::make_pair( _( "Plant seed: " ),
-                        !seed.is_empty() ? item::nname( itype_id( seed ) ) : _( "No seed" ) ) );
+        _( "Plant seed: " ),
+        !seed.is_empty() ? item::nname( itype_id( seed ) ) : _( "No seed" ) );
 
     return options;
 }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -997,7 +997,7 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
     if( player_character.has_trait( trait_DEBUG_HS ) ) {
         // Gift components
         for( const auto &it : con.requirements->get_components() ) {
-            used.emplace_back( item( it.front().type ) );
+            used.emplace_back( it.front().type );
         }
     } else {
         // Use up the components

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -300,9 +300,9 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
                                     iname = tmp_i.tname( 1U, true );
                                 }
                                 if( const std::optional<vpart_reference> vp = m.veh_at( p ).part_with_feature( "CARGO", true ) ) {
-                                    veh_items.emplace_back( std::pair<const vpart_reference, item>( vp.value(), tmp_i ) );
+                                    veh_items.emplace_back( vp.value(), tmp_i );
                                 } else {
-                                    map_items.emplace_back( std::pair<const tripoint, item>( p, tmp_i ) );
+                                    map_items.emplace_back( p, tmp_i );
                                 }
                             }
                             if( cont_not_empty && ( no_prompt || !query_yn( liq_cont_msg, iname ) ) ) {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -426,8 +426,8 @@ static int player_uilist()
         { uilist_entry( debug_menu_index::CONTROL_NPC, true, 'x', _( "Control NPC follower" ) ) },
     };
     if( !spell_type::get_all().empty() ) {
-        uilist_initializer.emplace_back( uilist_entry( debug_menu_index::CHANGE_SPELLS, true, 'S',
-                                         _( "Change spells" ) ) );
+        uilist_initializer.emplace_back( debug_menu_index::CHANGE_SPELLS, true, 'S',
+                                         _( "Change spells" ) );
     }
 
     return uilist( _( "Player…" ), uilist_initializer );
@@ -516,8 +516,8 @@ static int teleport_uilist()
     };
 
     const bool teleport_city_enabled = get_option<bool>( "SELECT_STARTING_CITY" );
-    uilist_initializer.emplace_back( uilist_entry( debug_menu_index::OM_TELEPORT_CITY,
-                                     teleport_city_enabled, 'c', _( "Teleport - specific city" ) ) );
+    uilist_initializer.emplace_back( debug_menu_index::OM_TELEPORT_CITY,
+                                     teleport_city_enabled, 'c', _( "Teleport - specific city" ) );
 
     return uilist( _( "Teleport…" ), uilist_initializer );
 }

--- a/src/dependency_tree.cpp
+++ b/src/dependency_tree.cpp
@@ -75,7 +75,7 @@ void dependency_node::check_cyclicity()
 
         if( nodes_visited.find( check->key ) != nodes_visited.end() ) {
             if( all_errors[CYCLIC].empty() ) {
-                all_errors[CYCLIC].push_back( "Error: Circular Dependency Circuit Found!" );
+                all_errors[CYCLIC].emplace_back( "Error: Circular Dependency Circuit Found!" );
             }
             continue;
         }
@@ -389,7 +389,7 @@ void dependency_tree::check_for_strongly_connected_components()
     }
     // now go back through this and give them all the circular error code!
     for( dependency_node * const &elem : in_circular_connection ) {
-        elem->all_errors[CYCLIC].push_back( "In Circular Dependency Cycle" );
+        elem->all_errors[CYCLIC].emplace_back( "In Circular Dependency Cycle" );
     }
 }
 

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -184,7 +184,7 @@ static void do_blast( const Creature *source, const tripoint &p, const float pow
     std::set<tripoint> closed;
     std::set<tripoint> bashed{ p };
     std::map<tripoint, float> dist_map;
-    open.push( std::make_pair( 0.0f, p ) );
+    open.emplace( 0.0f, p );
     dist_map[p] = 0.0f;
     // Find all points to blast
     while( !open.empty() ) {
@@ -258,7 +258,7 @@ static void do_blast( const Creature *source, const tripoint &p, const float pow
             }
 
             if( dist_map.count( dest ) == 0 || dist_map[dest] > next_dist ) {
-                open.push( std::make_pair( next_dist, dest ) );
+                open.emplace( next_dist, dest );
                 dist_map[dest] = next_dist;
             }
         }

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -275,17 +275,17 @@ void field_type::load( const JsonObject &jo, const std::string_view )
         immunity_data_flags.emplace_back( id );
     }
     for( JsonArray jao : jid.get_array( "body_part_env_resistance" ) ) {
-        immunity_data_body_part_env_resistance.emplace_back( std::make_pair(
-                    io::string_to_enum<body_part_type::type>( jao.get_string( 0 ) ), jao.get_int( 1 ) ) );
+        immunity_data_body_part_env_resistance.emplace_back( io::string_to_enum<body_part_type::type>
+                ( jao.get_string( 0 ) ), jao.get_int( 1 ) );
     }
     for( JsonArray jao : jid.get_array( "immunity_flags_worn" ) ) {
-        immunity_data_part_item_flags.emplace_back( std::make_pair(
-                    io::string_to_enum<body_part_type::type>( jao.get_string( 0 ) ), jao.get_string( 1 ) ) );
+        immunity_data_part_item_flags.emplace_back( io::string_to_enum<body_part_type::type>
+                ( jao.get_string( 0 ) ), jao.get_string( 1 ) );
     }
 
     for( JsonArray jao : jid.get_array( "immunity_flags_worn_any" ) ) {
-        immunity_data_part_item_flags_any.emplace_back( std::make_pair(
-                    io::string_to_enum<body_part_type::type>( jao.get_string( 0 ) ), jao.get_string( 1 ) ) );
+        immunity_data_part_item_flags_any.emplace_back( io::string_to_enum<body_part_type::type>
+                ( jao.get_string( 0 ) ), jao.get_string( 1 ) );
     }
 
     optional( jo, was_loaded, "immune_mtypes", immune_mtypes );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -324,7 +324,7 @@ input_context game::get_player_input( std::string &action )
                     if( m.is_outside( mapp ) && m.get_visibility( lighting, cache ) == visibility_type::CLEAR &&
                         !creatures.creature_at( mapp, true ) ) {
                         // Suppress if a critter is there
-                        wPrint.vdrops.emplace_back( std::make_pair( iRand.x, iRand.y ) );
+                        wPrint.vdrops.emplace_back( iRand.x, iRand.y );
                     }
                 }
             }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -6383,7 +6383,7 @@ void iexamine::workbench_internal( Character &you, const tripoint &examp,
 
         for( item &it : items_at_part ) {
             if( it.is_craft() ) {
-                crafts.emplace_back( item_location( vehicle_cursor( part->vehicle(), part->part_index() ), &it ) );
+                crafts.emplace_back( vehicle_cursor( part->vehicle(), part->part_index() ), &it );
             }
         }
     } else {
@@ -6397,7 +6397,7 @@ void iexamine::workbench_internal( Character &you, const tripoint &examp,
 
         for( item &it : items_at_furn ) {
             if( it.is_craft() ) {
-                crafts.emplace_back( item_location( map_cursor( examp ), &it ) );
+                crafts.emplace_back( map_cursor( examp ), &it );
             }
         }
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3796,7 +3796,7 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
     if( parts->test( iteminfo_parts::ARMOR_COVERAGE ) && covers_anything ) {
         std::map<int, std::vector<bodypart_id>> limb_groups;
         for( const bodypart_str_id &bp : get_covered_body_parts() ) {
-            limb_groups[portion_for_bodypart( bp )->coverage].push_back( bp );
+            limb_groups[portion_for_bodypart( bp )->coverage].emplace_back( bp );
         }
         // keep on one line if only 1 entry
         if( limb_groups.size() == 1 ) {
@@ -3825,7 +3825,7 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
             armor_encumb_data encumbrance( get_encumber( c, bp, item::encumber_flags::assume_empty ),
                                            get_encumber( c, bp ), get_encumber( c, bp, item::encumber_flags::assume_full ) );
 
-            limb_groups[encumbrance].push_back( bp );
+            limb_groups[encumbrance].emplace_back( bp );
         }
         // keep on one line if only 1 entry
         if( limb_groups.size() == 1 ) {
@@ -3868,7 +3868,7 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         // TODO: Make this less inflexible on anatomy
         std::map<int, std::vector<bodypart_id>> limb_groups;
         for( const bodypart_str_id &bp : get_covered_body_parts() ) {
-            limb_groups[get_warmth( bp )].push_back( bp );
+            limb_groups[get_warmth( bp )].emplace_back( bp );
         }
         // keep on one line if only 1 entry
         if( limb_groups.size() == 1 ) {
@@ -3891,7 +3891,7 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
 
         std::map<int, std::vector<bodypart_id>> limb_groups;
         for( const bodypart_str_id &bp : get_covered_body_parts() ) {
-            limb_groups[portion_for_bodypart( bp )->breathability].push_back( bp );
+            limb_groups[portion_for_bodypart( bp )->breathability].emplace_back( bp );
         }
         // keep on one line if only 1 entry
         if( limb_groups.size() == 1 ) {
@@ -4542,7 +4542,7 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                                           total_recipes ), total_recipes );
 
             insert_separation_line( info );
-            info.emplace_back( iteminfo( "DESCRIPTION", recipe_line ) );
+            info.emplace_back( "DESCRIPTION", recipe_line );
 
             if( !known_recipe_list.empty() ) {
                 const std::string recipe_line =
@@ -4551,7 +4551,7 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                                               known_recipe_list.size() ),
                                    known_recipe_list.size(), enumerate_lcsorted_with_limit( known_recipe_list ) );
 
-                info.emplace_back( iteminfo( "DESCRIPTION", recipe_line ) );
+                info.emplace_back( "DESCRIPTION", recipe_line );
             }
 
             if( !learnable_recipe_list.empty() ) {
@@ -4561,7 +4561,7 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                                               learnable_recipe_list.size() ),
                                    learnable_recipe_list.size(), enumerate_lcsorted_with_limit( learnable_recipe_list ) );
 
-                info.emplace_back( iteminfo( "DESCRIPTION", recipe_line ) );
+                info.emplace_back( "DESCRIPTION", recipe_line );
             }
 
             if( !unlearnable_recipe_list.empty() ) {
@@ -4571,7 +4571,7 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                                               unlearnable_recipe_list.size() ),
                                    unlearnable_recipe_list.size(), enumerate_lcsorted_with_limit( unlearnable_recipe_list ) );
 
-                info.emplace_back( iteminfo( "DESCRIPTION", recipe_line ) );
+                info.emplace_back( "DESCRIPTION", recipe_line );
             }
         }
     }
@@ -4637,8 +4637,8 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                                           total_ebooks ), total_ebooks );
 
             insert_separation_line( info );
-            info.emplace_back( iteminfo( "DESCRIPTION", recipe_line ) );
-            info.emplace_back( iteminfo( "DESCRIPTION", source_line ) );
+            info.emplace_back( "DESCRIPTION", recipe_line );
+            info.emplace_back( "DESCRIPTION", source_line );
 
             if( !known_recipe_list.empty() ) {
                 const std::string recipe_line =
@@ -4647,7 +4647,7 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                                               known_recipe_list.size() ),
                                    known_recipe_list.size(), enumerate_lcsorted_with_limit( known_recipe_list ) );
 
-                info.emplace_back( iteminfo( "DESCRIPTION", recipe_line ) );
+                info.emplace_back( "DESCRIPTION", recipe_line );
             }
 
             if( !learnable_recipe_list.empty() ) {
@@ -4657,7 +4657,7 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                                               learnable_recipe_list.size() ),
                                    learnable_recipe_list.size(), enumerate_lcsorted_with_limit( learnable_recipe_list ) );
 
-                info.emplace_back( iteminfo( "DESCRIPTION", recipe_line ) );
+                info.emplace_back( "DESCRIPTION", recipe_line );
             }
 
             if( !unlearnable_recipe_list.empty() ) {
@@ -4667,7 +4667,7 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                                               unlearnable_recipe_list.size() ),
                                    unlearnable_recipe_list.size(), enumerate_lcsorted_with_limit( unlearnable_recipe_list ) );
 
-                info.emplace_back( iteminfo( "DESCRIPTION", recipe_line ) );
+                info.emplace_back( "DESCRIPTION", recipe_line );
             }
         }
     }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1461,7 +1461,7 @@ void Item_factory::finalize_item_blacklist()
         if( maybe_ammo != m_templates.end() && maybe_ammo->second.ammo ) {
             auto replacement = m_templates.find( parent->replace );
             if( replacement->second.ammo ) {
-                migrated_ammo.emplace( std::make_pair( migrate.first, replacement->second.ammo->type ) );
+                migrated_ammo.emplace( migrate.first, replacement->second.ammo->type );
             } else {
                 debugmsg( "Replacement item %s for migrated ammo %s is not ammo.",
                           parent->replace.str(), migrate.first.str() );
@@ -1473,7 +1473,7 @@ void Item_factory::finalize_item_blacklist()
         if( maybe_mag != m_templates.end() && maybe_mag->second.magazine ) {
             auto replacement = m_templates.find( parent->replace );
             if( replacement->second.magazine ) {
-                migrated_magazines.emplace( std::make_pair( migrate.first, parent->replace ) );
+                migrated_magazines.emplace( migrate.first, parent->replace );
             } else {
                 debugmsg( "Replacement item %s for migrated magazine %s is not a magazine.",
                           parent->replace.str(), migrate.first.str() );
@@ -1521,7 +1521,7 @@ void Item_factory::load_item_blacklist( const JsonObject &json )
     bool whitelist = json.get_bool( "whitelist" );
     std::set<itype_id> tmp_blacklist;
     json.read( "items", tmp_blacklist, true );
-    item_blacklist.sub_blacklist.emplace_back( std::make_pair( whitelist, tmp_blacklist ) );
+    item_blacklist.sub_blacklist.emplace_back( whitelist, tmp_blacklist );
 }
 
 Item_factory::~Item_factory() = default;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -874,7 +874,7 @@ void place_monster_iuse::load( const JsonObject &obj )
     if( obj.has_array( "skills" ) ) {
         JsonArray skills_ja = obj.get_array( "skills" );
         for( JsonValue s : skills_ja ) {
-            skills.emplace( skill_id( s.get_string() ) );
+            skills.emplace( s.get_string() );
         }
     }
 }
@@ -2381,7 +2381,7 @@ std::optional<int> cast_spell_actor::use( Character &p, item &it, bool, const tr
         cast_spell.values.emplace_back( 0 );
     }
     p.assign_activity( cast_spell );
-    p.activity.targets.emplace_back( item_location( p, &it ) );
+    p.activity.targets.emplace_back( p, &it );
     // Actual handling of charges_to_use is in activity_handlers::spellcasting_finish
     return 0;
 }

--- a/src/iuse_software_sokoban.cpp
+++ b/src/iuse_software_sokoban.cpp
@@ -91,8 +91,8 @@ void sokoban_game::parse_level( std::istream &fin )
             }
 
             if( sLine[i] == '.' || sLine[i] == '*' || sLine[i] == '+' ) {
-                vLevelDone[iNumLevel].push_back( std::make_pair( static_cast<int>
-                                                 ( mLevelInfo[iNumLevel]["MaxLevelY"] ), static_cast<int>( i ) ) );
+                vLevelDone[iNumLevel].emplace_back( static_cast<int>
+                                                    ( mLevelInfo[iNumLevel]["MaxLevelY"] ), static_cast<int>( i ) );
             }
 
             vLevel[iNumLevel][mLevelInfo[iNumLevel]["MaxLevelY"]][i] = sLine[i];

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2197,11 +2197,11 @@ void spellcasting_callback::spell_info_text( const spell &sp, int width )
     for( const std::string &line : foldstring( sp.description(), width ) ) {
         info_txt.emplace_back( colorize( line, c_light_gray ) );
     }
-    info_txt.emplace_back( std::string() );
+    info_txt.emplace_back( );
     for( const std::string &line : foldstring( spell_desc::enumerate_spell_data( sp, pc ), width ) ) {
         info_txt.emplace_back( colorize( line, c_light_gray ) );
     }
-    info_txt.emplace_back( std::string() );
+    info_txt.emplace_back( );
 
     auto columnize = [&width]( const std::string & col1, const std::string & col2 ) {
         std::string line = col1;
@@ -2224,7 +2224,7 @@ void spellcasting_callback::spell_info_text( const spell &sp, int width )
                              string_format( "%s: %s", _( "to Next Level" ),
                                             colorize( std::to_string( sp.exp_to_next_level() ), c_light_green ) ) ), c_light_gray ) );
 
-    info_txt.emplace_back( std::string() );
+    info_txt.emplace_back( );
 
     const bool cost_encumb = spell_desc::energy_cost_encumbered( sp, pc );
     std::string cost_string = cost_encumb ? _( "Casting Cost (impeded)" ) : _( "Casting Cost" );
@@ -2243,7 +2243,7 @@ void spellcasting_callback::spell_info_text( const spell &sp, int width )
         colorize( string_format( "%s: %s", c_t_encumb ? _( "Casting Time (impeded)" ) : _( "Casting Time" ),
                                  moves_to_string( sp.casting_time( pc ) ) ), c_t_encumb  ? c_red : c_light_gray ) );
 
-    info_txt.emplace_back( std::string() );
+    info_txt.emplace_back( );
 
     std::string targets;
     if( sp.is_valid_target( spell_target::none ) ) {
@@ -2254,7 +2254,7 @@ void spellcasting_callback::spell_info_text( const spell &sp, int width )
     info_txt.emplace_back(
         colorize( string_format( "%s: %s", _( "Valid Targets" ), targets ), c_light_gray ) );
 
-    info_txt.emplace_back( std::string() );
+    info_txt.emplace_back( );
 
     std::string target_ids;
     target_ids = sp.list_targeted_monster_names();
@@ -2263,7 +2263,7 @@ void spellcasting_callback::spell_info_text( const spell &sp, int width )
              foldstring( string_format( _( "Only affects the monsters: %s" ), target_ids ), width ) ) {
             info_txt.emplace_back( colorize( line, c_light_gray ) );
         }
-        info_txt.emplace_back( std::string() );
+        info_txt.emplace_back( );
     }
 
     const int damage = sp.damage( pc );

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -2093,7 +2093,7 @@ void map::propagate_field( const tripoint &center, const field_type_id &type, in
     using gas_blast = std::pair<float, tripoint>;
     std::priority_queue<gas_blast, std::vector<gas_blast>, pair_greater_cmp_first> open;
     std::set<tripoint> closed;
-    open.push( { 0.0f, center } );
+    open.emplace( 0.0f, center );
 
     const bool not_gas = type.obj().phase != phase_id::GAS;
 
@@ -2147,7 +2147,7 @@ void map::propagate_field( const tripoint &center, const field_type_id &type, in
                     continue;
                 }
 
-                open.push( { static_cast<float>( rl_dist( center, pt ) ), pt } );
+                open.emplace( static_cast<float>( rl_dist( center, pt ) ), pt );
             }
         }
     }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3046,7 +3046,7 @@ class jmapgen_computer : public jmapgen_piece
             }
             if( jsi.has_array( "eocs" ) ) {
                 for( const std::string &eoc : jsi.get_string_array( "eocs" ) ) {
-                    eocs.emplace_back( effect_on_condition_id( eoc ) );
+                    eocs.emplace_back( eoc );
                 }
             }
             if( jsi.has_array( "chat_topics" ) ) {
@@ -3324,7 +3324,7 @@ class jmapgen_remove_vehicles : public jmapgen_piece
         std::vector<vproto_id> vehicles_to_remove;
         jmapgen_remove_vehicles( const JsonObject &jo, const std::string_view/*context*/ ) {
             for( std::string item_id : jo.get_string_array( "vehicles" ) ) {
-                vehicles_to_remove.emplace_back( vproto_id( item_id ) );
+                vehicles_to_remove.emplace_back( item_id );
             }
         }
         mapgen_phase phase() const override {

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -87,7 +87,7 @@ void material_type::load( const JsonObject &jsobj, const std::string_view )
         JsonObject jo = jsobj.get_object( "resist" );
         _resistances = load_resistances_instance( jo );
         for( const JsonMember &jmemb : jo ) {
-            _res_was_loaded.emplace_back( damage_type_id( jmemb.name() ) );
+            _res_was_loaded.emplace_back( jmemb.name() );
         }
     }
 

--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -242,7 +242,7 @@ std::vector<MonsterGroupResult> MonsterGroupManager::GetResultFromGroup(
             }
         } else if( use_pack_size ) {
             for( int i = 0; i < pack_size; i++ ) {
-                spawn_details.emplace_back( MonsterGroupResult( entry.name, pack_size, entry.data ) );
+                spawn_details.emplace_back( entry.name, pack_size, entry.data );
                 // And if a quantity pointer with remaining value was passed, will modify the external
                 // value as a side effect.  We will reduce it by the spawn rule's cost multiplier.
                 if( quantity ) {
@@ -250,7 +250,7 @@ std::vector<MonsterGroupResult> MonsterGroupManager::GetResultFromGroup(
                 }
             }
         } else {
-            spawn_details.emplace_back( MonsterGroupResult( entry.name, pack_size, entry.data ) );
+            spawn_details.emplace_back( entry.name, pack_size, entry.data );
             // And if a quantity pointer with remaining value was passed, will modify the external
             // value as a side effect.  We will reduce it by the spawn rule's cost multiplier.
             if( quantity ) {
@@ -270,7 +270,7 @@ std::vector<MonsterGroupResult> MonsterGroupManager::GetResultFromGroup(
     }
 
     if( !is_recursive && spawn_details.empty() ) {
-        spawn_details.emplace_back( MonsterGroupResult( group.defaultMonster, 1, spawn_data() ) );
+        spawn_details.emplace_back( group.defaultMonster, 1, spawn_data() );
         if( returned_default ) {
             ( *returned_default ) = true;
         }

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -811,7 +811,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     if( jo.has_array( "weakpoint_sets" ) ) {
         weakpoints_deferred.clear();
         for( JsonValue jval : jo.get_array( "weakpoint_sets" ) ) {
-            weakpoints_deferred.emplace_back( weakpoints_id( jval.get_string() ) );
+            weakpoints_deferred.emplace_back( jval.get_string() );
         }
     }
 
@@ -893,10 +893,10 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         absorb_material.clear();
         if( jo.has_array( "absorb_material" ) ) {
             for( std::string mat : jo.get_string_array( "absorb_material" ) ) {
-                absorb_material.emplace_back( material_id( mat ) );
+                absorb_material.emplace_back( mat );
             }
         } else {
-            absorb_material.emplace_back( material_id( jo.get_string( "absorb_material" ) ) );
+            absorb_material.emplace_back( jo.get_string( "absorb_material" ) );
         }
     }
 

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -503,7 +503,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string &src )
     }
 
     for( const std::string s : jo.get_array( "no_cbm_on_bp" ) ) {
-        no_cbm_on_bp.emplace( bodypart_str_id( s ) );
+        no_cbm_on_bp.emplace( s );
     }
 
     optional( jo, was_loaded, "category", category, string_id_reader<mutation_category_trait> {} );
@@ -600,7 +600,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string &src )
     }
 
     for( const JsonValue jv : jo.get_array( "integrated_armor" ) ) {
-        integrated_armor.emplace_back( itype_id( jv ) );
+        integrated_armor.emplace_back( jv );
     }
 
     for( JsonMember member : jo.get_object( "bionic_slot_bonuses" ) ) {
@@ -980,12 +980,12 @@ void mutation_branch::finalize_all()
     trait_factory.finalize();
     for( const mutation_branch &branch : get_all() ) {
         for( const mutation_category_id &cat : branch.category ) {
-            mutations_category[cat].push_back( trait_id( branch.id ) );
+            mutations_category[cat].emplace_back( branch.id );
         }
         // Don't include dummy mutations for the ANY category, since they have a very specific use case
         // Otherwise, the system will prioritize them
         if( !branch.dummy ) {
-            mutations_category[mutation_category_ANY].push_back( trait_id( branch.id ) );
+            mutations_category[mutation_category_ANY].emplace_back( branch.id );
         }
     }
     finalize_trait_blacklist();

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1255,11 +1255,11 @@ static struct {
 static void add_trait( std::vector<trait_and_var> &to, const trait_id &trait )
 {
     if( trait->variants.empty() ) {
-        to.emplace_back( trait_and_var( trait, "" ) );
+        to.emplace_back( trait, "" );
         return;
     }
     for( const std::pair<const std::string, mutation_variant> &var : trait->variants ) {
-        to.emplace_back( trait_and_var( trait, var.first ) );
+        to.emplace_back( trait, var.first );
     }
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -312,10 +312,10 @@ void npc_template::load( const JsonObject &jsobj )
     guy.mission = static_cast<npc_mission>( jsobj.get_int( "mission" ) );
     guy.chatbin.first_topic = jsobj.get_string( "chat" );
     if( jsobj.has_string( "mission_offered" ) ) {
-        guy.miss_ids.emplace_back( mission_type_id( jsobj.get_string( "mission_offered" ) ) );
+        guy.miss_ids.emplace_back( jsobj.get_string( "mission_offered" ) );
     } else if( jsobj.has_array( "mission_offered" ) ) {
         for( const std::string line : jsobj.get_array( "mission_offered" ) ) {
-            guy.miss_ids.emplace_back( mission_type_id( line ) );
+            guy.miss_ids.emplace_back( line );
         }
     }
     if( jsobj.has_string( "talk_radio" ) ) {

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -589,7 +589,7 @@ std::vector<npc_attack_rating> npc_attack_activate_item::all_evaluations( const 
     }
     // until we have better logic for grenades it's better to keep this as a last resort...
     const int emergency = source.emergency() ? 1 : 0;
-    effectiveness.emplace_back( npc_attack_rating( emergency, source.pos() ) );
+    effectiveness.emplace_back( emergency, source.pos() );
     return effectiveness;
 }
 

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1648,10 +1648,10 @@ overmapbuffer::t_notes_vector overmapbuffer::get_notes( int z, const std::string
                     // pattern not found in note text
                     continue;
                 }
-                result.push_back( t_point_with_note(
-                                      project_combine( om.pos(), p.xy() ),
-                                      om.note( p )
-                                  ) );
+                result.emplace_back(
+                    project_combine( om.pos(), p.xy() ),
+                    om.note( p )
+                );
             }
         }
     }
@@ -1675,10 +1675,10 @@ overmapbuffer::t_extras_vector overmapbuffer::get_extras( int z, const std::stri
                     // pattern not found in note text
                     continue;
                 }
-                result.push_back( t_point_with_extra(
-                                      project_combine( om.pos(), p.xy() ),
-                                      om.extra( p )
-                                  ) );
+                result.emplace_back(
+                    project_combine( om.pos(), p.xy() ),
+                    om.extra( p )
+                );
             }
         }
     }

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -349,11 +349,11 @@ static std::vector<window_panel> initialize_default_custom_panels( const widget 
 
     // Add compass, message log, and map to fill remaining space
     // TODO: Make these into proper widgets
-    ret.emplace_back( window_panel( draw_messages, "Log", to_translation( "Log" ),
-                                    -2, width, true ) );
+    ret.emplace_back( draw_messages, "Log", to_translation( "Log" ),
+                      -2, width, true );
 #if defined(TILES)
-    ret.emplace_back( window_panel( draw_mminimap, "Map", to_translation( "Map" ),
-                                    -1, width, true, default_render, true ) );
+    ret.emplace_back( draw_mminimap, "Map", to_translation( "Map" ),
+                      -1, width, true, default_render, true );
 #endif // TILES
 
     return ret;

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -100,7 +100,7 @@ struct pathfinder {
         layer.gscore[index] = gscore;
         layer.parent[index] = from;
         layer.score [index] = score;
-        open.push( std::make_pair( score, to ) );
+        open.emplace( score, to );
     }
 
     void close_point( const tripoint &p ) {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -376,20 +376,20 @@ void recipe::load( const JsonObject &jo, const std::string &src )
                 bp_resources.emplace_back( resource );
             }
             for( JsonObject provide : jo.get_array( "blueprint_provides" ) ) {
-                bp_provides.emplace_back( std::make_pair( provide.get_string( "id" ),
-                                          provide.get_int( "amount", 1 ) ) );
+                bp_provides.emplace_back( provide.get_string( "id" ),
+                                          provide.get_int( "amount", 1 ) );
             }
             // all blueprints provide themselves with needing it written in JSON
-            bp_provides.emplace_back( std::make_pair( result_.str(), 1 ) );
+            bp_provides.emplace_back( result_.str(), 1 );
             for( JsonObject require : jo.get_array( "blueprint_requires" ) ) {
-                bp_requires.emplace_back( std::make_pair( require.get_string( "id" ),
-                                          require.get_int( "amount", 1 ) ) );
+                bp_requires.emplace_back( require.get_string( "id" ),
+                                          require.get_int( "amount", 1 ) );
             }
             // all blueprints exclude themselves with needing it written in JSON
-            bp_excludes.emplace_back( std::make_pair( result_.str(), 1 ) );
+            bp_excludes.emplace_back( result_.str(), 1 );
             for( JsonObject exclude : jo.get_array( "blueprint_excludes" ) ) {
-                bp_excludes.emplace_back( std::make_pair( exclude.get_string( "id" ),
-                                          exclude.get_int( "amount", 1 ) ) );
+                bp_excludes.emplace_back( exclude.get_string( "id" ),
+                                          exclude.get_int( "amount", 1 ) );
             }
             check_blueprint_needs = jo.get_bool( "check_blueprint_needs", true );
             bool has_needs = jo.has_member( "blueprint_needs" );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -710,10 +710,10 @@ void overmap::unserialize_omap( const JsonValue &jsin, const cata_path &json_pat
                     count--;
                     layer[z + OVERMAP_DEPTH].terrain[i][j] = tmp_otid;
                     if( tmp_otid == oter_lake_shore || tmp_otid == oter_lake_surface ) {
-                        lake_points.emplace_back( tripoint_om_omt( i, j, z ) );
+                        lake_points.emplace_back( i, j, z );
                     }
                     if( tmp_otid == oter_forest || tmp_otid == oter_forest_thick ) {
-                        forest_points.emplace_back( tripoint_om_omt( i, j, z ) );
+                        forest_points.emplace_back( i, j, z );
                     }
                 }
             }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3299,7 +3299,7 @@ void vehicle_part::deserialize( const JsonObject &data )
 
     if( migration != nullptr ) {
         for( const itype_id &it : migration->add_veh_tools ) {
-            tools.emplace_back( item( it, calendar::turn ) );
+            tools.emplace_back( it, calendar::turn );
         }
     }
 }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -325,10 +325,10 @@ void sounds::sound( const tripoint &p, int vol, sound_t category, const std::str
     }
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
-    recent_sounds.emplace_back( std::make_pair( p, monster_sound_event{ vol, is_provocative( category ) } ) );
-    sounds_since_last_turn.emplace_back( std::make_pair( p,
+    recent_sounds.emplace_back( p, monster_sound_event{ vol, is_provocative( category ) } );
+    sounds_since_last_turn.emplace_back( p,
                                          sound_event { vol, category, description, ambient,
-                                                 false, id, variant, seas_str } ) );
+                                                 false, id, variant, seas_str } );
 }
 
 void sounds::sound( const tripoint &p, int vol, sound_t category, const translation &description,
@@ -342,8 +342,8 @@ void sounds::add_footstep( const tripoint &p, int volume, int, monster *,
 {
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
-    sounds_since_last_turn.emplace_back( std::make_pair( p, sound_event { volume,
-                                         sound_t::movement, footstep, false, true, "", "", seas_str} ) );
+    sounds_since_last_turn.emplace_back( p, sound_event { volume,
+                                         sound_t::movement, footstep, false, true, "", "", seas_str} );
 }
 
 template <typename C>

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -179,7 +179,7 @@ void trap::load( const JsonObject &jo, const std::string_view )
             charges = 1;
         }
         if( !item_type.is_empty() && quantity > 0 && charges > 0 ) {
-            components.emplace_back( std::make_tuple( item_type, quantity, charges ) );
+            components.emplace_back( item_type, quantity, charges );
         }
     }
     if( jo.has_object( "vehicle_data" ) ) {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2092,7 +2092,7 @@ void veh_interact::do_change_shape()
                 entry.extratxt.left = 1;
                 entry.extratxt.sym = special_symbol( shape->get_symbol() );
                 entry.extratxt.color = shape->color;
-                variants.emplace_back( std::string() );
+                variants.emplace_back( );
                 smenu.entries.emplace_back( entry );
             }
 

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -860,7 +860,7 @@ void vehicle::reload_seeds( const tripoint &pos )
     } );
 
     auto seed_entries = iexamine::get_seed_entries( seed_inv );
-    seed_entries.emplace( seed_entries.begin(), seed_tuple( itype_null, _( "No seed" ), 0 ) );
+    seed_entries.emplace( seed_entries.begin(), itype_null, _( "No seed" ), 0 );
 
     int seed_index = iexamine::query_seed( seed_entries );
 

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -976,7 +976,7 @@ units::temperature weather_manager::get_temperature( const tripoint &location )
         temp += temp_mod;
     }
 
-    temperature_cache.emplace( std::make_pair( location, temp ) );
+    temperature_cache.emplace( location, temp );
     return temp;
 }
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -419,7 +419,7 @@ void widget::load( const JsonObject &jo, const std::string_view )
 
     if( jo.has_string( "bodypart" ) ) {
         _bps.clear();
-        _bps.emplace( bodypart_id( jo.get_string( "bodypart" ) ) );
+        _bps.emplace( jo.get_string( "bodypart" ) );
     }
 
     if( jo.has_array( "bodyparts" ) ) {
@@ -429,7 +429,7 @@ void widget::load( const JsonObject &jo, const std::string_view )
                 jo.throw_error_at( "bodyparts", "Invalid string value in bodyparts array" );
                 continue;
             }
-            _bps.emplace( bodypart_id( val.get_string() ) );
+            _bps.emplace( val.get_string() );
         }
     }
 

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -2123,8 +2123,8 @@ TEST_CASE( "recipes inherit rot of components properly", "[crafting][rot]" )
     std::vector<item> tools;
     tools.insert( tools.end(), 10, tool_with_ammo( "hotplate", 500 ) );
     tools.insert( tools.end(), 10, tool_with_ammo( "dehydrator", 500 ) );
-    tools.emplace_back( item( "pot_canning" ) );
-    tools.emplace_back( item( "knife_butcher" ) );
+    tools.emplace_back( "pot_canning" );
+    tools.emplace_back( "knife_butcher" );
 
     GIVEN( "1 hour until rotten macaroni and fresh cheese" ) {
 

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -346,8 +346,8 @@ static std::vector<swim_scenario> generate_scenarios()
             for( const std::pair<const std::string, swimmer_skills> &skills : skills_map ) {
                 for( const std::pair<const std::string, swimmer_gear> &gear : gear_map ) {
                     for( const std::pair<const std::string, swimmer_traits> &traits : traits_map ) {
-                        scenarios.emplace_back( swim_scenario( move_mode, stats.first, skills.first, gear.first,
-                                                               traits.first ) );
+                        scenarios.emplace_back( move_mode, stats.first, skills.first, gear.first,
+                                                traits.first );
                     }
                 }
             }

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -140,7 +140,7 @@ static std::vector<std::string> scrape_win_at(
     cata_cursesport::WINDOW *win = static_cast<cata_cursesport::WINDOW *>( w.get() );
 
     for( int i = origin.y; i < rows && static_cast<size_t>( i ) < win->line.size(); i++ ) {
-        lines.emplace_back( std::string() );
+        lines.emplace_back( );
         for( int j = origin.x; j < cols && static_cast<size_t>( j ) < win->line[i].chars.size(); j++ ) {
             lines[i] += win->line[i].chars[j].ch;
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
More static analysis.

This check looks for places where `push_back` (and similar functions) could be replaced with `emplace_back`, or where `emplace_back` is being used as if it was `push_back`, which creates an unnecessary temporary object.

#### Describe the solution
We had this enabled before but it's expanded in the update to LLVM 16, so this is a bunch more changes.

Mostly these are removing unnecessary temporary objects created for emplace calls.

#### Describe alternatives you've considered
Some of these changes might make the code a little less clear because the type of the object being constructed is obscured, so we could have suppressed the changes instead.  But I don't think it's a big enough issue to be concerned about.

#### Testing
Run clang-tidy.

#### Additional context