### PR TITLE
Using default mags to calculate max capacity for guns with random ammo

### DIFF
--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -425,9 +425,22 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
     }
 
     int max_capacity = -1;
-    if( charges.first != -1 && charges.second == -1 && new_item.is_magazine() ) {
-        const int max_ammo = new_item.ammo_capacity( item_controller->find_template(
-                                 new_item.ammo_default() )->ammo->type );
+
+    if( charges.first != -1 && charges.second == -1 && ( new_item.is_magazine() ||
+            new_item.uses_magazine() ) ) {
+        int max_ammo = 0;
+
+        if( new_item.is_magazine() ) {
+            // Get the ammo capacity of the new item itself
+            max_ammo = new_item.ammo_capacity( item_controller->find_template(
+                                                   new_item.ammo_default() )->ammo->type );
+        } else if( !new_item.magazine_default().is_null() ) {
+            // Get the capacity of the item's default magazine
+            max_ammo = item_controller->find_template( new_item.magazine_default() )->magazine->capacity;
+        }
+        // Don't change the ammo capacity from 0 if the item isn't a magazine
+        // and doesn't have a default magazine with a capacity
+
         if( max_ammo > 0 ) {
             max_capacity = max_ammo;
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Using default magazine to calculate maximum capacity for guns with random ammo"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

This should fix #65412 (which is also discussed in #65847)

`doc/ITEM_SPAWN.md` states that "Setting only min and not max will make the game calculate the max charges based on container or ammo/magazine capacity."

The problem was that for magazine fed guns it would calculate the max charges based on the assumption it didn't have a magazine, which would result in a max of 0, which doesn't seem to match the documentation (and also doesn't match how it works with revolvers).

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

It now will calculate the max charges based on the capacity of the item's default magazine (if one exists).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

To fix the specific issue in #65412 I also considered a few other approaches:

1. Manually specifying maximum capacities for 20 or 30 guns in the JSON.
2. Tweaking the code so that `magazine` chance applies before calculating ammo capacity and adding a magazine chance to the top of the item group.

Both of these still result in: 
* semi-automatics acting differently to revolvers
* and code that doesn't match the docs

I also considered implementing one of the above, and changing the docs, but it seems unlikely that anyone would specify `charges-min` and really mean that they want exactly 0 charges (you'd expect them to specify `charges` then).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I added the following as a death drop for a debug monster and checked the results before before any after my change:

```
{
  "type": "item_group",
  "subtype": "collection",
  "id": "debug_death_drops_ammo_changes",
  "entries": [
    { "item": "glock_17",     "charges-min": 0 },
    { "item": "glock_19",     "charges-min": 5 },
    { "item": "glock_21",     "charges-min": 0, "charges-max": 13 },
    { "item": "glock_22",                       "charges-max": 15 },
    { "item": "glock_31" },

    { "item": "m1911mag", "charges-min": 0 },
    { "item": "m9mag",    "charges-min": 5 },
    { "item": "kp32mag",  "charges-min": 0, "charges-max": 7 },
    { "item": "px4_40mag",                  "charges-max": 14 },
    { "item": "px4mag" }
  ]
}
```

This had the following results:
| item | before change | after change |
| --- | --- | --- |
| Glock 17 | 0 ammo | 0 to 17 ammo |
| Glock 19 | 0 ammo | 0 to 15 ammo |
| Glock 21 | 0 to 13 ammo | 0 to 13 ammo |
| Glock 22 | 0 to 15 ammo | 0 to 15 ammo |
| Glock 31 | 0 ammo | 0 ammo |
| 1911 Mag | 0 ammo | 0 to 7 ammo |
| M9 Mag | 0 ammo | 0 to 15 ammo |
| P-32 Mag | 0 to 7 ammo | 0 to 7 ammo |
| Px4 .40 Mag | 0 to 14 ammo | 0 to 14 ammo |
| Px4 9mm Mag | 0 ammo | 0 ammo |

I also temporarily turned up the drop rate of EDC guns and checked that zombies where dropping guns that generally had ammo.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->