### PR TITLE
Update terrain-manufactured.json

### DIFF
--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -80,7 +80,6 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 3, 7 ] },
         { "item": "hose", "count": 1 }
-
       ]
     }
   },

--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -78,7 +78,9 @@
         { "item": "pipe_fittings", "count": [ 2, 6 ] },
         { "item": "pipe", "count": [ 4, 8 ] },
         { "item": "steel_chunk", "count": [ 1, 4 ] },
-        { "item": "scrap", "count": [ 3, 7 ] }
+        { "item": "scrap", "count": [ 3, 7 ] },
+        { "item": "hose", "count": 1 }
+
       ]
     }
   },
@@ -148,7 +150,8 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "pipe_fittings", "count": [ 2, 6 ] },
         { "item": "pipe", "count": [ 4, 8 ] },
-        { "item": "scrap", "count": [ 3, 7 ] }
+        { "item": "scrap", "count": [ 3, 7 ] },
+        { "item": "hose", "count": 1 }
       ]
     }
   },
@@ -196,7 +199,8 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "pipe_fittings", "count": [ 2, 6 ] },
         { "item": "pipe", "count": [ 4, 8 ] },
-        { "item": "scrap", "count": [ 3, 7 ] }
+        { "item": "scrap", "count": [ 3, 7 ] },
+        { "item": "hose", "count": 1 }
       ]
     }
   },
@@ -244,7 +248,8 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "pipe_fittings", "count": [ 2, 6 ] },
         { "item": "pipe", "count": [ 4, 8 ] },
-        { "item": "scrap", "count": [ 3, 7 ] }
+        { "item": "scrap", "count": [ 3, 7 ] },
+        { "item": "hose", "count": 1 }
       ]
     }
   },


### PR DESCRIPTION
Add hoses from destroyed fuel pumps

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Adds rubber hoses in destroyed fuel pumps"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allows the player to obtain a rubber hose from a destroyed fuel pump station when they sacrifice and destroy it. Implements issue #64880 .
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds rubber hoses to the list of items you get by destroying gasoline, diesel, avgas, and JP8 pump stations.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
See issue #64880 .
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested locally.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->