### PR TITLE
eoc/mission: pass EOC dialogue to mission utils

### DIFF
--- a/src/mission.h
+++ b/src/mission.h
@@ -167,8 +167,8 @@ void set_reveal_any( const JsonArray &ja,
                      std::vector<std::function<void( mission *miss )>> &funcs );
 mission_target_params parse_mission_om_target( const JsonObject &jo );
 std::optional<tripoint_abs_omt> assign_mission_target( const mission_target_params
-        &params );
-tripoint_abs_omt get_om_terrain_pos( const mission_target_params &params );
+        &params, dialogue &d );
+tripoint_abs_omt get_om_terrain_pos( const mission_target_params &params, dialogue &d );
 void set_assign_om_target( const JsonObject &jo,
                            std::vector<std::function<void( mission *miss )>> &funcs );
 bool set_update_mapgen( const JsonObject &jo,

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <vector>
 
+#include "avatar.h"
 #include "character.h"
 #include "computer.h"
 #include "coordinates.h"
@@ -312,7 +313,8 @@ void mission_start::reveal_refugee_center( mission *miss )
     min_distance.min.dbl_val = 0;
     t.min_distance = min_distance;
 
-    std::optional<tripoint_abs_omt> target_pos = mission_util::assign_mission_target( t );
+    dialogue d( get_talker_for( get_avatar() ), nullptr );
+    std::optional<tripoint_abs_omt> target_pos = mission_util::assign_mission_target( t, d );
 
     if( !target_pos ) {
         add_msg( _( "You don't know where the address could be…" ) );
@@ -332,7 +334,7 @@ void mission_start::reveal_refugee_center( mission *miss )
         dbl_or_var reveal_radius;
         reveal_radius.min.dbl_val = 3;
         t.reveal_radius = reveal_radius;
-        target_pos = mission_util::assign_mission_target( t );
+        target_pos = mission_util::assign_mission_target( t, d );
         const tripoint_abs_omt dest_refugee_center = overmap_buffer.find_closest( *target_pos,
                 "evac_center_18", 1, false );
         overmap_buffer.reveal_route( dest_road, dest_refugee_center, 1, false );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2936,7 +2936,7 @@ void talk_effect_fun_t::set_location_variable( const JsonObject &jo, const std::
         tripoint talker_pos = get_map().getabs( target->pos() );
         tripoint target_pos = talker_pos;
         if( target_params.has_value() ) {
-            const tripoint_abs_omt omt_pos = mission_util::get_om_terrain_pos( target_params.value() );
+            const tripoint_abs_omt omt_pos = mission_util::get_om_terrain_pos( target_params.value(), d );
             target_pos = tripoint( project_to<coords::ms>( omt_pos ).x(), project_to<coords::ms>( omt_pos ).y(),
                                    project_to<coords::ms>( omt_pos ).z() );
         }
@@ -3200,7 +3200,7 @@ void talk_effect_fun_t::set_mapgen_update( const JsonObject &jo, const std::stri
             if( d.has_beta ) {
                 update_params.guy = d.actor( true )->get_npc();
             }
-            omt_pos = mission_util::get_om_terrain_pos( update_params );
+            omt_pos = mission_util::get_om_terrain_pos( update_params, d );
         }
         time_duration future = dov_time_in_future.evaluate( d );
         if( future > 0_seconds ) {
@@ -3274,10 +3274,10 @@ void talk_effect_fun_t::set_npc_goal( const JsonObject &jo, const std::string_vi
                                             member ) );
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
-    function = [dest_params, true_eocs, false_eocs, is_npc]( dialogue const & d ) {
+    function = [dest_params, true_eocs, false_eocs, is_npc]( dialogue & d ) {
         npc *guy = d.actor( is_npc )->get_npc();
         if( guy ) {
-            tripoint_abs_omt destination = mission_util::get_om_terrain_pos( dest_params );
+            tripoint_abs_omt destination = mission_util::get_om_terrain_pos( dest_params, d );
             guy->goal = destination;
             guy->omt_path = overmap_buffer.get_travel_path( guy->global_omt_location(), guy->goal,
                             overmap_path_params::for_npc() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make context variables available to the `"mapgen_update"` effect.
* Fixes: #65843

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Pass the EOC `dialogue` instance to the mission util functions instead of creating a new one.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

1. Load this save [South Naknek-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/11571936/South.Naknek-trimmed.tar.gz)
2. Change [this chance](https://github.com/CleverRaven/Cataclysm-DDA/blob/d17ca9870af33eb22fb342a32aeaedb47e1df63e/data/json/encounters/randenc_caravans.json#LL15C22-L15C22) to `1` for easier testing
3. Activate `EOC_RandEnc_Roadstop_add`. Confirm the caravan spawned at the `public washroom` to the north rather than on top of you

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->