### PR TITLE
Rigid Plate Pockets

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -4280,9 +4280,56 @@
         "moves": 200,
         "description": "Pocket for left side plate",
         "flag_restriction": [ "ABLATIVE_MEDIUM" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "ablative": true,
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "800 ml",
+        "max_contains_weight": "2 kg",
+        "moves": 200,
+        "description": "Pocket for skirt",
+        "flag_restriction": [ "ABLATIVE_MEDIUM" ]
       }
     ],
     "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ] } ]
+  },
+  {
+    "id": "test_plate_skirt",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "ESAPI ballistic plate" },
+    "description": "A polygonal ceramic ballistic plate with a slightly concave profile.  Its inner surface is coated with Ultra High Molecular Weight Polyethylene, and is labeled \"TOP\", while its outer surface is labeled \"STRIKE FACE\".  This is intended to be worn in a ballistic vest and can withstand several high energy rifle rounds before breaking.",
+    "weight": "2500 g",
+    "volume": "1533 ml",
+    "price": 60000,
+    "price_postapoc": 100,
+    "material": [ "ceramic" ],
+    "symbol": ",",
+    "color": "dark_gray",
+    "material_thickness": 25,
+    "non_functional": "destroyed_large_ceramic_plate",
+    "flags": [ "ABLATIVE_MEDIUM", "CANT_WEAR" ],
+    "armor": [ { "encumbrance": 2, "coverage": 45, "covers": [ "leg_l" ], "specifically_covers": [ "leg_hip_l" ] } ]
+  },
+  {
+    "id": "test_plate_skirt_super",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "Super Leg Skirt" },
+    "//": "this item is designed to check that off limb ablative armor protects the player",
+    "description": "A polygonal ceramic ballistic plate with a slightly concave profile.  Its inner surface is coated with Ultra High Molecular Weight Polyethylene, and is labeled \"TOP\", while its outer surface is labeled \"STRIKE FACE\".  This is intended to be worn in a ballistic vest and can withstand several high energy rifle rounds before breaking.",
+    "weight": "2500 g",
+    "volume": "1533 ml",
+    "price": 60000,
+    "price_postapoc": 100,
+    "material": [ "ceramic" ],
+    "symbol": ",",
+    "color": "dark_gray",
+    "material_thickness": 1000,
+    "non_functional": "destroyed_large_ceramic_plate",
+    "flags": [ "ABLATIVE_MEDIUM", "CANT_WEAR" ],
+    "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "leg_l" ] } ]
   },
   {
     "id": "test_plate",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -585,6 +585,7 @@ Character::Character() :
     if( !!g && json_flag::is_ready() ) {
         recalc_sight_limits();
         calc_encumbrance();
+        worn.recalc_ablative_blocking(this);
     }
 }
 // *INDENT-ON*

--- a/src/character.h
+++ b/src/character.h
@@ -1140,7 +1140,7 @@ class Character : public Creature, public visitable
          * @return true if the armor was completely destroyed (and the item must be deleted).
          */
         bool armor_absorb( damage_unit &du, item &armor, const bodypart_id &bp, const sub_bodypart_id &sbp,
-                           int roll );
+                           int roll ) const;
         /**
          * Reduces and mutates du, prints messages about armor taking damage.
          * If the armor is fully destroyed it is replaced

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -241,11 +241,6 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
 {
     item::cover_type ctype = item::get_cover_type( du.type );
 
-    // if the armor location has ablative armor apply that first
-    if( armor.is_ablative() ) {
-        ablative_armor_absorb( du, armor, sbp, roll );
-    }
-
     // if the core armor is missed then exit
     if( roll > armor.get_coverage( sbp, ctype ) ) {
         return false;

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -237,7 +237,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
 }
 
 bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &bp,
-                              const sub_bodypart_id &sbp, int roll )
+                              const sub_bodypart_id &sbp, int roll ) const
 {
     item::cover_type ctype = item::get_cover_type( du.type );
 

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -292,9 +292,9 @@ bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_b
 {
     item::cover_type ctype = item::get_cover_type( du.type );
 
-    for( item_pocket *const pocket : armor.get_all_contained_pockets() ) {
+    for( item_pocket *const pocket : armor.get_all_ablative_pockets() ) {
         // if the pocket is ablative and not empty we should use its values
-        if( pocket->get_pocket_data()->ablative && !pocket->empty() ) {
+        if( !pocket->empty() ) {
             // get the contained plate
             item &ablative_armor = pocket->front();
 

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1375,47 +1375,11 @@ ret_val<void> outfit::check_rigid_conflicts( const item &clothing, side s ) cons
         }
     }
 
-    if( clothing.is_ablative() ) {
-        // need to check ablative armor too
-        for( const item_pocket *pocket : clothing.get_all_ablative_pockets() ) {
-            if( !pocket->empty() ) {
-                const item &ablative_armor = pocket->front();
-
-                for( const sub_bodypart_id &sbp : ablative_armor.get_covered_sub_body_parts() ) {
-                    if( ablative_armor.is_bp_rigid( sbp ) ) {
-                        to_test.emplace( sbp );
-                    }
-                }
-            }
-        }
-    }
-
     // go through all worn and see if already wearing something rigid
     for( const item &i : worn ) {
         ret_val<void> result = rigid_test( clothing, i, to_test );
         if( !result.success() ) {
             return result;
-        }
-
-        if( i.is_ablative() ) {
-            // if item has ablative armor we should check those too.
-            for( const item *ablative_armor : i.all_ablative_armor() ) {
-                // if the pocket is ablative and not empty we should use its values
-                result = rigid_test( clothing, *ablative_armor, to_test );
-                if( !result.success() ) {
-                    return result;
-                }
-            }
-        }
-    }
-
-    // ablative clothing we also need to check all of it's plates
-    if( clothing.is_ablative() ) {
-        for( const item *ablative_armor : clothing.all_ablative_armor() ) {
-            ret_val<void> ret = check_rigid_conflicts( *ablative_armor );
-            if( !ret.success() ) {
-                return ret;
-            }
         }
     }
 

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -327,9 +327,47 @@ std::optional<std::list<item>::iterator> outfit::wear_item( Character &guy, cons
         guy.calc_discomfort();
     }
 
+    if( to_wear.is_rigid() || to_wear.is_ablative() ) {
+        recalc_ablative_blocking( &guy );
+    }
+
     guy.recoil = MAX_RECOIL;
 
     return new_item_it;
+}
+
+void outfit::recalc_ablative_blocking( const Character *guy )
+{
+    std::set<sub_bodypart_id> rigid_locations;
+
+    // get all rigid locations
+    // ablative pocketed armor shouldn't block adding ablative pieces
+    for( const item &w : worn ) {
+        if( w.is_rigid() && !w.is_ablative() ) {
+            for( const sub_bodypart_id &sbp : w.get_covered_sub_body_parts() ) {
+                if( w.is_bp_rigid( sbp ) ) {
+                    rigid_locations.emplace( sbp );
+                }
+            }
+        }
+    }
+
+    bool should_warn = false;
+
+    // pass that info to all the ablative pockets
+    for( item &w : worn ) {
+        if( w.is_ablative() ) {
+            should_warn = true;
+            for( item_pocket *p : w.get_all_ablative_pockets() ) {
+                p->set_no_rigid( rigid_locations );
+            }
+        }
+    }
+
+    if( should_warn && !rigid_locations.empty() ) {
+        guy->add_msg_if_player( m_warning,
+                                _( "You are wearing rigid armor with armor that has pockets for armor.  Until hard armor is removed inserting plates on those locations will be disabled." ) );
+    }
 }
 
 std::optional<std::list<item>::iterator> Character::wear_item( const item &to_wear,
@@ -422,6 +460,7 @@ bool Character::takeoff( item_location loc, std::list<item> *res )
 
         recalc_sight_limits();
         calc_encumbrance();
+        worn.recalc_ablative_blocking( this );
         calc_discomfort();
         recoil = MAX_RECOIL;
         return true;
@@ -1222,7 +1261,7 @@ bool outfit::is_wearing_active_optcloak() const
     return false;
 }
 
-ret_val<void> outfit::only_one_conflicts( const item &clothing ) const
+ret_val<void> test_only_one_conflicts( const item &clothing, const item &i )
 {
     const bool this_restricts_only_one = clothing.has_flag( json_flag_ONE_PER_LAYER );
 
@@ -1242,18 +1281,67 @@ ret_val<void> outfit::only_one_conflicts( const item &clothing ) const
         return ret;
     };
 
+    if( i.has_flag( flag_ONLY_ONE ) && i.typeId() == clothing.typeId() ) {
+        return ret_val<void>::make_failure( _( "Can't wear more than one %s!" ), clothing.tname() );
+    }
+
+    if( this_restricts_only_one || i.has_flag( json_flag_ONE_PER_LAYER ) ) {
+        std::optional<side> overlaps = clothing.covers_overlaps( i );
+        if( overlaps && sidedness_conflicts( *overlaps ) ) {
+            return ret_val<void>::make_failure( _( "%1$s conflicts with %2$s!" ), clothing.tname(), i.tname() );
+        }
+    }
+
+    return ret_val<void>::make_success();
+}
+
+ret_val<void> outfit::only_one_conflicts( const item &clothing ) const
+{
     for( const item &i : worn ) {
-        if( i.has_flag( flag_ONLY_ONE ) && i.typeId() == clothing.typeId() ) {
-            return ret_val<void>::make_failure( _( "Can't wear more than one %s!" ), clothing.tname() );
+        ret_val<void> result = test_only_one_conflicts( clothing, i );
+        if( !result.success() ) {
+            return result;
         }
 
-        if( this_restricts_only_one || i.has_flag( json_flag_ONE_PER_LAYER ) ) {
-            std::optional<side> overlaps = clothing.covers_overlaps( i );
-            if( overlaps && sidedness_conflicts( *overlaps ) ) {
-                return ret_val<void>::make_failure( _( "%1$s conflicts with %2$s!" ), clothing.tname(), i.tname() );
+        if( i.is_ablative() ) {
+            // if item has ablative armor we should check those too.
+            for( const item *ablative_armor : i.all_ablative_armor() ) {
+                result = test_only_one_conflicts( clothing, *ablative_armor );
+                if( !result.success() ) {
+                    return result;
+                }
             }
         }
     }
+    return ret_val<void>::make_success();
+}
+
+ret_val<void> rigid_test( const item &clothing, const item &i,
+                          const std::vector<sub_bodypart_id> &to_test )
+{
+    // check each sublimb individually
+    for( const sub_bodypart_id &sbp : to_test ) {
+        // skip if the item doesn't currently cover the bp
+        if( !i.covers( sbp ) ) {
+            continue;
+        }
+
+        // skip if either item cares only about its layer and they don't match up
+        if( ( i.is_bp_rigid_selective( sbp ) || clothing.is_bp_rigid_selective( sbp ) ) &&
+            !i.has_layer( clothing.get_layer( sbp ), sbp ) ) {
+            continue;
+        }
+
+        // allow wearing splints on integrated armor such as protective bark
+        if( i.has_flag( flag_INTEGRATED ) && clothing.has_flag( flag_SPLINT ) ) {
+            continue;
+        }
+
+        if( i.is_bp_rigid( sbp ) ) {
+            return ret_val<void>::make_failure( _( "Can't wear more than one rigid item on %s!" ), sbp->name );
+        }
+    }
+
     return ret_val<void>::make_success();
 }
 
@@ -1289,26 +1377,29 @@ ret_val<void> outfit::check_rigid_conflicts( const item &clothing, side s ) cons
 
     // go through all worn and see if already wearing something rigid
     for( const item &i : worn ) {
-        // check each sublimb individually
-        for( const sub_bodypart_id &sbp : to_test ) {
-            // skip if the item doesn't currently cover the bp
-            if( !i.covers( sbp ) ) {
-                continue;
-            }
+        ret_val<void> result = rigid_test( clothing, i, to_test );
+        if( !result.success() ) {
+            return result;
+        }
 
-            // skip if either item cares only about its layer and they don't match up
-            if( ( i.is_bp_rigid_selective( sbp ) || clothing.is_bp_rigid_selective( sbp ) ) &&
-                !i.has_layer( clothing.get_layer( sbp ), sbp ) ) {
-                continue;
+        if( i.is_ablative() ) {
+            // if item has ablative armor we should check those too.
+            for( const item *ablative_armor : i.all_ablative_armor() ) {
+                // if the pocket is ablative and not empty we should use its values
+                result = rigid_test( clothing, *ablative_armor, to_test );
+                if( !result.success() ) {
+                    return result;
+                }
             }
+        }
+    }
 
-            // allow wearing splints on integrated armor such as protective bark
-            if( i.has_flag( flag_INTEGRATED ) && clothing.has_flag( flag_SPLINT ) ) {
-                continue;
-            }
-
-            if( i.is_bp_rigid( sbp ) ) {
-                return ret_val<void>::make_failure( _( "Can't wear more than one rigid item on %s!" ), sbp->name );
+    // ablative clothing we also need to check all of it's plates
+    if( clothing.is_ablative() ) {
+        for( const item *ablative_armor : clothing.all_ablative_armor() ) {
+            ret_val<void> ret = check_rigid_conflicts( *ablative_armor );
+            if( !ret.success() ) {
+                return ret;
             }
         }
     }

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -167,6 +167,8 @@ class outfit
         std::list<item>::iterator position_to_wear_new_item( const item &new_item );
         std::optional<std::list<item>::iterator> wear_item( Character &guy, const item &to_wear,
                 bool interactive, bool do_calc_encumbrance, bool do_sort_items = true, bool quiet = false );
+        // go through each worn ablative item and set the pockets as disabled for rigid if some hard armor is also worn
+        void recalc_ablative_blocking( const Character *guy );
         /** Calculate and return any bodyparts that are currently uncomfortable. */
         std::unordered_set<bodypart_id> where_discomfort( const Character &guy ) const;
         // used in game::wield

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -924,17 +924,6 @@ bool item::covers( const sub_bodypart_id &bp ) const
         does_cover = does_cover || bp == covered;
     } );
 
-    // check if a piece of ablative armor covers the location
-    for( const item_pocket *pocket : get_all_contained_pockets() ) {
-        // if the pocket is ablative and not empty we should check it
-        if( pocket->get_pocket_data()->ablative && !pocket->empty() ) {
-            // get the contained plate
-            const item &ablative_armor = pocket->front();
-
-            subpart_cover = subpart_cover || ablative_armor.covers( bp );
-        }
-    }
-
     return does_cover || subpart_cover;
 }
 
@@ -945,17 +934,6 @@ bool item::covers( const bodypart_id &bp ) const
     iterate_covered_body_parts_internal( get_side(), [&]( const bodypart_str_id & covered ) {
         does_cover = does_cover || bp == covered;
     } );
-
-    // check if a piece of ablative armor covers the location
-    for( const item_pocket *pocket : get_all_contained_pockets() ) {
-        // if the pocket is ablative and not empty we should check it
-        if( pocket->get_pocket_data()->ablative && !pocket->empty() ) {
-            // get the contained plate
-            const item &ablative_armor = pocket->front();
-
-            subpart_cover = subpart_cover || ablative_armor.covers( bp );
-        }
-    }
 
     return does_cover || subpart_cover;
 }
@@ -1047,10 +1025,10 @@ const std::array<bodypart_str_id, 4> &right_side_parts()
 
 } // namespace
 
-void item::iterate_covered_sub_body_parts_internal( const side s,
-        const std::function<void( const sub_bodypart_str_id & )> &cb ) const
+static void iterate_helper_sbp( const item *i, const side s,
+                                const std::function<void( const sub_bodypart_str_id & )> &cb )
 {
-    const islot_armor *armor = find_armor_data();
+    const islot_armor *armor = i->find_armor_data();
     if( armor == nullptr ) {
         return;
     }
@@ -1072,11 +1050,28 @@ void item::iterate_covered_sub_body_parts_internal( const side s,
     }
 }
 
-void item::iterate_covered_body_parts_internal( const side s,
-        const std::function<void( const bodypart_str_id & )> &cb ) const
+void item::iterate_covered_sub_body_parts_internal( const side s,
+        const std::function<void( const sub_bodypart_str_id & )> &cb ) const
 {
+    iterate_helper_sbp( this, s, cb );
 
-    const islot_armor *armor = find_armor_data();
+    //check for ablative armor too
+    if( is_ablative() ) {
+        for( const item_pocket *pocket : get_all_ablative_pockets() ) {
+            if( !pocket->empty() ) {
+                // get the contained plate
+                const item &ablative_armor = pocket->front();
+
+                iterate_helper_sbp( &ablative_armor, s, cb );
+            }
+        }
+    }
+}
+
+static void iterate_helper( const item *i, const side s,
+                            const std::function<void( const bodypart_str_id & )> &cb )
+{
+    const islot_armor *armor = i->find_armor_data();
     if( armor == nullptr ) {
         return;
     }
@@ -1098,6 +1093,24 @@ void item::iterate_covered_body_parts_internal( const side s,
                                bpid ) == opposite_side_parts.end() ) {
                     cb( bpid );
                 }
+            }
+        }
+    }
+}
+
+void item::iterate_covered_body_parts_internal( const side s,
+        const std::function<void( const bodypart_str_id & )> &cb ) const
+{
+    iterate_helper( this, s, cb );
+
+    //check for ablative armor too
+    if( is_ablative() ) {
+        for( const item_pocket *pocket : get_all_ablative_pockets() ) {
+            if( !pocket->empty() ) {
+                // get the contained plate
+                const item &ablative_armor = pocket->front();
+
+                iterate_helper( &ablative_armor, s, cb );
             }
         }
     }
@@ -3815,7 +3828,10 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
     if( parts->test( iteminfo_parts::ARMOR_COVERAGE ) && covers_anything ) {
         std::map<int, std::vector<bodypart_id>> limb_groups;
         for( const bodypart_str_id &bp : get_covered_body_parts() ) {
-            limb_groups[portion_for_bodypart( bp )->coverage].emplace_back( bp );
+            const armor_portion_data *portion = portion_for_bodypart( bp );
+            if( portion ) {
+                limb_groups[portion->coverage].emplace_back( bp );
+            }
         }
         // keep on one line if only 1 entry
         if( limb_groups.size() == 1 ) {
@@ -3910,7 +3926,10 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
 
         std::map<int, std::vector<bodypart_id>> limb_groups;
         for( const bodypart_str_id &bp : get_covered_body_parts() ) {
-            limb_groups[portion_for_bodypart( bp )->breathability].emplace_back( bp );
+            const armor_portion_data *portion = portion_for_bodypart( bp );
+            if( portion ) {
+                limb_groups[portion->breathability].emplace_back( bp );
+            }
         }
         // keep on one line if only 1 entry
         if( limb_groups.size() == 1 ) {
@@ -7816,11 +7835,11 @@ int item::get_encumber( const Character &p, const bodypart_id &bodypart,
                         encumber_flags flags ) const
 {
     const islot_armor *t = find_armor_data();
+    int encumber = 0;
     if( !t ) {
         return 0;
     }
 
-    int encumber = 0;
     float relative_encumbrance;
 
     if( flags & encumber_flags::assume_full ) {
@@ -7853,20 +7872,22 @@ int item::get_encumber( const Character &p, const bodypart_id &bodypart,
                                additional_encumbrance - portion_data->encumber ) );
 
         // add the encumbrance values of any ablative plates and additional encumbrance pockets
-        if( is_ablative() || has_additional_encumbrance() ) {
+        if( has_additional_encumbrance() ) {
             for( const item_pocket *pocket : contents.get_all_contained_pockets() ) {
-                if( pocket->get_pocket_data()->ablative && !pocket->empty() ) {
-                    // get the contained plate
-                    const item &ablative_armor = pocket->front();
-
-                    if( const armor_portion_data *ablative_portion_data = ablative_armor.portion_for_bodypart(
-                                bodypart ) ) {
-                        encumber += ablative_portion_data->encumber;
-                    }
-                }
                 if( pocket->get_pocket_data()->extra_encumbrance > 0 && !pocket->empty() ) {
                     encumber += pocket->get_pocket_data()->extra_encumbrance;
                 }
+            }
+        }
+    }
+
+    // even if we don't have data we might have ablative armor draped over it
+    if( is_ablative() ) {
+        for( const item_pocket *pocket : contents.get_all_ablative_pockets() ) {
+            if( !pocket->empty() ) {
+                // get the contained plate
+                const item &ablative_armor = pocket->front();
+                encumber += ablative_armor.get_encumber( p, bodypart, flags );
             }
         }
     }
@@ -7907,11 +7928,11 @@ std::vector<layer_level> item::get_layer() const
     return armor->all_layers;
 }
 
-std::vector<layer_level> item::get_layer( bodypart_id bp ) const
+static void get_layer_helper( const item *i, bodypart_id bp, std::set<layer_level> &layers )
 {
-    const islot_armor *t = find_armor_data();
+    const islot_armor *t = i->find_armor_data();
     if( t == nullptr ) {
-        return std::vector<layer_level>();
+        return;
     }
 
     for( const armor_portion_data &data : t->data ) {
@@ -7920,19 +7941,36 @@ std::vector<layer_level> item::get_layer( bodypart_id bp ) const
         }
         for( const bodypart_str_id &bpid : data.covers.value() ) {
             if( bp == bpid ) {
-                // if the item has additional pockets and is on the torso it should also be strapped
-                if( bp == body_part_torso && contents.has_additional_pockets() ) {
-                    std::set<layer_level> with_belted = data.layers;
-                    with_belted.insert( layer_level::BELTED );
-                    return std::vector<layer_level>( with_belted.begin(), with_belted.end() );
-                } else {
-                    return std::vector<layer_level>( data.layers.begin(), data.layers.end() );
-                }
+                layers.insert( data.layers.begin(), data.layers.end() );
             }
         }
     }
-    // body part not covered by this armour
-    return std::vector<layer_level>();
+}
+
+std::vector<layer_level> item::get_layer( bodypart_id bp ) const
+{
+
+    std::set<layer_level> layers;
+
+    get_layer_helper( this, bp, layers );
+
+    //get layers for ablative armor too
+    if( is_ablative() ) {
+        for( const item_pocket *pocket : get_all_ablative_pockets() ) {
+            if( !pocket->empty() ) {
+                // get the contained plate
+                const item &ablative_armor = pocket->front();
+                get_layer_helper( &ablative_armor, bp, layers );
+            }
+        }
+    }
+
+    // if the item has additional pockets and is on the torso it should also be strapped
+    if( bp == body_part_torso && contents.has_additional_pockets() ) {
+        layers.insert( layer_level::BELTED );
+    }
+
+    return std::vector<layer_level>( layers.begin(), layers.end() );
 }
 
 std::vector<layer_level> item::get_layer( sub_bodypart_id sbp ) const
@@ -13440,13 +13478,24 @@ bool item::is_rigid() const
         return false;
     }
 
+    bool is_rigid = false;
+
     for( const armor_portion_data &portion : armor->sub_data ) {
-        if( portion.rigid ) {
-            return true;
+        is_rigid |= portion.rigid;
+    }
+
+    // check if ablative pieces are rigid too
+    if( is_ablative() ) {
+        for( const item_pocket *pocket : contents.get_all_ablative_pockets() ) {
+            if( !pocket->empty() ) {
+                // get the contained plate
+                const item &ablative_armor = pocket->front();
+                is_rigid |= ablative_armor.is_rigid();
+            }
         }
     }
 
-    return false;
+    return is_rigid;
 }
 
 bool item::is_comfortable() const
@@ -13486,11 +13535,24 @@ bool item::is_bp_rigid( const T &bp ) const
 
     const armor_portion_data *portion = portion_for_bodypart( bp );
 
-    if( !portion ) {
-        return false;
+    bool is_rigid = false;
+
+    if( portion ) {
+        is_rigid |= portion->rigid;
     }
 
-    return portion->rigid;
+    // check if ablative pieces are rigid too
+    if( is_ablative() ) {
+        for( const item_pocket *pocket : contents.get_all_ablative_pockets() ) {
+            if( !pocket->empty() ) {
+                // get the contained plate
+                const item &ablative_armor = pocket->front();
+                is_rigid |= ablative_armor.is_bp_rigid( bp );
+            }
+        }
+    }
+
+    return is_rigid;
 }
 
 // initialize for sub_bodyparts and body parts

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9327,6 +9327,11 @@ std::vector<item_pocket *> item::get_all_ablative_pockets()
     return contents.get_all_ablative_pockets();
 }
 
+std::vector<const item_pocket *> item::get_all_ablative_pockets() const
+{
+    return contents.get_all_ablative_pockets();
+}
+
 item_pocket *item::contained_where( const item &contained )
 {
     return contents.contained_where( contained );

--- a/src/item.h
+++ b/src/item.h
@@ -816,6 +816,7 @@ class item : public visitable
         std::vector<const item_pocket *> get_all_standard_pockets() const;
         std::vector<item_pocket *> get_all_standard_pockets();
         std::vector<item_pocket *> get_all_ablative_pockets();
+        std::vector<const item_pocket *> get_all_ablative_pockets() const;
         /**
          * Updates the pockets of this item to be correct based on the mods that are installed.
          * Pockets which are modified that contain an item will be spilled

--- a/src/item.h
+++ b/src/item.h
@@ -815,7 +815,7 @@ class item : public visitable
         std::vector<item_pocket *> get_all_contained_pockets();
         std::vector<const item_pocket *> get_all_standard_pockets() const;
         std::vector<item_pocket *> get_all_standard_pockets();
-
+        std::vector<item_pocket *> get_all_ablative_pockets();
         /**
          * Updates the pockets of this item to be correct based on the mods that are installed.
          * Pockets which are modified that contain an item will be spilled
@@ -2802,6 +2802,9 @@ class item : public visitable
         /** returns a list of pointers to all visible or remembered top-level items */
         std::list<item *> all_known_contents();
         std::list<const item *> all_known_contents() const;
+
+        std::list<item *> all_ablative_armor();
+        std::list<const item *> all_ablative_armor() const;
 
         void clear_items();
         bool empty() const;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1617,6 +1617,20 @@ std::list<const item *> item_contents::all_known_contents() const
     } );
 }
 
+std::list<item *> item_contents::all_ablative_armor()
+{
+    return all_items_top( []( const item_pocket & pocket ) {
+        return pocket.is_ablative();
+    } );
+}
+
+std::list<const item *> item_contents::all_ablative_armor() const
+{
+    return all_items_top( []( const item_pocket & pocket ) {
+        return pocket.is_ablative();
+    } );
+}
+
 item &item_contents::legacy_front()
 {
     if( empty() ) {
@@ -1913,6 +1927,20 @@ std::vector<item_pocket *> item_contents::get_all_standard_pockets()
 {
     return get_pockets( []( item_pocket const & pocket ) {
         return pocket.is_standard_type();
+    } );
+}
+
+std::vector<const item_pocket *> item_contents::get_all_ablative_pockets() const
+{
+    return get_pockets( []( item_pocket const & pocket ) {
+        return pocket.is_ablative();
+    } );
+}
+
+std::vector<item_pocket *> item_contents::get_all_ablative_pockets()
+{
+    return get_pockets( []( item_pocket const & pocket ) {
+        return pocket.is_ablative();
     } );
 }
 

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -114,6 +114,10 @@ class item_contents
         std::list<item *> all_known_contents();
         std::list<const item *> all_known_contents() const;
 
+        // returns all the ablative armor in pockets
+        std::list<item *> all_ablative_armor();
+        std::list<const item *> all_ablative_armor() const;
+
         /** gets all gunmods in the item */
         std::vector<item *> gunmods();
         /** gets all gunmods in the item */
@@ -183,6 +187,8 @@ class item_contents
         std::vector<item_pocket *> get_all_contained_pockets();
         std::vector<const item_pocket *> get_all_standard_pockets() const;
         std::vector<item_pocket *> get_all_standard_pockets();
+        std::vector<const item_pocket *> get_all_ablative_pockets() const;
+        std::vector<item_pocket *> get_all_ablative_pockets();
         std::vector<const item_pocket *>
         get_pockets( std::function<bool( item_pocket const & )> const &filter ) const;
         std::vector<item_pocket *>

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -398,6 +398,9 @@ class item_pocket
         static void delete_preset( std::vector<item_pocket::favorite_settings>::iterator iter );
         static std::vector<item_pocket::favorite_settings> pocket_presets;
 
+        // Set wether rigid items are blocked in the pocket
+        void set_no_rigid( const std::set<sub_bodypart_id> &is_no_rigid );
+
         // should the name of this pocket be used as a description
         bool name_as_description = false; // NOLINT(cata-serialize)
     private:
@@ -408,6 +411,8 @@ class item_pocket
         // the items inside the pocket
         std::list<item> contents;
         bool _sealed = false;
+        // list of sub body parts that can't currently support rigid ablative armor
+        std::set<sub_bodypart_id> no_rigid;
 };
 
 /**

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -220,7 +220,7 @@ static tripoint read_legacy_creature_pos( const JsonObject &data )
 
 void item_contents::serialize( JsonOut &json ) const
 {
-    if( !contents.empty() ) {
+    if( !contents.empty() || !get_all_ablative_pockets().empty() || !additional_pockets.empty() ) {
         json.start_object();
 
         json.member( "contents", contents );
@@ -244,6 +244,7 @@ void item_pocket::serialize( JsonOut &json ) const
     json.member( "pocket_type", data->type );
     json.member( "contents", contents );
     json.member( "_sealed", _sealed );
+    json.member( "no_rigid", no_rigid );
     if( !this->settings.is_null() ) {
         json.member( "favorite_settings", this->settings );
     }
@@ -259,6 +260,7 @@ void item_pocket::deserialize( const JsonObject &data )
     _saved_type = static_cast<item_pocket::pocket_type>( saved_type_int );
     data.read( "_sealed", _sealed );
     _saved_sealed = _sealed;
+    data.read( "no_rigid", no_rigid );
     if( data.has_member( "favorite_settings" ) ) {
         data.read( "favorite_settings", this->settings );
     } else {

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -245,9 +245,9 @@ TEST_CASE( "Off Limb Ghost ablative vest", "[coverage]" )
 
         standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
         dude.wear_item( full, false );
-        damage_unit du_full = damage_unit( damage_type_id( "bash" ), 100.0f );
-        dude.armor_absorb( du_full, full, bodypart_id( "leg_l" ), 50 );
-        check_near( "Damage Protected", du_full.amount, 0.0f, 0.1f );
+        damage_instance du_full = damage_instance( damage_type_id( "bash" ), 100.0f );
+        dude.absorb_hit( weakpoint_attack(), bodypart_id( "leg_l" ), du_full );
+        check_near( "Damage Protected", du_full.total_damage(), 0.0f, 0.1f );
     }
 }
 

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -221,7 +221,7 @@ TEST_CASE( "Proportional armor material resistances", "[material]" )
 
 TEST_CASE( "Ghost ablative vest", "[coverage]" )
 {
-    SECTION( "Ablative not covered" ) {
+    SECTION( "Ablative not covered same limb" ) {
         item full = item( "test_ghost_vest" );
         full.force_insert_item( item( "test_plate" ), item_pocket::pocket_type::CONTAINER );
         full.force_insert_item( item( "test_plate" ), item_pocket::pocket_type::CONTAINER );
@@ -234,6 +234,26 @@ TEST_CASE( "Ghost ablative vest", "[coverage]" )
         const float dmg_empty = get_avg_melee_dmg( empty );
         // make sure the armor is counting even if the base vest doesn't do anything
         check_not_near( "Average damage", dmg_full, dmg_empty, 0.5f );
+    }
+}
+
+TEST_CASE( "Off Limb Ghost ablative vest", "[coverage]" )
+{
+    SECTION( "Ablative not covered seperate limb" ) {
+        item full = item( "test_ghost_vest" );
+        full.force_insert_item( item( "test_plate_skirt_super" ), item_pocket::pocket_type::CONTAINER );
+        item empty = item( "test_ghost_vest" );
+
+        standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
+
+        damage_unit du_full = damage_unit( damage_type_id( "bash" ), 100.0f );
+        damage_unit du_empty = damage_unit( damage_type_id( "bash" ), 100.0f );
+
+        dude.armor_absorb( du_full, full, bodypart_id( "leg_l" ), 50 );
+        dude.armor_absorb( du_empty, full, bodypart_id( "leg_l" ), 50 );
+
+        check_near( "Damage Protected", du_full.amount, 0.0f, 0.1f );
+        check_near( "Damage Unprotected", du_empty.amount, 100.0f, 0.1f );
     }
 }
 

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -245,7 +245,7 @@ TEST_CASE( "Off Limb Ghost ablative vest", "[coverage]" )
 
         standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
         dude.wear_item( full, false );
-        damage_instance du_full = damage_instance( damage_type_id( "bash" ), 100.0f );
+        damage_instance du_full = damage_instance( damage_bullet, 100.0f );
         dude.absorb_hit( weakpoint_attack(), bodypart_id( "leg_l" ), du_full );
         check_near( "Damage Protected", du_full.total_damage(), 0.0f, 0.1f );
     }

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -242,18 +242,12 @@ TEST_CASE( "Off Limb Ghost ablative vest", "[coverage]" )
     SECTION( "Ablative not covered seperate limb" ) {
         item full = item( "test_ghost_vest" );
         full.force_insert_item( item( "test_plate_skirt_super" ), item_pocket::pocket_type::CONTAINER );
-        item empty = item( "test_ghost_vest" );
 
         standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
-
+        dude.wear_item( full, false );
         damage_unit du_full = damage_unit( damage_type_id( "bash" ), 100.0f );
-        damage_unit du_empty = damage_unit( damage_type_id( "bash" ), 100.0f );
-
         dude.armor_absorb( du_full, full, bodypart_id( "leg_l" ), 50 );
-        dude.armor_absorb( du_empty, full, bodypart_id( "leg_l" ), 50 );
-
         check_near( "Damage Protected", du_full.amount, 0.0f, 0.1f );
-        check_near( "Damage Unprotected", du_empty.amount, 100.0f, 0.1f );
     }
 }
 

--- a/tests/encumbrance_test.cpp
+++ b/tests/encumbrance_test.cpp
@@ -107,6 +107,13 @@ TEST_CASE( "plate_encumbrance", "[encumbrance]" )
     test_encumbrance_items( { with_plates }, "torso", ballistic + plate );
 }
 
+TEST_CASE( "off_limb_ablative_encumbrance", "[encumbrance]" )
+{
+    item with_plates( "test_ghost_vest" );
+    with_plates.force_insert_item( item( "test_plate_skirt" ), item_pocket::pocket_type::CONTAINER );
+    test_encumbrance_items( { with_plates }, "leg_l", plate );
+}
+
 TEST_CASE( "separate_layer_encumbrance", "[encumbrance]" )
 {
     test_encumbrance( { "test_longshirt", "test_jacket_jean" }, "torso", longshirt_e + jacket_jean_e );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Ablative pocket armour with rigid plates becomes rigid"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Something I've been putting off for far too long, a vest or other armour that has rigid stuff in it, should be rigid. 

Also fixes #65704
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Pockets can now track rigid restrictions, this is all cached when you wear something.

Ablative armor is now counted as covers and handles rigidity.

Pile of refactored helpers and such to make this cleaner.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Unit tests included.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->