### PR TITLE
Forest floor should look like moss and not tall grass

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -19,7 +19,7 @@
     "description": "Covered in twigs and lots of brown, decaying leaves.",
     "symbol": ".",
     "color": "brown",
-    "looks_like": "t_grass_tall",
+    "looks_like": "t_dirt",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -19,7 +19,7 @@
     "description": "Covered in twigs and lots of brown, decaying leaves.",
     "symbol": ".",
     "color": "brown",
-    "looks_like": "t_dirt",
+    "looks_like": "t_moss",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }


### PR DESCRIPTION
#### Summary
Bugfixes "Forest floor should look like moss and not tall grass"

#### Purpose of change
Forest floor, described as being covered with twigs and dead leaves, but not grass, looks like tall grass, and does not slow movement. This affects tactics and makes it pretty confusing to tell at a glance.

#### Describe the solution
Change one line.

#### Describe alternatives you've considered
Making a new tile for it (out of scope, this is just changing a placeholder for a less bad placeholder)

#### Testing
Before:
![изображение](https://github.com/CleverRaven/Cataclysm-DDA/assets/52408044/35c5b95d-4c1e-4230-aaf6-58e6b7acd30f)

After:
![изображение](https://github.com/CleverRaven/Cataclysm-DDA/assets/52408044/495e18e6-44eb-4343-8def-39d8e9a10dd6)

#### Additional context
This is probably my smallest PR.