### PR TITLE
Civilians: bugfixes

### DIFF
--- a/data/json/mapgen/refugee_center/refugee_center.json
+++ b/data/json/mapgen/refugee_center/refugee_center.json
@@ -151,7 +151,7 @@
         { "class": "guard", "x": 54, "y": 20 },
         { "class": "guard", "x": 63, "y": 15 }
       ],
-      "place_monsters": [ { "monster": "GROUP_MALL", "x": [ 74, 87 ], "y": [ 4, 20 ], "density": 0.6 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 74, 87 ], "y": [ 4, 20 ], "density": 0.6 } ]
     }
   },
   {

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -10,10 +10,7 @@
       { "monster": "mon_zombie_fat", "weight": 50 },
       { "monster": "mon_zombie_rot", "weight": 50 },
       { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 2 },
-      { "monster": "mon_feral_human_pipe", "weight": 40 },
-      { "monster": "mon_feral_human_crowbar", "weight": 40 },
-      { "monster": "mon_feral_human_axe", "weight": 20, "cost_multiplier": 2 },
-      { "monster": "mon_feral_sapien_spear", "weight": 14, "cost_multiplier": 2 },
+      { "group": "GROUP_FERAL", "weight": 115 },
       { "monster": "mon_zombie_crawler", "weight": 25 },
       { "monster": "mon_zombie_brainless", "weight": 25 },
       { "monster": "mon_zombie_dog", "weight": 25, "pack_size": [ 1, 2 ] }
@@ -72,10 +69,7 @@
       { "monster": "mon_zombie_fat", "weight": 50 },
       { "monster": "mon_zombie_rot", "weight": 50, "pack_size": [ 1, 2 ] },
       { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 2 },
-      { "monster": "mon_feral_human_pipe", "weight": 20 },
-      { "monster": "mon_feral_human_crowbar", "weight": 20 },
-      { "monster": "mon_feral_human_axe", "weight": 10, "cost_multiplier": 2 },
-      { "monster": "mon_feral_sapien_spear", "weight": 5, "cost_multiplier": 2 },
+      { "group": "GROUP_FERAL", "weight": 55 },
       { "monster": "mon_zombie_crawler", "weight": 25 },
       { "monster": "mon_zombie_brainless", "weight": 25 }
     ]
@@ -120,7 +114,6 @@
       { "monster": "mon_dog_zombie_rot", "weight": 50, "cost_multiplier": 5 },
       { "monster": "mon_zombie_soldier", "weight": 100, "cost_multiplier": 2 },
       { "monster": "mon_zombie_cop", "weight": 200, "cost_multiplier": 3 },
-      { "monster": "mon_feral_cop", "weight": 1, "cost_multiplier": 3 },
       { "monster": "mon_zombie_fursuit", "weight": 1, "cost_multiplier": 3 },
       { "monster": "mon_zombie_swat", "weight": 100, "cost_multiplier": 3 },
       { "monster": "mon_zombie_medical", "weight": 100, "cost_multiplier": 2 },
@@ -133,12 +126,8 @@
       { "monster": "mon_zombie_survivor_elite", "weight": 10, "cost_multiplier": 25, "starts": "60 days" },
       { "monster": "mon_beekeeper", "weight": 10, "cost_multiplier": 5 },
       { "monster": "mon_zombie_technician", "weight": 10, "cost_multiplier": 12 },
-      { "monster": "mon_feral_human_tool", "weight": 10, "cost_multiplier": 5 },
       { "monster": "mon_zombie_runner", "weight": 200, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
-      { "monster": "mon_feral_human_pipe", "weight": 40, "pack_size": [ 2, 3 ] },
-      { "monster": "mon_feral_human_crowbar", "weight": 40, "pack_size": [ 2, 3 ] },
-      { "monster": "mon_feral_human_axe", "weight": 20, "cost_multiplier": 2, "pack_size": [ 1, 2 ] },
-      { "monster": "mon_feral_sapien_spear", "weight": 10, "cost_multiplier": 2 },
+      { "group": "GROUP_FERAL", "weight": 121 },
       { "monster": "mon_feral_soldier", "weight": 10, "cost_multiplier": 5 },
       { "monster": "mon_zombie_brainless", "weight": 650 }
     ]
@@ -166,7 +155,6 @@
       { "monster": "mon_dog_zombie_rot", "weight": 5, "cost_multiplier": 5 },
       { "monster": "mon_zombie_soldier", "weight": 10, "cost_multiplier": 2 },
       { "monster": "mon_zombie_cop", "weight": 20, "cost_multiplier": 3 },
-      { "monster": "mon_feral_cop", "weight": 1, "cost_multiplier": 5 },
       { "monster": "mon_zombie_swat", "weight": 10, "cost_multiplier": 3 },
       { "monster": "mon_zombie_medical", "weight": 10, "cost_multiplier": 2 },
       { "monster": "mon_zombie_hazmat", "weight": 10, "cost_multiplier": 3 },
@@ -178,13 +166,9 @@
       { "monster": "mon_zombie_survivor_elite", "weight": 1, "cost_multiplier": 25, "starts": "60 days" },
       { "monster": "mon_beekeeper", "weight": 1, "cost_multiplier": 5 },
       { "monster": "mon_zombie_technician", "weight": 1, "cost_multiplier": 12 },
-      { "monster": "mon_feral_human_tool", "weight": 1, "cost_multiplier": 5 },
-      { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
-      { "monster": "mon_feral_human_pipe", "weight": 4, "pack_size": [ 2, 3 ] },
-      { "monster": "mon_feral_human_crowbar", "weight": 4, "pack_size": [ 2, 3 ] },
-      { "monster": "mon_feral_human_axe", "weight": 2, "cost_multiplier": 2, "pack_size": [ 1, 2 ] },
-      { "monster": "mon_feral_sapien_spear", "weight": 1, "cost_multiplier": 2 },
+      { "group": "GROUP_FERAL", "weight": 13 },
       { "monster": "mon_feral_soldier", "weight": 1, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
       { "monster": "mon_zombie_brainless", "weight": 65 },
       { "monster": "mon_gas_zombie", "weight": 1, "cost_multiplier": 2, "starts": "7 days" }
     ]
@@ -203,8 +187,22 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_VANILLA_NO_FERAL",
-    "//": "also no civilians, currently used in the sealed hazardous waste sarcophagus chamber",
+    "name": "GROUP_FERAL",
+    "//": "default ferals",
+    "default": "mon_feral_human_crowbar",
+    "monsters": [
+      { "monster": "mon_feral_cop", "weight": 10, "cost_multiplier": 3 },
+      { "monster": "mon_feral_human_pipe", "weight": 40, "pack_size": [ 2, 3 ] },
+      { "monster": "mon_feral_human_crowbar", "weight": 30, "pack_size": [ 2, 3 ] },
+      { "monster": "mon_feral_human_axe", "weight": 10, "cost_multiplier": 2, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_feral_human_tool", "weight": 5, "cost_multiplier": 5 },
+      { "monster": "mon_feral_sapien_spear", "weight": 5, "cost_multiplier": 2 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_VANILLA_ONLY_HUMANS",
+    "//": "only human zombies, used in the refugee center and as upgrades for civilians",
     "default": "mon_zombie",
     "monsters": [
       { "monster": "mon_zombie", "weight": 264, "cost_multiplier": 0 },
@@ -212,9 +210,18 @@
       { "monster": "mon_zombie_child", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_zombie_tough", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_zombie_rot", "weight": 60, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_dog", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_zombie_crawler", "weight": 30, "cost_multiplier": 0 },
       { "monster": "mon_zombie_brainless", "weight": 30, "cost_multiplier": 0 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_VANILLA_NO_FERAL",
+    "//": "also no civilians, currently used in the sealed hazardous waste sarcophagus chamber",
+    "default": "mon_zombie",
+    "monsters": [
+      { "group": "GROUP_VANILLA_ONLY_HUMANS", "weight": 850, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_dog", "weight": 50, "cost_multiplier": 0 }
     ]
   },
   {
@@ -225,10 +232,7 @@
     "monsters": [
       { "group": "GROUP_VANILLA_NO_FERAL", "weight": 801, "cost_multiplier": 0 },
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 500, "cost_multiplier": 0 },
-      { "monster": "mon_feral_human_pipe", "weight": 30, "cost_multiplier": 0, "ends": "380 days" },
-      { "monster": "mon_feral_human_crowbar", "weight": 40, "cost_multiplier": 0, "ends": "380 days" },
-      { "monster": "mon_feral_human_axe", "weight": 20, "cost_multiplier": 0, "ends": "380 days" },
-      { "monster": "mon_feral_sapien_spear", "weight": 9, "cost_multiplier": 2, "ends": "400 days" }
+      { "group": "GROUP_FERAL", "weight": 99, "cost_multiplier": 0 }
     ]
   },
   {
@@ -628,10 +632,7 @@
       { "monster": "mon_zombie", "weight": 1, "cost_multiplier": 7, "pack_size": [ 5, 10 ] },
       { "monster": "mon_zombie", "weight": 1, "cost_multiplier": 13, "pack_size": [ 15, 20 ] },
       { "monster": "mon_zombie", "weight": 1, "cost_multiplier": 20, "pack_size": [ 25, 30 ] },
-      { "monster": "mon_feral_human_pipe", "weight": 4, "pack_size": [ 5, 9 ] },
-      { "monster": "mon_feral_human_crowbar", "weight": 4, "pack_size": [ 4, 7 ] },
-      { "monster": "mon_feral_human_axe", "weight": 2, "cost_multiplier": 2, "pack_size": [ 2, 4 ] },
-      { "monster": "mon_feral_sapien_spear", "weight": 1, "cost_multiplier": 2 },
+      { "group": "GROUP_FERAL", "weight": 13 },
       { "monster": "mon_zombie", "weight": 75, "cost_multiplier": 2 },
       { "monster": "mon_zombie_medical", "weight": 200, "cost_multiplier": 2 },
       { "monster": "mon_zombie_fat", "weight": 75, "cost_multiplier": 2 },
@@ -642,7 +643,6 @@
       { "monster": "mon_zombie_crawler", "weight": 25, "cost_multiplier": 3 },
       { "monster": "mon_zombie_soldier", "weight": 10, "cost_multiplier": 2 },
       { "monster": "mon_zombie_cop", "weight": 30, "cost_multiplier": 3 },
-      { "monster": "mon_feral_cop", "weight": 1, "cost_multiplier": 7 },
       { "monster": "mon_zombie_hazmat", "weight": 10, "cost_multiplier": 3 },
       { "monster": "mon_zombie_fireman", "weight": 10, "cost_multiplier": 2 },
       { "monster": "mon_zombie_swimmer_base", "weight": 10, "cost_multiplier": 5 },
@@ -652,7 +652,6 @@
       { "monster": "mon_zombie_survivor_elite", "weight": 1, "cost_multiplier": 25, "starts": "60 days" },
       { "monster": "mon_beekeeper", "weight": 1, "cost_multiplier": 5 },
       { "monster": "mon_zombie_technician", "weight": 1, "cost_multiplier": 12 },
-      { "monster": "mon_feral_human_tool", "weight": 1, "cost_multiplier": 5 },
       { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
       { "monster": "mon_zombie_brainless", "weight": 55 }
     ]
@@ -691,6 +690,7 @@
     "type": "monstergroup",
     "monsters": [
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 100, "cost_multiplier": 0 },
+      { "group": "GROUP_FERAL", "weight": 150, "cost_multiplier": 0 },
       { "monster": "mon_zombie", "weight": 920 },
       { "monster": "mon_zombie_fat", "weight": 30 },
       { "monster": "mon_zombie_cop", "weight": 10, "cost_multiplier": 2 },

--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -29,7 +29,7 @@
     "//": "They are human after all",
     "death_function": { "effect": { "id": "death_guilt", "min_level": 6 } },
     "path_settings": { "max_dist": 30, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
-    "upgrades": { "half_life": 1, "age_grow":  1, "into_group": "GROUP_CIVILIANS_UPGRADE" },
+    "upgrades": { "half_life": 1, "age_grow": 1, "into_group": "GROUP_CIVILIANS_UPGRADE" },
     "dodge": 1,
     "death_drops": "default_zombie_death_drops",
     "zombify_into": "mon_zombie",
@@ -118,8 +118,15 @@
       { "monster": "mon_civilian_zombiefighter", "weight": 16, "cost_multiplier": 0, "ends": "3 days" },
       { "monster": "mon_civilian_police", "weight": 4, "cost_multiplier": 3, "ends": "3 days" },
       { "monster": "mon_civilian_panic", "weight": 60, "cost_multiplier": 0, "ends": "2 days", "pack_size": [ 1, 5 ] },
-      { "monster": "mon_civilian_panic", "weight": 60, "cost_multiplier": 0, "starts": "2 days", "ends": "4 days", "pack_size": [ 1, 2 ] },
-      { "monster": "mon_civilian_panic", "weight": 60, "cost_multiplier": 0, "starts": "4 days", "ends": "6 days"}
+      {
+        "monster": "mon_civilian_panic",
+        "weight": 60,
+        "cost_multiplier": 0,
+        "starts": "2 days",
+        "ends": "4 days",
+        "pack_size": [ 1, 2 ]
+      },
+      { "monster": "mon_civilian_panic", "weight": 60, "cost_multiplier": 0, "starts": "4 days", "ends": "6 days" }
     ]
   }
 ]

--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -14,14 +14,13 @@
     "volume": "62500 ml",
     "weight": "81500 g",
     "hp": 75,
-    "speed": 105,
+    "speed": 90,
     "symbol": "@",
     "color": "white",
     "diff": 2,
     "aggression": -50,
     "morale": -50,
-    "vision_day": 30,
-    "vision_night": 3,
+    "vision_day": 10,
     "melee_dice": 1,
     "melee_dice_sides": 2,
     "melee_damage": [ { "damage_type": "cut", "amount": 3 } ],
@@ -30,7 +29,7 @@
     "//": "They are human after all",
     "death_function": { "effect": { "id": "death_guilt", "min_level": 6 } },
     "path_settings": { "max_dist": 30, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
-    "upgrades": { "half_life": 1, "into": "mon_feral_human_pipe" },
+    "upgrades": { "half_life": 1, "age_grow":  1, "into_group": "GROUP_CIVILIANS_UPGRADE" },
     "dodge": 1,
     "death_drops": "default_zombie_death_drops",
     "zombify_into": "mon_zombie",
@@ -58,6 +57,7 @@
     "aggression": 100,
     "morale": 100,
     "vision_day": 50,
+    "vision_night": 3,
     "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_body_armor" ],
     "//": "Copied from zombie cop",
     "melee_skill": 6,
@@ -102,6 +102,14 @@
     "melee_damage": [ { "damage_type": "bash", "amount": 4 } ]
   },
   {
+    "name": "GROUP_CIVILIANS_UPGRADE",
+    "type": "monstergroup",
+    "monsters": [
+      { "group": "GROUP_VANILLA_ONLY_HUMANS", "weight": 8, "cost_multiplier": 0 },
+      { "group": "GROUP_FERAL", "weight": 2, "cost_multiplier": 0 }
+    ]
+  },
+  {
     "name": "GROUP_CIVILIANS_STANDARD",
     "//": "Used for deduplication only, so one does not have to repeat the same standard ratio over and over again",
     "type": "monstergroup",
@@ -109,7 +117,9 @@
       { "monster": "mon_civilian_stationary", "weight": 30, "cost_multiplier": 0, "ends": "3 days" },
       { "monster": "mon_civilian_zombiefighter", "weight": 16, "cost_multiplier": 0, "ends": "3 days" },
       { "monster": "mon_civilian_police", "weight": 4, "cost_multiplier": 3, "ends": "3 days" },
-      { "monster": "mon_civilian_panic", "weight": 60, "cost_multiplier": 0, "ends": "5 days", "pack_size": [ 1, 5 ] }
+      { "monster": "mon_civilian_panic", "weight": 60, "cost_multiplier": 0, "ends": "2 days", "pack_size": [ 1, 5 ] },
+      { "monster": "mon_civilian_panic", "weight": 60, "cost_multiplier": 0, "starts": "2 days", "ends": "4 days", "pack_size": [ 1, 2 ] },
+      { "monster": "mon_civilian_panic", "weight": 60, "cost_multiplier": 0, "starts": "4 days", "ends": "6 days"}
     ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Misc bugfixes targeting the new civilian monsters"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Fixes #65796. Also addresses the comments in #64142 that were made after it was merged.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- The back bay of the refugee center was using the monster group `GROUP_MALL`. No wonder there were civilians in there. I changed this to a monster group consisting solely of human zombies. 
- Also adjusts `GROUP_MALL` to also spawn ferals. Seems off for malls to be devoid of them.
- Added a new monster group: `GROUP_FERAL`. I use this for civilian evolution and deduplicating of entries in other monster groups. I am aware there is already `FERAL_HUMANS` but it includes some tougher ferals that should definitely not spawn anymore, most notably the soldier, militia and biker varieties.
- Nerfed the panicked person to be slower and more shortsighted. This will cause it to not run as far I hope.
- Adjusted spawning and evolution. They will be noticably less common after a few days. I uh might not know the implications of using *both* `age_grow` and `half_life` but it appears to work and thats what counts, right?

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Renaming `FERAL_HUMANS` to `GROUP_FARM_SUPPLY_STORE` while I was at it. I do not know how many mods use that group though.
Given that this location is rural and full of materials needed for longer term survival, it does make sense in this location. Re-using that group anywhere else is tough since it is rather specific but its name promises something generic.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Loads fine.

- Teleported around at different days in the game. Population of civilians looks as expected.
- Checked the back bay of the refugee center. All as expected.
- Observed the behavior of a panicked person running away. It should be much better now since they will lose sight of the zombie that is chasing them frequently and not see obstacles such as other hordes ahead of them. As a bonus, this helps displaying their erratic and panicked nature.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->