### PR TITLE
Enable the clang-tidy check performance-inefficient-vector-operation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -80,7 +80,6 @@ readability-*,\
 -modernize-return-braced-init-list,\
 -modernize-use-default-member-init,\
 -modernize-use-nodiscard,\
--performance-inefficient-vector-operation,\
 -performance-unnecessary-copy-initialization,\
 -readability-container-data-pointer,\
 -readability-convert-member-functions-to-static,\

--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -751,6 +751,7 @@ std::string achievement_tracker::ui_text() const
 
     // Next: the requirements
     std::vector<std::optional<std::string>> req_texts;
+    req_texts.reserve( watchers_.size() );
     for( const std::unique_ptr<requirement_watcher> &watcher : watchers_ ) {
         req_texts.push_back( watcher->ui_text() );
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6474,6 +6474,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
         num_processed = 0;
         // TODO: fix point types
         std::vector<tripoint_abs_ms> src_set;
+        src_set.reserve( coord_set.size() );
         for( const tripoint &p : coord_set ) {
             src_set.emplace_back( p );
         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1984,6 +1984,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
         num_processed = 0;
         // TODO: fix point types
         std::vector<tripoint_abs_ms> src_set;
+        src_set.reserve( act.coord_set.size() );
         for( const tripoint &p : act.coord_set ) {
             src_set.emplace_back( p );
         }

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -3010,6 +3010,7 @@ std::optional<item> bionic::uninstall_weapon()
 std::vector<const item *> bionic::get_available_pseudo_items( bool include_weapon ) const
 {
     std::vector<const item *> ret;
+    ret.reserve( passive_pseudo_items.size() );
     for( const item &pseudo : passive_pseudo_items ) {
         ret.push_back( &pseudo );
     }

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -406,6 +406,7 @@ damage_instance damage_instance::di_considering_length( units::length barrel_len
     for( damage_unit &du : di.damage_units ) {
         if( !du.barrels.empty() ) {
             std::vector<std::pair<float, float>> lerp_points;
+            lerp_points.reserve( du.barrels.size() );
             for( const barrel_desc &b : du.barrels ) {
                 lerp_points.emplace_back( static_cast<float>( b.barrel_length.value() ), b.amount );
             }

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -27,6 +27,7 @@ diary_page::diary_page() = default;
 std::vector<std::string> diary::get_pages_list()
 {
     std::vector<std::string> result;
+    result.reserve( pages.size() );
     for( std::unique_ptr<diary_page> &n : pages ) {
         result.push_back( get_diary_time_str( n->turn, n->time_acc ) );
     }

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -1060,6 +1060,7 @@ static vitamin_applied_effect applied_from_rate( const bool reduced, const int i
 std::vector<vitamin_applied_effect> effect::vit_effects( const bool reduced ) const
 {
     std::vector<vitamin_applied_effect> ret;
+    ret.reserve( eff_type->vitamin_data.size() );
     for( const vitamin_rate_effect &vreff : eff_type->vitamin_data ) {
         ret.push_back( applied_from_rate( reduced, intensity, vreff ) );
     }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1890,6 +1890,7 @@ std::vector<const item *> item_contents::get_added_pockets() const
 {
     std::vector<const item *> items_added;
 
+    items_added.reserve( additional_pockets.size() );
     for( const item &it : additional_pockets ) {
         items_added.push_back( &it );
     }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1934,6 +1934,7 @@ spell &known_magic::get_spell( const spell_id &sp )
 std::vector<spell *> known_magic::get_spells()
 {
     std::vector<spell *> spells;
+    spells.reserve( spellbook.size() );
     for( auto &spell_pair : spellbook ) {
         spells.emplace_back( &spell_pair.second );
     }
@@ -1980,6 +1981,7 @@ void known_magic::update_mana( const Character &guy, float turns )
 std::vector<spell_id> known_magic::spells() const
 {
     std::vector<spell_id> spell_ids;
+    spell_ids.reserve( spellbook.size() );
     for( const std::pair<const spell_id, spell> &pair : spellbook ) {
         spell_ids.emplace_back( pair.first );
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5382,6 +5382,7 @@ void map::process_items_in_vehicles( submap &current_submap )
     // vehicle got destroyed by a bomb (an active item!), this list
     // won't change, but veh_in_nonant will change.
     std::vector<vehicle *> vehicles;
+    vehicles.reserve( current_submap.vehicles.size() );
     for( const auto &veh : current_submap.vehicles ) {
         vehicles.push_back( veh.get() );
     }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1403,6 +1403,7 @@ class mapgen_value
 
             std::vector<StringId> all_possible_results( const mapgen_parameters & ) const override {
                 std::vector<StringId> result;
+                result.reserve( cases.size() );
                 for( const std::pair<const std::string, StringId> &p : cases ) {
                     result.push_back( p.second );
                 }

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -1998,6 +1998,7 @@ void mapgen_forest( mapgendata &dat )
     int max_factor = 0;
     if( !dat.region.forest_composition.biomes.empty() ) {
         std::vector<int> factors;
+        factors.reserve( dat.region.forest_composition.biomes.size() );
         for( const auto &b : dat.region.forest_composition.biomes ) {
             factors.push_back( b.second.sparseness_adjacency_factor );
         }

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -862,6 +862,7 @@ const mutation_variant *mutation_branch::pick_variant_menu() const
     menu.desc_enabled = true;
     menu.text = string_format( _( "Pick variant for: %s" ), name() );
     std::vector<const mutation_variant *> options;
+    options.reserve( variants.size() );
     for( const std::pair<const std::string, mutation_variant> &var : variants ) {
         options.emplace_back( &var.second );
     }
@@ -891,6 +892,7 @@ void mutation_branch::reset_all()
 std::vector<std::string> dream::messages() const
 {
     std::vector<std::string> ret;
+    ret.reserve( raw_messages.size() );
     for( const translation &msg : raw_messages ) {
         ret.push_back( msg.translated() );
     }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1733,6 +1733,7 @@ struct mutable_overmap_placement_rule_remainder {
 
     std::vector<tripoint_rel_omt> positions( om_direction::type rot ) const {
         std::vector<tripoint_rel_omt> result;
+        result.reserve( parent->pieces.size() );
         for( const mutable_overmap_placement_rule_piece &piece : parent->pieces ) {
             result.push_back( rotate( piece.pos, rot ) );
         }
@@ -2265,6 +2266,7 @@ struct mutable_overmap_phase {
 
     mutable_overmap_phase_remainder realise() const {
         std::vector<mutable_overmap_placement_rule_remainder> realised_rules;
+        realised_rules.reserve( rules.size() );
         for( const mutable_overmap_placement_rule &rule : rules ) {
             realised_rules.push_back( rule.realise() );
         }

--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -239,6 +239,7 @@ std::vector<display_proficiency> proficiency_set::display() const
         sorted_known.emplace_back( cur->name(), cur );
     }
 
+    sorted_learning.reserve( learning.size() );
     for( const learning_proficiency &cur : learning ) {
         sorted_learning.emplace_back( cur.id->name(), cur.id );
     }
@@ -487,6 +488,7 @@ std::vector<proficiency_id> proficiency_set::known_profs() const
 std::vector<proficiency_id> proficiency_set::learning_profs() const
 {
     std::vector<proficiency_id> ret;
+    ret.reserve( learning.size() );
     for( const learning_proficiency &subject : learning ) {
         ret.push_back( subject.id );
     }

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -521,6 +521,7 @@ static cata::value_ptr<parameterized_build_reqs> calculate_all_blueprint_reqs(
         std::sort( mapgen_values.begin(), mapgen_values.end() );
 
         std::vector<std::string> bp_values;
+        bp_values.reserve( bp_param.second.size() );
         for( const std::pair<const std::string, translation> &p : bp_param.second ) {
             bp_values.push_back( p.first );
         }
@@ -959,6 +960,7 @@ std::string recipe::recipe_proficiencies_string() const
 {
     std::vector<proficiency_id> profs;
 
+    profs.reserve( proficiencies.size() );
     for( const recipe_proficiency &rec : proficiencies ) {
         profs.push_back( rec.id );
     }

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1481,6 +1481,7 @@ void game::serialize_master( std::ostream &fout )
 void faction_manager::serialize( JsonOut &jsout ) const
 {
     std::vector<faction> local_facs;
+    local_facs.reserve( factions.size() );
     for( const auto &elem : factions ) {
         local_facs.push_back( elem.second );
     }

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -438,6 +438,7 @@ const std::map<std::string, std::unique_ptr<WORLD>> &worldfactory::get_all_world
 std::vector<std::string> worldfactory::all_worldnames() const
 {
     std::vector<std::string> result;
+    result.reserve( all_worlds.size() );
     for( const auto &elem : all_worlds ) {
         result.push_back( elem.first );
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
More static analysis.

This check suggests vector reserve calls before a loops where push_back is called repeatedly.  This saves reallocations and moves, improving performance.

This is one that got turned off in the move to LLVM 16.  I think that's because the check improved the range of loops it was capable of analyzing.

#### Describe the solution
Enable the clang-tidy check `performance-inefficient-vector-operation`.

Run clang-tidy, and have it perform all the changes automatically.

#### Describe alternatives you've considered
None.

#### Testing
Run clang-tidy.

#### Additional context
There are 35 more checks to triage after this one.