### PR TITLE
'make clean-pch' should also clean pch files in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1305,6 +1305,7 @@ clean-pch:
 	rm -f pch/*pch.hpp.gch
 	rm -f pch/*pch.hpp.pch
 	rm -f pch/*pch.hpp.d
+	$(MAKE) -C tests clean-pch
 
 .PHONY: tests check ctags etags clean-tests clean-object_creator clean-pch install lint
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -70,9 +70,11 @@ check: $(TEST_TARGET) $(TEST_BATCHES)
 check-single: $(TEST_TARGET)
 	cd .. && tests/$(TEST_TARGET) --min-duration 0.2 --rng-seed time
 
-clean:
+clean: clean-pch
 	rm -rf *obj *objwin
 	rm -f *cata_test
+
+clean-pch:
 	rm -f pch/*pch.hpp.gch
 	rm -f pch/*pch.hpp.pch
 	rm -f pch/*pch.hpp.d
@@ -90,7 +92,7 @@ $(ODIR)/%.inc: %.cpp
 .PHONY: includes
 includes: $(OBJS:.o=.inc)
 
-.PHONY: clean check check-single tests precompile_header
+.PHONY: clean clean-pch check check-single tests precompile_header
 
 .SECONDARY: $(OBJS)
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Developer convenience.

There was already a `clean-pch` target in the `Makefile`, but it only cleaned the top-level pch files.  This is annoying in the situation where a developer changes compilers and does `make clean-pch && make` because it leads to compiler errors later in the build when it comes to the `tests` directory.

#### Describe the solution
Update the Makefiles so `clean-pch` also cleans the pch files within `tests`.  As a side-effect, this also allows `make clean-pch` within the `tests` dir, which is nice for consistency.

#### Describe alternatives you've considered
I have been thinking about whether it's possible to have the `Makefile` automatically detect when the compiler changes and recreate the `pch` files.  It's probably possible, but it's the kind of thing that's awkward to implement in make, so I didn't.

#### Testing
Ran `make clean-pch`.

#### Additional context
This shouldn't affect anything in-game or in the CI.