### PR TITLE
Enable clang-analyzer checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -66,9 +66,6 @@ readability-*,\
 -bugprone-throw-keyword-missing,\
 -bugprone-unchecked-optional-access,\
 -bugprone-unhandled-exception-at-new,\
--clang-analyzer-cplusplus.NewDeleteLeaks,\
--clang-analyzer-cplusplus.StringChecker,\
--clang-analyzer-optin.cplusplus.UninitializedObject,\
 -misc-confusable-identifiers,\
 -misc-const-correctness,\
 -misc-no-recursion,\

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13550,6 +13550,7 @@ std::vector<item_comp> item::get_uncraft_components() const
                 if( component.has_flag( flag_UNRECOVERABLE ) ) {
                     continue;
                 }
+                // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
                 auto iter = std::find_if( ret.begin(), ret.end(), [component]( item_comp & obj ) {
                     return obj.type == component.typeId();
                 } );

--- a/src/mapsharing.cpp
+++ b/src/mapsharing.cpp
@@ -96,8 +96,10 @@ void MAP_SHARING::setDefaults()
     MAP_SHARING::setCompetitive( false );
     MAP_SHARING::setWorldmenu( true );
     MAP_SHARING::setUsername( "" );
-    if( MAP_SHARING::getUsername().empty() && getenv( "USER" ) ) {
-        MAP_SHARING::setUsername( getenv( "USER" ) );
+    if( const char *user = getenv( "USER" ) ) {
+        MAP_SHARING::setUsername( user );
+    } else {
+        MAP_SHARING::setUsername( "" );
     }
     MAP_SHARING::addAdmin( "admin" );
 }

--- a/src/mapsharing.cpp
+++ b/src/mapsharing.cpp
@@ -95,7 +95,6 @@ void MAP_SHARING::setDefaults()
     MAP_SHARING::setSharing( false );
     MAP_SHARING::setCompetitive( false );
     MAP_SHARING::setWorldmenu( true );
-    MAP_SHARING::setUsername( "" );
     if( const char *user = getenv( "USER" ) ) {
         MAP_SHARING::setUsername( user );
     } else {

--- a/src/path_info.cpp
+++ b/src/path_info.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <string>
 
+#include "debug.h"
 #include "enums.h"
 #include "filesystem.h" // IWYU pragma: keep
 #include "make_static.h"
@@ -57,6 +58,16 @@ static cata_path options_path_value;
 static cata_path savedir_path_value;
 static cata_path user_dir_path_value;
 
+// Get the given env var, or abort the program if it is not set
+static const char *getenv_or_abort( const char *name )
+{
+    const char *result = getenv( name );
+    if( !result ) {
+        cata_fatal( "Required environment variable %s was not set", name );
+    }
+    return result;
+}
+
 void PATH_INFO::init_base_path( std::string path )
 {
     if( !path.empty() ) {
@@ -75,21 +86,21 @@ void PATH_INFO::init_user_dir( std::string dir )
     if( dir.empty() ) {
         const char *user_dir;
 #if defined(_WIN32)
-        user_dir = getenv( "LOCALAPPDATA" );
+        user_dir = getenv_or_abort( "LOCALAPPDATA" );
         // On Windows userdir without dot
         dir = std::string( user_dir ) + "/cataclysm-dda/";
 #elif defined(MACOSX)
-        user_dir = getenv( "HOME" );
+        user_dir = getenv_or_abort( "HOME" );
         dir = std::string( user_dir ) + "/Library/Application Support/Cataclysm/";
 #elif defined(USE_XDG_DIR)
         if( ( user_dir = getenv( "XDG_DATA_HOME" ) ) ) {
             dir = std::string( user_dir ) + "/cataclysm-dda/";
         } else {
-            user_dir = getenv( "HOME" );
+            user_dir = getenv_or_abort( "HOME" );
             dir = std::string( user_dir ) + "/.local/share/cataclysm-dda/";
         }
 #else
-        user_dir = getenv( "HOME" );
+        user_dir = getenv_or_abort( "HOME" );
         dir = std::string( user_dir ) + "/.cataclysm-dda/";
 #endif
     }
@@ -145,7 +156,7 @@ void PATH_INFO::set_standard_filenames()
     if( ( user_dir = getenv( "XDG_CONFIG_HOME" ) ) ) {
         dir = std::string( user_dir ) + "/cataclysm-dda/";
     } else {
-        user_dir = getenv( "HOME" );
+        user_dir = getenv_or_abort( "HOME" );
         dir = std::string( user_dir ) + "/.config/cataclysm-dda/";
     }
     config_dir_value = dir;

--- a/src/string_id.h
+++ b/src/string_id.h
@@ -223,7 +223,7 @@ class string_id
          * Note that this id class does not enforce empty id strings (or any specific string at all)
          * to be special. Every string (including the empty one) may be a valid id.
          */
-        string_id() : _id() {}
+        string_id() : _id() {} // NOLINT(clang-analyzer-optin.cplusplus.UninitializedObject)
         /**
          * Comparison, only useful when the id is used in std::map or std::set as key.
          * Guarantees total order, but DOESN'T guarantee the same order after process restart!


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
More static analysis.

The `clang-analyzer` checks do more complicated flow-control analysis.  This catches more subtle bugs but is also more prone to false-positives.

#### Describe the solution
Enable three `clang-analyzer` checks that were disabled in the move to LLVM16:

* `clang-analyzer-cplusplus.NewDeleteLeaks`
* `clang-analyzer-cplusplus.StringChecker`
* `clang-analyzer-optin.cplusplus.UninitializedObject`

These caused four warnings: two were genuine (failing to check the return value from `getenv` for being NULL); the other two seem to be false-positives which I've suppressed.

#### Describe alternatives you've considered
Disabling some of these checks for generating too many false-positives.

#### Testing
Run clang-tidy; unit tests.

#### Additional context