### PR TITLE
Residential-Decay

### DIFF
--- a/data/json/mapgen/nested/aux_nested.json
+++ b/data/json/mapgen/nested/aux_nested.json
@@ -7,6 +7,15 @@
   },
   {
     "type": "mapgen",
+    "nested_mapgen_id": "blood_field",
+    "method": "json",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "place_fields": [ { "field": "fd_blood", "x": 0, "y": 0, "intensity": [ 1, 3 ], "age": 10 } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "fire_field",
     "object": { "mapgensize": [ 1, 1 ], "place_fields": [ { "field": "fd_fire", "x": 0, "y": 0, "intensity": 2, "age": 10 } ] }
@@ -231,6 +240,16 @@
       "place_item": [ { "item": "corpse_generic_human", "x": 0, "y": 0, "chance": 100 } ],
       "place_items": [ { "item": "ammo_casings", "x": [ 0, 2 ], "y": [ 0, 2 ], "chance": 50 } ],
       "place_fields": [ { "field": "fd_blood", "x": [ 0, 2 ], "y": [ 0, 2 ], "intensity": 1, "age": 10 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "corpse_blood_1x1",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "place_item": [ { "item": "corpse_generic_human", "x": 0, "y": 0, "chance": 100 } ],
+      "place_fields": [ { "field": "fd_blood", "x": 0, "y": 0, "intensity": [ 1, 3 ], "age": 10 } ]
     }
   },
   {

--- a/data/json/mapgen_palettes/house_general_palette.json
+++ b/data/json/mapgen_palettes/house_general_palette.json
@@ -141,15 +141,17 @@
       "u": "t_region_groundcover_urban",
       "X": "t_region_groundcover_urban",
       ".": "t_region_groundcover_urban",
-      "+": [ [ "t_door_c", 5 ], [ "t_door_o", 5 ], [ "t_door_locked_interior", 1 ] ],
+      "+": [ [ "t_door_b", 2 ], [ "t_door_frame", 2 ], [ "t_door_c", 5 ], [ "t_door_o", 5 ], [ "t_door_locked_interior", 1 ] ],
       "*": [
+        [ "t_door_b", 5 ],
         [ "t_door_locked_peep", 2 ],
         "t_door_locked_alarm",
         [ "t_door_locked", 10 ],
         [ "t_door_elocked_peep", 4 ],
         "t_door_elocked_alarm",
         [ "t_door_elocked", 15 ],
-        "t_door_c"
+        "t_door_c",
+        [ "t_door_o", 2 ]
       ],
       "^": "t_gutter_downspout",
       "|": { "param": "interior_wall_type", "fallback": "t_wall_w" },
@@ -158,6 +160,7 @@
       ":": "t_wall_glass",
       "-": "t_sidewalk",
       "o": [
+        [ "t_window_frame", 4 ],
         [ "t_window_domestic", 10 ],
         "t_window_no_curtains",
         "t_window_open",
@@ -282,9 +285,14 @@
         { "item": "toy_store", "chance": 60, "repeat": [ 1, 2 ] },
         { "item": "games", "chance": 10, "repeat": [ 1, 2 ] },
         { "item": "allsporting", "chance": 5 }
-      ]
+      ],
+      " ": { "item": "trash", "chance": 1 }
     },
-    "mapping": { "÷": { "item": { "item": "doormat", "chance": 55 } } }
+    "mapping": { "÷": { "item": { "item": "doormat", "chance": 55 } } },
+    "nested": {
+      "#": { "chunks": [ [ "shelter_graffiti", 1 ], [ "general_graffiti", 1 ], [ "null", 298 ] ] },
+      " ": { "chunks": [ [ "corpse_blood_1x1", 1 ], [ "blood_field", 2 ], [ "bile_field", 1 ], [ "null", 196 ] ] }
+    }
   },
   {
     "type": "palette",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Mapgen changes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Somehow a few days into the Cataclysm buildings are still pristine even with riots and Zombies. Dirty up residential structures with Door and window damage. Blood, bile and body spawns as well as trash and graffiti. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Edited house-general_pallet and aux_nested files for small chance of décor spawning. Windows and doors have a chance to generate broken versions. Floor tiles in houses have a small chance for blood, bodies or trash to spawn settings relatively conservative currently. Could be adjusted higher or lower. Houses with dozens of zombies in / around them shouldn't be pristine. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Leaving the mapgen as it was. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Repeatedly generated maps and tested frequency of additions. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
![CDDA-Decay1](https://github.com/CleverRaven/Cataclysm-DDA/assets/14862800/4681125f-a283-4326-a6cc-3d8367b4c78d)
![CDDA-decay2](https://github.com/CleverRaven/Cataclysm-DDA/assets/14862800/ee6772ca-6ca7-4266-815b-558d32c43c05)
![CDDA-Decay3](https://github.com/CleverRaven/Cataclysm-DDA/assets/14862800/aaf0cbfc-8d30-41c9-9ff6-0e1c5eaf579d)
![CDDA-Decay4](https://github.com/CleverRaven/Cataclysm-DDA/assets/14862800/fd3411cb-c786-40ad-8f6c-26c18111fac1)
![CDDA-Decay5](https://github.com/CleverRaven/Cataclysm-DDA/assets/14862800/6768b7f9-4266-4abd-9622-cfaceef57f2a)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->