### PR TITLE
Revert "makeshift electrolyzer shouldn't contain lye (#65820)"

### DIFF
--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -654,6 +654,7 @@
       [ [ "pipe", 2 ] ],
       [ [ "sheet_metal_small", 12 ] ],
       [ [ "jar_3l_glass_sealed", 8 ] ],
+      [ [ "lye", 16 ] ],
       [ [ "sheet_metal", 1 ] ],
       [ [ "cable", 400 ] ],
       [ [ "scrap", 16 ] ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Revert 'makeshift electrolyzer shouldn't contain lye'"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
This reverts commit f8343f7c68e10374123d557bda441d48c1507927.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Clicked the revert commit button.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
- Increase electrolyzer energy cost
- Add hydrogen fuel cells and reuse it as electrolyzer parts (might be an upgrade path to a better makeshift hydrogen generator)

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Minor JSON change.

#### Additional context

https://en.wikipedia.org/wiki/Electrolysis_of_water

> [Electrolysis](https://en.wikipedia.org/wiki/Electrolysis) of pure water requires excess energy in the form of [overpotential](https://en.wikipedia.org/wiki/Overpotential) to overcome various activation barriers. Without the excess energy, electrolysis occurs slowly or not at all. This is in part due to the limited [self-ionization of water](https://en.wikipedia.org/wiki/Self-ionization_of_water).

> Pure water has an [electrical conductivity](https://en.wikipedia.org/wiki/Electrical_conductivity) about one-millionth that of seawater.

> Many [electrolytic cells](https://en.wikipedia.org/wiki/Electrolytic_cell) lack requisite [electrocatalysts](https://en.wikipedia.org/wiki/Electrocatalyst). Efficiency is increased through the addition of an [electrolyte](https://en.wikipedia.org/wiki/Electrolyte) (such as a [salt](https://en.wikipedia.org/wiki/Salt_(chemistry)), an [acid](https://en.wikipedia.org/wiki/Acid) or a [base](https://en.wikipedia.org/wiki/Base_(chemistry))) and [electrocatalysts](https://en.wikipedia.org/wiki/Electrocatalyst).

>Electrolysis in pure water consumes/reduces H+ [cations](https://en.wikipedia.org/wiki/Cation) at the cathode and consumes/oxidizes hydroxide (OH−) [anions](https://en.wikipedia.org/wiki/Anion) at the anode. This can be verified by adding a [pH indicator](https://en.wikipedia.org/wiki/PH_indicator) to the water: Water near the cathode is basic while water near the anode is acidic. The hydroxides OH− that approach the anode mostly combine with the positive hydronium ions (H3O+) to form water. The positive hydronium ions that approach the cathode mostly combine with negative hydroxide ions to form water. Relatively few hydroniums/hydroxide ions reach the cathode/anode. This can cause overpotential at both electrodes.

> Pure water has a charge carrier density similar to semiconductors since it has a low [autoionization](https://en.wikipedia.org/wiki/Self-ionization_of_water), Kw = 1.0×10−14 at room temperature and thus pure water conducts current poorly, 0.055 µS·cm−1. Unless a large potential is applied to increase the autoionization of water, electrolysis of pure water proceeds slowly, limited by the overall conductivity.

> An aqueous electrolyte can considerably raise conductivity. The electrolyte disassociates into [cations](https://en.wikipedia.org/wiki/Cation) and anions; the anions rush towards the anode and neutralize the buildup of positively charged H+ there; similarly, the cations rush towards the cathode and neutralize the buildup of negatively charged OH− there. This allows the continuous flow of electricity.

> Strong acids such as [sulfuric acid](https://en.wikipedia.org/wiki/Sulfuric_acid) (H2SO4), and strong bases such as [potassium hydroxide](https://en.wikipedia.org/wiki/Potassium_hydroxide) (KOH), and [sodium hydroxide](https://en.wikipedia.org/wiki/Sodium_hydroxide) (NaOH) are common choices as electrolytes due to their strong conducting abilities.

https://www.quora.com/Why-is-sodium-hydroxide-NaOH-such-an-effective-electrolyte-in-water-electrolysis-What-factors-determine-how-effective-an-electrolyte-is-in-electrolysis mentions that sodium hydroxide is not consumed. Schematic diagrams of alkaline water electrolysis machines also shows the lye solution being pumped in a loop.

I could not find any papers that entertains the idea of electrolyzing pure water without also mentioning proton exchange membranes or high temperatures steam electrolysis, technologies that are far out of reach from an apocalypse survivor. Most books instead describe alkaline water electrolysis as a [well-established](https://www.sciencedirect.com/science/article/abs/pii/S0378775303000776) and [cheapest](https://www.sciencedirect.com/science/article/abs/pii/B9780128197271000248) method.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->