### PR TITLE
Clarify low calorie messages

### DIFF
--- a/data/json/snippets/health_msgs.json
+++ b/data/json/snippets/health_msgs.json
@@ -182,11 +182,11 @@
   {
     "type": "snippet",
     "category": "empty_low_cal",
-    "text": "You've lost quite a bit of weight recently.  You might want to eat richer food."
+    "text": "You've lost quite a bit of weight recently.  You might want to eat more food."
   },
   {
     "type": "snippet",
     "category": "low_cal",
-    "text": "You feel that you need to eat more calorie-dense food."
+    "text": "You feel that you need to consume more calories."
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Clarify low calorie messages"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The messagess for being low on stored calories consistently confuse players. They imply that the problem is that the player is eating the wrong kind of food, when it'ss almost always that the player simply isn't eating enough food.

It's doubly confusing because "calorie-dense" food is barely even a thing, and in as far as it does exist, aren't remotely intuitive. E.g. most food has more or less the same calorie density, but chocolate is significantly _less_ calorie-dense than bread.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change the messages to more clearly reflect the actual poblem. The empty stomach low cal message now instructs the player to eat more food instead of richer food, and the non-empty message unambiguously tells the player to "consume more calories" rather than "eat more calorie-dense food".
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Be even more explicit about why these messages are showing up, but they seem to be trying to maintain at least a somewhat diegetic tone, so I didn't want to flash up a big sign that says "YOUR STORED CALORIES ARE TRENDING DOWNWARDS, APPROACHING THE THRESHOLD WHERE YOU START TO SUFFER MALNUTRITION PENALTIES"
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I'm sure people will still underestimate the amount of calories they're burning, but this should at least put a stop to the "what do you mean I need more calorie-dense food, I ate three whole candy bars today" confusion
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->