### PR TITLE
Fix cable pockets interfering with battery mods

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3677,18 +3677,20 @@ void Item_factory::add_special_pockets( itype &def )
     if( !has_pocket_type( def.pockets, item_pocket::pocket_type::MIGRATION ) ) {
         def.pockets.emplace_back( item_pocket::pocket_type::MIGRATION );
     }
-    const use_function *iuse = def.get_use( "link_up" );
-    if( iuse != nullptr ) {
-        const link_up_actor *actor_ptr =
-            static_cast<const link_up_actor *>( iuse->get_actor_ptr() );
-        if( actor_ptr != nullptr && !actor_ptr->is_cable_item ) {
-            pocket_data cable_pocket( item_pocket::pocket_type::CABLE );
-            cable_pocket.rigid = true;
-            cable_pocket.volume_capacity = units::from_milliliter( 1 );
-            cable_pocket.max_contains_weight = units::from_gram( 1 );
-            cable_pocket.weight_multiplier = 0.0f;
-            cable_pocket.volume_multiplier = 0.0f;
-            def.pockets.emplace_back( cable_pocket );
+    if( !has_pocket_type( def.pockets, item_pocket::pocket_type::CABLE ) ) {
+        const use_function *iuse = def.get_use( "link_up" );
+        if( iuse != nullptr ) {
+            const link_up_actor *actor_ptr =
+                static_cast<const link_up_actor *>( iuse->get_actor_ptr() );
+            if( actor_ptr != nullptr && !actor_ptr->is_cable_item ) {
+                pocket_data cable_pocket( item_pocket::pocket_type::CABLE );
+                cable_pocket.rigid = true;
+                cable_pocket.volume_capacity = units::from_milliliter( 1 );
+                cable_pocket.max_contains_weight = units::from_gram( 1 );
+                cable_pocket.weight_multiplier = 0.0f;
+                cable_pocket.volume_multiplier = 0.0f;
+                def.pockets.emplace_back( cable_pocket );
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix cable pockets interfering with battery mods"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #65921. The automatic cable pocket creation I added in #64334 wasn't checking for existing cable pockets, resulting in this:
1. `mp3` would automatically create a cable pocket during `add_special_pockets`
2. `mp3_on` would copy that cable pocket via `"copy-from": "mp3"`
3. `mp3_on` would then automatically create a second cable pocket during `add_special_pockets`.

This made the on/off versions of a device have differing amounts of pockets, causing battery mods to break. It feels like the kind of oversight that would cause more issues than just breaking battery mods, as well.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Only automatically add a cable pocket if the item doesn't have one defined already.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The cable pocket section of `add_special_pockets` is now a large part of the function, and it'd be better code aesthetics to do something cleaner like splitting it off into its own function.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added a battery mod to mp3 player and laptop, confirmed that the battery isn't lost when toggling them on and off, unplugged and not. It thankfully fixes saves made before this change, as well, so devices haven't been permanently marred with an extra invisible pocket.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->