### PR TITLE
eoc_math: don't allow assignment operators in conditional statements

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/initialization.json
+++ b/data/mods/Xedra_Evolved/eocs/initialization.json
@@ -4,13 +4,13 @@
     "id": "EOC_XE_VARIABLE_INIT",
     "eoc_type": "EVENT",
     "required_event": "game_begin",
-    "condition": { "not": { "math": [ "XE_INITIALIZATION", "=", "1" ] } },
+    "condition": { "math": [ "XE_INITIALIZATION", "!=", "1" ] },
     "effect": [ { "queue_eocs": "EOC_XE_VARIABLE_INITIALIZATION" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_XE_VARIABLE_INITIALIZATION",
-    "condition": { "not": { "math": [ "XE_INITIALIZATION", "=", "1" ] } },
+    "condition": { "math": [ "XE_INITIALIZATION", "!=", "1" ] },
     "effect": [
       { "math": [ "base_difficulty_1", "=", "2" ] },
       { "math": [ "base_difficulty_2", "=", "3" ] },

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1426,7 +1426,7 @@ void conditional_t::set_compare_num( const JsonObject &jo, const std::string_vie
 void conditional_t::set_math( const JsonObject &jo, const std::string_view member )
 {
     eoc_math math;
-    math.from_json( jo, member );
+    math.from_json( jo, member, true );
     condition = [math = std::move( math )]( dialogue & d ) {
         return math.act( d );
     };
@@ -2660,7 +2660,7 @@ void talk_effect_fun_t::set_math( const JsonObject &jo, const std::string_view m
     };
 }
 
-void eoc_math::from_json( const JsonObject &jo, std::string_view member )
+void eoc_math::from_json( const JsonObject &jo, std::string_view member, bool conditional )
 {
     JsonArray const objects = jo.get_array( member );
     if( objects.size() > 3 ) {
@@ -2710,6 +2710,17 @@ void eoc_math::from_json( const JsonObject &jo, std::string_view member )
         } else {
             jo.throw_error( "Invalid binary operator in " + jo.str() );
             return;
+        }
+    }
+    if( !conditional && action >= oper::equal ) {
+        objects.throw_error( "Comparison operators can only be used in conditional statements" );
+    }
+    if( conditional && action < oper::equal ) {
+        if( action == oper::assign ) {
+            objects.throw_error(
+                R"(Assignment operator "=" can't be used in a conditional statement.  Did you mean to use "=="? )" );
+        } else {
+            objects.throw_error( "Only comparison operators can be used in conditional statements" );
         }
     }
     bool const lhs_assign = action >= oper::assign && action <= oper::decrease;

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -175,7 +175,7 @@ struct eoc_math {
     std::shared_ptr<math_exp> rhs;
     eoc_math::oper action = oper::invalid;
 
-    void from_json( const JsonObject &jo, std::string_view member );
+    void from_json( const JsonObject &jo, std::string_view member, bool conditional = false );
     double act( dialogue &d ) const;
 };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
In `math`, the operators `=` and `==` are not equivalent unlike in `arithmetic` and can lead to nonsensical results.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Only allow comparison operators in conditional statements. Add a special case for `=` vs `==`.
Disallow comparison operators outside of `condition` objects.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<details>
<summary>= instead of ==</summary>

![ass in comp](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/52492f3b-3a7d-4e73-98d8-edb6d9b3a03c)


</details>

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I wanted the chevron to point to the right element but that doesn't seem to be possible for arrays.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->