### PR TITLE
Allow NPCs to read E-books

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
@@ -887,6 +887,12 @@
         "condition": { "and": [ { "not": "npc_has_activity" }, { "not": { "npc_has_trait": "HALLUCINATION" } } ] },
         "effect": "do_read"
       },
+	  {
+        "text": "Please study from an e-book.",
+        "topic": "TALK_DONE",
+        "condition": { "and": [ { "not": "npc_has_activity" }, { "not": { "npc_has_trait": "HALLUCINATION" } } ] },
+        "effect": "do_eread"
+      },
       {
         "text": "Please start deconstructing any vehicles in a deconstruction zone.",
         "topic": "TALK_DONE",

--- a/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
@@ -887,7 +887,7 @@
         "condition": { "and": [ { "not": "npc_has_activity" }, { "not": { "npc_has_trait": "HALLUCINATION" } } ] },
         "effect": "do_read"
       },
-	  {
+      {
         "text": "Please study from an e-book.",
         "topic": "TALK_DONE",
         "condition": { "and": [ { "not": "npc_has_activity" }, { "not": { "npc_has_trait": "HALLUCINATION" } } ] },

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1267,8 +1267,8 @@ class ereader_inventory_preset : public pickup_inventory_preset
 
 item_location game_menus::inv::ereader_to_use( Character &you )
 {
-	const std::string msg = _( "You don't have any e-readers you can use." );
-    return inv_internal( you, ereader_inventory_preset( you ), _( "Select e-reader." ), 1, msg );					 
+    const std::string msg = _( "You don't have any e-readers you can use." );
+    return inv_internal( you, ereader_inventory_preset( you ), _( "Select e-reader." ), 1, msg );
 }
 
 class read_inventory_preset: public pickup_inventory_preset

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1237,10 +1237,9 @@ class ereader_inventory_preset : public pickup_inventory_preset
 
         std::string get_denial( const item_location &loc ) const override {
             const item &it = *loc;
-            //const auto &uses = it.type->use_methods;
 
             if( it.is_broken() ) {
-                return /*string_format(*/ _( "E-reader is broken and won't turn on." ) /*)*/;
+                return _( "E-reader is broken and won't turn on." );
             }
 
             if( !it.ammo_sufficient( &you, "EBOOKREAD" ) ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1237,7 +1237,7 @@ class ereader_inventory_preset : public pickup_inventory_preset
 
         std::string get_denial( const item_location &loc ) const override {
             const item &it = *loc;
-            const auto &uses = it.type->use_methods;
+            //const auto &uses = it.type->use_methods;
 
             if( it.is_broken() ) {
                 return /*string_format(*/ _( "E-reader is broken and won't turn on." ) /*)*/;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1240,13 +1240,13 @@ class ereader_inventory_preset : public pickup_inventory_preset
             const auto &uses = it.type->use_methods;
 
             if( it.is_broken() ) {
-                return string_format( _( "E-reader is broken and won't turn on." ), it.tname() );
+                return /*string_format(*/ _( "E-reader is broken and won't turn on." ) /*)*/;
             }
 
-            if( !it.ammo_sufficient( &you, uses.count( "EBOOKREAD" ) ) ) {
+            if( !it.ammo_sufficient( &you, "EBOOKREAD" ) ) {
                 return string_format(
-                           n_gettext( "Needs at least %d charge",
-                                      "Needs at least %d charges", loc->ammo_required() ),
+                           n_gettext( "Needs at least %d charge.",
+                                      "Needs at least %d charges.", loc->ammo_required() ),
                            loc->ammo_required() );
             }
 
@@ -1259,7 +1259,7 @@ class ereader_inventory_preset : public pickup_inventory_preset
 
     protected:
         std::string get_action_name( const item &it ) const {
-            return _( "Read E-book" );
+            return string_format( "Read on %s.", it.tname() );
         }
     private:
         const Character &you;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1218,6 +1218,59 @@ item_location game_menus::inv::gun_to_modify( Character &you, const item &gunmod
                          _( "You don't have any guns to modify." ) );
 }
 
+class ereader_inventory_preset : public pickup_inventory_preset
+{
+    public:
+        explicit ereader_inventory_preset( const Character &you ) : pickup_inventory_preset( you ),
+            you( you ) {
+            _collate_entries = true;
+            if( get_option<bool>( "INV_USE_ACTION_NAMES" ) ) {
+                append_cell( [ this ]( const item_location & loc ) {
+                    return string_format( "<color_light_green>%s</color>", get_action_name( *loc ) );
+                }, _( "ACTION" ) );
+            }
+        }
+
+        bool is_shown( const item_location &loc ) const override {
+            return loc->is_ebook_storage();
+        }
+
+        std::string get_denial( const item_location &loc ) const override {
+            const item &it = *loc;
+            const auto &uses = it.type->use_methods;
+
+            if( it.is_broken() ) {
+                return string_format( _( "E-reader is broken and won't turn on." ), it.tname() );
+            }
+
+            if( !it.ammo_sufficient( &you, uses.count( "EBOOKREAD" ) ) ) {
+                return string_format(
+                           n_gettext( "Needs at least %d charge",
+                                      "Needs at least %d charges", loc->ammo_required() ),
+                           loc->ammo_required() );
+            }
+
+            if( !it.has_flag( flag_ALLOWS_REMOTE_USE ) ) {
+                return pickup_inventory_preset::get_denial( loc );
+            }
+
+            return std::string();
+        }
+
+    protected:
+        std::string get_action_name( const item &it ) const {
+            return _( "Read E-book" );
+        }
+    private:
+        const Character &you;
+};
+
+item_location game_menus::inv::ereader_to_use( Character &you )
+{
+	const std::string msg = _( "You don't have any e-readers you can use." );
+    return inv_internal( you, ereader_inventory_preset( you ), _( "Select e-reader." ), 1, msg );					 
+}
+
 class read_inventory_preset: public pickup_inventory_preset
 {
     public:

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -116,6 +116,8 @@ item_location disassemble( Character &you );
 item_location gun_to_modify( Character &you, const item &gunmod );
 /** Book reading menu. */
 item_location read( Character &you );
+/** E-Book reading menu. */
+item_location ereader_to_use( Character &you );
 /** eBook reading menu. */
 item_location ebookread( Character &you, item_location &ereader );
 /** Menu for stealing stuff. */

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1362,8 +1362,8 @@ void npc::do_npc_read( bool ebook )
         return;
     }
 
-	item_location book;
-	item_location ereader;
+    item_location book;
+    item_location ereader;
 
     if( !ebook ) {
 		book = game_menus::inv::read( *npc_player );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1354,7 +1354,7 @@ time_duration npc::time_to_read( const item &book, const Character &reader ) con
     return retval;
 }
 
-void npc::do_npc_read()
+void npc::do_npc_read( bool ebook )
 {
     // Can read items from inventory or within one tile (including in vehicles)
     Character *npc_player = as_character();
@@ -1362,7 +1362,21 @@ void npc::do_npc_read()
         return;
     }
 
-    item_location book = game_menus::inv::read( *npc_player );
+	item_location book;
+	item_location ereader;
+
+    if( !ebook ) {
+		book = game_menus::inv::read( *npc_player );
+	}
+	else {
+		ereader = game_menus::inv::ereader_to_use( *npc_player );
+		if( !ereader ) {
+			add_msg( _( "Never mind." ) );
+			return;
+		}
+		book = game_menus::inv::ebookread( *npc_player, ereader );
+	}
+	
     if( !book ) {
         add_msg( _( "Never mind." ) );
         return;
@@ -1380,7 +1394,7 @@ void npc::do_npc_read()
 
         // NPCs can't read to other NPCs yet
         const time_duration time_taken = time_to_read( *book, *this );
-        item_location ereader = {};
+        //item_location ereader = {};
 
         // NPCs read until they gain a level
         read_activity_actor actor( time_taken, book, ereader, true, getID().get_value() );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1393,7 +1393,6 @@ void npc::do_npc_read( bool ebook )
 
         // NPCs can't read to other NPCs yet
         const time_duration time_taken = time_to_read( *book, *this );
-        //item_location ereader = {};
 
         // NPCs read until they gain a level
         read_activity_actor actor( time_taken, book, ereader, true, getID().get_value() );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1366,17 +1366,16 @@ void npc::do_npc_read( bool ebook )
     item_location ereader;
 
     if( !ebook ) {
-		book = game_menus::inv::read( *npc_player );
-	}
-	else {
-		ereader = game_menus::inv::ereader_to_use( *npc_player );
-		if( !ereader ) {
-			add_msg( _( "Never mind." ) );
-			return;
-		}
-		book = game_menus::inv::ebookread( *npc_player, ereader );
-	}
-	
+        book = game_menus::inv::read( *npc_player );
+    } else {
+        ereader = game_menus::inv::ereader_to_use( *npc_player );
+        if( !ereader ) {
+            add_msg( _( "Never mind." ) );
+            return;
+        }
+        book = game_menus::inv::ebookread( *npc_player, ereader );
+    }
+
     if( !book ) {
         add_msg( _( "Never mind." ) );
         return;

--- a/src/npc.h
+++ b/src/npc.h
@@ -922,7 +922,7 @@ class npc : public Character
         bool wear_if_wanted( const item &it, std::string &reason );
         bool can_read( const item &book, std::vector<std::string> &fail_reasons );
         time_duration time_to_read( const item &book, const Character &reader ) const;
-        void do_npc_read();
+        void do_npc_read( bool ebook = false );
         void stow_item( item &it );
         bool wield( item &it ) override;
         void drop( const drop_locations &what, const tripoint &target,

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5061,6 +5061,7 @@ void talk_effect_t::parse_string_effect( const std::string &effect_id, const Jso
             WRAP( do_mining ),
             WRAP( do_mopping ),
             WRAP( do_read ),
+            WRAP( do_eread ),
             WRAP( do_butcher ),
             WRAP( do_farming ),
             WRAP( assign_guard ),

--- a/src/npctalk.h
+++ b/src/npctalk.h
@@ -53,7 +53,7 @@ void do_construction( npc & );
 void do_mining( npc & );
 void do_mopping( npc & );
 void do_read( npc & );
-void do_eread ( npc & );
+void do_eread( npc & );
 void do_chop_plank( npc & );
 void do_vehicle_deconstruct( npc & );
 void do_vehicle_repair( npc & );

--- a/src/npctalk.h
+++ b/src/npctalk.h
@@ -53,6 +53,7 @@ void do_construction( npc & );
 void do_mining( npc & );
 void do_mopping( npc & );
 void do_read( npc & );
+void do_eread ( npc & );
 void do_chop_plank( npc & );
 void do_vehicle_deconstruct( npc & );
 void do_vehicle_repair( npc & );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -261,6 +261,11 @@ void talk_function::do_read( npc &p )
     p.do_npc_read();
 }
 
+void talk_function::do_eread( npc &p )
+{	
+	p.do_npc_read( true );
+}
+
 void talk_function::dismount( npc &p )
 {
     p.npc_dismount();

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -262,8 +262,8 @@ void talk_function::do_read( npc &p )
 }
 
 void talk_function::do_eread( npc &p )
-{	
-	p.do_npc_read( true );
+{
+    p.do_npc_read( true );
 }
 
 void talk_function::dismount( npc &p )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Allow NPCs to read E-books - new activity added"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
From now on friendly NPCs (followers) are able to read e-books from suitable devices. They can be ordered to do so in similar manner to reading books. A new dialogue option was added to handle e-readers.

It seemed to me that NPCs should be able to use advantages of e-reader the same way player does. Devices are widespread enough and scanning and copying a rare book so a group can read it at the same time seems reasonable use case IRL.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- I have added a new dialogue option to NPCs that order them to read an e-book (same manner as existing read a book option).
- New inventory preset and menu were created to facilitate finding all E-readers in NPCs inventory and choosing the e-reader to use.
- After selcting of e-reader an existing e-book menu is started and allows selection of a book to read.
- If e-reader is broken or without battery charges it cannot be selected (proper message in selection menu).
- If e-reader stores no e-books a fitting pop-up shows up and exits menus.
- If it is too dark to read it is impossible to choose a book (all of them have proper text mentioning it)
- NPCs **DO NOT** turn on flashlight, screen etc. the same way player does (in order to read e-book) 
[this functionality can be added in the future - I took quite a bite (with my meager C++ skills) to code what is in this PR and by making it more complex I would fear choking on it ;) ].
- After e-book selction NPC proceeds to read a book as usual (using the same function he did with regular books)
- NPCs reading function was slightly adjusted (now it is called with bool parameter) to cater for choosing between regular book or e-book as reading material.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this PR
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- I have reused a world with my "disassemble in the dark" test NPC
- Spawned a bunch of "e-reader" devices (smartphone, e-ink PC, laptop)
- Spawned a number of books
- Loaded different books to devices (some devices were left empty)
- Read book as PC (avatar) and confirm it still works as before
- Read e-book from a device as PC (avatar) and confirm it still works as before
- Gave NPC regular book, asked him to read it, confirm it works as before
- Gave NPC charged "e-reader" with some books and asked him to read
- Confirmed that NPC performs task as intended
- Gave NPC more devices (various types, including non "e-reader" electronics) ["e-readers" stored various books]
- Confirmed all three, checked "e-reader" device types worked and no other devices showed up in "Select e-reader" menu
- Confirmed that "e-reader" without battery cannot be used and player sees proper message
- Confirmed that broken (by water) "e-reader" cannot be used and player sees proper message
- Confirmed that "e-reader" with no books stored does not open "Select e-book" menu but escapes with proper pop-up
- Confirmed that NPC cannot start reading in the dark
- Confirmed that both "Select e-reader" and "Select e-book" menus can be escaped from (with esc) and close properly (had a crash here while working on PR but it seems I solved it)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
TODO (in oher PRs - I consider this one finished): 
- Allow NPCs to use in-built lighting/screen options in the same way player can
- I believe that NPCs reading e-books currently does not use device charges, I suppose it should be added. (ATM. I am afraid it is too big chunk to bite but I think it can be looked into in follow-up PR, any assistance here is also appreciated)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->