### PR TITLE
Rework wallet pocket restrictions

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2144,5 +2144,25 @@
   {
     "id": "ELECTRONIC",
     "type": "json_flag"
+  },
+  {
+    "id": "CREDIT_CARD_SHAPED",
+    "type": "json_flag",
+    "restriction": "Item must be shaped like a credit card"
+  },
+  {
+    "id": "BANK_NOTE_SHAPED",
+    "type": "json_flag",
+    "restriction": "Item must be shaped like a bank note"
+  },
+  {
+    "id": "COIN_SHAPED",
+    "type": "json_flag",
+    "restriction": "Item must be shaped like a coin"
+  },
+  {
+    "id": "BANK_NOTE_STRAP_SHAPED",
+    "type": "json_flag",
+    "restriction": "Item must be shaped like a bank note strap"
   }
 ]

--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -23,6 +23,7 @@
     "color": "blue",
     "volume": "10 ml",
     "weight": "10 g",
+    "flags": [ "CREDIT_CARD_SHAPED" ],
     "use_action": {
       "type": "reveal_map",
       "radius": 90,

--- a/data/json/items/containers.json
+++ b/data/json/items/containers.json
@@ -2534,6 +2534,7 @@
         "max_item_length": "26 cm"
       }
     ],
+    "flags": [ "BANK_NOTE_SHAPED" ],
     "properties": [ [ "burst_when_filled", "75" ] ]
   },
   {

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -49,6 +49,7 @@
     "volume": "5 ml",
     "price": 800,
     "price_postapoc": 0,
+    "flags": [ "BANK_NOTE_SHAPED" ],
     "material": [ "paper" ],
     "symbol": "*",
     "color": "light_gray"

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -3783,19 +3783,7 @@
         "max_contains_weight": "60 g",
         "max_contains_volume": "150 ml",
         "moves": 100,
-        "item_restriction": [
-          "FMCNote",
-          "signed_chit",
-          "family_photo",
-          "money_one",
-          "money_two",
-          "money_five",
-          "money_ten",
-          "money_twenty",
-          "money_fifty",
-          "money_hundred",
-          "condom"
-        ]
+        "flag_restriction": [ "BANK_NOTE_SHAPED" ]
       },
       {
         "//": "Card Sleeves",
@@ -3804,32 +3792,7 @@
         "max_contains_weight": "60 g",
         "max_contains_volume": "150 ml",
         "moves": 100,
-        "item_restriction": [
-          "cash_card",
-          "gasdiscount_silver",
-          "gasdiscount_gold",
-          "gasdiscount_platinum",
-          "id_science",
-          "id_military",
-          "id_industrial",
-          "fp_loyalty_card",
-          "scorecard",
-          "robofac_test_data",
-          "icon",
-          "labmap",
-          "id_science_visitor_1",
-          "id_science_transport_1",
-          "id_science_maintenance_green",
-          "id_science_maintenance_yellow",
-          "id_science_maintenance_blue",
-          "id_science_security_yellow",
-          "id_science_security_magenta",
-          "id_science_security_black",
-          "id_science_mutagen_green",
-          "id_science_mutagen_pink",
-          "id_science_mutagen_cyan",
-          "id_science_medical_red"
-        ]
+        "flag_restriction": [ "CREDIT_CARD_SHAPED" ]
       },
       {
         "//": "Coin Purse",
@@ -3838,19 +3801,7 @@
         "max_contains_weight": "600 g",
         "max_contains_volume": "150 ml",
         "moves": 200,
-        "item_restriction": [
-          "FMCNote",
-          "RobofacCoin",
-          "FlatCoin",
-          "coin_penny",
-          "coin_nickel",
-          "coin_dime",
-          "coin_quarter",
-          "coin_half_dollar",
-          "coin_dollar",
-          "coin_silver",
-          "coin_gold"
-        ]
+        "flag_restriction": [ "COIN_SHAPED" ]
       }
     ]
   },
@@ -3891,19 +3842,7 @@
         "max_contains_weight": "80 g",
         "max_contains_volume": "175 ml",
         "moves": 100,
-        "item_restriction": [
-          "FMCNote",
-          "signed_chit",
-          "family_photo",
-          "money_one",
-          "money_two",
-          "money_five",
-          "money_ten",
-          "money_twenty",
-          "money_fifty",
-          "money_hundred",
-          "condom"
-        ]
+        "flag_restriction": [ "BANK_NOTE_SHAPED" ]
       },
       {
         "//": "Card Sleeves",
@@ -3912,32 +3851,7 @@
         "max_contains_weight": "80 g",
         "max_contains_volume": "175 ml",
         "moves": 100,
-        "item_restriction": [
-          "cash_card",
-          "gasdiscount_silver",
-          "gasdiscount_gold",
-          "gasdiscount_platinum",
-          "id_science",
-          "id_military",
-          "id_industrial",
-          "fp_loyalty_card",
-          "scorecard",
-          "robofac_test_data",
-          "icon",
-          "labmap",
-          "id_science_visitor_1",
-          "id_science_transport_1",
-          "id_science_maintenance_green",
-          "id_science_maintenance_yellow",
-          "id_science_maintenance_blue",
-          "id_science_security_yellow",
-          "id_science_security_magenta",
-          "id_science_security_black",
-          "id_science_mutagen_green",
-          "id_science_mutagen_pink",
-          "id_science_mutagen_cyan",
-          "id_science_medical_red"
-        ]
+        "flag_restriction": [ "BANK_NOTE_SHAPED" ]
       },
       {
         "//": "Coin Purse",
@@ -3946,19 +3860,7 @@
         "max_contains_weight": "600 g",
         "max_contains_volume": "175 ml",
         "moves": 200,
-        "item_restriction": [
-          "FMCNote",
-          "RobofacCoin",
-          "FlatCoin",
-          "coin_penny",
-          "coin_nickel",
-          "coin_dime",
-          "coin_quarter",
-          "coin_half_dollar",
-          "coin_dollar",
-          "coin_silver",
-          "coin_gold"
-        ]
+        "flag_restriction": [ "COIN_SHAPED" ]
       }
     ]
   },
@@ -3996,18 +3898,7 @@
         "max_contains_weight": "600 g",
         "max_contains_volume": "500 ml",
         "moves": 400,
-        "item_restriction": [
-          "cash_card",
-          "gasdiscount_silver",
-          "gasdiscount_gold",
-          "gasdiscount_platinum",
-          "id_science",
-          "id_military",
-          "id_industrial",
-          "fp_loyalty_card",
-          "robofac_test_data",
-          "condom"
-        ]
+        "flag_restriction": [ "BANK_NOTE_SHAPED", "CREDIT_CARD_SHAPED" ]
       }
     ],
     "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
@@ -4037,40 +3928,7 @@
         "max_contains_weight": "60 g",
         "max_contains_volume": "150 ml",
         "moves": 100,
-        "item_restriction": [
-          "cash_card",
-          "gasdiscount_silver",
-          "gasdiscount_gold",
-          "gasdiscount_platinum",
-          "id_science",
-          "id_military",
-          "id_industrial",
-          "fp_loyalty_card",
-          "robofac_test_data",
-          "icon",
-          "labmap",
-          "FMCNote",
-          "signed_chit",
-          "family_photo",
-          "money_one",
-          "money_two",
-          "money_five",
-          "money_ten",
-          "money_twenty",
-          "condom",
-          "id_science_visitor_1",
-          "id_science_transport_1",
-          "id_science_maintenance_green",
-          "id_science_maintenance_yellow",
-          "id_science_maintenance_blue",
-          "id_science_security_yellow",
-          "id_science_security_magenta",
-          "id_science_security_black",
-          "id_science_mutagen_green",
-          "id_science_mutagen_pink",
-          "id_science_mutagen_cyan",
-          "id_science_medical_red"
-        ]
+        "flag_restriction": [ "BANK_NOTE_SHAPED", "CREDIT_CARD_SHAPED" ]
       }
     ],
     "armor": [ { "encumbrance": 0, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
@@ -4292,44 +4150,7 @@
         "max_contains_weight": "2 kg",
         "max_contains_volume": "1 L",
         "moves": 100,
-        "item_restriction": [
-          "money_one",
-          "money_two",
-          "money_five",
-          "money_ten",
-          "money_twenty",
-          "money_fifty",
-          "money_hundred",
-          "FMCNote",
-          "money_strap_one",
-          "money_strap_two",
-          "money_strap_five",
-          "money_strap_ten",
-          "money_strap_twenty",
-          "money_strap_fifty",
-          "money_strap_hundred",
-          "money_strap_FMCNote",
-          "money_bundle_one",
-          "money_bundle_two",
-          "money_bundle_five",
-          "money_bundle_ten",
-          "money_bundle_twenty",
-          "money_bundle_fifty",
-          "money_bundle_hundred",
-          "money_bundle_FMCNote",
-          "coin_penny",
-          "coin_nickel",
-          "coin_dime",
-          "coin_quarter",
-          "coin_half_dollar",
-          "coin_dollar",
-          "coin_wrapper",
-          "coin_silver",
-          "coin_gold",
-          "RobofacCoin",
-          "FlatCoin",
-          "survnote"
-        ]
+        "flag_restriction": [ "BANK_NOTE_SHAPED", "BANK_NOTE_STRAP_SHAPED", "COIN_SHAPED", "CREDIT_CARD_SHAPED" ]
       }
     ],
     "melee_damage": { "bash": 12 }

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -3851,7 +3851,7 @@
         "max_contains_weight": "80 g",
         "max_contains_volume": "175 ml",
         "moves": 100,
-        "flag_restriction": [ "BANK_NOTE_SHAPED" ]
+        "flag_restriction": [ "CREDIT_CARD_SHAPED" ]
       },
       {
         "//": "Coin Purse",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -233,7 +233,7 @@
     "price": 0,
     "price_postapoc": 0,
     "material": [ "paper" ],
-    "flags": [ "TRADER_AVOID" ],
+    "flags": [ "TRADER_AVOID", "CREDIT_CARD_SHAPED" ],
     "weight": "3 g",
     "volume": "5 ml"
   },
@@ -3221,7 +3221,7 @@
     "price": 1000,
     "price_postapoc": 0,
     "material": [ "plastic" ],
-    "flags": [ "NO_UNLOAD", "NO_RELOAD", "TRADER_AVOID" ],
+    "flags": [ "NO_UNLOAD", "NO_RELOAD", "TRADER_AVOID", "CREDIT_CARD_SHAPED" ],
     "weight": "3 g",
     "volume": "5 ml",
     "to_hit": -3,
@@ -3279,7 +3279,7 @@
     "price": 500,
     "price_postapoc": 0,
     "material": [ "plastic" ],
-    "flags": [ "MISSION_ITEM" ],
+    "flags": [ "MISSION_ITEM", "CREDIT_CARD_SHAPED" ],
     "weight": "6 g",
     "volume": "5 ml",
     "to_hit": -3
@@ -3304,7 +3304,7 @@
     "price": 500,
     "price_postapoc": 0,
     "material": [ "plastic" ],
-    "flags": [ "GAS_DISCOUNT", "DISCOUNT_VALUE_1" ],
+    "flags": [ "GAS_DISCOUNT", "DISCOUNT_VALUE_1", "CREDIT_CARD_SHAPED" ],
     "weight": "6 g",
     "volume": "5 ml",
     "to_hit": -3
@@ -3320,7 +3320,7 @@
     "price": 500,
     "price_postapoc": 0,
     "material": [ "plastic" ],
-    "flags": [ "GAS_DISCOUNT", "DISCOUNT_VALUE_2" ],
+    "flags": [ "GAS_DISCOUNT", "DISCOUNT_VALUE_2", "CREDIT_CARD_SHAPED" ],
     "weight": "6 g",
     "volume": "5 ml",
     "to_hit": -3
@@ -3336,7 +3336,7 @@
     "price": 500,
     "price_postapoc": 0,
     "material": [ "plastic" ],
-    "flags": [ "GAS_DISCOUNT", "DISCOUNT_VALUE_3" ],
+    "flags": [ "GAS_DISCOUNT", "DISCOUNT_VALUE_3", "CREDIT_CARD_SHAPED" ],
     "weight": "6 g",
     "volume": "5 ml",
     "to_hit": -3

--- a/data/json/items/generic/currency.json
+++ b/data/json/items/generic/currency.json
@@ -13,6 +13,7 @@
     "to_hit": -3,
     "color": "white",
     "symbol": "$",
+    "flags": [ "BANK_NOTE_SHAPED" ],
     "material": [ "paper" ]
   },
   {
@@ -29,6 +30,7 @@
     "to_hit": -3,
     "color": "yellow",
     "symbol": "$",
+    "flags": [ "COIN_SHAPED" ],
     "material": [ "gold" ]
   },
   {
@@ -44,6 +46,7 @@
     "to_hit": -3,
     "color": "brown",
     "symbol": "$",
+    "flags": [ "COIN_SHAPED" ],
     "material": [ "copper" ]
   },
   {
@@ -59,6 +62,7 @@
     "to_hit": -3,
     "color": "white",
     "symbol": "$",
+    "flags": [ "BANK_NOTE_SHAPED" ],
     "material": [ "paper" ]
   },
   {
@@ -74,6 +78,7 @@
     "to_hit": -3,
     "color": "white",
     "symbol": "$",
+    "flags": [ "CREDIT_CARD_SHAPED" ],
     "material": [ "paper" ]
   },
   {
@@ -89,7 +94,7 @@
     "material": [ "copper" ],
     "symbol": "o",
     "color": "brown",
-    "flags": [ "OLD_CURRENCY" ],
+    "flags": [ "OLD_CURRENCY", "COIN_SHAPED" ],
     "use_action": [ "COIN_FLIP" ]
   },
   {
@@ -105,7 +110,7 @@
     "material": [ "copper" ],
     "symbol": "o",
     "color": "light_gray",
-    "flags": [ "OLD_CURRENCY" ],
+    "flags": [ "OLD_CURRENCY", "COIN_SHAPED" ],
     "use_action": [ "COIN_FLIP" ]
   },
   {
@@ -121,7 +126,7 @@
     "material": [ "copper" ],
     "symbol": "o",
     "color": "light_gray",
-    "flags": [ "OLD_CURRENCY" ],
+    "flags": [ "OLD_CURRENCY", "COIN_SHAPED" ],
     "use_action": [ "COIN_FLIP" ]
   },
   {
@@ -137,7 +142,7 @@
     "material": [ "copper" ],
     "symbol": "o",
     "color": "light_gray",
-    "flags": [ "OLD_CURRENCY" ],
+    "flags": [ "OLD_CURRENCY", "COIN_SHAPED" ],
     "use_action": [ "COIN_FLIP" ]
   },
   {
@@ -153,7 +158,7 @@
     "material": [ "copper" ],
     "symbol": "o",
     "color": "light_gray",
-    "flags": [ "OLD_CURRENCY" ],
+    "flags": [ "OLD_CURRENCY", "COIN_SHAPED" ],
     "use_action": [ "COIN_FLIP" ]
   },
   {
@@ -169,7 +174,7 @@
     "material": [ "copper" ],
     "symbol": "o",
     "color": "light_gray",
-    "flags": [ "OLD_CURRENCY" ],
+    "flags": [ "OLD_CURRENCY", "COIN_SHAPED" ],
     "use_action": [ "COIN_FLIP" ]
   },
   {
@@ -185,6 +190,7 @@
     "material": [ "silver" ],
     "symbol": "o",
     "color": "light_gray",
+    "flags": [ "COIN_SHAPED" ],
     "use_action": [ "COIN_FLIP" ]
   },
   {
@@ -200,6 +206,7 @@
     "material": [ "gold" ],
     "symbol": "o",
     "color": "yellow",
+    "flags": [ "COIN_SHAPED" ],
     "use_action": [ "COIN_FLIP" ]
   },
   {
@@ -238,7 +245,7 @@
     "symbol": "$",
     "color": "green",
     "to_hit": -3,
-    "flags": [ "OLD_CURRENCY" ]
+    "flags": [ "OLD_CURRENCY", "BANK_NOTE_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -251,7 +258,7 @@
     "symbol": "$",
     "price": 200,
     "price_postapoc": 0,
-    "flags": [ "OLD_CURRENCY" ]
+    "flags": [ "OLD_CURRENCY", "BANK_NOTE_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -264,7 +271,7 @@
     "symbol": "$",
     "price": 500,
     "price_postapoc": 0,
-    "flags": [ "OLD_CURRENCY" ]
+    "flags": [ "OLD_CURRENCY", "BANK_NOTE_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -277,7 +284,7 @@
     "symbol": "$",
     "price": 1000,
     "price_postapoc": 0,
-    "flags": [ "OLD_CURRENCY" ]
+    "flags": [ "OLD_CURRENCY", "BANK_NOTE_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -290,7 +297,7 @@
     "symbol": "$",
     "price": 2000,
     "price_postapoc": 0,
-    "flags": [ "OLD_CURRENCY" ]
+    "flags": [ "OLD_CURRENCY", "BANK_NOTE_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -303,7 +310,7 @@
     "symbol": "$",
     "price": 5000,
     "price_postapoc": 1,
-    "flags": [ "OLD_CURRENCY" ]
+    "flags": [ "OLD_CURRENCY", "BANK_NOTE_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -316,7 +323,7 @@
     "symbol": "$",
     "price": 10000,
     "price_postapoc": 1,
-    "flags": [ "OLD_CURRENCY" ]
+    "flags": [ "OLD_CURRENCY", "BANK_NOTE_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -333,7 +340,7 @@
     "material": [ "paper" ],
     "price": 10000,
     "price_postapoc": 0,
-    "flags": [ "OLD_CURRENCY" ]
+    "flags": [ "OLD_CURRENCY", "BANK_NOTE_STRAP_SHAPED" ]
   },
   {
     "type": "GENERIC",

--- a/data/json/items/id_cards.json
+++ b/data/json/items/id_cards.json
@@ -7,7 +7,7 @@
     "name": { "str": "science ID card" },
     "description": "An ID card that once belonged to a scientist.  The reverse side describes the protocol for using it; this could grant access at one control panel, if you can find one.",
     "price": 60000,
-    "flags": [ "SCIENCE_CARD" ],
+    "flags": [ "SCIENCE_CARD", "CREDIT_CARD_SHAPED" ],
     "price_postapoc": 250,
     "material": [ "plastic" ],
     "weight": "3 g",
@@ -23,7 +23,7 @@
     "name": { "str": "military ID card" },
     "description": "An ID card that once belonged to a military officer.  The reverse side describes the protocol for using it; this could grant access at one control panel, if you can find one.",
     "price": 120000,
-    "flags": [ "MILITARY_CARD" ],
+    "flags": [ "MILITARY_CARD", "CREDIT_CARD_SHAPED" ],
     "price_postapoc": 500,
     "material": [ "plastic" ],
     "weight": "3 g",
@@ -40,7 +40,7 @@
     "name": { "str": "industrial ID card" },
     "description": "An ID card that once belonged to a high-level technician.  The reverse side describes the protocol for using it; this could grant access at one control panel, if you can find one.",
     "price": 120000,
-    "flags": [ "INDUSTRIAL_CARD" ],
+    "flags": [ "INDUSTRIAL_CARD", "CREDIT_CARD_SHAPED" ],
     "price_postapoc": 100,
     "material": [ "plastic" ],
     "weight": "3 g",
@@ -57,7 +57,7 @@
     "name": { "str": "co-op badge" },
     "description": "A manually-encoded badge giving you access to the artisans' workshop.  It even has your name written on the back.",
     "price": 120000,
-    "flags": [ "COOP_CARD" ],
+    "flags": [ "COOP_CARD", "CREDIT_CARD_SHAPED" ],
     "price_postapoc": 100,
     "material": [ "plastic" ],
     "weight": "3 g",
@@ -73,7 +73,7 @@
     "name": { "str": "visitor's pass", "str_pl": "visitor's passes" },
     "description": "A visitor's pass to some sort of facility.  The reverse side describes the protocol for using it; this could grant one-time access at a card reader, if you can find one.  It also lists the addresses of nearby facilities; activate it to add their locations to your map.",
     "price": 60000,
-    "flags": [ "SCIENCE_CARD_VISITOR" ],
+    "flags": [ "SCIENCE_CARD_VISITOR", "CREDIT_CARD_SHAPED" ],
     "price_postapoc": 250,
     "material": [ "plastic" ],
     "weight": "3 g",
@@ -123,7 +123,7 @@
     "copy-from": "id_science",
     "name": { "str": "Maintenance: green zone badge" },
     "description": "An employee badge for a maintenance worker.  The reverse side describes the protocol for using it; this could grant access at green zone card readers.",
-    "flags": [ "SCIENCE_CARD_MAINTENANCE_GREEN", "PRESERVE_SPAWN_OMT" ]
+    "flags": [ "SCIENCE_CARD_MAINTENANCE_GREEN", "PRESERVE_SPAWN_OMT", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -132,7 +132,7 @@
     "copy-from": "id_science",
     "name": { "str": "Maintenance: ocher zone badge" },
     "description": "An employee badge for a maintenance worker.  The reverse side describes the protocol for using it; this could grant access at ocher zone card readers.",
-    "flags": [ "SCIENCE_CARD_MAINTENANCE_YELLOW", "PRESERVE_SPAWN_OMT" ]
+    "flags": [ "SCIENCE_CARD_MAINTENANCE_YELLOW", "PRESERVE_SPAWN_OMT", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -141,7 +141,7 @@
     "copy-from": "id_science",
     "name": { "str": "Maintenance: blue zone badge" },
     "description": "An employee badge for a maintenance worker.  The reverse side describes the protocol for using it; this could grant access at blue zone card readers.",
-    "flags": [ "SCIENCE_CARD_MAINTENANCE_BLUE", "PRESERVE_SPAWN_OMT" ]
+    "flags": [ "SCIENCE_CARD_MAINTENANCE_BLUE", "PRESERVE_SPAWN_OMT", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -150,7 +150,7 @@
     "copy-from": "id_science",
     "name": { "str": "transport freight employee badge" },
     "description": "An employee badge for a freight hauler.  The reverse side describes the protocol for using it; this could grant one-time access to a transport freight card reader.  It also lists the addresses of nearby facilities; activate it to add their locations to your map.",
-    "flags": [ "SCIENCE_CARD_TRANSPORT_1" ],
+    "flags": [ "SCIENCE_CARD_TRANSPORT_1", "CREDIT_CARD_SHAPED" ],
     "use_action": {
       "type": "reveal_map",
       "radius": 90,
@@ -194,7 +194,7 @@
     "copy-from": "id_science",
     "name": { "str": "Security: yellow zone badge" },
     "description": "An employee badge for a security officer.  The reverse side describes the protocol for using it; this could grant access at yellow zone card readers.",
-    "flags": [ "SCIENCE_CARD_SECURITY_YELLOW", "PRESERVE_SPAWN_OMT" ]
+    "flags": [ "SCIENCE_CARD_SECURITY_YELLOW", "PRESERVE_SPAWN_OMT", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -203,7 +203,7 @@
     "copy-from": "id_science",
     "name": { "str": "Security: magenta zone badge" },
     "description": "An employee badge for a security officer.  The reverse side describes the protocol for using it; this could grant access at magenta zone card readers.",
-    "flags": [ "SCIENCE_CARD_SECURITY_MAGENTA", "PRESERVE_SPAWN_OMT" ]
+    "flags": [ "SCIENCE_CARD_SECURITY_MAGENTA", "PRESERVE_SPAWN_OMT", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -212,7 +212,7 @@
     "copy-from": "id_science",
     "name": { "str": "Security: black zone badge" },
     "description": "An employee badge for a security officer.  The reverse side describes the protocol for using it; this could grant access at black zone card readers.",
-    "flags": [ "SCIENCE_CARD_SECURITY_BLACK", "PRESERVE_SPAWN_OMT" ]
+    "flags": [ "SCIENCE_CARD_SECURITY_BLACK", "PRESERVE_SPAWN_OMT", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -221,7 +221,7 @@
     "copy-from": "id_science",
     "name": { "str": "Researcher: light green zone badge" },
     "description": "An employee badge for a research scientist.  The reverse side describes the protocol for using it; this could grant access at light green zone card readers.",
-    "flags": [ "SCIENCE_CARD_MUTAGEN_GREEN", "PRESERVE_SPAWN_OMT" ]
+    "flags": [ "SCIENCE_CARD_MUTAGEN_GREEN", "PRESERVE_SPAWN_OMT", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -230,7 +230,7 @@
     "copy-from": "id_science",
     "name": { "str": "Researcher: pink zone badge" },
     "description": "An employee badge for a research scientist.  The reverse side describes the protocol for using it; this could grant access at pink zone card readers.",
-    "flags": [ "SCIENCE_CARD_MUTAGEN_PINK", "PRESERVE_SPAWN_OMT" ]
+    "flags": [ "SCIENCE_CARD_MUTAGEN_PINK", "PRESERVE_SPAWN_OMT", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -239,7 +239,7 @@
     "copy-from": "id_science",
     "name": { "str": "Researcher: cyan zone badge" },
     "description": "An employee badge for a research scientist.  The reverse side describes the protocol for using it; this could grant access at cyan zone card readers.",
-    "flags": [ "SCIENCE_CARD_MUTAGEN_CYAN", "PRESERVE_SPAWN_OMT" ]
+    "flags": [ "SCIENCE_CARD_MUTAGEN_CYAN", "PRESERVE_SPAWN_OMT", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -248,7 +248,7 @@
     "copy-from": "id_science",
     "name": { "str": "Doctor: red zone badge" },
     "description": "An employee badge for a medical doctor.  The reverse side describes the protocol for using it; this could grant access at red zone card readers.",
-    "flags": [ "SCIENCE_CARD_MEDICAL_RED", "PRESERVE_SPAWN_OMT" ]
+    "flags": [ "SCIENCE_CARD_MEDICAL_RED", "PRESERVE_SPAWN_OMT", "CREDIT_CARD_SHAPED" ]
   },
   {
     "type": "GENERIC",
@@ -258,6 +258,6 @@
     "name": { "str": "System supervisor: slate zone badge" },
     "//": "Given by Hub 01's director, intentionally works everywhere.",
     "description": "An employee badge for a system's supervisor.  The reverse side describes the protocol for using it; this could grant access through white zone card readers.",
-    "flags": [ "SCIENCE_CARD_MU_UNIVERSAL" ]
+    "flags": [ "SCIENCE_CARD_MU_UNIVERSAL", "CREDIT_CARD_SHAPED" ]
   }
 ]

--- a/data/json/items/newspaper.json
+++ b/data/json/items/newspaper.json
@@ -41,7 +41,7 @@
     "price": 0,
     "price_postapoc": 0,
     "material": [ "paper" ],
-    "flags": [ "TRADER_AVOID" ],
+    "flags": [ "TRADER_AVOID", "BANK_NOTE_SHAPED" ],
     "weight": "12 mg",
     "volume": "1 ml"
   },
@@ -285,7 +285,7 @@
     "price": 0,
     "price_postapoc": 0,
     "material": [ "paper" ],
-    "flags": [ "TRADER_AVOID" ],
+    "flags": [ "TRADER_AVOID", "CREDIT_CARD_SHAPED" ],
     "weight": "1 g",
     "volume": "2 ml"
   },

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -8,6 +8,7 @@
     "to_hit": -1,
     "color": "yellow",
     "symbol": ".",
+    "flags": [ "COIN_SHAPED" ],
     "material": [ "copper" ],
     "volume": "1 ml",
     "price": 1,

--- a/data/mods/Magiclysm/items/currency.json
+++ b/data/mods/Magiclysm/items/currency.json
@@ -12,6 +12,7 @@
     "to_hit": -3,
     "color": "light_gray",
     "symbol": "$",
+    "flags": [ "COIN_SHAPED" ],
     "material": [ "mithril_metal" ]
   }
 ]

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -744,6 +744,8 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 
 ### Flags
 
+- ```BANK_NOTE_SHAPED``` ... This item fits into the folded sleeve of wallets, like a bank note.
+- ```BANK_NOTE_STRAP_SHAPED``` ... This item fits into pockets intended for money straps (like a cash register).
 - ```BIONIC_NPC_USABLE``` ... Safe CBMs that NPCs can use without extensive NPC rewrites to utilize toggle CBMs.
 - ```BIONIC_TOGGLED``` ... This bionic only has a function when activated, instead of causing its effect every turn.
 - ```BIONIC_POWER_SOURCE``` ... This bionic is a source of bionic power.
@@ -752,6 +754,8 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```BIONIC_WEAPON``` ... This bionic is a weapon bionic and activating it will create (or destroy) its fake_item in the user's hands. Prevents all other activation effects.
 - ```BIONIC_ARMOR_INTERFACE``` ... This bionic can provide power to powered armor.
 - ```BIONIC_SLEEP_FRIENDLY``` ... This bionic won't provide a warning if the player tries to sleep while it's active.
+- ```COIN_SHAPED``` ... This item is shaped like a coin and fits into the coin purse of a wallet.
+- ```CREDIT_CARD_SHAPED``` ... This item is shaped like a credit card and fits into the card slots of a wallet and similar pockets.
 - ```CONDUCTIVE``` ... Item is considered as conducting electricity, even if material it's made of is non-conductive. Opposite of `NONCONDUCTIVE`.
 - ```CORPSE``` ... Flag used to spawn various human corpses during the mapgen.
 - ```CRUTCHES``` ... Item with this flag helps characters not to fall down if their legs are broken.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Magiclysm's denarii coins don't fit into the coin purse pocket of wallets, but `"pocket_data"`'s `"item_restriction"` can't be extended and having to overwrite all wallet pockets in a mod sounds like a giant headache for mod compatibility in the future.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* introduce new `*_SHAPED` flags for bank notes & straps, coins and (credit) cards
* apply the flags to all the items that (should) fit into wallets, ID card holders, and the cash register
* switch those containers to the appropriate `"flag_restriction"`s

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I thought about using volume/length restrictions instead, but I got a headache trying to figure out a way to handle bank notes, credit cards and coins since all of them are so much thinner than long.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* dc4fd35c153befbdfd979e3a643fcf4e1b113621 loaded without errors
* stuff still fit into wallets & cash register
* denarius now fits into wallets :'D

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

* Rubik's shiny farthing (`rubik_farthing`) now fits into coin purse pockets (and cash registers) since it's a coin
* you can use a `condom`'s pocket to circumvent the pocket restrictions, but you could do that before these changes already...
* `survnote` is now `BANK_NOTE_SHAPED` since it spawns in `cash_register` but doesn't make sense as `BANK_NOTE_STRAP_SHAPED`... there's probably a bunch of other note stuff that _could_ fit in the same pockets, but that's out of scope for this PR since I'm just trying to keep pocket parity as much as possible
* `cash_register` used to allow the various money bundles, but since all of them are too big (1.13 l volume vs 1.00 l pocket), I just dropped them from the `cash_register` (instead of adding a `BANK_NOTE_BUNDLE_SHAPED` flag)
* `FMCNote` no longer also fits into the coin purse since it's based on a $50 bill
* `id_artisan_member` now fits into the card slots which it didn't before
* the various special variants of `id_science` (like the colored ones of the TCL) now fit into wallet card slots, not just the lanyard, since they are the same shape as the normal ID card
* I didn't touch the `coin_wrapper` since that is explicitly for the specific USD coin denominations

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->