### PR TITLE
Small debugmsg argument fix

### DIFF
--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -158,7 +158,7 @@ void damage_type::check()
             return dt.id == dio.dmg_type;
         } );
         if( iter == dio_list.end() ) {
-            debugmsg( "damage type %s has no associated damage_info_order type." );
+            debugmsg( "damage type %s has no associated damage_info_order type.", dt.id.c_str() );
         }
     }
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I accidentally left out the damage type id in the validation message, oopsie

#### Describe the solution
Add the id to the `debugmsg` call

#### Describe alternatives you've considered

#### Testing
Tested loading with a missing `damage_info_order`, error message outputs in the expected format

#### Additional context
