### PR TITLE
Improve map memory visuals

### DIFF
--- a/data/json/obsoletion/migration_vehicle_parts.json
+++ b/data/json/obsoletion/migration_vehicle_parts.json
@@ -91,7 +91,7 @@
   },
   {
     "type": "vehicle_part_migration",
-    "from": "basketsm_bike_rear",
+    "from": "basketsm_bike",
     "to": "basketsm",
     "variant": "bike_rear"
   },

--- a/data/json/vehicleparts/boards.json
+++ b/data/json/vehicleparts/boards.json
@@ -6,79 +6,79 @@
     "categories": [ "hull" ],
     "flags": [ "OBSTACLE", "NO_ROOF_NEEDED" ],
     "variants": [
-      { "id": "horizontal", "label": "Horizontal", "symbols": "──││──││", "symbols_broken": "#" },
+      { "id": "horizontal", "label": "Horizontal", "symbols": "──│───│─", "symbols_broken": "#" },
       {
         "id": "horizontal_2",
         "label": "Thick Horizontal",
-        "symbols": "━━┃┃━━┃┃",
+        "symbols": "━━┃━━━┃━",
         "symbols_broken": "#"
       },
-      { "id": "vertical", "label": "Vertical", "symbols": "│/─\\│/─\\", "symbols_broken": "#" },
-      { "id": "vertical_2", "label": "Thick Vertical", "symbols": "┃┃━━┃┃━━", "symbols_broken": "#" },
-      { "id": "ne", "label": "Front Right", "symbols": "┐┐┘┘└└┌┌", "symbols_broken": "#" },
-      { "id": "nw", "label": "Front Left", "symbols": "┌┌┐┐┘┘└└", "symbols_broken": "#" },
-      { "id": "se", "label": "Rear Right", "symbols": "┘┘└└┌┌┐┐", "symbols_broken": "#" },
-      { "id": "sw", "label": "Rear Left", "symbols": "└└┌┌┐┐┘┘", "symbols_broken": "#" },
+      { "id": "vertical", "label": "Vertical", "symbols": "│\\─/│\\─/", "symbols_broken": "#" },
+      { "id": "vertical_2", "label": "Thick Vertical", "symbols": "┃┃━┃┃┃━┃", "symbols_broken": "#" },
+      { "id": "ne", "label": "Front Right", "symbols": "┐┐┌└└└┘┐", "symbols_broken": "#" },
+      { "id": "nw", "label": "Front Left", "symbols": "┌┌└┘┘┘┐┌", "symbols_broken": "#" },
+      { "id": "se", "label": "Rear Right", "symbols": "┘┘┐┌┌┌└┘", "symbols_broken": "#" },
+      { "id": "sw", "label": "Rear Left", "symbols": "└└┘┐┐┐┌└", "symbols_broken": "#" },
       { "id": "cross", "label": "Cross", "symbols": "┼X┼X┼X┼X", "symbols_broken": "#" },
-      { "id": "cover", "label": "Cover", "symbols": "^^>>vv<<", "symbols_broken": "#" },
-      { "id": "cover_left", "label": "Cover Left", "symbols": "──││──││", "symbols_broken": "#" },
-      { "id": "cover_right", "label": "Cover Right", "symbols": "──││──││", "symbols_broken": "#" },
+      { "id": "cover", "label": "Cover", "symbols": "^^<vvv>^", "symbols_broken": "#" },
+      { "id": "cover_left", "label": "Cover Left", "symbols": "──│───│─", "symbols_broken": "#" },
+      { "id": "cover_right", "label": "Cover Right", "symbols": "──│───│─", "symbols_broken": "#" },
       {
         "id": "horizontal_front",
         "label": "Front Horizontal",
-        "symbols": "──││──││",
+        "symbols": "──│───│─",
         "symbols_broken": "#"
       },
       {
         "id": "hatch_wheel_left",
         "label": "Hatchback Wheel Left",
-        "symbols": "└└┌┌┐┐┘┘",
+        "symbols": "└└┘┐┐┐┌└",
         "symbols_broken": "#"
       },
       {
         "id": "hatch_wheel_right",
         "label": "Hatchback Wheel Right",
-        "symbols": "┘┘└└┌┌┐┐",
+        "symbols": "┘┘┐┌┌┌└┘",
         "symbols_broken": "#"
       },
       {
         "id": "horizontal_rear",
         "label": "Rear Horizontal",
-        "symbols": "──││──││",
+        "symbols": "──│───│─",
         "symbols_broken": "#"
       },
       {
         "id": "horizontal_2_front",
         "label": "Front Thick Horizontal",
-        "symbols": "━━┃┃━━┃┃",
+        "symbols": "━━┃━━━┃━",
         "symbols_broken": "#"
       },
       {
         "id": "horizontal_2_rear",
         "label": "Rear Thick Horizontal",
-        "symbols": "━━┃┃━━┃┃",
+        "symbols": "━━┃━━━┃━",
         "symbols_broken": "#"
       },
-      { "id": "nw_edge", "label": "Front Left Corner", "symbols": "│/─\\│/─\\", "symbols_broken": "#" },
-      { "id": "ne_edge", "label": "Front Right Corner", "symbols": "│/─\\│/─\\", "symbols_broken": "#" },
-      { "id": "vertical_left", "label": "Left Vertical", "symbols": "│/─\\│/─\\", "symbols_broken": "#" },
-      { "id": "vertical_right", "label": "Right Vertical", "symbols": "│/─\\│/─\\", "symbols_broken": "#" },
-      { "id": "vertical_T_left", "label": "Left T Joint", "symbols": "[/-\\[/-\\", "symbols_broken": "#" },
-      { "id": "vertical_T_right", "label": "Right T Joint", "symbols": "]/-\\]/-\\", "symbols_broken": "#" },
+      { "id": "nw_edge", "label": "Front Left Corner", "symbols": "│\\─/│\\─/", "symbols_broken": "#" },
+      { "id": "ne_edge", "label": "Front Right Corner", "symbols": "│\\─/│\\─/", "symbols_broken": "#" },
+      { "id": "vertical_left", "label": "Left Vertical", "symbols": "│\\─/│\\─/", "symbols_broken": "#" },
+      { "id": "vertical_right", "label": "Right Vertical", "symbols": "│\\─/│\\─/", "symbols_broken": "#" },
+      { "id": "vertical_T_left", "label": "Left T Joint", "symbols": "[\\-/[\\-/", "symbols_broken": "#" },
+      { "id": "vertical_T_right", "label": "Right T Joint", "symbols": "]\\-/]\\-/", "symbols_broken": "#" },
       {
         "id": "vertical_2_left",
         "label": "Left Thick Vertical",
-        "symbols": "┃┃━━┃┃━━",
+        "symbols": "┃┃━┃┃┃━┃",
         "symbols_broken": "#"
       },
       {
         "id": "vertical_2_right",
         "label": "Right Thick Vertical",
-        "symbols": "┃┃━━┃┃━━",
+        "symbols": "┃┃━┃┃┃━┃",
         "symbols_broken": "#"
       },
-      { "id": "wheel_left", "label": "Wheel Left", "symbols": "│/─\\│/─\\", "symbols_broken": "#" },
-      { "id": "wheel_right", "label": "Wheel Right", "symbols": "│/─\\│/─\\", "symbols_broken": "#" }
+      { "id": "wheel_left", "label": "Wheel Left", "symbols": "│\\─/│\\─/", "symbols_broken": "#" },
+      { "id": "wheel_right", "label": "Wheel Right", "symbols": "│\\─/│\\─/", "symbols_broken": "#" }
     ]
   },
   {

--- a/data/json/vehicleparts/frames.json
+++ b/data/json/vehicleparts/frames.json
@@ -16,55 +16,55 @@
     "categories": [ "hull" ],
     "damage_reduction": { "all": 20 },
     "variants": [
-      { "id": "horizontal", "label": "Horizontal", "symbols": "──││──││", "symbols_broken": "#" },
+      { "id": "horizontal", "label": "Horizontal", "symbols": "──│───│─", "symbols_broken": "#" },
       {
         "id": "horizontal_front",
         "label": "Front Horizontal",
-        "symbols": "──││──││",
+        "symbols": "──│───│─",
         "symbols_broken": "#"
       },
       {
         "id": "horizontal_rear",
         "label": "Rear Horizontal",
-        "symbols": "──││──││",
+        "symbols": "──│───│─",
         "symbols_broken": "#"
       },
       {
         "id": "horizontal_2",
         "label": "Thick Horizontal",
-        "symbols": "━━┃┃━━┃┃",
+        "symbols": "━━┃━━━┃━",
         "symbols_broken": "#"
       },
       {
         "id": "horizontal_2_front",
         "label": "Front Thick Horizontal",
-        "symbols": "━━┃┃━━┃┃",
+        "symbols": "━━┃━━━┃━",
         "symbols_broken": "#"
       },
-      { "id": "vertical", "label": "Vertical", "symbols": "│/─\\│/─\\", "symbols_broken": "#" },
-      { "id": "vertical_left", "label": "Left Vertical", "symbols": "│/─\\│/─\\", "symbols_broken": "#" },
-      { "id": "vertical_right", "label": "Right Vertical", "symbols": "│/─\\│/─\\", "symbols_broken": "#" },
-      { "id": "vertical_T_left", "label": "Left T Joint", "symbols": "│/─\\│/─\\", "symbols_broken": "#" },
-      { "id": "vertical_T_right", "label": "Right T Joint", "symbols": "│/─\\│/─\\", "symbols_broken": "#" },
-      { "id": "vertical_2", "label": "Thick Vertical", "symbols": "┃┃━━┃┃━━", "symbols_broken": "#" },
+      { "id": "vertical", "label": "Vertical", "symbols": "│\\─/│\\─/", "symbols_broken": "#" },
+      { "id": "vertical_left", "label": "Left Vertical", "symbols": "│\\─/│\\─/", "symbols_broken": "#" },
+      { "id": "vertical_right", "label": "Right Vertical", "symbols": "│\\─/│\\─/", "symbols_broken": "#" },
+      { "id": "vertical_T_left", "label": "Left T Joint", "symbols": "│\\─/│\\─/", "symbols_broken": "#" },
+      { "id": "vertical_T_right", "label": "Right T Joint", "symbols": "│\\─/│\\─/", "symbols_broken": "#" },
+      { "id": "vertical_2", "label": "Thick Vertical", "symbols": "┃┃━┃┃┃━┃", "symbols_broken": "#" },
       {
         "id": "vertical_2_left",
         "label": "Left Thick Vertical",
-        "symbols": "┃┃━━┃┃━━",
+        "symbols": "┃┃━┃┃┃━┃",
         "symbols_broken": "#"
       },
       {
         "id": "vertical_2_right",
         "label": "Right Thick Vertical",
-        "symbols": "┃┃━━┃┃━━",
+        "symbols": "┃┃━┃┃┃━┃",
         "symbols_broken": "#"
       },
-      { "id": "cover", "label": "Cover", "symbols": "^^>>vv<<", "symbols_broken": "#" },
+      { "id": "cover", "label": "Cover", "symbols": "^^<vvv>^", "symbols_broken": "#" },
       { "id": "cross", "label": "Cross", "symbols": "┼X┼X┼X┼X", "symbols_broken": "#" },
-      { "id": "ne", "label": "Front Right", "symbols": "┐┐┘┘└└┌┌", "symbols_broken": "#" },
-      { "id": "nw", "label": "Front Left", "symbols": "┌┌┐┐┘┘└└", "symbols_broken": "#" },
-      { "id": "se", "label": "Rear Right", "symbols": "┘┘└└┌┌┐┐", "symbols_broken": "#" },
-      { "id": "sw", "label": "Rear Left", "symbols": "└└┌┌┐┐┘┘", "symbols_broken": "#" }
+      { "id": "ne", "label": "Front Right", "symbols": "┐┐┌└└└┘┐", "symbols_broken": "#" },
+      { "id": "nw", "label": "Front Left", "symbols": "┌┌└┘┘┘┐┌", "symbols_broken": "#" },
+      { "id": "se", "label": "Rear Right", "symbols": "┘┘┐┌┌┌└┘", "symbols_broken": "#" },
+      { "id": "sw", "label": "Rear Left", "symbols": "└└┘┐┐┐┌└", "symbols_broken": "#" }
     ]
   },
   {

--- a/data/json/vehicleparts/rams.json
+++ b/data/json/vehicleparts/rams.json
@@ -22,10 +22,10 @@
     },
     "flags": [ "PROTRUSION", "OBSTACLE" ],
     "variants": [
-      { "id": "front", "label": "Front", "symbols": "^^>>vv<<", "symbols_broken": "*" },
-      { "id": "rear", "label": "Rear", "symbols": "vv<<^^>>", "symbols_broken": "*" },
-      { "id": "left", "label": "Left", "symbols": "<<^^>>vv", "symbols_broken": "*" },
-      { "id": "right", "label": "Right", "symbols": ">>vv<<^^", "symbols_broken": "*" }
+      { "id": "front", "label": "Front", "symbols": "^^<vvv>^", "symbols_broken": "*" },
+      { "id": "rear", "label": "Rear", "symbols": "vv>^^^<v", "symbols_broken": "*" },
+      { "id": "left", "label": "Left", "symbols": "<<v>>>^<", "symbols_broken": "*" },
+      { "id": "right", "label": "Right", "symbols": ">>^<<<v>", "symbols_broken": "*" }
     ]
   },
   {

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -324,8 +324,8 @@
     "breaks_into": "ig_vp_sheet_metal",
     "damage_reduction": { "all": 28 },
     "variants": [
-      { "id": "horizontal", "label": "Horizontal", "symbols": "┃┃━━┃┃━━", "symbols_broken": "#" },
-      { "id": "vertical", "label": "Vertical", "symbols": "━━┃┃━━┃┃", "symbols_broken": "#" }
+      { "id": "horizontal", "label": "Horizontal", "symbols": "┃┃━┃┃┃━┃", "symbols_broken": "#" },
+      { "id": "vertical", "label": "Vertical", "symbols": "━━┃━━━┃━", "symbols_broken": "#" }
     ]
   },
   {

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -338,8 +338,8 @@
     "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT" ],
     "damage_reduction": { "bash": 6 },
     "variants": [
-      { "id": "front", "label": "Front", "symbols": "|/-\\|/-\\", "symbols_broken": "x" },
-      { "id": "rear", "label": "Rear", "symbols": "|/-\\|/-\\", "symbols_broken": "x" }
+      { "id": "front", "label": "Front", "symbols": "|\\-/|\\-/", "symbols_broken": "x" },
+      { "id": "rear", "label": "Rear", "symbols": "|\\-/|\\-/", "symbols_broken": "x" }
     ]
   },
   {

--- a/data/json/vehicleparts/windshields.json
+++ b/data/json/vehicleparts/windshields.json
@@ -21,59 +21,59 @@
     "variants_bases": [ { "id": "full", "label": "Full" } ],
     "variants": [
       { "id": "horizontal", "label": "Horizontal", "symbols": "\"", "symbols_broken": "0" },
-      { "id": "cover_left", "label": "Cover Left", "symbols": "──││──││", "symbols_broken": "0" },
-      { "id": "cover_right", "label": "Cover Right", "symbols": "──││──││", "symbols_broken": "0" },
-      { "id": "nw", "label": "Front Left", "symbols": "┌┌┐┐┘┘└└", "symbols_broken": "0" },
-      { "id": "ne", "label": "Front Right", "symbols": "┐┐┘┘└└┌┌", "symbols_broken": "0" },
-      { "id": "sw", "label": "Rear Left", "symbols": "└└┌┌┐┐┘┘", "symbols_broken": "0" },
-      { "id": "se", "label": "Rear Right", "symbols": "┘┘└└┌┌┐┐", "symbols_broken": "0" },
-      { "id": "nw_edge", "label": "Front Left Corner", "symbols": "┌┌┐┐┘┘└└", "symbols_broken": "0" },
-      { "id": "ne_edge", "label": "Front Right Corner", "symbols": "┐┐┘┘└└┌┌", "symbols_broken": "0" },
-      { "id": "sw_edge", "label": "Rear Left Corner", "symbols": "└└┌┌┐┐┘┘", "symbols_broken": "0" },
-      { "id": "se_edge", "label": "Rear Right Corner", "symbols": "┘┘└└┌┌┐┐", "symbols_broken": "0" },
-      { "id": "left", "label": "Left", "symbols": "│/─\\│/─\\", "symbols_broken": "0" },
-      { "id": "right", "label": "Right", "symbols": "│/─\\│/─\\", "symbols_broken": "0" },
-      { "id": "vertical", "label": "Vertical", "symbols": "│/─\\│/─\\", "symbols_broken": "0" },
-      { "id": "vertical_left", "label": "Left Vertical", "symbols": "│/─\\│/─\\", "symbols_broken": "0" },
-      { "id": "vertical_right", "label": "Right Vertical", "symbols": "│/─\\│/─\\", "symbols_broken": "0" },
+      { "id": "cover_left", "label": "Cover Left", "symbols": "──│───│─", "symbols_broken": "0" },
+      { "id": "cover_right", "label": "Cover Right", "symbols": "──│───│─", "symbols_broken": "0" },
+      { "id": "nw", "label": "Front Left", "symbols": "┌┌└┘┘┘┐┌", "symbols_broken": "0" },
+      { "id": "ne", "label": "Front Right", "symbols": "┐┐┌└└└┘┐", "symbols_broken": "0" },
+      { "id": "sw", "label": "Rear Left", "symbols": "└└┘┐┐┐┌└", "symbols_broken": "0" },
+      { "id": "se", "label": "Rear Right", "symbols": "┘┘┐┌┌┌└┘", "symbols_broken": "0" },
+      { "id": "nw_edge", "label": "Front Left Corner", "symbols": "┌┌└┘┘┘┐┌", "symbols_broken": "0" },
+      { "id": "ne_edge", "label": "Front Right Corner", "symbols": "┐┐┌└└└┘┐", "symbols_broken": "0" },
+      { "id": "sw_edge", "label": "Rear Left Corner", "symbols": "└└┘┐┐┐┌└", "symbols_broken": "0" },
+      { "id": "se_edge", "label": "Rear Right Corner", "symbols": "┘┘┐┌┌┌└┘", "symbols_broken": "0" },
+      { "id": "left", "label": "Left", "symbols": "│\\─/│\\─/", "symbols_broken": "0" },
+      { "id": "right", "label": "Right", "symbols": "│\\─/│\\─/", "symbols_broken": "0" },
+      { "id": "vertical", "label": "Vertical", "symbols": "│\\─/│\\─/", "symbols_broken": "0" },
+      { "id": "vertical_left", "label": "Left Vertical", "symbols": "│\\─/│\\─/", "symbols_broken": "0" },
+      { "id": "vertical_right", "label": "Right Vertical", "symbols": "│\\─/│\\─/", "symbols_broken": "0" },
       {
         "id": "vertical_2_left",
         "label": "Left Thick Vertical",
-        "symbols": "│/─\\│/─\\",
+        "symbols": "│\\─/│\\─/",
         "symbols_broken": "0"
       },
       {
         "id": "vertical_2_right",
         "label": "Right Thick Vertical",
-        "symbols": "│/─\\│/─\\",
+        "symbols": "│\\─/│\\─/",
         "symbols_broken": "0"
       },
       {
         "id": "horizontal_front",
         "label": "Front Horizontal",
-        "symbols": "──││──││",
+        "symbols": "──│───│─",
         "symbols_broken": "0"
       },
       {
         "id": "horizontal_front_edge",
         "label": "Front Edge Horizontal",
-        "symbols": "^^>>vv<<",
+        "symbols": "^^<vvv>^",
         "symbols_broken": "0"
       },
       {
         "id": "horizontal_rear",
         "label": "Rear Horizontal",
-        "symbols": "──││──││",
+        "symbols": "──│───│─",
         "symbols_broken": "0"
       },
       {
         "id": "horizontal_rear_edge",
         "label": "Rear Edge Horizontal",
-        "symbols": "━━┃┃━━┃┃",
+        "symbols": "━━┃━━━┃━",
         "symbols_broken": "0"
       },
-      { "id": "wheel_left", "label": "Wheel Left", "symbols": "┌┌┐┐┘┘└└", "symbols_broken": "0" },
-      { "id": "wheel_right", "label": "Wheel Right", "symbols": "┐┐┘┘└└┌┌", "symbols_broken": "0" }
+      { "id": "wheel_left", "label": "Wheel Left", "symbols": "┌┌└┘┘┘┐┌", "symbols_broken": "0" },
+      { "id": "wheel_right", "label": "Wheel Right", "symbols": "┐┐┌└└└┘┐", "symbols_broken": "0" }
     ]
   },
   {

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -2806,7 +2806,7 @@ Vehicle components when installed on a vehicle.
 #### Symbols and Variants
 Vehicle parts can have cosmetic variants that use different symbols and tileset sprites.  They are declared by the "variants" object.  Variants are used in the vehicle prototype as a suffix following the part id (ie `id#variant`), for example `"frame#nw"` or `"halfboard#cover"`.
 
-`symbols` and `symbols_broken` can be either a string of 1 character or 8 characters long (length is measured in console characters). A 1 character string is equivalent to 8 characters one where all characters are equal to first. An 8 character string represents the 8 symbols used for parts which can rotate; `abcdefgh` will put `a` when part is rotated north, `b` for NE, `c` for east etc.
+`symbols` and `symbols_broken` can be either a string of 1 character (A 1 character string is effectively 8 of that characters) or 8 characters long. The length is measured in console characters. An 8 character string represents the 8 symbols used for parts which can rotate; `abcdefgh` will put `a` when part is rotated north, `b` for NW, `c` for west, `d` for SW etc.
 
 A subset of unicode box drawing characters is supported as symbols: `│ ─ ┼ ┌ ┐ ┘ └`, thick vertical and thick horizontal lines `┃ ━` are partially supported, they're rendered as `H` and `=` because there are no equivalents in curses ACS encoding.
 

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -274,7 +274,7 @@ void avatar::prepare_map_memory_region( const tripoint &p1, const tripoint &p2 )
     player_map_memory->prepare_region( p1, p2 );
 }
 
-const memorized_terrain_tile &avatar::get_memorized_tile( const tripoint &pos ) const
+const memorized_tile &avatar::get_memorized_tile( const tripoint &pos ) const
 {
     return player_map_memory->get_tile( pos );
 }

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -274,30 +274,34 @@ void avatar::prepare_map_memory_region( const tripoint &p1, const tripoint &p2 )
     player_map_memory->prepare_region( p1, p2 );
 }
 
-const memorized_tile &avatar::get_memorized_tile( const tripoint &pos ) const
+const memorized_tile &avatar::get_memorized_tile( const tripoint &p ) const
 {
-    return player_map_memory->get_tile( pos );
+    if( should_show_map_memory() ) {
+        return player_map_memory->get_tile( p );
+    }
+    return mm_submap::default_tile;
 }
 
-void avatar::memorize_tile( const tripoint &pos, const std::string &ter, const int subtile,
-                            const int rotation )
+void avatar::memorize_terrain( const tripoint &p, const std::string_view id,
+                               int subtile, int rotation )
 {
-    player_map_memory->memorize_tile( pos, ter, subtile, rotation );
+    player_map_memory->set_tile_terrain( p, id, subtile, rotation );
 }
 
-void avatar::memorize_symbol( const tripoint &pos, const int symbol )
+void avatar::memorize_decoration( const tripoint &p, const std::string_view id,
+                                  int subtile, int rotation )
 {
-    player_map_memory->memorize_symbol( pos, symbol );
+    player_map_memory->set_tile_decoration( p, id, subtile, rotation );
 }
 
-int avatar::get_memorized_symbol( const tripoint &p ) const
+void avatar::memorize_symbol( const tripoint &p, char32_t symbol )
 {
-    return player_map_memory->get_symbol( p );
+    player_map_memory->set_tile_symbol( p, symbol );
 }
 
-void avatar::clear_memorized_tile( const tripoint &pos )
+void avatar::memorize_clear_vehicles( const tripoint &p )
 {
-    player_map_memory->clear_memorized_tile( pos );
+    player_map_memory->clear_tile_vehicles( p );
 }
 
 std::vector<mission *> avatar::get_active_missions() const
@@ -680,19 +684,17 @@ void avatar::grab( object_type grab_type, const tripoint &grab_point )
     [this]( const object_type gtype, const tripoint & gpoint, const bool erase ) {
         map &m = get_map();
         if( gtype == object_type::VEHICLE ) {
-            const optional_vpart_position vp = m.veh_at( pos() + gpoint );
-            if( vp ) {
-                const vehicle &veh = vp->vehicle();
-                for( const tripoint &target : veh.get_points() ) {
+            if( const optional_vpart_position ovp = m.veh_at( pos() + gpoint ) ) {
+                for( const tripoint &target : ovp->vehicle().get_points() ) {
                     if( erase ) {
-                        clear_memorized_tile( m.getabs( target ) );
+                        memorize_clear_vehicles( m.getabs( target ) );
                     }
                     m.set_memory_seen_cache_dirty( target );
                 }
             }
         } else if( gtype != object_type::NONE ) {
             if( erase ) {
-                clear_memorized_tile( m.getabs( pos() + gpoint ) );
+                memorize_clear_vehicles( m.getabs( pos() + gpoint ) );
             }
             m.set_memory_seen_cache_dirty( pos() + gpoint );
         }

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -44,7 +44,7 @@ class window;
 } // namespace catacurses
 enum class character_type : int;
 class map_memory;
-struct memorized_terrain_tile;
+class memorized_tile;
 
 namespace debug_menu
 {
@@ -144,7 +144,7 @@ class avatar : public Character
         void memorize_tile( const tripoint &pos, const std::string &ter, int subtile,
                             int rotation );
         /** Returns last stored map tile in given location in tiles mode */
-        const memorized_terrain_tile &get_memorized_tile( const tripoint &p ) const;
+        const memorized_tile &get_memorized_tile( const tripoint &p ) const;
         /** Memorizes a given tile in curses mode; finalize_terrain_memory_curses needs to be called after it */
         void memorize_symbol( const tripoint &pos, int symbol );
         /** Returns last stored map tile in given location in curses mode */

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -140,16 +140,11 @@ class avatar : public Character
         void toggle_map_memory();
         bool should_show_map_memory() const;
         void prepare_map_memory_region( const tripoint &p1, const tripoint &p2 );
-        /** Memorizes a given tile in tiles mode; finalize_tile_memory needs to be called after it */
-        void memorize_tile( const tripoint &pos, const std::string &ter, int subtile,
-                            int rotation );
-        /** Returns last stored map tile in given location in tiles mode */
         const memorized_tile &get_memorized_tile( const tripoint &p ) const;
-        /** Memorizes a given tile in curses mode; finalize_terrain_memory_curses needs to be called after it */
-        void memorize_symbol( const tripoint &pos, int symbol );
-        /** Returns last stored map tile in given location in curses mode */
-        int get_memorized_symbol( const tripoint &p ) const;
-        void clear_memorized_tile( const tripoint &pos );
+        void memorize_terrain( const tripoint &p, std::string_view id, int subtile, int rotation );
+        void memorize_decoration( const tripoint &p, std::string_view id, int subtile, int rotation );
+        void memorize_symbol( const tripoint &p, char32_t symbol );
+        void memorize_clear_vehicles( const tripoint &p );
 
         nc_color basic_symbol_color() const override;
         int print_info( const catacurses::window &w, int vStart, int vLines, int column ) const override;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2765,6 +2765,48 @@ bool cata_tiles::apply_vision_effects( const tripoint &pos,
     return true;
 }
 
+bool cata_tiles::has_memory_at( const tripoint &p ) const
+{
+    const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getabs( p ) );
+    return !mt.ter_id.empty() || !mt.dec_id.empty();
+}
+
+const memorized_tile &cata_tiles::get_terrain_memory_at( const tripoint &p ) const
+{
+    const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getabs( p ) );
+    if( !mt.ter_id.empty() ) {
+        return mt;
+    }
+    return mm_submap::default_tile;
+}
+
+const memorized_tile &cata_tiles::get_furniture_memory_at( const tripoint &p ) const
+{
+    const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getabs( p ) );
+    if( string_starts_with( mt.dec_id, "f_" ) ) {
+        return mt;
+    }
+    return mm_submap::default_tile;
+}
+
+const memorized_tile &cata_tiles::get_trap_memory_at( const tripoint &p ) const
+{
+    const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getabs( p ) );
+    if( string_starts_with( mt.dec_id, "tr_" ) ) {
+        return mt;
+    }
+    return mm_submap::default_tile;
+}
+
+const memorized_tile &cata_tiles::get_vpart_memory_at( const tripoint &p ) const
+{
+    const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getabs( p ) );
+    if( string_starts_with( mt.dec_id, "vp_" ) ) {
+        return mt;
+    }
+    return mm_submap::default_tile;
+}
+
 bool cata_tiles::draw_terrain_below( const tripoint &p, const lit_level, int &,
                                      const std::array<bool, 5> &invisible )
 {
@@ -2868,7 +2910,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             // do something to get other terrain orientation values
         }
         if( here.check_seen_cache( p ) ) {
-            get_avatar().memorize_tile( here.getabs( p ), tname, subtile, rotation );
+            get_avatar().memorize_terrain( here.getabs( p ), tname, subtile, rotation );
         }
         // draw the actual terrain if there's no override
         if( !neighborhood_overridden ) {
@@ -2900,120 +2942,16 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             return draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
                                         rotation, lit, nv, height_3d );
         }
-    } else if( invisible[0] && has_terrain_memory_at( p ) ) {
+    } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
-        const memorized_tile &t = get_terrain_memory_at( p );
-        return draw_from_id_string(
-                   t.ter_id, TILE_CATEGORY::TERRAIN, empty_string, p, t.ter_subtile, t.ter_rotation,
-                   lit_level::MEMORIZED, nv_goggles_activated, height_3d );
-    }
-    return false;
-}
-
-bool cata_tiles::has_memory_at( const tripoint &p ) const
-{
-    avatar &you = get_avatar();
-    if( you.should_show_map_memory() ) {
-        const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        return !t.ter_id.empty() || !t.dec_id.empty();
-    }
-    return false;
-}
-
-bool cata_tiles::has_terrain_memory_at( const tripoint &p ) const
-{
-    avatar &you = get_avatar();
-    if( you.should_show_map_memory() ) {
-        const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( !t.ter_id.empty() ) {
-            return true;
+        const memorized_tile &mt = get_terrain_memory_at( p );
+        if( !mt.ter_id.empty() ) {
+            return draw_from_id_string(
+                       mt.ter_id, TILE_CATEGORY::TERRAIN, empty_string, p, mt.ter_subtile, mt.ter_rotation,
+                       lit_level::MEMORIZED, nv_goggles_activated, height_3d );
         }
     }
     return false;
-}
-
-bool cata_tiles::has_furniture_memory_at( const tripoint &p ) const
-{
-    avatar &you = get_avatar();
-    if( you.should_show_map_memory() ) {
-        const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.dec_id, "f_" ) ) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool cata_tiles::has_trap_memory_at( const tripoint &p ) const
-{
-    avatar &you = get_avatar();
-    if( you.should_show_map_memory() ) {
-        const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.dec_id, "tr_" ) ) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool cata_tiles::has_vpart_memory_at( const tripoint &p ) const
-{
-    avatar &you = get_avatar();
-    if( you.should_show_map_memory() ) {
-        const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.dec_id, "vp_" ) ) {
-            return true;
-        }
-    }
-    return false;
-}
-
-memorized_tile cata_tiles::get_terrain_memory_at( const tripoint &p ) const
-{
-    avatar &you = get_avatar();
-    if( you.should_show_map_memory() ) {
-        memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( !t.ter_id.empty() ) {
-            return t;
-        }
-    }
-    return {};
-}
-
-memorized_tile cata_tiles::get_furniture_memory_at( const tripoint &p ) const
-{
-    avatar &you = get_avatar();
-    if( you.should_show_map_memory() ) {
-        memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.dec_id, "f_" ) ) {
-            return t;
-        }
-    }
-    return {};
-}
-
-memorized_tile cata_tiles::get_trap_memory_at( const tripoint &p ) const
-{
-    avatar &you = get_avatar();
-    if( you.should_show_map_memory() ) {
-        memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.dec_id, "tr_" ) ) {
-            return t;
-        }
-    }
-    return {};
-}
-
-memorized_tile cata_tiles::get_vpart_memory_at( const tripoint &p ) const
-{
-    avatar &you = get_avatar();
-    if( you.should_show_map_memory() ) {
-        memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.dec_id, "vp_" ) ) {
-            return t;
-        }
-    }
-    return {};
 }
 
 bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &height_3d,
@@ -3055,7 +2993,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         if( !( you.get_grab_type() == object_type::FURNITURE
                && p == you.pos() + you.grab_point )
             && here.check_seen_cache( p ) ) {
-            you.memorize_tile( here.getabs( p ), fname, subtile, rotation );
+            you.memorize_decoration( here.getabs( p ), fname, subtile, rotation );
         }
         // draw the actual furniture if there's no override
         if( !neighborhood_overridden ) {
@@ -3099,12 +3037,14 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
             return draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
                                         rotation, lit, nv, height_3d );
         }
-    } else if( invisible[0] && has_furniture_memory_at( p ) ) {
+    } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
-        const memorized_tile &t = get_furniture_memory_at( p );
-        return draw_from_id_string(
-                   t.dec_id, TILE_CATEGORY::FURNITURE, empty_string, p, t.dec_subtile, t.dec_rotation,
-                   lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+        const memorized_tile &mt = get_furniture_memory_at( p );
+        if( !mt.dec_id.empty() ) {
+            return draw_from_id_string(
+                       mt.dec_id, TILE_CATEGORY::FURNITURE, empty_string, p, mt.dec_subtile, mt.dec_rotation,
+                       lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+        }
     }
     return false;
 }
@@ -3140,7 +3080,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
         get_tile_values( tr.loadid.to_i(), neighborhood, subtile, rotation, 0 );
         const std::string trname = tr.loadid.id().str();
         if( here.check_seen_cache( p ) ) {
-            you.memorize_tile( here.getabs( p ), trname, subtile, rotation );
+            you.memorize_decoration( here.getabs( p ), trname, subtile, rotation );
         }
         // draw the actual trap if there's no override
         if( !neighborhood_overridden ) {
@@ -3177,12 +3117,14 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
             return draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
                                         rotation, lit, nv, height_3d );
         }
-    } else if( invisible[0] && has_trap_memory_at( p ) ) {
+    } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
-        const memorized_tile &t = get_trap_memory_at( p );
-        return draw_from_id_string(
-                   t.dec_id, TILE_CATEGORY::TRAP, empty_string, p, t.dec_subtile, t.dec_rotation,
-                   lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+        const memorized_tile &mt = get_trap_memory_at( p );
+        if( !mt.dec_id.empty() ) {
+            return draw_from_id_string(
+                       mt.dec_id, TILE_CATEGORY::TRAP, empty_string, p, mt.dec_subtile, mt.dec_rotation,
+                       lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+        }
     }
     return false;
 }
@@ -3196,7 +3138,7 @@ bool cata_tiles::draw_part_con( const tripoint &p, const lit_level ll, int &heig
         avatar &you = get_avatar();
         std::string const &trname = tr_unfinished_construction.str();;
         if( here.check_seen_cache( p ) ) {
-            you.memorize_tile( here.getabs( p ), trname, 0, 0 );
+            you.memorize_decoration( here.getabs( p ), trname, 0, 0 );
         }
         return draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, 0,
                                     0, ll, nv_goggles_activated, height_3d );
@@ -3572,7 +3514,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
                 && !( you.get_grab_type() == object_type::VEHICLE
                       && veh.get_points().count( you.pos() + you.grab_point ) )
                 && here.check_seen_cache( p ) ) {
-                you.memorize_tile( here.getabs( p ), vd.get_tileset_id(), subtile, rotation );
+                you.memorize_decoration( here.getabs( p ), vd.get_tileset_id(), subtile, rotation );
             }
             if( !overridden ) {
                 int height_3d_temp = 0;
@@ -3612,20 +3554,22 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             }
             return ret;
         }
-    } else if( !roof && invisible[0] && has_vpart_memory_at( p ) ) {
+    } else if( !roof && invisible[0] ) {
         // try drawing memory if invisible and not overridden
         const memorized_tile &t = get_vpart_memory_at( p );
-        int height_3d_temp = 0;
-        std::string_view tid = t.dec_id;
-        std::string_view tvar;
-        const size_t variant_separator = tid.find( vehicles::variant_separator );
-        if( variant_separator != std::string::npos ) {
-            tvar = tid.substr( variant_separator + 1 );
-            tid = tid.substr( 0, variant_separator );
+        if( !t.dec_id.empty() ) {
+            int height_3d_temp = 0;
+            std::string_view tid = t.dec_id;
+            std::string_view tvar;
+            const size_t variant_separator = tid.find( vehicles::variant_separator );
+            if( variant_separator != std::string::npos ) {
+                tvar = tid.substr( variant_separator + 1 );
+                tid = tid.substr( 0, variant_separator );
+            }
+            return draw_from_id_string(
+                       std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p, t.dec_subtile, t.dec_rotation,
+                       lit_level::MEMORIZED, nv_goggles_activated, height_3d_temp, 0, std::string( tvar ) );
         }
-        return draw_from_id_string(
-                   std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p, t.dec_subtile, t.dec_rotation,
-                   lit_level::MEMORIZED, nv_goggles_activated, height_3d_temp, 0, std::string( tvar ) );
     }
     return false;
 }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2904,7 +2904,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
         // try drawing memory if invisible and not overridden
         const memorized_tile &t = get_terrain_memory_at( p );
         return draw_from_id_string(
-                   t.tile, TILE_CATEGORY::TERRAIN, empty_string, p, t.subtile, t.rotation,
+                   t.ter_id, TILE_CATEGORY::TERRAIN, empty_string, p, t.ter_subtile, t.ter_rotation,
                    lit_level::MEMORIZED, nv_goggles_activated, height_3d );
     }
     return false;
@@ -2915,7 +2915,7 @@ bool cata_tiles::has_memory_at( const tripoint &p ) const
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
         const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        return !t.tile.empty();
+        return !t.ter_id.empty() || !t.dec_id.empty();
     }
     return false;
 }
@@ -2925,7 +2925,7 @@ bool cata_tiles::has_terrain_memory_at( const tripoint &p ) const
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
         const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "t_" ) ) {
+        if( !t.ter_id.empty() ) {
             return true;
         }
     }
@@ -2937,7 +2937,7 @@ bool cata_tiles::has_furniture_memory_at( const tripoint &p ) const
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
         const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "f_" ) ) {
+        if( string_starts_with( t.dec_id, "f_" ) ) {
             return true;
         }
     }
@@ -2949,7 +2949,7 @@ bool cata_tiles::has_trap_memory_at( const tripoint &p ) const
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
         const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "tr_" ) ) {
+        if( string_starts_with( t.dec_id, "tr_" ) ) {
             return true;
         }
     }
@@ -2961,7 +2961,7 @@ bool cata_tiles::has_vpart_memory_at( const tripoint &p ) const
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
         const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "vp_" ) ) {
+        if( string_starts_with( t.dec_id, "vp_" ) ) {
             return true;
         }
     }
@@ -2973,7 +2973,7 @@ memorized_tile cata_tiles::get_terrain_memory_at( const tripoint &p ) const
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
         memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "t_" ) ) {
+        if( !t.ter_id.empty() ) {
             return t;
         }
     }
@@ -2985,7 +2985,7 @@ memorized_tile cata_tiles::get_furniture_memory_at( const tripoint &p ) const
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
         memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "f_" ) ) {
+        if( string_starts_with( t.dec_id, "f_" ) ) {
             return t;
         }
     }
@@ -2997,7 +2997,7 @@ memorized_tile cata_tiles::get_trap_memory_at( const tripoint &p ) const
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
         memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "tr_" ) ) {
+        if( string_starts_with( t.dec_id, "tr_" ) ) {
             return t;
         }
     }
@@ -3009,7 +3009,7 @@ memorized_tile cata_tiles::get_vpart_memory_at( const tripoint &p ) const
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
         memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "vp_" ) ) {
+        if( string_starts_with( t.dec_id, "vp_" ) ) {
             return t;
         }
     }
@@ -3103,7 +3103,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         // try drawing memory if invisible and not overridden
         const memorized_tile &t = get_furniture_memory_at( p );
         return draw_from_id_string(
-                   t.tile, TILE_CATEGORY::FURNITURE, empty_string, p, t.subtile, t.rotation,
+                   t.dec_id, TILE_CATEGORY::FURNITURE, empty_string, p, t.dec_subtile, t.dec_rotation,
                    lit_level::MEMORIZED, nv_goggles_activated, height_3d );
     }
     return false;
@@ -3181,7 +3181,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
         // try drawing memory if invisible and not overridden
         const memorized_tile &t = get_trap_memory_at( p );
         return draw_from_id_string(
-                   t.tile, TILE_CATEGORY::TRAP, empty_string, p, t.subtile, t.rotation,
+                   t.dec_id, TILE_CATEGORY::TRAP, empty_string, p, t.dec_subtile, t.dec_rotation,
                    lit_level::MEMORIZED, nv_goggles_activated, height_3d );
     }
     return false;
@@ -3616,7 +3616,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         // try drawing memory if invisible and not overridden
         const memorized_tile &t = get_vpart_memory_at( p );
         int height_3d_temp = 0;
-        std::string_view tid = t.tile;
+        std::string_view tid = t.dec_id;
         std::string_view tvar;
         const size_t variant_separator = tid.find( vehicles::variant_separator );
         if( variant_separator != std::string::npos ) {
@@ -3624,7 +3624,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             tid = tid.substr( 0, variant_separator );
         }
         return draw_from_id_string(
-                   std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p, t.subtile, t.rotation,
+                   std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p, t.dec_subtile, t.dec_rotation,
                    lit_level::MEMORIZED, nv_goggles_activated, height_3d_temp, 0, std::string( tvar ) );
     }
     return false;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2902,7 +2902,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
         }
     } else if( invisible[0] && has_terrain_memory_at( p ) ) {
         // try drawing memory if invisible and not overridden
-        const memorized_terrain_tile &t = get_terrain_memory_at( p );
+        const memorized_tile &t = get_terrain_memory_at( p );
         return draw_from_id_string(
                    t.tile, TILE_CATEGORY::TERRAIN, empty_string, p, t.subtile, t.rotation,
                    lit_level::MEMORIZED, nv_goggles_activated, height_3d );
@@ -2914,7 +2914,7 @@ bool cata_tiles::has_memory_at( const tripoint &p ) const
 {
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
-        const memorized_terrain_tile t = you.get_memorized_tile( get_map().getabs( p ) );
+        const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
         return !t.tile.empty();
     }
     return false;
@@ -2924,7 +2924,7 @@ bool cata_tiles::has_terrain_memory_at( const tripoint &p ) const
 {
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
-        const memorized_terrain_tile t = you.get_memorized_tile( get_map().getabs( p ) );
+        const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "t_" ) ) {
             return true;
         }
@@ -2936,7 +2936,7 @@ bool cata_tiles::has_furniture_memory_at( const tripoint &p ) const
 {
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
-        const memorized_terrain_tile t = you.get_memorized_tile( get_map().getabs( p ) );
+        const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "f_" ) ) {
             return true;
         }
@@ -2948,7 +2948,7 @@ bool cata_tiles::has_trap_memory_at( const tripoint &p ) const
 {
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
-        const memorized_terrain_tile t = you.get_memorized_tile( get_map().getabs( p ) );
+        const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "tr_" ) ) {
             return true;
         }
@@ -2960,7 +2960,7 @@ bool cata_tiles::has_vpart_memory_at( const tripoint &p ) const
 {
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
-        const memorized_terrain_tile t = you.get_memorized_tile( get_map().getabs( p ) );
+        const memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "vp_" ) ) {
             return true;
         }
@@ -2968,11 +2968,11 @@ bool cata_tiles::has_vpart_memory_at( const tripoint &p ) const
     return false;
 }
 
-memorized_terrain_tile cata_tiles::get_terrain_memory_at( const tripoint &p ) const
+memorized_tile cata_tiles::get_terrain_memory_at( const tripoint &p ) const
 {
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
-        memorized_terrain_tile t = you.get_memorized_tile( get_map().getabs( p ) );
+        memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "t_" ) ) {
             return t;
         }
@@ -2980,11 +2980,11 @@ memorized_terrain_tile cata_tiles::get_terrain_memory_at( const tripoint &p ) co
     return {};
 }
 
-memorized_terrain_tile cata_tiles::get_furniture_memory_at( const tripoint &p ) const
+memorized_tile cata_tiles::get_furniture_memory_at( const tripoint &p ) const
 {
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
-        memorized_terrain_tile t = you.get_memorized_tile( get_map().getabs( p ) );
+        memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "f_" ) ) {
             return t;
         }
@@ -2992,11 +2992,11 @@ memorized_terrain_tile cata_tiles::get_furniture_memory_at( const tripoint &p ) 
     return {};
 }
 
-memorized_terrain_tile cata_tiles::get_trap_memory_at( const tripoint &p ) const
+memorized_tile cata_tiles::get_trap_memory_at( const tripoint &p ) const
 {
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
-        memorized_terrain_tile t = you.get_memorized_tile( get_map().getabs( p ) );
+        memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "tr_" ) ) {
             return t;
         }
@@ -3004,11 +3004,11 @@ memorized_terrain_tile cata_tiles::get_trap_memory_at( const tripoint &p ) const
     return {};
 }
 
-memorized_terrain_tile cata_tiles::get_vpart_memory_at( const tripoint &p ) const
+memorized_tile cata_tiles::get_vpart_memory_at( const tripoint &p ) const
 {
     avatar &you = get_avatar();
     if( you.should_show_map_memory() ) {
-        memorized_terrain_tile t = you.get_memorized_tile( get_map().getabs( p ) );
+        memorized_tile t = you.get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "vp_" ) ) {
             return t;
         }
@@ -3101,7 +3101,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         }
     } else if( invisible[0] && has_furniture_memory_at( p ) ) {
         // try drawing memory if invisible and not overridden
-        const memorized_terrain_tile &t = get_furniture_memory_at( p );
+        const memorized_tile &t = get_furniture_memory_at( p );
         return draw_from_id_string(
                    t.tile, TILE_CATEGORY::FURNITURE, empty_string, p, t.subtile, t.rotation,
                    lit_level::MEMORIZED, nv_goggles_activated, height_3d );
@@ -3179,7 +3179,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
         }
     } else if( invisible[0] && has_trap_memory_at( p ) ) {
         // try drawing memory if invisible and not overridden
-        const memorized_terrain_tile &t = get_trap_memory_at( p );
+        const memorized_tile &t = get_trap_memory_at( p );
         return draw_from_id_string(
                    t.tile, TILE_CATEGORY::TRAP, empty_string, p, t.subtile, t.rotation,
                    lit_level::MEMORIZED, nv_goggles_activated, height_3d );
@@ -3614,7 +3614,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         }
     } else if( !roof && invisible[0] && has_vpart_memory_at( p ) ) {
         // try drawing memory if invisible and not overridden
-        const memorized_terrain_tile &t = get_vpart_memory_at( p );
+        const memorized_tile &t = get_vpart_memory_at( p );
         int height_3d_temp = 0;
         std::string_view tid = t.tile;
         std::string_view tvar;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -65,6 +65,7 @@
 #include "translations.h"
 #include "trap.h"
 #include "type_id.h"
+#include "units_utility.h"
 #include "veh_type.h"
 #include "vehicle.h"
 #include "vpart_position.h"
@@ -2228,8 +2229,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
                     if( subtile == open_ ) {
                         sym = '\'';
                     } else {
-                        const units::angle direction = units::from_degrees( rota ) + 90_degrees;
-                        sym = vv.get_symbol_curses( direction, subtile == broken );
+                        sym = vv.get_symbol_curses( 90_degrees * rota, subtile == broken );
                     }
                     col = vpi.color;
                     subtile = -1;
@@ -2431,10 +2431,6 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
                     seed = simple_point_hash( vp->mount() );
                 }
             }
-
-            // convert vehicle 360-degree direction (0=E,45=SE, etc) to 4-way tile
-            // rotation (0=N,1=W,etc)
-            rota = 3 - units::angle_to_dir4( units::from_degrees( rota ) );
         }
         break;
         case TILE_CATEGORY::FURNITURE: {
@@ -3508,7 +3504,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         const vpart_display vd = veh.get_display_of_tile( ovp->mount() );
         if( !vd.id.is_null() ) {
             const int subtile = vd.is_open ? open_ : vd.is_broken ? broken : 0;
-            const int rotation = std::round( to_degrees( veh.face.dir() ) );
+            const int rotation = angle_to_dir4( 270_degrees - veh.face.dir() );
             avatar &you = get_avatar();
             if( !veh.forward_velocity() && !veh.player_in_control( you )
                 && !( you.get_grab_type() == object_type::VEHICLE
@@ -3537,7 +3533,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         if( vp2 ) {
             const char part_mod = std::get<1>( override->second );
             const int subtile = part_mod == 1 ? open_ : part_mod == 2 ? broken : 0;
-            const units::angle rotation = std::get<2>( override->second );
+            const int rotation = angle_to_dir4( 270_degrees - std::get<2>( override->second ) );
             const int draw_highlight = std::get<3>( override->second );
             const std::string vpname = "vp_" + vp2.str();
             // tile overrides are never memorized
@@ -3545,7 +3541,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             int height_3d_temp = 0;
             const bool ret =
                 draw_from_id_string( vpname, TILE_CATEGORY::VEHICLE_PART, empty_string, p, subtile,
-                                     to_degrees( rotation ), lit_level::LIT, false, height_3d_temp );
+                                     rotation, lit_level::LIT, false, height_3d_temp );
             if( !roof ) {
                 height_3d = height_3d_temp;
             }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2768,13 +2768,13 @@ bool cata_tiles::apply_vision_effects( const tripoint &pos,
 bool cata_tiles::has_memory_at( const tripoint &p ) const
 {
     const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getabs( p ) );
-    return !mt.ter_id.empty() || !mt.dec_id.empty();
+    return !mt.get_ter_id().empty() || !mt.get_dec_id().empty();
 }
 
 const memorized_tile &cata_tiles::get_terrain_memory_at( const tripoint &p ) const
 {
     const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getabs( p ) );
-    if( !mt.ter_id.empty() ) {
+    if( !mt.get_ter_id().empty() ) {
         return mt;
     }
     return mm_submap::default_tile;
@@ -2783,7 +2783,7 @@ const memorized_tile &cata_tiles::get_terrain_memory_at( const tripoint &p ) con
 const memorized_tile &cata_tiles::get_furniture_memory_at( const tripoint &p ) const
 {
     const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getabs( p ) );
-    if( string_starts_with( mt.dec_id, "f_" ) ) {
+    if( string_starts_with( mt.get_dec_id(), "f_" ) ) {
         return mt;
     }
     return mm_submap::default_tile;
@@ -2792,7 +2792,7 @@ const memorized_tile &cata_tiles::get_furniture_memory_at( const tripoint &p ) c
 const memorized_tile &cata_tiles::get_trap_memory_at( const tripoint &p ) const
 {
     const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getabs( p ) );
-    if( string_starts_with( mt.dec_id, "tr_" ) ) {
+    if( string_starts_with( mt.get_dec_id(), "tr_" ) ) {
         return mt;
     }
     return mm_submap::default_tile;
@@ -2801,7 +2801,7 @@ const memorized_tile &cata_tiles::get_trap_memory_at( const tripoint &p ) const
 const memorized_tile &cata_tiles::get_vpart_memory_at( const tripoint &p ) const
 {
     const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getabs( p ) );
-    if( string_starts_with( mt.dec_id, "vp_" ) ) {
+    if( string_starts_with( mt.get_dec_id(), "vp_" ) ) {
         return mt;
     }
     return mm_submap::default_tile;
@@ -2945,10 +2945,10 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
         const memorized_tile &mt = get_terrain_memory_at( p );
-        if( !mt.ter_id.empty() ) {
+        if( !mt.get_ter_id().empty() ) {
             return draw_from_id_string(
-                       mt.ter_id, TILE_CATEGORY::TERRAIN, empty_string, p, mt.ter_subtile, mt.ter_rotation,
-                       lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+                       mt.get_ter_id(), TILE_CATEGORY::TERRAIN, empty_string, p, mt.get_ter_subtile(),
+                       mt.get_ter_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d );
         }
     }
     return false;
@@ -3040,10 +3040,10 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
         const memorized_tile &mt = get_furniture_memory_at( p );
-        if( !mt.dec_id.empty() ) {
+        if( !mt.get_dec_id().empty() ) {
             return draw_from_id_string(
-                       mt.dec_id, TILE_CATEGORY::FURNITURE, empty_string, p, mt.dec_subtile, mt.dec_rotation,
-                       lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+                       mt.get_dec_id(), TILE_CATEGORY::FURNITURE, empty_string, p, mt.get_dec_subtile(),
+                       mt.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d );
         }
     }
     return false;
@@ -3120,9 +3120,9 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
         const memorized_tile &mt = get_trap_memory_at( p );
-        if( !mt.dec_id.empty() ) {
+        if( !mt.get_dec_id().empty() ) {
             return draw_from_id_string(
-                       mt.dec_id, TILE_CATEGORY::TRAP, empty_string, p, mt.dec_subtile, mt.dec_rotation,
+                       mt.get_dec_id(), TILE_CATEGORY::TRAP, empty_string, p, mt.get_dec_subtile(), mt.get_dec_rotation(),
                        lit_level::MEMORIZED, nv_goggles_activated, height_3d );
         }
     }
@@ -3557,9 +3557,9 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
     } else if( !roof && invisible[0] ) {
         // try drawing memory if invisible and not overridden
         const memorized_tile &t = get_vpart_memory_at( p );
-        if( !t.dec_id.empty() ) {
+        std::string_view tid = t.get_dec_id();
+        if( !tid.empty() ) {
             int height_3d_temp = 0;
-            std::string_view tid = t.dec_id;
             std::string_view tvar;
             const size_t variant_separator = tid.find( vehicles::variant_separator );
             if( variant_separator != std::string::npos ) {
@@ -3567,8 +3567,9 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
                 tid = tid.substr( 0, variant_separator );
             }
             return draw_from_id_string(
-                       std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p, t.dec_subtile, t.dec_rotation,
-                       lit_level::MEMORIZED, nv_goggles_activated, height_3d_temp, 0, std::string( tvar ) );
+                       std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p, t.get_dec_subtile(),
+                       t.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d_temp, 0,
+                       std::string( tvar ) );
         }
     }
     return false;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -494,10 +494,10 @@ class cata_tiles
         bool has_furniture_memory_at( const tripoint &p ) const;
         bool has_trap_memory_at( const tripoint &p ) const;
         bool has_vpart_memory_at( const tripoint &p ) const;
-        memorized_terrain_tile get_terrain_memory_at( const tripoint &p ) const;
-        memorized_terrain_tile get_furniture_memory_at( const tripoint &p ) const;
-        memorized_terrain_tile get_trap_memory_at( const tripoint &p ) const;
-        memorized_terrain_tile get_vpart_memory_at( const tripoint &p ) const;
+        memorized_tile get_terrain_memory_at( const tripoint &p ) const;
+        memorized_tile get_furniture_memory_at( const tripoint &p ) const;
+        memorized_tile get_trap_memory_at( const tripoint &p ) const;
+        memorized_tile get_vpart_memory_at( const tripoint &p ) const;
 
         /** Drawing Layers */
         bool would_apply_vision_effects( visibility_type visibility ) const;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -490,14 +490,10 @@ class cata_tiles
 
         /** Map memory */
         bool has_memory_at( const tripoint &p ) const;
-        bool has_terrain_memory_at( const tripoint &p ) const;
-        bool has_furniture_memory_at( const tripoint &p ) const;
-        bool has_trap_memory_at( const tripoint &p ) const;
-        bool has_vpart_memory_at( const tripoint &p ) const;
-        memorized_tile get_terrain_memory_at( const tripoint &p ) const;
-        memorized_tile get_furniture_memory_at( const tripoint &p ) const;
-        memorized_tile get_trap_memory_at( const tripoint &p ) const;
-        memorized_tile get_vpart_memory_at( const tripoint &p ) const;
+        const memorized_tile &get_terrain_memory_at( const tripoint &p ) const;
+        const memorized_tile &get_furniture_memory_at( const tripoint &p ) const;
+        const memorized_tile &get_trap_memory_at( const tripoint &p ) const;
+        const memorized_tile &get_vpart_memory_at( const tripoint &p ) const;
 
         /** Drawing Layers */
         bool would_apply_vision_effects( visibility_type visibility ) const;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5720,9 +5720,8 @@ void game::control_vehicle()
     if( veh ) {
         // If we reached here, we gained control of a vehicle.
         // Clear the map memory for the area covered by the vehicle to eliminate ghost vehicles.
-        // FIXME: change map memory to memorize all memorizable objects and only erase vehicle part memory.
         for( const tripoint &target : veh->get_points() ) {
-            u.clear_memorized_tile( m.getabs( target ) );
+            u.memorize_clear_vehicles( m.getabs( target ) );
             m.set_memory_seen_cache_dirty( target );
         }
         veh->is_following = false;

--- a/src/lru_cache.h
+++ b/src/lru_cache.h
@@ -11,8 +11,6 @@
 #include "enums.h" // IWYU pragma: keep
 #include "point.h"
 
-struct memorized_terrain_tile;
-
 template<typename Key, typename Value>
 class lru_cache
 {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1825,7 +1825,7 @@ uint8_t map::get_known_connections( const tripoint &p,
     if( use_tiles ) {
         is_memorized =
         [&]( const tripoint & q ) {
-            return !player_character.get_memorized_tile( getabs( q ) ).tile.empty();
+            return !player_character.get_memorized_tile( getabs( q ) ).ter_id.empty();
         };
     } else {
 #endif
@@ -1910,7 +1910,7 @@ uint8_t map::get_known_connections_f( const tripoint &p,
 #ifdef TILES
     if( use_tiles ) {
         is_memorized = [&]( const tripoint & q ) {
-            return !player_character.get_memorized_tile( getabs( q ) ).tile.empty();
+            return !player_character.get_memorized_tile( getabs( q ) ).dec_id.empty();
         };
     } else {
 #endif

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1823,7 +1823,7 @@ uint8_t map::get_known_connections( const tripoint &p,
     if( use_tiles ) {
         is_memorized =
         [&]( const tripoint & q ) {
-            return !player_character.get_memorized_tile( getabs( q ) ).ter_id.empty();
+            return !player_character.get_memorized_tile( getabs( q ) ).get_ter_id().empty();
         };
     } else {
 #endif
@@ -1908,7 +1908,7 @@ uint8_t map::get_known_connections_f( const tripoint &p,
 #ifdef TILES
     if( use_tiles ) {
         is_memorized = [&]( const tripoint & q ) {
-            return !player_character.get_memorized_tile( getabs( q ) ).dec_id.empty();
+            return !player_character.get_memorized_tile( getabs( q ) ).get_dec_id().empty();
         };
     } else {
 #endif

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -504,9 +504,7 @@ std::unique_ptr<vehicle> map::detach_vehicle( vehicle *veh )
     for( size_t i = 0; i < current_submap->vehicles.size(); i++ ) {
         if( current_submap->vehicles[i].get() == veh ) {
             for( const tripoint &pt : veh->get_points() ) {
-                // FIXME: allow memorizing all objects in a tile and only clear
-                // vehicle memory here.
-                get_avatar().clear_memorized_tile( getabs( pt ) );
+                get_avatar().memorize_clear_vehicles( getabs( pt ) );
                 set_memory_seen_cache_dirty( pt );
             }
             ch.vehicle_list.erase( veh );
@@ -1831,7 +1829,7 @@ uint8_t map::get_known_connections( const tripoint &p,
 #endif
         is_memorized =
         [&]( const tripoint & q ) {
-            return player_character.get_memorized_symbol( getabs( q ) );
+            return player_character.get_memorized_tile( getabs( q ) ).symbol != 0;
         };
 #ifdef TILES
     }
@@ -1915,7 +1913,7 @@ uint8_t map::get_known_connections_f( const tripoint &p,
     } else {
 #endif
         is_memorized = [&]( const tripoint & q ) {
-            return player_character.get_memorized_symbol( getabs( q ) );
+            return player_character.get_memorized_tile( getabs( q ) ).symbol != 0;
         };
 #ifdef TILES
     }
@@ -6456,23 +6454,13 @@ visibility_type map::get_visibility( const lit_level ll,
     return visibility_type::HIDDEN;
 }
 
-static bool has_memory_at( const tripoint &p )
+static std::optional<char32_t> get_memory_at( const tripoint &p )
 {
-    avatar &you = get_avatar();
-    if( you.should_show_map_memory() ) {
-        int t = you.get_memorized_symbol( get_map().getabs( p ) );
-        return t != 0;
+    const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getabs( p ) );
+    if( mt.symbol != 0 ) {
+        return mt.symbol;
     }
-    return false;
-}
-
-static int get_memory_at( const tripoint &p )
-{
-    avatar &you = get_avatar();
-    if( you.should_show_map_memory() ) {
-        return you.get_memorized_symbol( get_map().getabs( p ) );
-    }
-    return ' ';
+    return std::nullopt;
 }
 
 void map::draw( const catacurses::window &w, const tripoint &center )
@@ -6513,8 +6501,8 @@ void map::draw( const catacurses::window &w, const tripoint &center )
     const auto draw_background = [&]( const tripoint & p ) {
         int sym = ' ';
         nc_color col = c_black;
-        if( has_memory_at( p ) ) {
-            sym = get_memory_at( p );
+        if( const std::optional<char32_t> memorized_symbol = get_memory_at( p ) ) {
+            sym = *memorized_symbol;
             col = c_brown;
         }
         wputch( w, col, sym );

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -85,6 +85,86 @@ bool mm_region::is_empty() const
     return true;
 }
 
+const std::string &memorized_tile::get_ter_id() const
+{
+    return ter_id.str();
+}
+
+const std::string &memorized_tile::get_dec_id() const
+{
+    return dec_id;
+}
+
+void memorized_tile::set_ter_id( const std::string_view id )
+{
+    ter_id = ter_str_id( id );
+}
+
+void memorized_tile::set_dec_id( const std::string_view id )
+{
+    dec_id = id;
+}
+
+int memorized_tile::get_ter_rotation() const
+{
+    return ter_rotation;
+}
+
+void memorized_tile::set_ter_rotation( int rotation )
+{
+    if( rotation < std::numeric_limits<decltype( ter_rotation )>::min() ||
+        rotation > std::numeric_limits<decltype( ter_rotation )>::max() ) {
+        debugmsg( "map memory can't store rotation value %d", rotation );
+        rotation = 0;
+    }
+    ter_rotation = rotation;
+}
+
+int memorized_tile::get_dec_rotation() const
+{
+    return dec_rotation;
+}
+
+void memorized_tile::set_dec_rotation( int rotation )
+{
+    if( rotation < std::numeric_limits<decltype( dec_rotation )>::min() ||
+        rotation > std::numeric_limits<decltype( dec_rotation )>::max() ) {
+        debugmsg( "map memory can't store rotation value %d", rotation );
+        rotation = 0;
+    }
+    dec_rotation = rotation;
+}
+
+int memorized_tile::get_ter_subtile() const
+{
+    return ter_subtile;
+}
+
+void memorized_tile::set_ter_subtile( int subtile )
+{
+    if( subtile < std::numeric_limits<decltype( ter_subtile )>::min() ||
+        subtile > std::numeric_limits<decltype( ter_subtile )>::max() ) {
+        debugmsg( "map memory can't store terrain subtile value %d", subtile );
+        subtile = 0;
+    }
+    ter_subtile = subtile;
+}
+
+int memorized_tile::get_dec_subtile() const
+{
+    return dec_subtile;
+}
+
+void memorized_tile::set_dec_subtile( int subtile )
+{
+    if( subtile < std::numeric_limits<decltype( dec_subtile )>::min() ||
+        subtile > std::numeric_limits<decltype( dec_subtile )>::max() ) {
+        debugmsg( "map memory can't store decoration subtile value %d", subtile );
+        subtile = 0;
+    }
+    dec_subtile = subtile;
+}
+
 bool memorized_tile::operator==( const memorized_tile &rhs ) const
 {
     return symbol == rhs.symbol &&
@@ -122,9 +202,9 @@ void map_memory::set_tile_terrain( const tripoint &pos, const std::string_view i
         return;
     }
     memorized_tile mt = sm.get_tile( p.loc );
-    mt.ter_id = id;
-    mt.ter_subtile = subtile;
-    mt.ter_rotation = rotation;
+    mt.set_ter_id( id );
+    mt.set_ter_subtile( subtile );
+    mt.set_ter_rotation( rotation );
     sm.set_tile( p.loc, mt );
 }
 
@@ -137,9 +217,9 @@ void map_memory::set_tile_decoration( const tripoint &pos, const std::string_vie
         return;
     }
     memorized_tile mt = sm.get_tile( p.loc );
-    mt.dec_id = id;
-    mt.dec_subtile = subtile;
-    mt.dec_rotation = rotation;
+    mt.set_dec_id( id );
+    mt.set_dec_subtile( subtile );
+    mt.set_dec_rotation( rotation );
     sm.set_tile( p.loc, mt );
 }
 
@@ -163,10 +243,10 @@ void map_memory::clear_tile_vehicles( const tripoint &pos )
         return;
     }
     memorized_tile mt = sm.get_tile( p.loc );
-    if( string_starts_with( mt.dec_id, "vp_" ) ) {
-        mt.dec_id.clear();
-        mt.dec_rotation = 0;
-        mt.dec_subtile = 0;
+    if( string_starts_with( mt.get_dec_id(), "vp_" ) ) {
+        mt.set_dec_id( "" );
+        mt.set_dec_rotation( 0 );
+        mt.set_dec_subtile( 0 );
         mt.symbol = 0;
     }
     sm.set_tile( p.loc, mt );

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -104,9 +104,12 @@ bool mm_region::is_empty() const
 bool memorized_tile::operator==( const memorized_tile &rhs ) const
 {
     return symbol == rhs.symbol &&
-           rotation == rhs.rotation &&
-           subtile == rhs.subtile &&
-           tile == rhs.tile;
+           ter_rotation == rhs.ter_rotation &&
+           dec_rotation == rhs.dec_rotation &&
+           ter_subtile == rhs.ter_subtile &&
+           dec_subtile == rhs.dec_subtile &&
+           ter_id == rhs.ter_id &&
+           dec_id == rhs.dec_id;
 }
 
 map_memory::coord_pair::coord_pair( const tripoint &p ) : loc( p.xy() )
@@ -126,18 +129,24 @@ const memorized_tile &map_memory::get_tile( const tripoint &pos ) const
     return sm.tile( p.loc );
 }
 
-void map_memory::memorize_tile( const tripoint &pos, const std::string &ter,
-                                const int subtile, const int rotation )
+void map_memory::memorize_tile( const tripoint &pos, const std::string &id, int subtile,
+                                int rotation )
 {
     coord_pair p( pos );
     mm_submap &sm = get_submap( p.sm );
     if( !sm.is_valid() ) {
         return;
     }
-    memorized_tile t;
-    t.tile = ter;
-    t.subtile = subtile;
-    t.rotation = rotation;
+    memorized_tile t = sm.tile( p.loc );
+    if( string_starts_with( id, "t_" ) ) {
+        t.ter_id = id;
+        t.ter_subtile = subtile;
+        t.ter_rotation = rotation;
+    } else {
+        t.dec_id = id;
+        t.dec_subtile = subtile;
+        t.dec_rotation = rotation;
+    }
     sm.set_tile( p.loc, std::move( t ) );
 }
 

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -67,7 +67,7 @@ struct mm_submap {
         void set_tile( const point &p, const memorized_tile &value );
 
         void serialize( JsonOut &jsout ) const;
-        void deserialize( const JsonArray &ja );
+        void deserialize( int version, const JsonArray &ja );
 
     private:
         // NOLINTNEXTLINE(cata-serialize)

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -17,9 +17,12 @@ class memorized_tile
 {
     public:
         char32_t symbol = 0;
-        std::string tile;
-        int subtile = 0;
-        int rotation = 0;
+        std::string ter_id; // terrain tile id
+        std::string dec_id; // decoration tile id (furniture, vparts ...)
+        int ter_subtile = 0;
+        int dec_subtile = 0;
+        int ter_rotation = 0;
+        int dec_rotation = 0;
 
         bool operator==( const memorized_tile &rhs ) const;
         bool operator!=( const memorized_tile &rhs ) const {
@@ -73,10 +76,6 @@ struct mm_region {
 
 /**
  * Manages map tiles memorized by the avatar.
- * Note that there are 2 separate memories in here:
- *   1. memorized graphic tiles (for TILES with a tileset)
- *   2. memorized symbols (for CURSES or TILES in ascii mode)
- * TODO: combine tiles and curses. Also, split map memory into layers (terrain/furn/vpart/...)?
  */
 class map_memory
 {
@@ -114,8 +113,7 @@ class map_memory
          * Memorizes given tile, overwriting old value.
          * @param pos tile position, in global ms coords.
          */
-        void memorize_tile( const tripoint &pos, const std::string &ter,
-                            int subtile, int rotation );
+        void memorize_tile( const tripoint &pos, const std::string &id, int subtile, int rotation );
         /**
          * Returns memorized tile.
          * @param pos tile position, in global ms coords.

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -44,8 +44,8 @@ class memorized_tile
         friend struct mm_submap; // serialization needs access to private members
         ter_str_id ter_id;       // terrain tile id
         std::string dec_id;      // decoration tile id (furniture, vparts ...)
-        int16_t ter_rotation = 0;
-        int16_t dec_rotation = 0;
+        int8_t ter_rotation = 0;
+        int8_t dec_rotation = 0;
         int8_t ter_subtile = 0;
         int8_t dec_subtile = 0;
 };

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -43,13 +43,11 @@ struct mm_submap {
         // @returns true if mm_submap is valid, i.e. not returned from an uninitialized region.
         bool is_valid() const;
 
-        const memorized_tile &tile( const point &p ) const;
+        const memorized_tile &get_tile( const point &p ) const;
         void set_tile( const point &p, const memorized_tile &value );
-        char32_t symbol( const point &p ) const;
-        void set_symbol( const point &p, char32_t value );
 
         void serialize( JsonOut &jsout ) const;
-        void deserialize( const JsonValue &ja );
+        void deserialize( const JsonArray &ja );
 
     private:
         // NOLINTNEXTLINE(cata-serialize)
@@ -110,33 +108,34 @@ class map_memory
         bool prepare_region( const tripoint &p1, const tripoint &p2 );
 
         /**
-         * Memorizes given tile, overwriting old value.
-         * @param pos tile position, in global ms coords.
-         */
-        void memorize_tile( const tripoint &pos, const std::string &id, int subtile, int rotation );
-        /**
          * Returns memorized tile.
          * @param pos tile position, in global ms coords.
          */
         const memorized_tile &get_tile( const tripoint &pos ) const;
 
         /**
-         * Memorizes given symbol, overwriting old value.
+         * Memorizes terrain at \p pos, overwriting old terrain values.
+         * @param pos tile position, in global ms coords.
+         */
+        void set_tile_terrain( const tripoint &pos, std::string_view id, int subtile, int rotation );
+
+        /**
+         * Memorizes decoraiton at \p pos, overwriting old decoration values.
+         * @param pos tile position, in global ms coords.
+         */
+        void set_tile_decoration( const tripoint &pos, std::string_view id, int subtile, int rotation );
+
+        /**
+         * Memorizes symbol at \p pos, overwriting old symbol.
          * @param pos tile position, in global ms coords.
         */
-        void memorize_symbol( const tripoint &pos, char32_t symbol );
+        void set_tile_symbol( const tripoint &pos, char32_t symbol );
 
         /**
-         * Returns memorized symbol.
+         * Clears memorized vehicles and symbol.
          * @param pos tile position, in global ms coords.
          */
-        char32_t get_symbol( const tripoint &pos ) const;
-
-        /**
-         * Clears memorized tile and symbol.
-         * @param pos tile position, in global ms coords.
-         */
-        void clear_memorized_tile( const tripoint &pos );
+        void clear_tile_vehicles( const tripoint &pos );
 
     private:
         std::map<tripoint, shared_ptr_fast<mm_submap>> submaps;

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -135,9 +135,6 @@ class map_memory
         /** Load memorized submaps around given global map square pos. */
         void load( const tripoint &pos );
 
-        /** Load legacy memory file. TODO: remove after 0.F (or whatever BN will have instead). */
-        void load_legacy( const JsonValue &jv );
-
         /** Save memorized submaps to disk, drop ones far from given global map square pos. */
         bool save( const tripoint &pos );
 

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -13,21 +13,41 @@ class JsonObject;
 class JsonOut;
 class JsonValue;
 
+struct ter_t;
+using ter_str_id = string_id<ter_t>;
+
 class memorized_tile
 {
     public:
         char32_t symbol = 0;
-        std::string ter_id; // terrain tile id
-        std::string dec_id; // decoration tile id (furniture, vparts ...)
-        int ter_subtile = 0;
-        int dec_subtile = 0;
-        int ter_rotation = 0;
-        int dec_rotation = 0;
+
+        const std::string &get_ter_id() const;
+        const std::string &get_dec_id() const;
+        void set_ter_id( std::string_view id );
+        void set_dec_id( std::string_view id );
+
+        int get_ter_rotation() const;
+        void set_ter_rotation( int rotation );
+        int get_dec_rotation() const;
+        void set_dec_rotation( int rotation );
+
+        int get_ter_subtile() const;
+        void set_ter_subtile( int subtile );
+        int get_dec_subtile() const;
+        void set_dec_subtile( int subtile );
 
         bool operator==( const memorized_tile &rhs ) const;
         bool operator!=( const memorized_tile &rhs ) const {
             return !( *this == rhs );
         }
+    private:
+        friend struct mm_submap; // serialization needs access to private members
+        ter_str_id ter_id;       // terrain tile id
+        std::string dec_id;      // decoration tile id (furniture, vparts ...)
+        int16_t ter_rotation = 0;
+        int16_t dec_rotation = 0;
+        int8_t ter_subtile = 0;
+        int8_t dec_subtile = 0;
 };
 
 /** Represent a submap-sized chunk of tile memory. */

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -16,6 +16,7 @@ class JsonValue;
 class memorized_tile
 {
     public:
+        char32_t symbol = 0;
         std::string tile;
         int subtile = 0;
         int rotation = 0;
@@ -30,7 +31,6 @@ class memorized_tile
 struct mm_submap {
     public:
         static const memorized_tile default_tile;
-        static const int default_symbol;
 
         mm_submap() = default;
         explicit mm_submap( bool make_valid );
@@ -42,8 +42,8 @@ struct mm_submap {
 
         const memorized_tile &tile( const point &p ) const;
         void set_tile( const point &p, const memorized_tile &value );
-        int symbol( const point &p ) const;
-        void set_symbol( const point &p, int value );
+        char32_t symbol( const point &p ) const;
+        void set_symbol( const point &p, char32_t value );
 
         void serialize( JsonOut &jsout ) const;
         void deserialize( const JsonValue &ja );
@@ -52,8 +52,7 @@ struct mm_submap {
         // NOLINTNEXTLINE(cata-serialize)
         std::vector<memorized_tile> tiles; // holds either 0 or SEEX*SEEY elements
         // NOLINTNEXTLINE(cata-serialize)
-        std::vector<int> symbols; // holds either 0 or SEEX*SEEY elements
-        bool valid = true; // NOLINT(cata-serialize)
+        bool valid = true;
 };
 
 /**
@@ -127,13 +126,13 @@ class map_memory
          * Memorizes given symbol, overwriting old value.
          * @param pos tile position, in global ms coords.
         */
-        void memorize_symbol( const tripoint &pos, int symbol );
+        void memorize_symbol( const tripoint &pos, char32_t symbol );
 
         /**
          * Returns memorized symbol.
          * @param pos tile position, in global ms coords.
          */
-        int get_symbol( const tripoint &pos ) const;
+        char32_t get_symbol( const tripoint &pos ) const;
 
         /**
          * Clears memorized tile and symbol.

--- a/src/path_info.h
+++ b/src/path_info.h
@@ -11,7 +11,6 @@ enum class holiday : int;
 const std::string SAVE_MASTER( "master.gsav" );
 const std::string SAVE_ARTIFACTS( "artifacts.gsav" );
 const std::string SAVE_EXTENSION( ".sav" );
-const std::string SAVE_EXTENSION_MAP_MEMORY( ".mm" );
 const std::string SAVE_EXTENSION_LOG( ".log" );
 const std::string SAVE_EXTENSION_WEATHER( ".weather" );
 const std::string SAVE_EXTENSION_SHORTCUTS( ".shortcuts" );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4011,11 +4011,13 @@ void mm_submap::serialize( JsonOut &jsout ) const
         jsout.write( num_same );
         jsout.write( last.symbol );
         jsout.write( last.ter_id );
-        jsout.write( last.ter_subtile );
-        jsout.write( last.ter_rotation );
-        jsout.write( last.dec_id );
-        jsout.write( last.dec_subtile );
-        jsout.write( last.dec_rotation );
+        jsout.write( static_cast<int>( last.ter_subtile ) );
+        jsout.write( static_cast<int>( last.ter_rotation ) );
+        if( !last.get_dec_id().empty() ) {
+            jsout.write( last.dec_id );
+            jsout.write( static_cast<int>( last.dec_subtile ) );
+            jsout.write( static_cast<int>( last.dec_rotation ) );
+        }
         jsout.end_array();
     };
 
@@ -4058,19 +4060,19 @@ void mm_submap::deserialize( const JsonArray &ja )
                     std::string id = ja_tile.get_string( 0 );
                     // mid-0.G saves store either terrain or decoration, but not both
                     if( string_starts_with( id, "t_" ) ) {
-                        tile.ter_id = std::move( id );
-                        tile.ter_subtile = ja_tile.get_int( 1 );
-                        tile.ter_rotation = ja_tile.get_int( 2 );
-                        tile.dec_id.clear();
-                        tile.dec_subtile = 0;
-                        tile.dec_rotation = 0;
+                        tile.set_ter_id( std::move( id ) );
+                        tile.set_ter_subtile( ja_tile.get_int( 1 ) );
+                        tile.set_ter_rotation( ja_tile.get_int( 2 ) );
+                        tile.set_dec_id( "" );
+                        tile.set_dec_subtile( 0 );
+                        tile.set_dec_rotation( 0 );
                     } else {
-                        tile.ter_id.clear();
-                        tile.ter_subtile = 0;
-                        tile.ter_rotation = 0;
-                        tile.dec_id = std::move( id );
-                        tile.dec_subtile = ja_tile.get_int( 1 );
-                        tile.dec_rotation = ja_tile.get_int( 2 );
+                        tile.set_ter_id( "" );
+                        tile.set_ter_subtile( 0 );
+                        tile.set_ter_rotation( 0 );
+                        tile.set_dec_id( std::move( id ) );
+                        tile.set_dec_subtile( ja_tile.get_int( 1 ) );
+                        tile.set_dec_rotation( ja_tile.get_int( 2 ) );
                     }
                     tile.symbol = ja_tile.get_int( 3 );
                     if( ja_tile.size() > 4 ) {
@@ -4079,12 +4081,18 @@ void mm_submap::deserialize( const JsonArray &ja )
                 } else {
                     remaining = ja_tile.get_int( 0 ) - 1;
                     tile.symbol = ja_tile.get_int( 1 );
-                    tile.ter_id = ja_tile.get_string( 2 );
+                    tile.set_ter_id( ja_tile.get_string( 2 ) );
                     tile.ter_subtile = ja_tile.get_int( 3 );
                     tile.ter_rotation = ja_tile.get_int( 4 );
-                    tile.dec_id = ja_tile.get_string( 5 );
-                    tile.dec_subtile = ja_tile.get_int( 6 );
-                    tile.dec_rotation = ja_tile.get_int( 7 );
+                    if( ja_tile.size() > 5 ) {
+                        tile.set_dec_id( ja_tile.get_string( 5 ) );
+                        tile.dec_subtile = ja_tile.get_int( 6 );
+                        tile.dec_rotation = ja_tile.get_int( 7 );
+                    } else {
+                        tile.set_dec_id( "" );
+                        tile.dec_subtile = 0;
+                        tile.dec_rotation = 0;
+                    }
                 }
             }
             // Try to avoid assigning to save up on memory

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4120,55 +4120,6 @@ void mm_region::deserialize( const JsonValue &ja )
     }
 }
 
-void map_memory::load_legacy( const JsonValue &jv )
-{
-    struct mig_elem {
-        int symbol;
-        memorized_terrain_tile tile;
-    };
-    std::map<tripoint, mig_elem> elems;
-
-    JsonArray root_array = jv;
-    for( JsonArray elem_json : root_array.next_array() ) {
-        tripoint p;
-        p.x = elem_json.next_int();
-        p.y = elem_json.next_int();
-        p.z = elem_json.next_int();
-        mig_elem &elem = elems[p];
-        elem.tile.tile = elem_json.next_string();
-        elem.tile.subtile = elem_json.next_int();
-        elem.tile.rotation = elem_json.next_int();
-        if( elem_json.has_more() ) {
-            elem_json.throw_error( "Too many values for map memory entry" );
-        }
-    }
-
-    for( JsonArray symbols_json : root_array.next_array() ) {
-        tripoint p;
-        p.x = symbols_json.next_int();
-        p.y = symbols_json.next_int();
-        p.z = symbols_json.next_int();
-        elems[p].symbol = symbols_json.next_int();
-        if( symbols_json.has_more() ) {
-            symbols_json.throw_error( "Too many values for map memory symbol" );
-        }
-    }
-
-    for( const std::pair<const tripoint, mig_elem> &elem : elems ) {
-        coord_pair cp( elem.first );
-        shared_ptr_fast<mm_submap> sm = find_submap( cp.sm );
-        if( !sm ) {
-            sm = allocate_submap( cp.sm );
-        }
-        if( elem.second.tile != mm_submap::default_tile ) {
-            sm->set_tile( cp.loc, elem.second.tile );
-        }
-        if( elem.second.symbol != mm_submap::default_symbol ) {
-            sm->set_symbol( cp.loc, elem.second.symbol );
-        }
-    }
-}
-
 void point::deserialize( const JsonArray &jsin )
 {
     x = jsin.get_int( 0 );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3998,7 +3998,7 @@ void player_morale::load( const JsonObject &jsin )
 }
 
 struct mm_elem {
-    memorized_terrain_tile tile;
+    memorized_tile tile;
     int symbol;
 
     bool operator==( const mm_elem &rhs ) const {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -118,7 +118,7 @@
 #include "submap.h"
 #include "text_snippets.h"
 #include "tileray.h"
-#include "units.h"
+#include "units_utility.h"
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
@@ -4071,7 +4071,15 @@ void mm_submap::deserialize( int version, const JsonArray &ja )
                         tile.set_ter_rotation( 0 );
                         tile.set_dec_id( std::move( id ) );
                         tile.set_dec_subtile( ja_tile.get_int( 1 ) );
-                        tile.set_dec_rotation( ja_tile.get_int( 2 ) );
+                        const int legacy_rotation = ja_tile.get_int( 2 );
+                        if( string_starts_with( tile.dec_id, "vp_" ) ) {
+                            // legacy vehicle rotation needs to be converted from 0-360 degrees
+                            // to 0-3 tileset rotation
+                            const units::angle legacy_angle = units::from_degrees( legacy_rotation );
+                            tile.set_dec_rotation( angle_to_dir4( 270_degrees - legacy_angle ) );
+                        } else {
+                            tile.set_dec_rotation( legacy_rotation );
+                        }
                     }
                     tile.symbol = ja_tile.get_int( 3 );
                     if( ja_tile.size() > 4 ) {

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -128,29 +128,6 @@ void angle::deserialize( const JsonValue &jv )
     *this = read_from_json_string( jv, units::angle_units );
 }
 
-int angle_to_dir4( units::angle direction )
-{
-    // ensure direction is in range [0,360)
-    const units::angle dir = fmod( fmod( direction, 360_degrees ) + 360_degrees, 360_degrees );
-
-    // adjust and round values near diagonals before comparison to avoid floating point error
-    if( round_to_multiple_of( dir - 45_degrees, 1.5_degrees ) == 0_degrees ||
-        round_to_multiple_of( dir - 135_degrees, 1.5_degrees ) == 0_degrees ) {
-        return 1;
-    }
-    if( round_to_multiple_of( dir - 225_degrees, 1.5_degrees ) == 0_degrees ||
-        round_to_multiple_of( dir - 315_degrees, 1.5_degrees ) == 0_degrees ) {
-        return 3;
-    }
-
-    return std::fmod( 4 + ( direction + 45_degrees ) / 90_degrees, 4 );
-}
-
-int angle_to_dir8( units::angle direction )
-{
-    return std::fmod( 8 + ( direction + 22.5_degrees ) / 45_degrees, 8 );
-}
-
 std::string display( const units::energy &v )
 {
     const int kj = units::to_kilojoule( v );

--- a/src/units.h
+++ b/src/units.h
@@ -741,13 +741,6 @@ inline constexpr double to_arcmin( const units::angle v )
     return to_degrees( v ) * 60;
 }
 
-// convert angle to nearest of 0=east, 1=south, 2=west, 3=north
-// ties broken in favor of north/south
-int angle_to_dir4( units::angle direction );
-
-// convert angle to nearest of 0=east 1=SE 2=south 3=SW...
-int angle_to_dir8( units::angle direction );
-
 // converts a volume as if it were a cube to the length of one side
 template<typename value_type>
 inline constexpr quantity<value_type, length_in_millimeter_tag> default_length_from_volume(

--- a/src/units_utility.h
+++ b/src/units_utility.h
@@ -22,7 +22,20 @@ T divide_round_up( units::quantity<T, U> num, units::quantity<T, U> den )
  *
  * With a second argument, can use a different maximum.
  */
-units::angle normalize( units::angle a, const units::angle &mod = 360_degrees );
+units::angle normalize( units::angle a, units::angle mod = 360_degrees );
+
+// @example angle_delta( 270_degrees, 0_degrees ) == 90_degrees
+// @example angle_delta( 90_degrees, 0_degrees ) == 90_degrees
+// @returns the smaller difference angle between \p a and \p b angles
+units::angle angle_delta( units::angle a, units::angle b );
+
+// convert angle to nearest of 0=north, 1=west, 2=south, 3=east, NE/NW return N, SE/SW return S,
+// this is used to render vehicle parts in tiles mode where they only have 4 orientations and
+// biased to north / south.
+int angle_to_dir4( units::angle direction );
+
+// convert angle to nearest of 0=north 1=NE 2=east 3=SE...
+int angle_to_dir8( units::angle direction );
 
 template<typename T, typename U, std::enable_if_t<std::is_floating_point<T>::value>* = nullptr>
 units::quantity<T, U> round_to_multiple_of( units::quantity<T, U> val, units::quantity<T, U> of )

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1267,8 +1267,7 @@ std::string vpart_variant::get_label() const
 
 char32_t vpart_variant::get_symbol( units::angle direction, bool is_broken ) const
 {
-    // offset by 90 degrees to match vehicle facing zeroed to the east
-    const int dir8 = units::angle_to_dir8( direction );
+    const int dir8 = angle_to_dir8( direction );
     return is_broken ? symbols_broken[dir8] : symbols[dir8];
 }
 
@@ -1292,7 +1291,7 @@ static int utf32_to_ncurses_ACS( char32_t sym )
 
 int vpart_variant::get_symbol_curses( units::angle direction, bool is_broken ) const
 {
-    return utf32_to_ncurses_ACS( get_symbol( direction, is_broken ) );
+    return get_symbol_curses( get_symbol( direction, is_broken ) );
 }
 
 int vpart_variant::get_symbol_curses( char32_t sym )

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -203,15 +203,18 @@ class vpart_variant
 
         std::string get_label() const;
 
+        // @note if input is vehicle facing convert using `270_degrees - vehicle.face.dir()` first
         // @param direction facing angle, 0 = north, 90 = east...
         // @param is_broken if true returns the broken symbol else
         // @returns unicode symbol for this variant given a direction and broken status
         char32_t get_symbol( units::angle direction, bool is_broken ) const;
 
+        // @note if input is vehicle facing convert using `270_degrees - vehicle.face.dir()` first
         // @param direction facing angle, 0 = north, 90 = east...
         // @param is_broken whether to return the broken symbol
         // @returns ncurses ACS code for this variant given a direction and broken status
         int get_symbol_curses( units::angle direction, bool is_broken ) const;
+
         // @returns ncurses ACS code for a unicode \p sym symbol
         static int get_symbol_curses( char32_t sym );
 

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -89,7 +89,7 @@ vpart_display vehicle::get_display_of_tile( const point &dp, bool rotate, bool i
         ret.symbol = '\'';
         ret.symbol_curses = '\'';
     } else {
-        const units::angle direction = rotate ? face.dir() + 90_degrees : 0_degrees;
+        const units::angle direction = rotate ? 270_degrees - face.dir() : 0_degrees;
         ret.symbol = vv.get_symbol( direction, ret.is_broken );
         ret.symbol_curses = vpart_variant::get_symbol_curses( ret.symbol );
     }

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -60,29 +60,29 @@ TEST_CASE( "map_memory_remembers", "[map_memory]" )
 
     const memorized_tile &mt = memory.get_tile( p2 );
 
-    memory.set_tile_decoration( p2, "foo", 42, 270 );
+    memory.set_tile_decoration( p2, "foo", 42, 3 );
     CHECK( mt.get_dec_id() == "foo" );
     CHECK( mt.get_dec_subtile() == 42 );
-    CHECK( mt.get_dec_rotation() == 270 );
+    CHECK( mt.get_dec_rotation() == 3 );
     CHECK( mt.get_ter_id().empty() );
     CHECK( mt.get_ter_subtile() == 0 );
     CHECK( mt.get_ter_rotation() == 0 );
 
-    memory.set_tile_terrain( p2, "t_foo", 43, 180 );
+    memory.set_tile_terrain( p2, "t_foo", 43, 2 );
     CHECK( mt.get_dec_id() == "foo" );
     CHECK( mt.get_dec_subtile() == 42 );
-    CHECK( mt.get_dec_rotation() == 270 );
+    CHECK( mt.get_dec_rotation() == 3 );
     CHECK( mt.get_ter_id() == "t_foo" );
     CHECK( mt.get_ter_subtile() == 43 );
-    CHECK( mt.get_ter_rotation() == 180 );
+    CHECK( mt.get_ter_rotation() == 2 );
 
-    memory.set_tile_decoration( p2, "bar", 44, 90 );
+    memory.set_tile_decoration( p2, "bar", 44, 1 );
     CHECK( mt.get_dec_id() == "bar" );
     CHECK( mt.get_dec_subtile() == 44 );
-    CHECK( mt.get_dec_rotation() == 90 );
+    CHECK( mt.get_dec_rotation() == 1 );
     CHECK( mt.get_ter_id() == "t_foo" );
     CHECK( mt.get_ter_subtile() == 43 );
-    CHECK( mt.get_ter_rotation() == 180 );
+    CHECK( mt.get_ter_rotation() == 2 );
 }
 
 TEST_CASE( "map_memory_overwrites", "[map_memory]" )
@@ -100,23 +100,23 @@ TEST_CASE( "map_memory_forgets", "[map_memory]" )
 {
     map_memory memory;
     memory.prepare_region( p1, p2 );
-    memory.set_tile_decoration( p1, "vp_foo", 42, 270 );
-    memory.set_tile_terrain( p1, "t_foo", 43, 180 );
+    memory.set_tile_decoration( p1, "vp_foo", 42, 3 );
+    memory.set_tile_terrain( p1, "t_foo", 43, 2 );
     const memorized_tile &mt = memory.get_tile( p1 );
     CHECK( mt.symbol == 0 );
     CHECK( mt.get_ter_id() == "t_foo" );
     CHECK( mt.get_ter_subtile() == 43 );
-    CHECK( mt.get_ter_rotation() == 180 );
+    CHECK( mt.get_ter_rotation() == 2 );
     CHECK( mt.get_dec_id() == "vp_foo" );
     CHECK( mt.get_dec_subtile() == 42 );
-    CHECK( mt.get_dec_rotation() == 270 );
+    CHECK( mt.get_dec_rotation() == 3 );
     memory.set_tile_symbol( p1, 1 );
     CHECK( mt.symbol == 1 );
     memory.clear_tile_vehicles( p1 );
     CHECK( mt.symbol == 0 );
     CHECK( mt.get_ter_id() == "t_foo" );
     CHECK( mt.get_ter_subtile() == 43 );
-    CHECK( mt.get_ter_rotation() == 180 );
+    CHECK( mt.get_ter_rotation() == 2 );
     CHECK( mt.get_dec_id().empty() );
     CHECK( mt.get_dec_subtile() == 0 );
     CHECK( mt.get_dec_rotation() == 0 );

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -39,7 +39,7 @@ TEST_CASE( "map_memory_defaults", "[map_memory]" )
     map_memory memory;
     memory.prepare_region( p1, p2 );
     CHECK( memory.get_symbol( p1 ) == 0 );
-    memorized_terrain_tile default_tile = memory.get_tile( p1 );
+    memorized_tile default_tile = memory.get_tile( p1 );
     CHECK( default_tile.tile.empty() );
     CHECK( default_tile.subtile == 0 );
     CHECK( default_tile.rotation == 0 );

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -40,9 +40,13 @@ TEST_CASE( "map_memory_defaults", "[map_memory]" )
     memory.prepare_region( p1, p2 );
     CHECK( memory.get_symbol( p1 ) == 0 );
     memorized_tile default_tile = memory.get_tile( p1 );
-    CHECK( default_tile.tile.empty() );
-    CHECK( default_tile.subtile == 0 );
-    CHECK( default_tile.rotation == 0 );
+    CHECK( default_tile.symbol == 0 );
+    CHECK( default_tile.ter_id.empty() );
+    CHECK( default_tile.ter_subtile == 0 );
+    CHECK( default_tile.ter_rotation == 0 );
+    CHECK( default_tile.dec_id.empty() );
+    CHECK( default_tile.dec_subtile == 0 );
+    CHECK( default_tile.dec_rotation == 0 );
 }
 
 TEST_CASE( "map_memory_remembers", "[map_memory]" )
@@ -53,6 +57,32 @@ TEST_CASE( "map_memory_remembers", "[map_memory]" )
     memory.memorize_symbol( p2, 2 );
     CHECK( memory.get_symbol( p1 ) == 1 );
     CHECK( memory.get_symbol( p2 ) == 2 );
+
+    const memorized_tile &mt = memory.get_tile( p2 );
+
+    memory.memorize_tile( p2, "foo", 42, 270 );
+    CHECK( mt.dec_id == "foo" );
+    CHECK( mt.dec_subtile == 42 );
+    CHECK( mt.dec_rotation == 270 );
+    CHECK( mt.ter_id.empty() );
+    CHECK( mt.ter_subtile == 0 );
+    CHECK( mt.ter_rotation == 0 );
+
+    memory.memorize_tile( p2, "t_foo", 43, 180 );
+    CHECK( mt.dec_id == "foo" );
+    CHECK( mt.dec_subtile == 42 );
+    CHECK( mt.dec_rotation == 270 );
+    CHECK( mt.ter_id == "t_foo" );
+    CHECK( mt.ter_subtile == 43 );
+    CHECK( mt.ter_rotation == 180 );
+
+    memory.memorize_tile( p2, "bar", 44, 90 );
+    CHECK( mt.dec_id == "bar" );
+    CHECK( mt.dec_subtile == 44 );
+    CHECK( mt.dec_rotation == 90 );
+    CHECK( mt.ter_id == "t_foo" );
+    CHECK( mt.ter_subtile == 43 );
+    CHECK( mt.ter_rotation == 180 );
 }
 
 TEST_CASE( "map_memory_overwrites", "[map_memory]" )

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -41,12 +41,12 @@ TEST_CASE( "map_memory_defaults", "[map_memory]" )
     CHECK( memory.get_tile( p1 ).symbol == 0 );
     memorized_tile default_tile = memory.get_tile( p1 );
     CHECK( default_tile.symbol == 0 );
-    CHECK( default_tile.ter_id.empty() );
-    CHECK( default_tile.ter_subtile == 0 );
-    CHECK( default_tile.ter_rotation == 0 );
-    CHECK( default_tile.dec_id.empty() );
-    CHECK( default_tile.dec_subtile == 0 );
-    CHECK( default_tile.dec_rotation == 0 );
+    CHECK( default_tile.get_ter_id().empty() );
+    CHECK( default_tile.get_ter_subtile() == 0 );
+    CHECK( default_tile.get_ter_rotation() == 0 );
+    CHECK( default_tile.get_dec_id().empty() );
+    CHECK( default_tile.get_dec_subtile() == 0 );
+    CHECK( default_tile.get_dec_rotation() == 0 );
 }
 
 TEST_CASE( "map_memory_remembers", "[map_memory]" )
@@ -61,28 +61,28 @@ TEST_CASE( "map_memory_remembers", "[map_memory]" )
     const memorized_tile &mt = memory.get_tile( p2 );
 
     memory.set_tile_decoration( p2, "foo", 42, 270 );
-    CHECK( mt.dec_id == "foo" );
-    CHECK( mt.dec_subtile == 42 );
-    CHECK( mt.dec_rotation == 270 );
-    CHECK( mt.ter_id.empty() );
-    CHECK( mt.ter_subtile == 0 );
-    CHECK( mt.ter_rotation == 0 );
+    CHECK( mt.get_dec_id() == "foo" );
+    CHECK( mt.get_dec_subtile() == 42 );
+    CHECK( mt.get_dec_rotation() == 270 );
+    CHECK( mt.get_ter_id().empty() );
+    CHECK( mt.get_ter_subtile() == 0 );
+    CHECK( mt.get_ter_rotation() == 0 );
 
     memory.set_tile_terrain( p2, "t_foo", 43, 180 );
-    CHECK( mt.dec_id == "foo" );
-    CHECK( mt.dec_subtile == 42 );
-    CHECK( mt.dec_rotation == 270 );
-    CHECK( mt.ter_id == "t_foo" );
-    CHECK( mt.ter_subtile == 43 );
-    CHECK( mt.ter_rotation == 180 );
+    CHECK( mt.get_dec_id() == "foo" );
+    CHECK( mt.get_dec_subtile() == 42 );
+    CHECK( mt.get_dec_rotation() == 270 );
+    CHECK( mt.get_ter_id() == "t_foo" );
+    CHECK( mt.get_ter_subtile() == 43 );
+    CHECK( mt.get_ter_rotation() == 180 );
 
     memory.set_tile_decoration( p2, "bar", 44, 90 );
-    CHECK( mt.dec_id == "bar" );
-    CHECK( mt.dec_subtile == 44 );
-    CHECK( mt.dec_rotation == 90 );
-    CHECK( mt.ter_id == "t_foo" );
-    CHECK( mt.ter_subtile == 43 );
-    CHECK( mt.ter_rotation == 180 );
+    CHECK( mt.get_dec_id() == "bar" );
+    CHECK( mt.get_dec_subtile() == 44 );
+    CHECK( mt.get_dec_rotation() == 90 );
+    CHECK( mt.get_ter_id() == "t_foo" );
+    CHECK( mt.get_ter_subtile() == 43 );
+    CHECK( mt.get_ter_rotation() == 180 );
 }
 
 TEST_CASE( "map_memory_overwrites", "[map_memory]" )
@@ -104,22 +104,22 @@ TEST_CASE( "map_memory_forgets", "[map_memory]" )
     memory.set_tile_terrain( p1, "t_foo", 43, 180 );
     const memorized_tile &mt = memory.get_tile( p1 );
     CHECK( mt.symbol == 0 );
-    CHECK( mt.ter_id == "t_foo" );
-    CHECK( mt.ter_subtile == 43 );
-    CHECK( mt.ter_rotation == 180 );
-    CHECK( mt.dec_id == "vp_foo" );
-    CHECK( mt.dec_subtile == 42 );
-    CHECK( mt.dec_rotation == 270 );
+    CHECK( mt.get_ter_id() == "t_foo" );
+    CHECK( mt.get_ter_subtile() == 43 );
+    CHECK( mt.get_ter_rotation() == 180 );
+    CHECK( mt.get_dec_id() == "vp_foo" );
+    CHECK( mt.get_dec_subtile() == 42 );
+    CHECK( mt.get_dec_rotation() == 270 );
     memory.set_tile_symbol( p1, 1 );
     CHECK( mt.symbol == 1 );
     memory.clear_tile_vehicles( p1 );
     CHECK( mt.symbol == 0 );
-    CHECK( mt.ter_id == "t_foo" );
-    CHECK( mt.ter_subtile == 43 );
-    CHECK( mt.ter_rotation == 180 );
-    CHECK( mt.dec_id.empty() );
-    CHECK( mt.dec_subtile == 0 );
-    CHECK( mt.dec_rotation == 0 );
+    CHECK( mt.get_ter_id() == "t_foo" );
+    CHECK( mt.get_ter_subtile() == 43 );
+    CHECK( mt.get_ter_rotation() == 180 );
+    CHECK( mt.get_dec_id().empty() );
+    CHECK( mt.get_dec_subtile() == 0 );
+    CHECK( mt.get_dec_rotation() == 0 );
 }
 
 // TODO: map memory save / load

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -38,7 +38,7 @@ TEST_CASE( "map_memory_defaults", "[map_memory]" )
 {
     map_memory memory;
     memory.prepare_region( p1, p2 );
-    CHECK( memory.get_symbol( p1 ) == 0 );
+    CHECK( memory.get_tile( p1 ).symbol == 0 );
     memorized_tile default_tile = memory.get_tile( p1 );
     CHECK( default_tile.symbol == 0 );
     CHECK( default_tile.ter_id.empty() );
@@ -53,14 +53,14 @@ TEST_CASE( "map_memory_remembers", "[map_memory]" )
 {
     map_memory memory;
     memory.prepare_region( p1, p2 );
-    memory.memorize_symbol( p1, 1 );
-    memory.memorize_symbol( p2, 2 );
-    CHECK( memory.get_symbol( p1 ) == 1 );
-    CHECK( memory.get_symbol( p2 ) == 2 );
+    memory.set_tile_symbol( p1, 1 );
+    memory.set_tile_symbol( p2, 2 );
+    CHECK( memory.get_tile( p1 ).symbol == 1 );
+    CHECK( memory.get_tile( p2 ).symbol == 2 );
 
     const memorized_tile &mt = memory.get_tile( p2 );
 
-    memory.memorize_tile( p2, "foo", 42, 270 );
+    memory.set_tile_decoration( p2, "foo", 42, 270 );
     CHECK( mt.dec_id == "foo" );
     CHECK( mt.dec_subtile == 42 );
     CHECK( mt.dec_rotation == 270 );
@@ -68,7 +68,7 @@ TEST_CASE( "map_memory_remembers", "[map_memory]" )
     CHECK( mt.ter_subtile == 0 );
     CHECK( mt.ter_rotation == 0 );
 
-    memory.memorize_tile( p2, "t_foo", 43, 180 );
+    memory.set_tile_terrain( p2, "t_foo", 43, 180 );
     CHECK( mt.dec_id == "foo" );
     CHECK( mt.dec_subtile == 42 );
     CHECK( mt.dec_rotation == 270 );
@@ -76,7 +76,7 @@ TEST_CASE( "map_memory_remembers", "[map_memory]" )
     CHECK( mt.ter_subtile == 43 );
     CHECK( mt.ter_rotation == 180 );
 
-    memory.memorize_tile( p2, "bar", 44, 90 );
+    memory.set_tile_decoration( p2, "bar", 44, 90 );
     CHECK( mt.dec_id == "bar" );
     CHECK( mt.dec_subtile == 44 );
     CHECK( mt.dec_rotation == 90 );
@@ -89,18 +89,37 @@ TEST_CASE( "map_memory_overwrites", "[map_memory]" )
 {
     map_memory memory;
     memory.prepare_region( p1, p2 );
-    memory.memorize_symbol( p1, 1 );
-    memory.memorize_symbol( p2, 2 );
-    memory.memorize_symbol( p2, 3 );
-    CHECK( memory.get_symbol( p1 ) == 1 );
-    CHECK( memory.get_symbol( p2 ) == 3 );
+    memory.set_tile_symbol( p1, 1 );
+    memory.set_tile_symbol( p2, 2 );
+    memory.set_tile_symbol( p2, 3 );
+    CHECK( memory.get_tile( p1 ).symbol == 1 );
+    CHECK( memory.get_tile( p2 ).symbol == 3 );
 }
 
 TEST_CASE( "map_memory_forgets", "[map_memory]" )
 {
     map_memory memory;
-    memory.memorize_symbol( tripoint_zero, 1 );
-    memory.memorize_symbol( p3, 1 );
+    memory.prepare_region( p1, p2 );
+    memory.set_tile_decoration( p1, "vp_foo", 42, 270 );
+    memory.set_tile_terrain( p1, "t_foo", 43, 180 );
+    const memorized_tile &mt = memory.get_tile( p1 );
+    CHECK( mt.symbol == 0 );
+    CHECK( mt.ter_id == "t_foo" );
+    CHECK( mt.ter_subtile == 43 );
+    CHECK( mt.ter_rotation == 180 );
+    CHECK( mt.dec_id == "vp_foo" );
+    CHECK( mt.dec_subtile == 42 );
+    CHECK( mt.dec_rotation == 270 );
+    memory.set_tile_symbol( p1, 1 );
+    CHECK( mt.symbol == 1 );
+    memory.clear_tile_vehicles( p1 );
+    CHECK( mt.symbol == 0 );
+    CHECK( mt.ter_id == "t_foo" );
+    CHECK( mt.ter_subtile == 43 );
+    CHECK( mt.ter_rotation == 180 );
+    CHECK( mt.dec_id.empty() );
+    CHECK( mt.dec_subtile == 0 );
+    CHECK( mt.dec_rotation == 0 );
 }
 
 // TODO: map memory save / load


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Make map memory remember terrain separately from furniture, traps and vparts; makes aesthetics more consistent, since drawing e.g. a trap or vehicle part from map memory is doing so on an ugly fallback tile.

#### Describe the solution

PR makes map memory remember both the terrain and the "decoration" (either of furniture/trap/vpart) for each tile.

Old map memory will be loaded but will have the ugly fallbacks until player gets sight on each tile.

#### Describe alternatives you've considered

#### Testing

For curses nothing "should" change except a bit more memory used, as it only draws one symbol per tile.
For tiles visually:
Smashbutton is barely changed
Ultica_iso/Ultica/MSXotto start rendering terrain under vehicles/furniture/traps

Render time is almost unaffected - or at least the noise of gpu regulating itself had more effect than the difference (tested with vsync flag compiled out):
Before patch 5 seconds: 899 frames / 180 fps average
Before patch 60 seconds: 10797 frames / 179 fps average
After patch run 1 5 seconds: 886 frames / 177 fps average
After patch run 1 60 seconds: 10755 frames / 179 fps average
After patch run 2 5 seconds: 923 frames / 184 fps average
After patch run 2 60 seconds: 11054 frames / 184 fps average

The change in memory usage seems to be swallowed in the noise of all the other allocations, worst case the map chunks can be dumped to disk and discarded from memory more often if it becomes a problem

#### Additional context

Before (notice black splotches on wall wires, vehicle parts, flower/rock "furniture", less prominent but also the tables/shelves inside the shelter
![pre](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/676afa78-6cb8-4917-a790-a07cf592d25d)
After:
![post](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/99fc7382-4f5a-4de3-a622-704f9e0e0012)

Another example, street lights:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/67323573-377e-4bce-a1df-8feb714d81c2)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/00138cc8-d30e-4001-b19e-2b0dff9f9dc4)
