### PR TITLE
Rework and expand NRE data recordings

### DIFF
--- a/data/json/effect_on_condition.json
+++ b/data/json/effect_on_condition.json
@@ -447,42 +447,119 @@
     },
     "deactivate_condition": { "not": { "is_weather": "portal_storm" } },
     "effect": [
-      { "u_adjust_var": "portal_storm_record", "type": "counter", "context": "nre_recorder", "adjustment": 1 },
+      { "math": [ "u_portal_storm_record", "++" ] },
+      {
+        "run_eocs": [
+          {
+            "id": "large_printout_portal_storm_data_ping",
+            "condition": { "math": [ "u_portal_storm_record", ">=", "25" ] },
+            "effect": [ { "u_message": "The NRE recorder emits a three beep sequence!", "type": "info" } ],
+            "false_effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "medium_printout_portal_storm_data_ping",
+                    "condition": { "math": [ "u_portal_storm_record", ">=", "3" ] },
+                    "effect": [ { "u_message": "The NRE recorder emits a two beep sequence!", "type": "info" } ],
+                    "false_effect": [
+                      {
+                        "run_eocs": [
+                          {
+                            "id": "small_printout_portal_storm_data_ping",
+                            "condition": { "math": [ "u_portal_storm_record", ">=", "1" ] },
+                            "effect": [ { "u_message": "The NRE recorder emits a sharp beep!", "type": "info" } ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "capture_generic_nre_anomaly",
+    "global": true,
+    "condition": { "u_has_items": { "item": "nre_recorder", "charges": 1 } },
+    "effect": [
+      { "math": [ "u_generic_nre_anomaly", "++" ] },
       { "u_message": "The NRE recorder emits a sharp beep!", "type": "info" }
     ]
   },
   {
     "type": "effect_on_condition",
-    "id": "print_portal_storm_data",
-    "condition": { "u_compare_var": "portal_storm_record", "type": "counter", "context": "nre_recorder", "op": ">=", "value": 1 },
-    "deactivate_condition": { "not": { "is_weather": "portal_storm" } },
+    "id": "EOC_on_kill_capture_generic_nre_anomaly",
+    "eoc_type": "EVENT",
+    "required_event": "character_kills_monster",
+    "//": "Only add monsters with significant reality altering powers, not just anything in the nether species.",
+    "condition": {
+      "and": [
+        { "u_has_items": { "item": "nre_recorder", "charges": 1 } },
+        {
+          "or": [
+            { "compare_string": [ "mon_hound_tindalos", { "context_val": "victim_type" } ] },
+            { "compare_string": [ "mon_darkman", { "context_val": "victim_type" } ] },
+            { "compare_string": [ "mon_zombie_phase_shrike", { "context_val": "victim_type" } ] },
+            { "compare_string": [ "mon_swarm_structure", { "context_val": "victim_type" } ] },
+            { "compare_string": [ "mon_better_half", { "context_val": "victim_type" } ] },
+            { "compare_string": [ "mon_hallucinator", { "context_val": "victim_type" } ] },
+            { "compare_string": [ "mon_archunk_strong", { "context_val": "victim_type" } ] },
+            { "compare_string": [ "mon_void_spider", { "context_val": "victim_type" } ] },
+            { "compare_string": [ "mon_XEDRA_officer", { "context_val": "victim_type" } ] }
+          ]
+        }
+      ]
+    },
+    "effect": [
+      { "math": [ "u_generic_nre_anomaly", "++" ] },
+      { "u_message": "The NRE recorder emits a sharp beep!", "type": "info" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "print_nre_data",
+    "condition": { "or": [ { "math": [ "u_portal_storm_record", ">", "0" ] }, { "math": [ "u_generic_nre_anomaly", ">", "0" ] } ] },
     "effect": {
       "run_eocs": [
         {
           "id": "large_printout_portal_storm_data",
-          "condition": { "u_compare_var": "portal_storm_record", "type": "counter", "context": "nre_recorder", "op": ">=", "value": 25 },
+          "condition": { "math": [ "u_portal_storm_record", ">=", "25" ] },
           "effect": [
             { "u_message": "The recorder whirs as it starts printing the recorded data.", "type": "info" },
             { "u_spawn_item": "large_printout_portal_storm_data", "count": 1 },
-            { "u_add_var": "portal_storm_record", "type": "counter", "context": "nre_recorder", "value": "0" }
+            { "math": [ "u_portal_storm_record", "=", "0" ] }
           ]
         },
         {
           "id": "medium_printout_portal_storm_data",
-          "condition": { "u_compare_var": "portal_storm_record", "type": "counter", "context": "nre_recorder", "op": ">=", "value": 3 },
+          "condition": { "math": [ "u_portal_storm_record", ">=", "3" ] },
           "effect": [
             { "u_message": "The recorder whirs as it starts printing the recorded data.", "type": "info" },
             { "u_spawn_item": "medium_printout_portal_storm_data", "count": 1 },
-            { "u_add_var": "portal_storm_record", "type": "counter", "context": "nre_recorder", "value": "0" }
+            { "math": [ "u_portal_storm_record", "=", "0" ] }
           ]
         },
         {
           "id": "small_printout_portal_storm_data",
-          "condition": { "u_compare_var": "portal_storm_record", "type": "counter", "context": "nre_recorder", "op": ">=", "value": 1 },
+          "condition": { "math": [ "u_portal_storm_record", ">=", "1" ] },
           "effect": [
             { "u_message": "The recorder whirs as it starts printing the recorded data.", "type": "info" },
             { "u_spawn_item": "small_printout_portal_storm_data", "count": 1 },
-            { "u_add_var": "portal_storm_record", "type": "counter", "context": "nre_recorder", "value": "0" }
+            { "math": [ "u_portal_storm_record", "=", "0" ] }
+          ]
+        },
+        {
+          "id": "printout_nre_anomaly_data",
+          "condition": { "math": [ "u_generic_nre_anomaly", ">=", "1" ] },
+          "effect": [
+            { "u_message": "The recorder whirs as it starts printing the recorded data.", "type": "info" },
+            { "u_spawn_item": "nre_anomaly_printout_data", "count": { "u_val": "generic_nre_anomaly", "default": 1 } },
+            { "math": [ "u_generic_nre_anomaly", "=", "0" ] }
           ]
         }
       ]

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -227,7 +227,7 @@
     "id": "nre_anomaly_printout_data",
     "copy-from": "small_printout_portal_storm_data",
     "name": { "str": "NRE anomaly printout" },
-    "description": "A long sequence of overlapping numbers plotted in thermal paper, at times so densely-packed that they disappear into thick blots of oxide-colored ink.  The printed values increased along rhythmical waves, but the humber 5 is always skipped.",
+    "description": "A long sequence of overlapping numbers plotted in thermal paper, at times so densely-packed that they disappear into thick blots of oxide-colored ink.  The printed values increased along rhythmical waves, but the number 5 is always skipped.",
     "weight": "10 g",
     "volume": "50 ml"
   },

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -236,7 +236,7 @@
     "id": "nre_zero_reading_printout",
     "copy-from": "small_printout_portal_storm_data",
     "name": { "str": "NRE zero reading" },
-    "description": "A long near uniform sequence of evenly spaced zeroes plotted in thermal paper. The monotony is rarely broken by small numbered series.",
+    "description": "A long near uniform sequence of evenly spaced zeroes plotted in thermal paper.  The monotony is rarely broken by small numbered series.",
     "weight": "10 g",
     "volume": "50 ml"
   },

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -224,6 +224,24 @@
   },
   {
     "type": "GENERIC",
+    "id": "nre_anomaly_printout_data",
+    "copy-from": "small_printout_portal_storm_data",
+    "name": { "str": "NRE anomaly printout" },
+    "description": "A long sequence of overlapping numbers plotted in thermal paper, at times so densely-packed that they disappear into thick blots of oxide-colored ink.  The printed values increased along rhythmical waves, but the humber 5 is always skipped.",
+    "weight": "10 g",
+    "volume": "50 ml"
+  },
+  {
+    "type": "GENERIC",
+    "id": "nre_zero_reading_printout",
+    "copy-from": "small_printout_portal_storm_data",
+    "name": { "str": "NRE zero reading" },
+    "description": "A long near uniform sequence of evenly spaced zeroes plotted in thermal paper. The monotony is rarely broken by small numbered series.",
+    "weight": "10 g",
+    "volume": "50 ml"
+  },
+  {
+    "type": "GENERIC",
     "id": "fp_loyalty_card",
     "category": "other",
     "symbol": "-",

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -288,7 +288,7 @@
     "use_action": {
       "type": "effect_on_conditions",
       "description": "Activate the recorder's printer",
-      "effect_on_conditions": [ "print_portal_storm_data" ]
+      "effect_on_conditions": [ "print_nre_data" ]
     },
     "pocket_data": [
       {

--- a/data/json/nether_glass_effect_on_condition.json
+++ b/data/json/nether_glass_effect_on_condition.json
@@ -35,6 +35,7 @@
           "id": "EOC_nether_glass_yrax_encounter",
           "condition": { "and": [ { "x_in_y_chance": { "x": 1, "y": 250 } }, { "u_at_om_location": "nether_glass_deep" } ] },
           "effect": [
+            { "run_eocs": [ "capture_generic_nre_anomaly" ] },
             {
               "u_spawn_monster": "mon_yrax_apeirogon",
               "real_count": 1,

--- a/data/json/npcs/EOC_talkers/portal_storm.json
+++ b/data/json/npcs/EOC_talkers/portal_storm.json
@@ -3,6 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_PORTAL_STORM",
     "dynamic_line": "&You feel a presence both inside yourself and somewhere far far away.",
+    "speaker_effect": { "effect": { "run_eocs": [ "capture_generic_nre_anomaly" ] }, "sentinel": "first_contact" },
     "responses": [ { "text": "Contact it.", "topic": "TALK_PORTAL_STORM_CONVERSATION" }, { "text": "Ignore it.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/computers/TALK_MSU14.json
+++ b/data/json/npcs/computers/TALK_MSU14.json
@@ -86,6 +86,7 @@
       {
         "text": "Press any key and shut down.",
         "effect": [
+          { "run_eocs": [ "capture_generic_nre_anomaly" ] },
           { "u_spawn_item": "melchior_science_doc", "count": 1 },
           {
             "u_adjust_var": "dimensional_heuristics",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
@@ -54,6 +54,15 @@
     "dynamic_line": "Excellent; please deposit the printouts in the intercom's tray.  We'll issue a reward based on the quality of your recordings.",
     "responses": [
       {
+        "text": "[Deposit a NRE anomaly printout.]",
+        "condition": { "u_has_items": { "item": "nre_anomaly_printout_data", "count": 1 } },
+        "effect": [
+          { "u_consume_item": "nre_anomaly_printout_data", "count": 1, "popup": true },
+          { "u_spawn_item": "RobofacCoin", "count": 10 }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_SELL_PORTAL_STORM_DATA_Large"
+      },
+      {
         "text": "[Deposit a long NRE printout.]",
         "condition": { "u_has_items": { "item": "large_printout_portal_storm_data", "count": 1 } },
         "effect": [
@@ -64,18 +73,31 @@
       },
       {
         "text": "[Deposit an NRE printout.]",
-        "condition": { "u_has_items": { "item": "medium_printout_portal_storm_data", "count": 1 } },
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "medium_printout_portal_storm_data", "count": 1 } },
+            { "math": [ "portal_storm_medium_data_sold", "<", "15" ] }
+          ]
+        },
         "effect": [
           { "u_consume_item": "medium_printout_portal_storm_data", "count": 1, "popup": true },
+          { "math": [ "portal_storm_medium_data_sold", "++" ] },
           { "u_spawn_item": "RobofacCoin", "count": 5 }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SELL_PORTAL_STORM_DATA_Medium"
       },
       {
         "text": "[Deposit a short NRE printout.]",
-        "condition": { "u_has_items": { "item": "small_printout_portal_storm_data", "count": 1 } },
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "small_printout_portal_storm_data", "count": 1 } },
+            { "math": [ "portal_storm_medium_data_sold", "<", "15" ] },
+            { "math": [ "portal_storm_small_data_sold", "<", "3" ] }
+          ]
+        },
         "effect": [
           { "u_consume_item": "small_printout_portal_storm_data", "count": 1, "popup": true },
+          { "math": [ "portal_storm_small_data_sold", "++" ] },
           { "u_spawn_item": "RobofacCoin", "count": 1 }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SELL_PORTAL_STORM_DATA_Small"
@@ -87,12 +109,16 @@
     "id": "TALK_ROBOFAC_INTERCOM_SELL_PORTAL_STORM_DATA_Small",
     "type": "talk_topic",
     "dynamic_line": {
-      "npc_has_var": "accepted_nre_recording",
-      "type": "dialogue",
-      "context": "intercom",
-      "value": "yes",
-      "no": "Excellent; this should be enough to work with.  Here's your agreed-upon reward.\"  The tray slides shut, and quickly reopens with your payment.  \"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record.",
-      "yes": "&\"Thank you.\"  The recording changes hands."
+      "math": [ "portal_storm_small_data_sold", ">=", "3" ],
+      "yes": "Extrapolating trends from these recordings has become difficult.  Research has requested we only accept higher quality data from now on.",
+      "no": {
+        "npc_has_var": "accepted_nre_recording",
+        "type": "dialogue",
+        "context": "intercom",
+        "value": "yes",
+        "no": "Excellent; this should be enough to work with.  Here's your agreed-upon reward.\"  The tray slides shut, and quickly reopens with your payment.  \"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record.",
+        "yes": "&\"Thank you.\"  The recording changes hands."
+      }
     },
     "speaker_effect": {
       "effect": [
@@ -106,12 +132,16 @@
     "id": "TALK_ROBOFAC_INTERCOM_SELL_PORTAL_STORM_DATA_Medium",
     "type": "talk_topic",
     "dynamic_line": {
-      "npc_has_var": "accepted_nre_recording",
-      "type": "dialogue",
-      "context": "intercom",
-      "value": "yes",
-      "no": "Great!  This looks like a very high-quality recording.  Because this data is much better, we are willing to pay five times what we paid for the base data collected.\"  The tray slides shut, and quickly reopens with your payment.  \"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record.",
-      "yes": "&\"Excellent.\"  The recording changes hands."
+      "math": [ "portal_storm_medium_data_sold", ">=", "15" ],
+      "yes": "Extrapolating trends from these recordings has become difficult.  Research has requested we only accept higher quality data from now on.",
+      "no": {
+        "npc_has_var": "accepted_nre_recording",
+        "type": "dialogue",
+        "context": "intercom",
+        "value": "yes",
+        "no": "Great!  This looks like a very high-quality recording.  Because this data is much better, we are willing to pay five times what we paid for the base data collected.\"  The tray slides shut, and quickly reopens with your payment.  \"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record.",
+        "yes": "&\"Excellent.\"  The recording changes hands."
+      }
     },
     "speaker_effect": {
       "effect": [

--- a/data/json/portal_storm_effect_on_condition.json
+++ b/data/json/portal_storm_effect_on_condition.json
@@ -988,7 +988,7 @@
       { "arithmetic": [ { "global_val": "var", "var_name": "portal_dungeon_level" }, "++" ] },
       { "mapgen_update": "portal_dungeon_cleanup", "target_var": { "global_val": "dungeon_loc" } },
       { "u_teleport": { "global_val": "dungeon_start" }, "fail_message": "Something is very wrong!", "force": true },
-      { "run_eocs": [ "EOC_PORTAL_STORM_DUNGEON_REFLECTION_SPAWN" ] },
+      { "run_eocs": [ "EOC_PORTAL_STORM_DUNGEON_REFLECTION_SPAWN", "capture_generic_nre_anomaly" ] },
       { "mapgen_update": "portal_dungeon", "target_var": { "global_val": "dungeon_loc" } },
       { "u_message": "Weren't you just here? It feels thicker somehow though." },
       { "u_message": { "global_val": "portal_storm_voice_mood", "default_str": "none" }, "snippet": true }

--- a/src/condition.h
+++ b/src/condition.h
@@ -46,7 +46,7 @@ const std::unordered_set<std::string> complex_conds = { {
         "days_since_cataclysm", "is_season", "mission_goal", "u_has_var", "npc_has_var", "expects_vars",
         "u_has_skill", "npc_has_skill", "u_know_recipe", "u_compare_var", "npc_compare_var",
         "u_compare_time_since_var", "npc_compare_time_since_var", "is_weather", "mod_is_loaded", "one_in_chance", "x_in_y_chance",
-        "u_is_height", "npc_is_height",
+        "u_is_height", "npc_is_height", "math",
         "u_has_worn_with_flag", "npc_has_worn_with_flag", "u_has_wielded_with_flag", "npc_has_wielded_with_flag",
         "u_has_pain", "npc_has_pain", "u_has_power", "npc_has_power", "u_has_focus", "npc_has_focus", "u_has_morale",
         "npc_has_morale", "u_is_on_terrain", "npc_is_on_terrain", "u_is_in_field", "npc_is_in_field", "compare_int",


### PR DESCRIPTION
#### Summary

Features "Rework and expand NRE data recordings"

#### Purpose of change

Quell some gameplay antipatterns involving NRE data recording and expand the ways in which data can be collected.

#### Describe the solution

Noticed that players were making exploit adjacent setups to collect portal storm data at nearly no risk whatsoever. This limits the efficacy of such things by limiting the amount of short and normal length NRE printouts Hub 01 will accept (to 3 and 15 respectively, may still be too many?). Hub will still accept an infinite number of long printouts.

To compensate, I've made it so certain interactions can also create "anomaly data", that Hub will also buy indefinitely. Mostly you get those by killing notable nether monster or by interacting with the portal dungeon, with some more spoiler adjacent interactions also giving data.

Additionally the NRE recorder now indicates what type of portal storm data it has stored through warning beeps, so its easier to track what kind of printout you'll receive.

#### Testing

Collected both anomaly and portal storm data normally. Traded them with hub 01