### PR TITLE
Update zed_explosive.json

### DIFF
--- a/data/json/monsters/zed_explosive.json
+++ b/data/json/monsters/zed_explosive.json
@@ -44,7 +44,6 @@
       "REVIVES",
       "BILE_BLOOD",
       "PUSH_MON",
-      "PATH_AVOID_DANGER_1",
       "FILTHY"
     ],
     "armor": { "electric": 2 }
@@ -98,7 +97,6 @@
       "REVIVES",
       "BILE_BLOOD",
       "PUSH_MON",
-      "PATH_AVOID_DANGER_1",
       "FILTHY"
     ],
     "armor": { "bash": 5, "cut": 5, "bullet": 4, "electric": 3 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

Balance "Removed Pit Avoidance from Boomer and Huge Boomer"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

"Boomer" type zombies currently avoid holes in the ground (e.g. caused by Meteor explosions) and similar hazards. Both of these Monster types (Boomer, Huge Boomer) include this line of behavior, but no other Explosive Zombies do, including Fungal Boomer.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Removed "path_avoid_danger_1" line from Boomer and Huge Boomer Zombie Monsters, checked other Explosive Zombie variants and Fungal Boomer for consistency.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Considered leaving Boomer and Huge Boomer behavior intact for historic reasons and due to the "one time use" nature of their attack to increase game difficulty or player expectations.

Considered adding "path_avoid_danger_1" to other intelligence Zombie type monsters, such as those mentioning "intelligence" in their descriptions. Or alternatively to expand this behavior to all Explosive Zombie types (and potentially Fungal Boomer) to increase behavioral consistency. Since the majority of Explosive Zombies (and Fungal Boomer) do not share this behavior, and since I did not feel this behavior was intrinsically benifical to the Boomer/Huge Boomer or Explosive Zombie's gameplay or lore identity, I thought it was better to remove this behavior than to further expand it.

#### Testing

Loaded test world pre-change, created a 2x10 pit of Open Air and 1 Boomer and 1 Huge Boomer Zombies, who avoided falling into pit and eventually tried to run around the edge of the pit to eat me.

Modified "data/json/monsters/zed_explosive.json" by replacing "zed_explosive.json" file with modified version on lines 47 for Boomer and 101 for Huge Boomer, removing "path_avoid_danger_1" for both mobs. Repeated test with 2x10 Open Air pit against 1 Boomer and 1 Huge Boomer, both mobs fell into hole.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
![Screen Shot 2023-06-02 at 4 19 35 PM](https://github.com/CleverRaven/Cataclysm-DDA/assets/115378524/07ce70e5-9ef3-45a0-b8d2-bc2deb09108f)
![Screen Shot 2023-06-02 at 4 22 47 PM](https://github.com/CleverRaven/Cataclysm-DDA/assets/115378524/6e7a72fc-5683-4259-a5a6-0522da892d8f)
![Screen Shot 2023-06-02 at 4 22 57 PM](https://github.com/CleverRaven/Cataclysm-DDA/assets/115378524/8f3d6fc4-4d28-4fde-bfb8-8618d5380d38)
![Screen Shot 2023-06-02 at 4 26 44 PM](https://github.com/CleverRaven/Cataclysm-DDA/assets/115378524/231acf84-5bc5-40fb-a78f-ec8d36773e16)
![Screen Shot 2023-06-02 at 4 26 53 PM](https://github.com/CleverRaven/Cataclysm-DDA/assets/115378524/8681bd02-551d-4fdf-b778-58b65724d50c)
