### PR TITLE
Morvarchprincess/addknotweedtomorerecipies

### DIFF
--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -1044,7 +1044,11 @@
       { "type": "COMPONENT_ID", "condition": "veggy", "name": { "str_sp": "%s, plant marrow" } },
       { "type": "COMPONENT_ID", "condition": "veggy_wild", "name": { "str_sp": "%s, wild vegetables" } },
       { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } },
-      { "type": "COMPONENT_ID", "condition": "japanese_knotweed_stem", "name": { "str_sp": "%s, japanese_knotweed_stem" } }
+      {
+        "type": "COMPONENT_ID",
+        "condition": "japanese_knotweed_stem",
+        "name": { "str_sp": "%s, japanese_knotweed_stem" }
+      }
     ],
     "copy-from": "veggy",
     "proportional": { "weight": 0.5 },

--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -827,7 +827,7 @@
       {
         "type": "COMPONENT_ID",
         "condition": "japanese_knotweed_stem",
-        "name": { "str_sp": "%s, japanese_knotweed_stem" }
+        "name": { "str_sp": "%s, japanese knotweed stem" }
       }
     ],
     "weight": "259 g",
@@ -887,7 +887,7 @@
       {
         "type": "COMPONENT_ID",
         "condition": "japanese_knotweed_stem",
-        "name": { "str_sp": "%s, japanese_knotweed_stem" }
+        "name": { "str_sp": "%s, japanese knotweed stem" }
       }
     ],
     "weight": "192 g",
@@ -1051,7 +1051,7 @@
       {
         "type": "COMPONENT_ID",
         "condition": "japanese_knotweed_stem",
-        "name": { "str_sp": "%s, japanese_knotweed_stem" }
+        "name": { "str_sp": "%s, japanese knotweed stem" }
       }
     ],
     "copy-from": "veggy",
@@ -1130,7 +1130,7 @@
       {
         "type": "COMPONENT_ID",
         "condition": "japanese_knotweed_stem",
-        "name": { "str_sp": "%s, japanese_knotweed_stem" }
+        "name": { "str_sp": "%s, japanese knotweed stem" }
       }
     ],
     "copy-from": "veggy",

--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -824,7 +824,11 @@
       { "type": "COMPONENT_ID", "condition": "veggy", "name": { "str_sp": "%s, plant marrow" } },
       { "type": "COMPONENT_ID", "condition": "veggy_wild", "name": { "str_sp": "%s, wild vegetables" } },
       { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } },
-      { "type": "COMPONENT_ID", "condition": "japanese_knotweed_stem", "name": { "str_sp": "%s, japanese_knotweed_stem" } }
+      {
+        "type": "COMPONENT_ID",
+        "condition": "japanese_knotweed_stem",
+        "name": { "str_sp": "%s, japanese_knotweed_stem" }
+      }
     ],
     "weight": "259 g",
     "color": "green",

--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -789,41 +789,186 @@
     "id": "veggy_canned",
     "name": { "str": "canned veggy", "str_pl": "canned veggies" },
     "conditional_names": [
-      { "type": "COMPONENT_ID", "condition": "bamboo_cooked", "name": { "str_sp": "%s, cooked bamboo shoots" } },
-      { "type": "COMPONENT_ID", "condition": "broccoli", "name": { "str_sp": "%s, broccoli" } },
-      { "type": "COMPONENT_ID", "condition": "bell_pepper", "name": { "str_sp": "%s, bell pepper" } },
-      { "type": "COMPONENT_ID", "condition": "burdock", "name": { "str_sp": "%s, burdock" } },
-      { "type": "COMPONENT_ID", "condition": "burdock_cooked", "name": { "str_sp": "%s, cooked burdock greens" } },
-      { "type": "COMPONENT_ID", "condition": "cabbage", "name": { "str_sp": "%s, cabbage" } },
-      { "type": "COMPONENT_ID", "condition": "carrot", "name": { "str_sp": "%s, carrot" } },
-      { "type": "COMPONENT_ID", "condition": "carrot_wild", "name": { "str_sp": "%s, wild root" } },
-      { "type": "COMPONENT_ID", "condition": "cattail_stalk", "name": { "str_sp": "%s, cattail stalk" } },
-      { "type": "COMPONENT_ID", "condition": "burdock_stalk", "name": { "str_sp": "%s, burdock stalk" } },
-      { "type": "COMPONENT_ID", "condition": "celery", "name": { "str_sp": "%s, celery" } },
-      { "type": "COMPONENT_ID", "condition": "corn_kernels", "name": { "str_sp": "%s, corn kernels" } },
-      { "type": "COMPONENT_ID", "condition": "cucumber", "name": { "str_sp": "%s, cucumber" } },
-      { "type": "COMPONENT_ID", "condition": "dandelion", "name": { "str_sp": "%s, dandelion" } },
-      { "type": "COMPONENT_ID", "condition": "dandelion_cooked", "name": { "str_sp": "%s, cooked dandelion greens" } },
-      { "type": "COMPONENT_ID", "condition": "grape_leaves", "name": { "str_sp": "%s, grape leaves" } },
-      { "type": "COMPONENT_ID", "condition": "groundnut_prepared", "name": { "str_sp": "%s, ground nuts" } },
-      { "type": "COMPONENT_ID", "condition": "horseradish_greens", "name": { "str_sp": "%s, horseradish greens" } },
-      { "type": "COMPONENT_ID", "condition": "lettuce", "name": { "str_sp": "%s, lettuce" } },
-      { "type": "COMPONENT_ID", "condition": "onion", "name": { "str_sp": "%s, onion" } },
-      { "type": "COMPONENT_ID", "condition": "plantain", "name": { "str_sp": "%s, cooking banana" } },
-      { "type": "COMPONENT_ID", "condition": "plant_sac", "name": { "str_sp": "%s, fungal fluid sac" } },
-      { "type": "COMPONENT_ID", "condition": "popcorn_raw", "name": { "str_sp": "%s, popcorn kernels" } },
-      { "type": "COMPONENT_ID", "condition": "potato", "name": { "str_sp": "%s, potato" } },
-      { "type": "COMPONENT_ID", "condition": "pumpkin", "name": { "str_sp": "%s, pumpkin" } },
-      { "type": "COMPONENT_ID", "condition": "raw_bamboo", "name": { "str_sp": "%s, bamboo shoots" } },
-      { "type": "COMPONENT_ID", "condition": "raw_beans", "name": { "str_sp": "%s, beans" } },
-      { "type": "COMPONENT_ID", "condition": "raw_lentils", "name": { "str_sp": "%s, lentils" } },
-      { "type": "COMPONENT_ID", "condition": "rhubarb", "name": { "str_sp": "%s, rhubarb" } },
-      { "type": "COMPONENT_ID", "condition": "spinach", "name": { "str_sp": "%s, spinach" } },
-      { "type": "COMPONENT_ID", "condition": "sugar_beet", "name": { "str_sp": "%s, sugar beet" } },
-      { "type": "COMPONENT_ID", "condition": "tomato", "name": { "str_sp": "%s, tomato" } },
-      { "type": "COMPONENT_ID", "condition": "veggy", "name": { "str_sp": "%s, plant marrow" } },
-      { "type": "COMPONENT_ID", "condition": "veggy_wild", "name": { "str_sp": "%s, wild vegetables" } },
-      { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } }
+      {
+        "type": "COMPONENT_ID",
+        "condition": "bamboo_cooked",
+        "name": { "str_sp": "%s, cooked bamboo shoots" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "broccoli",
+        "name": { "str_sp": "%s, broccoli" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "bell_pepper",
+        "name": { "str_sp": "%s, bell pepper" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "burdock",
+        "name": { "str_sp": "%s, burdock" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "burdock_cooked",
+        "name": { "str_sp": "%s, cooked burdock greens" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "cabbage",
+        "name": { "str_sp": "%s, cabbage" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "carrot",
+        "name": { "str_sp": "%s, carrot" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "carrot_wild",
+        "name": { "str_sp": "%s, wild root" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "cattail_stalk",
+        "name": { "str_sp": "%s, cattail stalk" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "burdock_stalk",
+        "name": { "str_sp": "%s, burdock stalk" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "celery",
+        "name": { "str_sp": "%s, celery" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "corn_kernels",
+        "name": { "str_sp": "%s, corn kernels" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "cucumber",
+        "name": { "str_sp": "%s, cucumber" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "dandelion",
+        "name": { "str_sp": "%s, dandelion" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "dandelion_cooked",
+        "name": { "str_sp": "%s, cooked dandelion greens" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "grape_leaves",
+        "name": { "str_sp": "%s, grape leaves" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "groundnut_prepared",
+        "name": { "str_sp": "%s, ground nuts" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "horseradish_greens",
+        "name": { "str_sp": "%s, horseradish greens" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "lettuce",
+        "name": { "str_sp": "%s, lettuce" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "onion",
+        "name": { "str_sp": "%s, onion" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "plantain",
+        "name": { "str_sp": "%s, cooking banana" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "plant_sac",
+        "name": { "str_sp": "%s, fungal fluid sac" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "popcorn_raw",
+        "name": { "str_sp": "%s, popcorn kernels" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "potato",
+        "name": { "str_sp": "%s, potato" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "pumpkin",
+        "name": { "str_sp": "%s, pumpkin" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "raw_bamboo",
+        "name": { "str_sp": "%s, bamboo shoots" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "raw_beans",
+        "name": { "str_sp": "%s, beans" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "raw_lentils",
+        "name": { "str_sp": "%s, lentils" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "rhubarb",
+        "name": { "str_sp": "%s, rhubarb" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "spinach",
+        "name": { "str_sp": "%s, spinach" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "sugar_beet",
+        "name": { "str_sp": "%s, sugar beet" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "tomato",
+        "name": { "str_sp": "%s, tomato" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "veggy",
+        "name": { "str_sp": "%s, plant marrow" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "veggy_wild",
+        "name": { "str_sp": "%s, wild vegetables" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "zucchini",
+        "name": { "str_sp": "%s, zucchini" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "japanese_knotweed_stem",
+        "name": { "str_sp": "%s, japanese knotweed stem" }
+      }
     ],
     "weight": "259 g",
     "color": "green",
@@ -956,40 +1101,181 @@
     "id": "veggy_pickled",
     "name": { "str": "pickled veggy", "str_pl": "pickled veggies" },
     "conditional_names": [
-      { "type": "COMPONENT_ID", "condition": "bamboo_cooked", "name": { "str_sp": "%s, cooked bamboo shoots" } },
-      { "type": "COMPONENT_ID", "condition": "broccoli", "name": { "str_sp": "%s, broccoli" } },
-      { "type": "COMPONENT_ID", "condition": "bell_pepper", "name": { "str_sp": "%s, bell pepper" } },
-      { "type": "COMPONENT_ID", "condition": "burdock", "name": { "str_sp": "%s, burdock" } },
-      { "type": "COMPONENT_ID", "condition": "burdock_cooked", "name": { "str_sp": "%s, cooked burdock greens" } },
-      { "type": "COMPONENT_ID", "condition": "cabbage", "name": { "str_sp": "%s, cabbage" } },
-      { "type": "COMPONENT_ID", "condition": "carrot", "name": { "str_sp": "%s, carrot" } },
-      { "type": "COMPONENT_ID", "condition": "carrot_wild", "name": { "str_sp": "%s, wild root" } },
-      { "type": "COMPONENT_ID", "condition": "cattail_stalk", "name": { "str_sp": "%s, cattail stalk" } },
-      { "type": "COMPONENT_ID", "condition": "celery", "name": { "str_sp": "%s, celery" } },
-      { "type": "COMPONENT_ID", "condition": "corn_kernels", "name": { "str_sp": "%s, corn kernels" } },
-      { "type": "COMPONENT_ID", "condition": "cucumber", "name": { "str_sp": "%s, cucumber" } },
-      { "type": "COMPONENT_ID", "condition": "dandelion", "name": { "str_sp": "%s, dandelion" } },
-      { "type": "COMPONENT_ID", "condition": "dandelion_cooked", "name": { "str_sp": "%s, cooked dandelion greens" } },
-      { "type": "COMPONENT_ID", "condition": "grape_leaves", "name": { "str_sp": "%s, grape leaves" } },
-      { "type": "COMPONENT_ID", "condition": "groundnut_prepared", "name": { "str_sp": "%s, ground nuts" } },
-      { "type": "COMPONENT_ID", "condition": "horseradish_greens", "name": { "str_sp": "%s, horseradish greens" } },
-      { "type": "COMPONENT_ID", "condition": "lettuce", "name": { "str_sp": "%s, lettuce" } },
-      { "type": "COMPONENT_ID", "condition": "onion", "name": { "str_sp": "%s, onion" } },
-      { "type": "COMPONENT_ID", "condition": "plantain", "name": { "str_sp": "%s, cooking banana" } },
-      { "type": "COMPONENT_ID", "condition": "plant_sac", "name": { "str_sp": "%s, fungal fluid sac" } },
-      { "type": "COMPONENT_ID", "condition": "popcorn_raw", "name": { "str_sp": "%s, popcorn kernels" } },
-      { "type": "COMPONENT_ID", "condition": "potato", "name": { "str_sp": "%s, potato" } },
-      { "type": "COMPONENT_ID", "condition": "pumpkin", "name": { "str_sp": "%s, pumpkin" } },
-      { "type": "COMPONENT_ID", "condition": "raw_bamboo", "name": { "str_sp": "%s, bamboo shoots" } },
-      { "type": "COMPONENT_ID", "condition": "raw_beans", "name": { "str_sp": "%s, beans" } },
-      { "type": "COMPONENT_ID", "condition": "raw_lentils", "name": { "str_sp": "%s, lentils" } },
-      { "type": "COMPONENT_ID", "condition": "rhubarb", "name": { "str_sp": "%s, rhubarb" } },
-      { "type": "COMPONENT_ID", "condition": "spinach", "name": { "str_sp": "%s, spinach" } },
-      { "type": "COMPONENT_ID", "condition": "sugar_beet", "name": { "str_sp": "%s, sugar beet" } },
-      { "type": "COMPONENT_ID", "condition": "tomato", "name": { "str_sp": "%s, tomato" } },
-      { "type": "COMPONENT_ID", "condition": "veggy", "name": { "str_sp": "%s, plant marrow" } },
-      { "type": "COMPONENT_ID", "condition": "veggy_wild", "name": { "str_sp": "%s, wild vegetables" } },
-      { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } }
+      {
+        "type": "COMPONENT_ID",
+        "condition": "bamboo_cooked",
+        "name": { "str_sp": "%s, cooked bamboo shoots" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "broccoli",
+        "name": { "str_sp": "%s, broccoli" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "bell_pepper",
+        "name": { "str_sp": "%s, bell pepper" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "burdock",
+        "name": { "str_sp": "%s, burdock" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "burdock_cooked",
+        "name": { "str_sp": "%s, cooked burdock greens" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "cabbage",
+        "name": { "str_sp": "%s, cabbage" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "carrot",
+        "name": { "str_sp": "%s, carrot" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "carrot_wild",
+        "name": { "str_sp": "%s, wild root" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "cattail_stalk",
+        "name": { "str_sp": "%s, cattail stalk" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "celery",
+        "name": { "str_sp": "%s, celery" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "corn_kernels",
+        "name": { "str_sp": "%s, corn kernels" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "cucumber",
+        "name": { "str_sp": "%s, cucumber" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "dandelion",
+        "name": { "str_sp": "%s, dandelion" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "dandelion_cooked",
+        "name": { "str_sp": "%s, cooked dandelion greens" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "grape_leaves",
+        "name": { "str_sp": "%s, grape leaves" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "groundnut_prepared",
+        "name": { "str_sp": "%s, ground nuts" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "horseradish_greens",
+        "name": { "str_sp": "%s, horseradish greens" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "lettuce",
+        "name": { "str_sp": "%s, lettuce" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "onion",
+        "name": { "str_sp": "%s, onion" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "plantain",
+        "name": { "str_sp": "%s, cooking banana" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "plant_sac",
+        "name": { "str_sp": "%s, fungal fluid sac" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "popcorn_raw",
+        "name": { "str_sp": "%s, popcorn kernels" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "potato",
+        "name": { "str_sp": "%s, potato" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "pumpkin",
+        "name": { "str_sp": "%s, pumpkin" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "raw_bamboo",
+        "name": { "str_sp": "%s, bamboo shoots" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "raw_beans",
+        "name": { "str_sp": "%s, beans" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "raw_lentils",
+        "name": { "str_sp": "%s, lentils" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "rhubarb",
+        "name": { "str_sp": "%s, rhubarb" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "spinach",
+        "name": { "str_sp": "%s, spinach" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "sugar_beet",
+        "name": { "str_sp": "%s, sugar beet" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "tomato",
+        "name": { "str_sp": "%s, tomato" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "veggy",
+        "name": { "str_sp": "%s, plant marrow" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "veggy_wild",
+        "name": { "str_sp": "%s, wild vegetables" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "zucchini",
+        "name": { "str_sp": "%s, zucchini" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "japanese_knotweed_stem",
+        "name": { "str_sp": "%s, japanese knotweed stem" }
+      }
     ],
     "copy-from": "veggy",
     "color": "light_green",
@@ -1037,7 +1323,16 @@
       { "type": "COMPONENT_ID", "condition": "tomato", "name": { "str_sp": "%s, tomato" } },
       { "type": "COMPONENT_ID", "condition": "veggy", "name": { "str_sp": "%s, plant marrow" } },
       { "type": "COMPONENT_ID", "condition": "veggy_wild", "name": { "str_sp": "%s, wild vegetables" } },
-      { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } }
+      {
+        "type": "COMPONENT_ID",
+        "condition": "zucchini",
+        "name": { "str_sp": "%s, zucchini" }
+      },
+      {
+        "type": "COMPONENT_ID",
+        "condition": "japanese_knotweed_stem",
+        "name": { "str_sp": "%s, japanese knotweed stem" }
+      }
     ],
     "copy-from": "veggy",
     "proportional": { "weight": 0.5 },

--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -1127,7 +1127,11 @@
       { "type": "COMPONENT_ID", "condition": "veggy", "name": { "str_sp": "%s, plant marrow" } },
       { "type": "COMPONENT_ID", "condition": "veggy_wild", "name": { "str_sp": "%s, wild vegetables" } },
       { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } },
-      { "type": "COMPONENT_ID", "condition": "japanese_knotweed_stem", "name": { "str_sp": "%s, japanese_knotweed_stem" } }
+      {
+        "type": "COMPONENT_ID",
+        "condition": "japanese_knotweed_stem",
+        "name": { "str_sp": "%s, japanese_knotweed_stem" }
+      }
     ],
     "copy-from": "veggy",
     "color": "light_green",

--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -884,7 +884,11 @@
       { "type": "COMPONENT_ID", "condition": "veggy", "name": { "str_sp": "%s, plant marrow" } },
       { "type": "COMPONENT_ID", "condition": "veggy_wild", "name": { "str_sp": "%s, wild vegetables" } },
       { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } },
-      { "type": "COMPONENT_ID", "condition": "japanese_knotweed_stem", "name": { "str_sp": "%s, japanese_knotweed_stem" } }
+      {
+        "type": "COMPONENT_ID",
+        "condition": "japanese_knotweed_stem",
+        "name": { "str_sp": "%s, japanese_knotweed_stem" }
+      }
     ],
     "weight": "192 g",
     "color": "green",

--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -789,186 +789,42 @@
     "id": "veggy_canned",
     "name": { "str": "canned veggy", "str_pl": "canned veggies" },
     "conditional_names": [
-      {
-        "type": "COMPONENT_ID",
-        "condition": "bamboo_cooked",
-        "name": { "str_sp": "%s, cooked bamboo shoots" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "broccoli",
-        "name": { "str_sp": "%s, broccoli" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "bell_pepper",
-        "name": { "str_sp": "%s, bell pepper" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "burdock",
-        "name": { "str_sp": "%s, burdock" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "burdock_cooked",
-        "name": { "str_sp": "%s, cooked burdock greens" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "cabbage",
-        "name": { "str_sp": "%s, cabbage" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "carrot",
-        "name": { "str_sp": "%s, carrot" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "carrot_wild",
-        "name": { "str_sp": "%s, wild root" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "cattail_stalk",
-        "name": { "str_sp": "%s, cattail stalk" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "burdock_stalk",
-        "name": { "str_sp": "%s, burdock stalk" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "celery",
-        "name": { "str_sp": "%s, celery" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "corn_kernels",
-        "name": { "str_sp": "%s, corn kernels" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "cucumber",
-        "name": { "str_sp": "%s, cucumber" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "dandelion",
-        "name": { "str_sp": "%s, dandelion" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "dandelion_cooked",
-        "name": { "str_sp": "%s, cooked dandelion greens" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "grape_leaves",
-        "name": { "str_sp": "%s, grape leaves" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "groundnut_prepared",
-        "name": { "str_sp": "%s, ground nuts" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "horseradish_greens",
-        "name": { "str_sp": "%s, horseradish greens" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "lettuce",
-        "name": { "str_sp": "%s, lettuce" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "onion",
-        "name": { "str_sp": "%s, onion" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "plantain",
-        "name": { "str_sp": "%s, cooking banana" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "plant_sac",
-        "name": { "str_sp": "%s, fungal fluid sac" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "popcorn_raw",
-        "name": { "str_sp": "%s, popcorn kernels" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "potato",
-        "name": { "str_sp": "%s, potato" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "pumpkin",
-        "name": { "str_sp": "%s, pumpkin" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "raw_bamboo",
-        "name": { "str_sp": "%s, bamboo shoots" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "raw_beans",
-        "name": { "str_sp": "%s, beans" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "raw_lentils",
-        "name": { "str_sp": "%s, lentils" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "rhubarb",
-        "name": { "str_sp": "%s, rhubarb" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "spinach",
-        "name": { "str_sp": "%s, spinach" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "sugar_beet",
-        "name": { "str_sp": "%s, sugar beet" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "tomato",
-        "name": { "str_sp": "%s, tomato" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "veggy",
-        "name": { "str_sp": "%s, plant marrow" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "veggy_wild",
-        "name": { "str_sp": "%s, wild vegetables" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "zucchini",
-        "name": { "str_sp": "%s, zucchini" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "japanese_knotweed_stem",
-        "name": { "str_sp": "%s, japanese knotweed stem" }
-      }
+      { "type": "COMPONENT_ID", "condition": "bamboo_cooked", "name": { "str_sp": "%s, cooked bamboo shoots" } },
+      { "type": "COMPONENT_ID", "condition": "broccoli", "name": { "str_sp": "%s, broccoli" } },
+      { "type": "COMPONENT_ID", "condition": "bell_pepper", "name": { "str_sp": "%s, bell pepper" } },
+      { "type": "COMPONENT_ID", "condition": "burdock", "name": { "str_sp": "%s, burdock" } },
+      { "type": "COMPONENT_ID", "condition": "burdock_cooked", "name": { "str_sp": "%s, cooked burdock greens" } },
+      { "type": "COMPONENT_ID", "condition": "cabbage", "name": { "str_sp": "%s, cabbage" } },
+      { "type": "COMPONENT_ID", "condition": "carrot", "name": { "str_sp": "%s, carrot" } },
+      { "type": "COMPONENT_ID", "condition": "carrot_wild", "name": { "str_sp": "%s, wild root" } },
+      { "type": "COMPONENT_ID", "condition": "cattail_stalk", "name": { "str_sp": "%s, cattail stalk" } },
+      { "type": "COMPONENT_ID", "condition": "burdock_stalk", "name": { "str_sp": "%s, burdock stalk" } },
+      { "type": "COMPONENT_ID", "condition": "celery", "name": { "str_sp": "%s, celery" } },
+      { "type": "COMPONENT_ID", "condition": "corn_kernels", "name": { "str_sp": "%s, corn kernels" } },
+      { "type": "COMPONENT_ID", "condition": "cucumber", "name": { "str_sp": "%s, cucumber" } },
+      { "type": "COMPONENT_ID", "condition": "dandelion", "name": { "str_sp": "%s, dandelion" } },
+      { "type": "COMPONENT_ID", "condition": "dandelion_cooked", "name": { "str_sp": "%s, cooked dandelion greens" } },
+      { "type": "COMPONENT_ID", "condition": "grape_leaves", "name": { "str_sp": "%s, grape leaves" } },
+      { "type": "COMPONENT_ID", "condition": "groundnut_prepared", "name": { "str_sp": "%s, ground nuts" } },
+      { "type": "COMPONENT_ID", "condition": "horseradish_greens", "name": { "str_sp": "%s, horseradish greens" } },
+      { "type": "COMPONENT_ID", "condition": "lettuce", "name": { "str_sp": "%s, lettuce" } },
+      { "type": "COMPONENT_ID", "condition": "onion", "name": { "str_sp": "%s, onion" } },
+      { "type": "COMPONENT_ID", "condition": "plantain", "name": { "str_sp": "%s, cooking banana" } },
+      { "type": "COMPONENT_ID", "condition": "plant_sac", "name": { "str_sp": "%s, fungal fluid sac" } },
+      { "type": "COMPONENT_ID", "condition": "popcorn_raw", "name": { "str_sp": "%s, popcorn kernels" } },
+      { "type": "COMPONENT_ID", "condition": "potato", "name": { "str_sp": "%s, potato" } },
+      { "type": "COMPONENT_ID", "condition": "pumpkin", "name": { "str_sp": "%s, pumpkin" } },
+      { "type": "COMPONENT_ID", "condition": "raw_bamboo", "name": { "str_sp": "%s, bamboo shoots" } },
+      { "type": "COMPONENT_ID", "condition": "raw_beans", "name": { "str_sp": "%s, beans" } },
+      { "type": "COMPONENT_ID", "condition": "raw_lentils", "name": { "str_sp": "%s, lentils" } },
+      { "type": "COMPONENT_ID", "condition": "rhubarb", "name": { "str_sp": "%s, rhubarb" } },
+      { "type": "COMPONENT_ID", "condition": "spinach", "name": { "str_sp": "%s, spinach" } },
+      { "type": "COMPONENT_ID", "condition": "sugar_beet", "name": { "str_sp": "%s, sugar beet" } },
+      { "type": "COMPONENT_ID", "condition": "tomato", "name": { "str_sp": "%s, tomato" } },
+      { "type": "COMPONENT_ID", "condition": "veggy", "name": { "str_sp": "%s, plant marrow" } },
+      { "type": "COMPONENT_ID", "condition": "veggy_wild", "name": { "str_sp": "%s, wild vegetables" } },
+      { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } },
+      { "type": "COMPONENT_ID", "condition": "japanese_knotweed_stem", "name": { "str_sp": "%s, japanese_knotweed_stem" } }
     ],
     "weight": "259 g",
     "color": "green",
@@ -1023,7 +879,8 @@
       { "type": "COMPONENT_ID", "condition": "tomato", "name": { "str_sp": "%s, tomato" } },
       { "type": "COMPONENT_ID", "condition": "veggy", "name": { "str_sp": "%s, plant marrow" } },
       { "type": "COMPONENT_ID", "condition": "veggy_wild", "name": { "str_sp": "%s, wild vegetables" } },
-      { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } }
+      { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } },
+      { "type": "COMPONENT_ID", "condition": "japanese_knotweed_stem", "name": { "str_sp": "%s, japanese_knotweed_stem" } }
     ],
     "weight": "192 g",
     "color": "green",
@@ -1101,181 +958,40 @@
     "id": "veggy_pickled",
     "name": { "str": "pickled veggy", "str_pl": "pickled veggies" },
     "conditional_names": [
-      {
-        "type": "COMPONENT_ID",
-        "condition": "bamboo_cooked",
-        "name": { "str_sp": "%s, cooked bamboo shoots" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "broccoli",
-        "name": { "str_sp": "%s, broccoli" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "bell_pepper",
-        "name": { "str_sp": "%s, bell pepper" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "burdock",
-        "name": { "str_sp": "%s, burdock" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "burdock_cooked",
-        "name": { "str_sp": "%s, cooked burdock greens" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "cabbage",
-        "name": { "str_sp": "%s, cabbage" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "carrot",
-        "name": { "str_sp": "%s, carrot" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "carrot_wild",
-        "name": { "str_sp": "%s, wild root" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "cattail_stalk",
-        "name": { "str_sp": "%s, cattail stalk" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "celery",
-        "name": { "str_sp": "%s, celery" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "corn_kernels",
-        "name": { "str_sp": "%s, corn kernels" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "cucumber",
-        "name": { "str_sp": "%s, cucumber" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "dandelion",
-        "name": { "str_sp": "%s, dandelion" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "dandelion_cooked",
-        "name": { "str_sp": "%s, cooked dandelion greens" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "grape_leaves",
-        "name": { "str_sp": "%s, grape leaves" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "groundnut_prepared",
-        "name": { "str_sp": "%s, ground nuts" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "horseradish_greens",
-        "name": { "str_sp": "%s, horseradish greens" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "lettuce",
-        "name": { "str_sp": "%s, lettuce" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "onion",
-        "name": { "str_sp": "%s, onion" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "plantain",
-        "name": { "str_sp": "%s, cooking banana" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "plant_sac",
-        "name": { "str_sp": "%s, fungal fluid sac" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "popcorn_raw",
-        "name": { "str_sp": "%s, popcorn kernels" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "potato",
-        "name": { "str_sp": "%s, potato" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "pumpkin",
-        "name": { "str_sp": "%s, pumpkin" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "raw_bamboo",
-        "name": { "str_sp": "%s, bamboo shoots" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "raw_beans",
-        "name": { "str_sp": "%s, beans" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "raw_lentils",
-        "name": { "str_sp": "%s, lentils" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "rhubarb",
-        "name": { "str_sp": "%s, rhubarb" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "spinach",
-        "name": { "str_sp": "%s, spinach" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "sugar_beet",
-        "name": { "str_sp": "%s, sugar beet" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "tomato",
-        "name": { "str_sp": "%s, tomato" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "veggy",
-        "name": { "str_sp": "%s, plant marrow" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "veggy_wild",
-        "name": { "str_sp": "%s, wild vegetables" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "zucchini",
-        "name": { "str_sp": "%s, zucchini" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "japanese_knotweed_stem",
-        "name": { "str_sp": "%s, japanese knotweed stem" }
-      }
+      { "type": "COMPONENT_ID", "condition": "bamboo_cooked", "name": { "str_sp": "%s, cooked bamboo shoots" } },
+      { "type": "COMPONENT_ID", "condition": "broccoli", "name": { "str_sp": "%s, broccoli" } },
+      { "type": "COMPONENT_ID", "condition": "bell_pepper", "name": { "str_sp": "%s, bell pepper" } },
+      { "type": "COMPONENT_ID", "condition": "burdock", "name": { "str_sp": "%s, burdock" } },
+      { "type": "COMPONENT_ID", "condition": "burdock_cooked", "name": { "str_sp": "%s, cooked burdock greens" } },
+      { "type": "COMPONENT_ID", "condition": "cabbage", "name": { "str_sp": "%s, cabbage" } },
+      { "type": "COMPONENT_ID", "condition": "carrot", "name": { "str_sp": "%s, carrot" } },
+      { "type": "COMPONENT_ID", "condition": "carrot_wild", "name": { "str_sp": "%s, wild root" } },
+      { "type": "COMPONENT_ID", "condition": "cattail_stalk", "name": { "str_sp": "%s, cattail stalk" } },
+      { "type": "COMPONENT_ID", "condition": "celery", "name": { "str_sp": "%s, celery" } },
+      { "type": "COMPONENT_ID", "condition": "corn_kernels", "name": { "str_sp": "%s, corn kernels" } },
+      { "type": "COMPONENT_ID", "condition": "cucumber", "name": { "str_sp": "%s, cucumber" } },
+      { "type": "COMPONENT_ID", "condition": "dandelion", "name": { "str_sp": "%s, dandelion" } },
+      { "type": "COMPONENT_ID", "condition": "dandelion_cooked", "name": { "str_sp": "%s, cooked dandelion greens" } },
+      { "type": "COMPONENT_ID", "condition": "grape_leaves", "name": { "str_sp": "%s, grape leaves" } },
+      { "type": "COMPONENT_ID", "condition": "groundnut_prepared", "name": { "str_sp": "%s, ground nuts" } },
+      { "type": "COMPONENT_ID", "condition": "horseradish_greens", "name": { "str_sp": "%s, horseradish greens" } },
+      { "type": "COMPONENT_ID", "condition": "lettuce", "name": { "str_sp": "%s, lettuce" } },
+      { "type": "COMPONENT_ID", "condition": "onion", "name": { "str_sp": "%s, onion" } },
+      { "type": "COMPONENT_ID", "condition": "plantain", "name": { "str_sp": "%s, cooking banana" } },
+      { "type": "COMPONENT_ID", "condition": "plant_sac", "name": { "str_sp": "%s, fungal fluid sac" } },
+      { "type": "COMPONENT_ID", "condition": "popcorn_raw", "name": { "str_sp": "%s, popcorn kernels" } },
+      { "type": "COMPONENT_ID", "condition": "potato", "name": { "str_sp": "%s, potato" } },
+      { "type": "COMPONENT_ID", "condition": "pumpkin", "name": { "str_sp": "%s, pumpkin" } },
+      { "type": "COMPONENT_ID", "condition": "raw_bamboo", "name": { "str_sp": "%s, bamboo shoots" } },
+      { "type": "COMPONENT_ID", "condition": "raw_beans", "name": { "str_sp": "%s, beans" } },
+      { "type": "COMPONENT_ID", "condition": "raw_lentils", "name": { "str_sp": "%s, lentils" } },
+      { "type": "COMPONENT_ID", "condition": "rhubarb", "name": { "str_sp": "%s, rhubarb" } },
+      { "type": "COMPONENT_ID", "condition": "spinach", "name": { "str_sp": "%s, spinach" } },
+      { "type": "COMPONENT_ID", "condition": "sugar_beet", "name": { "str_sp": "%s, sugar beet" } },
+      { "type": "COMPONENT_ID", "condition": "tomato", "name": { "str_sp": "%s, tomato" } },
+      { "type": "COMPONENT_ID", "condition": "veggy", "name": { "str_sp": "%s, plant marrow" } },
+      { "type": "COMPONENT_ID", "condition": "veggy_wild", "name": { "str_sp": "%s, wild vegetables" } },
+      { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } }
     ],
     "copy-from": "veggy",
     "color": "light_green",
@@ -1323,16 +1039,8 @@
       { "type": "COMPONENT_ID", "condition": "tomato", "name": { "str_sp": "%s, tomato" } },
       { "type": "COMPONENT_ID", "condition": "veggy", "name": { "str_sp": "%s, plant marrow" } },
       { "type": "COMPONENT_ID", "condition": "veggy_wild", "name": { "str_sp": "%s, wild vegetables" } },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "zucchini",
-        "name": { "str_sp": "%s, zucchini" }
-      },
-      {
-        "type": "COMPONENT_ID",
-        "condition": "japanese_knotweed_stem",
-        "name": { "str_sp": "%s, japanese knotweed stem" }
-      }
+      { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } },
+      { "type": "COMPONENT_ID", "condition": "japanese_knotweed_stem", "name": { "str_sp": "%s, japanese_knotweed_stem" } }
     ],
     "copy-from": "veggy",
     "proportional": { "weight": 0.5 },
@@ -1406,7 +1114,8 @@
       { "type": "COMPONENT_ID", "condition": "tomato", "name": { "str_sp": "%s, tomato" } },
       { "type": "COMPONENT_ID", "condition": "veggy", "name": { "str_sp": "%s, plant marrow" } },
       { "type": "COMPONENT_ID", "condition": "veggy_wild", "name": { "str_sp": "%s, wild vegetables" } },
-      { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } }
+      { "type": "COMPONENT_ID", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } },
+      { "type": "COMPONENT_ID", "condition": "japanese_knotweed_stem", "name": { "str_sp": "%s, japanese_knotweed_stem" } }
     ],
     "copy-from": "veggy",
     "color": "light_green",

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -1108,7 +1108,8 @@
         [ "irradiated_zucchini", 1 ],
         [ "carrot_wild", 1 ],
         [ "wild_garlic", 2 ],
-        [ "spinach", 1 ]
+        [ "spinach", 1 ],
+        [ "japanese_knotweed_stem", 1 ]
       ]
     ]
   },


### PR DESCRIPTION
#### Summary
Content "Adding Japanese Knotweed to additional veggy recipes."

#### Purpose of change

Fixes #65890 

#### Describe the solution

I added fresh knotweed stems to the generic veggy list, and to the descriptions of a number of the recipes that use it.
I did not add knotweed to the following recipes mentioned in the issue:
veggy_picked: I didn't see other similar veggys in here, so I decided to leave it out for now.
fruit_leather: this isn't a sweet fruit.
sugar: this isn't a sweet fruit.

#### Describe alternatives you've considered

Could add it to veggy_pickled, as per issue author knotweed tastes good pickled.

#### Testing

I confirmed in game that knotweed showed up as a viable option in every recipe that I modified.

#### Additional context


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->