### PR TITLE
math_parser: improve handling of dialogue functions

### DIFF
--- a/data/mods/BombasticPerks/corefiles/welcomemenu.json
+++ b/data/mods/BombasticPerks/corefiles/welcomemenu.json
@@ -20,7 +20,7 @@
       },
       {
         "text": "Custom Value",
-        "effect": [ { "math": [ "u_exp_to_perk", "=", "num_input('Exp until first level?', '100')" ] } ],
+        "effect": [ { "math": [ "u_exp_to_perk", "=", "num_input('Exp until first level?', 100)" ] } ],
         "topic": "TALK_PERK_MENU_WELCOME_EXP_INCREMENT"
       },
       { "text": "Back", "topic": "TALK_PERK_MENU_WELCOME" }
@@ -38,7 +38,7 @@
       },
       {
         "text": "Custom Value",
-        "effect": [ { "math": [ "u_exp_per_level", "=", "num_input('Exp increase?', '300')" ] } ],
+        "effect": [ { "math": [ "u_exp_per_level", "=", "num_input('Exp increase?', 300)" ] } ],
         "topic": "TALK_PERK_MENU_WELCOME_REQUIREMENTS"
       },
       { "text": "Back", "topic": "TALK_PERK_MENU_WELCOME_FIRST_LEVEL" }
@@ -100,7 +100,7 @@
       {
         "text": "Enabled, Custom Cost",
         "effect": [
-          { "math": [ "u_playstyle_cost", "=", "num_input('Playstyle Perks Cost?', '4') - 1" ] },
+          { "math": [ "u_playstyle_cost", "=", "num_input('Playstyle Perks Cost?', 4) - 1" ] },
           { "math": [ "u_no_playstyle", "=", "0" ] },
           {
             "u_add_var": "playstyle_note",

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1425,18 +1425,20 @@ Common math functions are supported:
 Function composition is also supported, for example `sin( rng(0, max( 0.5, u_sin_var ) ) )`
 
 #### Dialogue functions
-Dialogue functions take single-quoted strings as arguments and can return or manipulate game values. They are scoped just like [variables](#variables).
+Dialogue functions return or manipulate game values. They are scoped just like [variables](#variables).
+
+These functions support keyword-value pairs as optional arguments (kwargs) of the form `'keyword': argument`.
 
 This section is a work in progress as functions are ported from `arithmetic` to `math`.
 
-_function arguments are either `s`trings or `v`[ariables](#variables)_
+_function arguments are `d`oubles (or sub-expressions), `s`trings, or `v`[ariables](#variables)_
 
 | Function | Eval | Assign |Scopes | Description |
 |----------|------|--------|-------|-------------|
 | armor(`s`/`v`,`s`/`v`)    |  ✅   |   ❌  | u, n  | Return the numerical value for a characters armor on a body part, for a damage type.<br/> Variables are damagetype ID, bodypart ID.<br/> Example:<br/>`"condition": { "math": [ "u_armor('bash', 'torso')", ">=", "5"] }`|  
 | attack_speed()    |  ✅   |   ❌  | u, n  | Return the characters current adjusted attack speed with their current weapon.<br/> Example:<br/>`"condition": { "math": [ "u_attack_speed()", ">=", "10"] }`| 
 | game_option(`s`/`v`)   |  ✅  |   ❌   | N/A<br/>(global)  | Return the numerical value of a game option<br/> Example:<br/>`"condition": { "math": [ "game_option('NPC_SPAWNTIME')", ">=", "5"] }`|
-| num_input(`s`/`v`,`s`/`v`)   |  ✅  |   ❌   | N/A<br/>(global)  | Prompt the player for a number.<br/> Variables are Prompt text, Default Value:<br/>`"math": [ "u_value_to_set", "=", "num_input('Playstyle Perks Cost?', '4')" ]`|
+| num_input(`s`/`v`,`d`/`v`)   |  ✅  |   ❌   | N/A<br/>(global)  | Prompt the player for a number.<br/> Variables are Prompt text, Default Value:<br/>`"math": [ "u_value_to_set", "=", "num_input('Playstyle Perks Cost?', 4)" ]`|
 | pain()     |  ✅  |   ✅   | u, n  | Return or set pain<br/> Example:<br/>`{ "math": [ "n_pain()", "=", "u_pain() + 9000" ] }`|
 | skill(`s`/`v`)    |  ✅  |   ✅   | u, n  | Return or set skill level<br/> Example:<br/>`"condition": { "math": [ "u_skill('driving')", ">=", "5"] }`<br/>`"condition": { "math": [ "u_skill(someskill)", ">=", "5"] }`|
 | weather(`s`)  |  ✅  |   ✅   | N/A<br/>(global)  | Return or set a weather aspect<br/><br/>Aspect must be one of:<br/>`temperature` (in Kelvin),<br/>`humidity` (as percentage),<br/>`pressure` (in millibar),<br/>`windpower` (in mph).<br/><br/>Temperature conversion functions are available: `celsius()`, `fahrenheit()`, `from_celsius()`, and `from_fahrenheit()`.<br/><br/>Examples:<br/>`{ "math": [ "weather('temperature')", "<", "from_fahrenheit( 33 )" ] }`<br/>`{ "math": [ "fahrenheit( weather('temperature') )", "==", "21" ] }`|

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -1,8 +1,10 @@
 #include "cata_utility.h"
 
 #include <cctype>
+#include <cerrno>
 #include <charconv>
 #include <clocale>
+#include <cstdlib>
 #include <cwctype>
 #include <algorithm>
 #include <cmath>
@@ -863,4 +865,16 @@ std::string io::enum_to_string<aggregate_type>( aggregate_type agg )
             break;
     }
     cata_fatal( "Invalid aggregate type." );
+}
+
+std::optional<double> svtod( std::string_view token )
+{
+    char *pEnd = nullptr;
+    double const val = std::strtod( token.data(), &pEnd );
+    if( pEnd == token.data() + token.size() ) {
+        return { val };
+    }
+    errno = 0;
+
+    return std::nullopt;
 }

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -697,4 +697,6 @@ struct overloaded : Ts... {
 template <class... Ts>
 explicit overloaded( Ts... ) -> overloaded<Ts...>;
 
+std::optional<double> svtod( std::string_view token );
+
 #endif // CATA_SRC_CATA_UTILITY_H

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -2,10 +2,9 @@
 
 #include <algorithm>
 #include <array>
-#include <cerrno>
 #include <cstddef>
-#include <cstdlib>
 #include <locale>
+#include <map>
 #include <memory>
 #include <optional>
 #include <stack>
@@ -17,6 +16,8 @@
 #include <vector>
 
 #include "cata_assert.h"
+#include "cata_scope_helpers.h"
+#include "cata_utility.h"
 #include "condition.h"
 #include "debug.h"
 #include "dialogue.h"
@@ -27,6 +28,7 @@
 #include "math_parser_impl.h"
 #include "math_parser_jmath.h"
 #include "string_formatter.h"
+#include "type_id.h"
 
 namespace
 {
@@ -54,23 +56,11 @@ constexpr std::optional<double> get_constant( std::string_view token )
 
 std::optional<double> get_number( std::string_view token )
 {
-    char *pEnd = nullptr;
-    double const val = std::strtod( token.data(), &pEnd );
-    if( pEnd == token.data() + token.size() ) {
-        return { val };
+    if( std::optional<double> ret = svtod( token ); ret ) {
+        return *ret;
     }
-    errno = 0;
 
     return get_constant( token );
-}
-
-constexpr std::optional<std::string_view> get_string( std::string_view token )
-{
-    if( token.front() == '\'' && token.back() == '\'' ) {
-        return { token.substr( 1, token.size() - 2 ) };
-    }
-
-    return std::nullopt;
 }
 
 constexpr std::optional<pmath_func> get_function( std::string_view token )
@@ -126,6 +116,7 @@ struct parse_state {
         operand,
         lparen,  // operand alias used for functions
         rparen,
+        string,
         eof,     // oper alias used for EOF
     };
     static constexpr std::string_view expect_to_string( expect e ) {
@@ -135,6 +126,7 @@ struct parse_state {
             case expect::operand: return "operand";
             case expect::lparen: return "left parenthesis";
             case expect::rparen: return "right parenthesis";
+            case expect::string: return "string delimiter";
             case expect::eof: ;
             // *INDENT-ON*
         }
@@ -154,7 +146,7 @@ struct parse_state {
                                              expect_to_string( next ).data() ) );
         }
     }
-    void set( expect current, bool unary_ok ) {
+    void set( expect current, bool unary_ok = false ) {
         previous = expected;
         expected = current;
         allows_prefix_unary = unary_ok;
@@ -163,6 +155,8 @@ struct parse_state {
     expect expected = expect::operand;
     expect previous = expect::eof;
     bool allows_prefix_unary = true;
+    bool instring = false;
+    std::string_view strpos;
 };
 
 bool is_function( op_t const &op )
@@ -187,6 +181,24 @@ std::vector<double> _eval_params( std::vector<thingie> const &params, dialogue &
         return e.eval( d );
     } );
     return elems;
+}
+
+template<typename T>
+void _validate_operand( thingie const &thing, T op )
+{
+    if( std::holds_alternative<std::string>( thing.data ) ) {
+        throw std::invalid_argument( string_format(
+                                         R"(Operator "%s" does not support string operands)", op->symbol ) );
+    }
+}
+
+void _validate_unused_kwargs( diag_kwargs const &kwargs )
+{
+    for( diag_kwargs::value_type const &v : kwargs ) {
+        if( !v.second.was_used() ) {
+            throw std::invalid_argument( string_format( R"(Unused kwarg "%s")", v.first ) );
+        }
+    }
 }
 
 } // namespace
@@ -220,6 +232,9 @@ double oper::eval( dialogue &d ) const
 class math_exp::math_exp_impl
 {
     public:
+        math_exp_impl() = default;
+        explicit math_exp_impl( thingie &&t ): tree( t ) {}
+
         bool parse( std::string_view str, bool assignment ) {
             if( str.empty() ) {
                 return false;
@@ -265,10 +280,19 @@ class math_exp::math_exp_impl
         std::stack<op_t> ops;
         std::stack<thingie> output;
         struct arity_t {
+            enum class type_t {
+                func = 0,
+                bracket,
+                kwarg,
+            };
+            arity_t( std::string_view sym_, int expected_, type_t type_, bool stringy_ = false ) : sym( sym_ ),
+                expected( expected_ ), type( type_ ), stringy( stringy_ ) {}
             std::string_view sym;
             int current{};
+            size_t nkwargs{};
             int expected{};
-            bool stringy = false;
+            type_t type{};
+            bool stringy{};
         };
         std::stack<arity_t> arity;
         thingie tree{ 0.0 };
@@ -276,7 +300,8 @@ class math_exp::math_exp_impl
         parse_state state;
 
         void _parse( std::string_view str, bool assignment );
-        void parse_string( std::string_view str, parse_state &state );
+        void parse_string( std::string_view token, std::string_view full, parse_state &state );
+        void parse_colon( parse_state &state );
         void parse_bin_op( pbin_op const &op, parse_state &state );
         template<typename T>
         void parse_diag_f( T const &token, parse_state &state );
@@ -289,25 +314,28 @@ class math_exp::math_exp_impl
         void maybe_first_argument();
         void error( std::string_view str, std::string_view what );
         void validate_string( std::string_view str, std::string_view label, std::string_view badlist );
-        std::vector<diag_value> _get_diag_vals( std::vector<thingie> &params,
-                                                size_t nparams ) const;
+        static std::vector<diag_value> _get_diag_vals( std::vector<thingie> &params );
+        static diag_value _get_diag_value( thingie &param );
 };
 
 void math_exp::math_exp_impl::maybe_first_argument()
 {
-    if( !arity.empty() && !arity.top().sym.empty() && arity.top().current == 0 ) {
+    if( !arity.empty() && arity.top().type == arity_t::type_t::func && arity.top().current == 0 ) {
         arity.top().current++;
     }
 }
 
 void math_exp::math_exp_impl::_parse( std::string_view str, bool assignment )
 {
-    constexpr std::string_view expression_separators = "+-*/^,()%";
+    constexpr std::string_view expression_separators = "+-*/^,()%':";
     state = {};
     for( std::string_view const token : tokenize( str, expression_separators ) ) {
         last_token = token;
-        if( std::optional<std::string_view> str = get_string( token ); str ) {
-            parse_string( *str, state );
+        if( state.instring || token == "'" ) {
+            parse_string( token, str, state );
+
+        } else if( token == ":" ) {
+            parse_colon( state );
 
         } else if( std::optional<double> val = get_number( token ); val ) {
             state.validate( parse_state::expect::operand );
@@ -319,14 +347,14 @@ void math_exp::math_exp_impl::_parse( std::string_view str, bool assignment )
             state.validate( parse_state::expect::operand );
             maybe_first_argument();
             ops.emplace( *ftoken );
-            arity.emplace( arity_t{ ( *ftoken )->symbol, 0, ( *ftoken )->num_params } );
+            arity.emplace( ( *ftoken )->symbol, ( *ftoken )->num_params, arity_t::type_t::func );
             state.set( parse_state::expect::lparen, false );
 
         } else if( jmath_func_id jmfid( token ); jmfid.is_valid() ) {
             state.validate( parse_state::expect::operand );
             maybe_first_argument();
             ops.emplace( jmfid );
-            arity.emplace( arity_t{ token, 0, jmfid->num_params } );
+            arity.emplace( token, jmfid->num_params, arity_t::type_t::func );
             state.set( parse_state::expect::lparen, false );
 
         } else if( std::optional<scoped_diag_eval> feval = get_dialogue_eval( token ); feval &&
@@ -380,16 +408,40 @@ void math_exp::math_exp_impl::_parse( std::string_view str, bool assignment )
     output.pop();
 }
 
-void math_exp::math_exp_impl::parse_string( std::string_view str, parse_state &state )
+void math_exp::math_exp_impl::parse_string( std::string_view token, std::string_view full,
+        parse_state &state )
 {
-    state.validate( parse_state::expect::operand );
-    maybe_first_argument();
-    if( arity.empty() || !arity.top().stringy ) {
-        throw std::invalid_argument( "String arguments can only be used in dialogue functions" );
+    if( !state.instring ) {
+        state.validate( parse_state::expect::operand );
+        maybe_first_argument();
+        if( arity.empty() || !arity.top().stringy ) {
+            throw std::invalid_argument( "String arguments can only be used in dialogue functions" );
+        }
+        state.instring = true;
+        state.strpos = token;
+        state.set( parse_state::expect::string );
+    } else if( token == "'" ) {
+        // FIXME: write a better tokenizer that returns the entire quoted string as a single token
+        output.emplace( std::in_place_type_t<std::string>(), full, state.strpos.data() - full.data() + 1,
+                        token.data() - state.strpos.data() - 1 );
+        state.instring = false;
+        state.set( parse_state::expect::oper );
+    } else {
+        // skip tokens inside string
     }
-    validate_string( str, "string", "\'" );
-    output.emplace( std::string{ str } );
-    state.set( parse_state::expect::oper, false );
+}
+
+void math_exp::math_exp_impl::parse_colon( parse_state &state )
+{
+    state.validate( parse_state::expect::oper );
+    if( arity.empty() || arity.top().type != arity_t::type_t::func || output.empty() ||
+        !std::holds_alternative<std::string>( output.top().data ) ) {
+        throw std::invalid_argument( "Misplaced colon or kwarg key is not a string" );
+    }
+    ops.emplace( std::in_place_type_t<kwarg>(), std::get<std::string>( output.top().data ) );
+    arity.emplace( std::string_view{}, 0, arity_t::type_t::kwarg, true );
+    output.pop();
+    state.set( parse_state::expect::operand, true );
 }
 
 void math_exp::math_exp_impl::parse_bin_op( pbin_op const &op, parse_state &state )
@@ -407,14 +459,14 @@ void math_exp::math_exp_impl::parse_diag_f( T const &token, parse_state &state )
 {
     state.validate( parse_state::expect::operand );
     ops.emplace( token );
-    arity.emplace( arity_t{ token.df->symbol, 0, token.df->num_params, true } );
+    arity.emplace( token.df->symbol, token.df->num_params, arity_t::type_t::func, true );
     state.set( parse_state::expect::lparen, false );
 }
 
 void math_exp::math_exp_impl::parse_comma( parse_state &state )
 {
     state.validate( parse_state::expect::oper );
-    if( arity.empty() || arity.top().sym.empty() ) {
+    if( arity.empty() || arity.top().type == arity_t::type_t::bracket ) {
         throw std::invalid_argument( "Misplaced comma" );
     }
     while( ops.top() > paren::left ) {
@@ -428,7 +480,7 @@ void math_exp::math_exp_impl::parse_lparen( parse_state &state )
 {
     state.validate( parse_state::expect::lparen );
     if( ops.empty() || !is_function( ops.top() ) ) {
-        arity.emplace( arity_t{ {}, 0, 0 } );
+        arity.emplace( std::string_view{}, 0, arity_t::type_t::bracket );
     }
     ops.emplace( paren::left );
     state.set( parse_state::expect::operand, true );
@@ -467,20 +519,30 @@ void math_exp::math_exp_impl::new_func()
         }
 
         std::vector<thingie> params( nparams );
+        diag_kwargs kwargs;
+        for( std::vector<kwarg>::size_type i = 0; i < arity.top().nkwargs; i++ ) {
+            if( !std::holds_alternative<kwarg>( output.top().data ) ) {
+                throw std::invalid_argument(
+                    "All positional parameters must precede keyword-value pairs" );
+            }
+            kwarg &kw = std::get<kwarg>( output.top().data );
+            kwargs.emplace( kw.key, _get_diag_value( *kw.val ) );
+            output.pop();
+        }
         for( std::vector<thingie>::size_type i = 0; i < nparams; i++ ) {
             params[nparams - i - 1] = std::move( output.top() );
             output.pop();
         }
         std::visit( overloaded{
-            [&params, nparams, this]( scoped_diag_eval const & v )
+            [&params, &kwargs, this]( scoped_diag_eval const & v )
             {
-                std::vector<diag_value> const strings = _get_diag_vals( params, nparams );
-                output.emplace( std::in_place_type_t<func_diag_eval>(), v.df->f( v.scope, strings ) );
+                std::vector<diag_value> const args = _get_diag_vals( params );
+                output.emplace( std::in_place_type_t<func_diag_eval>(), v.df->f( v.scope, args, kwargs ) );
             },
-            [&params, nparams, this]( scoped_diag_ass const & v )
+            [&params, &kwargs, this]( scoped_diag_ass const & v )
             {
-                std::vector<diag_value> const strings = _get_diag_vals( params, nparams );
-                output.emplace( std::in_place_type_t<func_diag_ass>(), v.df->f( v.scope, strings ) );
+                std::vector<diag_value> const args = _get_diag_vals( params );
+                output.emplace( std::in_place_type_t<func_diag_ass>(), v.df->f( v.scope, args, kwargs ) );
             },
             [&params, this]( pmath_func v )
             {
@@ -496,32 +558,41 @@ void math_exp::math_exp_impl::new_func()
             },
         },
         ops.top() );
+        _validate_unused_kwargs( kwargs );
         ops.pop();
     }
 }
 
-std::vector<diag_value> math_exp::math_exp_impl::_get_diag_vals( std::vector<thingie> &params,
-        size_t nparams ) const
+diag_value math_exp::math_exp_impl::_get_diag_value( thingie &param )
 {
-    std::vector<diag_value> vals( nparams );
-    for( decltype( vals )::size_type i = 0; i < params.size(); i++ ) {
-        std::visit( overloaded{
-            [&vals, i]( std::string & v )
-            {
-                vals[i].data.emplace<std::string>( std::move( v ) );
-            },
-            [&vals, i]( var & v )
-            {
-                vals[i].data.emplace<var_info>( std::move( v.varinfo ) );
-            },
-            [this]( auto const &/* v */ )
-            {
-                throw std::invalid_argument(
-                    string_format( "Parameters for %s() must be variables or strings contained in single quotes",
-                                   arity.top().sym ) );
-            },
+    diag_value val;
+    std::visit( overloaded{
+        [&val]( double v )
+        {
+            val.data.emplace<double>( v );
         },
-        params[i].data );
+        [&val]( std::string & v )
+        {
+            val.data.emplace<std::string>( std::move( v ) );
+        },
+        [&val]( var & v )
+        {
+            val.data.emplace<var_info>( std::move( v.varinfo ) );
+        },
+        [&val, &param]( auto const &/* v */ )
+        {
+            val.data.emplace<math_exp>( math_exp_impl{ std::move( param ) } );
+        },
+    },
+    param.data );
+    return val;
+}
+
+std::vector<diag_value> math_exp::math_exp_impl::_get_diag_vals( std::vector<thingie> &params )
+{
+    std::vector<diag_value> vals( params.size() );
+    for( decltype( vals )::size_type i = 0; i < params.size(); i++ ) {
+        vals[i] = _get_diag_value( params[i] );
     }
     return vals;
 }
@@ -536,6 +607,8 @@ void math_exp::math_exp_impl::new_oper()
             output.pop();
             thingie lhs = std::move( output.top() );
             output.pop();
+            _validate_operand( lhs, v );
+            _validate_operand( rhs, v );
             output.emplace( std::in_place_type_t<oper>(), lhs, rhs, v->f );
         },
         [this]( punary_op v )
@@ -543,7 +616,20 @@ void math_exp::math_exp_impl::new_oper()
             cata_assert( !output.empty() );
             thingie rhs = std::move( output.top() );
             output.pop();
+            _validate_operand( rhs, v );
             output.emplace( std::in_place_type_t<oper>(), thingie { 0.0 }, rhs, v->f );
+        },
+        [this]( kwarg & v )
+        {
+            if( arity.empty() || !arity.top().stringy ) {
+                throw std::invalid_argument( "Kwargs can only be used as parameters for dialogue functions" );
+            }
+            v.val = std::make_shared<thingie>( std::move( output.top() ) );
+            output.pop();
+            output.emplace( std::move( v ) );
+            arity.pop();
+            arity.top().current--;
+            arity.top().nkwargs++;
         },
         []( auto /* v */ )
         {
@@ -611,6 +697,11 @@ void math_exp::math_exp_impl::validate_string( std::string_view str, std::string
         throw std::invalid_argument( string_format( R"(Stray " %c " inside %s operand "%.*s")",
                                      str[pos], label.data(), str.size(), str.data() ) );
     }
+}
+
+math_exp::math_exp( math_exp_impl impl_ )
+    : impl( std::make_unique<math_exp_impl>( std::move( impl_ ) ) )
+{
 }
 
 bool math_exp::parse( std::string_view str, bool assignment )

--- a/src/math_parser.h
+++ b/src/math_parser.h
@@ -9,19 +9,21 @@ struct dialogue;
 class math_exp
 {
     public:
+        class math_exp_impl;
+
         ~math_exp();
         math_exp();
         math_exp( math_exp const &other );
         math_exp( math_exp &&/* other */ ) noexcept;
         math_exp &operator=( math_exp const &other );
         math_exp &operator=( math_exp &&/* other */ ) noexcept;
+        explicit math_exp( math_exp_impl impl_ );
 
         bool parse( std::string_view str, bool assignment = false );
         double eval( dialogue &d ) const;
         void assign( dialogue &d, double val ) const;
 
     private:
-        class math_exp_impl;
         std::unique_ptr<math_exp_impl> impl;
 };
 

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -2,11 +2,13 @@
 
 #include <functional>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "cata_utility.h"
 #include "condition.h"
 #include "dialogue.h"
+#include "game.h"
 #include "math_parser_shim.h"
 #include "options.h"
 #include "string_input_popup.h"
@@ -25,31 +27,95 @@ bool is_beta( char scope )
             return false;
     }
 }
-} // namespace
 
-std::string diag_value::str() const
+template<typename T>
+constexpr std::string_view _str_type_of( T /* t */ )
 {
-    return std::string{ sv() };
+    if constexpr( std::is_same_v<T, double> ) {
+        return "double";
+    } else if constexpr( std::is_same_v<T, std::string> ) {
+        return "string";
+    } else if constexpr( std::is_same_v<T, var_info> ) {
+        return "variable";
+    } else if constexpr( std::is_same_v<T, math_exp> ) {
+        return "sub-expression";
+    }
+    return "cookies";
 }
 
-std::string_view diag_value::sv() const
+} // namespace
+
+double diag_value::dbl() const
+{
+    return std::visit( overloaded{
+        []( double v )
+        {
+            return v;
+        },
+        []( auto const & v ) -> double
+        {
+            throw std::invalid_argument( string_format( "Expected number, got %s", _str_type_of( v ) ) );
+        },
+    },
+    data );
+}
+
+double diag_value::dbl( dialogue const &d ) const
+{
+    return std::visit( overloaded{
+        []( double v )
+        {
+            return v;
+        },
+        []( std::string const & v )
+        {
+            if( std::optional<double> ret = svtod( v ); ret ) {
+                return *ret;
+            }
+            debugmsg( R"(Could not convert string "%s" to double)", v );
+            return 0.0;
+        },
+        [&d]( var_info const & v )
+        {
+            std::string const val = read_var_value( v, d );
+            if( std::optional<double> ret = svtod( val ); ret ) {
+                return *ret;
+            }
+            debugmsg( R"(Could not convert variable "%s" with value "%s" to double)", v.name, val );
+            return 0.0;
+        },
+        [&d]( math_exp const & v )
+        {
+            // FIXME: maybe re-constify eval paths?
+            return v.eval( const_cast<dialogue &>( d ) );
+        }
+    },
+    data );
+}
+
+std::string_view diag_value::str() const
 {
     return std::visit( overloaded{
         []( std::string const & v ) -> std::string const &
         {
             return v;
         },
-        []( var_info const & /* v */ ) -> std::string const &
+        []( auto const & v ) -> std::string const &
         {
-            throw std::invalid_argument( "Variables are not supported in this context" );
+            throw std::invalid_argument( string_format( "Expected string, got %s", _str_type_of( v ) ) );
         },
     },
     data );
 }
 
-std::string diag_value::eval( dialogue const &d ) const
+std::string diag_value::str( dialogue const &d ) const
 {
     return std::visit( overloaded{
+        []( double v )
+        {
+            // NOLINTNEXTLINE(cata-translate-string-literal)
+            return string_format( "%g", v );
+        },
         []( std::string const & v )
         {
             return v;
@@ -58,12 +124,32 @@ std::string diag_value::eval( dialogue const &d ) const
         {
             return read_var_value( v, d );
         },
+        [&d]( math_exp const & v )
+        {
+            // NOLINTNEXTLINE(cata-translate-string-literal)
+            return string_format( "%g", v.eval( const_cast<dialogue &>( d ) ) );
+        }
+    },
+    data );
+}
+
+var_info diag_value::var() const
+{
+    return std::visit( overloaded{
+        []( var_info const & v )
+        {
+            return v;
+        },
+        []( auto const & v ) -> var_info
+        {
+            throw std::invalid_argument( string_format( "Expected variable, got %s", _str_type_of( v ) ) );
+        },
     },
     data );
 }
 
 std::function<double( dialogue & )> u_val( char scope,
-        std::vector<diag_value> const &params )
+        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     kwargs_shim const shim( params, scope );
     try {
@@ -77,7 +163,7 @@ std::function<double( dialogue & )> u_val( char scope,
 }
 
 std::function<void( dialogue &, double )> u_val_ass( char scope,
-        std::vector<diag_value> const &params )
+        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     kwargs_shim const shim( params, scope );
     try {
@@ -89,34 +175,34 @@ std::function<void( dialogue &, double )> u_val_ass( char scope,
 }
 
 std::function<double( dialogue & )> option_eval( char /* scope */,
-        std::vector<diag_value> const &params )
+        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     return[option = params[0]]( dialogue const & d ) {
-        return get_option<float>( option.eval( d ) );
+        return get_option<float>( option.str( d ) );
     };
 }
 
 std::function<double( dialogue & )> armor_eval( char scope,
-        std::vector<diag_value> const &params )
+        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     return[type = params[0], bpid = params[1], beta = is_beta( scope )]( dialogue const & d ) {
-        damage_type_id dt( type.eval( d ) );
-        bodypart_id bp( bpid.eval( d ) );
+        damage_type_id dt( type.str( d ) );
+        bodypart_id bp( bpid.str( d ) );
         return d.actor( beta )->armor_at( dt, bp );
     };
 }
 
 std::function<double( dialogue & )> num_input_eval( char /*scope*/,
-        std::vector<diag_value> const &params )
+        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     return[prompt = params[0], default_val = params[1]]( dialogue const & d ) {
         string_input_popup popup;
-        double dv = std::stod( default_val.eval( d ) );
+        double dv = default_val.dbl( d );
         int popup_val = dv;
         popup
         .title( _( "Input a value:" ) )
         .width( 20 )
-        .description( prompt.eval( d ) )
+        .description( prompt.str( d ) )
         .edit( popup_val );
         if( popup.canceled() ) {
             return dv;
@@ -125,7 +211,8 @@ std::function<double( dialogue & )> num_input_eval( char /*scope*/,
     };
 }
 
-std::function<double( dialogue & )> attack_speed_eval( char scope, std::vector<diag_value> const & )
+std::function<double( dialogue & )> attack_speed_eval( char scope,
+        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d ) {
         return d.actor( beta )->attack_speed();
@@ -133,7 +220,7 @@ std::function<double( dialogue & )> attack_speed_eval( char scope, std::vector<d
 }
 
 std::function<double( dialogue & )> pain_eval( char scope,
-        std::vector<diag_value> const &/* params */ )
+        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
 {
     return [beta = is_beta( scope )]( dialogue const & d ) {
         return d.actor( beta )->pain_cur();
@@ -141,7 +228,7 @@ std::function<double( dialogue & )> pain_eval( char scope,
 }
 
 std::function<void( dialogue &, double )> pain_ass( char scope,
-        std::vector<diag_value> const &/* params */ )
+        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
 {
     return [beta = is_beta( scope )]( dialogue const & d, double val ) {
         d.actor( beta )->set_pain( val );
@@ -149,23 +236,41 @@ std::function<void( dialogue &, double )> pain_ass( char scope,
 }
 
 std::function<double( dialogue & )> skill_eval( char scope,
-        std::vector<diag_value> const &params )
+        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     return [beta = is_beta( scope ), sid = params[0] ]( dialogue const & d ) {
-        return d.actor( beta )->get_skill_level( skill_id( sid.eval( d ) ) );
+        return d.actor( beta )->get_skill_level( skill_id( sid.str( d ) ) );
     };
 }
 
 std::function<void( dialogue &, double )> skill_ass( char scope,
-        std::vector<diag_value> const &params )
+        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     return [beta = is_beta( scope ), sid = params[0] ]( dialogue const & d, double val ) {
-        return d.actor( beta )->set_skill_level( skill_id( sid.eval( d ) ), val );
+        return d.actor( beta )->set_skill_level( skill_id( sid.str( d ) ), val );
+    };
+}
+
+std::function<double( dialogue & )> test_diag( char /* scope */,
+        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+{
+    std::vector<diag_value> all_params( params );
+    for( diag_kwargs::value_type const &v : kwargs ) {
+        if( v.first != "test_unused_kwarg" ) {
+            all_params.emplace_back( *v.second );
+        }
+    }
+    return [all_params]( dialogue const & d ) {
+        double ret = 0;
+        for( diag_value const &v : all_params ) {
+            ret += v.dbl( d );
+        }
+        return ret;
     };
 }
 
 std::function<double( dialogue & )> weather_eval( char /* scope */,
-        std::vector<diag_value> const &params )
+        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     if( params[0] == "temperature" ) {
         return []( dialogue const & ) {
@@ -187,11 +292,11 @@ std::function<double( dialogue & )> weather_eval( char /* scope */,
             return get_weather().weather_precise->pressure;
         };
     }
-    throw std::invalid_argument( "Unknown weather aspect " + params[0].str() );
+    throw std::invalid_argument( string_format( "Unknown weather aspect %s", params[0].str() ) );
 }
 
 std::function<void( dialogue &, double )> weather_ass( char /* scope */,
-        std::vector<diag_value> const &params )
+        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     if( params[0] == "temperature" ) {
         return []( dialogue const &, double val ) {
@@ -218,5 +323,5 @@ std::function<void( dialogue &, double )> weather_ass( char /* scope */,
             get_weather().clear_temp_cache();
         };
     }
-    throw std::invalid_argument( "Unknown weather aspect " + params[0].str() );
+    throw std::invalid_argument( string_format( "Unknown weather aspect %s", params[0].str() ) );
 }

--- a/src/math_parser_diag.h
+++ b/src/math_parser_diag.h
@@ -1,7 +1,6 @@
 #ifndef CATA_SRC_MATH_PARSER_DIAG_H
 #define CATA_SRC_MATH_PARSER_DIAG_H
 
-#include <array>
 #include <functional>
 #include <map>
 #include <string>
@@ -14,9 +13,8 @@
 class math_exp;
 struct dialogue;
 struct dialogue_func {
-    dialogue_func( std::string_view s_, std::string_view sc_, int n_ ) : symbol( s_ ),
+    dialogue_func( std::string_view sc_, int n_ ) :
         scopes( sc_ ), num_params( n_ ) {}
-    std::string_view symbol;
     std::string_view scopes;
     int num_params{};
 };
@@ -75,8 +73,8 @@ struct dialogue_func_eval : dialogue_func {
     using f_t = std::function<double( dialogue & )> ( * )( char scope,
                 std::vector<diag_value> const &, diag_kwargs const & );
 
-    dialogue_func_eval( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
-        : dialogue_func( s_, sc_, n_ ), f( f_ ) {}
+    dialogue_func_eval( std::string_view sc_, int n_, f_t f_ )
+        : dialogue_func( sc_, n_ ), f( f_ ) {}
 
     f_t f;
 };
@@ -85,8 +83,8 @@ struct dialogue_func_ass : dialogue_func {
     using f_t = std::function<void( dialogue &, double )> ( * )( char scope,
                 std::vector<diag_value> const &, diag_kwargs const & );
 
-    dialogue_func_ass( std::string_view s_, std::string_view sc_, int n_, f_t f_ )
-        : dialogue_func( s_, sc_, n_ ), f( f_ ) {}
+    dialogue_func_ass( std::string_view sc_, int n_, f_t f_ )
+        : dialogue_func( sc_, n_ ), f( f_ ) {}
 
     f_t f;
 };
@@ -113,23 +111,23 @@ decl_diag_ass u_val_ass;
 decl_diag_eval weather_eval;
 decl_diag_ass weather_ass;
 
-inline std::array<dialogue_func_eval, 9> const dialogue_eval_f{
-    dialogue_func_eval{ "_test_diag_", "g", -1, test_diag },
-    dialogue_func_eval{ "val", "un", -1, u_val },
-    dialogue_func_eval{ "game_option", "g", 1, option_eval },
-    dialogue_func_eval{ "pain", "un", 0, pain_eval },
-    dialogue_func_eval{ "skill", "un", 1, skill_eval },
-    dialogue_func_eval{ "weather", "g", 1, weather_eval },
-    dialogue_func_eval{ "armor", "un", 2, armor_eval },
-    dialogue_func_eval{ "num_input", "g", 2, num_input_eval },
-    dialogue_func_eval{ "attack_speed", "un", 0, attack_speed_eval }
+inline std::map<std::string_view, dialogue_func_eval> const dialogue_eval_f{
+    { "_test_diag_", { "g", -1, test_diag } },
+    { "armor", { "un", 2, armor_eval } },
+    { "attack_speed", { "un", 0, attack_speed_eval } },
+    { "game_option", { "g", 1, option_eval } },
+    { "num_input", { "g", 2, num_input_eval } },
+    { "pain", { "un", 0, pain_eval } },
+    { "skill", { "un", 1, skill_eval } },
+    { "val", { "un", -1, u_val } },
+    { "weather", { "g", 1, weather_eval } },
 };
 
-inline std::array<dialogue_func_ass, 4> const dialogue_assign_f{
-    dialogue_func_ass{ "val", "un", -1, u_val_ass },
-    dialogue_func_ass{ "pain", "un", 0, pain_ass },
-    dialogue_func_ass{ "skill", "un", 1, skill_ass },
-    dialogue_func_ass{ "weather", "g", 1, weather_ass },
+inline std::map<std::string_view, dialogue_func_ass> const dialogue_assign_f{
+    { "pain", { "un", 0, pain_ass } },
+    { "skill", { "un", 1, skill_ass } },
+    { "val", { "un", -1, u_val_ass } },
+    { "weather", { "g", 1, weather_ass } },
 };
 
 #endif // CATA_SRC_MATH_PARSER_DIAG_H

--- a/src/math_parser_diag.h
+++ b/src/math_parser_diag.h
@@ -116,7 +116,7 @@ decl_diag_ass weather_ass;
 inline std::array<dialogue_func_eval, 9> const dialogue_eval_f{
     dialogue_func_eval{ "_test_diag_", "g", -1, test_diag },
     dialogue_func_eval{ "val", "un", -1, u_val },
-    dialogue_func_eval{ "game_option", "g", -1, option_eval },
+    dialogue_func_eval{ "game_option", "g", 1, option_eval },
     dialogue_func_eval{ "pain", "un", 0, pain_eval },
     dialogue_func_eval{ "skill", "un", 1, skill_eval },
     dialogue_func_eval{ "weather", "g", 1, weather_eval },

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -117,6 +117,12 @@ struct var {
 
     var_info varinfo;
 };
+struct kwarg {
+    kwarg() = default;
+    explicit kwarg( std::string_view key_ ): key( key_ ) {}
+    std::string key;
+    std::shared_ptr<thingie> val;
+};
 struct thingie {
     thingie() = default;
     template <class U>
@@ -128,7 +134,7 @@ struct thingie {
     constexpr double eval( dialogue &d ) const;
 
     using impl_t =
-        std::variant<double, std::string, oper, func, func_jmath, func_diag_eval, func_diag_ass, var>;
+        std::variant<double, std::string, oper, func, func_jmath, func_diag_eval, func_diag_ass, var, kwarg>;
     impl_t data;
 };
 
@@ -145,6 +151,11 @@ constexpr double thingie::eval( dialogue &d ) const
             debugmsg( "Unexpected string operand %.*s", v.size(), v.data() );
             return 0.0;
         },
+        []( kwarg const & v )
+        {
+            debugmsg( "Unexpected kwarg %s", v.key );
+            return 0.0;
+        },
         [&d]( auto const & v ) -> double
         {
             return v.eval( d );
@@ -154,7 +165,7 @@ constexpr double thingie::eval( dialogue &d ) const
 }
 
 using op_t =
-    std::variant<pbin_op, punary_op, pmath_func, jmath_func_id, scoped_diag_eval, scoped_diag_ass, paren>;
+    std::variant<pbin_op, punary_op, pmath_func, jmath_func_id, scoped_diag_eval, scoped_diag_ass, paren, kwarg>;
 
 constexpr bool operator>( op_t const &lhs, binary_op const &rhs )
 {

--- a/src/math_parser_shim.cpp
+++ b/src/math_parser_shim.cpp
@@ -12,7 +12,7 @@ kwargs_shim::kwargs_shim( std::vector<diag_value> const &tokens, char scope )
 {
     bool positional = false;
     for( diag_value const &token : tokens ) {
-        std::vector<std::string_view> parts = tokenize( token.sv(), ":", false );
+        std::vector<std::string_view> parts = tokenize( token.str(), ":", false );
         if( parts.size() == 1 && !positional ) {
             kwargs.emplace(
                 // NOLINTNEXTLINE(cata-translate-string-literal): not a user-visible string
@@ -22,7 +22,7 @@ kwargs_shim::kwargs_shim( std::vector<diag_value> const &tokens, char scope )
         } else if( parts.size() == 2 ) {
             kwargs.emplace( parts[0], parts[1] );
         } else {
-            debugmsg( "Too many parts in token %s", token.sv() );
+            debugmsg( "Too many parts in token %s", token.str() );
         }
     }
 }

--- a/src/math_parser_shim.h
+++ b/src/math_parser_shim.h
@@ -1,10 +1,12 @@
 #ifndef CATA_SRC_MATH_PARSER_SHIM_H
 #define CATA_SRC_MATH_PARSER_SHIM_H
 
+#include <limits>
 #include <map>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "flexbuffer_json.h"
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4049,6 +4049,8 @@ options_manager::cOpt &options_manager::get_option( const std::string &name )
     std::unordered_map<std::string, cOpt>::iterator opt = options.find( name );
     if( opt == options.end() ) {
         debugmsg( "requested non-existing option %s", name );
+        static cOpt nullopt;
+        return nullopt;
     }
     if( !world_options.has_value() ) {
         // Global options contains the default for new worlds, which is good enough here.

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -115,6 +115,25 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
     CHECK( testexp.parse( "2 * 1.5" ) );
     CHECK( testexp.eval( d ) == Approx( 3 ) );
 
+    // diag functions. _test_diag adds up all the (kw)args except for "test_unused_kwarg"
+    CHECK( testexp.parse( "_test_diag_('1', 2, 3*4)" ) ); // mixed arg types
+    CHECK( testexp.eval( d ) == Approx( 15 ) );
+    CHECK( testexp.parse( "_test_diag_('1+2*3:() sin(1)')" ) ); // string with token delimiters
+    CHECK( testexp.parse( "_test_diag_(sin(pi), _test_diag_('1'))" ) ); // compounding
+    CHECK( testexp.eval( d ) == Approx( 1 ) );
+    CHECK( testexp.parse( "_test_diag_('1':'2')" ) );  // string kwarg
+    CHECK( testexp.eval( d ) == Approx( 2 ) );
+    CHECK( testexp.parse( "_test_diag_(1, '2', '1':'2', '3':'4')" ) );  // kwargs after positional
+    CHECK( testexp.eval( d ) == Approx( 9 ) );
+    CHECK( testexp.parse( "_test_diag_('1':2)" ) );  // double kwarg
+    CHECK( testexp.eval( d ) == Approx( 2 ) );
+    CHECK( testexp.parse( "_test_diag_('1':2*3)" ) );  // sub-expression kwarg
+    CHECK( testexp.eval( d ) == Approx( 6 ) );
+    CHECK( testexp.parse( "_test_diag_('1':3.5*sin(pi/2))" ) );  // sub-expression kwarg
+    CHECK( testexp.eval( d ) == Approx( 3.5 ) );
+    CHECK( testexp.parse( "_test_diag_('1':2*_test_diag_('2':'3'))" ) );  // kwarg compounding
+    CHECK( testexp.eval( d ) == Approx( 6 ) );
+
     // failed validation
     // NOLINTNEXTLINE(readability-function-cognitive-complexity): false positive
     std::string dmsg = capture_debugmsg_during( [&testexp, &d]() {
@@ -138,7 +157,17 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
         CHECK_FALSE( testexp.parse( "_test_(1)" ) );
         CHECK_FALSE( testexp.parse( "'string'" ) );
         CHECK_FALSE( testexp.parse( "('wrong')" ) );
-        CHECK_FALSE( testexp.parse( "u_val('wr'ong')" ) ); // stray ' inside string
+        CHECK_FALSE( testexp.parse( "_test_diag_('wr'ong')" ) ); // stray ' inside string
+        CHECK_FALSE( testexp.parse( "_test_diag_('wrong)" ) ); // unterminated string
+        CHECK_FALSE( testexp.parse( "_test_diag_('1'+'2')" ) );  // no string operators (yet)
+        CHECK_FALSE( testexp.parse( "_test_diag_(1:'2')" ) );    // kwarg key is not string
+        CHECK_FALSE( testexp.parse( "_test_diag_('1':'2', 3)" ) ); // positional after kwargs
+        CHECK_FALSE( testexp.parse( "_test_diag_('test_unused_kwarg': 'mustfail')" ) ); // unused kwarg
+        CHECK_FALSE( testexp.parse( "_test_diag_('1':'2':)" ) );
+        CHECK_FALSE( testexp.parse( "_test_diag_('1':'2':'3')" ) );
+        CHECK_FALSE( testexp.parse( "_test_diag_(:)" ) );
+        CHECK_FALSE( testexp.parse( "sin('1':'2')" ) ); // no kwargs in math functions (yet?)
+        CHECK_FALSE( testexp.parse( "'1':'2'" ) );
         CHECK_FALSE( testexp.parse( "2 2*2" ) ); // stray space inside variable name
         CHECK_FALSE( testexp.parse( "2+++2" ) );
         CHECK( testexp.parse( "2+3" ) );
@@ -177,7 +206,7 @@ TEST_CASE( "math_parser_dialogue_integration", "[math_parser]" )
 
     // reading scoped values with u_val shim
     std::string dmsg = capture_debugmsg_during( [&testexp]() {
-        CHECK_FALSE( testexp.parse( "u_val( 3 )" ) ); // only quoted strings or variables accepted
+        CHECK_FALSE( testexp.parse( "u_val( 3 )" ) ); // this function doesn't support numbers
         CHECK_FALSE( testexp.parse( "u_val(myval)" ) ); // this function doesn't support variables
         CHECK_FALSE( testexp.parse( "val( 'stamina' )" ) ); // invalid scope for this function
     } );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Dialogue functions in the math parser are currently a bit of a hack that circumvents most of the parser and so they don't support almost any of its features.

Some EOC functions can't be ported cleanly without optional named parameters.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Integrate dialogue functions more tightly into the math parser:
- allow doubles and math sub-expressions to be passed as parameters, instead of just strings and variables
- add support for optional named parameters (kwargs)

An example with the new features:
```JSON
"condition": { "math": [ "u_monsters_nearby( 'radius': sin(u_somevar * pi/2) + 5, 'location': some_loc_var )", ">", "10" ] }
```

Also did a bit of housekeeping on the diag interface that should reduce churn in the future:
- dialogue function declarations on the C++ side now use a typedef
- functions are stored in a map
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Instead of real kwargs I could have promoted string processing similar to the existing processing of string tags like `<global_val:blorg>`: I'd rather have all the parsing done in one place with one codebase. Also, putting a parser in a parser in a parser is a little too much even if you really like parsleyrs.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Updated test unit with that provides 95% coverage for `math_parser`.

Also fuzzed for about a day with this fuzz target https://github.com/andrei8l/Cataclysm-DDA/commit/869e7246cc8d56fc7056ddbaaa3b9daa636466ec.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
I also ported the `u_val` shim to real kwargs, but decided against including it in order to reduce churn. I will instead focus on porting the few EOC functions that need kwargs ASAP, then remove the fake kwargs from the shim entirely.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->