### PR TITLE
sprayable chloramine actually uses bleach/ammonia

### DIFF
--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -875,10 +875,10 @@
       [ "recipe_labchem", 3 ],
       [ "textbook_anarch", 3 ]
     ],
-    "proficiencies": [ { "proficiency": "prof_intro_chemistry" }, { "proficiency": "prof_inorganic_chemistry" } ],
+    "proficiencies": [ { "proficiency": "prof_intro_chemistry" } ],
     "qualities": [ { "id": "CHEM", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
-    "components": [ [ [ "oxy_powder", 100 ] ], [ [ "lye_powder", 100 ] ] ]
+    "components": [ [ [ "bleach", 1 ] ], [ [ "ammonia_hydroxide", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -877,7 +877,6 @@
     ],
     "proficiencies": [ { "proficiency": "prof_intro_chemistry" } ],
     "qualities": [ { "id": "CHEM", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
     "components": [ [ [ "bleach", 1 ] ], [ [ "ammonia_hydroxide", 1 ] ] ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Chloramine is made of liquid cleaner instead of powders"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Sprayable toxic gas is chloramine, made of ammonia hydroxide and bleach, but the in game recipe was made of powdered lye and "oxidizer powder" (which is an ambiguous old material). As far as I can tell mixing powders wouldn't produce a toxic gas. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Previously the recipe used 125 ml each of oxidizer and lye powder. Now it's bleach and ammonia solution, 1 each (each unit is 0.125 liters as a gallon jug has 30)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Liquid lye and bleach? The ratio would need to be bumped up because lye liquid is 0.25 liters.
- Liquid Ammonia and bleach? (So actual chlorine gas instead of chloramine, to justify the lethality of poison gas clouds against mobs)
- Is the surface heat needed? you're just pressurizing some gas and then spraying it and you don't need to hotplate the bleach and ammonia to get the gas.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->