### PR TITLE
Refresh crafting speed less frequently

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3306,15 +3306,16 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         level_up |= crafter.craft_skill_gain( craft, num_practice_ticks );
     }
     int refresh_ratio;
-    if( cur_total_moves < 100'000 ) { // less than 1000 turns (~20min)
+    if( cur_total_moves < 1'000 ) { // less than 1000 turns (~20min)
         refresh_ratio = 1; // every turn
     } else if( cur_total_moves < 1'000'000 ) { // less than 10000 turns (~3hr)
-        refresh_ratio = cur_total_moves / 1000; // every 10 turns
+        refresh_ratio = 10; // every 10 turns
     } else {
-        refresh_ratio = cur_total_moves / 10000; // every 100 turns
+        refresh_ratio = 100; // every 100 turns
     }
-    int one_percent_steps = craft.item_counter / refresh_ratio - old_counter / refresh_ratio;
-    if( one_percent_steps > 0 ) {
+    int turns_advanced = ( craft.item_counter * cur_total_moves - old_counter * cur_total_moves ) /
+                         10'000'000'00;
+    if( turns_advanced > refresh_ratio ) {
         refresh_speed = true;
     }
     // Proficiencies and tools are gained/consumed after every 5% progress

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3305,7 +3305,15 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     if( num_practice_ticks > 0 ) {
         level_up |= crafter.craft_skill_gain( craft, num_practice_ticks );
     }
-    int one_percent_steps = craft.item_counter / 100'000 - old_counter / 100'000;
+    int refresh_ratio;
+    if( cur_total_moves < 100'000 ) { // less than 1000 turns (~20min)
+        refresh_ratio = 1; // every turn
+    } else if( cur_total_moves < 1'000'000 ) { // less than 10000 turns (~3hr)
+        refresh_ratio = cur_total_moves / 1000; // every 10 turns
+    } else {
+        refresh_ratio = cur_total_moves / 10000; // every 100 turns
+    }
+    int one_percent_steps = craft.item_counter / refresh_ratio - old_counter / refresh_ratio;
     if( one_percent_steps > 0 ) {
         refresh_speed = true;
     }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -891,7 +891,7 @@ class craft_activity_actor : public activity_actor
         int cached_assistants; // NOLINT(cata-serialize)
         double cached_base_total_moves; // NOLINT(cata-serialize)
         double cached_cur_total_moves; // NOLINT(cata-serialize)
-
+        bool refresh_speed; // NOLINT(cata-serialize)
         bool check_if_craft_okay( item_location &craft_item, Character &crafter );
     public:
         craft_activity_actor( item_location &it, bool is_long );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -1264,13 +1264,13 @@ TEST_CASE( "crafting_skill_gain", "[skill],[crafting],[slow]" )
     }
     SECTION( "lvl 7 -> 8" ) {
         GIVEN( "nominal morale" ) {
-            test_skill_progression( recipe_armguard_lightplate, 52138, 0, true );
+            test_skill_progression( recipe_armguard_lightplate, 52139, 0, true );
         }
         GIVEN( "high morale" ) {
-            test_skill_progression( recipe_armguard_lightplate, 42657, 50, true );
+            test_skill_progression( recipe_armguard_lightplate, 42658, 50, true );
         }
         GIVEN( "very high morale" ) {
-            test_skill_progression( recipe_armguard_lightplate, 39079, 100, true );
+            test_skill_progression( recipe_armguard_lightplate, 39080, 100, true );
         }
     }
     SECTION( "lvl 8 -> 9" ) {
@@ -1297,15 +1297,15 @@ TEST_CASE( "crafting_skill_gain", "[skill],[crafting],[slow]" )
     }
     SECTION( "long craft with proficiency delays" ) {
         GIVEN( "nominal morale" ) {
-            test_skill_progression( recipe_longbow, 71192, 0, false );
+            test_skill_progression( recipe_longbow, 71201, 0, false );
             test_skill_progression( recipe_longbow, 28805, 0, true );
         }
         GIVEN( "high morale" ) {
-            test_skill_progression( recipe_longbow, 56945, 50, false );
+            test_skill_progression( recipe_longbow, 56957, 50, false );
             test_skill_progression( recipe_longbow, 23609, 50, true );
         }
         GIVEN( "very high morale" ) {
-            test_skill_progression( recipe_longbow, 52211, 100, false );
+            test_skill_progression( recipe_longbow, 52227, 100, false );
             test_skill_progression( recipe_longbow, 21651, 100, true );
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Refresh crafting speed less frequently"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Mitigate #63586.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Refresh crafting speed every 1, 10 or 100 turns, according to recipe time. For recipes that need 20min or less to craft, the behavior remains unchanged. For recipes that need 20min to around 3 hrs, refresh crafting speed every 10 turns. For recipes that need more 3 hrs, refresh crafting speed every 100 turns. Because every factor of crafting speed (lighting, workbench, morale and mutation) is a gradually transitioning or mostly consistent thing. So I think this approximation is not that unacceptable. 

Using figures from [here](https://github.com/CleverRaven/Cataclysm-DDA/issues/63586#issuecomment-1470034659), ~130 seconds is taken when checking everything every turn, and ~12s is taken when checking a portion of things every turn. So I think at least 130-12=118 seconds are consumed to actually check everything. 

For a 7hr30min in-game recipe, everything are checked 27000 times (turns.) Now they are checked 90% or 99% lesser frequently. This is especially good for long recipes.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Refresh crafting speed every 1% or 0.1% of progress. This is not ideal, because for extremely long recipes ( that take seasons or years to craft, 0.1% might still be a too big step.


<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Using the save from [here](https://github.com/CleverRaven/Cataclysm-DDA/issues/63586#issuecomment-1470034659).

Crafting a steel plate ( 9 hr recipe ) when both doors are closed consumed 7.7s.

Crafting a steel plate when both doors are open consumed ~16s. Far better than 2min-2min40s.

Crafting a lutefisk ( 18 min recipe ) when both doors are open consumed 9s.

Crafting a meat_tainted ( 1hr 30min recipe ) when both doors are open consumed 6.7s.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->