### PR TITLE
Cache crafting speed's workbench multiplier

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3200,7 +3200,7 @@ craft_activity_actor::craft_activity_actor( item_location &it, const bool is_lon
     cached_assistants = 0;
     cached_base_total_moves = 1;
     cached_cur_total_moves = 1;
-    cached_workbench_multipler = -1;
+    cached_workbench_multiplier = -1;
 }
 
 bool craft_activity_actor::check_if_craft_okay( item_location &craft_item, Character &crafter )
@@ -3236,7 +3236,7 @@ void craft_activity_actor::start( player_activity &act, Character &crafter )
     }
     activity_override = craft_item.get_item()->get_making().exertion_level();
     cached_crafting_speed = 0;
-    cached_workbench_multipler = -1;
+    cached_workbench_multiplier = -1;
 }
 
 void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
@@ -3253,7 +3253,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
             ? std::optional<tripoint>() : std::optional<tripoint>( craft_item.position() );
     const recipe &rec = craft.get_making();
     const float crafting_speed = crafter.crafting_speed_multiplier( craft, location,
-                                 cached_workbench_multipler );
+                                 cached_workbench_multiplier );
     const int assistants = crafter.available_assistant_count( craft.get_making() );
 
     if( crafting_speed <= 0.0f ) {
@@ -3316,7 +3316,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         level_up |= crafter.craft_proficiency_gain( craft, pct_time * five_percent_steps );
         // Invalidate the crafting time cache because proficiencies may have changed
         cached_crafting_speed = 0;
-        cached_workbench_multipler = -1;
+        cached_workbench_multiplier = -1;
     }
 
     // Unlike skill, tools are consumed once at the start and should not be consumed at the end
@@ -4664,7 +4664,7 @@ void disassemble_activity_actor::start( player_activity &act, Character &who )
 
     activity_override = target->get_making().exertion_level();
 
-    cached_workbench_multipler = -1;
+    cached_workbench_multiplier = -1;
 }
 
 void disassemble_activity_actor::do_turn( player_activity &act, Character &who )
@@ -4680,7 +4680,7 @@ void disassemble_activity_actor::do_turn( player_activity &act, Character &who )
     const std::optional<tripoint> location = target.where() == item_location::type::character
             ? std::optional<tripoint>() : std::optional<tripoint>( target.position() );
     const float crafting_speed = who.crafting_speed_multiplier( craft, location,
-                                 cached_workbench_multipler );
+                                 cached_workbench_multiplier );
 
     if( crafting_speed <= 0.0f ) {
         who.cancel_activity();

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3253,7 +3253,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
             ? std::optional<tripoint>() : std::optional<tripoint>( craft_item.position() );
     const recipe &rec = craft.get_making();
     const float crafting_speed = crafter.crafting_speed_multiplier( craft, location,
-                                 cached_workbench_multiplier );
+                                 &cached_workbench_multiplier );
     const int assistants = crafter.available_assistant_count( craft.get_making() );
 
     if( crafting_speed <= 0.0f ) {
@@ -4680,7 +4680,7 @@ void disassemble_activity_actor::do_turn( player_activity &act, Character &who )
     const std::optional<tripoint> location = target.where() == item_location::type::character
             ? std::optional<tripoint>() : std::optional<tripoint>( target.position() );
     const float crafting_speed = who.crafting_speed_multiplier( craft, location,
-                                 cached_workbench_multiplier );
+                                 &cached_workbench_multiplier );
 
     if( crafting_speed <= 0.0f ) {
         who.cancel_activity();

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3200,7 +3200,8 @@ craft_activity_actor::craft_activity_actor( item_location &it, const bool is_lon
     cached_assistants = 0;
     cached_base_total_moves = 1;
     cached_cur_total_moves = 1;
-    cached_workbench_multiplier = -1;
+    cached_workbench_multiplier = 0;
+    use_cached_workbench_multiplier = false;
 }
 
 bool craft_activity_actor::check_if_craft_okay( item_location &craft_item, Character &crafter )
@@ -3236,7 +3237,8 @@ void craft_activity_actor::start( player_activity &act, Character &crafter )
     }
     activity_override = craft_item.get_item()->get_making().exertion_level();
     cached_crafting_speed = 0;
-    cached_workbench_multiplier = -1;
+    cached_workbench_multiplier = 0;
+    use_cached_workbench_multiplier = false;
 }
 
 void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
@@ -3252,8 +3254,13 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     const std::optional<tripoint> location = craft_item.where() == item_location::type::character
             ? std::optional<tripoint>() : std::optional<tripoint>( craft_item.position() );
     const recipe &rec = craft.get_making();
+    if( !use_cached_workbench_multiplier ) {
+        cached_workbench_multiplier = crafter.workbench_crafting_speed_multiplier( craft, location );
+        use_cached_workbench_multiplier = true;
+    }
     const float crafting_speed = crafter.crafting_speed_multiplier( craft, location,
-                                 &cached_workbench_multiplier );
+                                 use_cached_workbench_multiplier,
+                                 cached_workbench_multiplier );
     const int assistants = crafter.available_assistant_count( craft.get_making() );
 
     if( crafting_speed <= 0.0f ) {
@@ -3316,7 +3323,8 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         level_up |= crafter.craft_proficiency_gain( craft, pct_time * five_percent_steps );
         // Invalidate the crafting time cache because proficiencies may have changed
         cached_crafting_speed = 0;
-        cached_workbench_multiplier = -1;
+        // Also reset the multiplier
+        use_cached_workbench_multiplier = false;
     }
 
     // Unlike skill, tools are consumed once at the start and should not be consumed at the end
@@ -4664,7 +4672,8 @@ void disassemble_activity_actor::start( player_activity &act, Character &who )
 
     activity_override = target->get_making().exertion_level();
 
-    cached_workbench_multiplier = -1;
+    cached_workbench_multiplier = 0;
+    use_cached_workbench_multiplier = false;
 }
 
 void disassemble_activity_actor::do_turn( player_activity &act, Character &who )
@@ -4679,8 +4688,12 @@ void disassemble_activity_actor::do_turn( player_activity &act, Character &who )
 
     const std::optional<tripoint> location = target.where() == item_location::type::character
             ? std::optional<tripoint>() : std::optional<tripoint>( target.position() );
+    if( !use_cached_workbench_multiplier ) {
+        cached_workbench_multiplier = who.workbench_crafting_speed_multiplier( craft, location );
+        use_cached_workbench_multiplier = true;
+    }
     const float crafting_speed = who.crafting_speed_multiplier( craft, location,
-                                 &cached_workbench_multiplier );
+                                 use_cached_workbench_multiplier, cached_workbench_multiplier );
 
     if( crafting_speed <= 0.0f ) {
         who.cancel_activity();

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -891,7 +891,7 @@ class craft_activity_actor : public activity_actor
         int cached_assistants; // NOLINT(cata-serialize)
         double cached_base_total_moves; // NOLINT(cata-serialize)
         double cached_cur_total_moves; // NOLINT(cata-serialize)
-        float cached_workbench_multipler; // NOLINT(cata-serialize)
+        float cached_workbench_multiplier; // NOLINT(cata-serialize)
         bool check_if_craft_okay( item_location &craft_item, Character &crafter );
     public:
         craft_activity_actor( item_location &it, bool is_long );
@@ -1199,7 +1199,7 @@ class disassemble_activity_actor : public activity_actor
     private:
         int moves_total;
         float activity_override = NO_EXERCISE; // NOLINT(cata-serialize)
-        float cached_workbench_multipler; // NOLINT(cata-serialize)
+        float cached_workbench_multiplier; // NOLINT(cata-serialize)
     public:
         item_location target;
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -892,6 +892,7 @@ class craft_activity_actor : public activity_actor
         double cached_base_total_moves; // NOLINT(cata-serialize)
         double cached_cur_total_moves; // NOLINT(cata-serialize)
         float cached_workbench_multiplier; // NOLINT(cata-serialize)
+        bool use_cached_workbench_multiplier; // NOLINT(cata-serialize)
         bool check_if_craft_okay( item_location &craft_item, Character &crafter );
     public:
         craft_activity_actor( item_location &it, bool is_long );
@@ -1200,6 +1201,7 @@ class disassemble_activity_actor : public activity_actor
         int moves_total;
         float activity_override = NO_EXERCISE; // NOLINT(cata-serialize)
         float cached_workbench_multiplier; // NOLINT(cata-serialize)
+        bool use_cached_workbench_multiplier; // NOLINT(cata-serialize)
     public:
         item_location target;
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -891,7 +891,7 @@ class craft_activity_actor : public activity_actor
         int cached_assistants; // NOLINT(cata-serialize)
         double cached_base_total_moves; // NOLINT(cata-serialize)
         double cached_cur_total_moves; // NOLINT(cata-serialize)
-
+        float cached_workbench_multipler; // NOLINT(cata-serialize)
         bool check_if_craft_okay( item_location &craft_item, Character &crafter );
     public:
         craft_activity_actor( item_location &it, bool is_long );
@@ -1199,7 +1199,7 @@ class disassemble_activity_actor : public activity_actor
     private:
         int moves_total;
         float activity_override = NO_EXERCISE; // NOLINT(cata-serialize)
-
+        float cached_workbench_multipler; // NOLINT(cata-serialize)
     public:
         item_location target;
 

--- a/src/character.h
+++ b/src/character.h
@@ -3128,7 +3128,7 @@ class Character : public Creature, public visitable
         float crafting_speed_multiplier( const recipe &rec ) const;
         /** For use with in progress crafts */
         float crafting_speed_multiplier( const item &craft, const std::optional<tripoint> &loc,
-                                         float &cached_workbench_multiplier ) const;
+                                         float *cached_workbench_multiplier = nullptr ) const;
         int available_assistant_count( const recipe &rec ) const;
         /**
          * Expected time to craft a recipe, with assumption that multipliers stay constant.

--- a/src/character.h
+++ b/src/character.h
@@ -3128,7 +3128,7 @@ class Character : public Creature, public visitable
         float crafting_speed_multiplier( const recipe &rec ) const;
         /** For use with in progress crafts */
         float crafting_speed_multiplier( const item &craft, const std::optional<tripoint> &loc,
-                                         float &cached_workbench_multipler ) const;
+                                         float &cached_workbench_multiplier ) const;
         int available_assistant_count( const recipe &rec ) const;
         /**
          * Expected time to craft a recipe, with assumption that multipliers stay constant.

--- a/src/character.h
+++ b/src/character.h
@@ -3131,7 +3131,7 @@ class Character : public Creature, public visitable
         /** For use with in progress crafts.
          *  Workbench multiplier calculation (especially finding lifters nearby)
          *  is expensive when numorous items are around.
-         *  So use pre-calculated cache if possible. 
+         *  So use pre-calculated cache if possible.
          */
         float crafting_speed_multiplier( const item &craft, const std::optional<tripoint> &loc,
                                          bool use_cached_workbench_multiplier = false, float cached_workbench_multiplier = 0.0f

--- a/src/character.h
+++ b/src/character.h
@@ -3126,9 +3126,16 @@ class Character : public Creature, public visitable
         float morale_crafting_speed_multiplier( const recipe &rec ) const;
         float lighting_craft_speed_multiplier( const recipe &rec ) const;
         float crafting_speed_multiplier( const recipe &rec ) const;
-        /** For use with in progress crafts */
+        float workbench_crafting_speed_multiplier( const item &craft,
+                const std::optional<tripoint> &loc )const;
+        /** For use with in progress crafts.
+         *  Workbench multiplier calculation (especially finding lifters nearby)
+         *  is expensive when numorous items are around.
+         *  So use pre-calculated cache if possible. 
+         */
         float crafting_speed_multiplier( const item &craft, const std::optional<tripoint> &loc,
-                                         float *cached_workbench_multiplier = nullptr ) const;
+                                         bool use_cached_workbench_multiplier = false, float cached_workbench_multiplier = 0.0f
+                                       ) const;
         int available_assistant_count( const recipe &rec ) const;
         /**
          * Expected time to craft a recipe, with assumption that multipliers stay constant.

--- a/src/character.h
+++ b/src/character.h
@@ -3127,7 +3127,8 @@ class Character : public Creature, public visitable
         float lighting_craft_speed_multiplier( const recipe &rec ) const;
         float crafting_speed_multiplier( const recipe &rec ) const;
         /** For use with in progress crafts */
-        float crafting_speed_multiplier( const item &craft, const std::optional<tripoint> &loc ) const;
+        float crafting_speed_multiplier( const item &craft, const std::optional<tripoint> &loc,
+                                         float &cached_workbench_multipler ) const;
         int available_assistant_count( const recipe &rec ) const;
         /**
          * Expected time to craft a recipe, with assumption that multipliers stay constant.

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -275,7 +275,7 @@ float Character::crafting_speed_multiplier( const recipe &rec ) const
 }
 
 float Character::crafting_speed_multiplier( const item &craft,
-        const std::optional<tripoint> &loc ) const
+        const std::optional<tripoint> &loc, float &cached_workbench_multipler ) const
 {
     if( !craft.is_craft() ) {
         debugmsg( "Can't calculate crafting speed multiplier of non-craft '%s'", craft.tname() );
@@ -285,7 +285,9 @@ float Character::crafting_speed_multiplier( const item &craft,
     const recipe &rec = craft.get_making();
 
     const float light_multi = lighting_craft_speed_multiplier( rec );
-    const float bench_multi = workbench_crafting_speed_multiplier( *this, craft, loc );
+    const float bench_multi = cached_workbench_multipler <= 0 ? workbench_crafting_speed_multiplier(
+                                  *this, craft, loc ) : cached_workbench_multipler;
+    cached_workbench_multipler = bench_multi;
     const float morale_multi = morale_crafting_speed_multiplier( rec );
     const float mut_multi = mutation_value( "crafting_speed_multiplier" );
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -275,7 +275,7 @@ float Character::crafting_speed_multiplier( const recipe &rec ) const
 }
 
 float Character::crafting_speed_multiplier( const item &craft,
-        const std::optional<tripoint> &loc, float &cached_workbench_multiplier ) const
+        const std::optional<tripoint> &loc, float *cached_workbench_multiplier ) const
 {
     if( !craft.is_craft() ) {
         debugmsg( "Can't calculate crafting speed multiplier of non-craft '%s'", craft.tname() );
@@ -285,9 +285,12 @@ float Character::crafting_speed_multiplier( const item &craft,
     const recipe &rec = craft.get_making();
 
     const float light_multi = lighting_craft_speed_multiplier( rec );
-    const float bench_multi = cached_workbench_multiplier <= 0 ? workbench_crafting_speed_multiplier(
-                                  *this, craft, loc ) : cached_workbench_multiplier;
-    cached_workbench_multiplier = bench_multi;
+    const float bench_multi = ( cached_workbench_multiplier == nullptr ||
+                                *cached_workbench_multiplier <= 0 ) ? workbench_crafting_speed_multiplier(
+                                  *this, craft, loc ) : *cached_workbench_multiplier;
+    if( cached_workbench_multiplier != nullptr ) {
+        *cached_workbench_multiplier = bench_multi;
+    }
     const float morale_multi = morale_crafting_speed_multiplier( rec );
     const float mut_multi = mutation_value( "crafting_speed_multiplier" );
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -207,8 +207,8 @@ static float lerped_multiplier( const T &value, const T &low, const T &high )
     return 1.0f + ( value - low ) * ( 0.25f - 1.0f ) / ( high - low );
 }
 
-static float workbench_crafting_speed_multiplier( const Character &you, const item &craft,
-        const std::optional<tripoint> &loc )
+float Character::workbench_crafting_speed_multiplier( const item &craft,
+        const std::optional<tripoint> &loc )const
 {
     float multiplier;
     units::mass allowed_mass;
@@ -251,7 +251,7 @@ static float workbench_crafting_speed_multiplier( const Character &you, const it
     const units::mass &craft_mass = craft.weight();
     const units::volume &craft_volume = craft.volume();
 
-    units::mass lifting_mass = you.best_nearby_lifting_assist();
+    units::mass lifting_mass = best_nearby_lifting_assist();
 
     if( lifting_mass > craft_mass ) {
         return multiplier;
@@ -275,7 +275,8 @@ float Character::crafting_speed_multiplier( const recipe &rec ) const
 }
 
 float Character::crafting_speed_multiplier( const item &craft,
-        const std::optional<tripoint> &loc, float *cached_workbench_multiplier ) const
+        const std::optional<tripoint> &loc, bool use_cached_workbench_multiplier,
+        float cached_workbench_multiplier ) const
 {
     if( !craft.is_craft() ) {
         debugmsg( "Can't calculate crafting speed multiplier of non-craft '%s'", craft.tname() );
@@ -285,12 +286,9 @@ float Character::crafting_speed_multiplier( const item &craft,
     const recipe &rec = craft.get_making();
 
     const float light_multi = lighting_craft_speed_multiplier( rec );
-    const float bench_multi = ( cached_workbench_multiplier == nullptr ||
-                                *cached_workbench_multiplier <= 0 ) ? workbench_crafting_speed_multiplier(
-                                  *this, craft, loc ) : *cached_workbench_multiplier;
-    if( cached_workbench_multiplier != nullptr ) {
-        *cached_workbench_multiplier = bench_multi;
-    }
+    const float bench_multi = ( use_cached_workbench_multiplier ||
+                                cached_workbench_multiplier > 0.0f ) ? cached_workbench_multiplier :
+                              workbench_crafting_speed_multiplier( craft, loc );
     const float morale_multi = morale_crafting_speed_multiplier( rec );
     const float mut_multi = mutation_value( "crafting_speed_multiplier" );
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -275,7 +275,7 @@ float Character::crafting_speed_multiplier( const recipe &rec ) const
 }
 
 float Character::crafting_speed_multiplier( const item &craft,
-        const std::optional<tripoint> &loc, float &cached_workbench_multipler ) const
+        const std::optional<tripoint> &loc, float &cached_workbench_multiplier ) const
 {
     if( !craft.is_craft() ) {
         debugmsg( "Can't calculate crafting speed multiplier of non-craft '%s'", craft.tname() );
@@ -285,9 +285,9 @@ float Character::crafting_speed_multiplier( const item &craft,
     const recipe &rec = craft.get_making();
 
     const float light_multi = lighting_craft_speed_multiplier( rec );
-    const float bench_multi = cached_workbench_multipler <= 0 ? workbench_crafting_speed_multiplier(
-                                  *this, craft, loc ) : cached_workbench_multipler;
-    cached_workbench_multipler = bench_multi;
+    const float bench_multi = cached_workbench_multiplier <= 0 ? workbench_crafting_speed_multiplier(
+                                  *this, craft, loc ) : cached_workbench_multiplier;
+    cached_workbench_multiplier = bench_multi;
     const float morale_multi = morale_crafting_speed_multiplier( rec );
     const float mut_multi = mutation_value( "crafting_speed_multiplier" );
 

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -995,7 +995,7 @@ static int resume_craft()
     REQUIRE( crafts.size() == 1 );
     item *craft = crafts.front();
     set_time( midday ); // Ensure light for crafting
-    REQUIRE( player_character.crafting_speed_multiplier( *craft, std::nullopt ) == 1.0 );
+    REQUIRE( player_character.crafting_speed_multiplier( *craft, std::nullopt ) );
     REQUIRE( !player_character.activity );
     player_character.use( player_character.get_item_position( craft ) );
     REQUIRE( player_character.activity );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -995,9 +995,7 @@ static int resume_craft()
     REQUIRE( crafts.size() == 1 );
     item *craft = crafts.front();
     set_time( midday ); // Ensure light for crafting
-    float workbench_multiplier = -1;
-    REQUIRE( player_character.crafting_speed_multiplier( *craft, std::nullopt,
-             workbench_multiplier ) == 1.0 );
+    REQUIRE( player_character.crafting_speed_multiplier( *craft, std::nullopt ) == 1.0 );
     REQUIRE( !player_character.activity );
     player_character.use( player_character.get_item_position( craft ) );
     REQUIRE( player_character.activity );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -995,7 +995,8 @@ static int resume_craft()
     REQUIRE( crafts.size() == 1 );
     item *craft = crafts.front();
     set_time( midday ); // Ensure light for crafting
-    REQUIRE( player_character.crafting_speed_multiplier( *craft, std::nullopt ) == 1.0 );
+    float workbench_multiplier = -1;
+    REQUIRE( player_character.crafting_speed_multiplier( *craft, std::nullopt, workbench_multiplier ) == 1.0 );
     REQUIRE( !player_character.activity );
     player_character.use( player_character.get_item_position( craft ) );
     REQUIRE( player_character.activity );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -996,7 +996,8 @@ static int resume_craft()
     item *craft = crafts.front();
     set_time( midday ); // Ensure light for crafting
     float workbench_multiplier = -1;
-    REQUIRE( player_character.crafting_speed_multiplier( *craft, std::nullopt, workbench_multiplier ) == 1.0 );
+    REQUIRE( player_character.crafting_speed_multiplier( *craft, std::nullopt,
+             workbench_multiplier ) == 1.0 );
     REQUIRE( !player_character.activity );
     player_character.use( player_character.get_item_position( craft ) );
     REQUIRE( player_character.activity );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Cache crafting speed's workbench multiplier"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Mitigate https://github.com/CleverRaven/Cataclysm-DDA/issues/63586.

Using figures from https://github.com/CleverRaven/Cataclysm-DDA/issues/63586#issuecomment-1470034659, ~130 seconds is taken when checking every item surrounding every turn, and ~12s is taken when checking a portion of things every turn. So I think at least 130-12=118 seconds are consumed to actually check everything surrounding.

For a 7hr30min in-game recipe, every surrounding items are checked 27000 times (turns.) 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Cache the workbench multiplier in `craft_activity_actor`.

Workbench conditions mostly remain consistent during craft activities. So refresh it per 5% process.

I also added the cache for disassemble actor.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Refresh it more frequently, like per 1% or 0.1%.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Using the save from https://github.com/CleverRaven/Cataclysm-DDA/issues/63586#issuecomment-1470034659.

Craft a steel plate ( 9 hr recipe ) when both doors are closed consumed 10.5s.

Craft a steel plate when both doors are open consumed 13s. Much better than 2min or 2min40s.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->