### PR TITLE
Validate firstaid_activity_actor's item_location and add per-turn check

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5991,7 +5991,7 @@ std::unique_ptr<activity_actor> clear_rubble_activity_actor::deserialize( JsonVa
 void firstaid_activity_actor::do_turn( player_activity &act, Character & )
 {
     item_location it = act.targets.front();
-    if( !it.get_item() ) {
+    if( !it ) {
         // Erase activity and values.
         act.set_to_null();
         act.values.clear();
@@ -6018,7 +6018,7 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
     static const std::string iuse_name_string( "heal" );
 
     item_location it = act.targets.front();
-    item *used_tool = it.get_item() ? it->get_usable_item( iuse_name_string ) : nullptr;
+    item *used_tool = it ? it->get_usable_item( iuse_name_string ) : nullptr;
     if( used_tool == nullptr ) {
         debugmsg( "Lost tool used for healing" );
         act.set_to_null();

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5988,6 +5988,23 @@ std::unique_ptr<activity_actor> clear_rubble_activity_actor::deserialize( JsonVa
 
     return actor.clone();
 }
+void firstaid_activity_actor::do_turn( player_activity &act, Character & )
+{
+    item_location it = act.targets.front();
+    if( !it.get_item() ) {
+        // Erase activity and values.
+        act.set_to_null();
+        act.values.clear();
+    }
+    Character *patient = patientID == get_avatar().getID() ? &get_avatar() :
+                         dynamic_cast<Character *>( g->find_npc( patientID ) );
+    if( !patient ) {
+        debugmsg( "Your patient can no longer be found so you stop using the %s.", name );
+        act.set_to_null();
+        act.values.clear();
+        return;
+    }
+}
 
 void firstaid_activity_actor::start( player_activity &act, Character & )
 {
@@ -6001,7 +6018,7 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
     static const std::string iuse_name_string( "heal" );
 
     item_location it = act.targets.front();
-    item *used_tool = it->get_usable_item( iuse_name_string );
+    item *used_tool = it.get_item() ? it->get_usable_item( iuse_name_string ) : nullptr;
     if( used_tool == nullptr ) {
         debugmsg( "Lost tool used for healing" );
         act.set_to_null();

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1896,7 +1896,7 @@ class firstaid_activity_actor : public activity_actor
         }
 
         void start( player_activity &act, Character &who ) override;
-        void do_turn( player_activity &, Character & ) override {};
+        void do_turn( player_activity &act, Character &who ) override;
         void finish( player_activity &act, Character &who ) override;
 
         std::unique_ptr<activity_actor> clone() const override {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #66017 .
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Validate firstaid_activity_actor's item_location and add per-turn check
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Consume the bandage ( or other first-aid tools ) at the start of the activity. Because you won't have an intact and uncontaminated bandage if the first-aid gets interrupted. It's possible that it has been soaked with blood, or fallen onto ground if you decide to do some other things. 

Please comment on whether this alternative is better.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Fixed the crash.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->