### PR TITLE
tgz_archiver: get file size from ifstream

### DIFF
--- a/src/tgz_archiver.cpp
+++ b/src/tgz_archiver.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <chrono>
+#include <cmath>
 #include <fstream>
 #include <iomanip>
 #include <locale>
@@ -18,9 +19,8 @@ tgz_archiver::~tgz_archiver()
 }
 
 std::string tgz_archiver::_gen_tar_header( fs::path const &file_name, fs::path const &prefix,
-        fs::path const &real_path )
+        fs::path const &real_path, std::streamsize size )
 {
-    unsigned const size = fs::is_regular_file( real_path ) ? fs::file_size( real_path ) : 0;
     unsigned const type = fs::is_directory( real_path ) ? 5 : 0;
     unsigned const perms = fs::is_directory( real_path ) ? 0775 : 0664;
     // https://stackoverflow.com/a/61067330
@@ -85,20 +85,29 @@ bool tgz_archiver::add_file( fs::path const &real_path, fs::path const &archived
         file_name = archived_path;
     }
 
-    std::string const header = _gen_tar_header( file_name, prefix, real_path );
+    std::string header( tar_block_size, '\0' );
+    std::streamsize size = 0;
+    std::ifstream file( real_path, std::ios::binary | std::ios::ate );
+    if( fs::is_regular_file( real_path ) ) {
+        size = file.tellg();
+        header = _gen_tar_header( file_name, prefix, real_path, size );
+        file.seekg( 0 );
+        file.clear();
+    } else {
+        header = _gen_tar_header( file_name, prefix, real_path, 0 );
+    }
     bool ret = gzwrite( fd, header.c_str(), tar_block_size ) != 0;
 
-    if( !ret || !fs::is_regular_file( real_path ) ) {
+    if( !ret || !fs::is_regular_file( real_path ) || size == 0 ) {
         return ret;
     }
 
-    std::ifstream file( real_path, std::ios::binary );
-    while( !file.eof() && ret ) {
-        tar_block_t buf{};
-        file.read( buf.data(), buf.size() );
-        if( file.gcount() > 0 ) {
-            ret &= gzwrite( fd, buf.data(), buf.size() ) != 0;
-        }
+    double const buf_size = std::ceil( static_cast<double>( size ) / tar_block_size ) * tar_block_size;
+    std::string buf( static_cast<std::string::size_type>( buf_size ), '\0' );
+    if( file.read( buf.data(), size ) ) {
+        ret &= gzwrite( fd, buf.data(), buf.size() ) != 0;
+    } else {
+        debugmsg( "failed to read file %s", real_path.string() );
     }
 
     return ret;

--- a/src/tgz_archiver.h
+++ b/src/tgz_archiver.h
@@ -16,7 +16,7 @@ class tgz_archiver
         static constexpr std::size_t tar_block_size = 512;
         using tar_block_t = std::array<char, tar_block_size>;
         std::string _gen_tar_header( fs::path const &file_name, fs::path const &prefix,
-                                     fs::path const &real_path );
+                                     fs::path const &real_path, std::streamsize size );
 
         gzFile fd = nullptr;
         std::string const output;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Some archives from bug reports have a broken `debug.log` - the size recorded in the header is too small and the overflowing blocks are treated as corrupted tar headers. The result is that the unpacked `debug.log` gets trimmed and some programs refuse to unpack the archive at all.

Examples of broken archives:
[Chilhowee-currentnorail-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/11656105/Chilhowee-currentnorail-trimmed.tar.gz)
[TrailBalls-trimmed-broken.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/11656131/TrailBalls-trimmed-broken.tar.gz)
The issue can be verified by inflating and checking the header with your favorite hex editor (vim. I know it's vim.).


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
My best guess is that the size returned by `fs::file_size()` is too small because the file is still open for writing and the (latest) contents haven't been flushed yet. The solution is to get the size from `std::ifstream` instead, which either forces a FS sync or simply matches the existing flushed contents.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Karol1223 helped me verify that this fixes the issue on Windows 10. I cannot reproduce the issue on linux, but the archives should otherwise be almost identical (old code sometimes padded with one extra empty block).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->