### PR TITLE
Fix error spam on missing bionic_ids

### DIFF
--- a/data/json/obsoletion/migration_bionics.json
+++ b/data/json/obsoletion/migration_bionics.json
@@ -6,6 +6,12 @@
   },
   {
     "type": "bionic_migration",
+    "//": "remove after 0.H stable https://github.com/CleverRaven/Cataclysm-DDA/pull/61176",
+    "from": "bio_railgun",
+    "to": "bio_pitch_perfect"
+  },
+  {
+    "type": "bionic_migration",
     "//": "obsoleted as part of https://github.com/CleverRaven/Cataclysm-DDA/pull/65077",
     "from": "bio_power_armor_interface"
   },

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -3136,8 +3136,13 @@ static bionic_id migrate_bionic_id( const bionic_id &original )
 void bionic::deserialize( const JsonObject &jo )
 {
     id = migrate_bionic_id( bionic_id( jo.get_string( "id" ) ) );
+    if( !id.is_valid() ) {
+        debugmsg( "deserialized bionic id '%s' doesn't exist and has no migration", id.str() );
+        id = bionic_id::NULL_ID(); // remove it
+    }
     if( id.is_null() ) {
-        return; // obsoleted bionic
+        jo.allow_omitted_members();
+        return; // obsoleted bionics migrated to bionic_id::NULL_ID ids
     }
     invlet = jo.get_int( "invlet" );
     powered = jo.get_bool( "powered" );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/66031

#### Describe the solution

On load debugmsg once if no migration entry exists and delete the bionic

#### Describe alternatives you've considered

#### Testing

Load save in linked issue with just the 1st commit applied

#### Additional context
