### PR TITLE
Reduce tests output by trimming non-failing tests

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -177,7 +177,7 @@ jobs:
     - name: Run tests
       if: ${{ github.ref_name != 'master' }}
       run: |
-          .\Cataclysm-test-vcpkg-static-Release-x64.exe --min-duration 0.2 --rng-seed time
+          .\Cataclysm-test-vcpkg-static-Release-x64.exe --min-duration 20 --rng-seed time
 
     - name: Dump disk usage logs if job failed
       if: failure()


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Make tests output 70% to 80% less lines to make output more human readable

#### Describe the solution

Tests currently output ~1000 lines even for a successful basic test, most of that text is useless and mobile browsers get hiccups trying to render all of it, and requires a ton of scrolling to get to the actual error

Raises --min-duration of catch2 to output tests that take more than 20 seconds - this removes most of the test sections spam, leaving just the outliers which are candidates to move to [slow] tests

#### Describe alternatives you've considered

Removing `--linebuffer` from `parallel` might also be beneficial - this causes the 2 parallel test processes to interleave their output making it awkward to read, when the only benefit is if someone twiddles thumbs while the action log is scrolling, but this does make a functional difference

#### Testing

Passing tests should be ~400 lines (more than expected doh, can probably trim more from the all-mods test runs)

#### Additional context

Examples:

Basic test failing with this PR is ~167 lines
https://github.com/irwiss/Cataclysm-DDA/actions/runs/5191019546/jobs/9358293752#step:16:168
Basic test failing without this PR 954 lines https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5185340019/jobs/9345156586?pr=66034#step:16:265
( Actual error on line 265, requiring scrolling ~750 lines of mostly useless text )


Basic test passing with this PR 379 lines https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5192519291/jobs/9361794819?pr=66042#step:16:379
Basic test passing without this PR 1204 lines
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5183880675/jobs/9342297323?pr=66018#step:16:1205
