### PR TITLE
Void Weaver adjustment set

### DIFF
--- a/data/json/furniture_and_terrain/terrain-nether.json
+++ b/data/json/furniture_and_terrain/terrain-nether.json
@@ -11,6 +11,17 @@
   },
   {
     "type": "terrain",
+    "id": "t_nether_glass_floor_clairvoyance",
+    "name": "black glass",
+    "description": "An endless expanse of black glass.  It perfectly reflects the darkness around it.",
+    "symbol": " ",
+    "color": "black",
+    "move_cost": 2,
+    "emissions": [ "emit_clairvoyant" ],
+    "flags": [ "TRANSPARENT", "FLAT", "ROAD", "EMITTER" ]
+  },
+  {
+    "type": "terrain",
     "id": "t_nether_glass_floor_basalt",
     "name": "black glass",
     "description": "An endless expanse of black glass.  It perfectly reflects the darkness around it.",

--- a/data/json/items/ranged/archery.json
+++ b/data/json/items/ranged/archery.json
@@ -957,6 +957,7 @@
     "description": "A tall bow made from very finely grained black wood.  Its large asymmetrical limbs are improperly shaped to fire arrows of regular length, and they require incredible strength to pull back.",
     "price": "10 USD",
     "ammo": "strange_arrow",
+    "material": [ "wood", "monolith_heavy" ],
     "min_strength": 15,
     "weight": "22 kg",
     "volume": "6250 ml",
@@ -967,7 +968,7 @@
         {
           "material": [
             { "type": "wood", "covered_by_mat": 100, "thickness": 2.0 },
-            { "type": "monolith_heavy", "covered_by_mat": 20, "thickness": 2.0 }
+            { "type": "monolith_heavy", "covered_by_mat": 10, "thickness": 2.0 }
           ],
           "encumbrance": 25,
           "coverage": 14,

--- a/data/json/items/ranged/archery.json
+++ b/data/json/items/ranged/archery.json
@@ -958,14 +958,17 @@
     "price": "10 USD",
     "ammo": "strange_arrow",
     "min_strength": 15,
-    "weight": "3200 g",
+    "weight": "22 kg",
     "volume": "6250 ml",
     "longest_side": "218 cm",
     "price_postapoc": 2000,
     "armor_data": {
       "armor": [
         {
-          "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 2.0 } ],
+          "material": [
+            { "type": "wood", "covered_by_mat": 100, "thickness": 2.0 },
+            { "type": "monolith_heavy", "covered_by_mat": 20, "thickness": 2.0 }
+          ],
           "encumbrance": 25,
           "coverage": 14,
           "covers": [ "torso" ],

--- a/data/json/mapgen/sub_ramp.json
+++ b/data/json/mapgen/sub_ramp.json
@@ -5,7 +5,7 @@
     "om_terrain": [ "sub_ramp_above" ],
     "weight": 250,
     "object": {
-      "fill_ter": "t_thconc_floor",
+      "fill_ter": "t_rock_floor_no_roof",
       "rows": [
         "#   X   X      X   X   #",
         "#  -x---x-    -x---x-  #",

--- a/data/json/mapgen/void_spider.json
+++ b/data/json/mapgen/void_spider.json
@@ -203,8 +203,8 @@
         "|": "t_nether_basalt",
         ",": "t_nether_glass_floor",
         "B": "t_nether_glass_wall",
-        "A": "t_nether_glass_floor",
-        "b": "t_nether_glass_floor"
+        "A": "t_nether_glass_floor_clairvoyance",
+        "b": "t_nether_glass_floor_clairvoyance"
       },
       "items": {
         "A": { "item": "void_spider_corpse_mayor_loot", "chance": 100 },

--- a/data/json/monster_special_attacks/void_spider_mechanics.json
+++ b/data/json/monster_special_attacks/void_spider_mechanics.json
@@ -119,12 +119,14 @@
     "id": "mon_void_weaver_death",
     "name": { "str": "Void Weaver Death" },
     "description": "Ends the fight.",
-    "valid_targets": [ "self", "ground" ],
+    "valid_targets": [ "self", "hostile", "ally" ],
     "max_level": 1,
     "flags": [ "SILENT", "NO_HANDS", "NO_LEGS" ],
     "base_casting_time": 75,
     "min_range": 15,
     "max_range": 15,
+    "min_aoe": 30,
+    "max_aoe": 30,
     "shape": "blast",
     "effect": "effect_on_condition",
     "effect_str": "EOC_VOID_SPIDER_ON_DEATH"
@@ -225,18 +227,6 @@
                 "max_radius": 4,
                 "lifespan": [ "15 seconds", "25 seconds" ]
               }
-            ]
-          },
-          {
-            "id": "dissolve_void_spider_lair",
-            "condition": { "and": [ { "one_in_chance": 600 }, { "math": [ "void_spider_lairs_visited", "<=", "void_spider_killed" ] } ] },
-            "effect": [
-              { "u_message": "The cavern folds itself beyond perception.", "popup": true },
-              {
-                "u_location_variable": { "global_val": "nether_glass" },
-                "target_params": { "om_terrain": "nether_glass_deep", "z": -10, "search_range": 400, "min_distance": 1 }
-              },
-              { "u_teleport": { "global_val": "nether_glass" }, "force": true }
             ]
           }
         ]
@@ -352,10 +342,26 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VOID_SPIDER_ON_DEATH",
-    "global": true,
     "effect": [
       { "queue_eocs": "EOC_VOID_SPIDER_KILLED", "time_in_future": "0 seconds" },
-      { "queue_eocs": "EOC_VOID_SPIDER_RESET_VARS", "time_in_future": "2 hours" }
+      { "queue_eocs": "EOC_VOID_SPIDER_RESET_VARS", "time_in_future": "2 hours" },
+      { "queue_eocs": "EOC_DISSOLVE_VOID_SPIDER_LAIR", "time_in_future": "20 minutes" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DISSOLVE_VOID_SPIDER_LAIR",
+    "effect": [
+      { "u_message": "The cavern folds itself beyond perception.", "popup": true },
+      {
+        "u_location_variable": { "global_val": "nether_glass" },
+        "target_params": { "om_terrain": "nether_glass_deep", "z": -10, "search_range": 400, "min_distance": 1 }
+      },
+      { "u_teleport": { "global_val": "nether_glass" }, "force": true },
+      {
+        "mapgen_update": "microlab_portal_elevator_physics_shift",
+        "om_terrain": "microlab_portal_elevator_physics_glass"
+      }
     ]
   },
   {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -92,6 +92,7 @@ static const ammotype ammo_flammable( "flammable" );
 static const ammotype ammo_homebrew_rocket( "homebrew_rocket" );
 static const ammotype ammo_m235( "m235" );
 static const ammotype ammo_metal_rail( "metal_rail" );
+static const ammotype ammo_strange_arrow( "strange_arrow" );
 
 static const bionic_id bio_railgun( "bio_railgun" );
 
@@ -2092,6 +2093,8 @@ item::sound_data item::gun_noise( const bool burst ) const
         return { 4, _( "Fwoosh!" ) };
     } else if( at.count( ammo_arrow ) ) {
         return { noise, _( "whizz!" ) };
+    } else if( at.count( ammo_strange_arrow ) ) {
+        return { noise, _( "Crack!" ) };
     } else if( at.count( ammo_bolt ) ) {
         return { noise, _( "thonk!" ) };
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

A set of adjustments and bugfixes that were reported/suggested through player testing.
Fix: #66000

#### Describe the solution

-Blackwood greatbow: Increase bow weight and add an unique firing sound.
-Better visibility for loot: The alcoves infrequently spawn clairvoyance fields.
-Fix subway ramp floors: self-evident.
-Ensure the cave can be properly escaped from: Adjust how the EOC is triggered and spawn the exit elevator in the physics lab.

#### Testing

Loaded and completed the fight with a debug character.

