### PR TITLE
Faster stomach contents tests

### DIFF
--- a/tests/stomach_contents_test.cpp
+++ b/tests/stomach_contents_test.cpp
@@ -34,10 +34,17 @@ static void reset_time()
 
 static void pass_time( Character &p, time_duration amt )
 {
-    for( time_duration turns = 1_turns; turns < amt; turns += 1_turns ) {
-        calendar::turn += 1_turns;
-        p.update_body();
+    constexpr time_duration time_chunk = 1_minutes;
+
+    // make sure we start spinning aligned to minutes, so that calendar::once_every
+    // in Character::update_body works correctly, 997 is a randomly picked prime
+    REQUIRE( to_seconds<int64_t>( calendar::turn - calendar::turn_zero + 997 * time_chunk ) % 60 == 0 );
+
+    while( amt > 0_seconds ) {
+        p.update_body( calendar::turn, calendar::turn + time_chunk );
         p.update_health();
+        calendar::turn += time_chunk;
+        amt -= time_chunk;
     }
 }
 
@@ -109,8 +116,7 @@ TEST_CASE( "starve_test", "[starve][slow]" )
     clear_stomach( dummy );
     dummy.reset_activity_level();
     dummy.set_stored_kcal( dummy.get_healthy_kcal() );
-    calendar::turn += 1_seconds;
-    dummy.update_body( calendar::turn, calendar::turn );
+    dummy.update_body( calendar::turn, calendar::turn + 1_seconds );
     dummy.set_activity_level( 1.0 );
 
     CAPTURE( dummy.metabolic_rate_base() );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Make stomach tests faster; currently stomach tests iterate ~75 in-game days by second-long intervals, this ends up taking 5-6 minutes of github runner real- time, when most code isn't triggered except in minute or longer intervals, and the code that is triggered is not under test anyway.

This is more visible with the PR to trim down successful tests output:
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5194689367/jobs/9366643214?pr=66042#step:16:140
The only test remotely close to time taken by these tests is `overmap_terrain_coverage`

#### Describe the solution

Advance time by 60 seconds chunks cutting the required simulations by 60x

#### Describe alternatives you've considered

#### Testing

Basic build and test, run tests section, without this patch ~17 minutes
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5205798197/jobs/9391641781?pr=66059#step:16:1

Basic build and test, run tests section, with this patch ~12 minutes
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5206213560/jobs/9392540709?pr=66061#step:16:1

There's a few minutes of variance, likely depends on runner load, but looks to be reducing a few mins at least from basic build and test

#### Additional context
