### PR TITLE
Fix skin and armor mutations

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -70,7 +70,6 @@
     "mutation_conflicts": [
       "THICKSKIN",
       "THINSKIN",
-      "SKIN_ROUGH",
       "M_SKIN",
       "M_SKIN2",
       "M_SKIN3",
@@ -180,7 +179,6 @@
     "mutation_conflicts": [
       "THICKSKIN",
       "THINSKIN",
-      "SKIN_ROUGH",
       "M_SKIN",
       "M_SKIN2",
       "M_SKIN3",
@@ -300,7 +298,6 @@
     "mutation_conflicts": [
       "THICKSKIN",
       "THINSKIN",
-      "SKIN_ROUGH",
       "M_SKIN",
       "M_SKIN2",
       "M_SKIN3",
@@ -396,7 +393,6 @@
     "mutation_conflicts": [
       "THICKSKIN",
       "THINSKIN",
-      "SKIN_ROUGH",
       "M_SKIN",
       "M_SKIN2",
       "M_SKIN3",

--- a/data/json/mutations/mutation_eocs.json
+++ b/data/json/mutations/mutation_eocs.json
@@ -19,5 +19,17 @@
         "targeted": true
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_RASHY_SKIN",
+    "recurrence": [ "1 hour", "12 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_trait": "SKIN_RASHY" },
+        { "not": { "u_has_effect": "formication" } }
+      ]
+    },
+    "effect": [ { "u_add_effect": "formication", "duration": "10 minutes" } ]
   }
 ]

--- a/data/json/mutations/mutation_eocs.json
+++ b/data/json/mutations/mutation_eocs.json
@@ -24,12 +24,7 @@
     "type": "effect_on_condition",
     "id": "EOC_RASHY_SKIN",
     "recurrence": [ "1 hour", "12 hours" ],
-    "condition": {
-      "and": [
-        { "u_has_trait": "SKIN_RASHY" },
-        { "not": { "u_has_effect": "formication" } }
-      ]
-    },
+    "condition": { "and": [ { "u_has_trait": "SKIN_RASHY" }, { "not": { "u_has_effect": "formication" } } ] },
     "effect": [ { "u_add_effect": "formication", "duration": "10 minutes" } ]
   }
 ]

--- a/data/json/mutations/mutation_eocs.json
+++ b/data/json/mutations/mutation_eocs.json
@@ -23,8 +23,8 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_RASHY_SKIN",
-    "recurrence": [ "1 hour", "12 hours" ],
+    "recurrence": [ "2 hour", "24 hours" ],
     "condition": { "and": [ { "u_has_trait": "SKIN_RASHY" }, { "not": { "u_has_effect": "formication" } } ] },
-    "effect": [ { "u_add_effect": "formication", "duration": "10 minutes" } ]
+    "effect": [ { "u_add_effect": "formication", "duration": "10 minutes", "target_part": "random" } ]
   }
 ]

--- a/data/json/mutations/mutation_eocs.json
+++ b/data/json/mutations/mutation_eocs.json
@@ -23,13 +23,13 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_RASHY_SKIN",
-    "recurrence": [ "1 hour", "12 hours" ],
+    "recurrence": [ "2 hours", "24 hours" ],
     "condition": {
       "and": [
         { "u_has_trait": "SKIN_RASHY" },
         { "not": { "u_has_effect": "formication" } }
       ]
     },
-    "effect": [ { "u_add_effect": "formication", "duration": "10 minutes" } ]
+    "effect": [ { "u_add_effect": "formication", "duration": "10 minutes", "target_part": "RANDOM" } ]
   }
 ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1963,7 +1963,7 @@
     "visibility": 1,
     "ugliness": 1,
     "description": "It's subtle, but your skin has definitely taken on a sickly yellow-green hue.",
-    "types": [ "SKIN", "BODY_ARMOR" ],
+    "types": [ "SKIN", "BODY_ARMOR", "TORSO_ARMOR", "BODY_ARMOR_MOD", "ARMOR" ],
     "changes_to": [ "PLANTSKIN" ],
     "category": [
       "PLANT",
@@ -1978,7 +1978,7 @@
     "visibility": 2,
     "ugliness": 1,
     "description": "You have goosebumps that never seem to go away.  Are they getting bigger?",
-    "types": [ "SKIN", "BODY_ARMOR" ],
+    "types": [ "SKIN", "BODY_ARMOR", "TORSO_ARMOR", "BODY_ARMOR_MOD", "ARMOR" ],
     "changes_to": [ "FEATHERS" ],
     "category": [ "BIRD" ]
   },
@@ -1988,9 +1988,9 @@
     "name": { "str": "Rashy Skin" },
     "points": -1,
     "visibility": 2,
-    "ugliness": 2,
+    "ugliness": 1,
     "description": "You've developed a persistent skin rash.  Sometimes it's fine, other times it itches like hell.",
-    "types": [ "SKIN", "BODY_ARMOR" ],
+    "types": [ "SKIN", "BODY_ARMOR", "TORSO_ARMOR", "BODY_ARMOR_MOD", "ARMOR" ],
     "changes_to": ["PATCHSKIN1" ],
     "category": [ "CHIMERA" ]
   },
@@ -2000,7 +2000,7 @@
     "name": { "str": "Hirsute" },
     "points": 0,
     "description": "Your body hair is growing in thicker than it used to.  It's almost like you're going through a second puberty or something.",
-    "types": [ "SKIN", "BODY_ARMOR" ],
+    "types": [ "SKIN", "BODY_ARMOR", "TORSO_ARMOR", "BODY_ARMOR_MOD", "ARMOR" ],
     "changes_to": [ "LIGHTFUR" ],
     "category": [
       "MOUSE",
@@ -2021,7 +2021,7 @@
     "visibility": 2,
     "ugliness": 2,
     "description": "Your skin keeps peeling in big flakes, like you're recovering from a bad sunburn.  Oddly, it doesn't hurt at all.",
-    "types": [ "SKIN", "BODY_ARMOR" ],
+    "types": [ "SKIN", "BODY_ARMOR", "TORSO_ARMOR", "BODY_ARMOR_MOD", "ARMOR" ],
     "changes_to": [ "SPARSE_SCALES" ],
     "category": [
       "LIZARD",
@@ -2037,7 +2037,7 @@
     "visibility": 1,
     "ugliness": 1,
     "description": "Your skin has lost some of its color and taken on a smooth, papery texture.  This slightly reduces wet effects, but also makes you a little more vulnerable to cuts and scrapes.",
-    "types": [ "SKIN", "BODY_ARMOR" ],
+    "types": [ "SKIN", "BODY_ARMOR", "TORSO_ARMOR", "BODY_ARMOR_MOD", "ARMOR" ],
     "changes_to": [ "CHITIN" ],
     "category": [
       "SPIDER",
@@ -7578,8 +7578,7 @@
     "ugliness": 3,
     "description": "You have grown a thick shell over your torso, providing excellent armor, but you cannot wear anything on your torso.  Somewhat reduces wet effects.",
     "types": [ "TORSO_ARMOR" ],
-    "prereqs": [ "CHITIN", "THICKSKIN" ],
-    "cancels": [ "CHITIN3" ],
+    "prereqs": [ "THICKSKIN" ],
     "changes_to": [ "SHELL2" ],
     "category": [ "CEPHALOPOD", "GASTROPOD" ],
     "wet_protection": [ { "part": "torso", "ignored": 26 } ],

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1957,33 +1957,105 @@
   },
   {
     "type": "mutation",
-    "id": "SKIN_ROUGH",
-    "name": { "str": "Rough Skin" },
+    "id": "JAUNDICE",
+    "name": { "str": "Jaundice" },
+    "points": 0,
+    "visibility": 1,
+    "ugliness": 1,
+    "description": "It's subtle, but your skin has definitely taken on a sickly yellow-green hue.",
+    "types": [ "SKIN", "BODY_ARMOR" ],
+    "changes_to": [ "PLANTSKIN" ],
+    "category": [
+      "PLANT",
+      "ELFA"
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "GOOSEBUMPS",
+    "name": { "str": "Goosebumps" },
     "points": 0,
     "visibility": 2,
     "ugliness": 1,
-    "description": "Your skin is slightly rough.  This has no gameplay effect.",
-    "types": [ "SKIN" ],
-    "changes_to": [ "SPARSE_SCALES", "FEATHERS", "LIGHTFUR", "CHITIN", "PLANTSKIN", "PATCHSKIN1" ],
+    "description": "You have goosebumps that never seem to go away.  Are they getting bigger?",
+    "types": [ "SKIN", "BODY_ARMOR" ],
+    "changes_to": [ "FEATHERS" ],
+    "category": [ "BIRD" ]
+  },
+  {
+    "type": "mutation",
+    "id": "SKIN_RASHY",
+    "name": { "str": "Rashy Skin" },
+    "points": -1,
+    "visibility": 2,
+    "ugliness": 2,
+    "description": "You've developed a persistent skin rash.  Sometimes it's fine, other times it itches like hell.",
+    "types": [ "SKIN", "BODY_ARMOR" ],
+    "changes_to": ["PATCHSKIN1" ],
+    "category": [ "CHIMERA" ]
+  },
+  {
+    "type": "mutation",
+    "id": "HIRSUTE",
+    "name": { "str": "Hirsute" },
+    "points": 0,
+    "description": "Your body hair is growing in thicker than it used to.  It's almost like you're going through a second puberty or something.",
+    "types": [ "SKIN", "BODY_ARMOR" ],
+    "changes_to": [ "LIGHTFUR" ],
     "category": [
-      "LIZARD",
-      "RAPTOR",
-      "BIRD",
-      "SPIDER",
       "MOUSE",
-      "PLANT",
-      "CHIMERA",
-      "FISH",
       "BEAST",
       "CATTLE",
       "RAT",
       "FELINE",
       "LUPINE",
       "RABBIT",
+      "URSINE"
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "SKIN_PEELING",
+    "name": { "str": "Peeling Skin" },
+    "points": 0,
+    "visibility": 2,
+    "ugliness": 2,
+    "description": "Your skin keeps peeling in big flakes, like you're recovering from a bad sunburn.  Oddly, it doesn't hurt at all.",
+    "types": [ "SKIN", "BODY_ARMOR" ],
+    "changes_to": [ "SPARSE_SCALES" ],
+    "category": [
+      "LIZARD",
+      "RAPTOR",
+      "FISH"
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "SKIN_SMOOTH",
+    "name": { "str": "Smooth Skin" },
+    "points": 0,
+    "visibility": 1,
+    "ugliness": 1,
+    "description": "Your skin has lost some of its color and taken on a smooth, papery texture.  This slightly reduces wet effects, but also makes you a little more vulnerable to cuts and scrapes.",
+    "types": [ "SKIN", "BODY_ARMOR" ],
+    "changes_to": [ "CHITIN" ],
+    "category": [
+      "SPIDER",
       "INSECT",
-      "ELFA",
-      "URSINE",
       "CRUSTACEAN"
+    ],
+    "armor": [ { "part_types": [ "torso", "head", "arm", "hand", "leg", "foot", "mouth", "tail" ], "cut": -1 } ],
+    "wet_protection": [
+      { "part": "head", "neutral": 3 },
+      { "part": "leg_l", "neutral": 4 },
+      { "part": "leg_r", "neutral": 4 },
+      { "part": "foot_l", "neutral": 1 },
+      { "part": "foot_r", "neutral": 1 },
+      { "part": "arm_l", "neutral": 4 },
+      { "part": "arm_r", "neutral": 4 },
+      { "part": "hand_l", "neutral": 6 },
+      { "part": "hand_r", "neutral": 6},
+      { "part": "torso", "neutral": 5 }
     ]
   },
   {
@@ -2466,7 +2538,7 @@
     "description": "Your skin has toughened and grown thin, flexible scales in some places, acting as natural armor.",
     "types": [ "SKIN" ],
     "category": [ "RAPTOR", "LIZARD", "FISH" ],
-    "prereqs": [ "SKIN_ROUGH" ],
+    "prereqs": [ "SKIN_PEELING" ],
     "changes_to": [ "SCALES" ],
     "wet_protection": [
       { "part": "head", "ignored": 2 },
@@ -2592,7 +2664,7 @@
     "description": "Iridescent feathers have grown to cover your entire body, providing a marginal protection against attacks and minor protection from cold.  They also provide a natural waterproofing.",
     "types": [ "SKIN" ],
     "leads_to": [ "DOWN" ],
-    "prereqs": [ "SKIN_ROUGH" ],
+    "prereqs": [ "GOOSEBUMPS" ],
     "category": [ "BIRD" ],
     "armor": [ { "part_types": [ "torso", "head", "arm", "hand", "leg", "foot", "mouth", "tail" ], "bash": 1 } ]
   },
@@ -2622,7 +2694,7 @@
     "description": "Light fur has grown to cover your entire body, providing marginal protection against attacks and slight protection from cold.",
     "category": [ "MOUSE", "BEAST", "CATTLE", "RAT", "FELINE", "LUPINE", "RABBIT", "URSINE" ],
     "types": [ "SKIN" ],
-    "prereqs": [ "SKIN_ROUGH" ],
+    "prereqs": [ "HIRSUTE" ],
     "changes_to": [ "FUR", "FELINE_FUR", "LUPINE_FUR", "RABBIT_FUR" ],
     "integrated_armor": [ "integrated_lightfur" ]
   },
@@ -2721,7 +2793,7 @@
     ],
     "category": [ "CHIMERA" ],
     "types": [ "SKIN" ],
-    "prereqs": [ "SKIN_ROUGH" ],
+    "prereqs": [ "SKIN_RASHY" ],
     "changes_to": [ "PATCHSKIN2" ],
     "integrated_armor": [ "integrated_patchskin1" ]
   },
@@ -2790,7 +2862,7 @@
     "ugliness": 2,
     "description": "Your epidermis has turned into a thin, flexible layer of chitin.  It provides decent physical protection.  Slightly reduces wet effects.",
     "types": [ "SKIN" ],
-    "prereqs": [ "SKIN_ROUGH" ],
+    "prereqs": [ "SKIN_SMOOTH" ],
     "leads_to": [ "CHITIN2", "CHITIN_FUR", "CHITIN_FUR2", "CHITIN_FUR3" ],
     "category": [ "SPIDER", "INSECT", "CRUSTACEAN" ],
     "integrated_armor": [ "integrated_chitin" ],
@@ -3116,6 +3188,7 @@
     "ugliness": 2,
     "description": "Your skin is light green and has a slightly woody quality to it.  This provides armor and helps you retain moisture, resulting in less thirst.  Greatly decreases wet penalties.",
     "types": [ "SKIN" ],
+    "prereqs": [ "JAUNDICE" ],
     "leads_to": [ "BARK", "THORNS", "LEAVES" ],
     "category": [ "PLANT", "ELFA" ],
     "thirst_modifier": -0.2,

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2023,11 +2023,7 @@
     "description": "Your skin keeps peeling in big flakes, like you're recovering from a bad sunburn.  Oddly, it doesn't hurt at all.",
     "types": [ "SKIN", "BODY_ARMOR" ],
     "changes_to": [ "SPARSE_SCALES" ],
-    "category": [
-      "LIZARD",
-      "RAPTOR",
-      "FISH"
-    ]
+    "category": [ "LIZARD", "RAPTOR", "FISH" ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1969,7 +1969,7 @@
   },
   {
     "type": "mutation",
-    "id": "GOOSEBUMPS",
+    "id": "SKIN_ROUGH",
     "name": { "str": "Goosebumps" },
     "points": 0,
     "visibility": 2,
@@ -2644,7 +2644,7 @@
     "description": "Iridescent feathers have grown to cover your entire body, providing a marginal protection against attacks and minor protection from cold.  They also provide a natural waterproofing.",
     "types": [ "SKIN" ],
     "leads_to": [ "DOWN" ],
-    "prereqs": [ "GOOSEBUMPS" ],
+    "prereqs": [ "SKIN_ROUGH" ],
     "category": [ "BIRD" ],
     "armor": [ { "part_types": [ "torso", "head", "arm", "hand", "leg", "foot", "mouth", "tail" ], "bash": 1 } ]
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1965,10 +1965,7 @@
     "description": "It's subtle, but your skin has definitely taken on a sickly yellow-green hue.",
     "types": [ "SKIN", "BODY_ARMOR" ],
     "changes_to": [ "PLANTSKIN" ],
-    "category": [
-      "PLANT",
-      "ELFA"
-    ]
+    "category": [ "PLANT", "ELFA" ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1999,16 +1999,7 @@
     "description": "Your body hair is growing in thicker than it used to.  It's almost like you're going through a second puberty or something.",
     "types": [ "SKIN", "BODY_ARMOR" ],
     "changes_to": [ "LIGHTFUR" ],
-    "category": [
-      "MOUSE",
-      "BEAST",
-      "CATTLE",
-      "RAT",
-      "FELINE",
-      "LUPINE",
-      "RABBIT",
-      "URSINE"
-    ]
+    "category": [ "MOUSE", "BEAST", "CATTLE", "RAT", "FELINE", "LUPINE", "RABBIT", "URSINE" ]
   },
   {
     "type": "mutation",
@@ -2032,11 +2023,7 @@
     "description": "Your skin has lost some of its color and taken on a smooth, papery texture.  This slightly reduces wet effects, but also makes you a little more vulnerable to cuts and scrapes.",
     "types": [ "SKIN", "BODY_ARMOR" ],
     "changes_to": [ "CHITIN" ],
-    "category": [
-      "SPIDER",
-      "INSECT",
-      "CRUSTACEAN"
-    ],
+    "category": [ "SPIDER", "INSECT", "CRUSTACEAN" ],
     "armor": [ { "part_types": [ "torso", "head", "arm", "hand", "leg", "foot", "mouth", "tail" ], "cut": -1 } ],
     "wet_protection": [
       { "part": "head", "neutral": 3 },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1991,7 +1991,7 @@
     "ugliness": 2,
     "description": "You've developed a persistent skin rash.  Sometimes it's fine, other times it itches like hell.",
     "types": [ "SKIN", "BODY_ARMOR" ],
-    "changes_to": ["PATCHSKIN1" ],
+    "changes_to": [ "PATCHSKIN1" ],
     "category": [ "CHIMERA" ]
   },
   {

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1963,7 +1963,7 @@
     "visibility": 1,
     "ugliness": 1,
     "description": "It's subtle, but your skin has definitely taken on a sickly yellow-green hue.",
-    "types": [ "SKIN", "BODY_ARMOR" ],
+    "types": [ "SKIN", "BODY_ARMOR", "ARMOR", "BODY_ARMOR_MOD" ],
     "changes_to": [ "PLANTSKIN" ],
     "category": [ "PLANT", "ELFA" ]
   },
@@ -1975,7 +1975,7 @@
     "visibility": 2,
     "ugliness": 1,
     "description": "You have goosebumps that never seem to go away.  Are they getting bigger?",
-    "types": [ "SKIN", "BODY_ARMOR" ],
+    "types": [ "SKIN", "BODY_ARMOR", "ARMOR", "BODY_ARMOR_MOD" ],
     "changes_to": [ "FEATHERS" ],
     "category": [ "BIRD" ]
   },
@@ -1987,7 +1987,7 @@
     "visibility": 2,
     "ugliness": 2,
     "description": "You've developed a persistent skin rash.  Sometimes it's fine, other times it itches like hell.",
-    "types": [ "SKIN", "BODY_ARMOR" ],
+    "types": [ "SKIN", "BODY_ARMOR", "ARMOR", "BODY_ARMOR_MOD" ],
     "changes_to": [ "PATCHSKIN1" ],
     "category": [ "CHIMERA" ]
   },
@@ -1997,7 +1997,7 @@
     "name": { "str": "Hirsute" },
     "points": 0,
     "description": "Your body hair is growing in thicker than it used to.  It's almost like you're going through a second puberty or something.",
-    "types": [ "SKIN", "BODY_ARMOR" ],
+    "types": [ "SKIN", "BODY_ARMOR", "ARMOR", "BODY_ARMOR_MOD" ],
     "changes_to": [ "LIGHTFUR" ],
     "category": [ "MOUSE", "BEAST", "CATTLE", "RAT", "FELINE", "LUPINE", "RABBIT", "URSINE" ]
   },
@@ -2009,7 +2009,7 @@
     "visibility": 2,
     "ugliness": 2,
     "description": "Your skin keeps peeling in big flakes, like you're recovering from a bad sunburn.  Oddly, it doesn't hurt at all.",
-    "types": [ "SKIN", "BODY_ARMOR" ],
+    "types": [ "SKIN", "BODY_ARMOR", "ARMOR", "BODY_ARMOR_MOD" ],
     "changes_to": [ "SPARSE_SCALES" ],
     "category": [ "LIZARD", "RAPTOR", "FISH" ]
   },
@@ -2021,7 +2021,7 @@
     "visibility": 1,
     "ugliness": 1,
     "description": "Your skin has lost some of its color and taken on a smooth, papery texture.  This slightly reduces wet effects, but also makes you a little more vulnerable to cuts and scrapes.",
-    "types": [ "SKIN", "BODY_ARMOR" ],
+    "types": [ "SKIN", "BODY_ARMOR", "ARMOR", "BODY_ARMOR_MOD" ],
     "changes_to": [ "CHITIN" ],
     "category": [ "SPIDER", "INSECT", "CRUSTACEAN" ],
     "armor": [ { "part_types": [ "torso", "head", "arm", "hand", "leg", "foot", "mouth", "tail" ], "cut": -1 } ],

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2050,7 +2050,7 @@
       { "part": "arm_l", "neutral": 4 },
       { "part": "arm_r", "neutral": 4 },
       { "part": "hand_l", "neutral": 6 },
-      { "part": "hand_r", "neutral": 6},
+      { "part": "hand_r", "neutral": 6 },
       { "part": "torso", "neutral": 5 }
     ]
   },

--- a/data/mods/Aftershock/mutations/mutations.json
+++ b/data/mods/Aftershock/mutations/mutations.json
@@ -486,8 +486,15 @@
   },
   {
     "type": "mutation",
+    "id": "HIRSUTE",
+    "copy-from": "HIRSUTE",
+    "extend": { "category": [ "MASTODON" ] }
+  },
+  {
+    "type": "mutation",
     "id": "LIGHTFUR",
     "copy-from": "LIGHTFUR",
+    "prereqs": [ "HIRSUTE" ],
     "extend": { "category": [ "MASTODON" ] }
   },
   {
@@ -684,12 +691,6 @@
     "type": "mutation",
     "id": "MET_RAT",
     "copy-from": "MET_RAT",
-    "extend": { "category": [ "MASTODON" ] }
-  },
-  {
-    "type": "mutation",
-    "id": "SKIN_ROUGH",
-    "copy-from": "SKIN_ROUGH",
     "extend": { "category": [ "MASTODON" ] }
   },
   {

--- a/data/mods/DinoMod/mutations/mutations.json
+++ b/data/mods/DinoMod/mutations/mutations.json
@@ -241,8 +241,8 @@
   },
   {
     "type": "mutation",
-    "id": "SKIN_ROUGH",
-    "copy-from": "SKIN_ROUGH",
+    "id": "SKIN_PEELING",
+    "copy-from": "SKIN_PEELING",
     "extend": { "category": [ "STEGO", "TYRANT", "HORNS" ] }
   },
   {

--- a/data/mods/Magiclysm/mutations/mutations.json
+++ b/data/mods/Magiclysm/mutations/mutations.json
@@ -96,8 +96,8 @@
   },
   {
     "type": "mutation",
-    "id": "SKIN_ROUGH",
-    "copy-from": "SKIN_ROUGH",
+    "id": "SKIN_PEELING",
+    "copy-from": "SKIN_PEELING",
     "extend": { "category": [ "DRAGON_BLACK" ] }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix improperly overlapping skin and armor mutations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

fixes #66049 

Several skin mutations shared a common precursor, rough skin, which only had the SKIN type. This meant that you could acquire epicuticle and chitin carapace, then mutate to feathers, losing epicuticle while keeping chitin carapace, despite the former being a prerequisite for the latter. This was also true of the shell mutations, which are supposed to require thick skin. This could cause all kinds of conflicts between different types of integrated armor competing for the same layer, integrated armor without padding, etc.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Rough skin had no effect and was previously the sole precursor to a bunch of skin mutations, including patchy scales, patchwork skin, lightly furred, epicuticle, and phelloderm. I decided to split it out into six precursor mutations with mild effects designed to promote the body horror aspect of mutation. Most of the effects are somewhat negative, which will hopefully prompt would-be mutants to take more mutagen to evolve past them.

Peeling skin - 2 ugliness, no other effect. Leads to patchy scales.
Jaundice - ugliness, no other effect. Leads to phelloder..
Smooth skin - 1 ugliness, very mild wet effect reduction, -1 cut armor. Leads to epicuticle.
Rashy skin - 1 ugliness, randomly procs the formication effect for ten minutes a couple of times a day. Leads to patchwork skin.
Hirsute - No effect whatsoever. Leads to lightly furred.
Goosebumps - 1 ugliness. Leads to feathered.

Each of these mutations has the SKIN, BODY_ARMOR, TORSO_ARMOR, and BODY_ARMOR_MOD, and ARMOR types. These mutations are not kept when advancing to their next stage. 

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

* Specifically canceling undesirable mutations in each mutation's json entry - This is painstaking and would create a lot of work for future contributors.

* Just making rough skin have all those types so it cancels everything. - Where's the fun in that? The method I've used also sets up possible future changes such as allowing two different types of skin to both have access to the same armor mutation without losing it when you mutate between them.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

* Spawned into a world, gave myself epicuticle and chitin carapace.
* Mutated feathers, saw that I lost both epicuticle and chitin carapace in the process
* Gave myself rashy skin. Waited a few hours until I started itching. Saw that itching lasted a reasonable length of time and was not excessive in frequency
* Gave myself all the second stage skin mutations, saw that they all were appropriately gained and lost
* Completed a molt cycle with chitin carapace and hairy chitin to make sure that hairy chitin wasn't somehow going to get lost in the shuffle

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

muties rule

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->