### PR TITLE
Raise melee test margin

### DIFF
--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -385,7 +385,8 @@ static void check_damage_from_test_fire( const std::vector<std::string> &armor_i
     }
     CHECK( total_hits == Approx( 1000 ).margin( 100 ) );
     CHECK( set_on_fire == total_hits );
-    CHECK( total_dmg / static_cast<float>( total_hits ) == Approx( expected_avg_dmg ).epsilon( 0.05 ) );
+    const float avg_dmg = total_dmg / static_cast<float>( total_hits );
+    CHECK( avg_dmg == Approx( expected_avg_dmg ).epsilon( 0.075 ) );
 }
 
 TEST_CASE( "Damage type effectiveness vs. monster resistance", "[melee][damage]" )


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Reduce tests flaking https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5209635365/jobs/9399725367?pr=66061#step:16:129

#### Describe the solution

Raise margin

#### Describe alternatives you've considered

#### Testing

#### Additional context
