### PR TITLE
Optimize the way map::process_items() handles vehicles

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5294,20 +5294,20 @@ void map::process_items()
     const int maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z();
     for( int gz = minz; gz <= maxz; ++gz ) {
         level_cache &cache = access_cache( gz );
-        std::set<tripoint> submaps_with_vehicles;
+        std::set<submap * > submaps_with_vehicles;
         for( vehicle *this_vehicle : cache.vehicle_list ) {
             tripoint pos = this_vehicle->global_pos3();
-            submaps_with_vehicles.emplace( pos.x / SEEX, pos.y / SEEY, pos.z );
-        }
-        for( const tripoint &pos : submaps_with_vehicles ) {
             submap *const current_submap = get_submap_at_grid( pos );
             if( current_submap == nullptr ) {
                 debugmsg( "Tried to process items at (%d,%d,%d) but the submap is not loaded", pos.x, pos.y,
                           pos.z );
                 continue;
             }
+            submaps_with_vehicles.emplace( current_submap );
+        }
+        for( submap *submap : submaps_with_vehicles ) {
             // Vehicles first in case they get blown up and drop active items on the map.
-            process_items_in_vehicles( *current_submap );
+            process_items_in_vehicles( *submap );
         }
     }
     update_submaps_with_active_items();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There's a non-negligible portion of CPU cycles consumed on this function when crafting a sword inside a vehicle with tons of items ( using the save file attached at https://github.com/CleverRaven/Cataclysm-DDA/issues/64552#issue-1640442831 ), as can be seen on the flame graph:
![捕获](https://github.com/CleverRaven/Cataclysm-DDA/assets/22912139/4e1afbf9-eaf0-498a-830b-915f04c09ab8)


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Grab the submaps first, then process each submap, which is more intuitive than the current implementation. 

Frankly, although I haven't figured out why it becomes faster, the flame graph does show improvement:

![捕获1](https://github.com/CleverRaven/Cataclysm-DDA/assets/22912139/dcb91666-db15-4984-a69d-a2d72dc2de7b)

The biggest part( map::process_items() ) mysteriously eliminates.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

The game does run faster.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->