### PR TITLE
Asynchronous animation type including sprinting and smashing

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -881,7 +881,7 @@ void game::draw_async_anim( const tripoint &p, const std::string &tile_id, const
 
     if( !use_tiles ) {
         if( !ncstr.empty() ) {
-            hit_animation( get_avatar(), p, nccol, ncstr );
+            g->init_draw_async_anim_curses( p, ncstr, nccol );
         }
         return;
     }
@@ -894,7 +894,7 @@ void game::draw_async_anim( const tripoint &p, const std::string &, const std::s
                             const nc_color &nccol )
 {
     if( !ncstr.empty() ) {
-        hit_animation( get_avatar(), p, nccol, ncstr );
+        g->init_draw_async_anim_curses( p, ncstr, nccol );
     }
 }
 #endif

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -863,8 +863,8 @@ void game::draw_zones( const tripoint &start, const tripoint &end, const tripoin
 #endif
 
 #if defined(TILES)
-void game::draw_async_anim( const tripoint &p, const std::string tile_id, const std::string ncstr,
-                            const nc_color nccol )
+void game::draw_async_anim( const tripoint &p, const std::string &tile_id, const std::string &ncstr,
+                            const nc_color &nccol )
 {
     if( test_mode ) {
         // avoid segfault from null tilecontext in tests
@@ -890,8 +890,8 @@ void game::draw_async_anim( const tripoint &p, const std::string tile_id, const 
     g->invalidate_main_ui_adaptor();
 }
 #else
-void game::draw_async_anim( const tripoint &p, const std::string, const std::string ncstr,
-                            const nc_color nccol )
+void game::draw_async_anim( const tripoint &p, const std::string &, const std::string &ncstr,
+                            const nc_color &nccol )
 {
     if( ncstr != "" ) {
         hit_animation( get_avatar(), p, nccol, ncstr );

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -886,11 +886,8 @@ void game::draw_async_anim( const tripoint &p, const std::string tile_id, const 
         return;
     }
 
-    shared_ptr_fast<draw_callback_t> async_anim_cb = make_shared_fast<draw_callback_t>( [&]() {
-        tilecontext->init_draw_async_anim( p, tile_id );
-    } );
-    add_draw_callback( async_anim_cb );
-    ui_manager::redraw();
+    tilecontext->init_draw_async_anim( p, tile_id );
+    g->invalidate_main_ui_adaptor();
 }
 #else
 void game::draw_async_anim( const tripoint &p, const std::string, const std::string ncstr,

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -880,7 +880,7 @@ void game::draw_async_anim( const tripoint &p, const std::string &tile_id, const
     }
 
     if( !use_tiles ) {
-        if( ncstr != "" ) {
+        if( !ncstr.empty() ) {
             hit_animation( get_avatar(), p, nccol, ncstr );
         }
         return;
@@ -893,7 +893,7 @@ void game::draw_async_anim( const tripoint &p, const std::string &tile_id, const
 void game::draw_async_anim( const tripoint &p, const std::string &, const std::string &ncstr,
                             const nc_color &nccol )
 {
-    if( ncstr != "" ) {
+    if( !ncstr.empty() ) {
         hit_animation( get_avatar(), p, nccol, ncstr );
     }
 }

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -893,7 +893,7 @@ void game::draw_async_anim( const tripoint &p, const std::string tile_id, const 
     ui_manager::redraw();
 }
 #else
-void game::draw_async_anim( const tripoint &p, const std::string tile_id, const std::string ncstr,
+void game::draw_async_anim( const tripoint &p, const std::string, const std::string ncstr,
                             const nc_color nccol )
 {
     if( ncstr != "" ) {

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -863,6 +863,46 @@ void game::draw_zones( const tripoint &start, const tripoint &end, const tripoin
 #endif
 
 #if defined(TILES)
+void game::draw_async_anim( const tripoint &p, const std::string tile_id, const std::string ncstr,
+                            const nc_color nccol )
+{
+    if( test_mode ) {
+        // avoid segfault from null tilecontext in tests
+        return;
+    }
+
+    if( !get_option<bool>( "ANIMATIONS" ) ) {
+        return;
+    }
+
+    if( !u.sees( p ) ) {
+        return;
+    }
+
+    if( !use_tiles ) {
+        if( ncstr != "" ) {
+            hit_animation( get_avatar(), p, nccol, ncstr );
+        }
+        return;
+    }
+
+    shared_ptr_fast<draw_callback_t> async_anim_cb = make_shared_fast<draw_callback_t>( [&]() {
+        tilecontext->init_draw_async_anim( p, tile_id );
+    } );
+    add_draw_callback( async_anim_cb );
+    ui_manager::redraw();
+}
+#else
+void game::draw_async_anim( const tripoint &p, const std::string tile_id, const std::string ncstr,
+                            const nc_color nccol )
+{
+    if( ncstr != "" ) {
+        hit_animation( get_avatar(), p, nccol, ncstr );
+    }
+}
+#endif
+
+#if defined(TILES)
 void game::draw_radiation_override( const tripoint &p, const int rad )
 {
     if( use_tiles ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1735,7 +1735,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     in_animation = do_draw_explosion || do_draw_custom_explosion ||
                    do_draw_bullet || do_draw_hit || do_draw_line ||
                    do_draw_cursor || do_draw_highlight || do_draw_weather ||
-                   do_draw_sct || do_draw_zones;
+                   do_draw_sct || do_draw_zones || do_draw_async_anim;
 
     draw_footsteps_frame( center );
     if( in_animation ) {
@@ -1775,6 +1775,9 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         if( do_draw_highlight ) {
             draw_highlight();
             void_highlight();
+        }
+        if( do_draw_async_anim ) {
+            draw_async_anim();
         }
     } else if( you.view_offset != tripoint_zero && !you.in_vehicle ) {
         // check to see if player is located at ter
@@ -4047,6 +4050,11 @@ void cata_tiles::init_draw_zones( const tripoint &_start, const tripoint &_end,
     zone_end = _end;
     zone_offset = _offset;
 }
+void cata_tiles::init_draw_async_anim( const tripoint &p, const std::string tile_id )
+{
+    do_draw_async_anim = true;
+    async_anim_layer[ p ] = tile_id;
+}
 void cata_tiles::init_draw_radiation_override( const tripoint &p, const int rad )
 {
     radiation_override.emplace( p, rad );
@@ -4146,6 +4154,11 @@ void cata_tiles::void_sct()
 void cata_tiles::void_zones()
 {
     do_draw_zones = false;
+}
+void cata_tiles::void_async_anim()
+{
+    do_draw_async_anim = false;
+    async_anim_layer.clear();
 }
 void cata_tiles::void_radiation_override()
 {
@@ -4431,6 +4444,20 @@ void cata_tiles::draw_zones_frame()
         }
     }
 
+}
+
+void cata_tiles::draw_async_anim()
+{
+    // game::draw_async_anim can be called multiple times, storing each animation to be played in async_anim_layer
+    // Iterate through every tripoint-tileid pair in async_anim_layer
+    for( const auto &anim : async_anim_layer ) {
+        const tripoint p = anim.first;
+        const std::string tile_id = anim.second;
+        // Only draw if sprite found
+        if( find_tile_looks_like( tile_id, TILE_CATEGORY::NONE, "" ) ) {
+            draw_from_id_string( tile_id, p, 0, 0, lit_level::LIT, nv_goggles_activated );
+        }
+    }
 }
 
 void cata_tiles::draw_footsteps_frame( const tripoint &center )

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -4050,7 +4050,7 @@ void cata_tiles::init_draw_zones( const tripoint &_start, const tripoint &_end,
     zone_end = _end;
     zone_offset = _offset;
 }
-void cata_tiles::init_draw_async_anim( const tripoint &p, const std::string tile_id )
+void cata_tiles::init_draw_async_anim( const tripoint &p, const std::string &tile_id )
 {
     do_draw_async_anim = true;
     async_anim_layer[ p ] = tile_id;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -584,7 +584,7 @@ class cata_tiles
         void draw_zones_frame();
         void void_zones();
 
-        void init_draw_async_anim( const tripoint &p, const std::string tile_id );
+        void init_draw_async_anim( const tripoint &p, const std::string &tile_id );
         void draw_async_anim();
         void void_async_anim();
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -584,6 +584,10 @@ class cata_tiles
         void draw_zones_frame();
         void void_zones();
 
+        void init_draw_async_anim( const tripoint &p, const std::string tile_id );
+        void draw_async_anim();
+        void void_async_anim();
+
         void init_draw_radiation_override( const tripoint &p, int rad );
         void void_radiation_override();
 
@@ -713,11 +717,13 @@ class cata_tiles
         bool do_draw_weather = false;
         bool do_draw_sct = false;
         bool do_draw_zones = false;
+        bool do_draw_async_anim = false;
 
         tripoint exp_pos;
         int exp_rad = 0;
 
         std::map<tripoint, explosion_tile> custom_explosion_layer;
+        std::map<tripoint, std::string> async_anim_layer;
 
         tripoint bul_pos;
         std::string bul_id;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3808,10 +3808,6 @@ void game::draw_async_anim_curses()
 void game::void_async_anim_curses()
 {
     async_anim_layer_curses.clear();
-#if !defined(TILES)
-    // Curses does not redraw itself so do it here
-    ui_manager::redraw();
-#endif
 }
 
 void game::draw( ui_adaptor &ui )

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10407,25 +10407,25 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
         if( get_option<bool>( "ANIMATIONS" ) && u.is_running() ) {
             if( u.posy() < oldpos.y ) {
                 if( u.posx() < oldpos.x ) {
-                    draw_async_anim( oldpos, "run_nw", "*", c_light_gray );
+                    draw_async_anim( oldpos, "run_nw", "\\", c_light_gray );
                 } else if( u.posx() == oldpos.x ) {
-                    draw_async_anim( oldpos, "run_n", "*", c_light_gray );
+                    draw_async_anim( oldpos, "run_n", "|", c_light_gray );
                 } else {
-                    draw_async_anim( oldpos, "run_ne", "*", c_light_gray );
+                    draw_async_anim( oldpos, "run_ne", "/", c_light_gray );
                 }
             } else if( u.posy() == oldpos.y ) {
                 if( u.posx() < oldpos.x ) {
-                    draw_async_anim( oldpos, "run_w", "*", c_light_gray );
+                    draw_async_anim( oldpos, "run_w", "-", c_light_gray );
                 } else {
-                    draw_async_anim( oldpos, "run_e", "*", c_light_gray );
+                    draw_async_anim( oldpos, "run_e", "-", c_light_gray );
                 }
             } else {
                 if( u.posx() < oldpos.x ) {
-                    draw_async_anim( oldpos, "run_sw", "*", c_light_gray );
+                    draw_async_anim( oldpos, "run_sw", "/", c_light_gray );
                 } else if( u.posx() == oldpos.x ) {
-                    draw_async_anim( oldpos, "run_s", "*", c_light_gray );
+                    draw_async_anim( oldpos, "run_s", "-", c_light_gray );
                 } else {
-                    draw_async_anim( oldpos, "run_se", "*", c_light_gray );
+                    draw_async_anim( oldpos, "run_se", "\\", c_light_gray );
                 }
             }
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10423,7 +10423,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
                 if( u.posx() < oldpos.x ) {
                     draw_async_anim( oldpos, "run_sw", "/", c_light_gray );
                 } else if( u.posx() == oldpos.x ) {
-                    draw_async_anim( oldpos, "run_s", "-", c_light_gray );
+                    draw_async_anim( oldpos, "run_s", "|", c_light_gray );
                 } else {
                     draw_async_anim( oldpos, "run_se", "\\", c_light_gray );
                 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3782,6 +3782,34 @@ static shared_ptr_fast<game::draw_callback_t> create_trail_callback(
     } );
 }
 
+void game::init_draw_async_anim_curses( const tripoint &p, const std::string &ncstr,
+                                        const nc_color &nccol )
+{
+    std::pair <std::string, nc_color> anim( ncstr, nccol );
+    async_anim_layer_curses[p] = anim;
+}
+
+void game::draw_async_anim_curses()
+{
+    // game::draw_async_anim_curses can be called multiple times, storing each animation to be played in async_anim_layer_curses
+    // Iterate through every animation in async_anim_layer
+    for( const auto &anim : async_anim_layer_curses ) {
+        const tripoint p = anim.first - u.view_offset + tripoint( POSX - u.posx(), POSY - u.posy(),
+                           -u.posz() );
+        const std::string ncstr = anim.second.first;
+        const nc_color nccol = anim.second.second;
+
+        mvwprintz( w_terrain, p.xy(), nccol, ncstr );
+        //shared_ptr_fast<game::draw_callback_t> hit_cb = make_shared_fast<game::draw_callback_t>( [&]() { mvwprintz( w_terrain, p.xy(), nccol, ncstr ); } );
+        //g->add_draw_callback( hit_cb );
+    }
+}
+
+void game::void_async_anim_curses()
+{
+    async_anim_layer_curses.clear();
+}
+
 void game::draw( ui_adaptor &ui )
 {
     if( test_mode ) {
@@ -3804,6 +3832,7 @@ void game::draw( ui_adaptor &ui )
             it = draw_callbacks.erase( it );
         }
     }
+    draw_async_anim_curses();
     wnoutrefresh( w_terrain );
 
     draw_panels( true );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3808,6 +3808,10 @@ void game::draw_async_anim_curses()
 void game::void_async_anim_curses()
 {
     async_anim_layer_curses.clear();
+#if !defined(TILES)
+    // Curses does not redraw itself so do it here
+    ui_manager::redraw();
+#endif
 }
 
 void game::draw( ui_adaptor &ui )

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10405,29 +10405,27 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
 
         // Add trail animation when sprinting
         if( get_option<bool>( "ANIMATIONS" ) && u.is_running() ) {
-            std::map<tripoint, nc_color> area_color;
-            area_color[oldpos] = c_black;
             if( u.posy() < oldpos.y ) {
                 if( u.posx() < oldpos.x ) {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_nw" );
+                    draw_async_anim( oldpos, "run_nw", "*", c_light_gray );
                 } else if( u.posx() == oldpos.x ) {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_n" );
+                    draw_async_anim( oldpos, "run_n", "*", c_light_gray );
                 } else {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_ne" );
+                    draw_async_anim( oldpos, "run_ne", "*", c_light_gray );
                 }
             } else if( u.posy() == oldpos.y ) {
                 if( u.posx() < oldpos.x ) {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_w" );
+                    draw_async_anim( oldpos, "run_w", "*", c_light_gray );
                 } else {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_e" );
+                    draw_async_anim( oldpos, "run_e", "*", c_light_gray );
                 }
             } else {
                 if( u.posx() < oldpos.x ) {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_sw" );
+                    draw_async_anim( oldpos, "run_sw", "*", c_light_gray );
                 } else if( u.posx() == oldpos.x ) {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_s" );
+                    draw_async_anim( oldpos, "run_s", "*", c_light_gray );
                 } else {
-                    explosion_handler::draw_custom_explosion( oldpos, area_color, "run_se" );
+                    draw_async_anim( oldpos, "run_se", "*", c_light_gray );
                 }
             }
         }

--- a/src/game.h
+++ b/src/game.h
@@ -756,6 +756,9 @@ class game
         // Draw a highlight graphic at p, for example when examining something.
         // TILES only, in curses this does nothing
         void draw_highlight( const tripoint &p );
+        // Draws an asynchronous animation at p with tile_id as its sprite. If ncstr is specified, it will also be displayed in curses.
+        void draw_async_anim( const tripoint &p, const std::string tile_id, const std::string ncstr = "",
+                              const nc_color nccol = c_black );
         void draw_radiation_override( const tripoint &p, int rad );
         void draw_terrain_override( const tripoint &p, const ter_id &id );
         void draw_furniture_override( const tripoint &p, const furn_id &id );

--- a/src/game.h
+++ b/src/game.h
@@ -262,7 +262,8 @@ class game
         void draw_async_anim_curses();
         void void_async_anim_curses();
     protected:
-        std::map<tripoint, std::pair <std::string, nc_color>> async_anim_layer_curses;
+        std::map<tripoint, std::pair <std::string, nc_color>>
+                async_anim_layer_curses; // NOLINT(cata-serialize)
 
     public:
         // when force_redraw is true, redraw all panel instead of just animated panels

--- a/src/game.h
+++ b/src/game.h
@@ -757,8 +757,8 @@ class game
         // TILES only, in curses this does nothing
         void draw_highlight( const tripoint &p );
         // Draws an asynchronous animation at p with tile_id as its sprite. If ncstr is specified, it will also be displayed in curses.
-        void draw_async_anim( const tripoint &p, const std::string tile_id, const std::string ncstr = "",
-                              const nc_color nccol = c_black );
+        void draw_async_anim( const tripoint &p, const std::string &tile_id, const std::string &ncstr = "",
+                              const nc_color &nccol = c_black );
         void draw_radiation_override( const tripoint &p, int rad );
         void draw_terrain_override( const tripoint &p, const ter_id &id );
         void draw_furniture_override( const tripoint &p, const furn_id &id );

--- a/src/game.h
+++ b/src/game.h
@@ -256,6 +256,15 @@ class game
         std::vector<weak_ptr_fast<draw_callback_t>> draw_callbacks; // NOLINT(cata-serialize)
 
     public:
+        // Curses counterpart of the async_anim functions in cata_tiles
+        void init_draw_async_anim_curses( const tripoint &p, const std::string &ncstr,
+                                          const nc_color &nccol );
+        void draw_async_anim_curses();
+        void void_async_anim_curses();
+    protected:
+        std::map<tripoint, std::pair <std::string, nc_color>> async_anim_layer_curses;
+
+    public:
         // when force_redraw is true, redraw all panel instead of just animated panels
         // mostly used after UI updates
         void draw_panels( bool force_draw = false );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -22,7 +22,6 @@
 #include "bodypart.h"
 #include "cached_options.h"
 #include "calendar.h"
-#include "cata_tiles.h"
 #include "catacharset.h"
 #include "character.h"
 #include "character_martial_arts.h"
@@ -79,7 +78,6 @@
 #include "rng.h"
 #include "safemode_ui.h"
 #include "scores_ui.h"
-#include "sdltiles.h"
 #include "sounds.h"
 #include "string_formatter.h"
 #include "timed_event.h"
@@ -95,6 +93,11 @@
 #include "weather.h"
 #include "weather_type.h"
 #include "worldfactory.h"
+
+#if defined(TILES)
+#include "cata_tiles.h" // all animation functions will be pushed out to a cata_tiles function in some manner
+#include "sdltiles.h"
+#endif
 
 static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
 static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
@@ -383,10 +386,12 @@ input_context game::get_player_input( std::string &action )
                 .on_top( true );
             }
 
+#if defined(TILES)
             // Remove asynchronous animations after animation delay if no input
             if( current_turn.async_anim_timeout() ) {
                 tilecontext->void_async_anim();
             }
+#endif
 
             ui_manager::redraw_invalidated();
         } while( handle_mouseview( ctxt, action ) && uquit != QUIT_WATCH
@@ -2843,9 +2848,11 @@ bool game::handle_action()
         ctxt = get_player_input( action );
     }
 
+#if defined(TILES)
     // Remove asynchronous animations if any action taken before the input timeout
     // Otherwise repeated input can cause animations to accumulate as the timeout is never reached
     tilecontext->void_async_anim();
+#endif
 
     bool veh_ctrl = has_vehicle_control( player_character );
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -388,10 +388,13 @@ input_context game::get_player_input( std::string &action )
 
             // Remove asynchronous animations after animation delay if no input
             if( current_turn.async_anim_timeout() ) {
+                g->void_async_anim_curses();
 #if defined(TILES)
                 tilecontext->void_async_anim();
+#else
+                // Curses does not redraw itself so do it here
+                g->invalidate_main_ui_adaptor();
 #endif
-                g->void_async_anim_curses();
             }
 
             ui_manager::redraw_invalidated();
@@ -2851,10 +2854,13 @@ bool game::handle_action()
 
     // Remove asynchronous animations if any action taken before the input timeout
     // Otherwise repeated input can cause animations to accumulate as the timeout is never reached
+    g->void_async_anim_curses();
 #if defined(TILES)
     tilecontext->void_async_anim();
+#else
+    // Curses does not redraw itself so do it here
+    g->invalidate_main_ui_adaptor();
 #endif
-    g->void_async_anim_curses();
 
     bool veh_ctrl = has_vehicle_control( player_character );
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -896,25 +896,15 @@ static void smash()
         player_character.moves -= move_cost * weary_mult;
         player_character.recoil = MAX_RECOIL;
 
-        // Variables for bash animation
-        std::map<tripoint, nc_color> anim_area;
-        anim_area[smashp] = c_black;
-
         if( bash_result.success ) {
             // Bash results in destruction of target
-            if( get_option<bool>( "ANIMATIONS" ) ) {
-                explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_complete" );
-            }
+            g->draw_async_anim( smashp, "bash_complete", "X", c_light_gray );
         } else if( smashskill >= here.bash_resistance( smashp ) ) {
             // Bash effective but target not yet destroyed
-            if( get_option<bool>( "ANIMATIONS" ) ) {
-                explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_effective" );
-            }
+            g->draw_async_anim( smashp, "bash_effective", "/", c_light_gray );
         } else {
             // Bash not effective
-            if( get_option<bool>( "ANIMATIONS" ) ) {
-                explosion_handler::draw_custom_explosion( smashp, anim_area, "bash_ineffective" );
-            }
+            g->draw_async_anim( smashp, "bash_ineffective" );
             if( one_in( 10 ) ) {
                 if( here.has_furn( smashp ) && here.furn( smashp ).obj().bash.str_min != -1 ) {
                     // %s is the smashed furniture

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -386,12 +386,13 @@ input_context game::get_player_input( std::string &action )
                 .on_top( true );
             }
 
-#if defined(TILES)
             // Remove asynchronous animations after animation delay if no input
             if( current_turn.async_anim_timeout() ) {
+#if defined(TILES)
                 tilecontext->void_async_anim();
-            }
 #endif
+                g->void_async_anim_curses();
+            }
 
             ui_manager::redraw_invalidated();
         } while( handle_mouseview( ctxt, action ) && uquit != QUIT_WATCH
@@ -2848,11 +2849,12 @@ bool game::handle_action()
         ctxt = get_player_input( action );
     }
 
-#if defined(TILES)
     // Remove asynchronous animations if any action taken before the input timeout
     // Otherwise repeated input can cause animations to accumulate as the timeout is never reached
+#if defined(TILES)
     tilecontext->void_async_anim();
 #endif
+    g->void_async_anim_curses();
 
     bool veh_ctrl = has_vehicle_control( player_character );
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2962,6 +2962,7 @@ bool game::handle_action()
             destination_preview.clear();
         }
     }
+
     if( act == ACTION_NULL ) {
         const input_event &&evt = ctxt.get_raw_input();
         if( !evt.sequence.empty() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Asynchronous animations including sprinting and smashing"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#65622 uses the custom explosion system to introduce some new animations.  While it achieves its purpose, it is hardly the most efficient way to draw animations.  Said animations are also synchronous - the game basically waits for the `ANIMATION_DELAY` to elapse before handing control back to the player.  #65666 also pointed out that those animations can cause excessive pop-up messages.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Introduce asynchronous animations, a new type of animation that does not pause the game while running.  It follows existing animation settings and works both tiles and curses.  Sprinting and smashing animations are changed to use this new animation type instead.  Fixes #65666.

Usage:
`g->draw_async_anim( p, tile_id, ncstr, nc_color );`
`p` is the location in tripoint form
`tile_id` is the sprite name as a string. If invalid, nothing is displayed (tiles only)
`ncstr` is the character to display as a string (curses only) (optional)
`nccol` is the color of the displayed character as nc_color (curses only) (optional)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Sprinting and smashing animations tested to be working in both tiles and curses.  Animations are modified by animation settings as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->