### PR TITLE
Port from BN: Add command to pet menu for removing individual items from storage

### DIFF
--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -281,6 +281,40 @@ bool give_items_to( monster &z )
     return to_move.size() == items.size();
 }
 
+void take_items_from( monster &z )
+{
+    const std::string pet_name = z.get_name();
+    std::vector<item> &monster_inv = z.inv;
+    if( monster_inv.empty() ) {
+        return;
+    }
+
+    int i = 0;
+    uilist selection_menu;
+    selection_menu.text = string_format( _( "Select an item to remove from the %s." ), pet_name );
+    selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Cancel" ) );
+    for( auto iter : monster_inv ) {
+        selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Retrieve %s" ), iter.tname() );
+    }
+    selection_menu.selected = 1;
+    selection_menu.query();
+    const int index = selection_menu.ret;
+    if( index == 0 || index == UILIST_CANCEL || index < 0 ||
+        index > static_cast<int>( monster_inv.size() ) ) {
+        return;
+    }
+
+    // because the first entry is the cancel option
+    const int selection = index - 1;
+    item retrieved_item = monster_inv[selection];
+    monster_inv.erase( monster_inv.begin() + selection );
+
+    add_msg( _( "You remove the %1$s from the %2$s's bag." ), retrieved_item.tname(), pet_name );
+
+    avatar &you = get_avatar();
+    you.i_add( retrieved_item );
+}
+
 item_location pet_armor_loc( monster &z )
 {
     auto filter = [z]( const item & it ) {
@@ -572,6 +606,7 @@ bool monexamine::pet_menu( monster &z )
         remove_bag,
         drop_all,
         give_items,
+        take_items,
         mon_armor_add,
         mon_harness_remove,
         mon_armor_remove,
@@ -613,10 +648,11 @@ bool monexamine::pet_menu( monster &z )
     Character &player_character = get_player_character();
     if( z.has_effect( effect_has_bag ) ) {
         amenu.addentry( give_items, true, 'g', _( "Place items into bag" ) );
-        amenu.addentry( remove_bag, true, 'b', _( "Remove bag from %s" ), pet_name );
         if( !z.inv.empty() ) {
+            amenu.addentry( take_items, true, 'T', _( "Take items from bag" ) );
             amenu.addentry( drop_all, true, 'd', _( "Remove all items from bag" ) );
         }
+        amenu.addentry( remove_bag, true, 'b', _( "Remove bag from %s" ), pet_name );
     } else if( !z.has_flag( MF_RIDEABLE_MECH ) ) {
         amenu.addentry( attach_bag, true, 'b', _( "Attach bag to %s" ), pet_name );
     }
@@ -762,6 +798,9 @@ bool monexamine::pet_menu( monster &z )
             break;
         case give_items:
             return give_items_to( z );
+        case take_items:
+            take_items_from( z );
+            break;
         case mon_armor_add:
             return add_armor( z );
         case mon_harness_remove:

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -285,15 +285,12 @@ void take_items_from( monster &z )
 {
     const std::string pet_name = z.get_name();
     std::vector<item> &monster_inv = z.inv;
-    if( monster_inv.empty() ) {
-        return;
-    }
 
     int i = 0;
     uilist selection_menu;
     selection_menu.text = string_format( _( "Select an item to remove from the %s." ), pet_name );
     selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Cancel" ) );
-    for( auto iter : monster_inv ) {
+    for( const item& iter : monster_inv ) {
         selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Retrieve %s" ), iter.tname() );
     }
     selection_menu.selected = 1;

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -290,7 +290,7 @@ void take_items_from( monster &z )
     uilist selection_menu;
     selection_menu.text = string_format( _( "Select an item to remove from the %s." ), pet_name );
     selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Cancel" ) );
-    for( const item& iter : monster_inv ) {
+    for( const item &iter : monster_inv ) {
         selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Retrieve %s" ), iter.tname() );
     }
     selection_menu.selected = 1;

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -296,7 +296,7 @@ void take_items_from( monster &z )
     selection_menu.selected = 1;
     selection_menu.query();
     const int index = selection_menu.ret;
-    if( index == 0 || index == UILIST_CANCEL || index < 0 ||
+    if( index <= 0 || index == UILIST_CANCEL ||
         index > static_cast<int>( monster_inv.size() ) ) {
         return;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Thie  is [Add command to pet menu for removing individual items from storage](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2868) in BN.I think this can further enhance the practicality of pets. It is also great for players who like pets, and transplantation does not require much work.



<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a new function `take_items_from (Monster& z)` and new enumeration item in monexamine.cpp, and apply them in fact.
And I adjusted the position of 'Remove bag from' slightly, placing it later may be better.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

After：
![show_02](https://github.com/CleverRaven/Cataclysm-DDA/assets/112397151/b78d54c2-9dee-4cb7-bb1f-b0c9849bf6dd)
![CLB_8{6 ONR1X284BD(OPH7](https://github.com/CleverRaven/Cataclysm-DDA/assets/112397151/6c8cfabe-4fb5-4084-bfa9-5683af2e9b1d)
![show_01](https://github.com/CleverRaven/Cataclysm-DDA/assets/112397151/e81f00b9-6f3b-4e81-a397-43e632492ba1)

I generated a cow and then give and take items multiple times normally.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->