### PR TITLE
breaching shotgun spawns on SWAT zombies

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -1330,6 +1330,7 @@
       { "item": "hk_mp5k", "prob": 10, "charges-min": 0, "charges-max": 30 },
       { "item": "hk_mp5sd", "prob": 5, "charges-min": 0, "charges-max": 30 },
       { "item": "mossberg_930", "variant": "m1014", "prob": 10, "charges-min": 0, "charges-max": 8 },
+      { "item": "remington_870_breacher", "prob": 10, "charges-min": 0, "charges-max": 4 },
       { "item": "modular_m4_carbine", "variant": "modular_m4a1", "prob": 35, "charges-min": 0, "charges-max": 30 },
       { "item": "as50", "prob": 5, "charges-min": 0, "charges-max": 10 },
       { "item": "axmc", "prob": 10, "charges-min": 0, "charges-max": 10 },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

This thing barely spawns anywhere, and breaching shotguns are often carried by law inforcement.

#### Describe the solution

Adds the Remington 870 MCS to the itemgroup `guns_swat`
