### PR TITLE
Port from BN: Add command to pet menu for removing individual items from storage

### DIFF
--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -296,7 +296,7 @@ void take_items_from( monster &z )
     selection_menu.selected = 1;
     selection_menu.query();
     const int index = selection_menu.ret;
-    if( index <= 0 || index == UILIST_CANCEL || index > static_cast<int>( monster_inv.size() ) ) {
+    if( index <= 0 || index > static_cast<int>( monster_inv.size() ) ) {
         return;
     }
 

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -296,8 +296,7 @@ void take_items_from( monster &z )
     selection_menu.selected = 1;
     selection_menu.query();
     const int index = selection_menu.ret;
-    if( index < 0 || index == UILIST_CANCEL  || index == 0  ||
-        index > static_cast<int>( monster_inv.size() ) ) {
+    if( index <= 0 || index == UILIST_CANCEL || index > static_cast<int>( monster_inv.size() ) ) {
         return;
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Thie  is [Add command to pet menu for removing individual items from storage](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2868) in BN.I think this can further enhance the practicality of pets. It is also great for players who like pets, and transplantation does not require much work.



<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a new function `take_items_from (Monster& z)` and new enumeration item in monexamine.cpp, and apply them in fact.
And I adjusted the position of 'Remove bag from' slightly, placing it later may be better.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

After：
![show_02](https://github.com/CleverRaven/Cataclysm-DDA/assets/112397151/b78d54c2-9dee-4cb7-bb1f-b0c9849bf6dd)
![CLB_8{6 ONR1X284BD(OPH7](https://github.com/CleverRaven/Cataclysm-DDA/assets/112397151/6c8cfabe-4fb5-4084-bfa9-5683af2e9b1d)
![show_01](https://github.com/CleverRaven/Cataclysm-DDA/assets/112397151/e81f00b9-6f3b-4e81-a397-43e632492ba1)

I generated a cow and then give and take items multiple times normally.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->