### PR TITLE
Cache Character's radiation leak level

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1343,6 +1343,7 @@ bool avatar::wield( item_location target )
 bool avatar::wield( item &target )
 {
     invalidate_inventory_validity_cache();
+    invalidate_leak_level_cache();
     return wield( target,
                   item_handling_cost( target, true,
                                       is_worn( target ) ? INVENTORY_HANDLING_PENALTY / 2 :

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2152,7 +2152,7 @@ void Character::process_turn()
     if( activity.targets.empty() && activity.do_drop_invalid_inventory() ) {
         drop_invalid_inventory();
     }
-    if (leak_level_dirty) {
+    if( leak_level_dirty ) {
         calculate_leak_level();
     }
     process_items();
@@ -6399,16 +6399,16 @@ void Character::mod_rad( int mod )
     set_rad( std::max( 0, get_rad() + mod ) );
 }
 
-void Character::calculate_leak_level() {
+void Character::calculate_leak_level()
+{
     float ret = 0.0f;
     // This is bad way to calculate radiation and should be rewritten some day.
-    for (const item_location& item_loc : const_cast<Character*>(this)->all_items_loc()) {
-        const item* it = item_loc.get_item();
-        if (it->has_flag(flag_RADIOACTIVE)) {
-            if (it->has_flag(flag_LEAK_ALWAYS)) {
-                ret += to_gram(it->weight()) / 250.f;
-            }
-            else if (it->has_flag(flag_LEAK_DAM)) {
+    for( const item_location &item_loc : const_cast<Character *>( this )->all_items_loc() ) {
+        const item *it = item_loc.get_item();
+        if( it->has_flag( flag_RADIOACTIVE ) ) {
+            if( it->has_flag( flag_LEAK_ALWAYS ) ) {
+                ret += to_gram( it->weight() ) / 250.f;
+            } else if( it->has_flag( flag_LEAK_DAM ) ) {
                 ret += it->damage_level();
             }
         }
@@ -6422,7 +6422,8 @@ float Character::get_leak_level() const
     return leak_level;
 }
 
-void Character::invalidate_leak_level_cache() {
+void Character::invalidate_leak_level_cache()
+{
     leak_level_dirty = true;
 }
 

--- a/src/character.h
+++ b/src/character.h
@@ -2165,8 +2165,6 @@ class Character : public Creature, public visitable
 
         bool covered_with_flag( const flag_id &flag, const body_part_set &parts ) const;
         bool is_waterproof( const body_part_set &parts ) const;
-        // Amount of radiation (mSv) leaked from carried items.
-        float leak_level() const;
 
         // --------------- Clothing Stuff ---------------
         /** Returns true if the player is wearing the item. */
@@ -2452,7 +2450,6 @@ class Character : public Creature, public visitable
         // Means player sit inside vehicle on the tile he is now
         bool in_vehicle = false;
         bool hauling = false;
-        float leaking_level;
         tripoint view_offset;
 
         player_activity stashed_outbounds_activity;
@@ -3299,6 +3296,19 @@ class Character : public Creature, public visitable
         bool irradiate( float rads, bool bypass = false );
         /** Handles the chance for broken limbs to spontaneously heal to 1 HP */
         void mend( int rate_multiplier );
+
+        private:
+            // Amount of radiation (mSv) leaked from carried items.
+            float leak_level = 0.0f;
+            /** Signify that leak_level needs refreshing. Set to true on inventory change. */
+            bool leak_level_dirty = true;
+        public:
+            float get_leak_level() const;
+            /** Iterate through the character inventory to get its leak level */
+            void calculate_leak_level();
+            /** Sets leak_level_dirty to true */
+            void invalidate_leak_level_cache();
+
 
         /** Creates an auditory hallucination */
         void sound_hallu();

--- a/src/character.h
+++ b/src/character.h
@@ -2452,7 +2452,7 @@ class Character : public Creature, public visitable
         // Means player sit inside vehicle on the tile he is now
         bool in_vehicle = false;
         bool hauling = false;
-
+        float leaking_level;
         tripoint view_offset;
 
         player_activity stashed_outbounds_activity;

--- a/src/character.h
+++ b/src/character.h
@@ -3297,17 +3297,17 @@ class Character : public Creature, public visitable
         /** Handles the chance for broken limbs to spontaneously heal to 1 HP */
         void mend( int rate_multiplier );
 
-        private:
-            // Amount of radiation (mSv) leaked from carried items.
-            float leak_level = 0.0f;
-            /** Signify that leak_level needs refreshing. Set to true on inventory change. */
-            bool leak_level_dirty = true;
-        public:
-            float get_leak_level() const;
-            /** Iterate through the character inventory to get its leak level */
-            void calculate_leak_level();
-            /** Sets leak_level_dirty to true */
-            void invalidate_leak_level_cache();
+    private:
+        // Amount of radiation (mSv) leaked from carried items.
+        float leak_level = 0.0f;
+        /** Signify that leak_level needs refreshing. Set to true on inventory change. */
+        bool leak_level_dirty = true;
+    public:
+        float get_leak_level() const;
+        /** Iterate through the character inventory to get its leak level */
+        void calculate_leak_level();
+        /** Sets leak_level_dirty to true */
+        void invalidate_leak_level_cache();
 
 
         /** Creates an auditory hallucination */

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -336,6 +336,7 @@ std::optional<std::list<item>::iterator> Character::wear_item( const item &to_we
         bool interactive, bool do_calc_encumbrance )
 {
     invalidate_inventory_validity_cache();
+    invalidate_leak_level_cache();
     const auto ret = can_wear( to_wear );
     if( !ret.success() ) {
         if( interactive ) {

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -522,7 +522,7 @@ void Character::drop_invalid_inventory()
         weap.overflow();
     }
     worn.overflow( *this );
-
+    leaking_level = leak_level();
     cache_inventory_is_valid = true;
 }
 

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -161,6 +161,7 @@ item_location Character::try_add( item it, const item *avoid, const item *origin
                                   const bool allow_wield, bool ignore_pkt_settings )
 {
     invalidate_inventory_validity_cache();
+    invalidate_leak_level_cache();
     itype_id item_type_id = it.typeId();
     last_item = item_type_id;
 
@@ -207,6 +208,7 @@ item_location Character::i_add( item it, bool /* should_stack */, const item *av
                                 const bool allow_wield, bool ignore_pkt_settings )
 {
     invalidate_inventory_validity_cache();
+    invalidate_leak_level_cache();
     item_location added = try_add( it, avoid, original_inventory_item, allow_wield,
                                    ignore_pkt_settings );
     if( added == item_location::nowhere ) {
@@ -289,6 +291,7 @@ item Character::i_rem( const item *it )
         debugmsg( "did not found item %s to remove it!", it->tname() );
         return item();
     }
+    invalidate_leak_level_cache();
     return tmp.front();
 }
 
@@ -428,7 +431,7 @@ void Character::drop( const drop_locations &what, const tripoint &target,
     if( what.empty() ) {
         return;
     }
-
+    invalidate_leak_level_cache();
     const std::optional<vpart_reference> vp = get_map().veh_at(
                 target ).part_with_feature( "CARGO", false );
     if( rl_dist( pos(), target ) > 1 || !( stash || get_map().can_put_items( target ) )
@@ -457,7 +460,7 @@ void Character::pick_up( const drop_locations &what )
     if( what.empty() ) {
         return;
     }
-
+    invalidate_leak_level_cache();
     //todo: refactor pickup_activity_actor to just use drop_locations, also rename drop_locations
     std::vector<item_location> items;
     std::vector<int> quantities;
@@ -522,7 +525,6 @@ void Character::drop_invalid_inventory()
         weap.overflow();
     }
     worn.overflow( *this );
-    leaking_level = leak_level();
     cache_inventory_is_valid = true;
 }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5443,9 +5443,9 @@ void iexamine::autodoc( Character &you, const tripoint &examp )
                     patient.add_effect( effect_pblue, 1_hours );
                 }
             }
-            if( static_cast<int>( patient.leak_level() ) ) {
+            if( static_cast<int>( patient.get_leak_level() ) ) {
                 popup( _( "Warning!  Autodoc detected a radiation leak of %d mSv from items in patient's possession.  Urgent decontamination procedures highly recommended." ),
-                       static_cast<int>( patient.leak_level() ) );
+                       static_cast<int>( patient.get_leak_level() ) );
             }
             break;
         }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3398,14 +3398,14 @@ std::optional<int> iuse::geiger( Character *p, item *it, bool t, const tripoint 
             const tripoint &pnt = *pnt_;
             if( pnt == p->pos() ) {
                 p->add_msg_if_player( m_info, _( "Your radiation level: %d mSv (%d mSv from items)" ), p->get_rad(),
-                                      static_cast<int>( p->leak_level() ) );
+                                      static_cast<int>( p->get_leak_level() ) );
                 break;
             }
             if( npc *const person_ = creatures.creature_at<npc>( pnt ) ) {
                 npc &person = *person_;
                 p->add_msg_if_player( m_info, _( "%s's radiation level: %d mSv (%d mSv from items)" ),
                                       person.get_name(), person.get_rad(),
-                                      static_cast<int>( person.leak_level() ) );
+                                      static_cast<int>( person.get_leak_level() ) );
             }
             break;
         }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1494,7 +1494,7 @@ bool npc::wield( item &it )
     } else {
         to_wield = it;
     }
-
+    invalidate_leak_level_cache();
     invalidate_inventory_validity_cache();
     cached_info.erase( "weapon_value" );
     item_location weapon = get_wielded_item();

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1285,7 +1285,8 @@ void suffer::from_radiation( Character &you )
 {
     map &here = get_map();
     // checking for radioactive items in inventory
-    const float item_radiation = you.leaking_level;
+    you.calculate_leak_level();
+    float item_radiation = you.get_leak_level();
     const int map_radiation = here.get_radiation( you.pos() );
     float rads = map_radiation / 100.0f + item_radiation / 10.0f;
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1284,8 +1284,7 @@ void suffer::from_other_mutations( Character &you )
 void suffer::from_radiation( Character &you )
 {
     map &here = get_map();
-    // checking for radioactive items in inventory
-    you.calculate_leak_level();
+    // get radioactive leak level of your inventory
     float item_radiation = you.get_leak_level();
     const int map_radiation = here.get_radiation( you.pos() );
     float rads = map_radiation / 100.0f + item_radiation / 10.0f;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1285,7 +1285,7 @@ void suffer::from_radiation( Character &you )
 {
     map &here = get_map();
     // checking for radioactive items in inventory
-    const float item_radiation = you.leak_level();
+    const float item_radiation = you.leaking_level;
     const int map_radiation = here.get_radiation( you.pos() );
     float rads = map_radiation / 100.0f + item_radiation / 10.0f;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Improve performance. 

`leak_level()` call is expensive, especially it has to be called every turn on every character. So cache it and re-cache on inventory change.

The impact of `leak_level()` on performance can be a lot more severe once #60885 gets merged.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Cache the leak level when character inventory changes. 

Add a dedicated set of functions to get and set the value, to our code spaghetti. This also makes it more easy to potentially add a feature that radioactive items contribute to the environmental leak level.

Mostly, where invalidate_inventory_cache() is called, this leak level cache should also be called. But I avoided reusing that variable, to maintain clarity. I'm unsure whether this is a good practice for this case?

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered


<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Test results are get by sleeping 9 hours with reasonably many items in character's inventory.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/22912139/8efc270d-8025-4606-a4d4-cc5f793056ba)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/22912139/35d5120a-af02-4124-8be7-1a29ea95d6f0)

Before:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/22912139/3ffa5d2b-bc33-4a9a-885c-443eca027ca0)

After:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/22912139/e5750c9f-418c-4eef-89ca-f18134c5e33c)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->