### PR TITLE
Update references to old mapgen ids

### DIFF
--- a/data/json/obsoletion/migration_overmap_specials.json
+++ b/data/json/obsoletion/migration_overmap_specials.json
@@ -97,7 +97,14 @@
   {
     "type": "overmap_special_migration",
     "id": "Mansion_Wild",
-    "//": "Removed in 0.G - no new id"
+    "new_id": "Mansion_Road_1",
+    "//": "Migrated in 0.H"
+  },
+  {
+    "type": "overmap_special_migration",
+    "id": "Mansion_WildAlt",
+    "new_id": "Mansion_Road_Alt_1",
+    "//": "Migrated in 0.H"
   },
   {
     "type": "overmap_special_migration",

--- a/data/mods/Aftershock/npcs/Backgrounds/BGBR_Sadie.json
+++ b/data/mods/Aftershock/npcs/Backgrounds/BGBR_Sadie.json
@@ -41,7 +41,7 @@
           "yes": "What a beautiful facility.  I bet they have all kinds of lovely toys to play with.  We should kill everyone here and do some creative self-experimentation."
         },
         {
-          "npc_at_om_location": "Mansion_Wild",
+          "npc_at_om_location": "Mansion_Road_1",
           "no": "",
           "yes": "Ooh, it's like a murder mystery here.  Are we the murderers, the murdered, or the mystery?"
         }

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -58,7 +58,7 @@ static const mongroup_id GROUP_ZOMBIE( "GROUP_ZOMBIE" );
 
 static const mtype_id mon_generator( "mon_generator" );
 
-static const overmap_special_id overmap_special_Mansion_Wild( "Mansion_Wild" );
+static const overmap_special_id overmap_special_Mansion_Road_1( "Mansion_Road_1" );
 static const overmap_special_id overmap_special_bar( "bar" );
 static const overmap_special_id overmap_special_hospital( "hospital" );
 static const overmap_special_id
@@ -280,7 +280,7 @@ void defense_game::init_map()
             break;
 
         case DEFLOC_MANSION:
-            defloc_special = overmap_special_Mansion_Wild;
+            defloc_special = overmap_special_Mansion_Road_1;
             break;
     }
     starting_om.place_special_forced( defloc_special, defloc_pos, om_direction::type::north );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix mansion scenario crash in defense mode"

#### Purpose of change
Fixes #65854

#### Describe the solution
Update the hardcoded references. Grep for any other references of Mansion_Wild. Update the other one I found.

#### Describe alternatives you've considered
Moving the defense mode scenarios out of hardcoding would be good but also not something I really feel like doing.

#### Testing
Compiled locally, scenario now loads without issue.

#### Additional context
@irwiss You placed an entry for `Mansion_Wild` in data/json/obsoletion/migration_overmap_specials.json with a comment saying "Removed in 0.G - no new id"... but it was migrated? It migrates to `Mansion_Road_1`. I still don't 100% understand the way we do obsoletions, so just want to mention it and make sure that looks right?

https://github.com/CleverRaven/Cataclysm-DDA/blame/4f113f720614bf82dfa7f49c6c29b2067d05a4a2/data/json/obsoletion/migration_overmap_specials.json#L98-L100


@ aftershock maintainers who will get notified, not sure if that text is still appropriate now that the wilderness mansion has a road?