### PR TITLE
Enable death effects on limited lifespan monsters

### DIFF
--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -344,6 +344,7 @@
     "melee_dice_sides": 5,
     "melee_skill": 3,
     "special_attacks": [ [ "GRAB", 7 ], [ "GRAB_DRAG", 15 ] ],
+    "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s shatters like pane of glass." },
     "delete": { "flags": [ "ATTACKMON", "ALWAYS_SEES_YOU", "HIT_AND_RUN" ] },
     "extend": { "flags": [ "SILENT_DISAPPEAR" ] }
   },
@@ -353,7 +354,6 @@
     "name": { "str": "skewered juvenile" },
     "copy-from": "mon_void_spider_spiderling",
     "color": "light_green",
-    "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s shatters like pane of glass." },
     "description": "Layers of flailing limbs struggle against an impaled emerald lance.",
     "death_drops": "void_spider_spiderling_skewered_drops"
   },

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2601,9 +2601,8 @@ void monster::die( Creature *nkiller )
     }
     mission::on_creature_death( *this );
 
-    // Also, perform our death function
-    if( is_hallucination() || lifespan_end ) {
-        //Hallucinations always just disappear
+    // Hallucinations always just disappear
+    if( is_hallucination() ) {
         mdeath::disappear( *this );
         return;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Enable death effects on limited lifespan monsters"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Fixes #65303.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Previous code was assuming that any monster with a lifespan is a hallucination even though it should be possible to summon a fully real monster but with a limited lifespan.

As an [example](https://github.com/CleverRaven/Cataclysm-DDA/blob/4f113f720614bf82dfa7f49c6c29b2067d05a4a2/data/json/portal_storm_effect_on_condition.json#L621),

```json
{
  "type": "effect_on_condition",
  "id": "EOC_PORTAL_SWARM_STRUCTURE",
  "effect": [
    {
      "u_spawn_monster": "mon_swarm_structure",
      "real_count": 1,
      "outdoor_only": true,
      "min_radius": 3,
      "max_radius": 20,
      "lifespan": [ "10 minutes", "30 minutes" ],
      "spawn_message": "The swarm structure was always here, right?"
    },
    { "math": [ "u_ire", "-=", "4" ] }
  ]
},
```

The bug is preventing the affected "real" monsters from dropping anything (like in the case of the chunks of unknown material) and also prevents their unique death texts from being shown (they all just "disappear").

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

None.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Tested for artifact drops on the save provided in #65303 by debug killing the chunks of unknown material. Also tested a backport of the same one line change on 0.G.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

As far as I can tell, nothing relies on having a lifespan == hallucination. However,
- [One](https://github.com/CleverRaven/Cataclysm-DDA/blob/4f113f720614bf82dfa7f49c6c29b2067d05a4a2/data/json/monster_special_attacks/void_spider_mechanics.json#L277) of the void spider EOCs might be affected since the summoned weaver juveniles will produce corpses after this.
- [Another](https://github.com/CleverRaven/Cataclysm-DDA/blob/4f113f720614bf82dfa7f49c6c29b2067d05a4a2/data/json/nether_glass_effect_on_condition.json#L35) is that physics lab (I think?) Yrax trifacets will now drop broken trifacets.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->