### PR TITLE
Potential fix for nether monster error on chunk placement failure

### DIFF
--- a/data/json/overmap/overmap_mutable/nether_monster_corpse.json
+++ b/data/json/overmap/overmap_mutable/nether_monster_corpse.json
@@ -10,8 +10,7 @@
     "flags": [ "WILDERNESS" ],
     "check_for_locations_area": [
       { "type": [ "land", "road" ], "from": [ 0, 0, 0 ], "to": [ 0, 0, 0 ] },
-      { "type": [ "subterranean_empty" ], "from": [ -11, -5, -1 ], "to": [ 11, 5, -1 ] },
-      { "type": [ "subterranean_empty" ], "from": [ -5, -11, -1 ], "to": [ 5, 11, -1 ] }
+      { "type": [ "subterranean_empty" ], "from": [ -15, -15, -1 ], "to": [ 15, 15, -1 ] }
     ],
     "check_for_locations": [  ],
     "joins": [


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #65983 
(Hopefully)

#### Describe the solution
Currently it's checking an 11x11 box for `subterranean_empty`. Issue appears to be due to chunks failing to be placed (silently failing?!). (See additional context for screenshots.)

But the maximum 'length' of placeable chunks is 13 tiles+1 for tentacle join. 11 is sufficient if checking from corpse_bowels_mid to head tip (I am unaware where it checks from), but does not account for *mandatory* tentacle placement on tentacle edges. Therefore, 14 should be the absolute minimum possible to never encounter the error.

I bumped it up to 15 to be sure. **This will make the spawns rarer.** If 15 works out, we can lower it afterwards.

#### Describe alternatives you've considered
Chunk placement failure should not be silent??? That's a rabbit hole I don't want to go down right now...

#### Testing
I was only able to reproduce the error in the 'wild' once, otherwise it's only appeared during automated tests. So... we bank on it failing the automated tests as it *quite often* does?

#### Additional context
Debug spawned placement failure:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/c573f2d2-87f5-4e08-94f5-78c46d718bbc)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/c988d42b-1392-4c08-918e-f0217f0ae171)

