### PR TITLE
Balance firestarter skill gain for long move costs

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1791,7 +1791,7 @@ void activity_handlers::start_fire_finish( player_activity *act, Character *you 
 
     it.activation_consume( 1, you->pos(), you );
 
-    you->practice( skill_survival, act->index, 2 );
+    you->practice( skill_survival, act->index, 5 );
 
     firestarter_actor::resolve_firestarter_use( *you, get_map().bub_from_abs( act->placement ) );
     act->set_to_null();

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1791,7 +1791,7 @@ void activity_handlers::start_fire_finish( player_activity *act, Character *you 
 
     it.activation_consume( 1, you->pos(), you );
 
-    you->practice( skill_survival, act->index, 5 );
+    you->practice( skill_survival, act->index, 2 );
 
     firestarter_actor::resolve_firestarter_use( *you, get_map().bub_from_abs( act->placement ) );
     act->set_to_null();

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1371,8 +1371,7 @@ std::optional<int> firestarter_actor::use( Character &p, item &it, bool t,
     }
 
     // skill gains are handled by the activity, but stored here in the index field
-    const int potential_skill_gain =
-        moves_modifier + moves_cost_fast / 100.0 + 2;
+    const int potential_skill_gain = moves_modifier * ( std::min( 10.0, moves_cost_fast / 100.0 ) + 2 );
     p.assign_activity( ACT_START_FIRE, moves, potential_skill_gain,
                        0, it.tname() );
     p.activity.targets.emplace_back( p, &it );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Firestarter skill gain for long move costs is way too high"

#### Purpose of change

In #62662, the move cost for fire drills got increased massively, from 500 to 30000 for the bow fire drill, and from 200 to 6000 for the pump fire drill. While I welcome this change, it causes balance issues with fire starting skill gain, which is basically `move cost / 100 + 2`.

This means that the pump file drill, which gave 4 exp before, gives 62 now, a ~15x increase, and the bow fire drill, which gave 7 exp before, gives 302 now, a whopping 43x increase!

This can easily be exploited. A fresh innawoods survivor (who starts with a bow fire drill) can cheese their survival skill from 0 to 4 well before noon on day 1, and to 6 (the cap) before the end of the day. 

Even when using the drill normally the skill gain feels way too fast. ~~Being able to get to level 6 survival just by starting fires also feels wrong.~~ Edit: Not an issue anymore with the proper skill gain.

#### Describe the solution

~~Reduce the cap from level 6 to level 3~~ and limit skill gain to somewhat match the values before the change, without greatly affecting non-fire-drill firestarters. To this end, I limited the maximum contribution of `move cost / 100` to 10. I also multiplied by `moves_modifier`, which is `0.8 ** (survival skill)`. This way skill gain is 11-12 at level 0, slightly decreasing to 6-7 at level 2.

This way the values are in the same ballpark as before again.

#### Describe alternatives you've considered

None

#### Testing

Tested fire drill exp gain by starting a lot of fires, can still easily go to level 1 survival, and to 2 with a bit of effort. To 3 would take a proper long time. Magnifying glasses still give the same amount of exp at level 0.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->