### PR TITLE
Small changes: to improve perf

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1772,8 +1772,9 @@ std::vector<effect> Creature::get_effects_from_bp( const bodypart_id &bp ) const
 {
     std::vector<effect> effs;
     for( auto &elem : *effects ) {
-        if( elem.second.find( bp ) != elem.second.end() ) {
-            effs.push_back( elem.second[bp] );
+        const auto iter = elem.second.find( bp );
+        if( iter != elem.second.end() ) {
+            effs.push_back( iter->second );
         }
     }
     return effs;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1752,7 +1752,7 @@ std::vector<std::reference_wrapper<const effect>> Creature::get_effects_with_fla
             continue;
         }
         for( const std::pair<const bodypart_id, effect> &_it : elem.second ) {
-            effs.push_back( std::ref( _it.second ) );
+            effs.emplace_back( _it.second );
         }
     }
     return effs;
@@ -1763,7 +1763,7 @@ std::vector<std::reference_wrapper<const effect>> Creature::get_effects() const
     std::vector<std::reference_wrapper<const effect>> effs;
     for( auto &elem : *effects ) {
         for( const std::pair<const bodypart_id, effect> &_it : elem.second ) {
-            effs.push_back( std::ref( _it.second ) );
+            effs.emplace_back( _it.second );
         }
     }
     return effs;
@@ -1776,7 +1776,7 @@ std::vector<std::reference_wrapper<const effect>> Creature::get_effects_from_bp(
     for( auto &elem : *effects ) {
         const auto iter = elem.second.find( bp );
         if( iter != elem.second.end() ) {
-            effs.push_back( std::ref( iter->second ) );
+            effs.emplace_back( iter->second );
         }
     }
     return effs;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1743,38 +1743,40 @@ bool Creature::has_effect_with_flag( const flag_id &flag ) const
     } );
 }
 
-std::vector<effect> Creature::get_effects_with_flag( const flag_id &flag ) const
+std::vector<std::reference_wrapper<const effect>> Creature::get_effects_with_flag(
+            const flag_id &flag ) const
 {
-    std::vector<effect> effs;
+    std::vector<std::reference_wrapper<const effect>> effs;
     for( auto &elem : *effects ) {
         if( !elem.first->has_flag( flag ) ) {
             continue;
         }
         for( const std::pair<const bodypart_id, effect> &_it : elem.second ) {
-            effs.push_back( _it.second );
+            effs.push_back( std::ref( _it.second ) );
         }
     }
     return effs;
 }
 
-std::vector<effect> Creature::get_effects() const
+std::vector<std::reference_wrapper<const effect>> Creature::get_effects() const
 {
-    std::vector<effect> effs;
+    std::vector<std::reference_wrapper<const effect>> effs;
     for( auto &elem : *effects ) {
         for( const std::pair<const bodypart_id, effect> &_it : elem.second ) {
-            effs.push_back( _it.second );
+            effs.push_back( std::ref( _it.second ) );
         }
     }
     return effs;
 }
 
-std::vector<effect> Creature::get_effects_from_bp( const bodypart_id &bp ) const
+std::vector<std::reference_wrapper<const effect>> Creature::get_effects_from_bp(
+            const bodypart_id &bp ) const
 {
-    std::vector<effect> effs;
+    std::vector<std::reference_wrapper<const effect>> effs;
     for( auto &elem : *effects ) {
         const auto iter = elem.second.find( bp );
         if( iter != elem.second.end() ) {
-            effs.push_back( iter->second );
+            effs.push_back( std::ref( iter->second ) );
         }
     }
     return effs;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1772,10 +1772,8 @@ std::vector<effect> Creature::get_effects_from_bp( const bodypart_id &bp ) const
 {
     std::vector<effect> effs;
     for( auto &elem : *effects ) {
-        for( const std::pair<const bodypart_id, effect> &_it : elem.second ) {
-            if( _it.first == bp ) {
-                effs.push_back( _it.second );
-            }
+        if( elem.second.find( bp ) != elem.second.end() ) {
+            effs.push_back( elem.second[bp] );
         }
     }
     return effs;

--- a/src/creature.h
+++ b/src/creature.h
@@ -626,9 +626,11 @@ class Creature : public viewer
         /** Check if creature has any effect with the given flag. */
         bool has_effect_with_flag( const flag_id &flag, const bodypart_id &bp ) const;
         bool has_effect_with_flag( const flag_id &flag ) const;
-        std::vector<effect> get_effects_with_flag( const flag_id &flag ) const;
-        std::vector<effect> get_effects_from_bp( const bodypart_id &bp ) const;
-        std::vector<effect> get_effects() const;
+        std::vector<std::reference_wrapper<const effect>> get_effects_with_flag(
+                    const flag_id &flag ) const;
+        std::vector<std::reference_wrapper<const effect>> get_effects_from_bp(
+                    const bodypart_id &bp ) const;
+        std::vector<std::reference_wrapper<const effect>> get_effects() const;
 
         /** Return the effect that matches the given arguments exactly. */
         const effect &get_effect( const efftype_id &eff_id,

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -660,7 +660,7 @@ static medical_column draw_stats_summary( const int column_count, avatar *player
     }
 
     std::map<std::string, int> speed_effects;
-    for( effect &elem : player->get_effects() ) {
+    for( const effect &elem : player->get_effects() ) {
         bool reduced = player->resists_effect( elem );
         int move_adjust = elem.get_mod( "SPEED", reduced );
         if( move_adjust != 0 ) {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -554,7 +554,7 @@ void veh_interact::do_main_loop()
 void veh_interact::cache_tool_availability()
 {
     Character &player_character = get_player_character();
-    crafting_inv = player_character.crafting_inventory();
+    crafting_inv = &player_character.crafting_inventory();
 
     cache_tool_availability_update_lifting( player_character.pos() );
     int mech_jack = 0;
@@ -2158,7 +2158,7 @@ int veh_interact::part_at( const point &d )
 bool veh_interact::can_potentially_install( const vpart_info &vpart )
 {
     bool engine_reqs_met = true;
-    bool can_make = vpart.install_requirements().can_make_with_inventory( crafting_inv,
+    bool can_make = vpart.install_requirements().can_make_with_inventory( *crafting_inv,
                     is_crafting_component );
     bool hammerspace = get_player_character().has_trait( trait_DEBUG_HS );
 

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -118,7 +118,7 @@ class veh_interact
         std::unique_ptr<remove_info_t> remove_info;
 
         vehicle *veh;
-        inventory crafting_inv;
+        const inventory *crafting_inv;
         input_context main_context;
 
         // maximum weight capacity of available lifting equipment (if any)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Improve bits of performance.

This is to accumulate some random small changes that do improve performance, but do not deserve a separate PR ( improvement not big enough. )

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use map::find() to replace an iterator.

Also return vectors of reference_wrapper to avoid copying.

Change veh_interact's `inventory` to a const pointer to save space and avoid copying.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Leave it as it is.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->