### PR TITLE
Rename `No Fungal Growth` mod to `Slowdown Fungal Growth`

### DIFF
--- a/data/mods/no_fungal_growth/modinfo.json
+++ b/data/mods/no_fungal_growth/modinfo.json
@@ -2,7 +2,7 @@
   {
     "type": "MOD_INFO",
     "id": "no_fungal_growth",
-    "name": "No Fungal Growth",
+    "name": "Slowdown Fungal Growth",
     "authors": [ "eltank" ],
     "description": "Removes the exponential growth ability of fungaloids.",
     "category": "rebalance",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
People always think No Fungal Growth means total removing fungal from the game, which is not. Of course no one read the description also.
#### Describe the solution
Rename the mod name in attempt to highlight this
#### Describe alternatives you've considered
Drop it
#### Additional context
There is probably a better name we can use, but i can't find it