### PR TITLE
Limb armor

### DIFF
--- a/src/subbodypart.cpp
+++ b/src/subbodypart.cpp
@@ -81,8 +81,11 @@ void sub_body_part_type::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "side", part_side );
     optional( jo, was_loaded, "name_multiple", name_multiple );
     optional( jo, was_loaded, "opposite", opposite );
+    optional( jo, was_loaded, "is_joint", is_joint );
     // defaults to self
     optional( jo, was_loaded, "locations_under", locations_under, { id } );
+    // defaults to self
+    optional( jo, was_loaded, "wears_like", wears_like, { id } );
 }
 
 void sub_body_part_type::reset()

--- a/src/subbodypart.h
+++ b/src/subbodypart.h
@@ -62,6 +62,12 @@ struct sub_body_part_type {
     // hanging locations.
     bool secondary = false;
 
+    // if this location needs to bend in rigid armor
+    bool is_joint = false;
+
+    // What does this part wear like? How does it relate to human limbs?
+    std::vector<sub_bodypart_str_id> wears_like;
+
     // the maximum coverage value for this part
     // if something entirely covered this part it
     // would have this value


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Needed for the limb rework.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
So the TLDR right now is that sublimbs will be describable as "joints" and the order stuff is described in the limb def is the order it assumes they go in. 

So if you have

Normal Arm:
Shoulder, upper arm, elbow, lower arm. 
VS.
Peg arm (just a stick of wood)
Wood arm.


They will all have proportions similar to now. So a wooden arm could be the same length as a normal arm or shorter / longer. 

Then rigid armor will check to make sure joints line up, and coverage will be proportional to proportion.

Then your limbs size will be compared with the hit size of the base human limb as well to check wears like.


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Nowhere near done just putting up a draft so I don't forget.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->