### PR TITLE
gutter_unify tool

### DIFF
--- a/tools/json_tools/gutter_unify.py
+++ b/tools/json_tools/gutter_unify.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+
+args = argparse.ArgumentParser()
+args.add_argument("dir", action="store", help="specify json directory")
+args_dict = vars(args.parse_args())
+
+
+def gen_new(path):
+    change = False
+    with open(path, "r", encoding="utf-8") as json_file:
+        try:
+            json_data = json.load(json_file)
+        except json.JSONDecodeError:
+            print(f"Json Decode Error at {path}")
+            print("Ensure that the file is a JSON file consisting of"
+                  " an array of objects!")
+            return None
+        for jo in json_data:
+            if jo["type"] == "mapgen" and "palettes" in jo["object"] and "rows" in jo["object"] and len(jo["object"]["palettes"]) == 1 and jo["object"]["palettes"][0] == "roof_palette":
+                terms = ["2", "3", "|"]
+                potentialterms = terms
+                if "terrain" in jo["object"]:
+                    for potentialterm in potentialterms:
+                        if potentialterm in jo["object"]["terrain"]:
+                            terms.remove(potentialterm)
+                if len(terms) != 0:
+                    rowsn = len(jo["object"]["rows"])
+                    i = 0
+                    while i < rowsn:
+                        for term in terms:
+                            jo["object"]["rows"][i] = jo["object"]["rows"][i].replace(term, "-")
+                            change = True
+                        i += 1
+
+    return json_data if change else None
+
+all_filepaths = set()
+for root, directories, filenames in os.walk(args_dict["dir"]):
+    for filename in filenames:
+        if not filename.endswith(".json"):
+            continue
+
+        path = os.path.join(root, filename)
+        all_filepaths.add(path)
+
+for path in all_filepaths:
+    new = gen_new(path)
+    if new is not None:
+        with open(path, "w", encoding="utf-8") as jf:
+            json.dump(new, jf, ensure_ascii=False)
+        os.system(f"./tools/format/json_formatter.cgi {path}")

--- a/tools/json_tools/gutter_unify.py
+++ b/tools/json_tools/gutter_unify.py
@@ -30,11 +30,9 @@ def gen_new(path):
             if isinstance(jo, dict): # Handles weird files like mods/replacement.json
                 if jo["type"] == "mapgen" and "palettes" in jo["object"] and "rows" in jo["object"] and "roof_palette" in jo["object"]["palettes"]:
                     if len(jo["object"]["palettes"]) == 1:
-                        terms = ["2", "3", "|"]
+                        terms = ["|", "2", "3"]
                         if "terrain" in jo["object"]:
-                            for term in terms:
-                                if term in jo["object"]["terrain"]:
-                                    terms.remove(term)
+                            terms[:] = [term for term in terms if term not in jo["object"]["terrain"]]
                         if len(terms) != 0:
                             pattern = r"[" + ''.join(terms) + r"]"
                             rowsn = len(jo["object"]["rows"])

--- a/tools/json_tools/gutter_unify.py
+++ b/tools/json_tools/gutter_unify.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 
+"""
+
+Unifies "2", "3", "|" old gutters into "-" on maps using the roof_palette which don't define their own terrain definition for said characters.
+Prints any maps using other palettes with the roof_palette for manual correcting.
+
+"""
 import argparse
 import json
 import os
+import re
 
 args = argparse.ArgumentParser()
 args.add_argument("dir", action="store", help="specify json directory")
 args_dict = vars(args.parse_args())
 
+manuallychange = set()
 
 def gen_new(path):
     change = False
@@ -20,36 +28,46 @@ def gen_new(path):
                   " an array of objects!")
             return None
         for jo in json_data:
-            if jo["type"] == "mapgen" and "palettes" in jo["object"] and "rows" in jo["object"] and len(jo["object"]["palettes"]) == 1 and jo["object"]["palettes"][0] == "roof_palette":
-                terms = ["2", "3", "|"]
-                potentialterms = terms
-                if "terrain" in jo["object"]:
-                    for potentialterm in potentialterms:
-                        if potentialterm in jo["object"]["terrain"]:
-                            terms.remove(potentialterm)
-                if len(terms) != 0:
-                    rowsn = len(jo["object"]["rows"])
-                    i = 0
-                    while i < rowsn:
-                        for term in terms:
-                            jo["object"]["rows"][i] = jo["object"]["rows"][i].replace(term, "-")
-                            change = True
-                        i += 1
-
+            if jo["type"] == "mapgen" and "palettes" in jo["object"] and "rows" in jo["object"] and "roof_palette" in jo["object"]["palettes"]:
+                if len(jo["object"]["palettes"]) == 1:
+                    terms = ["2", "3", "|"]
+                    potentialterms = terms
+                    if "terrain" in jo["object"]:
+                        for potentialterm in potentialterms:
+                            if potentialterm in jo["object"]["terrain"]:
+                                terms.remove(potentialterm)
+                    if len(terms) != 0:
+                        rowsn = len(jo["object"]["rows"])
+                        i = 0
+                        while i < rowsn:
+                            for term in terms:
+                                newrow = jo["object"]["rows"][i].replace(term, "-")
+                                if(jo["object"]["rows"][i] != newrow)
+                                change = True
+                            i += 1
+                else:
+                    if isinstance(jo["om_terrain"], str):
+                        mapname = jo["om_terrain"]
+                    else:
+                        mapnames = []
+                        omrowsn = len(jo["om_terrain"])
+                        j = 0
+                        while j < omrowsn:
+                            mapnames.append(','.join(jo["om_terrain"][j]))
+                            j += 1
+                        mapname = ','.join(mapnames)
+                    manuallychange.add("Can't automatically correct map(s):\n" + mapname + "\nin file " + path + "\n due to multiple palettes being present.")
     return json_data if change else None
 
-all_filepaths = set()
 for root, directories, filenames in os.walk(args_dict["dir"]):
     for filename in filenames:
-        if not filename.endswith(".json"):
-            continue
-
         path = os.path.join(root, filename)
-        all_filepaths.add(path)
+        if path.endswith(".json"):
+            new = gen_new(path)
+            if new is not None:
+                with open(path, "w", encoding="utf-8") as jf:
+                    json.dump(new, jf, ensure_ascii=False)
+                os.system(f"tools\\format\\json_formatter.exe {path}")
 
-for path in all_filepaths:
-    new = gen_new(path)
-    if new is not None:
-        with open(path, "w", encoding="utf-8") as jf:
-            json.dump(new, jf, ensure_ascii=False)
-        os.system(f"./tools/format/json_formatter.cgi {path}")
+for statement in manuallychange:
+    print(statement)

--- a/tools/json_tools/gutter_unify.py
+++ b/tools/json_tools/gutter_unify.py
@@ -4,7 +4,7 @@
 
 Unifies "2", "3", "|" old gutters into "-" on maps using the roof_palette
 which don't define their own terrain definition for said characters.
-Prints maps using palettes alongside roof_palette for manual correcting.
+Prints the names of maps using palettes alongside roof_palette for manual correcting.
 Can be run in /json and /mods
 
 """

--- a/tools/json_tools/gutter_unify.py
+++ b/tools/json_tools/gutter_unify.py
@@ -4,6 +4,7 @@
 
 Unifies "2", "3", "|" old gutters into "-" on maps using the roof_palette which don't define their own terrain definition for said characters.
 Prints any maps using other palettes with the roof_palette for manual correcting.
+Can be run in /json and /mods
 
 """
 import argparse
@@ -15,7 +16,7 @@ args = argparse.ArgumentParser()
 args.add_argument("dir", action="store", help="specify json directory")
 args_dict = vars(args.parse_args())
 
-manuallychange = set()
+failures = set()
 
 def gen_new(path):
     change = False
@@ -23,43 +24,40 @@ def gen_new(path):
         try:
             json_data = json.load(json_file)
         except json.JSONDecodeError:
-            print(f"Json Decode Error at {path}")
-            print("Ensure that the file is a JSON file consisting of"
-                  " an array of objects!")
+            failures.add("Json Decode Error at:\n" + path + "\nEnsure that the file is a JSON file consisting of an array of objects!")
             return None
+        print(path)
         for jo in json_data:
-            if jo["type"] == "mapgen" and "palettes" in jo["object"] and "rows" in jo["object"] and "roof_palette" in jo["object"]["palettes"]:
-                if len(jo["object"]["palettes"]) == 1:
-                    terms = ["2", "3", "|"]
-                    potentialterms = terms
-                    if "terrain" in jo["object"]:
-                        for potentialterm in potentialterms:
-                            if potentialterm in jo["object"]["terrain"]:
-                                terms.remove(potentialterm)
-                    if len(terms) != 0:
-                        for term in terms:
-                            if term == "|":
-                                term = "/|"
-                        pattern = r"'|'.join(terms)"
-                        rowsn = len(jo["object"]["rows"])
-                        i = 0
-                        while i < rowsn:
-                            if re.search(pattern, jo["object"]["rows"][i]):
-                                jo["object"]["rows"][i] = re.sub(pattern, '-',jo["object"]["rows"][i])
-                                change = True
-                            i += 1
-                else:
-                    if isinstance(jo["om_terrain"], str):
-                        mapname = jo["om_terrain"]
+            if isinstance(jo, dict): # Handles weird files like mods/replacement.json
+                if jo["type"] == "mapgen" and "palettes" in jo["object"] and "rows" in jo["object"] and "roof_palette" in jo["object"]["palettes"]:
+                    if len(jo["object"]["palettes"]) == 1:
+                        terms = ["2", "3", "|"]
+                        potentialterms = terms
+                        if "terrain" in jo["object"]:
+                            for potentialterm in potentialterms:
+                                if potentialterm in jo["object"]["terrain"]:
+                                    terms.remove(potentialterm)
+                        if len(terms) != 0:
+                            pattern = r"[" + ''.join(terms) + r"]"
+                            rowsn = len(jo["object"]["rows"])
+                            i = 0
+                            while i < rowsn:
+                                if re.search(pattern, jo["object"]["rows"][i]):
+                                    jo["object"]["rows"][i] = re.sub(pattern, '-',jo["object"]["rows"][i])
+                                    change = True
+                                i += 1
                     else:
-                        mapnames = []
-                        omrowsn = len(jo["om_terrain"])
-                        j = 0
-                        while j < omrowsn:
-                            mapnames.append(','.join(jo["om_terrain"][j]))
-                            j += 1
-                        mapname = ','.join(mapnames)
-                    manuallychange.add("Can't automatically correct map(s):\n" + mapname + "\nin file " + path + "\n due to multiple palettes being present.")
+                        if isinstance(jo["om_terrain"], str): # Handles merged maps
+                            mapname = jo["om_terrain"]
+                        else:
+                            mapnames = []
+                            omrowsn = len(jo["om_terrain"])
+                            j = 0
+                            while j < omrowsn:
+                                mapnames.append(','.join(jo["om_terrain"][j]))
+                                j += 1
+                            mapname = ','.join(mapnames)
+                        failures.add("Can't automatically correct map(s):\n" + mapname + "\nin file:\n" + path + "\ndue to multiple palettes being present.")
     return json_data if change else None
 
 for root, directories, filenames in os.walk(args_dict["dir"]):
@@ -72,5 +70,5 @@ for root, directories, filenames in os.walk(args_dict["dir"]):
                     json.dump(new, jf, ensure_ascii=False)
                 os.system(f"tools\\format\\json_formatter.exe {path}")
 
-for statement in manuallychange:
+for statement in failures:
     print(statement)

--- a/tools/json_tools/gutter_unify.py
+++ b/tools/json_tools/gutter_unify.py
@@ -2,8 +2,9 @@
 
 """
 
-Unifies "2", "3", "|" old gutters into "-" on maps using the roof_palette which don't define their own terrain definition for said characters.
-Prints any maps using other palettes with the roof_palette for manual correcting.
+Unifies "2", "3", "|" old gutters into "-" on maps using the roof_palette
+which don't define their own terrain definition for said characters.
+Prints maps using palettes alongside roof_palette for manual correcting.
 Can be run in /json and /mods
 
 """
@@ -26,18 +27,19 @@ def gen_new(path):
             json_data = json.load(json_file)
         except json.JSONDecodeError:
             failures.add(
-                "Json Decode Error at:\n"
-                + path
-                + "\nEnsure that the file is a JSON file consisting of an array of objects!"
+                "Json Decode Error at:\n" +
+                path +
+                "\nEnsure that the file is a JSON"
+                "file consisting of an array of objects!"
             )
             return None
         for jo in json_data:
-            if isinstance(jo, dict):  # Handles weird files like mods/replacement.json
+            if isinstance(jo, dict):
                 if (
-                    jo["type"] == "mapgen"
-                    and "palettes" in jo["object"]
-                    and "rows" in jo["object"]
-                    and "roof_palette" in jo["object"]["palettes"]
+                    jo["type"] == "mapgen" and
+                    "palettes" in jo["object"] and
+                    "rows" in jo["object"] and
+                    "roof_palette" in jo["object"]["palettes"]
                 ):
                     if len(jo["object"]["palettes"]) == 1:
                         terms = ["|", "2", "3"]
@@ -59,7 +61,7 @@ def gen_new(path):
                                     change = True
                                 i += 1
                     else:
-                        if isinstance(jo["om_terrain"], str):  # Handles merged maps
+                        if isinstance(jo["om_terrain"], str):
                             mapname = jo["om_terrain"]
                         else:
                             mapnames = []
@@ -70,11 +72,11 @@ def gen_new(path):
                                 j += 1
                             mapname = ",".join(mapnames)
                         failures.add(
-                            "Can't automatically correct map(s):\n"
-                            + mapname
-                            + "\nin file:\n"
-                            + path
-                            + "\ndue to multiple palettes being present."
+                            "Can't automatically correct map(s):\n" +
+                            mapname +
+                            "\nin file:\n" +
+                            path +
+                            "\ndue to multiple palettes being present."
                         )
     return json_data if change else None
 

--- a/tools/json_tools/gutter_unify.py
+++ b/tools/json_tools/gutter_unify.py
@@ -18,43 +18,66 @@ args_dict = vars(args.parse_args())
 
 failures = set()
 
+
 def gen_new(path):
     change = False
     with open(path, "r", encoding="utf-8") as json_file:
         try:
             json_data = json.load(json_file)
         except json.JSONDecodeError:
-            failures.add("Json Decode Error at:\n" + path + "\nEnsure that the file is a JSON file consisting of an array of objects!")
+            failures.add(
+                "Json Decode Error at:\n"
+                + path
+                + "\nEnsure that the file is a JSON file consisting of an array of objects!"
+            )
             return None
         for jo in json_data:
-            if isinstance(jo, dict): # Handles weird files like mods/replacement.json
-                if jo["type"] == "mapgen" and "palettes" in jo["object"] and "rows" in jo["object"] and "roof_palette" in jo["object"]["palettes"]:
+            if isinstance(jo, dict):  # Handles weird files like mods/replacement.json
+                if (
+                    jo["type"] == "mapgen"
+                    and "palettes" in jo["object"]
+                    and "rows" in jo["object"]
+                    and "roof_palette" in jo["object"]["palettes"]
+                ):
                     if len(jo["object"]["palettes"]) == 1:
                         terms = ["|", "2", "3"]
                         if "terrain" in jo["object"]:
-                            terms[:] = [term for term in terms if term not in jo["object"]["terrain"]]
+                            terms[:] = [
+                                term
+                                for term in terms
+                                if term not in jo["object"]["terrain"]
+                            ]
                         if len(terms) != 0:
-                            pattern = r"[" + ''.join(terms) + r"]"
+                            pattern = r"[" + "".join(terms) + r"]"
                             rowsn = len(jo["object"]["rows"])
                             i = 0
                             while i < rowsn:
                                 if re.search(pattern, jo["object"]["rows"][i]):
-                                    jo["object"]["rows"][i] = re.sub(pattern, '-',jo["object"]["rows"][i])
+                                    jo["object"]["rows"][i] = re.sub(
+                                        pattern, "-", jo["object"]["rows"][i]
+                                    )
                                     change = True
                                 i += 1
                     else:
-                        if isinstance(jo["om_terrain"], str): # Handles merged maps
+                        if isinstance(jo["om_terrain"], str):  # Handles merged maps
                             mapname = jo["om_terrain"]
                         else:
                             mapnames = []
                             omrowsn = len(jo["om_terrain"])
                             j = 0
                             while j < omrowsn:
-                                mapnames.append(','.join(jo["om_terrain"][j]))
+                                mapnames.append(",".join(jo["om_terrain"][j]))
                                 j += 1
-                            mapname = ','.join(mapnames)
-                        failures.add("Can't automatically correct map(s):\n" + mapname + "\nin file:\n" + path + "\ndue to multiple palettes being present.")
+                            mapname = ",".join(mapnames)
+                        failures.add(
+                            "Can't automatically correct map(s):\n"
+                            + mapname
+                            + "\nin file:\n"
+                            + path
+                            + "\ndue to multiple palettes being present."
+                        )
     return json_data if change else None
+
 
 def format_json(path):
     file_path = os.path.dirname(__file__)
@@ -67,6 +90,7 @@ def format_json(path):
         os.system(f"{format_path_win} {path}")
     else:
         print("No json formatter found")
+
 
 for root, directories, filenames in os.walk(args_dict["dir"]):
     for filename in filenames:

--- a/tools/json_tools/gutter_unify.py
+++ b/tools/json_tools/gutter_unify.py
@@ -26,17 +26,15 @@ def gen_new(path):
         except json.JSONDecodeError:
             failures.add("Json Decode Error at:\n" + path + "\nEnsure that the file is a JSON file consisting of an array of objects!")
             return None
-        print(path)
         for jo in json_data:
             if isinstance(jo, dict): # Handles weird files like mods/replacement.json
                 if jo["type"] == "mapgen" and "palettes" in jo["object"] and "rows" in jo["object"] and "roof_palette" in jo["object"]["palettes"]:
                     if len(jo["object"]["palettes"]) == 1:
                         terms = ["2", "3", "|"]
-                        potentialterms = terms
                         if "terrain" in jo["object"]:
-                            for potentialterm in potentialterms:
-                                if potentialterm in jo["object"]["terrain"]:
-                                    terms.remove(potentialterm)
+                            for term in terms:
+                                if term in jo["object"]["terrain"]:
+                                    terms.remove(term)
                         if len(terms) != 0:
                             pattern = r"[" + ''.join(terms) + r"]"
                             rowsn = len(jo["object"]["rows"])

--- a/tools/json_tools/gutter_unify.py
+++ b/tools/json_tools/gutter_unify.py
@@ -37,12 +37,15 @@ def gen_new(path):
                             if potentialterm in jo["object"]["terrain"]:
                                 terms.remove(potentialterm)
                     if len(terms) != 0:
+                        for term in terms:
+                            if term == "|":
+                                term = "/|"
+                        pattern = r"'|'.join(terms)"
                         rowsn = len(jo["object"]["rows"])
                         i = 0
                         while i < rowsn:
-                            for term in terms:
-                                newrow = jo["object"]["rows"][i].replace(term, "-")
-                                if(jo["object"]["rows"][i] != newrow)
+                            if re.search(pattern, jo["object"]["rows"][i]):
+                                jo["object"]["rows"][i] = re.sub(pattern, '-',jo["object"]["rows"][i])
                                 change = True
                             i += 1
                 else:

--- a/tools/json_tools/gutter_unify.py
+++ b/tools/json_tools/gutter_unify.py
@@ -56,6 +56,18 @@ def gen_new(path):
                         failures.add("Can't automatically correct map(s):\n" + mapname + "\nin file:\n" + path + "\ndue to multiple palettes being present.")
     return json_data if change else None
 
+def format_json(path):
+    file_path = os.path.dirname(__file__)
+    format_path_linux = os.path.join(file_path, "../format/json_formatter.cgi")
+    path_win = "../format/JsonFormatter-vcpkg-static-Release-x64.exe"
+    format_path_win = os.path.join(file_path, path_win)
+    if os.path.exists(format_path_linux):
+        os.system(f"{format_path_linux} {path}")
+    elif os.path.exists(format_path_win):
+        os.system(f"{format_path_win} {path}")
+    else:
+        print("No json formatter found")
+
 for root, directories, filenames in os.walk(args_dict["dir"]):
     for filename in filenames:
         path = os.path.join(root, filename)
@@ -64,7 +76,7 @@ for root, directories, filenames in os.walk(args_dict["dir"]):
             if new is not None:
                 with open(path, "w", encoding="utf-8") as jf:
                     json.dump(new, jf, ensure_ascii=False)
-                os.system(f"tools\\format\\json_formatter.exe {path}")
+                format_json(path)
 
 for statement in failures:
     print(statement)

--- a/tools/json_tools/gutter_unify.py
+++ b/tools/json_tools/gutter_unify.py
@@ -4,8 +4,12 @@
 
 Unifies "2", "3", "|" old gutters into "-" on maps using the roof_palette
 which don't define their own terrain definition for said characters.
-Prints the names of maps using palettes alongside roof_palette for manual correcting.
-Can be run in /json and /mods
+
+Prints the names of maps that use other palettes
+alongside roof_palette to be corrected manually.
+
+Can be run in /json and /mods, to run on specific maps
+just temporarily move them to their own folder.
 
 """
 import argparse


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

#63597 merged gutters but kept the old ids using alias, this tool will be the first step towards removing the ids altogether starting by allowing "|", "2" and "3" definitions to be removed from maps using roof_palette. Will make follow up PRs if reviewer is happy that the tool works in all use cases, applying this to a reasonable amount of files at a time as the total changes are roughly in this region - [branch comparison](https://github.com/Procyonae/Cataclysm-DDA/compare/GutterSymbolMerge...Procyonae:Cataclysm-DDA:GSMTest2)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/1859989a-88c0-420f-8966-288c484f9fd6)

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

 - The tool takes all json files in the directory given then checks each object in the file
- Next it checks if the object has been deserialized as a dict to avoid files like mods/replacement.json from passing lists to the next step
- Then it checks that the object is a mapgen, declares at least one palette, defines it's rows and that roof_palette is used
- Next if roof_palette isn't the only palette used it adds the map to an message to be send at the end to be manually changed
Otherwise it declares the terms we're looking for, "|", "2" and "3" and if there's a terrain object we check if the palette definitions are overridden for any of them in which case we don't want to change that symbol and remove it from terms
- Next as long as all terms weren't overridden we form a regex pattern and iterate through the rows doing a regex search for any of the terms and then replacing them with "-" and marking the file as changed
- Finally it returns the altered file if it's changed to be serialised and formatted

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ran on /json and /mods and checked a good portion of results as well as manually testing override cases

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->