### PR TITLE
[Magiclysm] Stormshaper Axe changes

### DIFF
--- a/data/mods/Magiclysm/items/enchanted_melee.json
+++ b/data/mods/Magiclysm/items/enchanted_melee.json
@@ -864,13 +864,13 @@
     "type": "GENERIC",
     "copy-from": "copper_ax",
     "name": { "str": "Stormshaper axe" },
-    "//": "Equivalent to copper axe +1.  Metals chosen for being two most conductive metals + balancing reasons",
+    "//": "Based off battle axe +1.  Metals chosen for being two most conductive metals + balancing reasons",
     "description": "A forged copper axe with silver trimmings and a wooden handle.  There is a Stormshaper rune embedded in the eye.",
-    "weight": "3330 g",
-    "volume": "3500 ml",
+    "weight": "2850 g",
+    "volume": "2025 ml",
     "longest_side": "90 cm",
     "price": 3900,
-    "to_hit": -1,
+    "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "uneven" },
     "material": [ "wood", "copper", "silver" ],
     "symbol": "/",
     "color": "brown",
@@ -878,7 +878,7 @@
     "qualities": [ [ "AXE", 1 ], [ "BUTCHER", -20 ] ],
     "use_action": [ "WEATHER_TOOL" ],
     "flags": [ "DURABLE_MELEE", "SHEATH_AXE", "TRADER_AVOID", "MAGIC_FOCUS", "HYGROMETER", "BAROMETER" ],
-    "melee_damage": { "bash": 33, "cut": 22 }
+    "melee_damage": { "bash": 21, "cut": 42 }
   },
   {
     "id": "rune_stormshaper_weapon_adept",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[Magiclysm] Changes Stormshaper axe to be more axe like"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #65137

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Bases the weight and volume off of the battle axe taking into account the reduced length and relative density of copper/silver compared to steel.
Updates damage and to_hit in line with battle axe +1 as it claims to be equivalent to copper axe +1 which it's not even remotely close too. Left the copy_from as I presume that's for sprites more than properties.
This is rather a huge buff which wasn't really the intention, see the pictures below.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Attacking more of the file

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Old
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/802486e8-89cf-477d-a781-e421d2388a61)
New
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/7e8feec8-1aea-4d77-9d7b-b1698d174ed6)
Battle Axe +1 for comparison
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/8fd7054c-66cc-44cd-bc8f-5189e9a0b9b9)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->