### PR TITLE
Speed up vehicle interact menu opening time

### DIFF
--- a/src/json.h
+++ b/src/json.h
@@ -786,6 +786,13 @@ class JsonOut
             v.serialize( *this );
         }
 
+        /// Overload to be able to write reference_wrapper as normal references.
+        template<typename T>
+        auto write( const std::reference_wrapper<const T> &v ) -> decltype( v.get().serialize( *this ),
+                void() ) {
+            v.get().serialize( *this );
+        }
+
         template <typename T, typename std::enable_if<std::is_enum<T>::value, int>::type = 0>
         void write( T val ) {
             write( static_cast<typename std::underlying_type<T>::type>( val ) );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7176,7 +7176,7 @@ time_duration vehicle::unfolding_time() const
 item vehicle::get_folded_item() const
 {
     item folded( "generic_folded_vehicle", calendar::turn );
-    const std::vector<vehicle_part> parts = real_parts();
+    const std::vector<std::reference_wrapper<const vehicle_part>> &parts = real_parts();
     try {
         std::ostringstream veh_data;
         JsonOut json( veh_data );
@@ -7709,14 +7709,14 @@ int vehicle::part_count_real_cached() const
     return static_cast<int>( parts.size() - fake_parts.size() );
 }
 
-std::vector<vehicle_part> vehicle::real_parts() const
+std::vector<std::reference_wrapper<const vehicle_part>> vehicle::real_parts() const
 {
-    std::vector<vehicle_part> ret;
+    std::vector<std::reference_wrapper<const vehicle_part>> ret;
     for( const vehicle_part &vp : parts ) {
         if( vp.removed || vp.is_fake ) {
             continue;
         }
-        ret.emplace_back( vp );
+        ret.emplace_back( std::ref( vp ) );
     }
     return ret;
 }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2028,7 +2028,7 @@ class vehicle
         // Master list of parts installed in the vehicle.
         std::vector<vehicle_part> parts; // NOLINT(cata-serialize)
         // Used in savegame.cpp to only save real parts to json
-        std::vector<vehicle_part> real_parts() const;
+        std::vector<std::reference_wrapper<const vehicle_part>> real_parts() const;
         // Map of edge parts and their adjacency information
         std::map<point, vpart_edge_info> edges; // NOLINT(cata-serialize)
         // For a given mount point, returns its adjacency info


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Speed up vehicle interact menu opening time, which can be quite slow for huge vehicles (like with ~300 parts), especially when the player wants to unrack bicycles.

Example save file ( not mine, got it from here https://github.com/CleverRaven/Cataclysm-DDA/issues/64552#issue-1640442831 ): 

[Emerald Lake Hills-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/11718337/Emerald.Lake.Hills-trimmed.tar.gz)

The reason is that real_parts() returns a vector of vehicle_part, thus has big big copying overhead.


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Return vector of reference_wrappers.

Add JsonOut::write() template overload to be able to write reference_wrapper objects.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered


<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Before: The delay can be clearly felt.

![23](https://github.com/CleverRaven/Cataclysm-DDA/assets/22912139/4124e51b-e684-423c-884a-1ab49eb4234c)

After: Instant opening of the menu.

![34](https://github.com/CleverRaven/Cataclysm-DDA/assets/22912139/8f8c5e04-1b71-4ce4-b414-a70b28fab62f)

(Shall I provide some perf data?)

Load the world, drive the vehicle for a while, save and load again. All vehicle parts are still there, as expected.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->