### PR TITLE
Shorten molt effect descriptions

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4219,7 +4219,7 @@
     "type": "effect_type",
     "id": "molting",
     "name": [ "Molting" ],
-    "desc": [ "Your exoskeleton feels uncomfortably tight.  Perhaps you should find somewhere to rest." ],
+    "desc": [ "You feel a strong urge to hide somewhere safe." ],
     "apply_message": "Your chitin plating itches against your body.",
     "rating": "bad",
     "base_mods": {
@@ -4239,7 +4239,7 @@
     "id": "molting_imminent",
     "name": [ "Imminent Molting" ],
     "desc": [
-      "Your exoskeleton has grown so tight and rigid that it grips you like a vise.  You must seek shelter for the coming molt."
+      "Seek shelter, you will be helpless when it begins."
     ],
     "apply_message": "You can hardly move in your tightening exoskeleton, and you feel a strong impulse to hunker down somewhere safe.",
     "rating": "bad",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4238,9 +4238,7 @@
     "type": "effect_type",
     "id": "molting_imminent",
     "name": [ "Imminent Molting" ],
-    "desc": [
-      "Seek shelter, you will be helpless when it begins."
-    ],
+    "desc": [ "Seek shelter, you will be helpless when it begins." ],
     "apply_message": "You can hardly move in your tightening exoskeleton, and you feel a strong impulse to hunker down somewhere safe.",
     "rating": "bad",
     "base_mods": {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Shorten molt effect descriptions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

There's a six line limit in effect descriptions, and five lines are taken up by the stat and limb score mods in the molting and molting_imminent effects. This was causing the description to not fit in the @ screen. Since this description contains important gameplay information, it needs to be readable.

closes #66143 

#### Describe the solution

I shortened the description to be a single line long, even at 2x magnification.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Figuring out a way to make it so that pressing enter on an effect opens a more detailed view. But I'm bad at C++ so I'm not doing that.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Opened the game, checked out the description.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->