### PR TITLE
[Innawood] Fix for arsonist's quest

### DIFF
--- a/data/mods/innawood/npcs/missiondef.json
+++ b/data/mods/innawood/npcs/missiondef.json
@@ -497,5 +497,19 @@
       "place_item": [ { "item": "tinder", "x": [ 5, 20 ], "y": [ 5, 20 ], "amount": 5, "repeat": 40 } ],
       "place_fields": [ { "field": "fd_fire", "x": [ 5, 20 ], "y": [ 5, 20 ], "repeat": 40 } ]
     }
+  },
+  {
+    "//": "MISSION_PYROMANIAC mission set this topic as starting topic for mission giver.",
+    "type": "talk_topic",
+    "id": "MISSION_PYROMANIAC",
+    "dynamic_line": "Are we there yet, <name_g>?  I can't wait to burn that building!",
+    "responses": [
+      {
+        "text": "We're here.  Let's do it!",
+        "topic": "TALK_MISSION_INQUIRE",
+        "condition": { "and": [ "mission_complete", { "u_has_items": { "item": "tinder" } } ] }
+      },
+      { "text": "Be patient, <name_g>, we're getting there soon.", "topic": "TALK_DONE" }
+    ]
   }
 ]

--- a/data/mods/innawood/npcs/missiondef.json
+++ b/data/mods/innawood/npcs/missiondef.json
@@ -474,7 +474,7 @@
       "effect": [ "follow_only", { "npc_first_topic": "MISSION_PYROMANIAC" } ],
       "assign_mission_target": { "om_terrain": "forest", "om_terrain_match_type": "PREFIX", "search_range": 75, "random": true, "z": 0 }
     },
-    "end": { "effect": [ "follow", { "u_consume_item": "tinder" }, { "mapgen_update": "MISSION_PYROMANIAC_BURN" } ] },
+    "end": { "effect": [ "follow", { "u_consume_item": "tinder" }, { "mapgen_update": "MISSION_PYROMANIAC_BURN_INNAWOOD" } ] },
     "origins": [ "ORIGIN_OPENER_NPC" ],
     "dialogue": {
       "describe": "Oh man, I want to <swear> burn it so bad…",
@@ -491,7 +491,7 @@
   {
     "//": "For MISSION_PYROMANIAC. Will spawn fire on tile where PC is standing.",
     "type": "mapgen",
-    "update_mapgen_id": "MISSION_PYROMANIAC_BURN",
+    "update_mapgen_id": "MISSION_PYROMANIAC_BURN_INNAWOOD",
     "method": "json",
     "object": {
       "place_item": [ { "item": "tinder", "x": [ 5, 20 ], "y": [ 5, 20 ], "amount": 5, "repeat": 40 } ],
@@ -502,14 +502,13 @@
     "//": "MISSION_PYROMANIAC mission set this topic as starting topic for mission giver.",
     "type": "talk_topic",
     "id": "MISSION_PYROMANIAC",
-    "dynamic_line": "Are we there yet, <name_g>?  I can't wait to burn that building!",
+    "dynamic_line": "Are we there yet, <name_g>?  I can't wait to burn that tree!",
     "responses": [
       {
         "text": "We're here.  Let's do it!",
         "topic": "TALK_MISSION_INQUIRE",
         "condition": { "and": [ "mission_complete", { "u_has_items": { "item": "tinder", "count": 1 } } ] }
-      },
-      { "text": "Be patient, <name_g>, we're getting there soon.", "topic": "TALK_DONE" }
+      }
     ]
   }
 ]

--- a/data/mods/innawood/npcs/missiondef.json
+++ b/data/mods/innawood/npcs/missiondef.json
@@ -507,7 +507,7 @@
       {
         "text": "We're here.  Let's do it!",
         "topic": "TALK_MISSION_INQUIRE",
-        "condition": { "and": [ "mission_complete", { "u_has_items": { "item": "tinder" } } ] }
+        "condition": { "and": [ "mission_complete", { "u_has_items": { "item": "tinder", "count": 1 } } ] }
       },
       { "text": "Be patient, <name_g>, we're getting there soon.", "topic": "TALK_DONE" }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The Innawood arsonist quest forgot to overwrite a piece of dialogue, so the quest could not be completed without gasoline.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Overwrite the missing dialogue piece so that the quest requires tinder as intended.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->