### PR TITLE
Clear more avatar state in clear_avatar()

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -797,6 +797,13 @@ void avatar::identify( const item &item )
     }
 }
 
+void avatar::clear_nutrition()
+{
+    calorie_diary.clear();
+    calorie_diary.emplace_front();
+    consumption_history.clear();
+}
+
 void avatar::clear_identified()
 {
     items_identified.clear();

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -222,6 +222,8 @@ class avatar : public Character
         bool has_identified( const itype_id &item_id ) const override;
         void identify( const item &item ) override;
         void clear_identified();
+        // clears nutrition related values e.g. calorie_diary, consumption_history...
+        void clear_nutrition();
 
         void add_snippet( snippet_id snippet );
         bool has_seen_snippet( const snippet_id &snippet ) const;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2892,6 +2892,8 @@ bionic &Character::bionic_at_index( int i )
 void Character::clear_bionics()
 {
     my_bionics->clear();
+    update_last_bionic_uid();
+    update_bionic_power_capacity();
 }
 
 void reset_bionics()

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -531,6 +531,11 @@ time_duration Character::vitamin_rate( const vitamin_id &vit ) const
 void Character::clear_vitamins()
 {
     vitamin_levels.clear();
+    daily_vitamins.clear();
+    for( const auto &[vitamin_id, vitamin] : vitamin::all() ) {
+        vitamin_levels[vitamin_id] = 0;
+        daily_vitamins[vitamin_id] = { 0, 0 };
+    }
 }
 
 std::map<vitamin_id, int> Character::effect_vitamin_mod( const std::map<vitamin_id, int> &vits )

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -25,6 +25,7 @@
 #include "point.h"
 #include "profession.h"
 #include "ret_val.h"
+#include "skill.h"
 #include "stomach.h"
 #include "type_id.h"
 
@@ -82,6 +83,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.stomach.empty();
     dummy.guts.empty();
     dummy.clear_vitamins();
+    dummy.health_tally = 0;
     dummy.update_body( calendar::turn, calendar::turn ); // sets last_updated to current turn
     if( !skip_nutrition ) {
         item food( "debug_nutrition" );
@@ -94,7 +96,9 @@ void clear_character( Character &dummy, bool skip_nutrition )
     // However, the above does not set stored kcal
     dummy.set_stored_kcal( dummy.get_healthy_kcal() );
 
-    dummy.empty_skills();
+    dummy.prof = profession::generic();
+    dummy.hobbies.clear();
+    dummy._skills->clear();
     dummy.martial_arts_data->clear_styles();
     dummy.clear_morale();
     dummy.clear_bionics();
@@ -131,8 +135,6 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.set_per_bonus( 0 );
 
     dummy.cash = 0;
-
-    dummy.prof = profession::generic();
 
     const tripoint spot( 60, 60, 0 );
     dummy.setpos( spot );
@@ -190,8 +192,10 @@ void arm_shooter( npc &shooter, const std::string &gun_type,
 
 void clear_avatar()
 {
-    clear_character( get_avatar() );
-    get_avatar().clear_identified();
+    avatar &avatar = get_avatar();
+    clear_character( avatar );
+    avatar.clear_identified();
+    avatar.clear_nutrition();
 }
 
 void equip_shooter( npc &shooter, const std::vector<std::string> &apparel )


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Some tests have order dependencies since not all of avatar is cleared

#### Describe the solution

Clear more avatar state

#### Describe alternatives you've considered

#### Testing

Will work:
`tests/cata_test "check swim move cost and distance values"`
Will fail (since swim test is normally before starve_test it normally succeeds):
`tests/cata_test "starve_test" , "check swim move cost and distance values"`

Apply patch - the second filter should also work

#### Additional context
