### PR TITLE
Clear avatar in vehicle_fake tests

### DIFF
--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -64,6 +64,7 @@ static void validate_part_count( const vehicle &veh, const int target_velocity,
 
 TEST_CASE( "ensure_fake_parts_enable_on_place", "[vehicle] [vehicle_fake]" )
 {
+    clear_avatar();
     const int original_parts = 120;
     const int fake_parts = 18;
     std::vector<int> active_fakes_by_angle = { 0, 2, 5, 15, 7, 2 };
@@ -99,6 +100,7 @@ TEST_CASE( "ensure_fake_parts_enable_on_place", "[vehicle] [vehicle_fake]" )
 
 TEST_CASE( "ensure_fake_parts_enable_on_turn", "[vehicle] [vehicle_fake]" )
 {
+    clear_avatar();
     const int original_parts = 120;
     const int fake_parts = 18;
     std::vector<int> active_fakes_by_angle = { 0, 3, 8, 15, 6, 1 };
@@ -161,6 +163,7 @@ TEST_CASE( "ensure_fake_parts_enable_on_turn", "[vehicle] [vehicle_fake]" )
 
 TEST_CASE( "ensure_vehicle_weight_is_constant", "[vehicle] [vehicle_fake]" )
 {
+    clear_avatar();
     really_clear_map();
     const tripoint test_origin( 30, 30, 0 );
     map &here = get_map();
@@ -188,6 +191,7 @@ TEST_CASE( "ensure_vehicle_weight_is_constant", "[vehicle] [vehicle_fake]" )
 
 TEST_CASE( "vehicle_collision_applies_damage_to_fake_parent", "[vehicle] [vehicle_fake]" )
 {
+    clear_avatar();
     really_clear_map();
     map &here = get_map();
     GIVEN( "A moving vehicle traveling at a 45 degree angle to the X axis" ) {
@@ -246,6 +250,7 @@ TEST_CASE( "vehicle_collision_applies_damage_to_fake_parent", "[vehicle] [vehicl
 
 TEST_CASE( "vehicle_to_vehicle_collision", "[vehicle] [vehicle_fake]" )
 {
+    clear_avatar();
     really_clear_map();
     map &here = get_map();
     GIVEN( "A moving vehicle traveling at a 30 degree angle to the X axis" ) {
@@ -302,6 +307,7 @@ TEST_CASE( "vehicle_to_vehicle_collision", "[vehicle] [vehicle_fake]" )
 
 TEST_CASE( "ensure_vehicle_with_no_obstacles_has_no_fake_parts", "[vehicle] [vehicle_fake]" )
 {
+    clear_avatar();
     really_clear_map();
     map &here = get_map();
     GIVEN( "A vehicle with no parts that block movement" ) {


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Break test order dependencies

#### Describe the solution

Clear avatar in [vehicle_fake] tests

#### Describe alternatives you've considered

#### Testing

`./tests/cata_test --abort "npc_act_multiple_construction,modify character stamina,burning stamina when overburdened may cause pain,stamina regeneration rate,suffering from albinism,walls should connect to walls as t-connections and fully,Ranged coverage vs. bullet,targeting_graph_complex_target,Default_anatomy_body_part_hit_chances,tape_worm_halves_nutrients,hunger,string_formatter,string_formatter_errors,static_string_ids_equality_test,string_ids_intern_test,string_ids_collection_equality,string_id_sorting_test,string_test,trim_by_length,str_cat,str_append,submap_empty_load,submap_terrain_rle_load,submap_terrain_load_invalid_ter_ids_as_t_dirt,submap_furniture_load,submap_trap_load,submap_rad_load,submap_item_load,submap_field_load,submap_graffiti_load,submap_cosmetics_load,submap_spawns_load,submap_vehicle_load,submap_construction_load,submap_computer_load,submap rotation,submap rotation2,daily solar cycle,sunlight and moonlight,noon sunlight levels,sunrise and sunset,sun_highest_at_noon,noon_sun_doesn't_move_much,dawn_dusk_fixed_during_eternal_season,sun_altitude_fixed_during_eternal_night_or_day,sunrise_sunset_consistency,movement_of_sun_through_day,temp_crafting_inv_test_amount,temp_crafting_inv_test_quality,Item spawns with right thermal attributes,Rate of temperature change,Temperature controlled location,basic_throwing_sanity_tests,ensure_fake_parts_enable_on_turn,ensure_vehicle_with_no_obstacles_has_no_fake_parts,open_and_close_fake_doors,verify_copy_from_gets_damage_reduction,vehicle_parts_seats_and_beds_have_beltable_flags,vehicle_parts_boardable_openable_parts_have_door_flag,vehicle_parts_have_at_least_one_category,craft_available_via_vehicle_rig,vehicle_ramp_test_61,vision_light_shining_in,vision_see_wall_in_moonlight,vision_moncam_otherz,weakpoint_basic,weakpoint_practice,Check order of weakpoint set application,Check damage from weakpoint sets,weary_24h_tasks"`
will fail before patch, shouldn't fail after patch

#### Additional context
