### PR TITLE
Fix copy-pasta bug in vpart_info::check

### DIFF
--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -827,7 +827,7 @@ void vpart_info::check()
             }
         }
 
-        for( const auto &e : part.install_reqs ) {
+        for( const auto &e : part.removal_reqs ) {
             if( !( e.first.is_null() || e.first.is_valid() ) || e.second < 0 ) {
                 debugmsg( "vehicle part %s has unknown or incorrectly specified removal requirements %s",
                           part.id.c_str(), e.first.c_str() );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Accidental copy pasta validates install_reqs twice, and ignores removal_reqs 

#### Describe the solution

Depends on https://github.com/CleverRaven/Cataclysm-DDA/pull/66168

Fix it

#### Describe alternatives you've considered

#### Testing

Tests should fail until https://github.com/CleverRaven/Cataclysm-DDA/pull/66168 gets merged, and go green when it's merged

#### Additional context
