### PR TITLE
check last_world_pos before deleteing world

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -1138,11 +1138,11 @@ void main_menu::world_tab( const std::string &worldname )
     }
 
     auto clear_world = [this, &worldname]( bool do_delete ) {
-        world_generator->delete_world( worldname, do_delete );
         // NOLINTNEXTLINE(cata-use-localized-sorting)
         if( last_world_pos > 0 && worldname <= world_generator->all_worldnames()[last_world_pos] ) {
             last_world_pos--;
         }
+        world_generator->delete_world( worldname, do_delete );
         savegames.clear();
         MAPBUFFER.clear();
         overmap_buffer.clear();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Heap overflow on deleting last world"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix the bug. In case of removing last world in a list, if that world was last loaded world, then we got heap overflow on [that line](https://github.com/CleverRaven/Cataclysm-DDA/blob/cea58414dda6fa661c4c15db6a54db1228cbaac5/src/main_menu.cpp#L1143), because `last_world_pos` is equal to size of list of all worlds after performing the delete .
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Check `last_world_pos` before deleting world
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
As alternative we can modify condition, like:
```
if( last_world_pos > 0 && (last_world_pos >  world_generator->all_worldnames().size() || worldname <= world_generator->all_worldnames()[last_world_pos]) ) {
```

But I don't like it by obvious reason
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I tested that manually with removing last loaded world (that also is last in the list) and checked asan output (no output)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Output of asan:

```
=================================================================
==5934==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6080000bc788 at pc 0x55700b892cfc bp 0x7ffd535aea80 sp 0x7ffd535aea70
READ of size 8 at 0x6080000bc788 thread T0
    #0 0x55700b892cfb in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::size() const /usr/include/c++/10/bits/basic_string.h:902
    #1 0x55700b892cfb in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::compare(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const /usr/include/c++/10/bits/basic_string.h:2855
    #2 0x55700b892cfb in bool std::operator<=<char, std::char_traits<char>, std::allocator<char> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /usr/include/c++/10/bits/basic_string.h:6356
    #3 0x55700b892cfb in operator() src/main_menu.cpp:1143
    #4 0x55700b8c6fec in main_menu::world_tab(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/main_menu.cpp:1176
    #5 0x55700b8cc921 in main_menu::opening_screen() src/main_menu.cpp:859
    #6 0x55700b8858d7 in main src/main.cpp:823
    #7 0x7f0f9e1e0082 in __libc_start_main ../csu/libc-start.c:308
    #8 0x55700769702d in _start (/home/levkovitch/Public/git/Cataclysm-DDA/cataclysm-tiles+0x13c802d)

0x6080000bc788 is located 8 bytes to the right of 96-byte region [0x6080000bc720,0x6080000bc780)
allocated by thread T0 here:
    #0 0x7f0f9eb90f27 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x557007914264 in __gnu_cxx::new_allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::allocate(unsigned long, void const*) /usr/include/c++/10/ext/new_allocator.h:115
    #2 0x557007914264 in std::allocator_traits<std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::allocate(std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&, unsigned long) /usr/include/c++/10/bits/alloc_traits.h:460
    #3 0x557007914264 in std::_Vector_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::_M_allocate(unsigned long) /usr/include/c++/10/bits/stl_vector.h:346
    #4 0x557007914264 in std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::reserve(unsigned long) /usr/include/c++/10/bits/vector.tcc:78
    #5 0x55700fa1f357 in worldfactory::all_worldnames[abi:cxx11]() const src/worldfactory.cpp:441
    #6 0x55700b892b11 in operator() src/main_menu.cpp:1143
    #7 0x55700b8c6fec in main_menu::world_tab(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/main_menu.cpp:1176
    #8 0x55700b8cc921 in main_menu::opening_screen() src/main_menu.cpp:859
    #9 0x55700b8858d7 in main src/main.cpp:823
    #10 0x7f0f9e1e0082 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: heap-buffer-overflow /usr/include/c++/10/bits/basic_string.h:902 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::size() const
Shadow bytes around the buggy address:
  0x0c108000f8a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c108000f8b0: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fa
  0x0c108000f8c0: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 06
  0x0c108000f8d0: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c108000f8e0: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c108000f8f0: fa[fa]fa fa 00 00 00 00 00 00 00 00 00 00 04 fa
  0x0c108000f900: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c108000f910: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fa
  0x0c108000f920: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 02
  0x0c108000f930: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c108000f940: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==5934==ABORTING
```
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->