### PR TITLE
More test state resets

### DIFF
--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -1162,19 +1162,19 @@
         "condition": { "math": [ "weather('pressure')", "==", "17" ] }
       },
       {
-        "text": "Pos_x is 18.",
+        "text": "Pos_x is -1.",
         "topic": "TALK_DONE",
-        "condition": { "compare_num": [ { "u_val": "pos_x" }, "=", { "const": 18 } ] }
+        "condition": { "compare_num": [ { "u_val": "pos_x" }, "=", { "const": -1 } ] }
       },
       {
-        "text": "Pos_y is 19.",
+        "text": "Pos_y is -2.",
         "topic": "TALK_DONE",
-        "condition": { "compare_num": [ { "u_val": "pos_y" }, "=", { "const": 19 } ] }
+        "condition": { "compare_num": [ { "u_val": "pos_y" }, "=", { "const": -2 } ] }
       },
       {
-        "text": "Pos_z is 20. This should be cause for alarm.",
+        "text": "Pos_z is -3.",
         "topic": "TALK_DONE",
-        "condition": { "compare_num": [ { "u_val": "pos_z" }, "=", { "const": 20 } ] }
+        "condition": { "compare_num": [ { "u_val": "pos_z" }, "=", { "const": -3 } ] }
       },
       { "text": "Pain level is 21.", "topic": "TALK_DONE", "condition": { "math": [ "u_pain()", "==", "21" ] } },
       {
@@ -1466,19 +1466,19 @@
         "effect": { "math": [ "u_skill('driving')", "=", "10" ] }
       },
       {
-        "text": "Sets pos_x to 14.",
+        "text": "Sets pos_x to -1.",
         "topic": "TALK_DONE",
-        "effect": { "arithmetic": [ { "u_val": "pos_x" }, "=", { "const": 14 } ] }
+        "effect": { "arithmetic": [ { "u_val": "pos_x" }, "=", { "const": -1 } ] }
       },
       {
-        "text": "Sets pos_y to 15.",
+        "text": "Sets pos_y to -2.",
         "topic": "TALK_DONE",
-        "effect": { "arithmetic": [ { "u_val": "pos_y" }, "=", { "const": 15 } ] }
+        "effect": { "arithmetic": [ { "u_val": "pos_y" }, "=", { "const": -2 } ] }
       },
       {
-        "text": "Sets pos_z to 16.",
+        "text": "Sets pos_z to -3.",
         "topic": "TALK_DONE",
-        "effect": { "arithmetic": [ { "u_val": "pos_z" }, "=", { "const": 16 } ] }
+        "effect": { "arithmetic": [ { "u_val": "pos_z" }, "=", { "const": -3 } ] }
       },
       { "text": "Sets pain to 17.", "topic": "TALK_DONE", "effect": { "math": [ "u_pain()", "=", "17" ] } },
       {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2869,6 +2869,7 @@ void Character::remove_bionic( const bionic &bio )
 
     const bool has_enchantments = !bio.id->enchantments.empty();
     *my_bionics = new_my_bionics;
+    update_last_bionic_uid();
     invalidate_pseudo_items();
     update_bionic_power_capacity();
     calc_encumbrance();
@@ -2891,9 +2892,10 @@ bionic &Character::bionic_at_index( int i )
 
 void Character::clear_bionics()
 {
-    my_bionics->clear();
-    update_last_bionic_uid();
-    update_bionic_power_capacity();
+    set_max_power_level_modifier( 0_kJ );
+    while( !my_bionics->empty() ) {
+        remove_bionic( my_bionics->front() );
+    }
 }
 
 void reset_bionics()

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -553,7 +553,7 @@ Character::Character() :
 
     move_mode = move_mode_walk;
     next_expected_position = std::nullopt;
-    crafting_cache.time = calendar::before_time_starts;
+    invalidate_crafting_inventory();
 
     set_power_level( 0_kJ );
     cash = 0;

--- a/src/character.h
+++ b/src/character.h
@@ -3674,6 +3674,7 @@ class Character : public Creature, public visitable
         struct weighted_int_list<std::string> melee_miss_reasons;
 
         struct crafting_cache_type {
+            bool valid = false; // other fields are only valid if this flag is true
             time_point time;
             int moves;
             tripoint position;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -574,7 +574,8 @@ const inventory &Character::crafting_inventory( const tripoint &src_pos, int rad
     if( src_pos == tripoint_zero ) {
         inv_pos = pos();
     }
-    if( moves == crafting_cache.moves
+    if( crafting_cache.valid
+        && moves == crafting_cache.moves
         && radius == crafting_cache.radius
         && calendar::turn == crafting_cache.time
         && inv_pos == crafting_cache.position ) {
@@ -615,6 +616,7 @@ const inventory &Character::crafting_inventory( const tripoint &src_pos, int rad
         *crafting_cache.crafting_inventory += item( "shovel", calendar::turn );
     }
 
+    crafting_cache.valid = true;
     crafting_cache.moves = moves;
     crafting_cache.time = calendar::turn;
     crafting_cache.position = inv_pos;
@@ -624,7 +626,8 @@ const inventory &Character::crafting_inventory( const tripoint &src_pos, int rad
 
 void Character::invalidate_crafting_inventory()
 {
-    crafting_cache.time = calendar::before_time_starts;
+    crafting_cache.valid = false;
+    crafting_cache.crafting_inventory->clear();
 }
 
 void Character::make_craft( const recipe_id &id_to_make, int batch_size,

--- a/tests/bionics_test.cpp
+++ b/tests/bionics_test.cpp
@@ -36,22 +36,12 @@ static const flag_id json_flag_PSEUDO( "PSEUDO" );
 static const itype_id itype_solarpack_on( "solarpack_on" );
 static const itype_id itype_test_backpack( "test_backpack" );
 
-static void clear_bionics( Character &you )
-{
-    you.my_bionics->clear();
-    you.update_last_bionic_uid();
-    you.update_bionic_power_capacity();
-    you.set_power_level( 0_kJ );
-    you.set_max_power_level_modifier( 0_kJ );
-}
-
 TEST_CASE( "Bionic power capacity", "[bionics] [power]" )
 {
     avatar &dummy = get_avatar();
 
     GIVEN( "character starts without bionics and no bionic power" ) {
         clear_avatar();
-        clear_bionics( dummy );
         REQUIRE( !dummy.has_max_power() );
 
         WHEN( "a Power Storage CBM is installed" ) {
@@ -65,7 +55,6 @@ TEST_CASE( "Bionic power capacity", "[bionics] [power]" )
 
     GIVEN( "character starts with 3 power storage bionics" ) {
         clear_avatar();
-        clear_bionics( dummy );
         dummy.add_bionic( bio_power_storage );
         dummy.add_bionic( bio_power_storage );
         dummy.add_bionic( bio_power_storage );
@@ -108,7 +97,6 @@ TEST_CASE( "bionic UIDs", "[bionics]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();
-    clear_bionics( dummy );
 
     GIVEN( "character doesn't have any CBMs installed" ) {
         REQUIRE( dummy.get_bionics().empty() );
@@ -144,14 +132,13 @@ TEST_CASE( "bionic weapons", "[bionics] [weapon] [item]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();
-    clear_bionics( dummy );
-    dummy.set_max_power_level( units::from_kilojoule( 200 ) );
+    dummy.add_bionic( bio_power_storage );
+    dummy.add_bionic( bio_power_storage );
     dummy.set_power_level( dummy.get_max_power_level() );
+    REQUIRE( dummy.get_power_level() == 200_kJ );
     REQUIRE( dummy.is_max_power() );
 
     GIVEN( "character has two weapon CBM" ) {
-        dummy.add_bionic( bio_power_storage );
-        dummy.add_bionic( bio_power_storage );
         dummy.add_bionic( bio_surgical_razor );
         bionic &bio2 = dummy.bionic_at_index( dummy.get_bionics().size() - 1 );
         dummy.add_bionic( bio_power_storage );
@@ -346,7 +333,6 @@ TEST_CASE( "included bionics", "[bionics]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();
-    clear_bionics( dummy );
 
     GIVEN( "character doesn't have any CBMs installed" ) {
         REQUIRE( dummy.get_bionics().empty() );
@@ -379,21 +365,25 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();
-    clear_bionics( dummy );
 
+    // 500kJ ought to be enough for everybody, make sure not to add any bionics in the
+    // tests after taking reference to a bionic, if bionics vector is too small and gets
+    // reallocated the references become invalid
     dummy.add_bionic( bio_power_storage );
+    dummy.add_bionic( bio_power_storage );
+    dummy.add_bionic( bio_power_storage );
+    dummy.add_bionic( bio_power_storage );
+    dummy.add_bionic( bio_power_storage );
+
     REQUIRE( !dummy.has_power() );
     REQUIRE( dummy.has_max_power() );
 
     SECTION( "bio_fuel_cell_gasoline" ) {
-        dummy.add_bionic( bio_fuel_cell_gasoline );
-        // Dirty way of getting the bionic
-        bionic_id gas_bionic = dummy.get_bionics()[1];
-        bionic &bio = dummy.bionic_at_index( 1 );
+        bionic &bio = *dummy.find_bionic_by_uid( dummy.add_bionic( bio_fuel_cell_gasoline ) ).value();
         item_location gasoline_tank = dummy.top_items_loc().front();
 
         // There should be no fuel available, can't turn bionic on and no power is produced
-        CHECK( dummy.get_bionic_fuels( gas_bionic ).empty() );
+        CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK( dummy.get_cable_ups().empty() );
         CHECK( dummy.get_cable_solar().empty() );
         CHECK( dummy.get_cable_vehicle().empty() );
@@ -408,7 +398,7 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
         gasoline_tank->put_in( gasoline, item_pocket::pocket_type::CONTAINER );
         REQUIRE( gasoline_tank->only_item().charges == 2 );
         CHECK( dummy.activate_bionic( bio ) );
-        CHECK_FALSE( dummy.get_bionic_fuels( gas_bionic ).empty() );
+        CHECK_FALSE( dummy.get_bionic_fuels( bio.id ).empty() );
         dummy.suffer();
         CHECK( units::to_joule( dummy.get_power_level() ) == 8550 );
         CHECK( gasoline_tank->only_item().charges == 1 );
@@ -423,15 +413,12 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
     }
 
     SECTION( "bio_batteries" ) {
-        dummy.add_bionic( bio_batteries );
-        // Dirty way of getting the bionic
-        bionic_id bat_bionic = dummy.get_bionics()[1];
-        bionic &bio = dummy.bionic_at_index( 1 );
+        bionic &bio = *dummy.find_bionic_by_uid( dummy.add_bionic( bio_batteries ) ).value();
         item_location bat_compartment = dummy.top_items_loc().front();
 
         // There should be no fuel available, can't turn bionic on and no power is produced
         REQUIRE( bat_compartment->ammo_remaining() == 0 );
-        CHECK( dummy.get_bionic_fuels( bat_bionic ).empty() );
+        CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK( dummy.get_cable_ups().empty() );
         CHECK( dummy.get_cable_solar().empty() );
         CHECK( dummy.get_cable_vehicle().empty() );
@@ -444,7 +431,7 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
         CHECK( bat_compartment->can_reload_with( battery, true ) );
         bat_compartment->put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
         REQUIRE( bat_compartment->ammo_remaining() == 0 );
-        CHECK( dummy.get_bionic_fuels( bat_bionic ).empty() );
+        CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK( dummy.get_cable_ups().empty() );
         CHECK( dummy.get_cable_solar().empty() );
         CHECK( dummy.get_cable_vehicle().empty() );
@@ -456,7 +443,7 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
         bat_compartment->magazine_current()->ammo_set( battery.ammo_default(), 2 );
         REQUIRE( bat_compartment->ammo_remaining() == 2 );
         CHECK( dummy.activate_bionic( bio ) );
-        CHECK_FALSE( dummy.get_bionic_fuels( bat_bionic ).empty() );
+        CHECK_FALSE( dummy.get_bionic_fuels( bio.id ).empty() );
         dummy.suffer();
         CHECK( units::to_joule( dummy.get_power_level() ) == 1000 );
         CHECK( bat_compartment->ammo_remaining() == 1 );
@@ -471,13 +458,10 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
     }
 
     SECTION( "bio_cable ups" ) {
-        dummy.add_bionic( bio_cable );
-        // Dirty way of getting the bionic
-        bionic_id cable_bionic = dummy.get_bionics()[1];
-        bionic &bio = dummy.bionic_at_index( 1 );
+        bionic &bio = *dummy.find_bionic_by_uid( dummy.add_bionic( bio_cable ) ).value();
 
         // There should be no fuel available, can't turn bionic on and no power is produced
-        CHECK( dummy.get_bionic_fuels( cable_bionic ).empty() );
+        CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK( dummy.get_cable_ups().empty() );
         CHECK( dummy.get_cable_solar().empty() );
         CHECK( dummy.get_cable_vehicle().empty() );
@@ -496,7 +480,7 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
         cable->active = true;
 
         REQUIRE( ups->ammo_remaining() == 0 );
-        CHECK( dummy.get_bionic_fuels( cable_bionic ).empty() );
+        CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK( dummy.get_cable_ups().empty() );
         CHECK( dummy.get_cable_solar().empty() );
         CHECK( dummy.get_cable_vehicle().empty() );
@@ -508,7 +492,7 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
         item ups_mag( ups->magazine_default() );
         ups->put_in( ups_mag, item_pocket::pocket_type::MAGAZINE_WELL );
         REQUIRE( ups->ammo_remaining() == 0 );
-        CHECK( dummy.get_bionic_fuels( cable_bionic ).empty() );
+        CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK_FALSE( dummy.activate_bionic( bio ) );
         dummy.suffer();
         REQUIRE( !dummy.has_power() );
@@ -532,10 +516,7 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
     }
 
     SECTION( "bio_cable solar" ) {
-        dummy.add_bionic( bio_cable );
-        // Dirty way of getting the bionic
-        bionic_id cable_bionic = dummy.get_bionics()[1];
-        bionic &bio = dummy.bionic_at_index( 1 );
+        bionic &bio = *dummy.find_bionic_by_uid( dummy.add_bionic( bio_cable ) ).value();
 
         // Midday for solar test
         clear_map();
@@ -557,7 +538,7 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
         solar_pack->set_var( "cable", "plugged_in" );
         cable->active = true;
 
-        CHECK( dummy.get_bionic_fuels( cable_bionic ).empty() );
+        CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK( dummy.get_cable_ups().empty() );
         CHECK_FALSE( dummy.get_cable_solar().empty() );
         CHECK( dummy.get_cable_vehicle().empty() );
@@ -567,22 +548,14 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
     }
 
     SECTION( "bio_wood_burner" ) {
-        // Test bionic fueled with fuel that is not counted by charge
-        // wood_bionic is test only thing
-        dummy.add_bionic( bio_fuel_wood );
-        // Dirty way of getting the bionic
-        bionic_id wood_bionic = dummy.get_bionics()[1];
-        bionic &bio = dummy.bionic_at_index( 1 );
+        bionic &bio = *dummy.find_bionic_by_uid( dummy.add_bionic( bio_fuel_wood ) ).value();
         item_location woodshed = dummy.top_items_loc().front();
 
         // Turn safe fuel off since log produces too much energy
         bio.set_safe_fuel_thresh( -1.0f );
-        // And to still avoid hitting limit add more storage
-        dummy.add_bionic( bio_power_storage );
-        dummy.add_bionic( bio_power_storage );
 
         // There should be no fuel available, can't turn bionic on and no power is produced
-        CHECK( dummy.get_bionic_fuels( wood_bionic ).empty() );
+        CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK_FALSE( dummy.activate_bionic( bio ) );
         dummy.suffer();
         REQUIRE( !dummy.has_power() );
@@ -595,7 +568,7 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
         woodshed->put_in( wood_2, item_pocket::pocket_type::CONTAINER );
         REQUIRE( woodshed->all_items_ptr().size() == 2 );
         CHECK( dummy.activate_bionic( bio ) );
-        CHECK_FALSE( dummy.get_bionic_fuels( wood_bionic ).empty() );
+        CHECK_FALSE( dummy.get_bionic_fuels( bio.id ).empty() );
         dummy.suffer();
         CHECK( units::to_joule( dummy.get_power_level() ) == 62500 );
         CHECK( woodshed->all_items_ptr().size() == 1 );
@@ -608,7 +581,4 @@ TEST_CASE( "fueled bionics", "[bionics] [item]" )
         dummy.suffer();
         CHECK( units::to_joule( dummy.get_power_level() ) == 125000 );
     }
-
-    clear_bionics( dummy );
-    calendar::turn = calendar::turn_zero;
 }

--- a/tests/char_biometrics_test.cpp
+++ b/tests/char_biometrics_test.cpp
@@ -104,6 +104,7 @@ static int bmr_at_act_level( Character &dummy, float activity_level )
     dummy.reset_activity_level();
     dummy.set_stored_kcal( dummy.get_healthy_kcal() );
     dummy.update_body( calendar::turn, calendar::turn );
+    dummy.update_body( calendar::turn, calendar::turn + 10_minutes );
     dummy.set_activity_level( activity_level );
 
     return dummy.get_bmr();

--- a/tests/degradation_test.cpp
+++ b/tests/degradation_test.cpp
@@ -426,6 +426,8 @@ TEST_CASE( "Gun repair with degradation", "[item][degradation]" )
         item gun( itype_test_glock_degrade );
         clear_character( u );
         u.set_skill_level( skill_mechanics, 10 );
+        clear_map();
+        set_time_to_day();
 
         WHEN( "0 damage / 0 degradation" ) {
             gun.set_damage( 0 );

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -2235,9 +2235,10 @@ TEST_CASE( "picking up items respects pocket autoinsert settings", "[pocket][ite
 
 TEST_CASE( "multipocket liquid transfer test", "[pocket][item][liquid]" )
 {
+    clear_map();
+    clear_avatar();
     map &m = get_map();
     Character &u = get_player_character();
-    clear_character( u, true );
     item water( "water" );
     item cont_jug( "test_jug_plastic" );
     item cont_suit( "test_robofac_armor_rig" );

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -1,5 +1,7 @@
 #include "map_helpers.h"
 
+#include "catch/catch.hpp"
+
 #include <functional>
 #include <list>
 #include <map>
@@ -146,10 +148,10 @@ void clear_map_and_put_player_underground()
 monster &spawn_test_monster( const std::string &monster_type, const tripoint &start,
                              const bool death_drops )
 {
-    monster *const added = g->place_critter_at( mtype_id( monster_type ), start );
-    added->death_drops = death_drops;
-    cata_assert( added );
-    return *added;
+    monster *const test_monster_ptr = g->place_critter_at( mtype_id( monster_type ), start );
+    REQUIRE( test_monster_ptr );
+    test_monster_ptr->death_drops = death_drops;
+    return *test_monster_ptr;
 }
 
 // Build a map of size MAPSIZE_X x MAPSIZE_Y around tripoint_zero with a given

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -19,6 +19,10 @@ TEST_CASE( "map_coordinate_conversion_functions" )
 {
     map &here = get_map();
 
+    const on_out_of_scope restore_vertical_shift( [&here]() {
+        here.vertical_shift( 0 );
+    } );
+
     tripoint test_point =
         GENERATE( tripoint_zero, tripoint_south, tripoint_east, tripoint_above, tripoint_below );
     tripoint_bub_ms test_bub( test_point );

--- a/tests/martial_art_test.cpp
+++ b/tests/martial_art_test.cpp
@@ -81,12 +81,12 @@ TEST_CASE( "Martial art required weapon categories", "[martial_arts]" )
 
 TEST_CASE( "Martial art technique conditionals", "[martial_arts]" )
 {
+    clear_map();
     standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
     const tripoint target_1_pos = dude_pos + tripoint_east;
     const tripoint target_2_pos = dude_pos + tripoint_north;
     const tripoint target_3_pos = dude_pos + tripoint_west;
     clear_character( dude, true );
-    clear_creatures();
     dude.martial_arts_data->add_martialart( test_style_ma1 );
     dude.martial_arts_data->set_style( test_style_ma1, false );
     REQUIRE( dude.get_size() == 3 );

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -1213,7 +1213,7 @@ TEST_CASE( "npc_compare_int", "[npc_talk]" )
     get_weather().weather_precise->humidity = 16;
     get_weather().weather_precise->pressure = 17;
     get_weather().clear_temp_cache();
-    player_character.setpos( tripoint( 18, 19, 20 ) );
+    player_character.setpos( tripoint( -1, -2, -3 ) );
     player_character.set_pain( 21 );
     player_character.add_bionic( bio_power_storage );
     player_character.set_power_level( 22_mJ );
@@ -1274,9 +1274,9 @@ TEST_CASE( "npc_compare_int", "[npc_talk]" )
     CHECK( d.responses[ 20 ].text == "Windpower is 15." );
     CHECK( d.responses[ 21 ].text == "Humidity is 16." );
     CHECK( d.responses[ 22 ].text == "Pressure is 17." );
-    CHECK( d.responses[ 23 ].text == "Pos_x is 18." );
-    CHECK( d.responses[ 24 ].text == "Pos_y is 19." );
-    CHECK( d.responses[ 25 ].text == "Pos_z is 20. This should be cause for alarm." );
+    CHECK( d.responses[ 23 ].text == "Pos_x is -1." );
+    CHECK( d.responses[ 24 ].text == "Pos_y is -2." );
+    CHECK( d.responses[ 25 ].text == "Pos_z is -3." );
     CHECK( d.responses[ 26 ].text == "Pain level is 21." );
     CHECK( d.responses[ 27 ].text == "Bionic power is 22." );
     CHECK( d.responses[ 28 ].text == "Bionic power max is 44." );
@@ -1503,17 +1503,17 @@ TEST_CASE( "npc_arithmetic", "[npc_talk]" )
     // "Sets pos_x to 14."
     effects = d.responses[ 13 ].success;
     effects.apply( d );
-    CHECK( player_character.posx() == 14 );
+    CHECK( player_character.posx() == -1 );
 
     // "Sets pos_y to 15."
     effects = d.responses[ 14 ].success;
     effects.apply( d );
-    CHECK( player_character.posy() == 15 );
+    CHECK( player_character.posy() == -2 );
 
     // "Sets pos_z to 16."
     effects = d.responses[ 15 ].success;
     effects.apply( d );
-    CHECK( player_character.posz() == 16 );
+    CHECK( player_character.posz() == -3 );
 
     // "Sets pain to 17."
     effects = d.responses[ 16 ].success;

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -438,14 +438,12 @@ TEST_CASE( "npc-movement" )
 
 TEST_CASE( "npc_can_target_player" )
 {
-    set_time_to_day();
-
     g->faction_manager_ptr->create_if_needed();
 
+    clear_map();
+    clear_avatar();
+    set_time_to_day();
     g->place_player( tripoint_zero );
-
-    clear_npcs();
-    clear_creatures();
 
     Character &player_character = get_player_character();
     npc &hostile = spawn_npc( player_character.pos().xy() + point_south, "thug" );

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -1757,9 +1757,10 @@ static void update_cache( map &m )
 
 TEST_CASE( "activity interruption by distractions", "[activity][interruption]" )
 {
-    avatar &dummy = get_avatar();
     clear_avatar();
     clear_map();
+    set_time_to_day();
+    avatar &dummy = get_avatar();
     map &m = get_map();
     calendar::turn = daylight_time( calendar::turn ) + 2_hours;
 

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -104,12 +104,15 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.martial_arts_data->clear_styles();
     dummy.clear_morale();
     dummy.activity.set_to_null();
+    dummy.backlog.clear();
     dummy.reset_chargen_attributes();
     dummy.set_pain( 0 );
     dummy.reset_bonuses();
     dummy.set_speed_base( 100 );
     dummy.set_speed_bonus( 0 );
     dummy.set_sleep_deprivation( 0 );
+    dummy.set_moves( 0 );
+    dummy.oxygen = dummy.get_oxygen_max();
     for( const proficiency_id &prof : dummy.known_proficiencies() ) {
         dummy.lose_proficiency( prof, true );
     }
@@ -142,6 +145,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.clear_values();
     dummy.magic = pimpl<known_magic>();
     dummy.forget_all_recipes();
+    dummy.set_focus( dummy.calc_focus_equilibrium() );
 }
 
 void arm_shooter( npc &shooter, const std::string &gun_type,

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -77,6 +77,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.inv->clear();
     dummy.remove_weapon();
     dummy.clear_mutations();
+    dummy.clear_bionics();
 
     // Clear stomach and then eat a nutritious meal to normalize stomach
     // contents (needs to happen before clear_morale).
@@ -101,7 +102,6 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy._skills->clear();
     dummy.martial_arts_data->clear_styles();
     dummy.clear_morale();
-    dummy.clear_bionics();
     dummy.activity.set_to_null();
     dummy.reset_chargen_attributes();
     dummy.set_pain( 0 );

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -74,6 +74,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     // delete all worn items.
     dummy.worn.clear();
     dummy.calc_encumbrance();
+    dummy.invalidate_crafting_inventory();
     dummy.inv->clear();
     dummy.remove_weapon();
     dummy.clear_mutations();

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -129,7 +129,7 @@ static void test_craft_via_rig( const std::vector<item> &items, int give_battery
     clear_avatar();
     clear_map();
     clear_vehicles();
-    set_time( midday );
+    set_time_to_day();
 
     const tripoint test_origin( 60, 60, 0 );
     Character &character = get_player_character();
@@ -174,9 +174,7 @@ static void test_craft_via_rig( const std::vector<item> &items, int give_battery
     veh.discharge_battery( 500000 );
     veh.charge_battery( give_battery );
 
-    // Bust cache on crafting_inventory()
-    character.mod_moves( 1 );
-
+    character.invalidate_crafting_inventory();
     const inventory &crafting_inv = character.crafting_inventory();
     bool can_craft = recipe
                      .deduped_requirements()

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -13,6 +13,7 @@
 #include "itype.h"
 #include "make_static.h"
 #include "map.h"
+#include "map_helpers.h"
 #include "player_helpers.h"
 #include "point.h"
 #include "type_id.h"
@@ -37,6 +38,7 @@ static std::vector<const vpart_info *> all_turret_types()
 // Install, reload and fire every possible vehicle turret.
 TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
 {
+    clear_map();
     map &here = get_map();
     Character &player_character = get_player_character();
     for( const vpart_info *turret_vpi : all_turret_types() ) {

--- a/tests/weary_test.cpp
+++ b/tests/weary_test.cpp
@@ -286,6 +286,8 @@ TEST_CASE( "weary_recovery_mutations", "[weary][activities][mutations]" )
 
 TEST_CASE( "weary_recovery", "[weary][activities]" )
 {
+    calendar::turn = calendar::start_of_game;
+    clear_avatar();
     avatar &guy = get_avatar();
 
     tasklist soldier_8h;


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Make tests individually runnable / not dependent on order of other tests

#### Describe the solution

Cut test order dependencies, most changes are trivial except:

https://github.com/CleverRaven/Cataclysm-DDA/pull/66173/commits/9ba46a79b688b9280e28dc55f09b759496e32ef8 - The dialogs put player on invalid zlevels(16, 20), any test triggering lightmap rebuild crashes, this patches to put players on zlevel -3 instead

https://github.com/CleverRaven/Cataclysm-DDA/pull/66173/commits/d62d7a0eb629575afa67553195dc2b19acb1ced1 this is a slight refactor - 
* rejiggles bionics clearing - stops directly manipulating my_bionics vector, and instead removes bionics one-by-one (triggering enchantment recaching, eocs etc)
* ~~moves clearing bionics to clear_avatar - it's close to no-op if there are no bionics anyway, but potential failure if there's any that the test doesn't expect~~ actually it was already there, just moves it closer to mutation clearing, before 
* makes "fueled bionics" test add all bionics up front - previously it added them mid-test, if vector wasn't already a specific size, the vector gets move-resized and bionic references points at invalid address.
* makes "fueled bionics" test look up bionic by id (type) instead of by hardcoded vector index

https://github.com/CleverRaven/Cataclysm-DDA/pull/66173/commits/b3d56b56516ac06fcc6a11743afa8a1376d25145 - tests often "time travel" backwards to the same preset point (noon) making the cache valid when it shouldn't be, this makes an explicit flag for crafting inventory cache invalidation. Before this patch clear_avatar()/clear_character() didn't reset moves field, but even that requires [hacks](https://github.com/CleverRaven/Cataclysm-DDA/blob/7b5d9914ae0f3ae44b663e6e728a9c7e8f7da3e0/tests/vehicle_part_test.cpp#L177-L178) to actually inavlidate the crafting cache, instead of calling the correct method.

#### Describe alternatives you've considered

#### Testing

Each commit has the reproduction command in description, all of them together:
```sh
./tests/cata_test "map_coordinate_conversion_functions","Mattack dialog condition test"
./tests/cata_test "basal metabolic rate with various size and metabolism","mutations may affect character metabolic rate"
./tests/cata_test "npc_compare_int","npc_can_target_player"
./tests/cata_test "npc_arithmetic","npc_can_target_player"
./tests/cata_test "walls should connect to walls as end pieces","Martial art technique conditionals"
./tests/cata_test "vehicle_ramp_test_61","vehicle_turret"
./tests/cata_test "cube_direction_add_om_direction","Gun repair with degradation"
./tests/cata_test "fueled bionics"
./tests/cata_test "grenade_lethality_scaling_with_size","activity interruption by distractions"
./tests/cata_test "character should lose moves when opening or closing doors or windows","multipocket liquid transfer 
test"
./tests/cata_test craft_available_via_vehicle_rig,vision_see_wall_in_moonlight,vision_moncam_basic,weary_recovery
```


#### Additional context
