### PR TITLE
Adds in the ability to construct wooden chests.

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2228,6 +2228,18 @@
   },
   {
     "type": "construction",
+    "id": "constr_chest",
+    "group": "build_chest",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 2 ] ],
+    "time": "80 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 1 } ] ],
+    "components": [ [ "wood_panel", 5 ] ], [ [ "hinge", 2 ] ], [ [ "nail", 10 ] ] ],
+    "pre_special": "check_empty",
+    "post_terrain": "f_chest"
+  },
+  {
+    "type": "construction",
     "id": "constr_table",
     "group": "build_table",
     "category": "FURN",

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2234,7 +2234,7 @@
     "required_skills": [ [ "fabrication", 2 ] ],
     "time": "80 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 1 } ] ],
-    "components": [ [ "wood_panel", 5 ] ], [ [ "hinge", 2 ] ], [ [ "nail", 10 ] ] ],
+    "components": [ [ [ "wood_panel", 6 ] ], [ [ "hinge", 2 ] ], [ [ "nail", 10 ] ] ],
     "pre_special": "check_empty",
     "post_terrain": "f_chest"
   },

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -116,6 +116,11 @@
   },
   {
     "type": "construction_group",
+    "id": "build_chest",
+    "name": "Build Wooden Chest"
+  },
+  {
+    "type": "construction_group",
     "id": "build_chickenwire_fence",
     "name": "Build Chickenwire Fence"
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Adds in the ability to construct wooden chests"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

This, as the title suggests, adds in the ability to construct wooden chests.

I saw a wooden chest in a house i was looting, and it intrigued me as a storage option. Unfortunately, when i looked in the construction menu, no recipe for it existed. Therefore, i've decided to do something about it.

#### Describe the solution

Again, this adds a recipe for wooden chests, so you can actually construct them. As of now the recipe uses more-or-less what you get when you deconstruct it (6 wooden panels, 2 door hinges, and 10 nails.), takes 80 minutes to build, and requires a fabrication level of 2.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

As of now, i have yet to test this, although i'm pretty sure that there's no significant issues that need addressing, Nevertheless, i'm marking this as draft until my copy of the repo finishes compiling, and i can actually test it (Which, considering that i'm using a ThinkPad from 2013, is probably gonna take a while.).

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->