### PR TITLE
EOD helmet revision

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1184,9 +1184,7 @@
         "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ]
       },
       {
-        "material": [
-          { "type": "lvl4ballisticglass", "covered_by_mat": 100, "thickness": 3.0 },
-        ],
+        "material": [ { "type": "lvl4ballisticglass", "covered_by_mat": 100, "thickness": 3.0 } ],
         "covers": [ "mouth" ],
         "coverage": 100,
         "encumbrance": 15,
@@ -1194,7 +1192,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ "type": "lvl4ballisticglass", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [ { "type": "lvl4ballisticglass", "covered_by_mat": 100, "thickness": 3.0 } ],
         "covers": [ "eyes" ],
         "coverage": 100,
         "encumbrance": 5,

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1184,7 +1184,7 @@
         "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ]
       },
       {
-        "material": [ { "type": "lvl4ballisticglass", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 20.0 } ],
         "covers": [ "mouth" ],
         "coverage": 100,
         "encumbrance": 15,
@@ -1192,7 +1192,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "lvl4ballisticglass", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 20.0 } ],
         "covers": [ "eyes" ],
         "coverage": 100,
         "encumbrance": 5,
@@ -1201,7 +1201,7 @@
       }
     ],
     "warmth": 65,
-    "material": [ "kevlar_rigid", "lvl4ballisticglass", "plastic_pad" ],
+    "material": [ "kevlar_rigid", "plastic", "plastic_pad" ],
     "symbol": "[",
     "color": "light_gray",
     "environmental_protection": 3,

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1168,17 +1168,42 @@
     "category": "armor",
     "name": { "str": "EOD helmet" },
     "description": "An armored, electronically-shielded helmet containing a camera, a two-way radio, and a headlamp, all of which can be voice-activated for redundancy.  It is designed to protect against overpressure, fragmentation, impact, and heat.",
-    "weight": "5600 g",
+    "weight": "3600 g",
     "volume": "4 L",
     "price": 150000,
     "price_postapoc": 10000,
     "armor": [
-      { "covers": [ "head" ], "coverage": 100, "encumbrance": 20 },
-      { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 10 },
-      { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 15 }
+      {
+        "material": [
+          { "type": "kevlar_rigid", "covered_by_mat": 100, "thickness": 4.0 },
+          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 14.0 }
+        ],
+        "covers": [ "head" ],
+        "coverage": 100,
+        "layers": [ "OUTER", "NORMAL" ],
+        "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ]
+      },
+      {
+        "material": [
+          { "type": "lvl4ballisticglass", "covered_by_mat": 100, "thickness": 3.0 },
+        ],
+        "covers": [ "mouth" ],
+        "coverage": 100,
+        "encumbrance": 15,
+        "layers": [ "OUTER" ],
+        "rigid_layer_only": true
+      },
+      {
+        "material": [ "type": "lvl4ballisticglass", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "covers": [ "eyes" ],
+        "coverage": 100,
+        "encumbrance": 5,
+        "layers": [ "OUTER" ],
+        "rigid_layer_only": true
+      }
     ],
     "warmth": 65,
-    "material": [ "kevlar_rigid", "nomex" ],
+    "material": [ "kevlar_rigid", "lvl4ballisticglass", "plastic_pad" ],
     "symbol": "[",
     "color": "light_gray",
     "environmental_protection": 3,
@@ -1200,7 +1225,6 @@
       "need_charges": 1,
       "need_charges_msg": "\"Illumination disabled, low power.\""
     },
-    "material_thickness": 15,
     "flags": [ "STURDY", "OUTER", "RAINPROOF", "TWO_WAY_RADIO", "WATCH", "ALARMCLOCK" ]
   },
   {

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -744,7 +744,6 @@
       "condensor_coil",
       "waterskin2",
       "disinfectant",
-      "helmet_eod_on",
       "oil_lamp_clay_on",
       "corpse_halved_upper",
       "cranberries",

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -488,7 +488,6 @@
       "cheeseburger",
       "k_gambeson_vest_xs_loose",
       "tramadol",
-      "helmet_eod",
       "car_wide_headlight",
       "hickory_root",
       "leg",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Makes EOD helmet thickness, protection values and materials closer to realistic"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Resolves #65952.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Implements changes suggested in relevant issue.

Will likely go through other EOD armor, but the EOD helmet had the most glaring balance issues (better protection AND encumbrance than army helmet? I loot two!) and, as such, had to be reined in.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Faceplate 20 mm thick and made out of generic plastic. 40 bash, 40 cut, 40 ballistic resistance compared to 15 bash, 30 cut, 27   ballistic of 3 mm lvl4ballisticglass. lvl4ballisticglass was described as polycarbonate in glass though has extreme protection per mm... 3 mm thickness value was because of the thickness of the simulation material that was used.

See relevant issue.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

None for now, will do when possible.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

See relevant issue. 

Weight value based on https://en.wikipedia.org/wiki/Advanced_Bomb_Suit

Thickness values based on article linked in the relevant issue.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->