### PR TITLE
math_parser: implement ternary operator

### DIFF
--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1430,6 +1430,19 @@ Common math functions are supported:
 
 Function composition is also supported, for example `sin( rng(0, max( 0.5, u_sin_var ) ) )`
 
+#### Ternary and inline boolean operators
+Inline comparison operators evaluate as 1 for true and 0 for false.
+
+Ternary operators take the form `condition ? true_value : false_value`. They are right-associative so a chained ternary like `a ? b : c ? d :e` is parsed as `a ? b : (c ? d : e)`.
+
+Examples:
+```JSON
+    "//0": "returns 5 if u_blorg is greater than 4, otherwise 0",
+    { "math": [ "( u_blorg > 4 ) * 5" ] },
+    "//1": "returns rng( 0.5, 5 ) if u_blorg is greater than 5, otherwise rand(100)"
+    { "math": [ "u_blorg > 5 ? rng( 0.5, 5 ) : rand(100)" ] },
+```
+
 #### Dialogue functions
 Dialogue functions return or manipulate game values. They are scoped just like [variables](#variables).
 

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -327,7 +327,7 @@ void math_exp::math_exp_impl::maybe_first_argument()
 
 void math_exp::math_exp_impl::_parse( std::string_view str, bool assignment )
 {
-    constexpr std::string_view expression_separators = "+-*/^,()%':";
+    constexpr std::string_view expression_separators = "+-*/^,()%':><=!";
     state = {};
     for( std::string_view const token : tokenize( str, expression_separators ) ) {
         last_token = token;

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -146,15 +146,17 @@ struct parse_state {
                                              expect_to_string( next ).data() ) );
         }
     }
-    void set( expect current, bool unary_ok = false ) {
+    void set( expect current, bool unary_ok = false, bool kwargs_ok = false ) {
         previous = expected;
         expected = current;
         allows_prefix_unary = unary_ok;
+        allows_kwargs = kwargs_ok;
     }
 
     expect expected = expect::operand;
     expect previous = expect::eof;
     bool allows_prefix_unary = true;
+    bool allows_kwargs = false;
     bool instring = false;
     std::string_view strpos;
 };
@@ -229,6 +231,20 @@ double oper::eval( dialogue &d ) const
     return ( *op )( l->eval( d ), r->eval( d ) );
 }
 
+kwarg::kwarg( std::string_view key_, thingie val_ )
+    : key( key_ ),
+      val( std::make_shared<thingie>( std::move( val_ ) ) ) {}
+
+ternary::ternary( thingie cond_, thingie mhs_, thingie rhs_ )
+    : cond( std::make_shared<thingie>( std::move( cond_ ) ) ),
+      mhs( std::make_shared<thingie>( std::move( mhs_ ) ) ),
+      rhs( std::make_shared<thingie>( std::move( rhs_ ) ) ) {}
+
+double ternary::eval( dialogue &d ) const
+{
+    return cond->eval( d ) > 0 ? mhs->eval( d ) : rhs->eval( d );
+}
+
 class math_exp::math_exp_impl
 {
     public:
@@ -283,7 +299,6 @@ class math_exp::math_exp_impl
             enum class type_t {
                 func = 0,
                 bracket,
-                kwarg,
             };
             arity_t( std::string_view sym_, int expected_, type_t type_, bool stringy_ = false ) : sym( sym_ ),
                 expected( expected_ ), type( type_ ), stringy( stringy_ ) {}
@@ -301,7 +316,6 @@ class math_exp::math_exp_impl
 
         void _parse( std::string_view str, bool assignment );
         void parse_string( std::string_view token, std::string_view full, parse_state &state );
-        void parse_colon( parse_state &state );
         void parse_bin_op( pbin_op const &op, parse_state &state );
         template<typename T>
         void parse_diag_f( std::string_view symbol, T const &token, parse_state &state );
@@ -311,6 +325,8 @@ class math_exp::math_exp_impl
         void new_func();
         void new_oper();
         void new_var( std::string_view str );
+        void new_kwarg( thingie &lhs, thingie &rhs );
+        void new_ternary( thingie &lhs, thingie &rhs );
         void maybe_first_argument();
         void error( std::string_view str, std::string_view what );
         void validate_string( std::string_view str, std::string_view label, std::string_view badlist );
@@ -327,15 +343,12 @@ void math_exp::math_exp_impl::maybe_first_argument()
 
 void math_exp::math_exp_impl::_parse( std::string_view str, bool assignment )
 {
-    constexpr std::string_view expression_separators = "+-*/^,()%':><=!";
+    constexpr std::string_view expression_separators = "+-*/^,()%':><=!?";
     state = {};
     for( std::string_view const token : tokenize( str, expression_separators ) ) {
         last_token = token;
         if( state.instring || token == "'" ) {
             parse_string( token, str, state );
-
-        } else if( token == ":" ) {
-            parse_colon( state );
 
         } else if( std::optional<double> val = get_number( token ); val ) {
             state.validate( parse_state::expect::operand );
@@ -382,6 +395,9 @@ void math_exp::math_exp_impl::_parse( std::string_view str, bool assignment )
         } else if( token == ")" ) {
             parse_rparen( state );
 
+        } else if( token == "=" ) {
+            throw std::invalid_argument( R"(Misplaced "=".  Did you mean "=="?)" );
+
         } else {
             state.validate( parse_state::expect::operand );
             maybe_first_argument();
@@ -419,39 +435,33 @@ void math_exp::math_exp_impl::parse_string( std::string_view token, std::string_
         }
         state.instring = true;
         state.strpos = token;
-        state.set( parse_state::expect::string );
+        state.set( parse_state::expect::string, false, state.allows_kwargs );
     } else if( token == "'" ) {
         // FIXME: write a better tokenizer that returns the entire quoted string as a single token
         output.emplace( std::in_place_type_t<std::string>(), full, state.strpos.data() - full.data() + 1,
                         token.data() - state.strpos.data() - 1 );
         state.instring = false;
-        state.set( parse_state::expect::oper );
+        state.set( parse_state::expect::oper, false, state.allows_kwargs );
     } else {
         // skip tokens inside string
     }
 }
 
-void math_exp::math_exp_impl::parse_colon( parse_state &state )
-{
-    state.validate( parse_state::expect::oper );
-    if( arity.empty() || arity.top().type != arity_t::type_t::func || output.empty() ||
-        !std::holds_alternative<std::string>( output.top().data ) ) {
-        throw std::invalid_argument( "Misplaced colon or kwarg key is not a string" );
-    }
-    ops.emplace( std::in_place_type_t<kwarg>(), std::get<std::string>( output.top().data ) );
-    arity.emplace( std::string_view{}, 0, arity_t::type_t::kwarg, true );
-    output.pop();
-    state.set( parse_state::expect::operand, true );
-}
-
 void math_exp::math_exp_impl::parse_bin_op( pbin_op const &op, parse_state &state )
 {
+    if( op->symbol == ":" && !state.allows_kwargs ) {
+        // insert a pair of parens to help resolve nested ternaries like 0?0?-1:-2:1
+        parse_rparen( state );
+    }
     state.validate( parse_state::expect::oper );
     while( !ops.empty() && ops.top() > *op ) {
         new_oper();
     }
     ops.emplace( op );
     state.set( parse_state::expect::operand, true );
+    if( op->symbol == "?" ) {
+        parse_lparen( state );
+    }
 }
 
 template<typename T>
@@ -461,7 +471,7 @@ void math_exp::math_exp_impl::parse_diag_f( std::string_view symbol, T const &to
     state.validate( parse_state::expect::operand );
     ops.emplace( token );
     arity.emplace( symbol, token.df->num_params, arity_t::type_t::func, true );
-    state.set( parse_state::expect::lparen, false );
+    state.set( parse_state::expect::lparen, false, true );
 }
 
 void math_exp::math_exp_impl::parse_comma( parse_state &state )
@@ -474,7 +484,7 @@ void math_exp::math_exp_impl::parse_comma( parse_state &state )
         new_oper();
     }
     arity.top().current++;
-    state.set( parse_state::expect::operand, true );
+    state.set( parse_state::expect::operand, true, arity.top().stringy );
 }
 
 void math_exp::math_exp_impl::parse_lparen( parse_state &state )
@@ -484,7 +494,7 @@ void math_exp::math_exp_impl::parse_lparen( parse_state &state )
         arity.emplace( std::string_view{}, 0, arity_t::type_t::bracket );
     }
     ops.emplace( paren::left );
-    state.set( parse_state::expect::operand, true );
+    state.set( parse_state::expect::operand, true, state.allows_kwargs );
 }
 
 void math_exp::math_exp_impl::parse_rparen( parse_state &state )
@@ -555,7 +565,7 @@ void math_exp::math_exp_impl::new_func()
             },
             []( auto /* v */ )
             {
-                throw std::invalid_argument( "Internal error.  That's all we know." );
+                throw std::invalid_argument( "Internal func error.  That's all we know." );
             },
         },
         ops.top() );
@@ -598,6 +608,25 @@ std::vector<diag_value> math_exp::math_exp_impl::_get_diag_vals( std::vector<thi
     return vals;
 }
 
+void math_exp::math_exp_impl::new_kwarg( thingie &lhs, thingie &rhs )
+{
+    output.emplace( std::in_place_type_t<kwarg>(), std::get<std::string>( lhs.data ), rhs );
+    arity.top().current--;
+    arity.top().nkwargs++;
+}
+
+void math_exp::math_exp_impl::new_ternary( thingie &lhs, thingie &rhs )
+{
+    ops.pop();
+    if( !std::holds_alternative<pbin_op>( ops.top() ) ||
+        std::get<pbin_op>( ops.top() )->symbol != "?" ) {
+        throw std::invalid_argument( "Misplaced colon" );
+    }
+    thingie cond = std::move( output.top() );
+    output.pop();
+    output.emplace( std::in_place_type_t<ternary>(), cond, lhs, rhs );
+}
+
 void math_exp::math_exp_impl::new_oper()
 {
     std::visit( overloaded{
@@ -608,9 +637,23 @@ void math_exp::math_exp_impl::new_oper()
             output.pop();
             thingie lhs = std::move( output.top() );
             output.pop();
-            _validate_operand( lhs, v );
-            _validate_operand( rhs, v );
-            output.emplace( std::in_place_type_t<oper>(), lhs, rhs, v->f );
+            if( v->symbol == "?" ) {
+                throw std::invalid_argument( "Unterminated ternary" );
+            }
+            if( v->symbol == ":" ) {
+                if( !arity.empty() && arity.top().stringy && arity.top().current > 0 &&
+                    std::holds_alternative<std::string>( lhs.data ) ) {
+                    new_kwarg( lhs, rhs );
+                } else if( ops.size() >= 2 && !output.empty() ) {
+                    new_ternary( lhs, rhs );
+                } else {
+                    throw std::invalid_argument( "Misplaced colon or kwarg key is not string" );
+                }
+            } else {
+                _validate_operand( lhs, v );
+                _validate_operand( rhs, v );
+                output.emplace( std::in_place_type_t<oper>(), lhs, rhs, v->f );
+            }
         },
         [this]( punary_op v )
         {
@@ -620,22 +663,10 @@ void math_exp::math_exp_impl::new_oper()
             _validate_operand( rhs, v );
             output.emplace( std::in_place_type_t<oper>(), thingie { 0.0 }, rhs, v->f );
         },
-        [this]( kwarg & v )
-        {
-            if( arity.empty() || !arity.top().stringy ) {
-                throw std::invalid_argument( "Kwargs can only be used as parameters for dialogue functions" );
-            }
-            v.val = std::make_shared<thingie>( std::move( output.top() ) );
-            output.pop();
-            output.emplace( std::move( v ) );
-            arity.pop();
-            arity.top().current--;
-            arity.top().nkwargs++;
-        },
         []( auto /* v */ )
         {
             // we should never get here due to paren validation
-            throw std::invalid_argument( "Internal error.  That's all we know." );
+            throw std::invalid_argument( "Internal oper error.  That's all we know." );
         }
     },
     ops.top() );

--- a/src/math_parser_func.cpp
+++ b/src/math_parser_func.cpp
@@ -10,6 +10,7 @@ std::vector<std::string_view> tokenize( std::string_view str, std::string_view s
     std::vector<std::string_view> ret;
     std::string_view::size_type start = 0;
     std::string_view::size_type pos = 0;
+    std::string_view last;
 
     while( pos != std::string_view::npos ) {
         pos = str.find_first_of( separators, start );
@@ -23,7 +24,16 @@ std::vector<std::string_view> tokenize( std::string_view str, std::string_view s
             }
         }
         if( pos != std::string_view::npos && include_seps ) {
-            ret.emplace_back( &str[pos], 1 );
+            if( str[pos] == '=' && start > 0 &&
+                ( last == "=" || last == ">" || last == "<" || last == "!" ) ) {
+                ret.pop_back();
+                ret.emplace_back( str.substr( pos - 1, 2 ) );
+            } else {
+                ret.emplace_back( &str[pos], 1 );
+            }
+        }
+        if( !ret.empty() ) {
+            last = ret.back();
         }
         start = pos + 1;
     }

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -178,6 +178,8 @@ constexpr bool operator>( op_t const &lhs, paren const &rhs )
     return !std::holds_alternative<paren>( lhs ) || std::less<paren> {}( rhs, std::get<paren>( lhs ) );
 }
 
+namespace math_opers
+{
 constexpr double neg( double /* zero */, double r )
 {
     return -r;
@@ -218,18 +220,56 @@ inline double math_pow( double l, double r )
     return std::pow( l, r );
 }
 
-constexpr std::array<binary_op, 6> binary_ops{
-    binary_op{ "+", 2, binary_op::associativity::left, add },
-    binary_op{ "-", 2, binary_op::associativity::left, sub },
-    binary_op{ "*", 3, binary_op::associativity::left, mul },
-    binary_op{ "/", 3, binary_op::associativity::left, div },
-    binary_op{ "%", 3, binary_op::associativity::right, mod },
-    binary_op{ "^", 4, binary_op::associativity::right, math_pow },
+inline double lt( double l, double r )
+{
+    return static_cast<double>( l < r );
+}
+
+inline double lte( double l, double r )
+{
+    return static_cast<double>( l <= r );
+}
+
+inline double gt( double l, double r )
+{
+    return static_cast<double>( l > r );
+}
+
+inline double gte( double l, double r )
+{
+    return static_cast<double>( l >= r );
+}
+
+inline double eq( double l, double r )
+{
+    return static_cast<double>( l == r );
+}
+
+inline double neq( double l, double r )
+{
+    return static_cast<double>( l != r );
+}
+
+} // namespace math_opers
+
+constexpr std::array<binary_op, 12> binary_ops{
+    binary_op{ "<", 1, binary_op::associativity::left, math_opers::lt },
+    binary_op{ "<=", 1, binary_op::associativity::left, math_opers::lte },
+    binary_op{ ">", 1, binary_op::associativity::left, math_opers::gt },
+    binary_op{ ">=", 1, binary_op::associativity::left, math_opers::gte },
+    binary_op{ "==", 1, binary_op::associativity::left, math_opers::eq },
+    binary_op{ "!=", 1, binary_op::associativity::left, math_opers::neq },
+    binary_op{ "+", 2, binary_op::associativity::left, math_opers::add },
+    binary_op{ "-", 2, binary_op::associativity::left, math_opers::sub },
+    binary_op{ "*", 3, binary_op::associativity::left, math_opers::mul },
+    binary_op{ "/", 3, binary_op::associativity::left, math_opers::div },
+    binary_op{ "%", 3, binary_op::associativity::right, math_opers::mod },
+    binary_op{ "^", 4, binary_op::associativity::right, math_opers::math_pow },
 };
 
 constexpr std::array<unary_op, 2> prefix_unary_ops{
-    unary_op{ "+", pos },
-    unary_op{ "-", neg },
+    unary_op{ "+", math_opers::pos },
+    unary_op{ "-", math_opers::neg },
 };
 
 

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -23,7 +23,7 @@ struct binary_op {
     int precedence;
     associativity assoc;
     using f_t = double ( * )( double, double );
-    f_t f;
+    f_t f = nullptr;
 };
 using pbin_op = binary_op const *;
 struct unary_op {
@@ -119,9 +119,18 @@ struct var {
 };
 struct kwarg {
     kwarg() = default;
-    explicit kwarg( std::string_view key_ ): key( key_ ) {}
+    explicit kwarg( std::string_view key_, thingie val_ );
     std::string key;
     std::shared_ptr<thingie> val;
+};
+struct ternary {
+    ternary() = default;
+    explicit ternary( thingie cond_, thingie mhs_, thingie rhs_ );
+    std::shared_ptr<thingie> cond;
+    std::shared_ptr<thingie> mhs;
+    std::shared_ptr<thingie> rhs;
+
+    double eval( dialogue &d ) const;
 };
 struct thingie {
     thingie() = default;
@@ -134,7 +143,7 @@ struct thingie {
     constexpr double eval( dialogue &d ) const;
 
     using impl_t =
-        std::variant<double, std::string, oper, func, func_jmath, func_diag_eval, func_diag_ass, var, kwarg>;
+        std::variant<double, std::string, oper, func, func_jmath, func_diag_eval, func_diag_ass, var, kwarg, ternary>;
     impl_t data;
 };
 
@@ -165,7 +174,7 @@ constexpr double thingie::eval( dialogue &d ) const
 }
 
 using op_t =
-    std::variant<pbin_op, punary_op, pmath_func, jmath_func_id, scoped_diag_eval, scoped_diag_ass, paren, kwarg>;
+    std::variant<pbin_op, punary_op, pmath_func, jmath_func_id, scoped_diag_eval, scoped_diag_ass, paren>;
 
 constexpr bool operator>( op_t const &lhs, binary_op const &rhs )
 {
@@ -252,7 +261,9 @@ inline double neq( double l, double r )
 
 } // namespace math_opers
 
-constexpr std::array<binary_op, 12> binary_ops{
+constexpr std::array<binary_op, 15> binary_ops{
+    binary_op{ "?", 0, binary_op::associativity::right },
+    binary_op{ ":", 0, binary_op::associativity::right },
     binary_op{ "<", 1, binary_op::associativity::left, math_opers::lt },
     binary_op{ "<=", 1, binary_op::associativity::left, math_opers::lte },
     binary_op{ ">", 1, binary_op::associativity::left, math_opers::gt },
@@ -271,6 +282,5 @@ constexpr std::array<unary_op, 2> prefix_unary_ops{
     unary_op{ "+", math_opers::pos },
     unary_op{ "-", math_opers::neg },
 };
-
 
 #endif // CATA_SRC_MATH_PARSER_IMPL_H

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -36,6 +36,11 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
     CHECK( testexp.eval( d ) == Approx( 114 ) );
     CHECK( testexp.parse( "50 % 3" ) );
     CHECK( testexp.eval( d ) == Approx( 2 ) );
+    // boolean
+    CHECK( testexp.parse( "1 > 2" ) );
+    CHECK( testexp.eval( d ) == Approx( 0 ) );
+    CHECK( testexp.parse( "(1 <= 2) * 3" ) );
+    CHECK( testexp.eval( d ) == Approx( 3 ) );
 
     // unary
     CHECK( testexp.parse( "-50" ) );
@@ -170,6 +175,8 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
         CHECK_FALSE( testexp.parse( "'1':'2'" ) );
         CHECK_FALSE( testexp.parse( "2 2*2" ) ); // stray space inside variable name
         CHECK_FALSE( testexp.parse( "2+++2" ) );
+        CHECK_FALSE( testexp.parse( "1=2" ) );
+        CHECK_FALSE( testexp.parse( "1===2" ) );
         CHECK( testexp.parse( "2+3" ) );
         testexp.assign( d, 10 ); // assignment called on eval tree should not crash
     } );

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -62,6 +62,30 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
     CHECK( testexp.parse( "2+-3" ) ); // equivalent to 2+(-3)
     CHECK( testexp.eval( d ) == Approx( -1 ) );
 
+    //ternary
+    CHECK( testexp.parse( "0?1:2" ) );
+    CHECK( testexp.eval( d ) == Approx( 2 ) );
+    CHECK( testexp.parse( "0==0?1:2" ) );
+    CHECK( testexp.eval( d ) == Approx( 1 ) );
+    CHECK( testexp.parse( "1?0?-1:-2:1" ) );
+    CHECK( testexp.eval( d ) == Approx( -2 ) );
+    CHECK( testexp.parse( "1?1?-1:-2:1" ) );
+    CHECK( testexp.eval( d ) == Approx( -1 ) );
+    CHECK( testexp.parse( "0?0?-1:-2:1" ) );
+    CHECK( testexp.eval( d ) == Approx( 1 ) );
+    CHECK( testexp.parse( "0?(0?(-1):-2):1" ) );
+    CHECK( testexp.eval( d ) == Approx( 1 ) );
+    CHECK( testexp.parse( "1==1?2:3?4:5" ) );
+    CHECK( testexp.eval( d ) == Approx( 2 ) );
+    CHECK( testexp.parse( "0?2:3?4:5" ) );
+    CHECK( testexp.eval( d ) == Approx( 4 ) );
+    CHECK( testexp.parse( "0?2:0?4:5" ) );
+    CHECK( testexp.eval( d ) == Approx( 5 ) );
+    CHECK( testexp.parse( "(1==1?2:3)?4:5" ) );
+    CHECK( testexp.eval( d ) == Approx( 4 ) );
+    CHECK( testexp.parse( "1==1?2:(3?4:5)" ) );
+    CHECK( testexp.eval( d ) == Approx( 2 ) );
+
     // functions
     CHECK( testexp.parse( "_test_()" ) ); // nullary test function
     CHECK( testexp.parse( "max()" ) ); // variadic called with zero arguments
@@ -136,6 +160,8 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
     CHECK( testexp.eval( d ) == Approx( 6 ) );
     CHECK( testexp.parse( "_test_diag_('1':3.5*sin(pi/2))" ) );  // sub-expression kwarg
     CHECK( testexp.eval( d ) == Approx( 3.5 ) );
+    CHECK( testexp.parse( "_test_diag_('1':0==0?1:2)" ) );  // ternary kwarg
+    CHECK( testexp.eval( d ) == Approx( 1 ) );
     CHECK( testexp.parse( "_test_diag_('1':2*_test_diag_('2':'3'))" ) );  // kwarg compounding
     CHECK( testexp.eval( d ) == Approx( 6 ) );
 
@@ -177,6 +203,9 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
         CHECK_FALSE( testexp.parse( "2+++2" ) );
         CHECK_FALSE( testexp.parse( "1=2" ) );
         CHECK_FALSE( testexp.parse( "1===2" ) );
+        CHECK_FALSE( testexp.parse( "0?" ) );
+        CHECK_FALSE( testexp.parse( "0?1" ) );
+        CHECK_FALSE( testexp.parse( "0?1:" ) );
         CHECK( testexp.parse( "2+3" ) );
         testexp.assign( d, 10 ); // assignment called on eval tree should not crash
     } );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
* @Light-Wave asked for inline boolean operators in `math`
* I also considered using ternary operators for #65389
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Implement. The ternary operator is right-associative and should work exactly like the C equivalent.

Simple examples:
```JSON
    "//0": "returns 5 if u_blorg is greater than 4, otherwise 0",
    { "math": [ "( u_blorg > 4 ) * 5" ] },
    "//1": "returns rng( 0.5, 5 ) if u_blorg is greater than 5, otherwise rand(100)"
    { "math": [ "u_blorg > 5 ? rng( 0.5, 5 ) : rand(100)" ] },
```

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Piece-wise functions in `eoc_math`? They'd be bulkier for simple things, but much more versatile and easier to read. Can still be done in addition to this in the future, if the need arises.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Updated test unit

Only fuzzed for a few hours this time.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->