### PR TITLE
Expand mutation transforms

### DIFF
--- a/doc/MUTATIONS.md
+++ b/doc/MUTATIONS.md
@@ -213,7 +213,8 @@ Note that **all new traits that can be obtained through mutation must be purifia
     "target": "BIOLUM1",                      // Trait_id of the mutation this one will transform into.
     "msg_transform": "You turn your photophore OFF.", // Message displayed upon transformation.
     "active": false,                          // If true, mutation will start powered when activated (turn ON).
-    "moves": 100                              // Moves cost per activation (default: 0).
+    "moves": 100,                              // Moves cost per activation (default: 0).
+    "safe": false                              // If true the transformation will use the normal mutation progression rules - removing conflicting traits, requiring thresholds (but not using any vitamins or causing instability)
   },
   "triggers": [                               // List of sublist of triggers, all sublists must be True for the mutation to activate.
     [                                         // Sublist of trigger: at least one trigger must be true for the sublist to be true.

--- a/src/character.h
+++ b/src/character.h
@@ -1237,8 +1237,9 @@ class Character : public Creature, public visitable
         // Do the mutation updates necessary when adding a mutation (nonspecific cache updates)
         void do_mutation_updates();
         void unset_mutation( const trait_id & );
-        /**Unset switched mutation and set target mutation instead*/
-        void switch_mutations( const trait_id &switched, const trait_id &target, bool start_powered );
+        /**Unset switched mutation and set target mutation instead, if safe mutates towards the target mutation*/
+        void switch_mutations( const trait_id &switched, const trait_id &target, bool start_powered,
+                               bool safe = false );
 
         bool can_power_mutation( const trait_id &mut ) const;
         /** Generates and handles the UI for player interaction with installed bionics */

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -273,12 +273,18 @@ void Character::unset_mutation( const trait_id &trait_ )
 }
 
 void Character::switch_mutations( const trait_id &switched, const trait_id &target,
-                                  bool start_powered )
+                                  bool start_powered, bool safe )
 {
+    // Always lose the transformed trait
     unset_mutation( switched );
-
-    set_mutation( target );
-    my_mutations[target].powered = start_powered;
+    if( safe ) {
+        mutate_towards( target, mutation_category_ANY, nullptr, false );
+    } else {
+        set_mutation( target );
+    }
+    if( has_trait( target ) ) {
+        my_mutations[target].powered = start_powered;
+    }
 }
 
 bool Character::can_power_mutation( const trait_id &mut ) const
@@ -801,7 +807,7 @@ void Character::activate_mutation( const trait_id &mut )
     if( mdata.transform ) {
         const cata::value_ptr<mut_transform> trans = mdata.transform;
         mod_moves( - trans->moves );
-        switch_mutations( mut, trans->target, trans->active );
+        switch_mutations( mut, trans->target, trans->active, trans->safe );
 
         if( !mdata.transform->msg_transform.empty() ) {
             add_msg_if_player( m_neutral, mdata.transform->msg_transform );
@@ -937,7 +943,7 @@ void Character::deactivate_mutation( const trait_id &mut )
     if( mdata.transform ) {
         const cata::value_ptr<mut_transform> trans = mdata.transform;
         mod_moves( -trans->moves );
-        switch_mutations( mut, trans->target, trans->active );
+        switch_mutations( mut, trans->target, trans->active, trans->safe );
     }
 
     if( !mut->enchantments.empty() ) {

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -88,6 +88,8 @@ struct mut_transform {
     bool active = false;
     /** subtracted from @ref Creature::moves when transformation is successful */
     int moves = 0;
+    // If true the transformation uses the "normal" mutation rules - canceling conflicting traits etc
+    bool safe = false;
     mut_transform();
     bool load( const JsonObject &jsobj, std::string_view member );
 };

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -233,6 +233,7 @@ bool mut_transform::load( const JsonObject &jsobj, const std::string_view member
     assign( j, "target", target );
     assign( j, "msg_transform", msg_transform );
     assign( j, "active", active );
+    optional( j, false, "safe", safe, false );
     assign( j, "moves", moves );
 
     return true;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Allow mutation transformation using the normal mutation rules"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
While starting on limb stuff proper I decided to lean heavily onto (among other things) `condition->transform` to handle the trait progressions. For that to work it needed some more infrastructure.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Added the `safe` variable to mutation `transform` data - when true instead of flatly unsetting the base trait and adding the new one it routes through the actual mutation logic, removing conflicting traits/checking thresholds etc.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Include it in an upcoming limby PR but it can stand on its own (and is small and non-limby enough)

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Added `safe` to a transformation, it failed to give me the desired traits when missing the required threshold, gave the trait when all requirements were met.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->