### PR TITLE
Normalize autolearn for canned fruit

### DIFF
--- a/data/json/recipes/food/canned.json
+++ b/data/json/recipes/food/canned.json
@@ -1420,7 +1420,6 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "charges": 24,
-    "autolearn": true,
     "batch_time_factors": [ 83, 5 ],
     "using": [ [ "canning_low_heat", 6, "LIST" ] ],
     "//": "Acidic enough on their own that no canning_acid is needed",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
One of the canned fruit recipes had autolearn:true. Simple copy-paste error during the great food rebalancing

#### Describe the solution
Remove autolearn to bring it in line with the other 4 recipes

#### Describe alternatives you've considered
Make them all autolearn!!

#### Testing
I am relying on github tests here

#### Additional context
