### PR TITLE
Add auto-labeling for defense mode PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -276,3 +276,6 @@
   - "**/**vehicle**"
   - "**/vehicle**"
   - "src/veh_**"
+ 
+"Game: Defense Mode":
+  - "src/gamemode_defense**"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
We have a tag for defense mode, but it's gotten uh... 2 issues tagged, ever. One of them was me this week.

#### Describe the solution
Add it to the auto-tag workflow for PRs, might help? Won't hurt.

#### Describe alternatives you've considered


#### Testing
I copied existing working formatting so it should work, but I haven't tried to test it on my own repo or anything.

#### Additional context
