### PR TITLE
Fix build with GCC 13

### DIFF
--- a/src/translation_document.h
+++ b/src/translation_document.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include "translation_plural_evaluator.h"
 

--- a/src/translation_document.h
+++ b/src/translation_document.h
@@ -4,10 +4,10 @@
 
 #if defined(LOCALIZE)
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 #include "translation_plural_evaluator.h"
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Build was failing with GCC 13.

```
In file included from src/translation_manager_impl.h:10,
                 from src/translation_manager.cpp:3:
src/translation_document.h:46:14: error: ‘uint8_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   46 |         std::uint8_t GetByte( std::size_t byteIndex ) const;
      |              ^~~~~~~
      |              wint_t
src/translation_document.h:47:14: error: ‘uint32_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   47 |         std::uint32_t GetUint32BE( std::size_t byteIndex ) const;
      |              ^~~~~~~~
      |              wint_t
src/translation_document.h:48:14: error: ‘uint32_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   48 |         std::uint32_t GetUint32LE( std::size_t byteIndex ) const;
      |              ^~~~~~~~
      |              wint_t
src/translation_document.h:49:46: error: expected identifier before ‘*’ token
   49 |         std::uint32_t ( TranslationDocument::*GetUint32FPtr )( const std::size_t ) const;
      |                                              ^
src/translation_document.h:49:9: error: ISO C++ forbids declaration of ‘uint32_t’ with no type [-fpermissive]
   49 |         std::uint32_t ( TranslationDocument::*GetUint32FPtr )( const std::size_t ) const;
      |         ^~~
src/translation_document.h:49:84: error: ‘uint32_t’ declared as function returning a function
   49 |         std::uint32_t ( TranslationDocument::*GetUint32FPtr )( const std::size_t ) const;
      |                                                                                    ^~~~~
src/translation_document.h:50:14: error: ‘uint32_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   50 |         std::uint32_t GetUint32( std::size_t byteIndex ) const;
      |              ^~~~~~~~
      |              wint_t
```

#### Describe the solution

Include `cstdint` header.

#### Testing

It compiles successfully with GCC 13 (13.1.0).

#### Additional context

https://gcc.gnu.org/gcc-13/porting_to.html