### PR TITLE
Adding relevant recipe requirements to atomic butter

### DIFF
--- a/data/mods/Aftershock/requirements.json
+++ b/data/mods/Aftershock/requirements.json
@@ -37,6 +37,18 @@
     "extend": { "components": [ [ [ "frost_human_lard", 1 ], [ "alien_lard", 1 ] ] ] }
   },
   {
+    "id": "any_butter",
+    "type": "requirement",
+    "//": "Butter of all types and other future butter substitutes",
+    "components": [ [ [ "atomic_butter", 1 ] ] ]
+  },
+  {
+    "id": "any_butter_or_oil",
+    "type": "requirement",
+    "//": "For when a recipe calls for either cooking oil or butter, like many baking recipes do.",
+    "components": [ [ [ "atomic_butter", 1 ] ] ]
+  },
+  {
     "id": "meat_offal",
     "type": "requirement",
     "//": "Anything you might consider offal or intestines.",

--- a/data/mods/Aftershock/requirements.json
+++ b/data/mods/Aftershock/requirements.json
@@ -40,13 +40,13 @@
     "id": "any_butter",
     "type": "requirement",
     "//": "Butter of all types and other future butter substitutes",
-    "components": [ [ [ "atomic_butter", 1 ] ] ]
+    "extend": { "components": [ [ [ "atomic_butter", 1 ] ] ] }
   },
   {
     "id": "any_butter_or_oil",
     "type": "requirement",
     "//": "For when a recipe calls for either cooking oil or butter, like many baking recipes do.",
-    "components": [ [ [ "atomic_butter", 1 ] ] ]
+    "extend": { "components": [ [ [ "atomic_butter", 1 ] ] ] }
   },
   {
     "id": "meat_offal",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Adds missing recipe requirments to atomic butter"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allows atomic butter to act as a kind of butter.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added any_butter & any_butter_or_oil to the requirements, and assigned atomic butter to these, allowing it to be used by any recipe that requires those tags.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Testing
Loaded into CDDA, checked meat confit for the any_butter tag-- worked! Then check with glazed tenderloins for that any_butter_or_oil tag-- worked! Atomic butter was successfully assigned to both tags.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->