### PR TITLE
Fixed inability to disassemble laser turret in No Hope mod

### DIFF
--- a/data/mods/No_Hope/monsters.json
+++ b/data/mods/No_Hope/monsters.json
@@ -22,8 +22,8 @@
       {
         "type": "gun",
         "cooldown": 1,
-        "gun_type": "laser_cannon",
-        "fake_skills": [ [ "gun", 4 ], [ "rifle", 8 ] ],
+        "gun_type": "v29_turret",
+        "fake_skills": [ [ "gun", 4 ], [ "pistol", 4 ] ],
         "ranges": [ [ 0, 30, "DEFAULT" ] ]
       }
     ],

--- a/data/mods/No_Hope/recipes.json
+++ b/data/mods/No_Hope/recipes.json
@@ -17,5 +17,27 @@
       { "proficiency": "prof_toolsmithing" }
     ],
     "tools": [ [ [ "hotcut", -1 ] ] ]
+  },
+  {
+    "result": "broken_laserturret",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "difficulty": 4,
+    "time": "1 h",
+    "using": [ [ "soldering_standard", 10 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "v29_turret", 1 ] ],
+      [ [ "medium_storage_battery", 1 ] ],
+      [ [ "solar_cell", 4 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "robot_controls", 1 ] ],
+      [ [ "turret_chassis", 1 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Fixed inability to disassemble laser turret in No Hope mod"

#### Purpose of change
Fix inability to disassemble laser turret in No Hope mod.

#### Describe the solution
Ported https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/pull/17:
- Added an uncraft recipe for broken laser turret;
- Also changed gun type for laser turret from `laser_cannon` to `v29_turret`, to be consistent with prototype laser turret from vanilla.

#### Describe alternatives you've considered
None

#### Testing
Found broken laser turret in the mod, successfully disassembled it.

#### Additional context
None.