### PR TITLE
Hands encumbrance no longer affects crafting speed, except when it's encumbrance from integrated armor or when gloves are a part of whole-body suit

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2179,5 +2179,9 @@
     "id": "BANK_NOTE_STRAP_SHAPED",
     "type": "json_flag",
     "restriction": "Item must be shaped like a bank note strap"
+  },
+  {
+    "id": "WHOLE_BODY_SUIT",
+    "type": "json_flag"
   }
 ]

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -90,7 +90,7 @@
     "warmth": 50,
     "material_thickness": 8,
     "environmental_protection": 6,
-    "flags": [ "WATERPROOF", "STURDY", "UNBREAKABLE_MELEE" ],
+    "flags": [ "WATERPROOF", "STURDY", "UNBREAKABLE_MELEE", "WHOLE_BODY_SUIT" ],
     "armor": [
       {
         "encumbrance": 40,
@@ -217,7 +217,7 @@
     "environmental_protection": 16,
     "ammo": "battery",
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "power_armor_basic_on", "active": true },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "COMBAT_TOGGLEABLE", "UNBREAKABLE_MELEE" ],
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "COMBAT_TOGGLEABLE", "UNBREAKABLE_MELEE", "WHOLE_BODY_SUIT" ],
     "armor": [
       {
         "encumbrance": 50,
@@ -234,7 +234,16 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "combat exoskeleton (on)", "str_pl": "combat exoskeletons (on)" },
     "description": "These were the second wave of military combat exoskeleton, and got a lot of media attention, with popular Navy commercials featuring them heavily.  It consists of a muscle-boosting exoskeleton frame with overlaid segmented alloy plating.  Despite advancements over the original bulky 'tank suits', the wearer still cannot easily fit through narrow spaces, or sit down comfortably (and it ruins upholstery).  There is an integrated chemical-resistant bodyglove that precludes wearing other clothing.  It is turned on and continually drawing power.  Use it to turn it off.",
-    "flags": [ "USE_UPS", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "TRADER_AVOID", "COMBAT_TOGGLEABLE", "UNBREAKABLE_MELEE" ],
+    "flags": [
+      "USE_UPS",
+      "WATERPROOF",
+      "STURDY",
+      "ELECTRIC_IMMUNE",
+      "TRADER_AVOID",
+      "COMBAT_TOGGLEABLE",
+      "UNBREAKABLE_MELEE",
+      "WHOLE_BODY_SUIT"
+    ],
     "power_draw": "4 kW",
     "revert_to": "power_armor_basic",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s armor disengages.", "target": "power_armor_basic" },

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -37,7 +37,7 @@
     "color": "blue",
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY", "WHOLE_BODY_SUIT" ],
     "armor": [
       {
         "coverage": 100,
@@ -573,7 +573,7 @@
     "color": "dark_gray",
     "warmth": 20,
     "material_thickness": 0.1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY", "WHOLE_BODY_SUIT" ],
     "armor": [
       {
         "coverage": 100,

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -4701,7 +4701,7 @@
         "coverage": 100
       }
     ],
-    "extend": { "flags": [ "ELECTRIC_IMMUNE" ] }
+    "extend": { "flags": [ "ELECTRIC_IMMUNE", "WHOLE_BODY_SUIT" ] }
   },
   {
     "id": "xl_chainmail_suit_faraday",
@@ -4859,7 +4859,7 @@
     "longest_side": "30 cm",
     "material_thickness": 5,
     "environmental_protection": 20,
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "STURDY", "OUTER" ],
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "STURDY", "OUTER", "WHOLE_BODY_SUIT" ],
     "armor": [
       {
         "encumbrance": 50,
@@ -4963,7 +4963,17 @@
     "warmth": 40,
     "material_thickness": 2,
     "environmental_protection": 20,
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "OUTER", "SOFT" ],
+    "flags": [
+      "VARSIZE",
+      "WATERPROOF",
+      "RAINPROOF",
+      "GAS_PROOF",
+      "RAD_PROOF",
+      "ELECTRIC_IMMUNE",
+      "OUTER",
+      "SOFT",
+      "WHOLE_BODY_SUIT"
+    ],
     "armor": [
       {
         "encumbrance": 37,
@@ -5159,7 +5169,7 @@
       "msg": "You slip out of the top of the suit and tie the sleeves around your waist.",
       "target": "robofac_enviro_suit_casual"
     },
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "STURDY", "WHOLE_BODY_SUIT" ]
   },
   {
     "id": "robofac_enviro_suit_casual",

--- a/data/json/items/armor/swimming.json
+++ b/data/json/items/armor/swimming.json
@@ -970,7 +970,7 @@
     "color": "light_red",
     "warmth": 5,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "ELECTRIC_IMMUNE" ],
+    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "ELECTRIC_IMMUNE", "WHOLE_BODY_SUIT" ],
     "armor": [
       {
         "encumbrance": 30,
@@ -1002,7 +1002,7 @@
     "color": "light_red",
     "warmth": 5,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY" ],
+    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "WHOLE_BODY_SUIT" ],
     "armor": [
       {
         "encumbrance": 30,

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -387,6 +387,7 @@ Some armor flags, such as `WATCH` and `ALARMCLOCK` are compatible with other ite
 - ```WATCH``` Acts as a watch and allows the player to see actual time.
 - ```WATERPROOF``` Prevents the covered body-part(s) from getting wet in any circumstance.
 - ```WATER_FRIENDLY``` Prevents the item from making the body part count as unfriendly to water and thus reducing morale from being wet.
+- ```WHOLE_BODY_SUIT``` This item covers torso, hands, and legs (and sometimes head). Character can't free his hands or legs without taking off the suit.
 
 
 ## Bionics

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -85,6 +85,7 @@ static const activity_id ACT_DISASSEMBLE( "ACT_DISASSEMBLE" );
 static const efftype_id effect_contacts( "contacts" );
 
 static const flag_id json_flag_INTEGRATED( "INTEGRATED" );
+static const flag_id json_flag_WHOLE_BODY_SUIT( "WHOLE_BODY_SUIT" );
 
 static const itype_id itype_disassembly( "disassembly" );
 static const itype_id itype_plut_cell( "plut_cell" );
@@ -267,13 +268,15 @@ float Character::workbench_crafting_speed_multiplier( const item &craft,
 
 float Character::crafting_speed_multiplier( const recipe &rec ) const
 {
-    const bool integrated_armor_affects_hands =
+    const bool non_detachable_gloves =
+        get_avatar().worn_with_flag( json_flag_WHOLE_BODY_SUIT ) ||
+        // TODO: make this check for non-basic hands too
         get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_l" ) ) ||
         get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_r" ) );
 
     const float result = morale_crafting_speed_multiplier( rec ) *
                          lighting_craft_speed_multiplier( rec ) *
-                         ( integrated_armor_affects_hands ? get_limb_score( limb_score_manip ) : 1 );
+                         ( non_detachable_gloves ? get_limb_score( limb_score_manip ) : 1 );
     add_msg_debug( debugmode::DF_CHARACTER, "Limb score multiplier %.1f, crafting speed multiplier %1f",
                    get_limb_score( limb_score_manip ), result );
 
@@ -298,12 +301,14 @@ float Character::crafting_speed_multiplier( const item &craft,
     const float morale_multi = morale_crafting_speed_multiplier( rec );
     const float mut_multi = mutation_value( "crafting_speed_multiplier" );
 
-    const bool integrated_armor_affects_hands =
+    const bool non_detachable_gloves =
+        get_avatar().worn_with_flag( json_flag_WHOLE_BODY_SUIT ) ||
+        // TODO: make this check for non-basic hands too
         get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_l" ) ) ||
         get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_r" ) );
 
     const float total_multi = light_multi * bench_multi * morale_multi * mut_multi *
-                              ( integrated_armor_affects_hands ? get_limb_score( limb_score_manip ) : 1 );
+                              ( non_detachable_gloves ? get_limb_score( limb_score_manip ) : 1 );
 
     if( light_multi <= 0.0f ) {
         add_msg_if_player( m_bad, _( "You can no longer see well enough to keep crafting." ) );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -84,6 +84,8 @@ static const activity_id ACT_DISASSEMBLE( "ACT_DISASSEMBLE" );
 
 static const efftype_id effect_contacts( "contacts" );
 
+static const flag_id json_flag_INTEGRATED( "INTEGRATED" );
+
 static const itype_id itype_disassembly( "disassembly" );
 static const itype_id itype_plut_cell( "plut_cell" );
 
@@ -265,9 +267,13 @@ float Character::workbench_crafting_speed_multiplier( const item &craft,
 
 float Character::crafting_speed_multiplier( const recipe &rec ) const
 {
+    const bool integrated_armor_affects_hands =
+        get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_l" ) ) ||
+        get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_r" ) );
+
     const float result = morale_crafting_speed_multiplier( rec ) *
                          lighting_craft_speed_multiplier( rec ) *
-                         get_limb_score( limb_score_manip );
+                         ( integrated_armor_affects_hands ? get_limb_score( limb_score_manip ) : 1 );
     add_msg_debug( debugmode::DF_CHARACTER, "Limb score multiplier %.1f, crafting speed multiplier %1f",
                    get_limb_score( limb_score_manip ), result );
 
@@ -292,8 +298,12 @@ float Character::crafting_speed_multiplier( const item &craft,
     const float morale_multi = morale_crafting_speed_multiplier( rec );
     const float mut_multi = mutation_value( "crafting_speed_multiplier" );
 
+    const bool integrated_armor_affects_hands =
+        get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_l" ) ) ||
+        get_avatar().worn_with_flag( json_flag_INTEGRATED, bodypart_id( "hand_r" ) );
+
     const float total_multi = light_multi * bench_multi * morale_multi * mut_multi *
-                              get_limb_score( limb_score_manip );
+                              ( integrated_armor_affects_hands ? get_limb_score( limb_score_manip ) : 1 );
 
     if( light_multi <= 0.0f ) {
         add_msg_if_player( m_bad, _( "You can no longer see well enough to keep crafting." ) );


### PR DESCRIPTION
#### Summary
Features "Hands encumbrance no longer affects crafting speed, except when it's encumbrance from integrated armor"

#### Purpose of change
Currently player has to manually take off gloves or similar hands-covering clothing/armor before crafting (and wear them once again after the crafting), which only increases keypresses. Also it differs from our other conventions, such as virtual walking in 6-tile radius during crafting, or that we don't need to take off masks and other mouth-covering clothing/armor during eating.

#### Describe the solution
Ported https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/pull/18: 

- only calculate decrease of crafting speed due to hands encumbrance if it's the encumbrance from integrated armor. Otherwise, presume that player character automatically takes off gloves and the like before crafting and wears them back after crafting.

#### Describe alternatives you've considered
None.

#### Testing
Wore mittens, checked amount of time required to craft zweitimber (no increase), crafted it, noticed that time spent is correct.
Took off mittens, debug-get myself bark mutation, checked amount of time required to craft zweitimber (30% increase), crafted it, noticed that time spent is correct.

#### Additional context
None.