### PR TITLE
Tests tweaks

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -5007,11 +5007,9 @@ std::vector<options_manager::id_and_option> cata_tiles::build_renderer_list()
         { "opengles2", to_translation( "opengles2" ) },
     };
     int numRenderDrivers = SDL_GetNumRenderDrivers();
-    DebugLog( D_INFO, DC_ALL ) << "Number of render drivers on your system: " << numRenderDrivers;
     for( int ii = 0; ii < numRenderDrivers; ii++ ) {
         SDL_RendererInfo ri;
         SDL_GetRenderDriverInfo( ii, &ri );
-        DebugLog( D_INFO, DC_ALL ) << "Render driver: " << ii << "/" << ri.name;
         // First default renderer name we will put first on the list. We can use it later as
         // default value.
         if( ri.name == default_renderer_names.front().first ) {
@@ -5019,8 +5017,11 @@ std::vector<options_manager::id_and_option> cata_tiles::build_renderer_list()
         } else {
             renderer_names.emplace_back( ri.name, no_translation( ri.name ) );
         }
-
     }
+    DebugLog( D_INFO, DC_ALL ) << "SDL render devices: " << enumerate_as_string( renderer_names,
+    []( const options_manager::id_and_option & iao ) {
+        return iao.first;
+    }, enumeration_conjunction::none );
 
     return renderer_names.empty() ? default_renderer_names : renderer_names;
 }

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -166,11 +166,6 @@ void for_each_dir_entry( const fs::path &path, Function &&function )
         function( dir_entry );
     }
 }
-template <typename Function>
-void for_each_dir_entry( const std::string &path, Function &&function )
-{
-    for_each_dir_entry( fs::u8path( path ), std::forward < Function && > ( function ) );
-}
 
 //--------------------------------------------------------------------------------------------------
 // Returns true if entry is a directory, false otherwise.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -501,16 +501,14 @@ void DynamicDataLoader::load_data_from_path( const cata_path &path, const std::s
     // the first loaded mode might provide a vehicle that uses that frame
     // But not the other way round.
 
-    // get a list of all files in the directory
-    std::vector<cata_path> files = get_files_from_path( ".json", path, true, true );
-    if( files.empty() ) {
-        std::ifstream tmp( path.get_unrelative_path(), std::ios::in );
-        if( tmp ) {
-            // path is actually a file, don't checking the extension,
-            // assume we want to load this file anyway
-            files.push_back( path );
-        }
+    std::vector<cata_path> files;
+    if( dir_exist( path.get_unrelative_path() ) ) {
+        const std::vector<cata_path> dir_files = get_files_from_path( ".json", path, true, true );
+        files.insert( files.end(), dir_files.begin(), dir_files.end() );
+    } else if( file_exist( path.get_unrelative_path() ) ) {
+        files.emplace_back( path );
     }
+
     // iterate over each file
     for( const cata_path &file : files ) {
         try {

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -198,6 +198,9 @@ bool mod_manager::set_default_mods( const mod_id &ident )
 
 void mod_manager::load_mods_from( const cata_path &path )
 {
+    if( !dir_exist( path.get_unrelative_path() ) ) {
+        return; // don't try to enumerate non-existing directories
+    }
     for( cata_path &mod_file : get_files_from_path( MOD_SEARCH_FILE, path, true ) ) {
         load_mod_info( mod_file );
     }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1154,6 +1154,9 @@ static std::vector<options_manager::id_and_option> build_resource_list(
     std::vector<options_manager::id_and_option> resource_names;
 
     resource_option.clear();
+    if( !dir_exist( dirname.get_unrelative_path() ) ) {
+        return resource_names; // don't try to enumerate non-existing directories
+    }
     const auto resource_dirs = get_directories_with( filename, dirname, true );
 
     for( const cata_path &resource_dir : resource_dirs ) {

--- a/src/past_games_info.cpp
+++ b/src/past_games_info.cpp
@@ -106,6 +106,7 @@ void past_games_info::ensure_loaded()
     refresh_display();
 
     const cata_path &memorial_dir = PATH_INFO::memorialdir_path();
+    assure_dir_exist( memorial_dir );
     std::vector<cata_path> filenames = get_files_from_path( ".json", memorial_dir, true, true );
 
     // Sort the files by the date & time encoded in the filename

--- a/src/translation_manager_impl.cpp
+++ b/src/translation_manager_impl.cpp
@@ -51,23 +51,25 @@ std::string TranslationManager::Impl::LanguageCodeOfPath( const std::string_view
 
 void TranslationManager::Impl::ScanTranslationDocuments()
 {
-    DebugLog( D_INFO, DC_ALL ) << "[i18n] Scanning core translations from " << locale_dir();
-    DebugLog( D_INFO, DC_ALL ) << "[i18n] Scanning mod translations from " << PATH_INFO::user_moddir();
     std::vector<std::pair<std::string, std::string>> mo_dirs;
-    for( const auto &dir : get_files_from_path( "LC_MESSAGES",
-            PATH_INFO::user_moddir(),
-            true ) ) {
-        mo_dirs.emplace_back( dir, ".mo" );
+    if( dir_exist( PATH_INFO::user_moddir() ) ) {
+        DebugLog( D_INFO, DC_ALL ) << "[i18n] Scanning mod translations from " << PATH_INFO::user_moddir();
+        for( const std::string & dir
+             : get_files_from_path( "LC_MESSAGES", PATH_INFO::user_moddir(), true ) ) {
+            mo_dirs.emplace_back( dir, ".mo" );
+        }
     }
-    for( const auto &dir : get_files_from_path( "LC_MESSAGES", locale_dir(),
-            true ) ) {
-        mo_dirs.emplace_back( dir, "cataclysm-dda.mo" );
+    if( dir_exist( locale_dir() ) ) {
+        DebugLog( D_INFO, DC_ALL ) << "[i18n] Scanning core translations from " << locale_dir();
+        for( const std::string &dir : get_files_from_path( "LC_MESSAGES", locale_dir(), true ) ) {
+            mo_dirs.emplace_back( dir, "cataclysm-dda.mo" );
+        }
     }
-    for( const auto &entry : mo_dirs ) {
-        const auto &dir = entry.first;
-        const auto &pattern = entry.second;
+    for( const std::pair<std::string, std::string> &entry : mo_dirs ) {
+        const std::string &dir = entry.first;
+        const std::string &pattern = entry.second;
         std::vector<std::string> mo_dir_files = get_files_from_path( pattern, dir, false, true );
-        for( const auto &file : mo_dir_files ) {
+        for( const std::string &file : mo_dir_files ) {
             const std::string lang = LanguageCodeOfPath( file );
             if( mo_files.count( lang ) == 0 ) {
                 mo_files[lang] = std::vector<std::string>();

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -393,7 +393,12 @@ int main( int argc, const char *argv[] )
     if( result == 0 || dont_save ) {
         world_generator->delete_world( world_name, true );
     } else {
-        DebugLog( D_INFO, DC_ALL ) << "Test world " << world_name << " left for inspection.";
+        if( g->save() ) {
+            DebugLog( D_INFO, DC_ALL ) << "Test world " << world_name << " left for inspection.";
+        } else {
+            DebugLog( D_ERROR, DC_ALL ) << "Test world " << world_name << " failed to save.";
+            result = 1;
+        }
     }
 
     std::chrono::duration<double> elapsed_seconds = end - start;

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -384,14 +384,10 @@ int main( int argc, const char *argv[] )
 
     bool error_during_initialization = debug_has_error_been_observed();
 
+    DebugLog( D_INFO, DC_ALL ) << "Game data loaded, running Catch2 session:" << std::endl;
     const std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
-    std::time_t start_time = std::chrono::system_clock::to_time_t( start );
-    // Leading newline in case there were debug messages during
-    // initialization.
-    DebugLog( D_INFO, DC_ALL ) << "Starting the actual test at " << std::ctime( &start_time );
     result = session.run();
     const std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
-    std::time_t end_time = std::chrono::system_clock::to_time_t( end );
 
     std::string world_name = world_generator->active_world->world_name;
     if( result == 0 || dont_save ) {
@@ -401,12 +397,11 @@ int main( int argc, const char *argv[] )
     }
 
     std::chrono::duration<double> elapsed_seconds = end - start;
-    DebugLog( D_INFO, DC_ALL ) << "Ended test at " << std::ctime( &end_time );
-    DebugLog( D_INFO, DC_ALL ) << "The test took " << elapsed_seconds.count() << " seconds";
+    DebugLog( D_INFO, DC_ALL ) << "Finished in " << elapsed_seconds.count() << " seconds";
 
     if( seed ) {
         // Also print the seed at the end so it can be easily found
-        DebugLog( D_INFO, DC_ALL ) << "Randomness seeded to: " << seed;
+        DebugLog( D_INFO, DC_ALL ) << "Randomness seeded to: " << seed << std::endl;
     }
 
     if( error_during_initialization ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Tidy log output and actually save test game world for inspection

#### Describe the solution

Shorten some log output
Check if directories exist before enumerating into them so opendir warning doesn't get spammed.
Call g->save() if tests failed, since without it the only thing left to "inspect" is world settings and mods list which are identical between runs.

#### Describe alternatives you've considered

#### Testing

#### Additional context
