### PR TITLE
Make more tests independent of order

### DIFF
--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -252,13 +252,11 @@ TEST_CASE( "available_recipes", "[recipes]" )
 
             AND_WHEN( "he searches for the recipe in the book" ) {
                 THEN( "he finds it!" ) {
-                    // update the crafting inventory cache
-                    dummy.moves++;
+                    dummy.invalidate_crafting_inventory();
                     CHECK( dummy.get_recipes_from_books( dummy.crafting_inventory() ).contains( r ) );
                 }
                 THEN( "it's easier in the book" ) {
-                    // update the crafting inventory cache
-                    dummy.moves++;
+                    dummy.invalidate_crafting_inventory();
                     CHECK( dummy.get_recipes_from_books( dummy.crafting_inventory() ).get_custom_difficulty( r ) == 2 );
                 }
                 THEN( "he still hasn't the recipe memorized" ) {
@@ -269,8 +267,7 @@ TEST_CASE( "available_recipes", "[recipes]" )
                 craftbook.remove_item();
 
                 THEN( "he can't brew the recipe anymore" ) {
-                    // update the crafting inventory cache
-                    dummy.moves++;
+                    dummy.invalidate_crafting_inventory();
                     CHECK_FALSE( dummy.get_recipes_from_books( dummy.crafting_inventory() ).contains( r ) );
                 }
             }
@@ -289,8 +286,7 @@ TEST_CASE( "available_recipes", "[recipes]" )
 
             AND_WHEN( "he searches for the recipe in the tablet" ) {
                 THEN( "he finds it!" ) {
-                    // update the crafting inventory cache
-                    dummy.moves++;
+                    dummy.invalidate_crafting_inventory();
                     CHECK( dummy.get_recipes_from_books( dummy.crafting_inventory() ).contains( r2 ) );
                 }
                 THEN( "he still hasn't the recipe memorized" ) {
@@ -301,8 +297,7 @@ TEST_CASE( "available_recipes", "[recipes]" )
                 eink.remove_item();
 
                 THEN( "he can't make the recipe anymore" ) {
-                    // update the crafting inventory cache
-                    dummy.moves++;
+                    dummy.invalidate_crafting_inventory();
                     CHECK_FALSE( dummy.get_recipes_from_books( dummy.crafting_inventory() ).contains( r2 ) );
                 }
             }
@@ -333,8 +328,7 @@ TEST_CASE( "crafting_with_a_companion", "[.]" )
         const auto helpers( dummy.get_crafting_helpers() );
 
         REQUIRE( std::find( helpers.begin(), helpers.end(), &who ) != helpers.end() );
-        // update the crafting inventory cache
-        dummy.moves++;
+        dummy.invalidate_crafting_inventory();
         REQUIRE_FALSE( dummy.get_available_recipes( dummy.crafting_inventory(), &helpers ).contains( r ) );
         REQUIRE_FALSE( who.knows_recipe( r ) );
 
@@ -345,8 +339,7 @@ TEST_CASE( "crafting_with_a_companion", "[.]" )
                 who.learn_recipe( r );
 
                 THEN( "he helps you" ) {
-                    // update the crafting inventory cache
-                    dummy.moves++;
+                    dummy.invalidate_crafting_inventory();
                     CHECK( dummy.get_available_recipes( dummy.crafting_inventory(), &helpers ).contains( r ) );
                 }
             }
@@ -357,8 +350,7 @@ TEST_CASE( "crafting_with_a_companion", "[.]" )
                 REQUIRE_FALSE( cookbook->type->book->recipes.empty() );
 
                 THEN( "he shows it to you" ) {
-                    // update the crafting inventory cache
-                    dummy.moves++;
+                    dummy.invalidate_crafting_inventory();
                     CHECK( dummy.get_available_recipes( dummy.crafting_inventory(), &helpers ).contains( r ) );
                 }
             }
@@ -388,6 +380,7 @@ static void give_tools( const std::vector<item> &tools )
     for( const item &gear : boil ) {
         REQUIRE( player_character.i_add( gear ) );
     }
+    player_character.invalidate_crafting_inventory();
 }
 
 static int apply_offset( int skill, int offset )
@@ -433,7 +426,6 @@ static void prep_craft( const recipe_id &rid, const std::vector<item> &tools,
     }
 
     give_tools( tools );
-    player_character.moves--;
     const inventory &crafting_inv = player_character.crafting_inventory();
 
     bool can_craft_with_crafting_inv = r.deduped_requirements()

--- a/tests/degradation_test.cpp
+++ b/tests/degradation_test.cpp
@@ -87,6 +87,8 @@ TEST_CASE( "Damage indicator thresholds", "[item][damage_level]" )
 
 TEST_CASE( "Degradation on spawned items", "[item][degradation]" )
 {
+    clear_map();
+
     SECTION( "Non-spawned items have no degradation" ) {
         item norm( itype_test_baseball );
         item half( itype_test_baseball_half_degradation );
@@ -210,10 +212,7 @@ TEST_CASE( "Items that get damaged gain degradation", "[item][degradation]" )
 
 static void setup_repair( item &fix, player_activity &act, Character &u )
 {
-    // Setup map
     map &m = get_map();
-    set_time( calendar::turn_zero + 12_hours );
-    REQUIRE( static_cast<int>( m.light_at( spawn_pos ) ) > 2 );
 
     // Setup character
     clear_character( u, true );
@@ -245,6 +244,11 @@ static void setup_repair( item &fix, player_activity &act, Character &u )
 // Testing activity_handlers::repair_item_finish / repair_item_actor::repair
 TEST_CASE( "Repairing degraded items", "[item][degradation]" )
 {
+    // Setup map
+    clear_map();
+    set_time_to_day();
+    REQUIRE( static_cast<int>( get_map().light_at( spawn_pos ) ) > 2 );
+
     GIVEN( "Item with normal degradation" ) {
         Character &u = get_player_character();
         item fix( itype_test_baseball );

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -2602,8 +2602,7 @@ TEST_CASE( "show available recipes with item as an ingredient", "[iteminfo][reci
                 item_location textbook = player_character.i_add( item( "textbook_chemistry" ) );
                 player_character.identify( *textbook );
                 REQUIRE( player_character.has_identified( itype_textbook_chemistry ) );
-                // update the crafting inventory cache
-                player_character.moves++;
+                player_character.invalidate_crafting_inventory();
 
                 THEN( "they can use potassium iodide tablets to craft it" ) {
                     CHECK( item_info_str( *iodine, crafting ) ==

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -47,6 +47,8 @@ static const itype_id itype_towel_wet( "towel_wet" );
 TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
 {
     avatar dummy;
+    dummy.normalize();
+
     item eyedrops( "saline", calendar::turn_zero, item::default_charges_tag{} );
 
     int charges_before = eyedrops.charges;
@@ -85,6 +87,8 @@ TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
 TEST_CASE( "antifungal", "[iuse][antifungal]" )
 {
     avatar dummy;
+    dummy.normalize();
+
     item antifungal( "antifungal", calendar::turn_zero, item::default_charges_tag{} );
 
     int charges_before = antifungal.charges;
@@ -136,6 +140,8 @@ TEST_CASE( "antifungal", "[iuse][antifungal]" )
 TEST_CASE( "antiparasitic", "[iuse][antiparasitic]" )
 {
     avatar dummy;
+    dummy.normalize();
+
     item antiparasitic( "antiparasitic", calendar::turn_zero, item::default_charges_tag{} );
 
     int charges_before = antiparasitic.charges;
@@ -192,6 +198,8 @@ TEST_CASE( "antiparasitic", "[iuse][antiparasitic]" )
 TEST_CASE( "anticonvulsant", "[iuse][anticonvulsant]" )
 {
     avatar dummy;
+    dummy.normalize();
+
     item anticonvulsant( "diazepam", calendar::turn_zero, item::default_charges_tag{} );
 
     int charges_before = anticonvulsant.charges;
@@ -225,6 +233,8 @@ TEST_CASE( "anticonvulsant", "[iuse][anticonvulsant]" )
 TEST_CASE( "oxygen tank", "[iuse][oxygen_bottle]" )
 {
     avatar dummy;
+    dummy.normalize();
+
     item oxygen( "oxygen_tank" );
     itype_id o2_ammo( "oxygen" );
     oxygen.ammo_set( o2_ammo );
@@ -327,6 +337,7 @@ TEST_CASE( "oxygen tank", "[iuse][oxygen_bottle]" )
 TEST_CASE( "caffeine and atomic caffeine", "[iuse][caff][atomic_caff]" )
 {
     avatar dummy;
+    dummy.normalize();
 
     // Baseline fatigue level before caffeinating
     int fatigue_before = 200;
@@ -356,7 +367,8 @@ TEST_CASE( "caffeine and atomic caffeine", "[iuse][caff][atomic_caff]" )
 TEST_CASE( "towel", "[iuse][towel]" )
 {
     avatar dummy;
-    dummy.set_body();
+    dummy.normalize();
+
     item towel( "towel", calendar::turn_zero, item::default_charges_tag{} );
 
     GIVEN( "avatar is wet" ) {
@@ -476,7 +488,9 @@ TEST_CASE( "towel", "[iuse][towel]" )
 TEST_CASE( "thorazine", "[iuse][thorazine]" )
 {
     avatar dummy;
+    dummy.normalize();
     dummy.set_fatigue( 0 );
+
     item thorazine( "thorazine", calendar::turn_zero, item::default_charges_tag{} );
 
     int charges_before = thorazine.charges;
@@ -525,6 +539,8 @@ TEST_CASE( "thorazine", "[iuse][thorazine]" )
 TEST_CASE( "prozac", "[iuse][prozac]" )
 {
     avatar dummy;
+    dummy.normalize();
+
     item prozac( "prozac", calendar::turn_zero, item::default_charges_tag{} );
 
     SECTION( "prozac gives prozac and visible prozac effect" ) {
@@ -591,6 +607,8 @@ TEST_CASE( "inhaler", "[iuse][inhaler]" )
 TEST_CASE( "panacea", "[iuse][panacea]" )
 {
     avatar dummy;
+    dummy.normalize();
+
     item panacea( "panacea", calendar::turn_zero, item::default_charges_tag{} );
 
     SECTION( "panacea gives cure-all effect" ) {
@@ -604,6 +622,8 @@ TEST_CASE( "panacea", "[iuse][panacea]" )
 TEST_CASE( "xanax", "[iuse][xanax]" )
 {
     avatar dummy;
+    dummy.normalize();
+
     item xanax( "xanax", calendar::turn_zero, item::default_charges_tag{} );
 
     SECTION( "xanax gives xanax and visible xanax effects" ) {


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Make more tests independent of order

#### Describe the solution

Reset more test state

Use cache bust from https://github.com/CleverRaven/Cataclysm-DDA/commit/b3d56b56516ac06fcc6a11743afa8a1376d25145 to invalidate crafting inventory instead of moves hack

#### Describe alternatives you've considered

#### Testing

```bash
./tests/cata_test --rng-seed 1686874819 "check mutagen addiction effects","body_part_sorting_all","body_part_sorting_main","mtype_species_test","cube_direction_add_om_direction","cube_direction_add_int","cube_direction_subtract_int","Damage indicator thresholds","Degradation on spawned items"
./tests/cata_test --rng-seed 1686797449 "check amphetamine addiction effects","check_monster_behavior_tree_locust","check_monster_behavior_tree_theoretical_absorb","Bionic power capacity","bionic UIDs","bionic weapons","included bionics","fueled bionics","cardio is and isn't affected by certain traits","total crafting time with or without interruption","prompt for liquid containers - crafting 1 makeshift funnel","prompt for liquid containers - batch crafting 3 makeshift funnels","recipes inherit rot of components properly"
./tests/cata_test --rng-seed 1686796277 "item cannot contain contents it already has","Sawed off fits in large holster","bag with restrictions and nested bag doesn't fit too large items","pocket_leak","stacking_over_time","item length sanity check","techniques when wielded","armor rigidity","armor_stats","book info","food character is allergic to","list of item actions","tool info","pocket info units - imperial or metric","ammo restriction info","tool transform when activated","eyedrops","antifungal","antiparasitic"
```

#### Additional context
