### PR TITLE
Normalize TEST_CASE names

### DIFF
--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -30,7 +30,7 @@ unit is a `TEST_CASE`. Each test `.cpp` file should define at least one test
 case, with a name, and an optional (but strongly encouraged) list of tags:
 
 ```cpp
-    TEST_CASE( "sweet junk food", "[food][junk][sweet]" )
+    TEST_CASE( "sweet_junk_food", "[food][junk][sweet]" )
     {
         // ...
     }
@@ -44,7 +44,7 @@ that encourages a high level of readability is the
 Here's an outline of what a test might look like using those:
 
 ```cpp
-    TEST_CASE( "sweet junk food", "[food][junk][sweet]" )
+    TEST_CASE( "sweet_junk_food", "[food][junk][sweet]" )
     {
         GIVEN( "character has a sweet tooth" ) {
 
@@ -66,7 +66,7 @@ expectations (the `THEN` part, naturally).
 Filling in the above with actual test code might look like this:
 
 ```cpp
-    TEST_CASE( "sweet junk food", "[food][junk][sweet]" )
+    TEST_CASE( "sweet_junk_food", "[food][junk][sweet]" )
     {
         avatar dummy;
         dummy.clear_morale();

--- a/tests/addiction_test.cpp
+++ b/tests/addiction_test.cpp
@@ -107,7 +107,7 @@ static int suffer_addiction( const addiction_id &aid, const int intens, Characte
     return ret;
 }
 
-TEST_CASE( "hardcoded and json addictions", "[addiction]" )
+TEST_CASE( "hardcoded_and_json_addictions", "[addiction]" )
 {
     REQUIRE( !addiction_test_caffeine->get_effect().is_null() );
     REQUIRE( addiction_test_caffeine->get_builtin().empty() );
@@ -156,7 +156,7 @@ TEST_CASE( "hardcoded and json addictions", "[addiction]" )
     }
 }
 
-TEST_CASE( "check caffeine addiction effects", "[addiction]" )
+TEST_CASE( "check_caffeine_addiction_effects", "[addiction]" )
 {
     Character &u = get_player_character();
     clear_character( u );
@@ -201,7 +201,7 @@ TEST_CASE( "check caffeine addiction effects", "[addiction]" )
     }
 }
 
-TEST_CASE( "check nicotine addiction effects", "[addiction]" )
+TEST_CASE( "check_nicotine_addiction_effects", "[addiction]" )
 {
     Character &u = get_player_character();
     clear_character( u );
@@ -246,7 +246,7 @@ TEST_CASE( "check nicotine addiction effects", "[addiction]" )
     }
 }
 
-TEST_CASE( "check alcohol addiction effects", "[addiction]" )
+TEST_CASE( "check_alcohol_addiction_effects", "[addiction]" )
 {
     Character &u = get_player_character();
     clear_character( u );
@@ -291,7 +291,7 @@ TEST_CASE( "check alcohol addiction effects", "[addiction]" )
     }
 }
 
-TEST_CASE( "check diazepam addiction effects", "[addiction]" )
+TEST_CASE( "check_diazepam_addiction_effects", "[addiction]" )
 {
     Character &u = get_player_character();
     clear_character( u );
@@ -336,7 +336,7 @@ TEST_CASE( "check diazepam addiction effects", "[addiction]" )
     }
 }
 
-TEST_CASE( "check opiate addiction effects", "[addiction]" )
+TEST_CASE( "check_opiate_addiction_effects", "[addiction]" )
 {
     Character &u = get_player_character();
     clear_character( u );
@@ -381,7 +381,7 @@ TEST_CASE( "check opiate addiction effects", "[addiction]" )
     }
 }
 
-TEST_CASE( "check amphetamine addiction effects", "[addiction]" )
+TEST_CASE( "check_amphetamine_addiction_effects", "[addiction]" )
 {
     Character &u = get_player_character();
     clear_character( u );
@@ -426,7 +426,7 @@ TEST_CASE( "check amphetamine addiction effects", "[addiction]" )
     }
 }
 
-TEST_CASE( "check cocaine addiction effects", "[addiction]" )
+TEST_CASE( "check_cocaine_addiction_effects", "[addiction]" )
 {
     Character &u = get_player_character();
     clear_character( u );
@@ -471,7 +471,7 @@ TEST_CASE( "check cocaine addiction effects", "[addiction]" )
     }
 }
 
-TEST_CASE( "check crack addiction effects", "[addiction]" )
+TEST_CASE( "check_crack_addiction_effects", "[addiction]" )
 {
     Character &u = get_player_character();
     clear_character( u );
@@ -516,7 +516,7 @@ TEST_CASE( "check crack addiction effects", "[addiction]" )
     }
 }
 
-TEST_CASE( "check mutagen addiction effects", "[addiction]" )
+TEST_CASE( "check_mutagen_addiction_effects", "[addiction]" )
 {
     Character &u = get_player_character();
     clear_character( u );
@@ -601,7 +601,7 @@ TEST_CASE( "check mutagen addiction effects", "[addiction]" )
     }
 }
 
-TEST_CASE( "check marloss addiction effects", "[addiction]" )
+TEST_CASE( "check_marloss_addiction_effects", "[addiction]" )
 {
     Character &u = get_player_character();
     clear_character( u );
@@ -718,7 +718,7 @@ TEST_CASE( "check marloss addiction effects", "[addiction]" )
     }
 }
 
-TEST_CASE( "check that items can inflict multiple addictions", "[addiction]" )
+TEST_CASE( "check_that_items_can_inflict_multiple_addictions", "[addiction]" )
 {
     item addict_itm( "test_whiskey_caffenated" );
     REQUIRE( addict_itm.is_comestible() );

--- a/tests/ammo_set_test.cpp
+++ b/tests/ammo_set_test.cpp
@@ -13,7 +13,7 @@
 #include "type_id.h"
 #include "value_ptr.h"
 
-TEST_CASE( "ammo_set items with MAGAZINE pockets", "[ammo_set][magazine][ammo]" )
+TEST_CASE( "ammo_set_items_with_MAGAZINE_pockets", "[ammo_set][magazine][ammo]" )
 {
     GIVEN( "empty 9mm CZ 75 20-round magazine" ) {
         item cz75mag_20rd( "cz75mag_20rd" );
@@ -180,7 +180,7 @@ TEST_CASE( "ammo_set items with MAGAZINE pockets", "[ammo_set][magazine][ammo]" 
     }
 }
 
-TEST_CASE( "ammo_set items with MAGAZINE_WELL pockets with magazine",
+TEST_CASE( "ammo_set_items_with_MAGAZINE_WELL_pockets_with_magazine",
            "[ammo_set][magazine][ammo]" )
 {
     GIVEN( "CZ 75 B 9mm gun with empty 9mm CZ 75 20-round magazine" ) {
@@ -290,7 +290,7 @@ TEST_CASE( "ammo_set items with MAGAZINE_WELL pockets with magazine",
     }
 }
 
-TEST_CASE( "ammo_set items with MAGAZINE_WELL pockets without magazine",
+TEST_CASE( "ammo_set_items_with_MAGAZINE_WELL_pockets_without_magazine",
            "[ammo_set][magazine][ammo]" )
 {
     GIVEN( "CZ 75 B 9mm gun w/o magazine" ) {
@@ -373,7 +373,7 @@ TEST_CASE( "ammo_set items with MAGAZINE_WELL pockets without magazine",
     }
 }
 
-TEST_CASE( "ammo_set items with CONTAINER pockets", "[ammo_set][magazine][ammo]" )
+TEST_CASE( "ammo_set_items_with_CONTAINER_pockets", "[ammo_set][magazine][ammo]" )
 {
     GIVEN( "small box" ) {
         item box( "box_small" );

--- a/tests/ammo_test.cpp
+++ b/tests/ammo_test.cpp
@@ -41,7 +41,7 @@ static bool has_ammo_types( const item &it )
     return !it.ammo_types().empty();
 }
 
-TEST_CASE( "ammo types", "[ammo][ammo_types]" )
+TEST_CASE( "ammo_types", "[ammo][ammo_types]" )
 {
     // Only a few kinds of item have ammo_types:
     // - Items with type=MAGAZINE (including batteries as well as gun magazines)
@@ -162,7 +162,7 @@ TEST_CASE( "ammo types", "[ammo][ammo_types]" )
 }
 
 // The same items with no ammo_types, also have no ammo_default.
-TEST_CASE( "ammo default", "[ammo][ammo_default]" )
+TEST_CASE( "ammo_default", "[ammo][ammo_default]" )
 {
     // TOOLMOD type, and TOOL type items with MAGAZINE_WELL pockets have no ammo_default
     SECTION( "items without ammo_default" ) {
@@ -200,7 +200,7 @@ TEST_CASE( "ammo default", "[ammo][ammo_default]" )
     }
 }
 
-TEST_CASE( "barrel test", "[ammo][weapon]" )
+TEST_CASE( "barrel_test", "[ammo][weapon]" )
 {
     SECTION( "basic ammo and barrel length test" ) {
         item base_gun( "test_glock_super_long" );
@@ -221,7 +221,7 @@ TEST_CASE( "barrel test", "[ammo][weapon]" )
     }
 }
 
-TEST_CASE( "battery energy test", "[ammo][energy][item]" )
+TEST_CASE( "battery_energy_test", "[ammo][energy][item]" )
 {
     item test_battery( "medium_battery_cell" );
     test_battery.ammo_set( test_battery.ammo_default(), 300 );

--- a/tests/battery_mod_test.cpp
+++ b/tests/battery_mod_test.cpp
@@ -67,7 +67,7 @@ static const itype_id itype_medium_plus_battery_cell( "medium_plus_battery_cell"
 // both to ensure they work as expected, and to exhibit their attributes and terminology (like the
 // curious fact that a battery is treated like a magazine full of ammunition).
 //
-TEST_CASE( "battery tool mod test", "[battery][mod]" )
+TEST_CASE( "battery_tool_mod_test", "[battery][mod]" )
 {
     item med_mod( "magazine_battery_medium_mod" );
 
@@ -217,7 +217,7 @@ TEST_CASE( "battery tool mod test", "[battery][mod]" )
 //   - Can be reloaded with a compatible "magazine" (battery)
 //   - Charge left in the tool's battery is "ammo remaining"
 //
-TEST_CASE( "battery and tool properties", "[battery][tool][properties]" )
+TEST_CASE( "battery_and_tool_properties", "[battery][tool][properties]" )
 {
     const item bat_cell( "light_battery_cell" );
     const item flashlight( "flashlight" );
@@ -316,7 +316,7 @@ TEST_CASE( "battery and tool properties", "[battery][tool][properties]" )
     }
 }
 
-TEST_CASE( "installing battery in tool", "[battery][tool][install]" )
+TEST_CASE( "installing_battery_in_tool", "[battery][tool][install]" )
 {
     item bat_cell( "light_battery_cell" );
     item flashlight( "flashlight" );

--- a/tests/bionics_test.cpp
+++ b/tests/bionics_test.cpp
@@ -36,7 +36,7 @@ static const flag_id json_flag_PSEUDO( "PSEUDO" );
 static const itype_id itype_solarpack_on( "solarpack_on" );
 static const itype_id itype_test_backpack( "test_backpack" );
 
-TEST_CASE( "Bionic power capacity", "[bionics] [power]" )
+TEST_CASE( "Bionic_power_capacity", "[bionics] [power]" )
 {
     avatar &dummy = get_avatar();
 
@@ -93,7 +93,7 @@ TEST_CASE( "Bionic power capacity", "[bionics] [power]" )
     }
 }
 
-TEST_CASE( "bionic UIDs", "[bionics]" )
+TEST_CASE( "bionic_UIDs", "[bionics]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();
@@ -128,7 +128,7 @@ TEST_CASE( "bionic UIDs", "[bionics]" )
     }
 }
 
-TEST_CASE( "bionic weapons", "[bionics] [weapon] [item]" )
+TEST_CASE( "bionic_weapons", "[bionics] [weapon] [item]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();
@@ -329,7 +329,7 @@ TEST_CASE( "bionic weapons", "[bionics] [weapon] [item]" )
     }
 }
 
-TEST_CASE( "included bionics", "[bionics]" )
+TEST_CASE( "included_bionics", "[bionics]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();
@@ -361,7 +361,7 @@ TEST_CASE( "included bionics", "[bionics]" )
     }
 }
 
-TEST_CASE( "fueled bionics", "[bionics] [item]" )
+TEST_CASE( "fueled_bionics", "[bionics] [item]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();

--- a/tests/cardio_test.cpp
+++ b/tests/cardio_test.cpp
@@ -139,7 +139,7 @@ static void check_trait_cardio_stamina_run( Character &they, std::string trait_n
 }
 
 // Baseline character with default attributes and no traits
-TEST_CASE( "base cardio", "[cardio][base]" )
+TEST_CASE( "base_cardio", "[cardio][base]" )
 {
     verify_default_cardio_options();
     Character &they = get_player_character();
@@ -176,7 +176,7 @@ TEST_CASE( "base cardio", "[cardio][base]" )
 // - stamina_regen_modifier
 //   - Fast Metabolism, Persistence Hunter: Increased stamina regeneration
 //
-TEST_CASE( "cardio is and isn't affected by certain traits", "[cardio][traits]" )
+TEST_CASE( "cardio_is_and_is_not_affected_by_certain_traits", "[cardio][traits]" )
 {
     verify_default_cardio_options();
     Character &they = get_player_character();
@@ -239,19 +239,19 @@ TEST_CASE( "cardio is and isn't affected by certain traits", "[cardio][traits]" 
     }
 }
 
-TEST_CASE( "cardio affects stamina regeneration", "[cardio][stamina]" )
+TEST_CASE( "cardio_affects_stamina_regeneration", "[cardio][stamina]" )
 {
     // With baseline cardio, stamina regen is X
     // With low cardio, stamina regen is X--
     // With high cardio, stamina regen is X++
 }
 
-TEST_CASE( "cardio affects weariness", "[cardio][weariness]" )
+TEST_CASE( "cardio_affects_weariness", "[cardio][weariness]" )
 {
     // Weariness threshold is 1/2 cardio
 }
 
-TEST_CASE( "cardio is affected by activity level each day", "[cardio][activity]" )
+TEST_CASE( "cardio_is_affected_by_activity_level_each_day", "[cardio][activity]" )
 {
     // When activity increases, cardio goes up
     // When activity decreases, cardio goes down
@@ -264,7 +264,7 @@ TEST_CASE( "cardio is affected by activity level each day", "[cardio][activity]"
     // Then their cardio should increase slightly
 }
 
-TEST_CASE( "cardio isn't affected by character height", "[cardio][height]" )
+TEST_CASE( "cardio_is_not_affected_by_character_height", "[cardio][height]" )
 {
     verify_default_cardio_options();
     Character &they = get_player_character();
@@ -282,12 +282,12 @@ TEST_CASE( "cardio isn't affected by character height", "[cardio][height]" )
     }
 }
 
-TEST_CASE( "cardio is affected by character weight", "[cardio][weight]" )
+TEST_CASE( "cardio_is_affected_by_character_weight", "[cardio][weight]" )
 {
     // Underweight, overweight
 }
 
-TEST_CASE( "cardio is affected by character health", "[cardio][health]" )
+TEST_CASE( "cardio_is_affected_by_character_health", "[cardio][health]" )
 {
     verify_default_cardio_options();
     Character &they = get_player_character();
@@ -303,7 +303,7 @@ TEST_CASE( "cardio is affected by character health", "[cardio][health]" )
     }
 }
 
-TEST_CASE( "cardio is affected by athletics skill", "[cardio][athletics]" )
+TEST_CASE( "cardio_is_affected_by_athletics_skill", "[cardio][athletics]" )
 {
     verify_default_cardio_options();
     Character &they = get_player_character();

--- a/tests/char_biometrics_test.cpp
+++ b/tests/char_biometrics_test.cpp
@@ -155,7 +155,7 @@ static void for_each_size_category( const std::function< void( creature_size ) >
 
 //we are testing the character's "fat bmis" which are 3.5-5 for normal weight and 5-10 for overweight, 10+ obese
 //this model does mean we are potentially "skinnyfat" if low str but higher fat bmis
-TEST_CASE( "body mass index determines weight description", "[biometrics][bmi][weight]" )
+TEST_CASE( "body_mass_index_determines_weight_description", "[biometrics][bmi][weight]" )
 {
     avatar dummy;
 
@@ -186,7 +186,7 @@ TEST_CASE( "body mass index determines weight description", "[biometrics][bmi][w
 }
 
 //for an 8 strength character. strength scales linearly to 0 str below fat bmi of 2.0
-TEST_CASE( "stored kcal ratio influences body mass index", "[biometrics][kcal][bmi]" )
+TEST_CASE( "stored_kcal_ratio_influences_body_mass_index", "[biometrics][kcal][bmi]" )
 {
     avatar dummy;
 
@@ -227,7 +227,7 @@ TEST_CASE( "stored kcal ratio influences body mass index", "[biometrics][kcal][b
     CHECK( true_bmi_at_kcal_ratio( dummy, 5.0f ) == Approx( 45.0f ).margin( 0.01f ) );
 }
 
-TEST_CASE( "body mass index determines maximum healthiness", "[biometrics][bmi][max]" )
+TEST_CASE( "body_mass_index_determines_maximum_healthiness", "[biometrics][bmi][max]" )
 {
     // "BMIs under 20 and over 25 have been associated with higher all-causes mortality,
     // with the risk increasing with distance from the 20–25 range."
@@ -283,7 +283,7 @@ TEST_CASE( "body mass index determines maximum healthiness", "[biometrics][bmi][
     CHECK( max_healthy_at_bmi( dummy, 22.0f ) == -200 );
 }
 
-TEST_CASE( "character height should increase with their body size",
+TEST_CASE( "character_height_should_increase_with_their_body_size",
            "[biometrics][height][mutation]" )
 {
     using DummyMap = std::map<creature_size, avatar_ptr>;
@@ -313,7 +313,7 @@ TEST_CASE( "character height should increase with their body size",
     }
 }
 
-TEST_CASE( "default character (175 cm) bodyweights at various BMIs", "[biometrics][bodyweight]" )
+TEST_CASE( "default_character_175_cm_bodyweights_at_various_BMIs", "[biometrics][bodyweight]" )
 {
     avatar dummy;
     clear_character( dummy );
@@ -344,7 +344,7 @@ TEST_CASE( "default character (175 cm) bodyweights at various BMIs", "[biometric
     }
 }
 
-TEST_CASE( "character's weight should increase with their body size and BMI",
+TEST_CASE( "character_weight_should_increase_with_their_body_size_and_BMI",
            "[biometrics][bodyweight][mutation]" )
 {
     using DummyMap = std::map<creature_size, avatar_ptr>;
@@ -375,7 +375,7 @@ TEST_CASE( "character's weight should increase with their body size and BMI",
     }
 }
 
-TEST_CASE( "riding various creatures at various sizes", "[avatar][bodyweight]" )
+TEST_CASE( "riding_various_creatures_at_various_sizes", "[avatar][bodyweight]" )
 {
     monster cow( mon_cow );
     monster horse( mon_horse );
@@ -447,7 +447,7 @@ static void test_activity_duration( avatar &dummy, const float at_level,
     }
 }
 
-TEST_CASE( "activity levels and calories in daily diary", "[avatar][biometrics][activity][diary]" )
+TEST_CASE( "activity_levels_and_calories_in_daily_diary", "[avatar][biometrics][activity][diary]" )
 {
     // Typical spring start, day 61
     calendar::turn = calendar::turn_zero + 60_days;
@@ -484,7 +484,7 @@ TEST_CASE( "activity levels and calories in daily diary", "[avatar][biometrics][
     }
 }
 
-TEST_CASE( "mutations may affect character metabolic rate", "[biometrics][metabolism]" )
+TEST_CASE( "mutations_may_affect_character_metabolic_rate", "[biometrics][metabolism]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -521,7 +521,7 @@ TEST_CASE( "mutations may affect character metabolic rate", "[biometrics][metabo
     CHECK( metabolic_rate_with_mutation( dummy, "COLDBLOOD4" ) == Approx( 0.5f ) );
 }
 
-TEST_CASE( "basal metabolic rate with various size and metabolism", "[biometrics][bmr]" )
+TEST_CASE( "basal_metabolic_rate_with_various_size_and_metabolism", "[biometrics][bmr]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -598,7 +598,7 @@ TEST_CASE( "basal metabolic rate with various size and metabolism", "[biometrics
     }
 }
 
-TEST_CASE( "body mass effect on speed", "[bmi][speed]" )
+TEST_CASE( "body_mass_effect_on_speed", "[bmi][speed]" )
 {
     avatar dummy;
 

--- a/tests/char_edible_rating_test.cpp
+++ b/tests/char_edible_rating_test.cpp
@@ -55,7 +55,7 @@ static void expect_will_eat( avatar &dummy, item &food, const std::string &expec
     CHECK( rate_will.value() == expect_rating );
 }
 
-TEST_CASE( "cannot eat non-comestible", "[can_eat][will_eat][edible_rating][nonfood]" )
+TEST_CASE( "cannot_eat_non-comestible", "[can_eat][will_eat][edible_rating][nonfood]" )
 {
     avatar dummy;
     GIVEN( "something not edible" ) {
@@ -67,7 +67,7 @@ TEST_CASE( "cannot eat non-comestible", "[can_eat][will_eat][edible_rating][nonf
     }
 }
 
-TEST_CASE( "cannot eat dirty food", "[can_eat][edible_rating][dirty]" )
+TEST_CASE( "cannot_eat_dirty_food", "[can_eat][edible_rating][dirty]" )
 {
     avatar dummy;
 
@@ -82,7 +82,7 @@ TEST_CASE( "cannot eat dirty food", "[can_eat][edible_rating][dirty]" )
     }
 }
 
-TEST_CASE( "who can eat while underwater", "[can_eat][edible_rating][underwater]" )
+TEST_CASE( "who_can_eat_while_underwater", "[can_eat][edible_rating][underwater]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -123,7 +123,7 @@ TEST_CASE( "who can eat while underwater", "[can_eat][edible_rating][underwater]
     }
 }
 
-TEST_CASE( "when frozen food can be eaten", "[can_eat][edible_rating][frozen]" )
+TEST_CASE( "when_frozen_food_can_be_eaten", "[can_eat][edible_rating][frozen]" )
 {
     avatar dummy;
 
@@ -206,7 +206,7 @@ TEST_CASE( "when frozen food can be eaten", "[can_eat][edible_rating][frozen]" )
     }
 }
 
-TEST_CASE( "who can eat inedible animal food", "[can_eat][edible_rating][inedible][animal]" )
+TEST_CASE( "who_can_eat_inedible_animal_food", "[can_eat][edible_rating][inedible][animal]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -258,7 +258,7 @@ TEST_CASE( "who can eat inedible animal food", "[can_eat][edible_rating][inedibl
     }
 }
 
-TEST_CASE( "what herbivores can eat", "[can_eat][edible_rating][herbivore]" )
+TEST_CASE( "what_herbivores_can_eat", "[can_eat][edible_rating][herbivore]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -285,7 +285,7 @@ TEST_CASE( "what herbivores can eat", "[can_eat][edible_rating][herbivore]" )
     }
 }
 
-TEST_CASE( "what carnivores can eat", "[can_eat][edible_rating][carnivore]" )
+TEST_CASE( "what_carnivores_can_eat", "[can_eat][edible_rating][carnivore]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -334,7 +334,7 @@ TEST_CASE( "what carnivores can eat", "[can_eat][edible_rating][carnivore]" )
     }
 }
 
-TEST_CASE( "what you can eat with a mycus dependency", "[can_eat][edible_rating][mycus]" )
+TEST_CASE( "what_you_can_eat_with_a_mycus_dependency", "[can_eat][edible_rating][mycus]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -359,7 +359,7 @@ TEST_CASE( "what you can eat with a mycus dependency", "[can_eat][edible_rating]
     }
 }
 
-TEST_CASE( "what you can drink with a proboscis", "[can_eat][edible_rating][proboscis]" )
+TEST_CASE( "what_you_can_drink_with_a_proboscis", "[can_eat][edible_rating][proboscis]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -411,7 +411,7 @@ TEST_CASE( "what you can drink with a proboscis", "[can_eat][edible_rating][prob
     }
 }
 
-TEST_CASE( "can eat with nausea", "[will_eat][edible_rating][nausea]" )
+TEST_CASE( "can_eat_with_nausea", "[will_eat][edible_rating][nausea]" )
 {
     avatar dummy;
     item toastem( "toastem" );
@@ -428,7 +428,7 @@ TEST_CASE( "can eat with nausea", "[will_eat][edible_rating][nausea]" )
     }
 }
 
-TEST_CASE( "can eat with allergies", "[will_eat][edible_rating][allergy]" )
+TEST_CASE( "can_eat_with_allergies", "[will_eat][edible_rating][allergy]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -446,7 +446,7 @@ TEST_CASE( "can eat with allergies", "[will_eat][edible_rating][allergy]" )
     }
 }
 
-TEST_CASE( "who will eat rotten food", "[will_eat][edible_rating][rotten]" )
+TEST_CASE( "who_will_eat_rotten_food", "[will_eat][edible_rating][rotten]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -497,7 +497,7 @@ TEST_CASE( "who will eat rotten food", "[will_eat][edible_rating][rotten]" )
     }
 }
 
-TEST_CASE( "who will eat cooked human flesh", "[will_eat][edible_rating][cannibal]" )
+TEST_CASE( "who_will_eat_cooked_human_flesh", "[will_eat][edible_rating][cannibal]" )
 {
     avatar dummy;
     dummy.set_body();

--- a/tests/char_exposure_test.cpp
+++ b/tests/char_exposure_test.cpp
@@ -13,7 +13,7 @@
 // Covers functions:
 // - Character::bodypart_exposure
 
-TEST_CASE( "character body part exposure", "[char][bodypart][exposure]" )
+TEST_CASE( "character_body_part_exposure", "[char][bodypart][exposure]" )
 {
     Character &dummy = get_player_character();
     clear_avatar();

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -51,7 +51,7 @@ static float healing_rate_at_health( Character &dummy, const int healthy_value,
 
 // At baseline human defaults, with no treatment or traits, the character only heals while sleeping.
 // Default as of this writing is is 0.0001, or 8.64 HP per day.
-TEST_CASE( "baseline healing rate with no healing traits", "[heal][baseline]" )
+TEST_CASE( "baseline_healing_rate_with_no_healing_traits", "[heal][baseline]" )
 {
     avatar dummy;
 
@@ -80,7 +80,7 @@ TEST_CASE( "baseline healing rate with no healing traits", "[heal][baseline]" )
 
 // Healing rate may be affected by any of several traits/mutations, and the effects vary depending
 // on whether the character is asleep or awake.
-TEST_CASE( "traits and mutations affecting healing rate", "[heal][trait][mutation]" )
+TEST_CASE( "traits_and_mutations_affecting_healing_rate", "[heal][trait][mutation]" )
 {
     avatar dummy;
 
@@ -209,7 +209,7 @@ TEST_CASE( "traits and mutations affecting healing rate", "[heal][trait][mutatio
 
 // The "hidden health" stat returned by Character::get_lifestyle ranges from [-200, 200] and
 // influences healing rate significantly.
-TEST_CASE( "health effects on healing rate", "[heal][health]" )
+TEST_CASE( "health_effects_on_healing_rate", "[heal][health]" )
 {
     avatar dummy;
 
@@ -318,7 +318,7 @@ static float together_rate_with_extras( const std::string &bp_name,
 // The torso gets the most benefit from treatment, while the head gets the least benefit.
 // Healing rates from treatment are doubled while sleeping.
 //
-TEST_CASE( "healing_rate_medicine with bandages and/or disinfectant", "[heal][bandage][disinfect]" )
+TEST_CASE( "healing_rate_medicine_with_bandages_and/or_disinfectant", "[heal][bandage][disinfect]" )
 {
     // There are no healing effects from medicine if no medicine has been applied.
     SECTION( "no bandages or disinfectant" ) {

--- a/tests/char_sight_test.cpp
+++ b/tests/char_sight_test.cpp
@@ -48,7 +48,7 @@ static const trait_id trait_URSINE_EYE( "URSINE_EYE" );
 //
 // TODO: Test 'pos' (position) parameter to fine_detail_vision_mod
 //
-TEST_CASE( "light and fine_detail_vision_mod", "[character][sight][light][vision]" )
+TEST_CASE( "light_and_fine_detail_vision_mod", "[character][sight][light][vision]" )
 {
     Character &dummy = get_player_character();
     map &here = get_map();
@@ -111,7 +111,7 @@ TEST_CASE( "light and fine_detail_vision_mod", "[character][sight][light][vision
 //
 // Character::sight_impaired() returns true if sight is thus restricted.
 //
-TEST_CASE( "character sight limits", "[character][sight][vision]" )
+TEST_CASE( "character_sight_limits", "[character][sight][vision]" )
 {
     Character &dummy = get_player_character();
     map &here = get_map();
@@ -207,7 +207,7 @@ TEST_CASE( "character sight limits", "[character][sight][vision]" )
 // FIXME: Rename unimpaired_range() to impaired_range()
 // (it specifically includes all the things that impair visibility)
 //
-TEST_CASE( "ursine vision", "[character][ursine][vision]" )
+TEST_CASE( "ursine_vision", "[character][ursine][vision]" )
 {
     Character &dummy = get_player_character();
     map &here = get_map();

--- a/tests/char_stamina_test.cpp
+++ b/tests/char_stamina_test.cpp
@@ -143,7 +143,7 @@ static float actual_regen_rate( Character &dummy, int turns )
 // Test cases
 // ----------
 
-TEST_CASE( "stamina movement cost modifier", "[stamina][cost]" )
+TEST_CASE( "stamina_movement_cost_modifier", "[stamina][cost]" )
 {
     Character &dummy = get_player_character();
 
@@ -190,7 +190,7 @@ TEST_CASE( "stamina movement cost modifier", "[stamina][cost]" )
     }
 }
 
-TEST_CASE( "modify character stamina", "[stamina][modify]" )
+TEST_CASE( "modify_character_stamina", "[stamina][modify]" )
 {
     Character &dummy = get_player_character();
     clear_avatar();
@@ -265,7 +265,7 @@ TEST_CASE( "modify character stamina", "[stamina][modify]" )
     }
 }
 
-TEST_CASE( "stamina burn for movement", "[stamina][burn][move]" )
+TEST_CASE( "stamina_burn_for_movement", "[stamina][burn][move]" )
 {
     Character &dummy = get_player_character();
 
@@ -328,7 +328,7 @@ TEST_CASE( "stamina burn for movement", "[stamina][burn][move]" )
     }
 }
 
-TEST_CASE( "burning stamina when overburdened may cause pain", "[stamina][burn][pain]" )
+TEST_CASE( "burning_stamina_when_overburdened_may_cause_pain", "[stamina][burn][pain]" )
 {
     Character &dummy = get_player_character();
     int pain_before;
@@ -371,7 +371,7 @@ TEST_CASE( "burning stamina when overburdened may cause pain", "[stamina][burn][
     }
 }
 
-TEST_CASE( "stamina regeneration rate", "[stamina][update][regen]" )
+TEST_CASE( "stamina_regeneration_rate", "[stamina][update][regen]" )
 {
     Character &dummy = get_player_character();
     clear_avatar();
@@ -400,7 +400,7 @@ TEST_CASE( "stamina regeneration rate", "[stamina][update][regen]" )
     }
 }
 
-TEST_CASE( "stamina regen in different movement modes", "[stamina][update][regen][mode]" )
+TEST_CASE( "stamina_regen_in_different_movement_modes", "[stamina][update][regen][mode]" )
 {
     Character &dummy = get_player_character();
     clear_avatar();
@@ -436,7 +436,7 @@ TEST_CASE( "stamina regen in different movement modes", "[stamina][update][regen
     }
 }
 
-TEST_CASE( "stamina regen with mouth encumbrance", "[stamina][update][regen][encumbrance]" )
+TEST_CASE( "stamina_regen_with_mouth_encumbrance", "[stamina][update][regen][encumbrance]" )
 {
     Character &dummy = get_player_character();
     clear_avatar();

--- a/tests/char_suffer_test.cpp
+++ b/tests/char_suffer_test.cpp
@@ -98,7 +98,7 @@ static int test_suffer_pain_felt( Character &dummy, const time_duration &dur )
 // - Most of the time (59/60 chance), 1 focus is lost, or 2 without sunglasses
 // - Sometimes (1/60 chance), there is 1 pain instead, or 2 without sunglasses
 //
-TEST_CASE( "suffering from albinism", "[char][suffer][albino]" )
+TEST_CASE( "suffering_from_albinism", "[char][suffer][albino]" )
 {
     clear_map();
     avatar &dummy = get_avatar();
@@ -203,7 +203,7 @@ TEST_CASE( "suffering from albinism", "[char][suffer][albino]" )
 // - Chance of pain and HP loss is directly proportional to skin exposure on each body part
 // -
 //
-TEST_CASE( "suffering from sunburn", "[char][suffer][sunburn]" )
+TEST_CASE( "suffering_from_sunburn", "[char][suffer][sunburn]" )
 {
     clear_map();
     clear_avatar();
@@ -368,7 +368,7 @@ TEST_CASE( "suffering from sunburn", "[char][suffer][sunburn]" )
     }
 }
 
-TEST_CASE( "suffering from asphyxiation", "[char][suffer][oxygen][grab]" )
+TEST_CASE( "suffering_from_asphyxiation", "[char][suffer][oxygen][grab]" )
 {
     clear_map();
     clear_avatar();

--- a/tests/character_modifier_test.cpp
+++ b/tests/character_modifier_test.cpp
@@ -67,7 +67,7 @@ static void create_bird_char( Character &dude )
     REQUIRE( !dude.has_part( body_part_foot_r ) );
 }
 
-TEST_CASE( "Basic limb score test", "[character][encumbrance]" )
+TEST_CASE( "Basic_limb_score_test", "[character][encumbrance]" )
 {
     standard_npc dude( "Test NPC" );
     create_char( dude );
@@ -109,7 +109,7 @@ TEST_CASE( "Basic limb score test", "[character][encumbrance]" )
     }
 }
 
-TEST_CASE( "Basic character modifier test", "[character][encumbrance]" )
+TEST_CASE( "Basic_character_modifier_test", "[character][encumbrance]" )
 {
     standard_npc dude( "Test NPC" );
     create_char( dude );
@@ -153,7 +153,7 @@ TEST_CASE( "Basic character modifier test", "[character][encumbrance]" )
     }
 }
 
-TEST_CASE( "Body part armor vs. damage", "[character]" )
+TEST_CASE( "Body_part_armor_vs_damage", "[character]" )
 {
     standard_npc dude( "Test NPC" );
     create_char( dude );
@@ -208,7 +208,7 @@ static double get_limbtype_modval( const double &val, const bodypart_id &id,
     return ret;
 }
 
-TEST_CASE( "Mutation armor vs. damage", "[character][mutation]" )
+TEST_CASE( "Mutation_armor_vs_damage", "[character][mutation]" )
 {
     standard_npc dude( "Test NPC" );
     clear_character( dude, true );
@@ -350,7 +350,7 @@ TEST_CASE( "Mutation armor vs. damage", "[character][mutation]" )
     }
 }
 
-TEST_CASE( "Multi-limbscore modifiers", "[character]" )
+TEST_CASE( "Multi-limbscore_modifiers", "[character]" )
 {
     standard_npc dude( "Test NPC" );
     create_char( dude );
@@ -402,7 +402,7 @@ TEST_CASE( "Multi-limbscore modifiers", "[character]" )
     }
 }
 
-TEST_CASE( "Slip prevention modifier / weighted-list multi-score modifiers", "[character]" )
+TEST_CASE( "Slip_prevention_modifier_/_weighted-list_multi-score_modifiers", "[character]" )
 {
     standard_npc dude( "Test NPC" );
     create_char( dude );
@@ -450,7 +450,7 @@ TEST_CASE( "Slip prevention modifier / weighted-list multi-score modifiers", "[c
     }
 }
 
-TEST_CASE( "Weighted limb types", "[character]" )
+TEST_CASE( "Weighted_limb_types", "[character]" )
 {
     item boxing_gloves( "test_boxing_gloves" );
     item wing_covers( "test_winglets" );

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -61,7 +61,7 @@ void create_tile_zone( const std::string &name, const zone_type_id &zone_type, t
 
 } // namespace
 
-TEST_CASE( "zone unloading ammo belts", "[zones][items][ammo_belt][activities][unload]" )
+TEST_CASE( "zone_unloading_ammo_belts", "[zones][items][ammo_belt][activities][unload]" )
 {
     avatar &dummy = get_avatar();
     map &here = get_map();
@@ -119,7 +119,7 @@ TEST_CASE( "zone unloading ammo belts", "[zones][items][ammo_belt][activities][u
 // Comestibles sorting is a bit awkward. Unlike other loot, they're almost
 // always inside of a container, and their sort zone changes based on their
 // shelf life and whether the container prevents rotting.
-TEST_CASE( "zone sorting comestibles ", "[zones][items][food][activities]" )
+TEST_CASE( "zone_sorting_comestibles_", "[zones][items][food][activities]" )
 {
     clear_map();
     zone_manager &zm = zone_manager::get_manager();

--- a/tests/colony_test.cpp
+++ b/tests/colony_test.cpp
@@ -27,7 +27,7 @@ unsigned int xor_rand()
     return w = w ^ ( w >> 19 ) ^ ( t ^ ( t >> 8 ) );
 }
 
-TEST_CASE( "colony basics", "[colony]" )
+TEST_CASE( "colony_basics", "[colony]" )
 {
     cata::colony<int *> test_colony;
 
@@ -269,7 +269,7 @@ TEST_CASE( "colony basics", "[colony]" )
     CHECK( test_colony_2.max_size() > test_colony_2.size() );
 }
 
-TEST_CASE( "colony insert and erase", "[colony]" )
+TEST_CASE( "colony_insert_and_erase", "[colony]" )
 {
     cata::colony<int> test_colony;
 
@@ -504,7 +504,7 @@ TEST_CASE( "colony insert and erase", "[colony]" )
     CHECK( test_colony.size() == static_cast<size_t>( count ) );
 }
 
-TEST_CASE( "colony range erase", "[colony]" )
+TEST_CASE( "colony_range_erase", "[colony]" )
 {
     cata::colony<int> test_colony;
 
@@ -767,7 +767,7 @@ TEST_CASE( "colony range erase", "[colony]" )
     CHECK( test_colony.size() == 10 );
 }
 
-TEST_CASE( "colony sort", "[colony]" )
+TEST_CASE( "colony_sort", "[colony]" )
 {
     cata::colony<int> test_colony;
 
@@ -809,7 +809,7 @@ TEST_CASE( "colony sort", "[colony]" )
     CHECK( sorted );
 }
 
-TEST_CASE( "colony insertion methods", "[colony]" )
+TEST_CASE( "colony_insertion_methods", "[colony]" )
 {
     cata::colony<int> test_colony = {1, 2, 3};
 
@@ -892,7 +892,7 @@ TEST_CASE( "colony insertion methods", "[colony]" )
     CHECK( sum == 12060 );
 }
 
-TEST_CASE( "colony perfect forwarding", "[colony]" )
+TEST_CASE( "colony_perfect_forwarding", "[colony]" )
 {
     cata::colony<perfect_forwarding_test> test_colony;
 
@@ -905,7 +905,7 @@ TEST_CASE( "colony perfect forwarding", "[colony]" )
     CHECK( lvalueref == 1 );
 }
 
-TEST_CASE( "colony emplace", "[colony]" )
+TEST_CASE( "colony_emplace", "[colony]" )
 {
     cata::colony<small_struct> test_colony;
     int sum1 = 0;
@@ -926,7 +926,7 @@ TEST_CASE( "colony emplace", "[colony]" )
     CHECK( test_colony.size() == 100 );
 }
 
-TEST_CASE( "colony group size and capacity", "[colony]" )
+TEST_CASE( "colony_group_size_and_capacity", "[colony]" )
 {
     cata::colony<int> test_colony;
     test_colony.change_group_sizes( 50, 100 );
@@ -969,7 +969,7 @@ TEST_CASE( "colony group size and capacity", "[colony]" )
     CHECK( test_colony.capacity() == 3400 );
 }
 
-TEST_CASE( "colony splice", "[colony]" )
+TEST_CASE( "colony_splice", "[colony]" )
 {
     cata::colony<int> test_colony_1;
     cata::colony<int> test_colony_2;

--- a/tests/comestible_test.cpp
+++ b/tests/comestible_test.cpp
@@ -269,7 +269,7 @@ TEST_CASE( "cooked_veggies_get_correct_calorie_prediction", "[recipe]" )
 // representing the "satiety" of the food, with higher numbers being more calorie-dense, and lower
 // numbers being less so.
 //
-TEST_CASE( "effective food volume and satiety", "[character][food][satiety]" )
+TEST_CASE( "effective_food_volume_and_satiety", "[character][food][satiety]" )
 {
     const Character &u = get_player_character();
     double expect_ratio;
@@ -316,7 +316,7 @@ TEST_CASE( "effective food volume and satiety", "[character][food][satiety]" )
 // satiety_bar returns a colorized string indicating a satiety level, similar to hit point bars
 // where "....." is minimum (~ 0) and "|||||" is maximum (~ 1500)
 //
-TEST_CASE( "food satiety bar", "[character][food][satiety]" )
+TEST_CASE( "food_satiety_bar", "[character][food][satiety]" )
 {
     // NOLINTNEXTLINE(cata-text-style): verbatim ellipses necessary for validation
     CHECK( satiety_bar( 0 ) == "<color_c_red></color>....." );

--- a/tests/connect_rotate_test.cpp
+++ b/tests/connect_rotate_test.cpp
@@ -20,7 +20,7 @@ class cata_tiles_test_helper
         }
 };
 
-TEST_CASE( "walls should be unconnected without nearby walls", "[multitile][connects]" )
+TEST_CASE( "walls_should_be_unconnected_without_nearby_walls", "[multitile][connects]" )
 {
     map &here = get_map();
     clear_map();
@@ -50,7 +50,7 @@ TEST_CASE( "walls should be unconnected without nearby walls", "[multitile][conn
         }
     }
 }
-TEST_CASE( "walls should connect to walls as end pieces", "[multitile][connects]" )
+TEST_CASE( "walls_should_connect_to_walls_as_end_pieces", "[multitile][connects]" )
 {
     map &here = get_map();
     clear_map();
@@ -119,7 +119,7 @@ TEST_CASE( "walls should connect to walls as end pieces", "[multitile][connects]
         }
     }
 }
-TEST_CASE( "walls should connect to walls as corners", "[multitile][connects]" )
+TEST_CASE( "walls_should_connect_to_walls_as_corners", "[multitile][connects]" )
 {
     map &here = get_map();
     clear_map();
@@ -188,7 +188,7 @@ TEST_CASE( "walls should connect to walls as corners", "[multitile][connects]" )
         }
     }
 }
-TEST_CASE( "walls should connect to walls as edges", "[multitile][connects]" )
+TEST_CASE( "walls_should_connect_to_walls_as_edges", "[multitile][connects]" )
 {
     map &here = get_map();
     clear_map();
@@ -231,7 +231,7 @@ TEST_CASE( "walls should connect to walls as edges", "[multitile][connects]" )
         }
     }
 }
-TEST_CASE( "walls should connect to walls as t-connections and fully", "[multitile][connects]" )
+TEST_CASE( "walls_should_connect_to_walls_as_t-connections_and_fully", "[multitile][connects]" )
 {
     map &here = get_map();
     clear_map();
@@ -315,7 +315,7 @@ TEST_CASE( "walls should connect to walls as t-connections and fully", "[multiti
     }
 }
 
-TEST_CASE( "windows should connect to walls and rotate to indoor floor", "[multitile][rotates]" )
+TEST_CASE( "windows_should_connect_to_walls_and_rotate_to_indoor_floor", "[multitile][rotates]" )
 {
     map &here = get_map();
     clear_map();
@@ -439,7 +439,7 @@ TEST_CASE( "windows should connect to walls and rotate to indoor floor", "[multi
     }
 }
 
-TEST_CASE( "unconnected windows rotate to indoor floor", "[multitile][rotates]" )
+TEST_CASE( "unconnected_windows_rotate_to_indoor_floor", "[multitile][rotates]" )
 {
     map &here = get_map();
     clear_map();

--- a/tests/consumption_time_test.cpp
+++ b/tests/consumption_time_test.cpp
@@ -2,7 +2,7 @@
 #include "item.h"
 #include "cata_catch.h"
 
-TEST_CASE( "characters with no mutations take at least 1 second to consume comestibles",
+TEST_CASE( "characters_with_no_mutations_take_at_least_1_second_to_consume_comestibles",
            "[character][item][food][time]" )
 {
     GIVEN( "a character with no mutations and a comestible" ) {

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -157,7 +157,7 @@ static float get_avg_bullet_dmg( const std::string &clothing_id )
     return static_cast<float>( dam_acc ) / num_hits;
 }
 
-TEST_CASE( "Infections from filthy clothing", "[coverage]" )
+TEST_CASE( "Infections_from_filthy_clothing", "[coverage]" )
 {
     SECTION( "Full melee and ranged coverage vs. melee attack" ) {
         const float chance = get_avg_melee_dmg( "test_zentai", true );
@@ -170,7 +170,7 @@ TEST_CASE( "Infections from filthy clothing", "[coverage]" )
     }
 }
 
-TEST_CASE( "Melee coverage vs. melee damage", "[coverage] [melee] [damage]" )
+TEST_CASE( "Melee_coverage_vs_melee_damage", "[coverage] [melee] [damage]" )
 {
     SECTION( "Full melee and ranged coverage vs. melee attack" ) {
         const float dmg = get_avg_melee_dmg( "test_hazmat_suit" );
@@ -183,7 +183,7 @@ TEST_CASE( "Melee coverage vs. melee damage", "[coverage] [melee] [damage]" )
     }
 }
 
-TEST_CASE( "Ranged coverage vs. bullet", "[coverage] [ranged]" )
+TEST_CASE( "Ranged_coverage_vs_bullet", "[coverage] [ranged]" )
 {
     SECTION( "Full melee and ranged coverage vs. ranged attack" ) {
         const float dmg = get_avg_bullet_dmg( "test_hazmat_suit" );
@@ -196,7 +196,7 @@ TEST_CASE( "Ranged coverage vs. bullet", "[coverage] [ranged]" )
     }
 }
 
-TEST_CASE( "Proportional armor material resistances", "[material]" )
+TEST_CASE( "Proportional_armor_material_resistances", "[material]" )
 {
     SECTION( "Mostly steel armor vs. melee" ) {
         const float dmg = get_avg_melee_dmg( "test_swat_mostly_steel" );
@@ -219,7 +219,7 @@ TEST_CASE( "Proportional armor material resistances", "[material]" )
     }
 }
 
-TEST_CASE( "Ghost ablative vest", "[coverage]" )
+TEST_CASE( "Ghost_ablative_vest", "[coverage]" )
 {
     SECTION( "Ablative not covered same limb" ) {
         item full = item( "test_ghost_vest" );
@@ -237,7 +237,7 @@ TEST_CASE( "Ghost ablative vest", "[coverage]" )
     }
 }
 
-TEST_CASE( "Off Limb Ghost ablative vest", "[coverage]" )
+TEST_CASE( "Off_Limb_Ghost_ablative_vest", "[coverage]" )
 {
     SECTION( "Ablative not covered seperate limb" ) {
         item full = item( "test_ghost_vest" );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -732,7 +732,7 @@ TEST_CASE( "crafting_failure_rates_match_calculated", "[crafting][random]" )
     test_chances_for( armor_qt_lightplate, 98.f, 92.5, 89.f, 50.f, 81.f, 21.f, 2.25 );
 }
 
-TEST_CASE( "UPS shows as a crafting component", "[crafting][ups]" )
+TEST_CASE( "UPS_shows_as_a_crafting_component", "[crafting][ups]" )
 {
     avatar dummy;
     clear_character( dummy );
@@ -748,7 +748,7 @@ TEST_CASE( "UPS shows as a crafting component", "[crafting][ups]" )
     REQUIRE( units::to_kilojoule( dummy.available_ups() ) == 500 );
 }
 
-TEST_CASE( "UPS modded tools", "[crafting][ups]" )
+TEST_CASE( "UPS_modded_tools", "[crafting][ups]" )
 {
     constexpr int ammo_count = 500;
     bool const ups_on_ground = GENERATE( true, false );
@@ -795,7 +795,7 @@ TEST_CASE( "UPS modded tools", "[crafting][ups]" )
     REQUIRE( tinv.charges_of( soldering_iron->typeId() ) == ammo_count );
 }
 
-TEST_CASE( "tools use charge to craft", "[crafting][charge]" )
+TEST_CASE( "tools_use_charge_to_craft", "[crafting][charge]" )
 {
     std::vector<item> tools;
 
@@ -960,7 +960,7 @@ TEST_CASE( "tool_use", "[crafting][tool]" )
     }
 }
 
-TEST_CASE( "broken component", "[crafting][component]" )
+TEST_CASE( "broken_component", "[crafting][component]" )
 {
     GIVEN( "a recipe with its required components" ) {
         recipe_id test_recipe( "flashlight" );
@@ -1036,7 +1036,7 @@ static void verify_inventory( const std::vector<std::string> &has,
     }
 }
 
-TEST_CASE( "total crafting time with or without interruption", "[crafting][time][resume]" )
+TEST_CASE( "total_crafting_time_with_or_without_interruption", "[crafting][time][resume]" )
 {
     GIVEN( "a recipe and all the required tools and materials to craft it" ) {
         recipe_id test_recipe( "razor_shaving" );
@@ -1388,7 +1388,7 @@ static void clear_and_setup( Character &c, map &m, item &tool )
     m.i_clear( c.pos() );
 }
 
-TEST_CASE( "prompt for liquid containers - crafting 1 makeshift funnel", "[crafting]" )
+TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[crafting]" )
 {
     map &m = get_map();
     item pocketknife( itype_pockknife );
@@ -1603,7 +1603,7 @@ TEST_CASE( "prompt for liquid containers - crafting 1 makeshift funnel", "[craft
     }
 }
 
-TEST_CASE( "prompt for liquid containers - batch crafting 3 makeshift funnels", "[crafting]" )
+TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", "[crafting]" )
 {
     map &m = get_map();
     item pocketknife( itype_pockknife );
@@ -1830,7 +1830,7 @@ TEST_CASE( "prompt for liquid containers - batch crafting 3 makeshift funnels", 
     }
 }
 
-TEST_CASE( "Unloading non-empty components", "[crafting]" )
+TEST_CASE( "Unloading_non-empty_components", "[crafting]" )
 {
     item candle( itype_candle );
     item cash_card( itype_cash_card );
@@ -1850,7 +1850,7 @@ TEST_CASE( "Unloading non-empty components", "[crafting]" )
     CHECK( craft_command::safe_to_unload_comp( sewing_kit ) == true );
 }
 
-TEST_CASE( "Warn when using favorited component", "[crafting]" )
+TEST_CASE( "Warn_when_using_favorited_component", "[crafting]" )
 {
     map &m = get_map();
     clear_map();
@@ -1943,7 +1943,7 @@ static bool found_all_in_list( const std::vector<item> &items,
     return ret;
 }
 
-TEST_CASE( "recipe byproducts and byproduct groups", "[recipes][crafting]" )
+TEST_CASE( "recipe_byproducts_and_byproduct_groups", "[recipes][crafting]" )
 {
     GIVEN( "recipe with byproducts, normal definition" ) {
         const recipe *r = &recipe_test_tallow.obj();
@@ -2022,7 +2022,7 @@ TEST_CASE( "recipe byproducts and byproduct groups", "[recipes][crafting]" )
     }
 }
 
-TEST_CASE( "tools with charges as components", "[crafting]" )
+TEST_CASE( "tools_with_charges_as_components", "[crafting]" )
 {
     const int cotton_sheets_in_recipe = 2;
     const int threads_in_recipe = 10;
@@ -2115,7 +2115,7 @@ TEST_CASE( "tools with charges as components", "[crafting]" )
 // inherit_rot_from_components for a description of what "inheritied properly" means
 // using a default hotplate the macaroni uses 35x7 = 245 charges of hotplate, meat uses 35x20 = 700 charges of hotplate and 80x30 = 2400 charges of dehydrator
 // looks like tool_with_ammo cannot spawn a hotplate/dehydrator with more than 500 charges, so until the default battery is changed I'm giving player 10 of each
-TEST_CASE( "recipes inherit rot of components properly", "[crafting][rot]" )
+TEST_CASE( "recipes_inherit_rot_of_components_properly", "[crafting][rot]" )
 {
     Character &player_character = get_player_character();
     std::vector<item> tools;

--- a/tests/creature_effect_test.cpp
+++ b/tests/creature_effect_test.cpp
@@ -61,7 +61,7 @@ static const trait_id trait_SLIMY( "SLIMY" );
 // - Otherwise, add effect, and check if it is blocked by another effect
 
 // Characters have effects on separate body parts, or no particular part (indicated by `bp_null`)
-TEST_CASE( "character add_effect", "[creature][character][effect][add]" )
+TEST_CASE( "character_add_effect", "[creature][character][effect][add]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -103,7 +103,7 @@ TEST_CASE( "character add_effect", "[creature][character][effect][add]" )
 }
 
 // Monsters may have effects added to them, but they don't have separate body parts.
-TEST_CASE( "monster add_effect", "[creature][monster][effect][add]" )
+TEST_CASE( "monster_add_effect", "[creature][monster][effect][add]" )
 {
     monster mummy( mon_hallu_mom );
 
@@ -361,7 +361,7 @@ TEST_CASE( "has_effect_with_flag", "[creature][effect][has][flag]" )
 
 // monster::is_immune_effect
 //
-TEST_CASE( "monster is_immune_effect", "[creature][monster][effect][immune]" )
+TEST_CASE( "monster_is_immune_effect", "[creature][monster][effect][immune]" )
 {
     // TODO: Monster may be immune to:
     // - onfire (if is_immune_damage DT_HEAT, made_of LIQUID, has_flag MF_FIREY)
@@ -492,7 +492,7 @@ TEST_CASE( "monster is_immune_effect", "[creature][monster][effect][immune]" )
 
 // Character::is_immune_effect
 //
-TEST_CASE( "character is_immune_effect", "[creature][character][effect][immune]" )
+TEST_CASE( "character_is_immune_effect", "[creature][character][effect][immune]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -541,7 +541,7 @@ TEST_CASE( "character is_immune_effect", "[creature][character][effect][immune]"
 
 // Creature::resists_effect
 //
-TEST_CASE( "creature effect reistance", "[creature][effect][resist]" )
+TEST_CASE( "creature_effect_reistance", "[creature][effect][resist]" )
 {
     // TODO: Creature resists effect if:
     // - has effect from eff.get_resist_effects

--- a/tests/creature_test.cpp
+++ b/tests/creature_test.cpp
@@ -71,7 +71,7 @@ static void calculate_bodypart_distribution( const bool can_attack_high,
     }
 }
 
-TEST_CASE( "Check distribution of attacks to body parts for attackers who can't attack upper limbs.",
+TEST_CASE( "Check_distribution_of_attacks_to_body_parts_for_attackers_who_can_not_attack_upper_limbs",
            "[anatomy]" )
 {
     rng_set_engine_seed( 4242424242 );
@@ -84,7 +84,7 @@ TEST_CASE( "Check distribution of attacks to body parts for attackers who can't 
                                      expected_weights_max[0] );
 }
 
-TEST_CASE( "Check distribution of attacks to body parts for attackers who can attack upper limbs.",
+TEST_CASE( "Check_distribution_of_attacks_to_body_parts_for_attackers_who_can_attack_upper_limbs",
            "[anatomy]" )
 {
     rng_set_engine_seed( 4242424242 );

--- a/tests/degradation_test.cpp
+++ b/tests/degradation_test.cpp
@@ -48,7 +48,7 @@ static float get_avg_degradation( const itype_id &it, int count, int damage )
     return deg / count;
 }
 
-TEST_CASE( "Damage indicator thresholds", "[item][damage_level]" )
+TEST_CASE( "Damage_indicator_thresholds", "[item][damage_level]" )
 {
     struct damage_level_threshold {
         int min_damage;
@@ -85,7 +85,7 @@ TEST_CASE( "Damage indicator thresholds", "[item][damage_level]" )
     }
 }
 
-TEST_CASE( "Degradation on spawned items", "[item][degradation]" )
+TEST_CASE( "Degradation_on_spawned_items", "[item][degradation]" )
 {
     clear_map();
 
@@ -136,7 +136,7 @@ static void add_x_dmg_levels( item &it, int lvls )
     }
 }
 
-TEST_CASE( "Items that get damaged gain degradation", "[item][degradation]" )
+TEST_CASE( "Items_that_get_damaged_gain_degradation", "[item][degradation]" )
 {
     GIVEN( "An item with default degradation rate" ) {
         item it( itype_test_baseball );
@@ -242,7 +242,7 @@ static void setup_repair( item &fix, player_activity &act, Character &u )
 }
 
 // Testing activity_handlers::repair_item_finish / repair_item_actor::repair
-TEST_CASE( "Repairing degraded items", "[item][degradation]" )
+TEST_CASE( "Repairing_degraded_items", "[item][degradation]" )
 {
     // Setup map
     clear_map();
@@ -400,7 +400,7 @@ TEST_CASE( "Repairing degraded items", "[item][degradation]" )
 }
 
 // Testing activity_handlers::repair_item_finish / repair_item_actor::repair
-TEST_CASE( "Repairing items with specific requirements", "[item][degradation]" )
+TEST_CASE( "Repairing_items_with_specific_requirements", "[item][degradation]" )
 {
     Character &u = get_player_character();
     item fix( itype_test_steelball );
@@ -423,7 +423,7 @@ TEST_CASE( "Repairing items with specific requirements", "[item][degradation]" )
 }
 
 // Testing iuse::gun_repair
-TEST_CASE( "Gun repair with degradation", "[item][degradation]" )
+TEST_CASE( "Gun_repair_with_degradation", "[item][degradation]" )
 {
     GIVEN( "Gun with normal degradation" ) {
         Character &u = get_player_character();

--- a/tests/effect_test.cpp
+++ b/tests/effect_test.cpp
@@ -69,7 +69,7 @@ static void check_effect_init( const std::string &eff_name, const time_duration 
     CHECK( start_time == effect_obj.get_start_time() );
 }
 
-TEST_CASE( "effect initialization test", "[effect][init]" )
+TEST_CASE( "effect_initialization_test", "[effect][init]" )
 {
     // "debugged" effect is defined in data/mods/TEST_DATA/effects.json
     check_effect_init( "debugged", 1_days, "head", false, 5, calendar::turn_zero );
@@ -87,7 +87,7 @@ TEST_CASE( "effect initialization test", "[effect][init]" )
 // effect::mod_duration
 // effect::mult_duration
 //
-TEST_CASE( "effect duration", "[effect][duration]" )
+TEST_CASE( "effect_duration", "[effect][duration]" )
 {
     // "debugged" and "intensified" effects come from JSON effect data (data/mods/TEST_DATA/effects.json)
     effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 1_turns, body_part_bp_null,
@@ -153,7 +153,7 @@ TEST_CASE( "effect duration", "[effect][duration]" )
 // effect::get_int_dur_factor
 // effect::get_int_add_val
 //
-TEST_CASE( "effect intensity", "[effect][intensity]" )
+TEST_CASE( "effect_intensity", "[effect][intensity]" )
 {
     effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 3_turns, body_part_bp_null,
                          false, 1, calendar::turn );
@@ -179,7 +179,7 @@ TEST_CASE( "effect intensity", "[effect][intensity]" )
     }
 }
 
-TEST_CASE( "effect intensity removal", "[effect][intensity]" )
+TEST_CASE( "effect_intensity_removal", "[effect][intensity]" )
 {
     effect eff_test_int_remove( effect_source::empty(), &effect_test_int_remove.obj(), 3_turns,
                                 body_part_bp_null,
@@ -195,7 +195,7 @@ TEST_CASE( "effect intensity removal", "[effect][intensity]" )
 
 }
 
-TEST_CASE( "max effective intensity", "[effect][max][intensity]" )
+TEST_CASE( "max_effective_intensity", "[effect][max][intensity]" )
 {
     effect eff_maxed( effect_source::empty(), &effect_max_effected.obj(), 3_turns, body_part_bp_null,
                       false, 1, calendar::turn );
@@ -235,7 +235,7 @@ TEST_CASE( "max effective intensity", "[effect][max][intensity]" )
 // ------------
 // effect::decay
 //
-TEST_CASE( "effect decay", "[effect][decay]" )
+TEST_CASE( "effect_decay", "[effect][decay]" )
 {
     std::vector<efftype_id> rem_ids;
     std::vector<bodypart_id> rem_bps;
@@ -408,7 +408,7 @@ TEST_CASE( "effect decay", "[effect][decay]" )
 // ------------------
 // effect::disp_short_desc
 //
-TEST_CASE( "display short description", "[effect][desc]" )
+TEST_CASE( "display_short_description", "[effect][desc]" )
 {
     effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 1_turns, body_part_arm_r,
                          false, 1,
@@ -438,7 +438,7 @@ TEST_CASE( "display short description", "[effect][desc]" )
 // empty string (""), then it will not appear in the list of modifiers on the players speed (though
 // the effect might still have an effect)."""
 //
-TEST_CASE( "effect display and speed name may vary with intensity",
+TEST_CASE( "effect_display_and_speed_name_may_vary_with_intensity",
            "[effect][intensity][disp_name][speed_name]" )
 {
     GIVEN( "effect with names for each intensity level" ) {
@@ -507,7 +507,7 @@ TEST_CASE( "effect display and speed name may vary with intensity",
 // effect::pause_effect
 // effect::unpause_effect
 //
-TEST_CASE( "effect permanence", "[effect][permanent]" )
+TEST_CASE( "effect_permanence", "[effect][permanent]" )
 {
     // Grab right arm, not permanent
     effect eff_grabbed( effect_source::empty(), &effect_grabbed.obj(), 1_turns, body_part_arm_r, false,
@@ -533,7 +533,7 @@ TEST_CASE( "effect permanence", "[effect][permanent]" )
 // effect::set_bp
 // effect::get_bp
 //
-TEST_CASE( "effect body part", "[effect][bodypart]" )
+TEST_CASE( "effect_body_part", "[effect][bodypart]" )
 {
     // Grab right arm, initially
     effect eff_grabbed( effect_source::empty(), &effect_grabbed.obj(), 1_turns, body_part_arm_r, false,
@@ -559,7 +559,7 @@ TEST_CASE( "effect body part", "[effect][bodypart]" )
 // effect::get_sizing
 // effect::get_percentage
 //
-TEST_CASE( "effect modifiers", "[effect][modifier]" )
+TEST_CASE( "effect_modifiers", "[effect][modifier]" )
 {
     SECTION( "base_mods apply equally for any intensity" ) {
         effect eff_debugged( effect_source::empty(), &effect_debugged.obj(), 1_minutes, body_part_bp_null,
@@ -666,7 +666,7 @@ TEST_CASE( "bleed_effect_attribution", "[effect][bleed][monster]" )
     }
 }
 
-TEST_CASE( "Vitamin Effects", "[effect][vitamins]" )
+TEST_CASE( "Vitamin_Effects", "[effect][vitamins]" )
 {
     Character &subject = get_avatar();
     clear_avatar();
@@ -768,7 +768,7 @@ static void test_deadliness( const effect &applied, const int expected_dead, con
     CHECK( dead == Approx( expected_dead ).margin( margin ) );
 }
 
-TEST_CASE( "Death Effects", "[effect][death]" )
+TEST_CASE( "Death_Effects", "[effect][death]" )
 {
     effect placebo_effect( effect_source::empty(), &( *effect_test_fatalism ), 5_seconds,
                            body_part_torso, false, 1,

--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -111,7 +111,7 @@ static void check_accuracy_dps( avatar &attacker, monster &defender, item &wpn1,
     CHECK( dps_wpn2 > dps_wpn1 );
     CHECK( dps_wpn3 > dps_wpn2 );
 }
-TEST_CASE( "effective damage per second", "[effective][dps]" )
+TEST_CASE( "effective_damage_per_second", "[effective][dps]" )
 {
     avatar &dummy = get_avatar();
     clear_character( dummy );
@@ -174,7 +174,7 @@ TEST_CASE( "effective damage per second", "[effective][dps]" )
     }
 }
 
-TEST_CASE( "effective vs actual damage per second", "[actual][dps][!mayfail]" )
+TEST_CASE( "effective_vs_actual_damage_per_second", "[actual][dps][!mayfail]" )
 {
     avatar &dummy = get_avatar();
     clear_character( dummy );
@@ -206,7 +206,7 @@ TEST_CASE( "effective vs actual damage per second", "[actual][dps][!mayfail]" )
     }
 }
 
-TEST_CASE( "accuracy increases success", "[accuracy][dps]" )
+TEST_CASE( "accuracy_increases_success", "[accuracy][dps]" )
 {
     avatar &dummy = get_avatar();
     clear_character( dummy );
@@ -269,7 +269,7 @@ static void make_experienced_tester( avatar &test_guy )
  * of range without anyone noticing them and adjusting them.
  * Used expected_dps(), which should make actual dps because of the calculations above.
  */
-TEST_CASE( "expected weapon dps", "[expected][dps]" )
+TEST_CASE( "expected_weapon_dps", "[expected][dps]" )
 {
     avatar &test_guy = get_avatar();
     make_experienced_tester( test_guy );

--- a/tests/enchantments_test.cpp
+++ b/tests/enchantments_test.cpp
@@ -65,7 +65,7 @@ static enchant_test set_enc_test( avatar &p )
     return enc_test;
 }
 
-TEST_CASE( "worn enchantments", "[enchantments][worn][items]" )
+TEST_CASE( "worn_enchantments", "[enchantments][worn][items]" )
 {
     avatar p;
     clear_character( p );
@@ -84,7 +84,7 @@ TEST_CASE( "worn enchantments", "[enchantments][worn][items]" )
 
 }
 
-TEST_CASE( "bionic enchantments", "[enchantments][bionics]" )
+TEST_CASE( "bionic_enchantments", "[enchantments][bionics]" )
 {
     avatar p;
     clear_character( p );
@@ -99,7 +99,7 @@ TEST_CASE( "bionic enchantments", "[enchantments][bionics]" )
     test_generic_ench( p, enc_test );
 }
 
-TEST_CASE( "mutation enchantments", "[enchantments][mutations]" )
+TEST_CASE( "mutation_enchantments", "[enchantments][mutations]" )
 {
     avatar p;
     clear_character( p );

--- a/tests/encumbrance_test.cpp
+++ b/tests/encumbrance_test.cpp
@@ -122,7 +122,7 @@ TEST_CASE( "separate_layer_encumbrance", "[encumbrance]" )
                       longshirt_e + load_bearing );
 }
 
-TEST_CASE( "Complicated with split layers no conflict", "[encumbrance]" )
+TEST_CASE( "Complicated_with_split_layers_no_conflict", "[encumbrance]" )
 {
     test_encumbrance( { "test_complex_phase", "test_ballistic_vest" }, "torso",
                       ballistic + complex_phase );

--- a/tests/field_test.cpp
+++ b/tests/field_test.cpp
@@ -159,7 +159,7 @@ static void fields_test_cleanup()
     clear_map();
 }
 
-TEST_CASE( "fd_acid falls down", "[field]" )
+TEST_CASE( "fd_acid_falls_down", "[field]" )
 {
     fields_test_setup();
 
@@ -197,7 +197,7 @@ TEST_CASE( "fd_acid falls down", "[field]" )
     fields_test_cleanup();
 }
 
-TEST_CASE( "fire spreading", "[field][!mayfail]" )
+TEST_CASE( "fire_spreading", "[field][!mayfail]" )
 {
     fields_test_setup();
     scoped_weather_override weather_clear( WEATHER_CLEAR );
@@ -252,7 +252,7 @@ TEST_CASE( "fire spreading", "[field][!mayfail]" )
 }
 
 // tests fd_fire_vent <-> fd_flame_burst cycle
-TEST_CASE( "fd_fire and fd_fire_vent test", "[field]" )
+TEST_CASE( "fd_fire_and_fd_fire_vent_test", "[field]" )
 {
     fields_test_setup();
 
@@ -314,7 +314,7 @@ TEST_CASE( "fd_fire and fd_fire_vent test", "[field]" )
 }
 
 // tests wandering_field property fd_smoke_vent
-TEST_CASE( "wandering_field test", "[field]" )
+TEST_CASE( "wandering_field_test", "[field]" )
 {
     fields_test_setup();
 
@@ -344,7 +344,7 @@ TEST_CASE( "wandering_field test", "[field]" )
     fields_test_cleanup();
 }
 
-TEST_CASE( "radioactive field", "[field]" )
+TEST_CASE( "radioactive_field", "[field]" )
 {
     fields_test_setup();
     clear_radiation();
@@ -373,7 +373,7 @@ TEST_CASE( "radioactive field", "[field]" )
     fields_test_cleanup();
 }
 
-TEST_CASE( "fungal haze test", "[field]" )
+TEST_CASE( "fungal_haze_test", "[field]" )
 {
     fields_test_setup();
     const tripoint p{ 33, 33, 0 };
@@ -402,7 +402,7 @@ TEST_CASE( "fungal haze test", "[field]" )
     fields_test_cleanup();
 }
 
-TEST_CASE( "player_in_field test", "[field][player]" )
+TEST_CASE( "player_in_field_test", "[field][player]" )
 {
     fields_test_setup();
     clear_avatar();
@@ -441,7 +441,7 @@ TEST_CASE( "player_in_field test", "[field][player]" )
     fields_test_cleanup();
 }
 
-TEST_CASE( "field API test", "[field]" )
+TEST_CASE( "field_API_test", "[field]" )
 {
     fields_test_setup();
     const tripoint p{ 33, 33, 0 };

--- a/tests/firstaid_test.cpp
+++ b/tests/firstaid_test.cpp
@@ -38,7 +38,7 @@ static bool bandages_filter( const item &it )
     return ( it.typeId() == itype_bandages );
 }
 
-TEST_CASE( "avatar does healing", "[activity][firstaid][avatar]" )
+TEST_CASE( "avatar_does_healing", "[activity][firstaid][avatar]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();
@@ -93,7 +93,7 @@ TEST_CASE( "avatar does healing", "[activity][firstaid][avatar]" )
     }
 }
 
-TEST_CASE( "npc does healing", "[activity][firstaid][npc]" )
+TEST_CASE( "npc_does_healing", "[activity][firstaid][npc]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();

--- a/tests/food_fun_for_test.cpp
+++ b/tests/food_fun_for_test.cpp
@@ -27,7 +27,7 @@ static const trait_id trait_THRESH_LUPINE( "THRESH_LUPINE" );
 
 // Test cases for `Character::fun_for` defined in `src/consumption.cpp`
 
-TEST_CASE( "fun for non-food", "[fun_for][nonfood]" )
+TEST_CASE( "fun_for_non-food", "[fun_for][nonfood]" )
 {
     avatar dummy;
     std::pair<int, int> actual_fun;
@@ -42,7 +42,7 @@ TEST_CASE( "fun for non-food", "[fun_for][nonfood]" )
     }
 }
 
-TEST_CASE( "fun for food eaten while sick", "[fun_for][food][sick]" )
+TEST_CASE( "fun_for_food_eaten_while_sick", "[fun_for][food][sick]" )
 {
     avatar dummy;
     std::pair<int, int> actual_fun;
@@ -72,7 +72,7 @@ TEST_CASE( "fun for food eaten while sick", "[fun_for][food][sick]" )
     }
 }
 
-TEST_CASE( "fun for rotten food", "[fun_for][food][rotten]" )
+TEST_CASE( "fun_for_rotten_food", "[fun_for][food][rotten]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -117,7 +117,7 @@ TEST_CASE( "fun for rotten food", "[fun_for][food][rotten]" )
 }
 
 // N.B. food that tastes better hot is `modify_morale` with different math
-TEST_CASE( "fun for cold food", "[fun_for][food][cold]" )
+TEST_CASE( "fun_for_cold_food", "[fun_for][food][cold]" )
 {
     avatar dummy;
     std::pair<int, int> actual_fun;
@@ -208,7 +208,7 @@ TEST_CASE( "fun for cold food", "[fun_for][food][cold]" )
     }
 }
 
-TEST_CASE( "fun for melted food", "[fun_for][food][melted]" )
+TEST_CASE( "fun_for_melted_food", "[fun_for][food][melted]" )
 {
     avatar dummy;
     std::pair<int, int> actual_fun;
@@ -239,7 +239,7 @@ TEST_CASE( "fun for melted food", "[fun_for][food][melted]" )
     */
 }
 
-TEST_CASE( "fun for cat food", "[fun_for][food][cat][feline]" )
+TEST_CASE( "fun_for_cat_food", "[fun_for][food][cat][feline]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -270,7 +270,7 @@ TEST_CASE( "fun for cat food", "[fun_for][food][cat][feline]" )
     }
 }
 
-TEST_CASE( "fun for dog food", "[fun_for][food][dog][lupine]" )
+TEST_CASE( "fun_for_dog_food", "[fun_for][food][dog][lupine]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -302,7 +302,7 @@ TEST_CASE( "fun for dog food", "[fun_for][food][dog][lupine]" )
     }
 }
 
-TEST_CASE( "fun for gourmand", "[fun_for][food][gourmand]" )
+TEST_CASE( "fun_for_gourmand", "[fun_for][food][gourmand]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -361,7 +361,7 @@ TEST_CASE( "fun for gourmand", "[fun_for][food][gourmand]" )
     }
 }
 
-TEST_CASE( "fun for food eaten too often", "[fun_for][food][monotony]" )
+TEST_CASE( "fun_for_food_eaten_too_often", "[fun_for][food][monotony]" )
 {
     avatar dummy;
     std::pair<int, int> actual_fun;
@@ -406,7 +406,7 @@ TEST_CASE( "fun for food eaten too often", "[fun_for][food][monotony]" )
     }
 }
 
-TEST_CASE( "fun for bionic bio taste blocker", "[fun_for][food][bionic]" )
+TEST_CASE( "fun_for_bionic_bio_taste_blocker", "[fun_for][food][bionic]" )
 {
     avatar dummy;
     dummy.set_body();

--- a/tests/fuel_test.cpp
+++ b/tests/fuel_test.cpp
@@ -1,7 +1,7 @@
 #include "cata_catch.h"
 #include "item.h"
 
-TEST_CASE( "Fuel energy", "[energy]" )
+TEST_CASE( "Fuel_energy", "[energy]" )
 {
     item battery( "battery" );
     item gasoline( "gasoline" );

--- a/tests/gates_test.cpp
+++ b/tests/gates_test.cpp
@@ -10,7 +10,7 @@
 #include "sounds.h"
 #include "type_id.h"
 
-TEST_CASE( "doors should be able to open and close", "[gates]" )
+TEST_CASE( "doors_should_be_able_to_open_and_close", "[gates]" )
 {
     map &here = get_map();
     clear_map();
@@ -42,7 +42,7 @@ TEST_CASE( "doors should be able to open and close", "[gates]" )
     }
 }
 
-TEST_CASE( "windows should be able to open and close", "[gates]" )
+TEST_CASE( "windows_should_be_able_to_open_and_close", "[gates]" )
 {
     map &here = get_map();
     clear_map();
@@ -70,7 +70,7 @@ TEST_CASE( "windows should be able to open and close", "[gates]" )
 // Note that it is not intended for all doors and windows to make swish sound,
 // some doors and windows might make other types of sounds in the future
 // TODO: update test case when door and window sounds become defined in JSON.
-TEST_CASE( "doors and windows should make whoosh sound", "[gates]" )
+TEST_CASE( "doors_and_windows_should_make_whoosh_sound", "[gates]" )
 {
     map &here = get_map();
     clear_map();
@@ -137,7 +137,7 @@ TEST_CASE( "doors and windows should make whoosh sound", "[gates]" )
     }
 }
 
-TEST_CASE( "character should lose moves when opening or closing doors or windows", "[gates]" )
+TEST_CASE( "character_should_lose_moves_when_opening_or_closing_doors_or_windows", "[gates]" )
 {
     avatar &they = get_avatar();
     map &here = get_map();

--- a/tests/harvest_test.cpp
+++ b/tests/harvest_test.cpp
@@ -60,7 +60,7 @@ static void butcher_mon( const mtype_id &monid, const activity_id &actid, int *c
     }
 }
 
-TEST_CASE( "Harvest drops from dissecting corpse", "[harvest]" )
+TEST_CASE( "Harvest_drops_from_dissecting_corpse", "[harvest]" )
 {
     SECTION( "Mutagen samples" ) {
         int sample_count = 0;

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -747,7 +747,7 @@ static void merge_invlet_test( avatar &dummy, inventory_location from )
         merge_invlet_test( dummy, from ); \
     }
 
-TEST_CASE( "Inventory letter test", "[.invlet]" )
+TEST_CASE( "Inventory_letter_test", "[.invlet]" )
 {
     avatar &dummy = get_avatar();
     const tripoint spot( 60, 60, 0 );

--- a/tests/item_autopickup_test.cpp
+++ b/tests/item_autopickup_test.cpp
@@ -192,7 +192,7 @@ static void clear_everything()
     options.get_option( "AUTO_PICKUP_OWNED" ).setValue( "false" );
 }
 
-TEST_CASE( "auto pickup should recognize container content", "[autopickup][item]" )
+TEST_CASE( "auto_pickup_should_recognize_container_content", "[autopickup][item]" )
 {
     avatar &they = get_avatar();
     map &here = get_map();
@@ -270,7 +270,7 @@ TEST_CASE( "auto pickup should recognize container content", "[autopickup][item]
     }
 }
 
-TEST_CASE( "auto pickup should improve your life", "[autopickup][item]" )
+TEST_CASE( "auto_pickup_should_improve_your_life", "[autopickup][item]" )
 {
     avatar &they = get_avatar();
     map &here = get_map();
@@ -312,7 +312,7 @@ TEST_CASE( "auto pickup should improve your life", "[autopickup][item]" )
     }
 }
 
-TEST_CASE( "auto pickup should consider item rigidness and seal", "[autopickup][item]" )
+TEST_CASE( "auto_pickup_should_consider_item_rigidness_and_seal", "[autopickup][item]" )
 {
     avatar &they = get_avatar();
     clear_everything();
@@ -433,7 +433,7 @@ TEST_CASE( "auto pickup should consider item rigidness and seal", "[autopickup][
     }
 }
 
-TEST_CASE( "auto pickup should respect volume and weight limits", "[autopickup][item]" )
+TEST_CASE( "auto_pickup_should_respect_volume_and_weight_limits", "[autopickup][item]" )
 {
     avatar &they = get_avatar();
     clear_everything();
@@ -509,7 +509,7 @@ TEST_CASE( "auto pickup should respect volume and weight limits", "[autopickup][
     }
 }
 
-TEST_CASE( "auto pickup should consider item ownership", "[autopickup][item]" )
+TEST_CASE( "auto_pickup_should_consider_item_ownership", "[autopickup][item]" )
 {
     avatar &they = get_avatar();
     clear_everything();
@@ -570,7 +570,7 @@ TEST_CASE( "auto pickup should consider item ownership", "[autopickup][item]" )
     }
 }
 
-TEST_CASE( "auto pickup should not implicitly pickup corpses", "[autopickup][item]" )
+TEST_CASE( "auto_pickup_should_not_implicitly_pickup_corpses", "[autopickup][item]" )
 {
     avatar &they = get_avatar();
     clear_everything();

--- a/tests/item_contents_test.cpp
+++ b/tests/item_contents_test.cpp
@@ -87,7 +87,7 @@ TEST_CASE( "item_contents" )
     CHECK( tool_belt.empty() );
 }
 
-TEST_CASE( "overflow on combine", "[item]" )
+TEST_CASE( "overflow_on_combine", "[item]" )
 {
     clear_map();
     tripoint origin{ 60, 60, 0 };
@@ -104,7 +104,7 @@ TEST_CASE( "overflow on combine", "[item]" )
     CHECK( here.i_at( origin ).size() == 1 );
 }
 
-TEST_CASE( "overflow test", "[item]" )
+TEST_CASE( "overflow_test", "[item]" )
 {
     tripoint origin{ 60, 60, 0 };
     item purse( itype_purse );
@@ -116,7 +116,7 @@ TEST_CASE( "overflow test", "[item]" )
     CHECK( here.i_at( origin ).size() == 1 );
 }
 
-TEST_CASE( "overflow test into parent item", "[item]" )
+TEST_CASE( "overflow_test_into_parent_item", "[item]" )
 {
     clear_map();
     tripoint origin{ 60, 60, 0 };

--- a/tests/item_group_test.cpp
+++ b/tests/item_group_test.cpp
@@ -73,7 +73,7 @@ TEST_CASE( "spill_when_items_dont_fit", "[item_group]" )
     CHECK( observed_outside.size() == 3 );
 }
 
-TEST_CASE( "spawn with default charges and with ammo", "[item_group]" )
+TEST_CASE( "spawn_with_default_charges_and_with_ammo", "[item_group]" )
 {
     Item_modifier default_charges;
     default_charges.with_ammo = 100;
@@ -92,7 +92,7 @@ TEST_CASE( "spawn with default charges and with ammo", "[item_group]" )
     }
 }
 
-TEST_CASE( "Item_modifier damages item", "[item_group]" )
+TEST_CASE( "Item_modifier_damages_item", "[item_group]" )
 {
     Item_modifier damaged;
     damaged.damage.first = 1;
@@ -113,7 +113,7 @@ TEST_CASE( "Item_modifier damages item", "[item_group]" )
     }
 }
 
-TEST_CASE( "Item_modifier gun fouling", "[item_group]" )
+TEST_CASE( "Item_modifier_gun_fouling", "[item_group]" )
 {
     Item_modifier fouled;
     fouled.dirt.first = 1;
@@ -133,7 +133,7 @@ TEST_CASE( "Item_modifier gun fouling", "[item_group]" )
     }
 }
 
-TEST_CASE( "item_modifier modifies charges for item", "[item_group]" )
+TEST_CASE( "item_modifier_modifies_charges_for_item", "[item_group]" )
 {
     GIVEN( "an ammo item that uses charges" ) {
         const std::string item_id = "40x46mm_m1006";
@@ -241,7 +241,7 @@ TEST_CASE( "item_modifier modifies charges for item", "[item_group]" )
     }
 }
 
-TEST_CASE( "Event-based item spawns do not spawn outside event", "[item_group]" )
+TEST_CASE( "Event-based_item_spawns_do_not_spawn_outside_event", "[item_group]" )
 {
     override_option ev_spawn_opt( "EVENT_SPAWNS", "items" );
     REQUIRE( get_option<std::string>( "EVENT_SPAWNS" ) == "items" );

--- a/tests/item_pickup_test.cpp
+++ b/tests/item_pickup_test.cpp
@@ -20,7 +20,7 @@ static const itype_id itype_rope_6( "rope_6" );
 //
 // namely, that these functions create *copies* of the items, and the original item
 // references will not refer to the items placed in inventory.
-TEST_CASE( "putting items into inventory with put_in or i_add", "[pickup][inventory]" )
+TEST_CASE( "putting_items_into_inventory_with_put_in_or_i_add", "[pickup][inventory]" )
 {
     avatar &they = get_avatar();
     map &here = get_map();
@@ -133,7 +133,7 @@ TEST_CASE( "putting items into inventory with put_in or i_add", "[pickup][invent
 // The reproduction use case here is: Wearing only a backpack containing a rope, when picking up
 // an M4 from the ground, the M4 should go into the backpack, not into the rope, and neither the
 // rope nor the M4 should be dropped.
-TEST_CASE( "pickup m4 with a rope in a hiking backpack", "[pickup][container]" )
+TEST_CASE( "pickup_m4_with_a_rope_in_a_hiking_backpack", "[pickup][container]" )
 {
     avatar &they = get_avatar();
     map &here = get_map();

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -140,7 +140,7 @@ static void expect_cannot_insert( item_pocket &pocket, const item &it,
 // Functions:
 // item_pocket::can_contain
 //
-TEST_CASE( "max item length", "[pocket][max_item_length]" )
+TEST_CASE( "max_item_length", "[pocket][max_item_length]" )
 {
     // Test items with different lengths
     item screwdriver( "test_screwdriver" );
@@ -235,7 +235,7 @@ TEST_CASE( "max item length", "[pocket][max_item_length]" )
 // Functions:
 // item_pocket::can_contain
 //
-TEST_CASE( "max item volume", "[pocket][max_item_volume]" )
+TEST_CASE( "max_item_volume", "[pocket][max_item_volume]" )
 {
     // Test items
     item screwdriver( "test_screwdriver" );
@@ -313,7 +313,7 @@ TEST_CASE( "max item volume", "[pocket][max_item_volume]" )
 // Functions:
 // pocket_data::max_contains_volume
 //
-TEST_CASE( "max container volume", "[pocket][max_contains_volume]" )
+TEST_CASE( "max_container_volume", "[pocket][max_contains_volume]" )
 {
     // TODO: Add tests for having multiple ammo types in the ammo_restriction
 
@@ -358,7 +358,7 @@ TEST_CASE( "max container volume", "[pocket][max_contains_volume]" )
 // item_pocket::can_contain
 // item_pocket::insert_item
 //
-TEST_CASE( "magazine with ammo restriction", "[pocket][magazine][ammo_restriction]" )
+TEST_CASE( "magazine_with_ammo_restriction", "[pocket][magazine][ammo_restriction]" )
 {
     pocket_data data_mag( item_pocket::pocket_type::MAGAZINE );
 
@@ -453,7 +453,7 @@ TEST_CASE( "magazine with ammo restriction", "[pocket][magazine][ammo_restrictio
 // item_pocket::can_contain
 // pocket_data::max_contains_volume
 //
-TEST_CASE( "pocket with item flag restriction", "[pocket][flag_restriction]" )
+TEST_CASE( "pocket_with_item_flag_restriction", "[pocket][flag_restriction]" )
 {
     // Items with BELT_CLIP flag
     item screwdriver( "test_screwdriver" );
@@ -580,7 +580,7 @@ TEST_CASE( "pocket with item flag restriction", "[pocket][flag_restriction]" )
 // item_pocket::can_contain
 // item_pocket::insert_item
 //
-TEST_CASE( "holster can contain one fitting item", "[pocket][holster]" )
+TEST_CASE( "holster_can_contain_one_fitting_item", "[pocket][holster]" )
 {
     // Start with a basic test handgun from data/mods/TEST_DATA/items.json
     item glock( "test_glock" );
@@ -668,7 +668,7 @@ TEST_CASE( "holster can contain one fitting item", "[pocket][holster]" )
 // Functions:
 // item_pocket::watertight
 //
-TEST_CASE( "pockets containing liquids", "[pocket][watertight][liquid]" )
+TEST_CASE( "pockets_containing_liquids", "[pocket][watertight][liquid]" )
 {
     // Liquids
     item ketchup( "ketchup", calendar::turn_zero, item::default_charges_tag{} );
@@ -768,7 +768,7 @@ TEST_CASE( "pockets containing liquids", "[pocket][watertight][liquid]" )
 // Functions:
 // item_pocket::airtight
 //
-TEST_CASE( "pockets containing gases", "[pocket][airtight][gas]" )
+TEST_CASE( "pockets_containing_gases", "[pocket][airtight][gas]" )
 {
     item gas( "test_gas", calendar::turn_zero, item::default_charges_tag{} );
 
@@ -821,7 +821,7 @@ TEST_CASE( "pockets containing gases", "[pocket][airtight][gas]" )
 // item_pocket::insert_item
 // item_pocket::item_size_modifier
 //
-TEST_CASE( "rigid and non-rigid or flexible pockets", "[pocket][rigid][flexible]" )
+TEST_CASE( "rigid_and_non-rigid_or_flexible_pockets", "[pocket][rigid][flexible]" )
 {
     item rock( "test_rock" );
 
@@ -926,7 +926,7 @@ TEST_CASE( "rigid and non-rigid or flexible pockets", "[pocket][rigid][flexible]
 // item_pocket::can_contain
 // item_pocket::insert_item
 //
-TEST_CASE( "corpse can contain anything", "[pocket][corpse]" )
+TEST_CASE( "corpse_can_contain_anything", "[pocket][corpse]" )
 {
     item rock( "test_rock" );
     item glock( "test_glock" );
@@ -958,7 +958,7 @@ TEST_CASE( "corpse can contain anything", "[pocket][corpse]" )
 // item_pocket::sealed
 // item_pocket::sealable
 //
-TEST_CASE( "sealed containers", "[pocket][seal]" )
+TEST_CASE( "sealed_containers", "[pocket][seal]" )
 {
     item water( "water" );
 
@@ -1045,7 +1045,7 @@ TEST_CASE( "sealed containers", "[pocket][seal]" )
 // Functions:
 // item_pocket::better_pocket
 //
-TEST_CASE( "when one pocket is better than another", "[pocket][better]" )
+TEST_CASE( "when_one_pocket_is_better_than_another", "[pocket][better]" )
 {
     // TODO:
     // settings.is_better_favorite() is top priority
@@ -1117,7 +1117,7 @@ static item_pocket *get_only_pocket( item &container )
     return pockets[0];
 }
 
-TEST_CASE( "best pocket in item contents", "[pocket][item][best]" )
+TEST_CASE( "best_pocket_in_item_contents", "[pocket][item][best]" )
 {
     item_location loc;
 
@@ -1236,7 +1236,7 @@ TEST_CASE( "best pocket in item contents", "[pocket][item][best]" )
 // item_pocket::favorite_settings::get_item_whitelist
 // item_pocket::favorite_settings::get_item_blacklist
 //
-TEST_CASE( "pocket favorites allow or restrict items", "[pocket][favorite][item]" )
+TEST_CASE( "pocket_favorites_allow_or_restrict_items", "[pocket][favorite][item]" )
 {
     item_location loc;
 
@@ -1398,7 +1398,7 @@ TEST_CASE( "pocket favorites allow or restrict items", "[pocket][favorite][item]
     }
 }
 
-TEST_CASE( "pocket favorites allow or restrict containers", "[pocket][favorite][item]" )
+TEST_CASE( "pocket_favorites_allow_or_restrict_containers", "[pocket][favorite][item]" )
 {
     item_pocket::favorite_settings settings;
 
@@ -1577,7 +1577,7 @@ static item *add_item_to_best_pocket( Character &dummy, const item &it )
 // Character::best_pocket( it, avoid )
 // NOTE: different syntax than item_contents::best_pocket
 // (Second argument is `avoid` item pointer, not parent item location)
-TEST_CASE( "character best pocket", "[pocket][character][best]" )
+TEST_CASE( "character_best_pocket", "[pocket][character][best]" )
 {
     item_location loc;
     Character &dummy = get_player_character();
@@ -1717,7 +1717,7 @@ TEST_CASE( "character best pocket", "[pocket][character][best]" )
     }
 }
 
-TEST_CASE( "guns and gunmods", "[pocket][gunmod]" )
+TEST_CASE( "guns_and_gunmods", "[pocket][gunmod]" )
 {
     item m4a1( "m4_carbine" );
     item strap( "shoulder_strap" );
@@ -1726,7 +1726,7 @@ TEST_CASE( "guns and gunmods", "[pocket][gunmod]" )
     CHECK( m4a1.put_in( strap, item_pocket::pocket_type::MOD ).success() );
 }
 
-TEST_CASE( "usb drives and software", "[pocket][software]" )
+TEST_CASE( "usb_drives_and_software", "[pocket][software]" )
 {
     item usb( "usb_drive" );
     item software( "software_math" );
@@ -2222,7 +2222,7 @@ static void test_pickup_autoinsert( bool autopickup )
     }
 }
 
-TEST_CASE( "picking up items respects pocket autoinsert settings", "[pocket][item]" )
+TEST_CASE( "picking_up_items_respects_pocket_autoinsert_settings", "[pocket][item]" )
 {
     GIVEN( "autopickup" ) {
         test_pickup_autoinsert( true );
@@ -2233,7 +2233,7 @@ TEST_CASE( "picking up items respects pocket autoinsert settings", "[pocket][ite
     }
 }
 
-TEST_CASE( "multipocket liquid transfer test", "[pocket][item][liquid]" )
+TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
 {
     clear_map();
     clear_avatar();
@@ -2424,7 +2424,7 @@ static bool test_wallet_filled( Item_spawn_data *wallet_group )
     return wallets == 1;
 }
 
-TEST_CASE( "full wallet spawn test", "[pocket][item]" )
+TEST_CASE( "full_wallet_spawn_test", "[pocket][item]" )
 {
     const int iters = 100;
     const std::vector<Item_spawn_data *> groups = {
@@ -2452,7 +2452,7 @@ TEST_CASE( "full wallet spawn test", "[pocket][item]" )
     }
 }
 
-TEST_CASE( "best pocket for pocket-holster mix", "[pocket][item]" )
+TEST_CASE( "best_pocket_for_pocket-holster_mix", "[pocket][item]" )
 {
     avatar &u = get_avatar();
     item tool_belt( "test_tool_belt_pocket_mix" );
@@ -2595,7 +2595,7 @@ TEST_CASE( "best pocket for pocket-holster mix", "[pocket][item]" )
     }
 }
 
-TEST_CASE( "item cannot contain contents it already has", "[item][pocket]" )
+TEST_CASE( "item_cannot_contain_contents_it_already_has", "[item][pocket]" )
 {
     item backpack( "test_backpack" );
     item bottle( "bottle_plastic" );
@@ -2644,7 +2644,7 @@ TEST_CASE( "item cannot contain contents it already has", "[item][pocket]" )
     CHECK( !backpack_loc->can_contain( water_item, false, false, true, bottle_loc ).success() );
 }
 
-TEST_CASE( "Sawed off fits in large holster", "[item][pocket]" )
+TEST_CASE( "Sawed_off_fits_in_large_holster", "[item][pocket]" )
 {
     item double_barrel( "shotgun_d" );
     item large_holster( "XL_holster" );
@@ -2659,7 +2659,7 @@ TEST_CASE( "Sawed off fits in large holster", "[item][pocket]" )
 
 // this tests for cases where we try to find a nested pocket for items (when a parent pocket has some restrictions) and find a massive bag inside the parent pocket
 // need to make sure we don't try to fit things larger than the parent pockets remaining volume inside the child pocket if it is non-rigid
-TEST_CASE( "bag with restrictions and nested bag doesn't fit too large items", "[item][pocket]" )
+TEST_CASE( "bag_with_restrictions_and_nested_bag_does_not_fit_too_large_items", "[item][pocket]" )
 {
     item backpack( "test_backpack" );
     item backpack_two( "test_backpack" );

--- a/tests/item_spawn_test.cpp
+++ b/tests/item_spawn_test.cpp
@@ -32,7 +32,7 @@ static std::string get_section_name( const spawn_type &type )
     return "unknown type";
 }
 
-TEST_CASE( "correct amounts of an item spawn inside a container", "[item_spawn]" )
+TEST_CASE( "correct_amounts_of_an_item_spawn_inside_a_container", "[item_spawn]" )
 {
     REQUIRE_FALSE( test_data::container_spawn_data.empty() );
 

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -192,7 +192,7 @@ TEST_CASE( "stacking_over_time", "[item]" )
     }
 }
 
-TEST_CASE( "liquids at different temperatures", "[item][temperature][stack][combine]" )
+TEST_CASE( "liquids_at_different_temperatures", "[item][temperature][stack][combine]" )
 {
     item liquid_hot( "test_liquid" );
     item liquid_cold( "test_liquid" );
@@ -258,7 +258,7 @@ static void assert_minimum_length_to_volume_ratio( const item &target )
     CHECK( units::to_millimeter( target.length() ) >= minimal_diameter * 10.0 );
 }
 
-TEST_CASE( "item length sanity check", "[item]" )
+TEST_CASE( "item_length_sanity_check", "[item]" )
 {
     for( const itype *type : item_controller->all() ) {
         const item sample( type, calendar::turn_zero, item::solitary_tag {} );
@@ -266,7 +266,7 @@ TEST_CASE( "item length sanity check", "[item]" )
     }
 }
 
-TEST_CASE( "corpse length sanity check", "[item]" )
+TEST_CASE( "corpse_length_sanity_check", "[item]" )
 {
     for( const mtype &type : MonsterGenerator::generator().get_all_mtypes() ) {
         const item sample = item::make_corpse( type.id );
@@ -296,7 +296,7 @@ static void check_spawning_in_container( const std::string &item_type )
     }
 }
 
-TEST_CASE( "items spawn in their default containers", "[item]" )
+TEST_CASE( "items_spawn_in_their_default_containers", "[item]" )
 {
     check_spawning_in_container( "water" );
     check_spawning_in_container( "gunpowder" );
@@ -311,7 +311,7 @@ TEST_CASE( "items spawn in their default containers", "[item]" )
     check_spawning_in_container( "software_useless" );
 }
 
-TEST_CASE( "item variables round-trip accurately", "[item]" )
+TEST_CASE( "item_variables_round-trip_accurately", "[item]" )
 {
     item i( "water" );
     i.set_var( "A", 17 );
@@ -322,7 +322,7 @@ TEST_CASE( "item variables round-trip accurately", "[item]" )
     CHECK( i.get_var( "C", tripoint() ) == tripoint( 2, 3, 4 ) );
 }
 
-TEST_CASE( "water affect items while swimming check", "[item][water][swimming]" )
+TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" )
 {
     avatar &guy = get_avatar();
     clear_avatar();

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -45,7 +45,7 @@ static const skill_id skill_survival( "survival" );
 // - used, lit, plugged in, active, sawn-off
 // - favorite *
 
-TEST_CASE( "food with hidden effects", "[item][tname][hidden]" )
+TEST_CASE( "food_with_hidden_effects", "[item][tname][hidden]" )
 {
     Character &player_character = get_player_character();
     player_character.clear_mutations();
@@ -100,7 +100,7 @@ TEST_CASE( "food with hidden effects", "[item][tname][hidden]" )
     }
 }
 
-TEST_CASE( "items with a temperature flag", "[item][tname][temperature]" )
+TEST_CASE( "items_with_a_temperature_flag", "[item][tname][temperature]" )
 {
     GIVEN( "food that can melt" ) {
         item shake( "milkshake" );
@@ -231,7 +231,7 @@ TEST_CASE( "items with a temperature flag", "[item][tname][temperature]" )
     }
 }
 
-TEST_CASE( "wet item", "[item][tname][wet]" )
+TEST_CASE( "wet_item", "[item][tname][wet]" )
 {
     item rag( "rag" );
     rag.set_flag( flag_WET );
@@ -240,7 +240,7 @@ TEST_CASE( "wet item", "[item][tname][wet]" )
     CHECK( rag.tname() == "rag (wet)" );
 }
 
-TEST_CASE( "filthy item", "[item][tname][filthy]" )
+TEST_CASE( "filthy_item", "[item][tname][filthy]" )
 {
     item rag( "rag" );
     rag.set_flag( flag_FILTHY );
@@ -249,7 +249,7 @@ TEST_CASE( "filthy item", "[item][tname][filthy]" )
     CHECK( rag.tname() == "rag (filthy)" );
 }
 
-TEST_CASE( "diamond item", "[item][tname][diamond]" )
+TEST_CASE( "diamond_item", "[item][tname][diamond]" )
 {
     item katana( "katana" );
     katana.set_flag( flag_DIAMOND );
@@ -258,7 +258,7 @@ TEST_CASE( "diamond item", "[item][tname][diamond]" )
     CHECK( katana.tname() == "diamond katana" );
 }
 
-TEST_CASE( "truncated item name", "[item][tname][truncate]" )
+TEST_CASE( "truncated_item_name", "[item][tname][truncate]" )
 {
     SECTION( "plain item name can be truncated" ) {
         item katana( "katana" );
@@ -270,7 +270,7 @@ TEST_CASE( "truncated item name", "[item][tname][truncate]" )
     // TODO: color-coded or otherwise embellished item name can be truncated
 }
 
-TEST_CASE( "engine displacement volume", "[item][tname][engine]" )
+TEST_CASE( "engine_displacement_volume", "[item][tname][engine]" )
 {
     item vtwin = item( "v2_combustion" );
     item v12diesel = item( "v12_diesel" );
@@ -285,7 +285,7 @@ TEST_CASE( "engine displacement volume", "[item][tname][engine]" )
     CHECK( turbine.tname() == "27L 1,350 HP gas turbine engine" );
 }
 
-TEST_CASE( "wheel diameter", "[item][tname][wheel]" )
+TEST_CASE( "wheel_diameter", "[item][tname][wheel]" )
 {
     item wheel17 = item( "wheel" );
     item wheel24 = item( "wheel_wide" );
@@ -300,7 +300,7 @@ TEST_CASE( "wheel diameter", "[item][tname][wheel]" )
     CHECK( wheel32.tname() == "32\" armored wheel" );
 }
 
-TEST_CASE( "item health or damage bar", "[item][tname][health][damage]" )
+TEST_CASE( "item_health_or_damage_bar", "[item][tname][health][damage]" )
 {
     GIVEN( "some clothing" ) {
         item shirt( "longshirt" );
@@ -445,7 +445,7 @@ TEST_CASE( "item health or damage bar", "[item][tname][health][damage]" )
     }
 }
 
-TEST_CASE( "weapon fouling", "[item][tname][fouling][dirt]" )
+TEST_CASE( "weapon_fouling", "[item][tname][fouling][dirt]" )
 {
     GIVEN( "a gun with potential fouling" ) {
         item gun( "hk_mp5" );

--- a/tests/item_type_name_test.cpp
+++ b/tests/item_type_name_test.cpp
@@ -22,7 +22,7 @@ static const itype_id itype_test_test_item( "test_test_item" );
 static const mtype_id mon_chicken( "mon_chicken" );
 static const mtype_id mon_zombie( "mon_zombie" );
 
-TEST_CASE( "item name pluralization", "[item][type_name][plural]" )
+TEST_CASE( "item_name_pluralization", "[item][type_name][plural]" )
 {
     SECTION( "singular and plural item names" ) {
 
@@ -83,7 +83,7 @@ TEST_CASE( "item name pluralization", "[item][type_name][plural]" )
     }
 }
 
-TEST_CASE( "custom named item", "[item][type_name][named]" )
+TEST_CASE( "custom_named_item", "[item][type_name][named]" )
 {
     // Shop smart. Shop S-Mart.
     item shotgun( "shotgun_410" );
@@ -93,7 +93,7 @@ TEST_CASE( "custom named item", "[item][type_name][named]" )
     CHECK( shotgun.type_name() == "Boomstick" );
 }
 
-TEST_CASE( "blood item", "[item][type_name][blood]" )
+TEST_CASE( "blood_item", "[item][type_name][blood]" )
 {
     SECTION( "blood from a zombie corpse" ) {
         item corpse = item::make_corpse( mon_zombie );
@@ -124,7 +124,7 @@ TEST_CASE( "blood item", "[item][type_name][blood]" )
     }
 }
 
-TEST_CASE( "corpse item", "[item][type_name][corpse]" )
+TEST_CASE( "corpse_item", "[item][type_name][corpse]" )
 {
     // Anonymous corpses
 

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -271,7 +271,7 @@ TEST_CASE( "item requirements", "[iteminfo][requirements]" )
 
 // Functions:
 // item::basic_info
-TEST_CASE( "item contents", "[iteminfo][contents]" )
+TEST_CASE( "iteminfo contents", "[iteminfo][contents]" )
 {
     clear_avatar();
 

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -112,7 +112,7 @@ static std::string item_info_str( const item &it, const std::vector<iteminfo_par
 //
 // Functions:
 // item::basic_info
-TEST_CASE( "item volume and weight", "[iteminfo][volume][weight]" )
+TEST_CASE( "item_volume_and_weight", "[iteminfo][volume][weight]" )
 {
     clear_avatar();
 
@@ -169,7 +169,7 @@ TEST_CASE( "item volume and weight", "[iteminfo][volume][weight]" )
 //
 // Functions:
 // item::basic_info
-TEST_CASE( "item material, category, description", "[iteminfo][material][category][description]" )
+TEST_CASE( "item_material_category_description", "[iteminfo][material][category][description]" )
 {
     clear_avatar();
 
@@ -214,7 +214,7 @@ TEST_CASE( "item material, category, description", "[iteminfo][material][categor
 //
 // Functions:
 // item::basic_info
-TEST_CASE( "item owner", "[iteminfo][owner]" )
+TEST_CASE( "item_owner", "[iteminfo][owner]" )
 {
     clear_avatar();
 
@@ -240,7 +240,7 @@ TEST_CASE( "item owner", "[iteminfo][owner]" )
 //
 // Functions:
 // item::basic_info
-TEST_CASE( "item requirements", "[iteminfo][requirements]" )
+TEST_CASE( "item_requirements", "[iteminfo][requirements]" )
 {
     // TODO:
     // - get_min_str() - type->min_str with special gun/gunmod handling
@@ -271,7 +271,7 @@ TEST_CASE( "item requirements", "[iteminfo][requirements]" )
 
 // Functions:
 // item::basic_info
-TEST_CASE( "iteminfo contents", "[iteminfo][contents]" )
+TEST_CASE( "iteminfo_contents", "[iteminfo][contents]" )
 {
     clear_avatar();
 
@@ -350,7 +350,7 @@ TEST_CASE( "med_info", "[iteminfo][med]" )
 //
 // Functions:
 // item::final_info
-TEST_CASE( "item price and barter value", "[iteminfo][price]" )
+TEST_CASE( "item_price_and_barter_value", "[iteminfo][price]" )
 {
     clear_avatar();
 
@@ -398,7 +398,7 @@ TEST_CASE( "item price and barter value", "[iteminfo][price]" )
 //
 // Functions:
 // item::armor_info
-TEST_CASE( "item rigidity", "[iteminfo][rigidity]" )
+TEST_CASE( "item_rigidity", "[iteminfo][rigidity]" )
 {
     clear_avatar();
 
@@ -480,7 +480,7 @@ TEST_CASE( "item rigidity", "[iteminfo][rigidity]" )
 //
 // Functions:
 // item::combat_info
-TEST_CASE( "weapon attack ratings and moves", "[iteminfo][weapon]" )
+TEST_CASE( "weapon_attack_ratings_and_moves", "[iteminfo][weapon]" )
 {
     clear_avatar();
     Character &player_character = get_player_character();
@@ -698,7 +698,7 @@ TEST_CASE( "weapon attack ratings and moves", "[iteminfo][weapon]" )
 //
 // Functions:
 // item::combat_info
-TEST_CASE( "techniques when wielded", "[iteminfo][weapon][techniques]" )
+TEST_CASE( "techniques_when_wielded", "[iteminfo][weapon][techniques]" )
 {
     clear_avatar();
 
@@ -767,7 +767,7 @@ static void verify_item_encumbrance( const item &i, item::encumber_flags flags, 
 //
 // Functions:
 // item::armor_info
-TEST_CASE( "armor coverage, warmth, and encumbrance", "[iteminfo][armor][coverage]" )
+TEST_CASE( "armor_coverage_warmth_and_encumbrance", "[iteminfo][armor][coverage]" )
 {
     clear_avatar();
 
@@ -1162,7 +1162,7 @@ TEST_CASE( "armor coverage, warmth, and encumbrance", "[iteminfo][armor][coverag
 // Related JSON fields:
 // material softness
 // padded flag
-TEST_CASE( "armor rigidity", "[iteminfo][armor][coverage]" )
+TEST_CASE( "armor_rigidity", "[iteminfo][armor][coverage]" )
 {
     clear_avatar();
 
@@ -1183,7 +1183,7 @@ TEST_CASE( "armor rigidity", "[iteminfo][armor][coverage]" )
 //
 // Functions:
 // item::armor_fit_info
-TEST_CASE( "armor fit and sizing", "[iteminfo][armor][fit]" )
+TEST_CASE( "armor_fit_and_sizing", "[iteminfo][armor][fit]" )
 {
     clear_avatar();
 
@@ -1247,7 +1247,7 @@ TEST_CASE( "armor_stats", "[armor][protection]" )
 // Materials and protection calculations are not tested here; only their display in item info.
 //
 // item::armor_protection_info
-TEST_CASE( "armor protection", "[iteminfo][armor][protection]" )
+TEST_CASE( "armor_protection", "[iteminfo][armor][protection]" )
 {
     clear_avatar();
 
@@ -1355,7 +1355,7 @@ TEST_CASE( "armor protection", "[iteminfo][armor][protection]" )
 //
 // Functions:
 // item::book_info
-TEST_CASE( "book info", "[iteminfo][book]" )
+TEST_CASE( "book_info", "[iteminfo][book]" )
 {
     clear_avatar();
 
@@ -1477,7 +1477,7 @@ TEST_CASE( "book info", "[iteminfo][book]" )
 //
 // Functions:
 // item::gun_info
-TEST_CASE( "gun or other ranged weapon attributes", "[iteminfo][weapon][gun]" )
+TEST_CASE( "gun_or_other_ranged_weapon_attributes", "[iteminfo][weapon][gun]" )
 {
     clear_avatar();
 
@@ -1678,7 +1678,7 @@ TEST_CASE( "gun or other ranged weapon attributes", "[iteminfo][weapon][gun]" )
 
 // Functions:
 // item::gun_info
-TEST_CASE( "gun armor piercing, dispersion and other stats", "[iteminfo][gun][misc]" )
+TEST_CASE( "gun_armor_piercing_dispersion_and_other_stats", "[iteminfo][gun][misc]" )
 {
     clear_avatar();
 
@@ -1735,7 +1735,7 @@ TEST_CASE( "gun armor piercing, dispersion and other stats", "[iteminfo][gun][mi
 //
 // Functions:
 // item::gunmod_info
-TEST_CASE( "gunmod info", "[iteminfo][gunmod]" )
+TEST_CASE( "gunmod_info", "[iteminfo][gunmod]" )
 {
     clear_avatar();
 
@@ -1864,7 +1864,7 @@ TEST_CASE( "ammunition", "[iteminfo][ammo]" )
 
 // Functions:
 // item::food_info
-TEST_CASE( "nutrients in food", "[iteminfo][food]" )
+TEST_CASE( "nutrients_in_food", "[iteminfo][food]" )
 {
     clear_avatar();
 
@@ -1905,7 +1905,7 @@ TEST_CASE( "nutrients in food", "[iteminfo][food]" )
 //
 // Functions:
 // item::food_info
-TEST_CASE( "food freshness and lifetime", "[iteminfo][food]" )
+TEST_CASE( "food_freshness_and_lifetime", "[iteminfo][food]" )
 {
     clear_avatar();
 
@@ -1948,7 +1948,7 @@ TEST_CASE( "food freshness and lifetime", "[iteminfo][food]" )
 //
 // Functions:
 // item::food_info
-TEST_CASE( "basic food info", "[iteminfo][food]" )
+TEST_CASE( "basic_food_info", "[iteminfo][food]" )
 {
     clear_avatar();
 
@@ -1995,7 +1995,7 @@ TEST_CASE( "basic food info", "[iteminfo][food]" )
 //
 // Functions:
 // item::food_info
-TEST_CASE( "food character is allergic to", "[iteminfo][food][allergy]" )
+TEST_CASE( "food_character_is_allergic_to", "[iteminfo][food][allergy]" )
 {
     clear_avatar();
     Character &player_character = get_player_character();
@@ -2027,7 +2027,7 @@ TEST_CASE( "food character is allergic to", "[iteminfo][food][allergy]" )
 //
 // Functions:
 // item::food_info
-TEST_CASE( "food with hidden poison or hallucinogen", "[iteminfo][food][poison][hallu]" )
+TEST_CASE( "food_with_hidden_poison_or_hallucinogen", "[iteminfo][food][poison][hallu]" )
 {
     clear_avatar();
 
@@ -2105,7 +2105,7 @@ TEST_CASE( "food with hidden poison or hallucinogen", "[iteminfo][food][poison][
 //
 // Functions:
 // item::food_info
-TEST_CASE( "food that is made of human flesh", "[iteminfo][food][cannibal]" )
+TEST_CASE( "food_that_is_made_of_human_flesh", "[iteminfo][food][cannibal]" )
 {
     // TODO: Test food that is_tainted(): "This food is *tainted* and will poison you"
 
@@ -2146,7 +2146,7 @@ TEST_CASE( "food that is made of human flesh", "[iteminfo][food][cannibal]" )
 // Functions:
 // item::final_info
 // FIXME: Move conducivity out of final_info
-TEST_CASE( "item conductivity", "[iteminfo][conductivity]" )
+TEST_CASE( "item_conductivity", "[iteminfo][conductivity]" )
 {
     clear_avatar();
 
@@ -2196,7 +2196,7 @@ TEST_CASE( "item conductivity", "[iteminfo][conductivity]" )
 //
 // Functions:
 // item::qualities_info
-TEST_CASE( "list of item qualities", "[iteminfo][quality]" )
+TEST_CASE( "list_of_item_qualities", "[iteminfo][quality]" )
 {
     clear_avatar();
 
@@ -2280,7 +2280,7 @@ TEST_CASE( "list of item qualities", "[iteminfo][quality]" )
 //
 // Functions:
 // item::actions_info
-TEST_CASE( "list of item actions", "[iteminfo][action]" )
+TEST_CASE( "list_of_item_actions", "[iteminfo][action]" )
 {
     clear_avatar();
 
@@ -2299,7 +2299,7 @@ TEST_CASE( "list of item actions", "[iteminfo][action]" )
 //
 // Functions:
 // item::tool_info
-TEST_CASE( "tool info", "[iteminfo][tool]" )
+TEST_CASE( "tool_info", "[iteminfo][tool]" )
 {
     // TODO: Find a tool using this
     //std::vector<iteminfo_parts> mag_current = { iteminfo_parts::TOOL_MAGAZINE_CURRENT };
@@ -2390,7 +2390,7 @@ TEST_CASE( "tool info", "[iteminfo][tool]" )
 //
 // Functions:
 // item::bionic_info
-TEST_CASE( "bionic info", "[iteminfo][bionic]" )
+TEST_CASE( "bionic_info", "[iteminfo][bionic]" )
 {
     // TODO: Add a test for this
     //std::vector<iteminfo_parts> slots = { iteminfo_parts::DESCRIPTION_CBM_SLOTS };
@@ -2450,7 +2450,7 @@ TEST_CASE( "bionic info", "[iteminfo][bionic]" )
 
 // Functions:
 // item::repair_info
-TEST_CASE( "repairable and with what tools", "[iteminfo][repair]" )
+TEST_CASE( "repairable_and_with_what_tools", "[iteminfo][repair]" )
 {
     clear_avatar();
 
@@ -2479,7 +2479,7 @@ TEST_CASE( "repairable and with what tools", "[iteminfo][repair]" )
 
 // Functions:
 // item::disassembly_info
-TEST_CASE( "disassembly time and yield", "[iteminfo][disassembly]" )
+TEST_CASE( "disassembly_time_and_yield", "[iteminfo][disassembly]" )
 {
     clear_avatar();
 
@@ -2511,7 +2511,7 @@ TEST_CASE( "disassembly time and yield", "[iteminfo][disassembly]" )
 // Functions:
 // item::final_info
 // FIXME: Factor out of final_info
-TEST_CASE( "item description flags", "[iteminfo][flags]" )
+TEST_CASE( "item_description_flags", "[iteminfo][flags]" )
 {
     clear_avatar();
 
@@ -2552,7 +2552,7 @@ TEST_CASE( "item description flags", "[iteminfo][flags]" )
 
 // Functions:
 // item::final_info
-TEST_CASE( "show available recipes with item as an ingredient", "[iteminfo][recipes]" )
+TEST_CASE( "show_available_recipes_with_item_as_an_ingredient", "[iteminfo][recipes]" )
 {
     clear_avatar();
     avatar &player_character = get_avatar();
@@ -2628,7 +2628,7 @@ TEST_CASE( "show available recipes with item as an ingredient", "[iteminfo][reci
 // Functions:
 // item_contents::info
 // item_pocket::general_info
-TEST_CASE( "pocket info for a simple container", "[iteminfo][pocket][container]" )
+TEST_CASE( "pocket_info_for_a_simple_container", "[iteminfo][pocket][container]" )
 {
     clear_avatar();
 
@@ -2654,7 +2654,7 @@ TEST_CASE( "pocket info for a simple container", "[iteminfo][pocket][container]"
 // Functions:
 // item_contents::info
 // item_pocket::general_info
-TEST_CASE( "pocket info units - imperial or metric", "[iteminfo][pocket][units]" )
+TEST_CASE( "pocket_info_units_-_imperial_or_metric", "[iteminfo][pocket][units]" )
 {
     clear_avatar();
 
@@ -2701,7 +2701,7 @@ TEST_CASE( "pocket info units - imperial or metric", "[iteminfo][pocket][units]"
 // Functions:
 // item_contents::info
 // item_pocket::general_info
-TEST_CASE( "pocket info for a multi-pocket item", "[iteminfo][pocket][multiple]" )
+TEST_CASE( "pocket_info_for_a_multi-pocket_item", "[iteminfo][pocket][multiple]" )
 {
     clear_avatar();
 
@@ -2734,7 +2734,7 @@ TEST_CASE( "pocket info for a multi-pocket item", "[iteminfo][pocket][multiple]"
            "* <color_c_white>or</color> Item must fit in a sheath\n" );
 }
 
-TEST_CASE( "ammo restriction info", "[iteminfo][ammo_restriction]" )
+TEST_CASE( "ammo_restriction_info", "[iteminfo][ammo_restriction]" )
 {
     SECTION( "container pocket with ammo restriction" ) {
         // For non-MAGAZINE pockets with ammo_restriction, pocket info shows what it can hold
@@ -2830,7 +2830,7 @@ TEST_CASE( "weight_to_info", "[iteminfo][weight]" )
 
 // Functions:
 // item::final_info
-TEST_CASE( "final info", "[iteminfo][final]" )
+TEST_CASE( "final_info", "[iteminfo][final]" )
 {
     clear_avatar();
     Character &player_character = get_player_character();
@@ -2892,7 +2892,7 @@ TEST_CASE( "final info", "[iteminfo][final]" )
 // Functions:
 // item::debug_info
 // FIXME: This fails when run with other tests. May not be worth having a test on...
-TEST_CASE( "item debug info", "[iteminfo][debug][!mayfail][.]" )
+TEST_CASE( "item_debug_info", "[iteminfo][debug][!mayfail][.]" )
 {
     clear_avatar();
 
@@ -2936,7 +2936,7 @@ TEST_CASE( "item debug info", "[iteminfo][debug][!mayfail][.]" )
     }
 }
 
-TEST_CASE( "Armor values preserved after copy-from", "[iteminfo][armor][protection]" )
+TEST_CASE( "Armor_values_preserved_after_copy-from", "[iteminfo][armor][protection]" )
 {
     // Normal item definition, no copy
     item armor( itype_test_armor_chitin );

--- a/tests/itemname_test.cpp
+++ b/tests/itemname_test.cpp
@@ -15,7 +15,7 @@
 static const trait_id trait_HUGE_OK( "HUGE_OK" );
 static const trait_id trait_SMALL_OK( "SMALL_OK" );
 
-TEST_CASE( "item sizing display", "[item][iteminfo][display_name][sizing]" )
+TEST_CASE( "item_sizing_display", "[item][iteminfo][display_name][sizing]" )
 {
     Character &player_character = get_player_character();
     GIVEN( "player is a normal size" ) {
@@ -125,7 +125,7 @@ TEST_CASE( "item sizing display", "[item][iteminfo][display_name][sizing]" )
     }
 }
 
-TEST_CASE( "display name includes item contents", "[item][display_name][contents]" )
+TEST_CASE( "display_name_includes_item_contents", "[item][display_name][contents]" )
 {
     clear_avatar();
 

--- a/tests/iuse_actor_test.cpp
+++ b/tests/iuse_actor_test.cpp
@@ -82,7 +82,7 @@ TEST_CASE( "manhack", "[iuse_actor][manhack]" )
     g->clear_zombies();
 }
 
-TEST_CASE( "tool transform when activated", "[iuse][tool][transform]" )
+TEST_CASE( "tool_transform_when_activated", "[iuse][tool][transform]" )
 {
     Character &dummy = get_avatar();
     clear_avatar();

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -230,7 +230,7 @@ TEST_CASE( "anticonvulsant", "[iuse][anticonvulsant]" )
 }
 
 // test the `iuse::oxygen_bottle` function
-TEST_CASE( "oxygen tank", "[iuse][oxygen_bottle]" )
+TEST_CASE( "oxygen_tank", "[iuse][oxygen_bottle]" )
 {
     avatar dummy;
     dummy.normalize();
@@ -334,7 +334,7 @@ TEST_CASE( "oxygen tank", "[iuse][oxygen_bottle]" )
 }
 
 // test the `iuse::caff` and `iuse::atomic_caff` functions
-TEST_CASE( "caffeine and atomic caffeine", "[iuse][caff][atomic_caff]" )
+TEST_CASE( "caffeine_and_atomic_caffeine", "[iuse][caff][atomic_caff]" )
 {
     avatar dummy;
     dummy.normalize();

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -81,7 +81,7 @@ TEST_CASE( "avoid_serializing_default_values", "[json]" )
     REQUIRE( os.str() == "\"bar\":\"foo\"" );
 }
 
-TEST_CASE( "spell_type handles all members", "[json]" )
+TEST_CASE( "spell_type_handles_all_members", "[json]" )
 {
     const spell_type &test_spell = spell_test_spell_json.obj();
 

--- a/tests/line_test.cpp
+++ b/tests/line_test.cpp
@@ -132,7 +132,7 @@ TEST_CASE( "test_normalized_angle", "[line]" )
 }
 
 // NOLINTNEXTLINE(readability-function-size)
-TEST_CASE( "Test bounds for mapping x/y/z/ offsets to direction enum", "[line]" )
+TEST_CASE( "Test_bounds_for_mapping_x/y/z/_offsets_to_direction_enum", "[line]" )
 {
     // Test the unit cube, which are the only values this function is valid for.
     REQUIRE( make_xyz_unit( tripoint( -1, -1, 1 ) ) == direction::ABOVENORTHWEST );

--- a/tests/list_test.cpp
+++ b/tests/list_test.cpp
@@ -10,7 +10,7 @@
 #include "colony_list_test_helpers.h"
 #include "list.h"
 
-TEST_CASE( "list basics", "[list]" )
+TEST_CASE( "list_basics", "[list]" )
 {
     {
         cata::list<int *> test_list;
@@ -253,7 +253,7 @@ TEST_CASE( "list basics", "[list]" )
     }
 }
 
-TEST_CASE( "list insert and erase", "[list]" )
+TEST_CASE( "list_insert_and_erase", "[list]" )
 {
     cata::list<int> test_list;
 
@@ -453,7 +453,7 @@ TEST_CASE( "list insert and erase", "[list]" )
     }
 }
 
-TEST_CASE( "list merge", "[list]" )
+TEST_CASE( "list_merge", "[list]" )
 {
     cata::list<int> test_list;
     test_list.insert( test_list.end(), {1, 3, 5, 7, 9} );
@@ -473,7 +473,7 @@ TEST_CASE( "list merge", "[list]" )
     CHECK( passed );
 }
 
-TEST_CASE( "list splice", "[list]" )
+TEST_CASE( "list_splice", "[list]" )
 {
     cata::list<int> test_list = {1, 2, 3, 4, 5};
     cata::list<int> test_list_2 = {6, 7, 8, 9, 10};
@@ -556,7 +556,7 @@ TEST_CASE( "list splice", "[list]" )
     }
 }
 
-TEST_CASE( "list sort and reverse", "[list]" )
+TEST_CASE( "list_sort_and_reverse", "[list]" )
 {
     cata::list<int> test_list;
 
@@ -615,7 +615,7 @@ TEST_CASE( "list sort and reverse", "[list]" )
     }
 }
 
-TEST_CASE( "list unique", "[list]" )
+TEST_CASE( "list_unique", "[list]" )
 {
     cata::list<int> test_list = {1, 1, 2, 3, 3, 4, 5, 5};
 
@@ -651,7 +651,7 @@ TEST_CASE( "list unique", "[list]" )
     }
 }
 
-TEST_CASE( "list remove", "[list]" )
+TEST_CASE( "list_remove", "[list]" )
 {
     cata::list<int> test_list = {1, 3, 1, 50, 16, 15, 2, 22};
 
@@ -698,7 +698,7 @@ TEST_CASE( "list remove", "[list]" )
     }
 }
 
-TEST_CASE( "list reserve", "[list]" )
+TEST_CASE( "list_reserve", "[list]" )
 {
     cata::list<int> test_list;
 
@@ -731,7 +731,7 @@ TEST_CASE( "list reserve", "[list]" )
     CHECK( test_list.capacity() >= 15000 );
 }
 
-TEST_CASE( "list resize", "[list]" )
+TEST_CASE( "list_resize", "[list]" )
 {
     cata::list<int> test_list = { 1, 2, 3, 4, 5, 6, 7 };
 
@@ -746,7 +746,7 @@ TEST_CASE( "list resize", "[list]" )
     CHECK( count == 2 );
 }
 
-TEST_CASE( "list assign", "[list]" )
+TEST_CASE( "list_assign", "[list]" )
 {
     cata::list<int> test_list;
 
@@ -807,7 +807,7 @@ TEST_CASE( "list assign", "[list]" )
     }
 }
 
-TEST_CASE( "list insert", "[list]" )
+TEST_CASE( "list_insert", "[list]" )
 {
     cata::list<int> test_list;
 
@@ -858,7 +858,7 @@ TEST_CASE( "list insert", "[list]" )
     }
 }
 
-TEST_CASE( "list emplace, move, copy, and reverse iterate", "[list]" )
+TEST_CASE( "list_emplace_move_copy_and_reverse_iterate", "[list]" )
 {
     cata::list<small_struct> test_list;
 
@@ -1011,7 +1011,7 @@ TEST_CASE( "list emplace, move, copy, and reverse iterate", "[list]" )
     }
 }
 
-TEST_CASE( "list reorder", "[list]" )
+TEST_CASE( "list_reorder", "[list]" )
 {
     cata::list<int> test_list;
 
@@ -1136,7 +1136,7 @@ TEST_CASE( "list reorder", "[list]" )
     }
 }
 
-TEST_CASE( "list insertion styles", "[list]" )
+TEST_CASE( "list_insertion_styles", "[list]" )
 {
     cata::list<int> test_list = {1, 2, 3};
 
@@ -1161,7 +1161,7 @@ TEST_CASE( "list insertion styles", "[list]" )
     CHECK( test_list_2.size() == 500503 );
 }
 
-TEST_CASE( "list perfect forwarding", "[list]" )
+TEST_CASE( "list_perfect_forwarding", "[list]" )
 {
     cata::list<perfect_forwarding_test> test_list;
 

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -43,7 +43,7 @@ static const spell_id spell_test_spell_tp_mummy( "test_spell_tp_mummy" );
 // Functions:
 // spell::name
 //
-TEST_CASE( "spell name", "[magic][spell][name]" )
+TEST_CASE( "spell_name", "[magic][spell][name]" )
 {
     // Test spells from data/mods/TEST_DATA/magic.json
     spell_id pew_id( "test_spell_pew" );
@@ -73,7 +73,7 @@ TEST_CASE( "spell name", "[magic][spell][name]" )
 // spell::set_level
 // spell::exp_to_next_level
 
-TEST_CASE( "spell level", "[magic][spell][level]" )
+TEST_CASE( "spell_level", "[magic][spell][level]" )
 {
     npc guy;
     spell_id pew_id( "test_spell_pew" );
@@ -117,7 +117,7 @@ static int spell_xp_to_next_level( const spell_id &sp_id, const int from_level )
     return test_spell.exp_to_next_level();
 }
 
-TEST_CASE( "experience to gain spell levels", "[magic][spell][level][xp]" )
+TEST_CASE( "experience_to_gain_spell_levels", "[magic][spell][level][xp]" )
 {
     npc guy;
     spell_id pew_id( "test_spell_pew" );
@@ -243,7 +243,7 @@ static int spell_damage( const spell_id &sp_id, const int spell_level )
     return test_spell.damage( guy );
 }
 
-TEST_CASE( "spell damage", "[magic][spell][damage]" )
+TEST_CASE( "spell_damage", "[magic][spell][damage]" )
 {
     spell_id pew_id( "test_spell_pew" );
     const spell_type &pew_type = pew_id.obj();
@@ -296,7 +296,7 @@ static std::string spell_duration_string( const spell_id &sp_id, const int spell
     return test_spell.duration_string( guy );
 }
 
-TEST_CASE( "spell duration", "[magic][spell][duration]" )
+TEST_CASE( "spell_duration", "[magic][spell][duration]" )
 {
     spell_id lava_id( "test_spell_lava" );
     const spell_type &lava_type = lava_id.obj();
@@ -346,7 +346,7 @@ TEST_CASE( "spell duration", "[magic][spell][duration]" )
 // Spells with the PERMANENT flag have behavior that depends on what kind of spell it is
 // - If spell has "effect": "spawn_item", the spawned item only has permanent duration at maximum level
 // - If spell has "effect": "summon", the summoned monster can have permanent duration at any level
-TEST_CASE( "permanent spell duration depends on effect and level", "[magic][spell][permanent]" )
+TEST_CASE( "permanent_spell_duration_depends_on_effect_and_level", "[magic][spell][permanent]" )
 {
     npc guy;
     GIVEN( "spell with spawn_item effect, nonzero duration, and PERMANENT flag" ) {
@@ -418,7 +418,7 @@ static int spell_range( const spell_id &sp_id, const int spell_level )
     return test_spell.range( guy );
 }
 
-TEST_CASE( "spell range", "[magic][spell][range]" )
+TEST_CASE( "spell_range", "[magic][spell][range]" )
 {
     spell_id pew_id( "test_spell_pew" );
     const spell_type &pew_type = pew_id.obj();
@@ -473,7 +473,7 @@ static int spell_aoe( const spell_id &sp_id, const int spell_level )
     return test_spell.aoe( guy );
 }
 
-TEST_CASE( "spell area of effect", "[magic][spell][aoe]" )
+TEST_CASE( "spell_area_of_effect", "[magic][spell][aoe]" )
 {
     spell_id lava_id( "test_spell_lava" );
     const spell_type &lava_type = lava_id.obj();
@@ -524,7 +524,7 @@ TEST_CASE( "spell area of effect", "[magic][spell][aoe]" )
 // spell_effect::cone_attack
 
 // spell_effect::target_attack
-TEST_CASE( "spell effect - target_attack", "[magic][spell][effect][target_attack]" )
+TEST_CASE( "spell_effect_-_target_attack", "[magic][spell][effect][target_attack]" )
 {
     // World setup
     clear_map();
@@ -580,7 +580,7 @@ TEST_CASE( "spell effect - target_attack", "[magic][spell][effect][target_attack
 }
 
 // spell_effect::spawn_summoned_monster
-TEST_CASE( "spell effect - summon", "[magic][spell][effect][summon]" )
+TEST_CASE( "spell_effect_-_summon", "[magic][spell][effect][summon]" )
 {
     clear_map();
 
@@ -609,7 +609,7 @@ TEST_CASE( "spell effect - summon", "[magic][spell][effect][summon]" )
 }
 
 // spell_effect::recover_energy
-TEST_CASE( "spell effect - recover_energy", "[magic][spell][effect][recover_energy]" )
+TEST_CASE( "spell_effect_-_recover_energy", "[magic][spell][effect][recover_energy]" )
 {
     // Takes recovery amount from sp.damage
     // Takes energy source from sp.effect_data

--- a/tests/map_extra_test.cpp
+++ b/tests/map_extra_test.cpp
@@ -17,7 +17,7 @@
 
 static const string_id<map_extra> map_extra_mx_minefield( "mx_minefield" );
 
-TEST_CASE( "mx_minefield real spawn", "[map_extra][overmap][!mayfail]" )
+TEST_CASE( "mx_minefield_real_spawn", "[map_extra][overmap][!mayfail]" )
 {
     // Pick a point in the middle of the overmap so we don't generate quite so
     // many overmaps when searching.
@@ -53,7 +53,7 @@ TEST_CASE( "mx_minefield real spawn", "[map_extra][overmap][!mayfail]" )
     overmap_buffer.clear();
 }
 
-TEST_CASE( "mx_minefield theoretical spawn", "[map_extra][overmap]" )
+TEST_CASE( "mx_minefield_theoretical_spawn", "[map_extra][overmap]" )
 {
     overmap &om = overmap_buffer.get( point_abs_om() );
 

--- a/tests/map_iterator_test.cpp
+++ b/tests/map_iterator_test.cpp
@@ -14,7 +14,7 @@ static std::array<tripoint, 9> range_1_2d_centered = {
     }
 };
 
-TEST_CASE( "Radius one 2D square centered at origin.", "[tripoint_range]" )
+TEST_CASE( "Radius_one_2D_square_centered_at_origin", "[tripoint_range]" )
 {
     tripoint_range<tripoint> tested( tripoint_north_west, tripoint_south_east );
     REQUIRE( tested.size() == range_1_2d_centered.size() );
@@ -31,7 +31,7 @@ static std::array<tripoint, 9> range_1_2d_offset = {
     }
 };
 
-TEST_CASE( "Radius one 2D square centered at -4/-4/0.", "[tripoint_range]" )
+TEST_CASE( "Radius_one_2D_square_centered_at_-4/-4/0", "[tripoint_range]" )
 {
     tripoint_range<tripoint> tested( {-5, -5, 0}, {-3, -3, 0} );
     REQUIRE( tested.size() == range_1_2d_offset.size() );
@@ -41,7 +41,7 @@ TEST_CASE( "Radius one 2D square centered at -4/-4/0.", "[tripoint_range]" )
     }
 }
 
-TEST_CASE( "Radius one 2D square centered at -4/-4/0 in abs_omt coords.", "[tripoint_range]" )
+TEST_CASE( "Radius_one_2D_square_centered_at_-4/-4/0_in_abs_omt_coords", "[tripoint_range]" )
 {
     tripoint_range<tripoint_abs_omt> tested( {-5, -5, 0}, {-3, -3, 0} );
     REQUIRE( tested.size() == range_1_2d_offset.size() );
@@ -110,7 +110,7 @@ static std::array<tripoint, 343> range_3_3d_offset = {
     }
 };
 
-TEST_CASE( "Radius three 3D square centered at 8/8/1.", "[tripoint_range]" )
+TEST_CASE( "Radius_three_3D_square_centered_at_8/8/1", "[tripoint_range]" )
 {
     tripoint_range<tripoint> tested( {5, 5, -2}, {11, 11, 4} );
     REQUIRE( tested.size() == range_3_3d_offset.size() );

--- a/tests/martial_art_test.cpp
+++ b/tests/martial_art_test.cpp
@@ -30,7 +30,7 @@ static const species_id species_ZOMBIE( "ZOMBIE" );
 
 static constexpr tripoint dude_pos( HALF_MAPSIZE_X, HALF_MAPSIZE_Y, 0 );
 
-TEST_CASE( "martial arts", "[martial_arts]" )
+TEST_CASE( "martial_arts", "[martial_arts]" )
 {
     SECTION( "martial art valid weapon" ) {
         GIVEN( "a weapon that fits the martial art" ) {
@@ -43,7 +43,7 @@ TEST_CASE( "martial arts", "[martial_arts]" )
     }
 }
 
-TEST_CASE( "Martial art required weapon categories", "[martial_arts]" )
+TEST_CASE( "Martial_art_required_weapon_categories", "[martial_arts]" )
 {
     SECTION( "Weapon categories required for buff" ) {
         REQUIRE( !test_style_ma1->onmiss_buffs.empty() );
@@ -79,7 +79,7 @@ TEST_CASE( "Martial art required weapon categories", "[martial_arts]" )
     }
 }
 
-TEST_CASE( "Martial art technique conditionals", "[martial_arts]" )
+TEST_CASE( "Martial_art_technique_conditionals", "[martial_arts]" )
 {
     clear_map();
     standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );

--- a/tests/materials_test.cpp
+++ b/tests/materials_test.cpp
@@ -34,7 +34,7 @@ static void check_near( const std::string &subject, float prob, const float expe
     }
 }
 
-TEST_CASE( "Resistance vs. material portions", "[material]" )
+TEST_CASE( "Resistance_vs_material_portions", "[material]" )
 {
     const item mostly_steel( "test_shears_mostly_steel" );
     const item mostly_plastic( "test_shears_mostly_plastic" );
@@ -51,7 +51,7 @@ TEST_CASE( "Resistance vs. material portions", "[material]" )
     CHECK( mostly_steel.chip_resistance() > mostly_plastic.chip_resistance() );
 }
 
-TEST_CASE( "Portioned material flammability", "[material]" )
+TEST_CASE( "Portioned_material_flammability", "[material]" )
 {
     const item mostly_steel( "test_fire_ax_mostly_steel" );
     const item mostly_wood( "test_fire_ax_mostly_wood" );
@@ -69,7 +69,7 @@ TEST_CASE( "Portioned material flammability", "[material]" )
     CHECK( steel_burn < wood_burn );
 }
 
-TEST_CASE( "Glass portion breakability", "[material] [slow]" )
+TEST_CASE( "Glass_portion_breakability", "[material] [slow]" )
 {
     clear_creatures();
     standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -83,7 +83,7 @@ static float dodge_wearing_item( avatar &dummy, item &clothing )
     return dummy.get_dodge();
 }
 
-TEST_CASE( "monster::get_hit_base", "[monster][melee][hit]" )
+TEST_CASE( "monster_get_hit_base", "[monster][melee][hit]" )
 {
     clear_map();
 
@@ -93,7 +93,7 @@ TEST_CASE( "monster::get_hit_base", "[monster][melee][hit]" )
     }
 }
 
-TEST_CASE( "Character::get_hit_base", "[character][melee][hit][dex]" )
+TEST_CASE( "Character_get_hit_base", "[character][melee][hit][dex]" )
 {
     clear_map();
 
@@ -112,7 +112,7 @@ TEST_CASE( "Character::get_hit_base", "[character][melee][hit][dex]" )
     }
 }
 
-TEST_CASE( "monster::get_dodge_base", "[monster][melee][dodge]" )
+TEST_CASE( "monster_get_dodge_base", "[monster][melee][dodge]" )
 {
     clear_map();
 
@@ -122,7 +122,7 @@ TEST_CASE( "monster::get_dodge_base", "[monster][melee][dodge]" )
     }
 }
 
-TEST_CASE( "Character::get_dodge_base", "[character][melee][dodge][dex][skill]" )
+TEST_CASE( "Character_get_dodge_base", "[character][melee][dodge][dex][skill]" )
 {
     clear_map();
 
@@ -183,7 +183,7 @@ TEST_CASE( "Character::get_dodge_base", "[character][melee][dodge][dex][skill]" 
     }
 }
 
-TEST_CASE( "monster::get_dodge with effects", "[monster][melee][dodge][effect]" )
+TEST_CASE( "monster_get_dodge_with_effects", "[monster][melee][dodge][effect]" )
 {
     clear_map();
 
@@ -214,7 +214,7 @@ TEST_CASE( "monster::get_dodge with effects", "[monster][melee][dodge][effect]" 
     }
 }
 
-TEST_CASE( "player::get_dodge", "[player][melee][dodge]" )
+TEST_CASE( "player_get_dodge", "[player][melee][dodge]" )
 {
     clear_map();
 
@@ -235,7 +235,7 @@ TEST_CASE( "player::get_dodge", "[player][melee][dodge]" )
     }
 }
 
-TEST_CASE( "player::get_dodge with effects", "[player][melee][dodge][effect]" )
+TEST_CASE( "player_get_dodge_with_effects", "[player][melee][dodge][effect]" )
 {
     clear_map();
 
@@ -294,7 +294,7 @@ TEST_CASE( "player::get_dodge with effects", "[player][melee][dodge][effect]" )
     }
 }
 
-TEST_CASE( "player::get_dodge stamina effects", "[player][melee][dodge][stamina]" )
+TEST_CASE( "player_get_dodge_stamina_effects", "[player][melee][dodge][stamina]" )
 {
     avatar &dummy = get_avatar();
     clear_character( dummy );

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -88,7 +88,7 @@ static const int num_iters = 10000;
 
 static constexpr tripoint dude_pos( HALF_MAPSIZE_X, HALF_MAPSIZE_Y, 0 );
 
-TEST_CASE( "Character attacking a zombie", "[.melee]" )
+TEST_CASE( "Character_attacking_a_zombie", "[.melee]" )
 {
     monster zed( mon_zombie );
     INFO( "Zombie has get_dodge() == " + std::to_string( zed.get_dodge() ) );
@@ -117,7 +117,7 @@ TEST_CASE( "Character attacking a zombie", "[.melee]" )
     }
 }
 
-TEST_CASE( "Character attacking a manhack", "[.melee]" )
+TEST_CASE( "Character_attacking_a_manhack", "[.melee]" )
 {
     monster manhack( mon_manhack );
     INFO( "Manhack has get_dodge() == " + std::to_string( manhack.get_dodge() ) );
@@ -146,7 +146,7 @@ TEST_CASE( "Character attacking a manhack", "[.melee]" )
     }
 }
 
-TEST_CASE( "Zombie attacking a character", "[.melee]" )
+TEST_CASE( "Zombie_attacking_a_character", "[.melee]" )
 {
     monster zed( mon_zombie );
     INFO( "Zombie has get_hit() == " + std::to_string( zed.get_hit() ) );
@@ -185,7 +185,7 @@ TEST_CASE( "Zombie attacking a character", "[.melee]" )
     }
 }
 
-TEST_CASE( "Manhack attacking a character", "[.melee]" )
+TEST_CASE( "Manhack_attacking_a_character", "[.melee]" )
 {
     monster manhack( mon_manhack );
     INFO( "Manhack has get_hit() == " + std::to_string( manhack.get_hit() ) );
@@ -219,7 +219,7 @@ TEST_CASE( "Manhack attacking a character", "[.melee]" )
     }
 }
 
-TEST_CASE( "Hulk smashing a character", "[.], [melee], [monattack]" )
+TEST_CASE( "Hulk_smashing_a_character", "[.], [melee], [monattack]" )
 {
     monster zed( mon_zombie_hulk );
     INFO( "Hulk has get_hit() == " + std::to_string( zed.get_hit() ) );
@@ -253,7 +253,7 @@ TEST_CASE( "Hulk smashing a character", "[.], [melee], [monattack]" )
     }
 }
 
-TEST_CASE( "Charcter can dodge" )
+TEST_CASE( "Charcter_can_dodge" )
 {
     standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
     monster zed( mon_zombie );
@@ -271,7 +271,7 @@ TEST_CASE( "Charcter can dodge" )
     }
 }
 
-TEST_CASE( "Incapacited character can't dodge" )
+TEST_CASE( "Incapacited_character_can_not_dodge" )
 {
     standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
     monster zed( mon_zombie );
@@ -287,7 +287,7 @@ TEST_CASE( "Incapacited character can't dodge" )
     }
 }
 
-TEST_CASE( "Melee skill training caps", "[melee], [melee_training_cap], [skill]" )
+TEST_CASE( "Melee_skill_training_caps", "[melee], [melee_training_cap], [skill]" )
 {
     standard_npc dude( "TestCharacter", dude_pos, {} );
     monster dummy_1( debug_mon );
@@ -389,7 +389,7 @@ static void check_damage_from_test_fire( const std::vector<std::string> &armor_i
     CHECK( avg_dmg == Approx( expected_avg_dmg ).epsilon( 0.075 ) );
 }
 
-TEST_CASE( "Damage type effectiveness vs. monster resistance", "[melee][damage]" )
+TEST_CASE( "Damage_type_effectiveness_vs_monster_resistance", "[melee][damage]" )
 {
     clear_map();
 

--- a/tests/modify_morale_test.cpp
+++ b/tests/modify_morale_test.cpp
@@ -44,7 +44,7 @@ static const trait_id trait_VEGETARIAN( "VEGETARIAN" );
 
 // Test cases for `Character::modify_morale` defined in `src/consumption.cpp`
 
-TEST_CASE( "food enjoyability", "[food][modify_morale][fun]" )
+TEST_CASE( "food_enjoyability", "[food][modify_morale][fun]" )
 {
     avatar dummy;
     dummy.worn.wear_item( dummy, item( "backpack" ), false, false );
@@ -73,7 +73,7 @@ TEST_CASE( "food enjoyability", "[food][modify_morale][fun]" )
     }
 }
 
-TEST_CASE( "dining with table and chair", "[food][modify_morale][table][chair]" )
+TEST_CASE( "dining_with_table_and_chair", "[food][modify_morale][table][chair]" )
 {
     clear_map();
     map &here = get_map();
@@ -191,7 +191,7 @@ TEST_CASE( "dining with table and chair", "[food][modify_morale][table][chair]" 
     }
 }
 
-TEST_CASE( "eating hot food", "[food][modify_morale][hot]" )
+TEST_CASE( "eating_hot_food", "[food][modify_morale][hot]" )
 {
     avatar dummy;
     dummy.worn.wear_item( dummy, item( "backpack" ), false, false );
@@ -340,7 +340,7 @@ TEST_CASE( "cannibalism", "[food][modify_morale][cannibal]" )
     }
 }
 
-TEST_CASE( "sweet junk food", "[food][modify_morale][junk][sweet]" )
+TEST_CASE( "sweet_junk_food", "[food][modify_morale][junk][sweet]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -394,7 +394,7 @@ TEST_CASE( "sweet junk food", "[food][modify_morale][junk][sweet]" )
     }
 }
 
-TEST_CASE( "junk food that is not ingested", "[modify_morale][junk][no_ingest]" )
+TEST_CASE( "junk_food_that_is_not_ingested", "[modify_morale][junk][no_ingest]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -460,7 +460,7 @@ TEST_CASE( "junk food that is not ingested", "[modify_morale][junk][no_ingest]" 
     }
 }
 
-TEST_CASE( "food allergies and intolerances", "[food][modify_morale][allergy]" )
+TEST_CASE( "food_allergies_and_intolerances", "[food][modify_morale][allergy]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -547,7 +547,7 @@ TEST_CASE( "food allergies and intolerances", "[food][modify_morale][allergy]" )
     }
 }
 
-TEST_CASE( "saprophage character", "[food][modify_morale][saprophage]" )
+TEST_CASE( "saprophage_character", "[food][modify_morale][saprophage]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -584,7 +584,7 @@ TEST_CASE( "saprophage character", "[food][modify_morale][saprophage]" )
     }
 }
 
-TEST_CASE( "ursine honey", "[food][modify_morale][ursine][honey]" )
+TEST_CASE( "ursine_honey", "[food][modify_morale][ursine][honey]" )
 {
     avatar dummy;
     dummy.set_body();

--- a/tests/mongroup_test.cpp
+++ b/tests/mongroup_test.cpp
@@ -63,7 +63,7 @@ static void spawn_x_monsters( int x, const mongroup_id &grp, const std::vector<m
     }
 }
 
-TEST_CASE( "Event-based monster spawns do not spawn outside event", "[monster][mongroup]" )
+TEST_CASE( "Event-based_monster_spawns_do_not_spawn_outside_event", "[monster][mongroup]" )
 {
     override_option ev_spawn_opt( "EVENT_SPAWNS", "monsters" );
     REQUIRE( get_option<std::string>( "EVENT_SPAWNS" ) == "monsters" );
@@ -114,7 +114,7 @@ TEST_CASE( "Event-based monster spawns do not spawn outside event", "[monster][m
     }
 }
 
-TEST_CASE( "Event-based monsters from an event-only mongroup", "[monster][mongroup]" )
+TEST_CASE( "Event-based_monsters_from_an_event-only_mongroup", "[monster][mongroup]" )
 {
     override_option ev_spawn_opt( "EVENT_SPAWNS", "monsters" );
     REQUIRE( get_option<std::string>( "EVENT_SPAWNS" ) == "monsters" );
@@ -151,7 +151,7 @@ TEST_CASE( "Event-based monsters from an event-only mongroup", "[monster][mongro
     }
 }
 
-TEST_CASE( "Using mon_null as mongroup default monster", "[mongroup]" )
+TEST_CASE( "Using_mon_null_as_mongroup_default_monster", "[mongroup]" )
 {
     mongroup_id test_group1( "test_default_monster" );
     mongroup_id test_group2( "test_group_default_monster" );
@@ -163,7 +163,7 @@ TEST_CASE( "Using mon_null as mongroup default monster", "[mongroup]" )
     CHECK( test_group4->defaultMonster != mon_null );
 }
 
-TEST_CASE( "Nested monster groups spawn chance", "[mongroup]" )
+TEST_CASE( "Nested_monster_groups_spawn_chance", "[mongroup]" )
 {
     mongroup_id mg( "test_top_level_mongroup" );
 
@@ -218,7 +218,7 @@ TEST_CASE( "Nested monster groups spawn chance", "[mongroup]" )
     }
 }
 
-TEST_CASE( "Nested monster group pack size", "[mongroup]" )
+TEST_CASE( "Nested_monster_group_pack_size", "[mongroup]" )
 {
     const int iters = 100;
     calendar::turn += 1_turns;

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -255,7 +255,7 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
     }
 }
 
-TEST_CASE( "Mattack dialog condition test", "[mattack]" )
+TEST_CASE( "Mattack_dialog_condition_test", "[mattack]" )
 {
     clear_map();
     clear_creatures();
@@ -296,7 +296,7 @@ TEST_CASE( "Mattack dialog condition test", "[mattack]" )
     CHECK( !attack->call( test_monster ) );
 }
 
-TEST_CASE( "Targeted grab removal test", "[mattack][grab]" )
+TEST_CASE( "Targeted_grab_removal_test", "[mattack][grab]" )
 {
 
     const std::string grabber_left = "mon_debug_grabber_left";
@@ -337,7 +337,7 @@ TEST_CASE( "Targeted grab removal test", "[mattack][grab]" )
     REQUIRE( !you.has_effect( effect_grabbed, body_part_arm_l ) );
 }
 
-TEST_CASE( "Ranged pull tests", "[mattack][grab]" )
+TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
 {
     // Set up further from the target
     const tripoint target_location = attacker_location + tripoint{ 4, 0, 0 };
@@ -412,7 +412,7 @@ TEST_CASE( "Ranged pull tests", "[mattack][grab]" )
 }
 
 
-TEST_CASE( "Grab breaks against weak grabber(s)", "[mattack][grab]" )
+TEST_CASE( "Grab_breaks_against_weak_grabbers", "[mattack][grab]" )
 {
     const tripoint target_location = attacker_location + tripoint_east;
     const tripoint attacker_location_n = target_location + tripoint_north;
@@ -553,7 +553,7 @@ TEST_CASE( "Grab breaks against weak grabber(s)", "[mattack][grab]" )
     }
 }
 
-TEST_CASE( "Grab breaks against midline grabbers", "[mattack][grab]" )
+TEST_CASE( "Grab_breaks_against_midline_grabbers", "[mattack][grab]" )
 {
     const tripoint target_location = attacker_location + tripoint_east;
     const tripoint attacker_location_n = target_location + tripoint_north;
@@ -691,7 +691,7 @@ TEST_CASE( "Grab breaks against midline grabbers", "[mattack][grab]" )
     }
 }
 
-TEST_CASE( "Grab breaks against strong grabbers", "[mattack][grab]" )
+TEST_CASE( "Grab_breaks_against_strong_grabbers", "[mattack][grab]" )
 {
     const tripoint target_location = attacker_location + tripoint_east;
     const tripoint attacker_location_n = target_location + tripoint_north;

--- a/tests/monster_vision_test.cpp
+++ b/tests/monster_vision_test.cpp
@@ -20,7 +20,7 @@ static monster &spawn_and_clear( const tripoint &pos, bool set_floor )
 
 static const time_point midday = calendar::turn_zero + 12_hours;
 
-TEST_CASE( "monsters shouldn't see through floors", "[vision]" )
+TEST_CASE( "monsters_should_not_see_through_floors", "[vision]" )
 {
     override_option opt( "FOV_3D", "true" );
     restore_on_out_of_scope<bool> restore_fov_3d( fov_3d );

--- a/tests/moon_test.cpp
+++ b/tests/moon_test.cpp
@@ -37,7 +37,7 @@
 
 // The full lunar cycle takes a duration defined by lunar_month(), by default the synodic month
 // ~29.53 days when using the default season length of 91 days.
-TEST_CASE( "moon phase repeats once per synodic month", "[calendar][moon][phase][synodic]" )
+TEST_CASE( "moon_phase_repeats_once_per_synodic_month", "[calendar][moon][phase][synodic]" )
 {
     calendar::set_season_length( 91 );
     REQUIRE( calendar::season_from_default_ratio() == Approx( 1.0f ) );
@@ -73,7 +73,7 @@ TEST_CASE( "moon phase repeats once per synodic month", "[calendar][moon][phase]
 // length, one lunar (synodic) month is about 29.53 days. Longer or shorter seasons scale the lunar
 // month accordingly.
 //
-TEST_CASE( "lunar month is scaled by season default ratio", "[calendar][moon][month][season]" )
+TEST_CASE( "lunar_month_is_scaled_by_season_default_ratio", "[calendar][moon][month][season]" )
 {
     const time_point zero = calendar::turn_zero;
 
@@ -117,7 +117,7 @@ TEST_CASE( "lunar month is scaled by season default ratio", "[calendar][moon][mo
 // With 8 discrete phases during a 29-day period, each phase lasts three or four days.
 // Over a 1-month period of 30 or 31 days, the moon should go through all 8 phases.
 //
-TEST_CASE( "moon phases each day for a month", "[calendar][moon][phase]" )
+TEST_CASE( "moon_phases_each_day_for_a_month", "[calendar][moon][phase]" )
 {
     calendar::set_season_length( 91 );
     REQUIRE( calendar::season_from_default_ratio() == Approx( 1.0f ) );
@@ -162,7 +162,7 @@ TEST_CASE( "moon phases each day for a month", "[calendar][moon][phase]" )
 // To prevent the light level from abruptly changing in the middle of the night, the moon's phase
 // change occurs at noon (rather than midnight) on the appropriate day during the lunar cycle.
 //
-TEST_CASE( "moon phase changes at noon", "[calendar][moon][phase][change]" )
+TEST_CASE( "moon_phase_changes_at_noon", "[calendar][moon][phase][change]" )
 {
     calendar::set_season_length( 91 );
     REQUIRE( calendar::season_from_default_ratio() == Approx( 1.0f ) );
@@ -203,7 +203,7 @@ TEST_CASE( "moon phase changes at noon", "[calendar][moon][phase][change]" )
 
 // At dawn, light transitions from moonlight to sunlight level.
 // At dusk, light transitions from sunlight to moonlight level.
-TEST_CASE( "moonlight at dawn and dusk", "[calendar][moon][moonlight][dawn][dusk]" )
+TEST_CASE( "moonlight_at_dawn_and_dusk", "[calendar][moon][moonlight][dawn][dusk]" )
 {
     calendar::set_season_length( 91 );
     REQUIRE( calendar::season_from_default_ratio() == Approx( 1.0f ) );
@@ -299,7 +299,7 @@ static float phase_moonlight( const float phase_scale, const moon_phase expect_p
 }
 
 // Moonlight level varies with moon phase, from 1.0 at new moon to 10.0 at full moon.
-TEST_CASE( "moonlight for each phase", "[calendar][moon][phase][moonlight]" )
+TEST_CASE( "moonlight_for_each_phase", "[calendar][moon][phase][moonlight]" )
 {
     calendar::set_season_length( 91 );
     REQUIRE( calendar::season_from_default_ratio() == Approx( 1.0f ) );

--- a/tests/move_cost_test.cpp
+++ b/tests/move_cost_test.cpp
@@ -39,7 +39,7 @@ static const trait_id trait_LEG_TENTACLES( "LEG_TENTACLES" );
 static const trait_id trait_PADDED_FEET( "PADDED_FEET" );
 static const trait_id trait_TOUGH_FEET( "TOUGH_FEET" );
 
-TEST_CASE( "being knocked down triples movement cost", "[move_cost][downed]" )
+TEST_CASE( "being_knocked_down_triples_movement_cost", "[move_cost][downed]" )
 {
     avatar &ava = get_avatar();
     clear_avatar();
@@ -55,7 +55,7 @@ TEST_CASE( "being knocked down triples movement cost", "[move_cost][downed]" )
     CHECK( ava.run_cost( 400 ) == 1200 );
 }
 
-TEST_CASE( "footwear may affect movement cost", "[move_cost][shoes]" )
+TEST_CASE( "footwear_may_affect_movement_cost", "[move_cost][shoes]" )
 {
     avatar &ava = get_avatar();
     map &here = get_map();
@@ -157,7 +157,7 @@ TEST_CASE( "footwear may affect movement cost", "[move_cost][shoes]" )
     }
 }
 
-TEST_CASE( "mutations may affect movement cost", "[move_cost][mutation]" )
+TEST_CASE( "mutations_may_affect_movement_cost", "[move_cost][mutation]" )
 {
     avatar &ava = get_avatar();
     clear_avatar();
@@ -216,7 +216,7 @@ TEST_CASE( "mutations may affect movement cost", "[move_cost][mutation]" )
     }
 }
 
-TEST_CASE( "Crawl score effects on movement cost", "[move_cost]" )
+TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
 {
     // No limb damage
     GIVEN( "Character is uninjured and unencumbered" ) {

--- a/tests/mutation_test.cpp
+++ b/tests/mutation_test.cpp
@@ -103,7 +103,7 @@ std::string get_mutations_as_string( const Character &you )
 //
 // This test illustrates and verifies the above scenario, using the same categories and mutations.
 //
-TEST_CASE( "mutation category strength based on current mutations", "[mutations][category]" )
+TEST_CASE( "mutation_category_strength_based_on_current_mutations", "[mutations][category]" )
 {
     npc dummy;
 
@@ -152,7 +152,7 @@ TEST_CASE( "mutation category strength based on current mutations", "[mutations]
 
 // If character has all available mutations in a category (pre- or post-threshold), that should be
 // their strongest/highest category. This test verifies that expectation for every category.
-TEST_CASE( "Having all mutations give correct highest category", "[mutations][strongest]" )
+TEST_CASE( "Having_all_mutations_give_correct_highest_category", "[mutations][strongest]" )
 {
     for( const std::pair<const mutation_category_id, mutation_category_trait> &cat :
          mutation_category_trait::get_all() ) {
@@ -203,7 +203,7 @@ TEST_CASE( "Having all mutations give correct highest category", "[mutations][st
 // 65+ is the suggested range
 //
 // This test verifies the breach-power expectation for all mutation categories.
-TEST_CASE( "Having all pre-threshold mutations gives a sensible threshold breach power",
+TEST_CASE( "Having_all_pre-threshold_mutations_gives_a_sensible_threshold_breach_power",
            "[mutations][breach]" )
 {
     const int BREACH_POWER_MIN = 55;
@@ -248,7 +248,7 @@ TEST_CASE( "Having all pre-threshold mutations gives a sensible threshold breach
     }
 }
 
-TEST_CASE( "Mutation/starting trait interactions", "[mutations]" )
+TEST_CASE( "Mutation/starting_trait_interactions", "[mutations]" )
 {
     Character &dummy = get_player_character();
     clear_avatar();
@@ -336,7 +336,7 @@ TEST_CASE( "Mutation/starting trait interactions", "[mutations]" )
     }
 }
 
-TEST_CASE( "Scout and Topographagnosia traits affect overmap sight range", "[mutations][overmap]" )
+TEST_CASE( "Scout_and_Topographagnosia_traits_affect_overmap_sight_range", "[mutations][overmap]" )
 {
     Character &dummy = get_player_character();
     clear_avatar();
@@ -381,7 +381,7 @@ static void check_test_mutation_is_triggered( const Character &dummy, bool trigg
     }
 }
 
-TEST_CASE( "The various type of triggers work", "[mutations]" )
+TEST_CASE( "The_various_type_of_triggers_work", "[mutations]" )
 {
     Character &dummy = get_player_character();
     clear_avatar();
@@ -520,7 +520,7 @@ TEST_CASE( "The various type of triggers work", "[mutations]" )
 
 }
 
-TEST_CASE( "All valid mutations can be purified", "[mutations][purifier]" )
+TEST_CASE( "All_valid_mutations_can_be_purified", "[mutations][purifier]" )
 {
     std::vector<trait_id> dummies;
     std::vector<trait_id> valid_traits;
@@ -566,7 +566,7 @@ TEST_CASE( "All valid mutations can be purified", "[mutations][purifier]" )
 //neutral mutations, because those are always allowed.
 //This also incidentally tests that, given available mutations and enough mutagen,
 //Character::mutate always succeeds to give exactly one mutation.
-TEST_CASE( "Chance of bad mutations vs instability", "[mutations][instability]" )
+TEST_CASE( "Chance_of_bad_mutations_vs_instability", "[mutations][instability]" )
 {
     Character &dummy = get_player_character();
 
@@ -626,7 +626,7 @@ TEST_CASE( "Chance of bad mutations vs instability", "[mutations][instability]" 
 // If has_trait( trait_XXX )-checks for a certain trait have been 'flagified' to check for
 // has_flag( json_flag_XXX ) instead the check should be added here and it's recommended to
 // reference to the PR that changes it.
-TEST_CASE( "The mutation flags are associated to the corresponding base mutations",
+TEST_CASE( "The_mutation_flags_are_associated_to_the_corresponding_base_mutations",
            "[mutations][flags]" )
 {
     Character &dummy = get_player_character();

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -216,7 +216,7 @@ TEST_CASE( "starting_items", "[slow]" )
     REQUIRE( failures.empty() );
 }
 
-TEST_CASE( "Generated character with category mutations", "[mutation]" )
+TEST_CASE( "Generated_character_with_category_mutations", "[mutation]" )
 {
     REQUIRE( !trait_TAIL_FLUFFY.obj().category.empty() );
     avatar u = get_sanitized_player();

--- a/tests/normalized_test_names_test.cpp
+++ b/tests/normalized_test_names_test.cpp
@@ -1,0 +1,35 @@
+#include "cata_catch.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <iterator>
+#include <set>
+
+TEST_CASE( "enforce_normalized_test_cases" )
+{
+    const static std::string allowed_chars =
+        "abcdefghijklmnopqrstuvwxyz"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "0123456789"
+        "_-+/";
+
+    const std::set<char> allowed_set( allowed_chars.begin(), allowed_chars.end() );
+    INFO( "Prefer simple characters for TEST_CASE names to avoid need for escaping" );
+    CAPTURE( allowed_chars );
+
+    for( const Catch::TestCase &tc :
+         Catch::getAllTestCasesSorted( *Catch::getCurrentContext().getConfig() ) ) {
+        const std::string &test_case_name = tc.name;
+        CAPTURE( test_case_name );
+        int i = 0;
+        for( ; i < static_cast<int>( test_case_name.size() ); i++ ) {
+            if( allowed_set.count( test_case_name[i] ) <= 0 ) {
+                break;
+            }
+        }
+        const char invalid_char = test_case_name[i];
+        CAPTURE( invalid_char );
+        CHECK( i == static_cast<int>( test_case_name.size() ) );
+    }
+}

--- a/tests/npc_attack_test.cpp
+++ b/tests/npc_attack_test.cpp
@@ -65,7 +65,7 @@ static monster *spawn_zombie_at_range( const int range )
 }
 } // namespace npc_attack_setup
 
-TEST_CASE( "NPC faces zombies", "[npc_attack]" )
+TEST_CASE( "NPC_faces_zombies", "[npc_attack]" )
 {
     get_player_character().setpos( main_npc_start_tripoint );
     clear_map_and_put_player_underground();

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -1755,7 +1755,7 @@ static void update_cache( map &m )
     m.build_map_cache( 0 );
 }
 
-TEST_CASE( "activity interruption by distractions", "[activity][interruption]" )
+TEST_CASE( "activity_interruption_by_distractions", "[activity][interruption]" )
 {
     clear_avatar();
     clear_map();

--- a/tests/player_test.cpp
+++ b/tests/player_test.cpp
@@ -78,7 +78,7 @@ static void test_temperature_spread( Character *p, const std::array<int, 7> &amb
     temperature_check( p, ambient_temps[6], BODYTEMP_SCORCHING );
 }
 
-TEST_CASE( "player body temperatures converge on expected values.", "[.bodytemp]" )
+TEST_CASE( "player_body_temperatures_converge_on_expected_values", "[.bodytemp]" )
 {
 
     Character &dummy = get_player_character();

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -34,7 +34,7 @@ static const trait_id trait_ILLITERATE( "ILLITERATE" );
 static const trait_id trait_LOVES_BOOKS( "LOVES_BOOKS" );
 static const trait_id trait_SPIRITUAL( "SPIRITUAL" );
 
-TEST_CASE( "clearing identified books", "[reading][book][identify][clear]" )
+TEST_CASE( "clearing_identified_books", "[reading][book][identify][clear]" )
 {
     item book( "child_book" );
     SECTION( "using local avatar" ) {
@@ -51,7 +51,7 @@ TEST_CASE( "clearing identified books", "[reading][book][identify][clear]" )
     }
 }
 
-TEST_CASE( "identifying unread books", "[reading][book][identify]" )
+TEST_CASE( "identifying_unread_books", "[reading][book][identify]" )
 {
     clear_avatar();
     Character &dummy = get_avatar();
@@ -76,7 +76,7 @@ TEST_CASE( "identifying unread books", "[reading][book][identify]" )
     }
 }
 
-TEST_CASE( "reading a book for fun", "[reading][book][fun]" )
+TEST_CASE( "reading_a_book_for_fun", "[reading][book][fun]" )
 {
     clear_avatar();
     Character &dummy = get_avatar();
@@ -148,7 +148,7 @@ TEST_CASE( "reading a book for fun", "[reading][book][fun]" )
     }
 }
 
-TEST_CASE( "character reading speed", "[reading][character][speed]" )
+TEST_CASE( "character_reading_speed", "[reading][character][speed]" )
 {
     clear_avatar();
     Character &dummy = get_avatar();
@@ -194,7 +194,7 @@ TEST_CASE( "character reading speed", "[reading][character][speed]" )
     }
 }
 
-TEST_CASE( "estimated reading time for a book", "[reading][book][time]" )
+TEST_CASE( "estimated_reading_time_for_a_book", "[reading][book][time]" )
 {
     avatar dummy;
     //Give eyes to our dummy
@@ -286,7 +286,7 @@ TEST_CASE( "estimated reading time for a book", "[reading][book][time]" )
     }
 }
 
-TEST_CASE( "reasons for not being able to read", "[reading][reasons]" )
+TEST_CASE( "reasons_for_not_being_able_to_read", "[reading][reasons]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -376,7 +376,7 @@ TEST_CASE( "reasons for not being able to read", "[reading][reasons]" )
     }
 }
 
-TEST_CASE( "determining book mastery", "[reading][book][mastery]" )
+TEST_CASE( "determining_book_mastery", "[reading][book][mastery]" )
 {
     static const auto book_has_skill = []( const item & book ) -> bool {
         REQUIRE( book.is_book() );
@@ -431,7 +431,7 @@ TEST_CASE( "determining book mastery", "[reading][book][mastery]" )
     }
 }
 
-TEST_CASE( "reading a book for skill", "[reading][book][skill]" )
+TEST_CASE( "reading_a_book_for_skill", "[reading][book][skill]" )
 {
     clear_avatar();
     Character &dummy = get_avatar();
@@ -466,7 +466,7 @@ TEST_CASE( "reading a book for skill", "[reading][book][skill]" )
     }
 }
 
-TEST_CASE( "reading a book with an ebook reader", "[reading][book][ereader]" )
+TEST_CASE( "reading_a_book_with_an_ebook_reader", "[reading][book][ereader]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();

--- a/tests/reloading_test.cpp
+++ b/tests/reloading_test.cpp
@@ -603,7 +603,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
     }
 }
 
-TEST_CASE( "gunmod reloading", "[reload],[gun]" )
+TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
 {
     SECTION( "empty gun and gunmod" ) {
         item gun( "m4_carbine" );

--- a/tests/rewrite_vsnprintf_test.cpp
+++ b/tests/rewrite_vsnprintf_test.cpp
@@ -6,7 +6,7 @@
 #include "cata_catch.h"
 #include "output.h"
 
-TEST_CASE( "Test vsnprintf_rewrite" )
+TEST_CASE( "Test_vsnprintf_rewrite" )
 {
     CHECK( rewrite_vsnprintf( "%%hello%%" ) == "%%hello%%" );
     CHECK( rewrite_vsnprintf( "hello" ) == "hello" );

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -15,7 +15,7 @@ static void set_map_temperature( units::temperature new_temperature )
     get_weather().clear_temp_cache();
 }
 
-TEST_CASE( "Rate of rotting", "[rot]" )
+TEST_CASE( "Rate_of_rotting", "[rot]" )
 {
     SECTION( "Passage of time" ) {
         // Item rot is a time duration.
@@ -75,7 +75,7 @@ TEST_CASE( "Rate of rotting", "[rot]" )
     }
 }
 
-TEST_CASE( "Items rot away", "[rot]" )
+TEST_CASE( "Items_rot_away", "[rot]" )
 {
     SECTION( "Item in reality bubble rots away" ) {
         // Item should rot away when it has 2x of its shelf life in rot.
@@ -99,7 +99,7 @@ TEST_CASE( "Items rot away", "[rot]" )
     }
 }
 
-TEST_CASE( "Hourly rotpoints", "[rot]" )
+TEST_CASE( "Hourly_rotpoints", "[rot]" )
 {
     item normal_item( "meat_cooked" );
 

--- a/tests/start_date_test.cpp
+++ b/tests/start_date_test.cpp
@@ -10,7 +10,7 @@ static const string_id<scenario> scenario_test_random_day( "test_random_day" );
 static const string_id<scenario> scenario_test_random_hour( "test_random_hour" );
 static const string_id<scenario> scenario_test_random_year( "test_random_year" );
 
-TEST_CASE( "Test start dates" )
+TEST_CASE( "Test_start_dates" )
 {
     int default_initial_day = 60;
     int default_initial_time = 8;  // Note that the default for scenario time is same
@@ -88,7 +88,7 @@ TEST_CASE( "Test start dates" )
     calendar::turn = calendar::turn_zero;
 }
 
-TEST_CASE( "Random dates" )
+TEST_CASE( "Random_dates" )
 {
     int default_initial_time = 8;
 
@@ -131,7 +131,7 @@ TEST_CASE( "Random dates" )
     calendar::turn = calendar::turn_zero;
 }
 
-TEST_CASE( "Random scenario dates" )
+TEST_CASE( "Random_scenario_dates" )
 {
     // Days counted from start of year
     time_duration first_day_of_summer = calendar::season_length();

--- a/tests/submap_test.cpp
+++ b/tests/submap_test.cpp
@@ -5,7 +5,7 @@
 #include "point.h"
 #include "type_id.h"
 
-TEST_CASE( "submap rotation", "[submap]" )
+TEST_CASE( "submap_rotation", "[submap]" )
 {
     // Corners are labelled starting from the upper-left one, clockwise.
     constexpr point corner_1{};
@@ -89,7 +89,7 @@ TEST_CASE( "submap rotation", "[submap]" )
     }
 }
 
-TEST_CASE( "submap rotation2", "[submap]" )
+TEST_CASE( "submap_rotation2", "[submap]" )
 {
     int rotation_turns = GENERATE( 0, 1, 2, 3 );
     CAPTURE( rotation_turns );

--- a/tests/sun_test.cpp
+++ b/tests/sun_test.cpp
@@ -27,7 +27,7 @@
 // The times of sunrise and sunset will naturally depend on the current time of year; this aspect is
 // covered by the "sunrise and sunset" and solstice/equinox tests later in this file. Here we simply
 // use the first day of spring as a baseline.
-TEST_CASE( "daily solar cycle", "[sun][night][dawn][day][dusk]" )
+TEST_CASE( "daily_solar_cycle", "[sun][night][dawn][day][dusk]" )
 {
     // Use sunrise/sunset on the first day (spring equinox)
     const time_point midnight = calendar::turn_zero;
@@ -128,7 +128,7 @@ TEST_CASE( "daily solar cycle", "[sun][night][dawn][day][dusk]" )
 }
 
 // The calendar `sunlight` function returns light level for both sun and moon.
-TEST_CASE( "sunlight and moonlight", "[sun][sunlight][moonlight]" )
+TEST_CASE( "sunlight_and_moonlight", "[sun][sunlight][moonlight]" )
 {
     // Use sunrise/sunset on the first day (spring equinox)
     const time_point midnight = calendar::turn_zero;
@@ -211,7 +211,7 @@ TEST_CASE( "sunlight and moonlight", "[sun][sunlight][moonlight]" )
 }
 
 // sanity-check seasonally-adjusted maximum daylight level
-TEST_CASE( "noon sunlight levels", "[sun][daylight][equinox][solstice]" )
+TEST_CASE( "noon_sunlight_levels", "[sun][daylight][equinox][solstice]" )
 {
     const time_duration one_season = calendar::season_length();
     const time_point spring = calendar::turn_zero;
@@ -258,7 +258,7 @@ TEST_CASE( "noon sunlight levels", "[sun][daylight][equinox][solstice]" )
 
 // The times of sunrise and sunset vary throughout the year. Equinoxes occur on the
 // first day of spring and autumn, and solstices occur on the first day of summer and winter.
-TEST_CASE( "sunrise and sunset", "[sun][sunrise][sunset][equinox][solstice]" )
+TEST_CASE( "sunrise_and_sunset", "[sun][sunrise][sunset][equinox][solstice]" )
 {
     // Due to the "NN_days" math below, this test requires a default 91-day season length
     REQUIRE( calendar::season_from_default_ratio() == Approx( 1.0f ) );
@@ -400,7 +400,7 @@ TEST_CASE( "sun_highest_at_noon", "[sun]" )
     }
 }
 
-TEST_CASE( "noon_sun_doesn't_move_much", "[sun]" )
+TEST_CASE( "noon_sun_does_not_move_much", "[sun]" )
 {
     rl_vec2d noon_angle = checked_sunlight_angle( first_noon );
     for( int i = 1; i < 1000; ++i ) {

--- a/tests/temperature_test.cpp
+++ b/tests/temperature_test.cpp
@@ -15,7 +15,7 @@ static void set_map_temperature( units::temperature new_temperature )
     get_weather().clear_temp_cache();
 }
 
-TEST_CASE( "Item spawns with right thermal attributes", "[temperature]" )
+TEST_CASE( "Item_spawns_with_right_thermal_attributes", "[temperature]" )
 {
     item D( "meat_cooked" );
 
@@ -32,7 +32,7 @@ TEST_CASE( "Item spawns with right thermal attributes", "[temperature]" )
     CHECK( units::to_kelvin( D.temperature ) == Approx( 323.15 ) );
 }
 
-TEST_CASE( "Rate of temperature change", "[temperature]" )
+TEST_CASE( "Rate_of_temperature_change", "[temperature]" )
 {
     // Fahrenheits and kelvins get used and converted around
     // So there are small rounding errors everywhere. Use margins.
@@ -257,7 +257,7 @@ TEST_CASE( "Rate of temperature change", "[temperature]" )
     }
 }
 
-TEST_CASE( "Temperature controlled location", "[temperature]" )
+TEST_CASE( "Temperature_controlled_location", "[temperature]" )
 {
     SECTION( "Heater test" ) {
         // Spawn water

--- a/tests/throwing_test.cpp
+++ b/tests/throwing_test.cpp
@@ -23,7 +23,7 @@
 
 static const skill_id skill_throw( "throw" );
 
-TEST_CASE( "throwing distance test", "[throwing], [balance]" )
+TEST_CASE( "throwing_distance_test", "[throwing], [balance]" )
 {
     const standard_npc thrower( "Thrower", tripoint( 60, 60, 0 ), {}, 4, 10, 10, 10, 10 );
     item grenade( "grenade" );

--- a/tests/tool_quality_test.cpp
+++ b/tests/tool_quality_test.cpp
@@ -65,7 +65,7 @@ TEST_CASE( "get_quality", "[tool][quality]" )
 
 // Tools that run on battery power (or are otherwise "charged") may have "charged_qualities"
 // that are only available when the item is charged with at least "charges_per_use" charges.
-TEST_CASE( "battery-powered tool qualities", "[tool][battery][quality]" )
+TEST_CASE( "battery-powered_tool_qualities", "[tool][battery][quality]" )
 {
     item drill( "test_cordless_drill" );
     item battery( "medium_battery_cell" );

--- a/tests/translation_system_test.cpp
+++ b/tests/translation_system_test.cpp
@@ -12,7 +12,7 @@ static void LoadMODocument( const char *path )
     volatile TranslationDocument document( path );
 }
 
-TEST_CASE( "TranslationDocument loads valid MO", "[translations]" )
+TEST_CASE( "TranslationDocument_loads_valid_MO", "[translations]" )
 {
     const char *path = "./data/mods/TEST_DATA/lang/mo/ru/LC_MESSAGES/TEST_DATA.mo";
     CAPTURE( path );
@@ -20,7 +20,7 @@ TEST_CASE( "TranslationDocument loads valid MO", "[translations]" )
     REQUIRE_NOTHROW( LoadMODocument( path ) );
 }
 
-TEST_CASE( "TranslationDocument rejects invalid MO", "[translations]" )
+TEST_CASE( "TranslationDocument_rejects_invalid_MO", "[translations]" )
 {
     const char *path = "./data/mods/TEST_DATA/lang/mo/ru/LC_MESSAGES/INVALID_RAND.mo";
     CAPTURE( path );
@@ -28,7 +28,7 @@ TEST_CASE( "TranslationDocument rejects invalid MO", "[translations]" )
     REQUIRE_THROWS_AS( LoadMODocument( path ), InvalidTranslationDocumentException );
 }
 
-TEST_CASE( "TranslationDocument loads all core MO", "[translations]" )
+TEST_CASE( "TranslationDocument_loads_all_core_MO", "[translations]" )
 {
     const std::unordered_set<std::string> languages =
         TranslationManager::GetInstance().GetAvailableLanguages();
@@ -40,7 +40,7 @@ TEST_CASE( "TranslationDocument loads all core MO", "[translations]" )
     }
 }
 
-TEST_CASE( "No string buffer overlap in TranslationDocument", "[translations]" )
+TEST_CASE( "No_string_buffer_overlap_in_TranslationDocument", "[translations]" )
 {
     const std::unordered_set<std::string> languages =
         TranslationManager::GetInstance().GetAvailableLanguages();
@@ -67,14 +67,14 @@ TEST_CASE( "No string buffer overlap in TranslationDocument", "[translations]" )
     }
 }
 
-TEST_CASE( "TranslationDocument loading benchmark", "[.][benchmark][translations]" )
+TEST_CASE( "TranslationDocument_loading_benchmark", "[.][benchmark][translations]" )
 {
     BENCHMARK( "Load Russian" ) {
         return TranslationDocument( "./lang/mo/ru/LC_MESSAGES/cataclysm-dda.mo" );
     };
 }
 
-TEST_CASE( "TranslationManager loading benchmark", "[.][benchmark][translations]" )
+TEST_CASE( "TranslationManager_loading_benchmark", "[.][benchmark][translations]" )
 {
     BENCHMARK( "Load Russian" ) {
         TranslationManager manager;
@@ -83,7 +83,7 @@ TEST_CASE( "TranslationManager loading benchmark", "[.][benchmark][translations]
     };
 }
 
-TEST_CASE( "TranslationManager translate benchmark", "[.][benchmark][translations]" )
+TEST_CASE( "TranslationManager_translate_benchmark", "[.][benchmark][translations]" )
 {
     TranslationManager manager;
 
@@ -111,7 +111,7 @@ TEST_CASE( "TranslationManager translate benchmark", "[.][benchmark][translation
     };
 }
 
-TEST_CASE( "TranslationManager translates message", "[translations]" )
+TEST_CASE( "TranslationManager_translates_message", "[translations]" )
 {
     std::vector<std::string> files{"./data/mods/TEST_DATA/lang/mo/ru/LC_MESSAGES/TEST_DATA.mo"};
     TranslationManager manager;
@@ -120,7 +120,7 @@ TEST_CASE( "TranslationManager translates message", "[translations]" )
     CHECK( translated == "батарейка" );
 }
 
-TEST_CASE( "TranslationManager returns untranslated message as is", "[translations]" )
+TEST_CASE( "TranslationManager_returns_untranslated_message_as_is", "[translations]" )
 {
     std::vector<std::string> files{"./data/mods/TEST_DATA/lang/mo/ru/LC_MESSAGES/TEST_DATA.mo"};
     TranslationManager manager;
@@ -130,7 +130,7 @@ TEST_CASE( "TranslationManager returns untranslated message as is", "[translatio
     CHECK( translated == message );
 }
 
-TEST_CASE( "TranslationManager returns empty string as is", "[translations]" )
+TEST_CASE( "TranslationManager_returns_empty_string_as_is", "[translations]" )
 {
     std::vector<std::string> files{"./data/mods/TEST_DATA/lang/mo/ru/LC_MESSAGES/TEST_DATA.mo"};
     TranslationManager manager;
@@ -139,7 +139,7 @@ TEST_CASE( "TranslationManager returns empty string as is", "[translations]" )
     CHECK( translated.empty() );
 }
 
-TEST_CASE( "TranslationManager translates message with context", "[translations]" )
+TEST_CASE( "TranslationManager_translates_message_with_context", "[translations]" )
 {
     std::vector<std::string> files{"./data/mods/TEST_DATA/lang/mo/ru/LC_MESSAGES/TEST_DATA.mo"};
     TranslationManager manager;
@@ -205,7 +205,7 @@ TEST_CASE( "TranslationPluralRulesEvaluator", "[translations]" )
     }
 }
 
-TEST_CASE( "TranslationManager translates plural messages", "[translations]" )
+TEST_CASE( "TranslationManager_translates_plural_messages", "[translations]" )
 {
     SECTION( "English" ) {
         std::vector<std::string> files;

--- a/tests/try_parse_integer_test.cpp
+++ b/tests/try_parse_integer_test.cpp
@@ -2,9 +2,10 @@
 #include "cata_scope_helpers.h"
 #include "try_parse_integer.h"
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays)
-TEMPLATE_TEST_CASE( "try_parse_int_simple_parsing", "[try_parse_integer]", int, long, long long )
+template<typename TestType>
+void try_parse_int_simple_parsing()
 {
+    CAPTURE( demangle( typeid( TestType ).name() ) );
     std::locale const &oldloc = std::locale();
     on_out_of_scope reset_loc( [&oldloc]() {
         std::locale::global( oldloc );
@@ -69,9 +70,17 @@ TEMPLATE_TEST_CASE( "try_parse_int_simple_parsing", "[try_parse_integer]", int, 
     }
 }
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays)
-TEMPLATE_TEST_CASE( "try_parse_int_locale_parsing", "[try_parse_integer]", int, long, long long )
+TEST_CASE( "try_parse_int_simple_parsing", "[try_parse_integer]" )
 {
+    try_parse_int_simple_parsing<int>();
+    try_parse_int_simple_parsing<long>();
+    try_parse_int_simple_parsing<long long>();
+}
+
+template<typename TestType>
+void try_parse_int_locale_parsing()
+{
+    CAPTURE( demangle( typeid( TestType ).name() ) );
     std::locale const &oldloc = std::locale();
     on_out_of_scope reset_loc( [&oldloc]() {
         std::locale::global( oldloc );
@@ -123,4 +132,11 @@ TEMPLATE_TEST_CASE( "try_parse_int_locale_parsing", "[try_parse_integer]", int, 
             CHECK( result.str() == "Stray characters after integer in '1,234'" );
         }
     }
+}
+
+TEST_CASE( "try_parse_int_locale_parsing", "[try_parse_integer]" )
+{
+    try_parse_int_locale_parsing<int>();
+    try_parse_int_locale_parsing<long>();
+    try_parse_int_locale_parsing<long long>();
 }

--- a/tests/uncraft_test.cpp
+++ b/tests/uncraft_test.cpp
@@ -123,7 +123,7 @@ static int uncraft_yield( Character &they, const itype_id whole_itype, const ity
 //
 // Recovery may still fail if the original item was damaged; for that, see the [damage] test.
 //
-TEST_CASE( "uncraft difficulty and character skill", "[uncraft][difficulty][skill]" )
+TEST_CASE( "uncraft_difficulty_and_character_skill", "[uncraft][difficulty][skill]" )
 {
     Character &they = setup_uncraft_character();
 
@@ -170,7 +170,7 @@ TEST_CASE( "uncraft difficulty and character skill", "[uncraft][difficulty][skil
 }
 
 // Item damage_level (0-5) affects chance of successfully recovering components from disassembly.
-TEST_CASE( "uncraft from a damaged item", "[uncraft][damage]" )
+TEST_CASE( "uncraft_from_a_damaged_item", "[uncraft][damage]" )
 {
     Character &they = setup_uncraft_character();
 

--- a/tests/units_test.cpp
+++ b/tests/units_test.cpp
@@ -66,7 +66,7 @@ static units::energy parse_energy_quantity( const std::string &json )
     return read_from_json_string<units::energy>( jsin, units::energy_units );
 }
 
-TEST_CASE( "energy parsing from JSON", "[units]" )
+TEST_CASE( "energy_parsing_from_JSON", "[units]" )
 {
     CHECK_THROWS( parse_energy_quantity( "\"\"" ) ); // empty string
     CHECK_THROWS( parse_energy_quantity( "27" ) ); // not a string at all
@@ -90,7 +90,7 @@ static units::power parse_power_quantity( const std::string &json )
     return read_from_json_string<units::power>( jsin, units::power_units );
 }
 
-TEST_CASE( "power parsing from JSON", "[units]" )
+TEST_CASE( "power_parsing_from_JSON", "[units]" )
 {
     CHECK_THROWS( parse_power_quantity( "\"\"" ) ); // empty string
     CHECK_THROWS( parse_power_quantity( "27" ) ); // not a string at all
@@ -114,7 +114,7 @@ static time_duration parse_time_duration( const std::string &json )
     return read_from_json_string<time_duration>( jsin, time_duration::units );
 }
 
-TEST_CASE( "time_duration parsing from JSON", "[units]" )
+TEST_CASE( "time_duration_parsing_from_JSON", "[units]" )
 {
     CHECK_THROWS( parse_time_duration( "\"\"" ) ); // empty string
     CHECK_THROWS( parse_time_duration( "27" ) ); // not a string at all
@@ -294,7 +294,7 @@ static units::angle parse_angle( const std::string &json )
     return read_from_json_string<units::angle>( jsin, units::angle_units );
 }
 
-TEST_CASE( "angle parsing from JSON", "[units]" )
+TEST_CASE( "angle_parsing_from_JSON", "[units]" )
 {
     CHECK_THROWS( parse_angle( "\"\"" ) ); // empty string
     CHECK_THROWS( parse_angle( "27" ) ); // not a string at all
@@ -351,7 +351,7 @@ TEST_CASE( "Temperatures", "[temperature]" )
     }
 }
 
-TEST_CASE( "Temperature delta", "[temperature]" )
+TEST_CASE( "Temperature_delta", "[temperature]" )
 {
     SECTION( "Different units match" ) {
         CHECK( units::to_kelvin_delta( units::from_kelvin_delta( 10 ) ) == 10 );
@@ -393,7 +393,7 @@ TEST_CASE( "Temperature delta", "[temperature]" )
 
 }
 
-TEST_CASE( "Specific energy", "[temperature]" )
+TEST_CASE( "Specific_energy", "[temperature]" )
 {
     SECTION( "Different units match" ) {
         CHECK( units::to_joule_per_gram( units::from_joule_per_gram( 100 ) ) == 100 );

--- a/tests/value_ptr_test.cpp
+++ b/tests/value_ptr_test.cpp
@@ -3,7 +3,7 @@
 #include "cata_catch.h"
 #include "value_ptr.h"
 
-TEST_CASE( "value_ptr copy constructor", "[value_ptr]" )
+TEST_CASE( "value_ptr_copy_constructor", "[value_ptr]" )
 {
     cata::value_ptr<int> a = cata::make_value<int>( 7 );
     REQUIRE( !!a );
@@ -15,7 +15,7 @@ TEST_CASE( "value_ptr copy constructor", "[value_ptr]" )
     CHECK( !!b );
 }
 
-TEST_CASE( "value_ptr copy assignment", "[value_ptr]" )
+TEST_CASE( "value_ptr_copy_assignment", "[value_ptr]" )
 {
     cata::value_ptr<int> a = cata::make_value<int>( 7 );
     REQUIRE( !!a );
@@ -29,7 +29,7 @@ TEST_CASE( "value_ptr copy assignment", "[value_ptr]" )
     CHECK( !!b );
 }
 
-TEST_CASE( "value_ptr move constructor", "[value_ptr]" )
+TEST_CASE( "value_ptr_move_constructor", "[value_ptr]" )
 {
     cata::value_ptr<int> a = cata::make_value<int>( 7 );
     REQUIRE( !!a );
@@ -38,7 +38,7 @@ TEST_CASE( "value_ptr move constructor", "[value_ptr]" )
     CHECK( !!b );
 }
 
-TEST_CASE( "value_ptr move assignment", "[value_ptr]" )
+TEST_CASE( "value_ptr_move_assignment", "[value_ptr]" )
 {
     cata::value_ptr<int> a = cata::make_value<int>( 7 );
     cata::value_ptr<int> b = std::move( a );

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -39,7 +39,7 @@ static void reset_player()
     player_character.add_effect( effect_blind, 1_turns, true );
 }
 
-TEST_CASE( "vehicle power with reactor", "[vehicle][power]" )
+TEST_CASE( "vehicle_power_with_reactor", "[vehicle][power]" )
 {
     clear_vehicles();
     reset_player();
@@ -76,7 +76,7 @@ TEST_CASE( "vehicle power with reactor", "[vehicle][power]" )
     }
 }
 
-TEST_CASE( "power loss to cables", "[vehicle][power]" )
+TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
 {
     clear_vehicles();
     reset_player();
@@ -170,7 +170,7 @@ TEST_CASE( "power loss to cables", "[vehicle][power]" )
     }
 }
 
-TEST_CASE( "Solar power", "[vehicle][power]" )
+TEST_CASE( "Solar_power", "[vehicle][power]" )
 {
     clear_vehicles();
     reset_player();
@@ -249,7 +249,7 @@ TEST_CASE( "Solar power", "[vehicle][power]" )
     }
 }
 
-TEST_CASE( "Daily solar power", "[vehicle][power]" )
+TEST_CASE( "Daily_solar_power", "[vehicle][power]" )
 {
     clear_vehicles();
     reset_player();
@@ -311,7 +311,7 @@ TEST_CASE( "Daily solar power", "[vehicle][power]" )
     }
 }
 
-TEST_CASE( "maximum reverse velocity", "[vehicle][power][reverse]" )
+TEST_CASE( "maximum_reverse_velocity", "[vehicle][power][reverse]" )
 {
     reset_player();
     build_test_map( ter_id( "t_pavement" ) );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -269,7 +269,7 @@ static void unfold_and_check( const vehicle_preset &veh_preset, const damage_pre
 }
 
 // Testing iuse::unfold_generic and vehicle part degradation
-TEST_CASE( "Unfolding vehicle parts and testing degradation", "[item][degradation][vehicle]" )
+TEST_CASE( "Unfolding_vehicle_parts_and_testing_degradation", "[item][degradation][vehicle]" )
 {
     std::vector<vehicle_preset> vehicle_presets {
         { itype_folded_inflatable_boat,    { itype_hand_pump } },
@@ -405,7 +405,7 @@ static void check_folded_item_to_parts_damage_transfer( const folded_item_damage
     CHECK( player_folded_veh.get_var( "avg_part_damage", 0.0 ) == preset.item_damage_second_fold );
 }
 
-TEST_CASE( "Check folded item damage transfers to parts and vice versa", "[item][vehicle]" )
+TEST_CASE( "Check_folded_item_damage_transfers_to_parts_and_vice_versa", "[item][vehicle]" )
 {
     std::vector<folded_item_damage_preset> presets {
         { itype_folded_wheelchair_generic, 2111, 2411, 12666, 14466 },
@@ -697,7 +697,7 @@ static void rack_check( const rack_preset &preset )
 }
 
 // Testing vehicle racking and unracking
-TEST_CASE( "Racking and unracking tests", "[vehicle][bikerack]" )
+TEST_CASE( "Racking_and_unracking_tests", "[vehicle][bikerack]" )
 {
     std::vector<rack_preset> racking_presets {
         // basic test; rack bike on car, unrack it, everything should succeed

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -29,7 +29,7 @@ static void setup_test_lake()
     REQUIRE( here.ter( test_origin + tripoint( 0, 0, -2 ) ) == t_lake_bed );
 }
 
-TEST_CASE( "avatar diving", "[diving]" )
+TEST_CASE( "avatar_diving", "[diving]" )
 {
     setup_test_lake();
 
@@ -903,7 +903,7 @@ static std::map<std::string, swim_result> expected_results = {
     {"move: walk, stats: minimum, skills: professional, gear: none, traits: webbed hands and feet", swim_result{74, 364}},
 };
 
-TEST_CASE( "check swim move cost and distance values", "[swimming][slow]" )
+TEST_CASE( "check_swim_move_cost_and_distance_values", "[swimming][slow]" )
 {
     setup_test_lake();
 
@@ -920,7 +920,7 @@ TEST_CASE( "check swim move cost and distance values", "[swimming][slow]" )
 }
 
 // This "test" is used to generate the expected_results map above.
-TEST_CASE( "generate swim move cost and distance values", "[.]" )
+TEST_CASE( "generate_swim_move_cost_and_distance_values", "[.]" )
 {
     setup_test_lake();
 
@@ -938,7 +938,7 @@ TEST_CASE( "generate swim move cost and distance values", "[.]" )
     }
 }
 
-TEST_CASE( "export scenario swim move cost and distance values", "[.]" )
+TEST_CASE( "export_scenario_swim_move_cost_and_distance_values", "[.]" )
 {
     setup_test_lake();
 
@@ -963,7 +963,7 @@ TEST_CASE( "export scenario swim move cost and distance values", "[.]" )
 // assert anything here (yet) but for informational purposes it is
 // interesting to see the data as a slightly better "gut-check". Our
 // "professional swimmer" doesn't swim very well.
-TEST_CASE( "export profession swim cost and distance", "[.]" )
+TEST_CASE( "export_profession_swim_cost_and_distance", "[.]" )
 {
     setup_test_lake();
 
@@ -999,7 +999,7 @@ TEST_CASE( "export profession swim cost and distance", "[.]" )
 }
 
 // This "test" exports swim move cost and distance data to csv for analysis and review.
-TEST_CASE( "export swim move cost and distance data", "[.]" )
+TEST_CASE( "export_swim_move_cost_and_distance_data", "[.]" )
 {
     setup_test_lake();
 

--- a/tests/weakpoint_test.cpp
+++ b/tests/weakpoint_test.cpp
@@ -138,7 +138,7 @@ TEST_CASE( "weakpoint_practice", "[monster][weakpoint]" )
     CHECK( dummy.get_proficiency_practice( prof )  == Approx( 0.00111f ).epsilon( 0.05f ) );
 }
 
-TEST_CASE( "Check order of weakpoint set application", "[monster][weakpoint]" )
+TEST_CASE( "Check_order_of_weakpoint_set_application", "[monster][weakpoint]" )
 {
     bool has_wp_head = false;
     bool has_wp_eye = false;
@@ -170,7 +170,7 @@ TEST_CASE( "Check order of weakpoint set application", "[monster][weakpoint]" )
     REQUIRE( has_wp_leg );
 }
 
-TEST_CASE( "Check damage from weakpoint sets", "[monster][weakpoint]" )
+TEST_CASE( "Check_damage_from_weakpoint_sets", "[monster][weakpoint]" )
 {
     GIVEN( "100 bullet damage, 0 armor penetration" ) {
         weakpoint_report wr1 = damage_monster( mon_test_zombie_cop, damage_instance( damage_bullet,
@@ -211,7 +211,7 @@ TEST_CASE( "Check damage from weakpoint sets", "[monster][weakpoint]" )
     }
 }
 
-TEST_CASE( "Check deferred weakpoint set loading", "[monster][weakpoint]" )
+TEST_CASE( "Check_deferred_weakpoint_set_loading", "[monster][weakpoint]" )
 {
     weakpoints wplist = mon_zombie->weakpoints;
     CHECK( wplist.weakpoint_list.size() == 2 );
@@ -237,7 +237,7 @@ TEST_CASE( "Check deferred weakpoint set loading", "[monster][weakpoint]" )
     }
 }
 
-TEST_CASE( "Check copy-from inheritance between sets and inline weakpoints",
+TEST_CASE( "Check_copy-from_inheritance_between_sets_and_inline_weakpoints",
            "[monster][weakpoint]" )
 {
     weakpoints wplist = mon_test_weakpoint_mon->weakpoints;

--- a/tests/weather_test.cpp
+++ b/tests/weather_test.cpp
@@ -100,7 +100,7 @@ static year_of_weather_data collect_weather_data( unsigned seed )
 // Try a few randomly selected seeds.
 static const std::array<unsigned, 3> seeds = { {317'024'741, 870'078'684, 1'192'447'748} };
 
-TEST_CASE( "weather realism", "[weather]" )
+TEST_CASE( "weather_realism", "[weather]" )
 // Check our simulated weather against numbers from real data
 // from a few years in a few locations in New England. The numbers
 // are based on NOAA's Local Climatological Data (LCD). Analysis code
@@ -178,7 +178,7 @@ TEST_CASE( "eternal_season", "[weather]" )
     }
 }
 
-TEST_CASE( "local wind chill calculation", "[weather][wind_chill]" )
+TEST_CASE( "local_wind_chill_calculation", "[weather][wind_chill]" )
 {
     // `get_local_windchill` returns degrees F offset from current temperature,
     // representing the amount of temperature difference from wind chill alone.

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -162,7 +162,7 @@ static std::vector<std::string> scrape_win_at(
 }
 #endif
 
-TEST_CASE( "widget value strings", "[widget][value][string]" )
+TEST_CASE( "widget_value_strings", "[widget][value][string]" )
 {
     SECTION( "numeric values" ) {
         widget focus = widget_test_focus_num.obj();
@@ -234,7 +234,7 @@ TEST_CASE( "widget value strings", "[widget][value][string]" )
     }
 }
 
-TEST_CASE( "text widgets", "[widget][text]" )
+TEST_CASE( "text_widgets", "[widget][text]" )
 {
     SECTION( "words Zero-Ten for values 0-10" ) {
         widget words = widget_test_text_widget.obj();
@@ -246,7 +246,7 @@ TEST_CASE( "text widgets", "[widget][text]" )
     }
 }
 
-TEST_CASE( "number widgets with color", "[widget][number][color]" )
+TEST_CASE( "number_widgets_with_color", "[widget][number][color]" )
 {
     SECTION( "numbers 0-2 with 3 colors" ) {
         widget colornum = widget_test_color_number_widget.obj();
@@ -263,7 +263,7 @@ TEST_CASE( "number widgets with color", "[widget][number][color]" )
     }
 }
 
-TEST_CASE( "graph widgets", "[widget][graph]" )
+TEST_CASE( "graph_widgets", "[widget][graph]" )
 {
     SECTION( "graph widgets" ) {
         SECTION( "bucket fill with 12 states" ) {
@@ -331,7 +331,7 @@ TEST_CASE( "graph widgets", "[widget][graph]" )
     }
 }
 
-TEST_CASE( "graph widgets with color", "[widget][graph][color]" )
+TEST_CASE( "graph_widgets_with_color", "[widget][graph][color]" )
 {
     SECTION( "graph widget with 4 colors and 10 states" ) {
         widget colornum = widget_test_color_graph_widget.obj();
@@ -399,7 +399,7 @@ TEST_CASE( "graph widgets with color", "[widget][graph][color]" )
     }
 }
 
-TEST_CASE( "widgets showing avatar stats with color for normal value", "[widget][stats][color]" )
+TEST_CASE( "widgets_showing_avatar_stats_with_color_for_normal_value", "[widget][stats][color]" )
 {
     widget str_w = widget_test_str_color_num.obj();
     widget dex_w = widget_test_dex_color_num.obj();
@@ -447,7 +447,7 @@ TEST_CASE( "widgets showing avatar stats with color for normal value", "[widget]
     }
 }
 
-TEST_CASE( "widget showing character fatigue status", "[widget]" )
+TEST_CASE( "widget_showing_character_fatigue_status", "[widget]" )
 {
     widget fatigue_w = widget_test_fatigue_clause.obj();
 
@@ -464,7 +464,7 @@ TEST_CASE( "widget showing character fatigue status", "[widget]" )
     CHECK( fatigue_w.layout( ava ) == "Rest: <color_c_red>Exhausted</color>" );
 }
 
-TEST_CASE( "widgets showing avatar health with color for normal value", "[widget][health][color]" )
+TEST_CASE( "widgets_showing_avatar_health_with_color_for_normal_value", "[widget][health][color]" )
 {
     widget health_w = widget_test_health_color_num.obj();
     widget health_clause_w = widget_test_health_clause.obj();
@@ -495,7 +495,7 @@ TEST_CASE( "widgets showing avatar health with color for normal value", "[widget
     CHECK( health_clause_w.layout( ava ) == "Health: <color_c_light_green>Excellent</color>" );
 }
 
-TEST_CASE( "widgets showing body temperature and delta", "[widget]" )
+TEST_CASE( "widgets_showing_body_temperature_and_delta", "[widget]" )
 {
     widget w_temp = widget_test_body_temp_clause.obj();
     widget w_dtxt = widget_test_body_temp_delta_text.obj();
@@ -547,7 +547,7 @@ TEST_CASE( "widgets showing body temperature and delta", "[widget]" )
     CHECK( w_dsym.layout( ava ) == "Temp change: <color_c_blue>↓↓↓</color>" );
 }
 
-TEST_CASE( "widgets showing avatar stamina", "[widget][avatar][stamina]" )
+TEST_CASE( "widgets_showing_avatar_stamina", "[widget][avatar][stamina]" )
 {
     avatar &ava = get_avatar();
     clear_avatar();
@@ -598,7 +598,7 @@ static void set_avatar_bmi( avatar &ava, float bmi )
     ava.set_stored_kcal( ava.get_healthy_kcal() * ( bmi / 5 ) );
 }
 
-TEST_CASE( "widgets showing avatar weight", "[widget][weight]" )
+TEST_CASE( "widgets_showing_avatar_weight", "[widget][weight]" )
 {
     avatar &ava = get_avatar();
     clear_avatar();
@@ -660,7 +660,7 @@ TEST_CASE( "widgets showing avatar weight", "[widget][weight]" )
 
 }
 
-TEST_CASE( "widgets showing avatar attributes", "[widget][avatar]" )
+TEST_CASE( "widgets_showing_avatar_attributes", "[widget][avatar]" )
 {
     avatar &ava = get_avatar();
     clear_avatar();
@@ -746,7 +746,7 @@ TEST_CASE( "widgets showing avatar attributes", "[widget][avatar]" )
     }
 }
 
-TEST_CASE( "widgets showing activity level", "[widget][activity]" )
+TEST_CASE( "widgets_showing_activity_level", "[widget][activity]" )
 {
     avatar &ava = get_avatar();
     clear_avatar();
@@ -781,7 +781,7 @@ TEST_CASE( "widgets showing activity level", "[widget][activity]" )
     CHECK( activity_w.layout( ava ) == "Activity: <color_c_red>Extreme</color>" );
 }
 
-TEST_CASE( "widgets showing move counter and mode", "[widget][move_mode]" )
+TEST_CASE( "widgets_showing_move_counter_and_mode", "[widget][move_mode]" )
 {
     avatar &ava = get_avatar();
     clear_avatar();
@@ -828,7 +828,7 @@ TEST_CASE( "widgets showing move counter and mode", "[widget][move_mode]" )
     }
 }
 
-TEST_CASE( "thirst and hunger widgets", "[widget]" )
+TEST_CASE( "thirst_and_hunger_widgets", "[widget]" )
 {
     widget wt = widget_test_thirst_clause.obj();
     widget wh = widget_test_hunger_clause.obj();
@@ -890,7 +890,7 @@ TEST_CASE( "thirst and hunger widgets", "[widget]" )
     CHECK( wh.layout( ava ) == "HUNGER: <color_c_red>Engorged</color>" );
 }
 
-TEST_CASE( "widgets showing movement cost", "[widget][move_cost]" )
+TEST_CASE( "widgets_showing_movement_cost", "[widget][move_cost]" )
 {
     widget cost_num_w = widget_test_move_cost_num.obj();
 
@@ -919,7 +919,7 @@ TEST_CASE( "widgets showing movement cost", "[widget][move_cost]" )
     }
 }
 
-TEST_CASE( "widgets showing Sun and Moon position", "[widget]" )
+TEST_CASE( "widgets_showing_Sun_and_Moon_position", "[widget]" )
 {
     widget sundial_w = widget_test_sundial_text.obj();
 
@@ -1316,7 +1316,7 @@ static void check_bp_has_status( const std::string_view layout,
     }
 }
 
-TEST_CASE( "widget showing body part status text", "[widget][bp_status]" )
+TEST_CASE( "widget_showing_body_part_status_text", "[widget][bp_status]" )
 {
     avatar &ava = get_avatar();
     clear_avatar();
@@ -1423,7 +1423,7 @@ TEST_CASE( "widget showing body part status text", "[widget][bp_status]" )
     }
 }
 
-TEST_CASE( "compact bodypart status widgets + legend", "[widget][bp_status]" )
+TEST_CASE( "compact_bodypart_status_widgets_+_legend", "[widget][bp_status]" )
 {
     const int sidebar_width = 36;
     avatar &ava = get_avatar();
@@ -1564,7 +1564,7 @@ TEST_CASE( "compact bodypart status widgets + legend", "[widget][bp_status]" )
     }
 }
 
-TEST_CASE( "outer armor widget", "[widget][armor]" )
+TEST_CASE( "outer_armor_widget", "[widget][armor]" )
 {
     widget torso_armor_w = widget_test_torso_armor_outer_text.obj();
 
@@ -1590,7 +1590,7 @@ TEST_CASE( "outer armor widget", "[widget][armor]" )
            "Torso Armor: <color_c_green>++</color>\u00A0TEST hazmat suit (poor fit)" );
 }
 
-TEST_CASE( "radiation badge widget", "[widget][radiation]" )
+TEST_CASE( "radiation_badge_widget", "[widget][radiation]" )
 {
     widget rads_w = widget_test_rad_badge_text.obj();
 
@@ -1623,7 +1623,7 @@ TEST_CASE( "radiation badge widget", "[widget][radiation]" )
     CHECK( rads_w.layout( ava ) == "RADIATION: <color_c_pink> black </color>" );
 }
 
-TEST_CASE( "moon and lighting widgets", "[widget]" )
+TEST_CASE( "moon_and_lighting_widgets", "[widget]" )
 {
     // The CI tests have inconsistent lighting values for the same
     // time/day/weather/sun azimuth/etc, so just validate extreme lighting
@@ -1658,7 +1658,7 @@ TEST_CASE( "moon and lighting widgets", "[widget]" )
     CHECK( w_light.layout( ava ) == "LIGHTING: <color_c_yellow>bright</color>" );
 }
 
-TEST_CASE( "compass widget", "[widget][compass]" )
+TEST_CASE( "compass_widget", "[widget][compass]" )
 {
     const int sidebar_width = 36;
     widget c5s_N = widget_test_compass_N.obj();
@@ -1813,7 +1813,7 @@ TEST_CASE( "compass widget", "[widget][compass]" )
 // This test case calls layout() at different widths for 2-, 3-, and 4-column layouts,
 // to verify and demonstrate how the space is distributed among widgets in columns.
 //
-TEST_CASE( "layout widgets in columns", "[widget][layout][columns]" )
+TEST_CASE( "layout_widgets_in_columns", "[widget][layout][columns]" )
 {
     widget stat_w = widget_test_stat_panel.obj();
     widget two_w = widget_test_2_column_layout.obj();
@@ -1902,7 +1902,7 @@ TEST_CASE( "layout widgets in columns", "[widget][layout][columns]" )
     CHECK( four_w.layout( ava, 60 ) == "MOVE: 50        SPEED: 100      FOCUS: 120     MANA: 1000   " );
 }
 
-TEST_CASE( "widgets showing weather conditions", "[widget][weather]" )
+TEST_CASE( "widgets_showing_weather_conditions", "[widget][weather]" )
 {
     widget weather_w = widget_test_weather_text.obj();
 
@@ -1956,7 +1956,7 @@ static void fill_overmap_area( const avatar &ava, const oter_id &oter )
     }
 }
 
-TEST_CASE( "multi-line overmap text widget", "[widget][overmap]" )
+TEST_CASE( "multi-line_overmap_text_widget", "[widget][overmap]" )
 {
     widget overmap_w = widget_test_overmap_3x3_text.obj();
     avatar &ava = get_avatar();
@@ -2019,7 +2019,7 @@ TEST_CASE( "multi-line overmap text widget", "[widget][overmap]" )
     // TODO: Horde indicators
 }
 
-TEST_CASE( "Custom widget height and multiline formatting", "[widget]" )
+TEST_CASE( "Custom_widget_height_and_multiline_formatting", "[widget]" )
 {
     widget height1 = widget_test_weather_text.obj();
     widget height5 = widget_test_weather_text_height5.obj();
@@ -2081,7 +2081,7 @@ static int get_height_from_widget_factory( const widget_id &id )
 }
 
 // Use the compass legend as a proof-of-concept
-TEST_CASE( "Dynamic height for multiline widgets", "[widget]" )
+TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
 {
     const int sidebar_width = 36;
     widget c5s_legend3 = widget_test_compass_legend_3.obj();
@@ -2217,7 +2217,7 @@ TEST_CASE( "Dynamic height for multiline widgets", "[widget]" )
  *           L ARM:          $
  *           TORSO:          B
  */
-TEST_CASE( "Widget alignment", "[widget]" )
+TEST_CASE( "Widget_alignment", "[widget]" )
 {
     const int sidebar_width = 36;
     const int row_label_width = 15;
@@ -2514,7 +2514,7 @@ TEST_CASE( "Widget alignment", "[widget]" )
     }
 }
 
-TEST_CASE( "Clause conditions - pure JSON widgets", "[widget][clause][condition]" )
+TEST_CASE( "Clause_conditions_-_pure_JSON_widgets", "[widget][clause][condition]" )
 {
     const int sidebar_width = 20;
 
@@ -2592,7 +2592,7 @@ TEST_CASE( "Clause conditions - pure JSON widgets", "[widget][clause][condition]
     }
 }
 
-TEST_CASE( "widget disabled when empty", "[widget]" )
+TEST_CASE( "widget_disabled_when_empty", "[widget]" )
 {
     item blindfold( "blindfold" );
     avatar &ava = get_avatar();
@@ -2653,7 +2653,7 @@ TEST_CASE( "widget disabled when empty", "[widget]" )
 #endif
 }
 
-TEST_CASE( "widget rows in columns", "[widget]" )
+TEST_CASE( "widget_rows_in_columns", "[widget]" )
 {
     avatar &ava = get_avatar();
     clear_avatar();
@@ -2815,7 +2815,7 @@ static void test_widget_flag_nopad( const bodypart_id &bid, int bleed_int, avata
     }
 }
 
-TEST_CASE( "W_NO_PADDING widget flag", "[widget]" )
+TEST_CASE( "W_NO_PADDING_widget_flag", "[widget]" )
 {
     avatar &ava = get_avatar();
     clear_avatar();

--- a/tests/wield_times_test.cpp
+++ b/tests/wield_times_test.cpp
@@ -54,7 +54,7 @@ static void wield_check_from_ground( avatar &guy, const itype_id &item_name,
     CHECK( item_loc.obtain_cost( guy ) == Approx( expected_moves ).epsilon( 0.1f ) );
 }
 
-TEST_CASE( "Wield time test", "[wield]" )
+TEST_CASE( "Wield_time_test", "[wield]" )
 {
     clear_map();
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Reduce the need for escaping test names, some TEST_CASE names are clunky as they mix commas and spaces, when shell wants you to quote/escape spaces, catch2 wants to escape commas and if you have both you need to quote to "escape" spaces and then escape the commas, e.g. to run test case:
`list emplace, move, copy, and reverse iterate` from shell you need to escape it like so:
`./tests/cata_test "list emplace\, move\, copy\, and reverse iterate"`
after this patch it's callable with just:
`./tests/cata_test list_emplace_move_copy_and_reverse_iterate`

#### Describe the solution

The patch normalizes TEST_CASE names to fit a subset of characters:
```
abcdefghijklmnopqrstuvwxyz
ABCDEFGHIJKLMNOPQRSTUVWXYZ
0123456789"
_-+/`
```

This should eliminate the need for escaping in most cases

https://github.com/CleverRaven/Cataclysm-DDA/commit/0255e7e81c7f6b80a67c7c51a53f148226d72a09 - Makes try_parse_int_*_parsing tests normal TEST_CASEs instead of TEMPLATE_TEST_CASE - the catch template adds hardcoded " - " prefix, don't think there's any functionality lost there.

https://github.com/CleverRaven/Cataclysm-DDA/commit/dbd75da3ab4d59937bc2e7ee084a1c1c1620980e - Renames a test name (there's one with a space and one with underscore already)

https://github.com/CleverRaven/Cataclysm-DDA/pull/66241/commits/2148a2eb618e950df3351b1aa1a3a89395a6a4a6 - Makes a test to verify the names fit the allowed characters

https://github.com/CleverRaven/Cataclysm-DDA/pull/66241/commits/dd5b921976c94c285d54f841a5a53188118bf875 - Scripted rename ( script attached below )

#### Describe alternatives you've considered

Thought ot remove even more special characters, as practically every instance is just putting unnecessary test data into the test name

#### Testing

Add a . to the name field of a TEST_CASE, it should fail the new test and print allowed chars and which char failed

#### Additional context

```python
#!/usr/bin/env python3

import os
import re

bad_strings = {
    # single quotes
    "shouldn't": "should_not",
    "can't": "can_not",
    "doesn't": "does_not",
    "isn't": "is_not",
    #rarely used
    "::": " ",
    "vs.": "vs",
    "character's": "character",
    "(175 cm)": "_175_cm_",
    "grabber(s)": "grabbers",
    # commas, whitespace, double underscore
    "," : "_",
    ' ': '_',
    '__': '_',
}
allowed_extensions = [".md", ".cpp"]

def replacement_func(m: re.Match):
    case = m.group(1)

    for bk, bv in bad_strings.items():
        case = case.replace(bk, bv)

    case = case.strip(".")

    return f"TEST_CASE( \"{case}\""


for root, directories, filenames in os.walk(f"."):
    for filename in filenames:
        path = os.path.join(root, filename)
        _, file_ext = os.path.splitext(path)
        if file_ext not in allowed_extensions:
            continue
        with open(path) as f:
            s = f.read()

        s = re.sub( r'TEST_CASE\( "([^"]+)"', replacement_func, s )

        with open(path, "w") as f:
            f.write(s)

```