### PR TITLE
adjust bedding spawn weighting

### DIFF
--- a/data/json/itemgroups/furniture.json
+++ b/data/json/itemgroups/furniture.json
@@ -32,16 +32,17 @@
     "id": "bed",
     "subtype": "distribution",
     "entries": [
-      { "item": "blanket", "prob": 25 },
-      { "item": "down_blanket", "prob": 13 },
-      { "item": "pillow", "prob": 30 },
-      { "item": "down_pillow", "prob": 15 },
-      { "item": "electric_blanket", "prob": 4 },
-      { "item": "quilt", "prob": 10 },
-      { "item": "quilt_patchwork", "prob": 8 },
-      { "item": "teddy_bear", "prob": 2 },
-      { "item": "shark_plushie", "prob": 2 },
-      { "item": "bodypillow", "prob": 1 }
+      { "item": "blanket", "prob": 2500 },
+      { "item": "down_blanket", "prob": 1300 },
+      { "item": "pillow", "prob": 3000 },
+      { "item": "down_pillow", "prob": 1500 },
+      { "item": "electric_blanket", "prob": 400 },
+      { "item": "quilt", "prob": 1000 },
+      { "item": "quilt_patchwork", "prob": 800 },
+      { "item": "teddy_bear", "variant": "toy_plush_teddy", "prob": 190 },
+      { "item": "teddy_bear", "prob": 10 },
+      { "item": "shark_plushie", "prob": 5 },
+      { "item": "bodypillow", "prob": 2 }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Less body pillows and shark plushies"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There were way way way too many dakimakuras and animal plushies.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Massively bump up the weight of regular stuff to balance out the body pillows etc.
The blahaj subreddit has about 80k users. Not all blahaj owners use that subreddit but there is a considerable overlap between people who are online enough to subscribe to a subreddit and people who would own a blahaj due to its prevalence in specific communities. Even if we assume some users have more than one blahaj and they all live in america,  I'd still only expect one in like 3000 people to have a blahaj in their bed.
I've seen variable figures regarding anime consumption. Some sources say about 2/3 of americans watch anime periodically while others cite 15-20% of americans being "anime fans". I can't find a specific figure for this but I'm going to assume that maybe 1/1000 anime fans have anime body pillows/dakimakuras so they might have a frequency of something like 1/5000.
Teddy bears are much more common than any other kind of stuffed animal. Apparently teddy bear ownership is relatively high among adults in the USA so I've left teddy bear frequency somewhat high, although I have adjusted the frequencies such that teddy bears spawn much more often than any other animal plushie.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Different frequencies. Teddy bears could definitely be higher. Dakimakura spawns might still be too high.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->