### PR TITLE
Avoid potential execution of assert conditions in release builds

### DIFF
--- a/src/cata_assert.h
+++ b/src/cata_assert.h
@@ -1,17 +1,15 @@
 // NOLINTNEXTLINE(cata-header-guard)
 // Due to an inability to suppress assert popups when building against mingw-w64
-// and running on wine, and to suppress unused/uninitialized variable warnings
-// in release builds, we are wrapping the assert macro so that we can substitute
-// functional behavior.
+// and running on wine, and to suppress unused variable warnings in release builds,
+// we are wrapping the assert macro so that we can substitute functional behavior.
 
 // This copies the semantics of cassert, re-including the file re-defines the macro.
 #undef cata_assert
 
 // Might as well handle NDEBUG at the top level instead of just wrapping one variant.
 #ifdef NDEBUG
-// Use the expression to avoid unused variable warnings, use unreachable
-// intrinsics to avoid potentially uninitialized variable warnings, and place
-// the code in decltype to avoid actual evaluation.
+// Use the expression to (hopefully) avoid unused variable warnings, hint compiler with
+// unreachable intrinsics, and place the code in decltype to avoid actual evaluation.
 #if defined(_MSC_VER)
 #define cata_assert(exp) decltype((exp) ? void() : __assume(0))()
 #elif defined(__GNUC__) || defined(__clang__)

--- a/src/cata_assert.h
+++ b/src/cata_assert.h
@@ -1,26 +1,25 @@
 // NOLINTNEXTLINE(cata-header-guard)
-// Due to an inability to suppress assert popups when building against mingw-w64 and running on wine
-// We are wrapping the assert macro so that we can substitute functional behavior with that setup
+// Due to an inability to suppress assert popups when building against mingw-w64
+// and running on wine, and to suppress unused/uninitialized variable warnings
+// in release builds, we are wrapping the assert macro so that we can substitute
+// functional behavior.
 
 // This copies the semantics of cassert, re-including the file re-defines the macro.
 #undef cata_assert
 
 // Might as well handle NDEBUG at the top level instead of just wrapping one variant.
 #ifdef NDEBUG
-#ifdef __GNUC__
-#define cata_assert(expression) \
-    do { \
-        if( !( expression ) ) { \
-            __builtin_unreachable(); \
-        } \
-    } while(false)
+// Use the expression to avoid unused variable warnings, use unreachable
+// intrinsics to avoid potentially uninitialized variable warnings, and place
+// the code in decltype to avoid actual evaluation.
+#if defined(_MSC_VER)
+#define cata_assert(exp) decltype((exp) ? void() : __assume(0))()
+#elif defined(__GNUC__) || defined(__clang__)
+#define cata_assert(exp) decltype((exp) ? void() : __builtin_unreachable())()
 #else
-// Goes the convoluted way to avoid unused variable warnings. The inner declval
-// and decltype expressions are to workaround incorrect "left operand has no
-// effect" warning on some compilers.
-#define cata_assert(expression) \
-    ( static_cast<void>( decltype( std::declval<decltype( expression )>(), int() )() ) )
-#endif // __GNUC__
+#include <cstdlib>
+#define cata_assert(exp) decltype((exp) ? void() : std::abort())()
+#endif
 #else
 #ifdef _WIN32
 #include <cstdlib>

--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -349,7 +349,7 @@ std::wstring utf8_to_wstr( const std::string &str )
     std::size_t sz = std::mbstowcs( nullptr, str.c_str(), 0 );
     cata_assert( sz != static_cast<size_t>( -1 ) );
     std::wstring wstr( sz + 1, '\0' );
-    std::size_t converted = std::mbstowcs( wstr.data(), str.c_str(), sz );
+    [[maybe_unused]] const size_t converted = std::mbstowcs( wstr.data(), str.c_str(), sz );
     cata_assert( converted == sz );
     strip_trailing_nulls( wstr );
     return wstr;
@@ -368,7 +368,7 @@ std::string wstr_to_utf8( const std::wstring &wstr )
     std::size_t sz = std::wcstombs( nullptr, wstr.c_str(), 0 );
     cata_assert( sz != static_cast<size_t>( -1 ) );
     std::string str( sz + 1, '\0' );
-    std::size_t converted = std::wcstombs( str.data(), wstr.c_str(), sz );
+    [[maybe_unused]] const size_t converted = std::wcstombs( str.data(), wstr.c_str(), sz );
     cata_assert( converted == sz );
     strip_trailing_nulls( str );
     return str;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1931,7 +1931,7 @@ class joins_tracker
             consistency_check();
             for( iterator it : unresolved.all_at( pos ) ) {
                 postponed.add( *it );
-                bool erased = erase_unresolved( it->where );
+                [[maybe_unused]] const bool erased = erase_unresolved( it->where );
                 cata_assert( erased );
             }
             consistency_check();
@@ -2029,13 +2029,13 @@ class joins_tracker
             iterator add( const join &j ) {
                 joins.push_front( j );
                 auto it = joins.begin();
-                auto insert_result = position_index.emplace( j.where, it );
-                cata_assert( insert_result.second );
+                [[maybe_unused]] const bool inserted = position_index.emplace( j.where, it ).second;
+                cata_assert( inserted );
                 return it;
             }
 
             void erase( const iterator it ) {
-                size_t erased = position_index.erase( it->where );
+                [[maybe_unused]] const size_t erased = position_index.erase( it->where );
                 cata_assert( erased );
                 joins.erase( it );
             }
@@ -2052,8 +2052,8 @@ class joins_tracker
             if( unresolved_priority_index.size() <= priority ) {
                 unresolved_priority_index.resize( priority + 1 );
             }
-            auto insert_result_2 = unresolved_priority_index[priority].insert( it );
-            cata_assert( insert_result_2.second );
+            [[maybe_unused]] const bool inserted = unresolved_priority_index[priority].insert( it ).second;
+            cata_assert( inserted );
         }
 
         bool erase_unresolved( const om_pos_dir &p ) {
@@ -2064,7 +2064,7 @@ class joins_tracker
             iterator it = pos_it->second;
             unsigned priority = it->join->priority;
             cata_assert( priority < unresolved_priority_index.size() );
-            size_t erased = unresolved_priority_index[priority].erase( it );
+            [[maybe_unused]] const size_t erased = unresolved_priority_index[priority].erase( it );
             cata_assert( erased );
             unresolved.erase( it );
             return true;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
#58210 used unreachable intrinsic on GCC to suppress the `maybe-uninitialized` warning caused by `cata_assert` in release builds, however the code does not guarantee that the assert condition is never executed, which has performance implications.

#### Describe the solution
Wrap the code in `decltype` to prevent execution.

Also suppress dead-store warnings from clang-tidy by adding `[[maybe_unused]]` to the code, because I was not able to suppress them by changing `cata_assert` (not even by reverting `cata_assert` to before #58210)

#### Describe alternatives you've considered
Keep using the solution in #58210 which might actually be fine in practice?

#### Testing
Compiled on MinGW-w64 12.2 without warning. Also tested in [compiler explorer](https://gcc.godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGIM1ykrgAyeAyYAHI%2BAEaYxBIAzKQADqgKhE4MHt6%2B/oGp6Y4CoeFRLLHxXEl2mA6ZQgRMxATZPn4Btpj2RQwNTQQlkTFxibaNza25HQrjA2FD5SNVAJS2qF7EyOwc5gl4VADUWDTh6BAA%2BgCyQm7nAGrYAErLJhoAgrvH8weijedMCiUzQgmFUyWWR1qtAIAE9kpgoKDwQcTAkAGIHABuqDwZwhIAO53%2BgJ8CI0y2WEBe712XX2kJOmDORIA4hE5LdzhCTAB2Ny8twM%2BbM87IAxGInUj5mBJfcI/Jh/AFAgggsEQrBi2HwxHqlHorE4vEHAlE6JeOiOBjnLwMYiYJjIBBMaL0KmUqW02hKV7SvYMMVeLD6tzIGboWh4aKo7C%2Bz6YRkKpWAuKqpEaqHahFq5GojHY3FUk0HcMgEAukiqilUuMy1z7OPvMIEA4sJhhCDNg5NYDIUg/Z3EABUQ%2B5PKs7wOU5%2BAhmBy7TC4%2BoAIt3iL3URO3tOZww5wuzCu1xuElud78mMSVRBFy9T76d/aCBsGAcNJu4zzlxxVrROABWXg/A4LRSFQTh%2BUsawS3WTZMBRGUeFIAhNB/VYAGsQASAAOAA6AA2Lh/w0SQAE4cP/KpsPwnl8P0ThJCA1CwM4XgFBADRkNQ1Y4FgGBEBQVAWGSOg4nISg0GE0T4kxZBkmSc5MS4UjzgMAhMBmc5VHw6QsExPAtjuPBMAAdwAeXhYCkJoaE4nYiBomY6IwiaGEnJc4gYTM6JtFqFDuF4SS2EEMyGFoNyQN4LBzWANwxG9TgkKwNsjHESLSHwe06kxDTmNBWovHU5jmy6ZjI2iYhXI8LBEt4AhiDwFhatWKgDGABQjNMizGFqmRBBEMR2CkPr5CUNRmN0QJxWMaxrH0KN2MgVZUGSHp2I4AB6AB1eKDg20tTCgywuB5XhUBy4gGqwRaqU6bpMhcBh3E8No9BCeYygqPQCgyARJj8fI0l%2BhhBk%2BpY7r8%2BpZn%2BvQajqAQ%2BmaUHhkqMZ%2BhhwIZn6ZHFkqVYFFgrYJF/ACmPS8COAObTJFbBRZKxZTcLUjSWwgXBCBIBCEi4ZY6u4jD/A0XD/3/HSEgSSQJckSQeR5GX6I4RjSCa4jSGA0CKbYjiuMinj%2BIgJB1gIZJCvEiBJJE%2BhiAiVhtlUajafppTSKZxUWd4JkOauvR%2BH60RxGG33RpUdR0sm0gTMq5JmoVwC1eYimzMKk2W1QQ5qcd5AGZd5m5wgDwpKtrmeb53XVgQB0sHiW6/0V3gVc49WztY2xtf8rQKVITDueFhISNIyiuC4Ej8Mouja4SMmNZb9uf1IXioH1pALeks2V6tkBgGHswMswfTDOM8zLN6mz1OIezHPS5zmE89yb68ny/N6oLGAIULwuY6KvFi%2BL1qSzAUrADSqBTKkMcrrVAvlZAhVtigRKrXUC5VKqeWqtsJC9VGox1akwdqnUj49QCiNAaAdpBB0UCHCa/h9CGBmkdGw5UbrLVWpkdaABaHatBaAHHYaCeqTBuFmWANw8MqJlyHSsMdU6YELpXVyktCG8M/AgiehjIIT0cZfUBoUTIqifo9A0eDOGPREYtBerkTGXRIYI1mAY1GWMJhmIBmjJGH0UbEzWBsImPNY5T2bpTe2%2BFWE6QOL2LOw9cKHjZvgIgxBi68x1h3AWCQeQEQlmYUiZgzAaFFhkrg2FpC1yVg3eO5MW7sU4rPPW8ADYgCNinNeQlLZxBtmwTgGcWB0yzs7XCCQ46exibiH2shiFDVIbIch40w5UMjkwaOAUSYcDjk3FiHAk7G0KgcNOVNqJBJpqEg44TIkFyabE3YZh4mVPLpXEYNcGL1xAKrZZmtW4VP5l3fwLtsL/mliLYiOEpDYSmpwSeJTp4cFLokhWZhfErIhWhUgF10jOEkEAA) on various compilers and waiting to be tested in CI. I was not able to reproduce the `maybe-uninitialized` warning though. @andrei8l you mentioned you were having the same warning in #52657 so could you please help test if this does not cause regression on gcc 10.2/11.2?

#### Additional context

We should probably also check that assert conditions have no side effects but that requires static code analysis and is hard to implement to me.