### PR TITLE
Test tweaks for less order dependency

### DIFF
--- a/tests/item_contents_test.cpp
+++ b/tests/item_contents_test.cpp
@@ -20,6 +20,7 @@ static const itype_id itype_purse( "purse" );
 
 TEST_CASE( "item_contents" )
 {
+    clear_map();
     item tool_belt( "test_tool_belt" );
 
     const units::volume tool_belt_vol = tool_belt.volume();
@@ -106,12 +107,12 @@ TEST_CASE( "overflow_on_combine", "[item]" )
 
 TEST_CASE( "overflow_test", "[item]" )
 {
+    clear_map();
     tripoint origin{ 60, 60, 0 };
     item purse( itype_purse );
     item log( itype_log );
     purse.force_insert_item( log, item_pocket::pocket_type::MIGRATION );
     map &here = get_map();
-    here.i_clear( origin );
     purse.overflow( origin );
     CHECK( here.i_at( origin ).size() == 1 );
 }

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -176,11 +176,12 @@ void build_water_test_map( const ter_id &surface, const ter_id &mid, const ter_i
     constexpr int z_surface = 0;
     constexpr int z_bottom = -2;
 
-    clear_map( z_bottom, z_surface );
+    clear_map( z_bottom - 1, z_surface + 1 );
 
     map &here = get_map();
-    for( const tripoint &p : here.points_in_rectangle( tripoint_zero,
-            tripoint( MAPSIZE * SEEX, MAPSIZE * SEEY, z_bottom ) ) ) {
+    const tripoint p1( 0, 0, z_bottom - 1 );
+    const tripoint p2( MAPSIZE * SEEX, MAPSIZE * SEEY, z_surface + 1 );
+    for( const tripoint &p : here.points_in_rectangle( p1, p2 ) ) {
 
         if( p.z == z_surface ) {
             here.ter_set( p, surface );
@@ -188,6 +189,10 @@ void build_water_test_map( const ter_id &surface, const ter_id &mid, const ter_i
             here.ter_set( p, mid );
         } else if( p.z == z_bottom ) {
             here.ter_set( p, bottom );
+        } else if( p.z < z_bottom ) {
+            here.ter_set( p, t_rock );
+        } else if( p.z > z_surface ) {
+            here.ter_set( p, t_open_air );
         }
     }
 

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -31,9 +31,9 @@ static void setup_test_lake()
 
 TEST_CASE( "avatar_diving", "[diving]" )
 {
+    clear_avatar();
     setup_test_lake();
 
-    clear_avatar();
     Character &dummy = get_player_character();
     map &here = get_map();
     constexpr tripoint test_origin( 60, 60, 0 );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Make tests less dependent on order

#### Describe the solution

Teleport player back to starting position after eoc test - clear_avatar() doesn't deal with omt teleport

Add missing clear_map() to 2 item_contents tests so that overflow/spill contents don't randomly fail if avatar is on obstacle

#### Describe alternatives you've considered

#### Testing

#### Additional context
