### PR TITLE
Add a generic shotgun to Aftershock

### DIFF
--- a/data/mods/Aftershock/itemgroups/weapons/armories.json
+++ b/data/mods/Aftershock/itemgroups/weapons/armories.json
@@ -32,8 +32,9 @@
     "subtype": "distribution",
     "items": [
       { "group": "afs_any_ballistic_gun", "prob": 6 },
-      { "group": "afs_any_ballistic_mag", "prob": 1 },
-      { "group": "afs_any_ballistic_ammo", "prob": 4 }
+      { "group": "afs_any_ballistic_mag", "prob": 2 },
+      { "group": "afs_any_ballistic_ammo", "prob": 4 },
+      { "group": "afs_shotgun_gunmod", "prob": 1 }
     ]
   }
 ]

--- a/data/mods/Aftershock/itemgroups/weapons/balistic_gun_groups.json
+++ b/data/mods/Aftershock/itemgroups/weapons/balistic_gun_groups.json
@@ -23,7 +23,13 @@
     "subtype": "distribution",
     "ammo": 100,
     "magazine": 100,
-    "items": [ [ "afs_Accipitermg", 20 ], [ "afs_gibrifle", 40 ], [ "afs_25mm_goa", 5 ], [ "afs_drotik_shotpistol", 5 ] ]
+    "items": [
+      [ "afs_Accipitermg", 20 ],
+      [ "afs_gibrifle", 40 ],
+      [ "afs_shotgun", 15 ],
+      [ "afs_25mm_goa", 5 ],
+      [ "afs_drotik_shotpistol", 5 ]
+    ]
   },
   {
     "id": "afs_any_ballistic_h_gun",
@@ -107,5 +113,11 @@
     "ammo": 100,
     "magazine": 100,
     "items": [ [ "afs_25mm_shot", 40 ], [ "afs_25mm_apfsds", 5 ], [ "afs_25mm_frag", 10 ] ]
+  },
+  {
+    "id": "afs_shotgun_gunmod",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [ [ "afs_magnetic_choke", 10 ] ]
   }
 ]

--- a/data/mods/Aftershock/items/gun/shot.json
+++ b/data/mods/Aftershock/items/gun/shot.json
@@ -4,7 +4,7 @@
     "copy-from": "mossberg_590",
     "type": "GUN",
     "name": { "str": "Benelli 315" },
-    "description": "A widely popular combat shotgun featuring minor iterative refinements to a base design nearly three centuries old.  Wether the design is outdated or unsurpassable remains a matter of personal opinion.",
+    "description": "A widely popular combat shotgun featuring minor iterative refinements to a base design nearly three centuries old.  Whether the design is outdated or unsurpassable remains a matter of personal opinion.",
     "variants": [
       {
         "id": "vatforged",
@@ -14,7 +14,7 @@
       },
       {
         "id": "military",
-        "name": { "str": "m210-UASTA shotgun" },
+        "name": { "str": "m2101-UASTA shotgun" },
         "description": "The standard issue combat shotgun of UICA marine and colonial forces.  Shot shells have poor performance against modern combat armor, so the M2101 is more often used during policing and peacekeeping operations.",
         "weight": 2
       }

--- a/data/mods/Aftershock/items/gun/shot.json
+++ b/data/mods/Aftershock/items/gun/shot.json
@@ -1,5 +1,26 @@
 [
   {
+    "id": "afs_shotgun",
+    "copy-from": "mossberg_590",
+    "type": "GUN",
+    "name": { "str": "Benelli 315" },
+    "description": "A widely popular combat shotgun featuring minor iterative refinements to a base design nearly three centuries old.  Wether the design is outdated or unsurpassable remains a matter of personal opinion.",
+    "variants": [
+      {
+        "id": "vatforged",
+        "name": { "str": "vatforged shotgun" },
+        "description": "A crude but otherwise serviceable pump-action shotgun built from a hacked or scavenged template.  Frequently seen in the hands of frontier pirates, settlers or salvors.  Not that such groups are much different from one another.",
+        "weight": 3
+      },
+      {
+        "id": "military",
+        "name": { "str": "m210-UASTA shotgun" },
+        "description": "The standard issue combat shotgun of UICA marine and colonial forces.  Shot shells have poor performance against modern combat armor, so the M2101 is more often used during policing and peacekeeping operations.",
+        "weight": 2
+      }
+    ]
+  },
+  {
     "id": "afs_raketa_shotgun",
     "copy-from": "shotgun_base",
     "looks_like": "remington_870",

--- a/data/mods/Aftershock/items/gunmods/shotguns.json
+++ b/data/mods/Aftershock/items/gunmods/shotguns.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "afs_magnetic_choke",
+    "type": "GUNMOD",
+    "name": { "str": "magnetic choke" },
+    "//": "Yes lead isn't magnetic, no I don't care.",
+    "description": "A choke that uses a powerful cross-shaped electromagnet to pull the shot cloud together, greatly reducing the spread of shot.  Prevents the use of slugs.",
+    "weight": "300 g",
+    "volume": "150 ml",
+    "longest_side": "4 cm",
+    "integral_longest_side": "1 cm",
+    "price": 78000,
+    "price_postapoc": 1500,
+    "material": [ "steel" ],
+    "symbol": ":",
+    "color": "dark_gray",
+    "location": "muzzle",
+    "mod_targets": [ "shotgun" ],
+    "install_time": "3 m",
+    "shot_spread_multiplier_modifier": -0.8,
+    "flags": [ "CHOKE" ]
+  }
+]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Add a basic shotgun to the mod."

#### Purpose of change
#65562 Recently added shotguns using 00 ammo, but those are rather specialized firearms, and a standard, general use gun for that ammunition type was missing.


#### Describe the solution

Just a copy of the Mossberg 590  with new descriptions.

#### Testing
Loaded the game and fired the gun.

