### PR TITLE
Hotfix for #66273

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -82,7 +82,11 @@ std::string as_norm_dir( const std::string &path )
 {
     fs::path dir = fs::u8path( path ) / fs::path{};
     fs::path norm = dir.lexically_normal();
-    return norm.generic_u8string();
+    std::string ret = norm.generic_u8string();
+    if ("." == ret) {
+        ret = "./"; // TODO Change the many places that use strings instead of paths
+    }
+    return ret;
 }
 
 std::string as_norm_dir( const fs::path &path )

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -83,7 +83,7 @@ std::string as_norm_dir( const std::string &path )
     fs::path dir = fs::u8path( path ) / fs::path{};
     fs::path norm = dir.lexically_normal();
     std::string ret = norm.generic_u8string();
-    if ("." == ret) {
+    if( "." == ret ) {
         ret = "./"; // TODO Change the many places that use strings instead of paths
     }
     return ret;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -654,7 +654,7 @@ int main( int argc, const char *argv[] )
 #   if defined(USE_HOME_DIR) || defined(USE_XDG_DIR)
     PATH_INFO::init_user_dir( "" );
 #   else
-    PATH_INFO::init_user_dir( "./" );
+    PATH_INFO::init_user_dir( "." );
 #   endif
 #endif
     PATH_INFO::set_standard_filenames();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "All directories starting with dot"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #66273 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
`as_norm_dir` returns `./` if the directory normalizes to `.`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Rewrite all code using paths as strings to use `fs::path` and its append operator.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Run the executable, check for `.dir/`s, Play Now!, save and exit, restart, load again.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Waiting for Actions work out linting issues
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->