### PR TITLE
Prompt player to hold his breath upon entering tiles with a smoke

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10052,7 +10052,10 @@ bool game::prompt_dangerous_tile( const tripoint &dest_loc ) const
     std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
 
     if( !harmful_stuff.empty() &&
-        !query_yn( _( "Really step into %s?" ), enumerate_as_string( harmful_stuff ) ) ) {
+        !query_yn( m.get_field( dest_loc,
+                                fd_smoke ) ? // TODO: potentially take into account other fields that could be negated if you can hold breath.
+                   _( "Hold your breath and step into %s?" ) :
+                   _( "Really step into %s?" ), enumerate_as_string( harmful_stuff ) ) ) {
         return false;
     }
     if( !harmful_stuff.empty() && u.is_mounted() && m.tr_at( dest_loc ) == tr_ledge ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -204,6 +204,7 @@ static void without_sleep( Character &you, int sleep_deprivation );
 static void from_tourniquet( Character &you );
 static void from_nyctophobia( Character &you );
 static void from_artifact_resonance( Character &you, int amt );
+static void while_holding_breath( Character &you );
 } // namespace suffer
 
 static float addiction_scaling( float at_min, float at_max, float add_lvl )
@@ -1815,6 +1816,25 @@ void suffer::from_artifact_resonance( Character &you, int amt )
     }
 }
 
+void suffer::while_holding_breath( Character &you )
+{
+    you.oxygen--;
+
+    if( you.oxygen < 12 && you.worn_with_flag( flag_REBREATHER ) ) {
+        you.oxygen += 12;
+    }
+
+    if( you.oxygen == 3 ) {
+        you.add_msg_if_player( m_bad,
+                               _( "You feel that can you hold your breath only for a few seconds more!" ) );
+    }
+
+    if( you.oxygen == 1 ) {
+        you.add_msg_if_player( m_bad, _( "You can't hold your breath anymore and inhale deeply!" ) );
+    }
+
+}
+
 void Character::suffer()
 {
     const int current_stim = get_stim();
@@ -1844,6 +1864,9 @@ void Character::suffer()
 
     if( underwater ) {
         suffer::while_underwater( *this );
+    } else if( get_map().get_field( pos(),
+                                    fd_smoke ) ) { // TODO: factor in other conditions when someone may be holding breath
+        suffer::while_holding_breath( *this );
     }
 
     suffer::from_addictions( *this );

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -566,6 +566,7 @@ TEST_CASE( "inhaler", "[iuse][inhaler]" )
 {
     clear_avatar();
     avatar &dummy = get_avatar();
+    dummy.oxygen = 0;
     item inhaler( "inhaler" );
     inhaler.ammo_set( itype_albuterol );
     REQUIRE( inhaler.ammo_remaining() > 0 );


### PR DESCRIPTION
#### Summary
Features "Prompt player to hold his breath upon entering tiles with a smoke"

#### Purpose of change
Holding breath should be enough to safely traverse tiles with a smoke. Inspired by https://github.com/CleverRaven/Cataclysm-DDA/issues/58069#issuecomment-1143333891.

#### Describe the solution
Ported https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/pull/61 and https://github.com/AtomicFox556/Cataclysm-EOD/pull/97/commits/f63e2fe697b80781105a530aede43cb22b912c4d.
- Added a prompt upon entering tile with a smoke. If player answers yes, then player character automatically holds his breath until he quits tile with a smoke or his oxygen runs out
- While standing in that tile, oxygen doesn't recover
- After exit from that tile, oxygen starts to recover as usual
- If oxygen runs out while standing in that tile, player character automatically inhales deeply, resulting in lungs full of smoke
- The feature only works for smoke fields

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned a smoke vent to get a stable smoke field. Tried to enter the smoke, got a prompt. Answered yes, entered the tile. No inhaling the smoke since character holds his breath. Waited ~1 minute for oxygen to run out. Got a warning about low oxygen supply, then waited some more. Character inhaled deeply.

#### Additional context
![изображение](https://user-images.githubusercontent.com/11132525/233023727-42cb5845-7437-437a-b967-a56040a977fa.png)

![изображение](https://user-images.githubusercontent.com/11132525/233023965-67025a03-c606-42dd-afe0-8384d9377c19.png)
