### PR TITLE
No deduplication on rebuilding vehicle active items cache

### DIFF
--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -47,6 +47,9 @@ class active_item_cache
         std::unordered_map<special_item_type, std::list<item_reference>> special_items;
 
     public:
+        // Clear the active_items cache
+        void clear();
+
         /**
          * Removes the item if it is in the cache. Does nothing if the item is not in the cache.
          * Relies on the fact that item::processing_speed() is a constant.
@@ -55,11 +58,15 @@ class active_item_cache
         void remove( const item *it );
 
         /**
-         * Adds the reference to the cache. Does nothing if the reference is already in the cache.
+         * Adds the reference to the cache.
+         * By default, does nothing if the reference is already in the cache.
+         * if deduplicate is set to false, simply add to the cache without detecting duplicates .
+         * Checking reference's existence is expensive,
+         * so for cache rebuilding, clear the cache first, then add without deduplication is faster.
          * Relies on the fact that item::processing_speed() is a constant.
          */
         bool add( item &it, point location, item *parent = nullptr,
-                  std::vector<item_pocket const *> const &pocket_chain = {} );
+                  std::vector<item_pocket const *> const &pocket_chain = {}, bool deduplicate = true );
 
         /**
          * Returns true if the cache is empty

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5791,11 +5791,13 @@ void vehicle::enable_refresh()
 void vehicle::refresh_active_item_cache()
 {
     // Need to manually backfill the active item cache since the part loader can't call its vehicle.
+    active_items.clear();
     for( const vpart_reference &vp : get_any_parts( VPFLAG_CARGO ) ) {
         auto it = vp.part().items.begin();
         auto end = vp.part().items.end();
         for( ; it != end; ++it ) {
-            active_items.add( *it, vp.mount() );
+            // rebuilding the cache, so no need to duplicate
+            active_items.add( *it, vp.mount(), nullptr, {}, false );
         }
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

In [this senario](https://github.com/CleverRaven/Cataclysm-DDA/pull/60885#issuecomment-1596180470), I found the game almost unplayable, because loading the save, starting or stopping the vehicle's engine all take minutes irl.

The reason is, in `active_item_cache::add()`:

https://github.com/CleverRaven/Cataclysm-DDA/blob/b43755d5e75e5041f8f7a26a3d07f563bc64b51f/src/active_item_cache.cpp#L66-L73

This part is expensive, especially when refreshing active item cache:

https://github.com/CleverRaven/Cataclysm-DDA/blob/b43755d5e75e5041f8f7a26a3d07f563bc64b51f/src/vehicle.cpp#L5794-L5798

Which means if there are 30000 comestibles to add( that's not impossible once #60885 gets merged ), the code needs to iterate over 30000 items for 30000 times.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a param to `active_item_cache::add()` to skip checking duplicate active item entries, and only use that when fully rebuilding the cache.

Add a function for clearing the active items cache, which is needed to get rid of deduplication.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Separate the active item cache between vparts, instead of storing all things together. This might also be helpful, but doesn't provide as much improvement as this one ( the time complexity is still O(n^2) for rebuilding the cache, although `n` is smaller ).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The game is playable again in [this senario](https://github.com/CleverRaven/Cataclysm-DDA/pull/60885#issuecomment-1596180470).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->