### PR TITLE
adjust/fix cunning feral drops

### DIFF
--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -79,7 +79,7 @@
               { "item": "armor_riot_arm", "prob": 50, "damage": [ 0, 3 ] },
               { "item": "armor_riot_leg", "prob": 50, "damage": [ 0, 3 ] }
             ],
-           "prob": 30
+            "prob": 30
           }
         ],
         "prob": 95

--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -84,11 +84,11 @@
         ],
         "prob": 95
       },
-      { "group": "harddrugs", "prob": 50 },
-      { "group": "stash_food", "prob": 50 },
-      { "group": "ammo_common", "prob": 50 },
-      { "group": "stash_drugs", "prob": 50 },
-      { "group": "gear_survival", "prob": 50 }
+      { "group": "harddrugs", "prob": 15 },
+      { "group": "stash_food", "prob": 15 },
+      { "group": "ammo_common", "prob": 15 },
+      { "group": "stash_drugs", "prob": 15 },
+      { "group": "gear_survival", "prob": 15 }
     ]
   },
   {

--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -49,7 +49,7 @@
     "id": "feral_sapien_death_drops_spear",
     "entries": [
       { "group": "survivor_stabbing", "prob": 100, "damage": [ 0, 3 ] },
-      { "group": "mon_zombie_survivor_death_drops", "prob": 100 },
+      { "group": "survivor_basic_outfit", "prob": 100, "damage": [ 0, 3 ] },
       { "item": "spearsling", "prob": 100, "damage": [ 0, 3 ] },
       {
         "distribution": [
@@ -59,9 +59,36 @@
         ],
         "prob": 50
       },
-      { "item": "duster_leather", "prob": 25, "damage": [ 0, 3 ] },
-      { "item": "kevlar", "prob": 25, "damage": [ 0, 3 ] },
-      { "item": "tac_helmet", "prob": 10, "damage": [ 0, 3 ] }
+      { "item": "kevlar", "prob": 35, "damage": [ 0, 3 ] },
+      {
+        "distribution": [
+          { "item": "tac_helmet", "prob": 35, "damage": [ 0, 3 ] },
+          { "item": "helmet_army", "prob": 35, "damage": [ 0, 3 ] },
+          { "item": "helmet_riot", "prob": 30, "damage": [ 0, 3 ] }
+        ],
+        "prob": 50
+      },
+      {
+        "distribution": [
+          { "item": "armor_riot", "prob": 30, "damage": [ 0, 3 ] },
+          { "item": "duster_leather", "prob": 10, "damage": [ 0, 3 ] },
+          { "item": "ballistic_vest_heavy", "prob": 30, "damage": [ 0, 3 ] },
+          {
+            "collection": [
+              { "item": "level_3_vest", "prob": 100, "damage": [ 0, 3 ] },
+              { "item": "armor_riot_arm", "prob": 50, "damage": [ 0, 3 ] },
+              { "item": "armor_riot_leg", "prob": 50, "damage": [ 0, 3 ] }
+            ],
+           "prob": 30
+          }
+        ],
+        "prob": 95
+      },
+      { "group": "harddrugs", "prob": 50 },
+      { "group": "stash_food", "prob": 50 },
+      { "group": "ammo_common", "prob": 50 },
+      { "group": "stash_drugs", "prob": 50 },
+      { "group": "gear_survival", "prob": 50 }
     ]
   },
   {

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -80,12 +80,12 @@
     "aggression": 30,
     "morale": 100,
     "melee_skill": 3,
-    "melee_dice": 4,
+    "melee_dice": 2,
     "melee_dice_sides": 6,
-    "melee_damage": [ { "damage_type": "cut", "amount": 2 } ],
+    "melee_damage": [ { "damage_type": "stab", "amount": 12 } ],
     "dodge": 3,
-    "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_light_armor" ],
-    "families": [ "prof_intro_biology", "prof_physiology" ],
+    "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_body_armor" ],
+    "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_syn_armored" ],
     "special_attacks": [
       [ "PARROT_AT_DANGER", 0 ],
       {
@@ -120,7 +120,7 @@
       "PATH_AVOID_DANGER_1",
       "PRIORITIZE_TARGETS"
     ],
-    "armor": { "bash": 9, "cut": 7, "acid": 4, "bullet": 12 }
+    "armor": { "bash": 9, "cut": 14, "acid": 4, "bullet": 18 }
   },
   {
     "id": "mon_chud",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "cunning ferals wear more armor and survivor z drops don't bleed into them"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Cunning ferals used the entire survivor zombie loot table which led to weird double up of them wearing stuff on top of the gear they wore that was unique to them. They were also described as wearing riot armor, but never actually did that.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- They now just wear the regular survivor zombie clothes rather than the whole set (leather padded stuff, jeans, normal layer) and wear one of 3 swat/police zombie drops: an entire riot armor, a police vest with riot arm and leg guards, a heavy ballistic vest, or only a leather duster (rarely). Armor increased accordingly, they are harder to shoot now. Weakpoints also changed.
- Damage changed from 4d6 bash + 2 cut to 2d6 bash + 12 stab. They're using a spear so a decent portion of their damage should come from the poke.
- They drop some drugs/food/loose bullets sometimes also. Not as big of a loot list as the survivor zs themselves.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->