### PR TITLE
Better diagnostics for overmap_terrain_coverage test

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1811,8 +1811,10 @@ bool vehicle::remove_part( const int p, RemovePartHandler &handler )
     const tripoint part_loc = global_part_pos3( vp );
 
     if( !handler.get_map_ref().inbounds( part_loc ) ) {
-        debugmsg( "Removing out of bounds vehicle part at %s from vehicle %s (%s)",
-                  part_loc.to_string(), name, type.str() );
+        debugmsg( "vehicle::remove_part part '%s' at mount %s bub pos %s is out of map "
+                  "bounds on vehicle '%s'(%s), vehicle::pos is %s, vehicle::sm_pos is %s",
+                  vp.info().get_id().str(), vp.mount.to_string(), part_loc.to_string(),
+                  name, type.str(), pos.to_string(), sm_pos.to_string() );
     }
 
     // Unboard any entities standing on removed boardable parts


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

The current test output is too shallow, it also doesn't fail the test so you have to fish in the log for the actual error

#### Describe the solution

Add more info, specifically the oter type and some coord numbers, fail the test so it highlights the failure

#### Describe alternatives you've considered

#### Testing

Spam overmap_terrain_coverage test until it fails and see the message

#### Additional context
Before
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5309646787/jobs/9610574237#step:16:101

After:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/958be7d8-8986-4ad8-8b6c-5b0392107ba3)
