### PR TITLE
Fix clang-tidy check

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,7 @@ if (TILES)
                 SDL2_mixer::SDL2_mixer
             )
         endif()
+        add_definitions(-DSDL_SOUND)
     endif ()
 
     if (WIN32)

--- a/src/path_info.cpp
+++ b/src/path_info.cpp
@@ -68,7 +68,7 @@ static const char *getenv_or_abort( const char *name )
     return result;
 }
 
-void PATH_INFO::init_base_path( std::string path )
+void PATH_INFO::init_base_path( const std::string &path )
 {
     base_path_value = as_norm_dir( path );
     base_path_path_value = cata_path{ cata_path::root_path::base, fs::path{} };

--- a/src/path_info.h
+++ b/src/path_info.h
@@ -18,7 +18,7 @@ const std::string SAVE_EXTENSION_SHORTCUTS( ".shortcuts" );
 namespace PATH_INFO
 {
 
-void init_base_path( std::string path );
+void init_base_path( const std::string &path );
 void init_user_dir( std::string dir );
 void set_standard_filenames();
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix clang-tidy complaining about unused sound related stuff
Fix clang-tidy const lint for PATH_INFO::init_base_path

#### Describe the solution

clang-tidy seems to choke on stuff related to sounds as SDL_SOUND was here https://github.com/CleverRaven/Cataclysm-DDA/pull/65822/files#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L124 but seems to be gone in the new cmake config

Add -DSDL_SOUND to CMakeLists.txt
clang-tidy wants PATH_INFO::init_base_path to be const ref

#### Describe alternatives you've considered

#### Testing

~~Trivial sounds.cpp change here: https://github.com/irwiss/Cataclysm-DDA/pull/13, hopefully triggers clang-tidy to recheck the nearby material_hflesh~~

The fix works, one clang-tidy error left; https://github.com/irwiss/Cataclysm-DDA/actions/runs/5309594965/jobs/9610457507?pr=13#step:9:1112 and fixed in the second commit

#### Additional context
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5308191921/jobs/9607446297#step:9:1666
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5307243871/jobs/9605604539#step:9:2159
etc