### PR TITLE
Fix clang-tidy tests on Windows

### DIFF
--- a/src/translations.h
+++ b/src/translations.h
@@ -96,10 +96,14 @@ inline const char *npgettext( const char *const context, const char *const msgid
 
 // Avoid using these functions from libintl.h which won't work because we have
 // our own implementations with different names.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma GCC diagnostic ignored "-Wredundant-decls"
 [[deprecated( "Use _( ... ) instead" )]]
 char *gettext( const char *msgid );
 [[deprecated( "Use n_gettext( ... ) instead" )]]
 char *ngettext( const char *msgid, const char *msgid2, unsigned long int n );
+#pragma GCC diagnostic pop
 
 std::string locale_dir();
 

--- a/src/translations.h
+++ b/src/translations.h
@@ -100,8 +100,10 @@ inline const char *npgettext( const char *const context, const char *const msgid
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wredundant-decls"
 [[deprecated( "Use _( ... ) instead" )]]
+//NOLINTNEXTLINE(readability-redundant-declaration,readability-inconsistent-declaration-parameter-name,cata-no-long)
 char *gettext( const char *msgid );
 [[deprecated( "Use n_gettext( ... ) instead" )]]
+//NOLINTNEXTLINE(readability-redundant-declaration,readability-inconsistent-declaration-parameter-name,cata-no-long)
 char *ngettext( const char *msgid, const char *msgid2, unsigned long int n );
 #pragma GCC diagnostic pop
 

--- a/src/translations.h
+++ b/src/translations.h
@@ -94,6 +94,13 @@ inline const char *npgettext( const char *const context, const char *const msgid
 
 #endif // LOCALIZE
 
+// Avoid using these functions from libintl.h which won't work because we have
+// our own implementations with different names.
+[[deprecated( "Use _( ... ) instead" )]]
+char *gettext( const char *msgid );
+[[deprecated( "Use n_gettext( ... ) instead" )]]
+char *ngettext( const char *msgid, const char *msgid2, unsigned long int n );
+
 std::string locale_dir();
 
 void set_language_from_options();

--- a/tools/clang-tidy-plugin/JsonTranslationInputCheck.cpp
+++ b/tools/clang-tidy-plugin/JsonTranslationInputCheck.cpp
@@ -30,7 +30,7 @@ void JsonTranslationInputCheck::registerMatchers( MatchFinder *Finder )
                             anyOf(
                                 functionDecl(
                                     hasAnyName(
-                                        "_", "translation_argument_identity", "gettext", "pgettext",
+                                        "_", "translation_argument_identity", "pgettext",
                                         "n_gettext", "npgettext"
                                     )
                                 ).bind( "translationFunc" ),

--- a/tools/clang-tidy-plugin/NoStaticTranslationCheck.cpp
+++ b/tools/clang-tidy-plugin/NoStaticTranslationCheck.cpp
@@ -19,7 +19,7 @@ void NoStaticTranslationCheck::registerMatchers( MatchFinder *Finder )
                 decl(
                     anyOf(
                         functionDecl(
-                            hasAnyName( "_", "translation_argument_identity", "gettext", "pgettext",
+                            hasAnyName( "_", "translation_argument_identity", "pgettext",
                                         "n_gettext", "npgettext" )
                         ),
                         cxxMethodDecl(

--- a/tools/clang-tidy-plugin/TranslateStringLiteralCheck.cpp
+++ b/tools/clang-tidy-plugin/TranslateStringLiteralCheck.cpp
@@ -30,7 +30,6 @@ void TranslateStringLiteralCheck::registerMatchers( MatchFinder *Finder )
                                         hasAnyName(
                                             "_",
                                             "translation_argument_identity",
-                                            "gettext",
                                             "pgettext",
                                             "n_gettext",
                                             "npgettext"

--- a/tools/clang-tidy-plugin/TranslationsInDebugMessagesCheck.cpp
+++ b/tools/clang-tidy-plugin/TranslationsInDebugMessagesCheck.cpp
@@ -21,7 +21,7 @@ void TranslationsInDebugMessagesCheck::registerMatchers( MatchFinder *Finder )
                 functionDecl(
                     anyOf(
                         functionDecl(
-                            hasAnyName( "_", "translation_argument_identity", "gettext", "pgettext",
+                            hasAnyName( "_", "translation_argument_identity", "pgettext",
                                         "n_gettext", "npgettext", "to_translation", "pl_translation",
                                         "no_translation" )
                         ),

--- a/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp
+++ b/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp
@@ -231,7 +231,7 @@ void TranslatorCommentsCheck::registerMatchers( MatchFinder *Finder )
         );
     Finder->addMatcher(
         callExpr(
-            callee( functionDecl( hasAnyName( "_", "translation_argument_identity", "gettext" ) ) ),
+            callee( functionDecl( hasAnyName( "_", "translation_argument_identity" ) ) ),
             hasImmediateArgument( 0, stringLiteralArgumentBound )
         ),
         this

--- a/tools/clang-tidy-plugin/test/check_clang_tidy.py
+++ b/tools/clang-tidy-plugin/test/check_clang_tidy.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 #
+# Modified by the Cataclysm: Dark Days Ahead project.
+#
 #===- check_clang_tidy.py - ClangTidy Test Helper ------------*- python -*--===#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -20,8 +22,10 @@ Usage:
     [-check-suffix=<comma-separated-file-check-suffixes>] \
     [-check-suffixes=<comma-separated-file-check-suffixes>] \
     [-std=c++(98|11|14|17|20)[-or-later]] \
+    [-clang-tidy-binary=<path/to/clang-tidy>] \
+    [optional clang-tidy arguments]
     <source-file> <check-name> <temp-file> \
-    -- [optional clang-tidy arguments]
+    -- [optional clang arguments]
 
 Example:
   // RUN: %check_clang_tidy %s llvm-include-order %t -- -- -isystem %S/Inputs
@@ -82,6 +86,7 @@ class CheckRunner:
     self.original_file_name = self.temp_file_name + ".orig"
     self.expect_clang_tidy_error = args.expect_clang_tidy_error
     self.std = args.std
+    self.clang_tidy_binary = args.clang_tidy_binary
     self.check_suffix = args.check_suffix
     self.input_text = ''
     self.has_check_fixes = False
@@ -167,7 +172,7 @@ class CheckRunner:
     write_file(self.original_file_name, cleaned_test)
 
   def run_clang_tidy(self):
-    args = ['clang-tidy', self.temp_file_name, '-fix', '--checks=-*,' + self.check_name] + \
+    args = [self.clang_tidy_binary, self.temp_file_name, '-fix', '--checks=-*,' + self.check_name] + \
         self.clang_tidy_extra_args + ['--'] + self.clang_extra_args
     if self.expect_clang_tidy_error:
       args.insert(0, 'not')
@@ -251,6 +256,7 @@ def parse_arguments():
     help='comma-separated list of FileCheck suffixes')
   parser.add_argument('-std', type=csv, default=['c++11-or-later'])
   parser.add_argument('-allow-stdinc', action='store_true')
+  parser.add_argument('-clang-tidy-binary', default='clang-tidy')
   return parser.parse_known_args()
 
 

--- a/tools/clang-tidy-plugin/test/determinism.cpp
+++ b/tools/clang-tidy-plugin/test/determinism.cpp
@@ -23,9 +23,9 @@ int rand();
 void f()
 {
     std::mt19937 gen0;
-    // CHECK-MESSAGES: [[@LINE-1]]:18: warning: Construction of library random engine 'std::mt19937' (aka 'mersenne_twister_engine<unsigned long, 32, 624, 397, 31, 2567483615UL, 11, 4294967295UL, 7, 2636928640UL, 15, 4022730752UL, 18, 1812433253UL>'). To ensure determinism for a fixed seed, use the common tools from rng.h rather than your own random number engines. [cata-determinism]
+    // CHECK-MESSAGES: [[@LINE-1]]:18: warning: Construction of library random engine 'std::mt19937' (aka 'mersenne_twister_engine<unsigned {{(int|long)}}, 32, 624, 397, 31, 2567483615UL, 11, 4294967295UL, 7, 2636928640UL, 15, 4022730752UL, 18, 1812433253UL>').  To ensure determinism for a fixed seed, use the common tools from rng.h rather than your own random number engines. [cata-determinism]
     cata_default_random_engine gen1( 0 );
-    // CHECK-MESSAGES: [[@LINE-1]]:32: warning: Construction of library random engine 'cata_default_random_engine' (aka 'linear_congruential_engine<unsigned long, 16807UL, 0UL, 2147483647UL>').  To ensure determinism for a fixed seed, use the common tools from rng.h rather than your own random number engines. [cata-determinism]
+    // CHECK-MESSAGES: [[@LINE-1]]:32: warning: Construction of library random engine 'cata_default_random_engine' (aka 'linear_congruential_engine<unsigned {{(int|long)}}, 16807UL, 0UL, 2147483647UL>').  To ensure determinism for a fixed seed, use the common tools from rng.h rather than your own random number engines. [cata-determinism]
     SomeOtherStruct s0;
     StructWithSeedButNotResultType s1;
     SomeOtherAlias a;

--- a/tools/clang-tidy-plugin/test/no-static-translation.cpp
+++ b/tools/clang-tidy-plugin/test/no-static-translation.cpp
@@ -20,9 +20,6 @@ const std::string global_str_2{ _( "global_str_2" ) };
 static const std::string global_static_str = _( "global_static_str" );
 // CHECK-MESSAGES: [[@LINE-1]]:46: warning: Translation functions should not be called when initializing a static variable.  See the `### Static string variables` section in `doc/TRANSLATING.md` for details.
 
-const std::string global_gettext_str = gettext( "global_gettext_str" );
-// CHECK-MESSAGES: [[@LINE-1]]:40: warning: Translation functions should not be called when initializing a static variable.  See the `### Static string variables` section in `doc/TRANSLATING.md` for details.
-
 const std::string global_pgettext_str = pgettext( "ctxt", "global_pgettext_str" );
 // CHECK-MESSAGES: [[@LINE-1]]:41: warning: Translation functions should not be called when initializing a static variable.  See the `### Static string variables` section in `doc/TRANSLATING.md` for details.
 

--- a/tools/clang-tidy-plugin/test/translator-comments.cpp
+++ b/tools/clang-tidy-plugin/test/translator-comments.cpp
@@ -29,9 +29,6 @@ void foo()
 
     n_gettext( /*~ foo */ ( "bar" ), _( "baz" ), 0 );
 
-    //~ bar
-    gettext( "bar" );
-
     //~bar
     n_gettext( "bar", "baz", 1 );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Make clang-tidy work again on Windows after #65806.

#### Describe the solution
1. Remove `gettext` from clang-tidy checks and mark `gettext` and `ngettext` as `[[deprecated]]` to avoid accidentally using them when `libintl.h` is included by another system header. (Cannot use `=delete` because c++ does not allow redeclaring a function as deleted.)
2. Match both `int` and `long` in the random number generator check test due to MinGW-w64 using `int` instead of `long` for the rngs.
3. Add a parameter to `check_clang_tidy.py` to allow specifying the clang-tidy executable path on Windows.
4. Fix an error in the doc string of `check_clang_tidy.py`.
5. Add modification notice to `check_clang_tidy.py` to conform to its license.

#### Describe alternatives you've considered
None

#### Testing
Tested locally and all lit tests passed. Checked a few files with the compiled `CataAnalyzer` executable and everything worked as intended.

#### Additional context
None