### PR TITLE
Lower volume of MRE packages

### DIFF
--- a/data/json/itemgroups/SUS/mre_packages.json
+++ b/data/json/itemgroups/SUS/mre_packages.json
@@ -67,18 +67,18 @@
       { "item": "matches", "charges": 20 },
       { "item": "napkin", "count": 8 },
       { "item": "gum", "charges": 2 },
-      { "item": "pur_tablets", "charges": 6, "container-item": "beverage_bag" },
-      { "item": "sugar", "charges": 2, "container-item": "beverage_bag" },
+      { "item": "pur_tablets", "charges": 6, "container-item": "bag_zipper" },
+      { "item": "sugar", "charges": 2, "container-item": "bag_zipper" },
       { "item": "spork" },
       {
         "distribution": [
-          { "item": "instant_coffee", "count": 2, "container-item": "beverage_bag" },
-          { "item": "herbal_tea_bag", "count": 2, "container-item": "beverage_bag" },
-          { "item": "tea_bag", "count": 2, "container-item": "beverage_bag" },
-          { "item": "tea_bag_chamomile", "count": 2, "container-item": "beverage_bag" },
-          { "item": "tea_bag_dandelion", "count": 2, "container-item": "beverage_bag" },
-          { "item": "tea_fruit_bag", "count": 2, "container-item": "beverage_bag" },
-          { "item": "tea_green_bag", "count": 2, "container-item": "beverage_bag" }
+          { "item": "instant_coffee", "count": 2, "container-item": "bag_zipper" },
+          { "item": "herbal_tea_bag", "count": 2, "container-item": "bag_zipper" },
+          { "item": "tea_bag", "count": 2, "container-item": "bag_zipper" },
+          { "item": "tea_bag_chamomile", "count": 2, "container-item": "bag_zipper" },
+          { "item": "tea_bag_dandelion", "count": 2, "container-item": "bag_zipper" },
+          { "item": "tea_fruit_bag", "count": 2, "container-item": "bag_zipper" },
+          { "item": "tea_green_bag", "count": 2, "container-item": "bag_zipper" }
         ]
       }
     ]
@@ -128,18 +128,18 @@
       { "item": "matches", "charges": [ 0, 20 ] },
       { "item": "napkin", "count": [ 0, 8 ] },
       { "item": "gum", "charges": [ 0, 2 ] },
-      { "item": "pur_tablets", "charges": [ 0, 6 ], "container-item": "beverage_bag" },
-      { "item": "sugar", "charges": [ 0, 2 ], "container-item": "beverage_bag" },
+      { "item": "pur_tablets", "charges": [ 0, 6 ], "container-item": "bag_zipper" },
+      { "item": "sugar", "charges": [ 0, 2 ], "container-item": "bag_zipper" },
       { "item": "spork" },
       {
         "distribution": [
-          { "item": "instant_coffee", "count": [ 0, 2 ], "container-item": "beverage_bag" },
-          { "item": "herbal_tea_bag", "count": [ 0, 2 ], "container-item": "beverage_bag" },
-          { "item": "tea_bag", "count": [ 0, 2 ], "container-item": "beverage_bag" },
-          { "item": "tea_bag_chamomile", "count": [ 0, 2 ], "container-item": "beverage_bag" },
-          { "item": "tea_bag_dandelion", "count": [ 0, 2 ], "container-item": "beverage_bag" },
-          { "item": "tea_fruit_bag", "count": [ 0, 2 ], "container-item": "beverage_bag" },
-          { "item": "tea_green_bag", "count": [ 0, 2 ], "container-item": "beverage_bag" }
+          { "item": "instant_coffee", "count": [ 0, 2 ], "container-item": "bag_zipper" },
+          { "item": "herbal_tea_bag", "count": [ 0, 2 ], "container-item": "bag_zipper" },
+          { "item": "tea_bag", "count": [ 0, 2 ], "container-item": "bag_zipper" },
+          { "item": "tea_bag_chamomile", "count": [ 0, 2 ], "container-item": "bag_zipper" },
+          { "item": "tea_bag_dandelion", "count": [ 0, 2 ], "container-item": "bag_zipper" },
+          { "item": "tea_fruit_bag", "count": [ 0, 2 ], "container-item": "bag_zipper" },
+          { "item": "tea_green_bag", "count": [ 0, 2 ], "container-item": "bag_zipper" }
         ]
       }
     ]

--- a/data/json/items/containers.json
+++ b/data/json/items/containers.json
@@ -2847,7 +2847,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "1770 ml",
+        "max_contains_volume": "1769 ml",
         "max_contains_weight": "4 kg",
         "airtight": true,
         "moves": 50,

--- a/data/json/items/containers.json
+++ b/data/json/items/containers.json
@@ -2847,7 +2847,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "2777 ml",
+        "max_contains_volume": "1770 ml",
         "max_contains_weight": "4 kg",
         "airtight": true,
         "moves": 50,
@@ -2859,32 +2859,6 @@
     "flags": [ "COLLAPSE_CONTENTS" ],
     "symbol": ")",
     "color": "light_gray"
-  },
-  {
-    "id": "beverage_bag",
-    "type": "GENERIC",
-    "category": "container",
-    "name": { "str": "plastic beverage bag" },
-    "description": "A transparent, watertight plastic bag meant for holding drinks.",
-    "looks_like": "bag_plastic",
-    "weight": "6 g",
-    "volume": "262 ml",
-    "price": 0,
-    "price_postapoc": 0,
-    "to_hit": 1,
-    "material": [ "plastic" ],
-    "symbol": ")",
-    "color": "white",
-    "pocket_data": [
-      {
-        "pocket_type": "CONTAINER",
-        "rigid": false,
-        "watertight": true,
-        "open_container": true,
-        "max_contains_volume": "250 ml",
-        "max_contains_weight": "1 kg"
-      }
-    ]
   },
   {
     "id": "ipok",

--- a/data/json/obsoletion/migration_items.json
+++ b/data/json/obsoletion/migration_items.json
@@ -170,7 +170,7 @@
   {
     "id": "beverage_bag",
     "type": "MIGRATION",
-    "replace": "bag_zipper", 
-    "sealed": false 
+    "replace": "bag_zipper",
+    "sealed": false
   }
 ]

--- a/data/json/obsoletion/migration_items.json
+++ b/data/json/obsoletion/migration_items.json
@@ -166,5 +166,11 @@
     "type": "MIGRATION",
     "replace": "UPS_ON",
     "flags": [ "IS_UPS" ]
+  },
+  {
+    "id": "beverage_bag",
+    "type": "MIGRATION",
+    "replace": "bag_zipper", 
+    "sealed": false 
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Lower volume of MRE packages"

#### Purpose of change

MRE Packages are [~2.4 L in volume and ~800g in weight](https://www.dla.mil/Troop-Support/Subsistence/Operational-rations/mre/). In game, they are instead over 3 L weighing  approximately 1500g. This is unrealistic and also inconveniences the player since they don't really fit in pockets they're supposed to fit in.

#### Describe the solution

The MRE specific container beverage_bag is a non-rigid container with a base volume of 0.26 L and a pocket of 0.25 L, meaning a filled bag is twice the volume it's meant to be. This change migrates beverage_bag into zipper_bag, since every image I could find of an MRE beverage bag also included a zipper, meaning they're functionally identical to zipper_bag, 

#### Describe alternatives you've considered

Keeping beverage_bag as a near-copy of zipper_bag, but figured I might as well reduce bloat while I was at it.

Also reducing weight, but could not find measurements on reasonable weights on the containers or their contents.

#### Testing

Spawned in zombie soldiers and killed them to drop MRE packages and made sure nothing spilled and MREs still spawn sealed when full.
Teleported to military surplus and observed a spawned full MRE package
Loaded in a save that had beverage bags to make sure they migrated properly.
