### PR TITLE
re-reduce zombie survivor drops

### DIFF
--- a/data/json/monsterdrops/zombie_survivor.json
+++ b/data/json/monsterdrops/zombie_survivor.json
@@ -6,39 +6,48 @@
     "magazine": 100,
     "entries": [
       { "group": "survivor_basic_outfit", "damage": [ 1, 4 ] },
-      { "group": "bugout_bag" },
+      { "group": "bugout_bag", "prob": 20 },
       { "group": "book_survival", "prob": 15 },
-      { "group": "gear_survival", "prob": 25, "damage": [ 1, 4 ] },
-      { "group": "survivor_knife", "damage": [ 1, 4 ] },
+      { "group": "gear_survival", "prob": 20, "damage": [ 1, 4 ] },
+      { "group": "survivor_knife", "damage": [ 1, 4 ], "prob": 50 },
       {
         "distribution": [
-          { "group": "survivor_melee", "prob": 40, "damage": [ 1, 4 ] },
-          { "group": "survivor_longguns", "prob": 60, "contents-item": "shoulder_strap", "damage": [ 1, 4 ] }
+          { "group": "survivor_melee", "prob": 70, "damage": [ 1, 4 ] },
+          { "group": "survivor_longguns", "prob": 30, "contents-item": "shoulder_strap", "damage": [ 1, 4 ] }
         ],
         "prob": 50
       },
-      { "group": "survivor_grenades", "prob": 25 },
-      { "group": "stash_food", "prob": 90 },
-      { "group": "ammo_common", "prob": 95 },
-      { "group": "stash_drugs", "prob": 80 },
-      { "group": "gear_survival", "prob": 80 },
-      { "group": "mil_food", "prob": 55 },
-      { "group": "mil_food_nodrugs", "prob": 55 },
-      { "group": "shelter", "prob": 8 },
-      { "group": "mil_surplus", "prob": 60 },
-      { "group": "default_zombie_items_bags", "prob": 80 },
-      { "group": "default_zombie_items_pockets", "prob": 95 },
+      { "group": "survivor_grenades", "prob": 10 },
+      { "group": "stash_food", "prob": 20 },
+      { "group": "ammo_common", "prob": 25 },
+      { "group": "ammo_rare", "prob": 10 },
+      { "group": "stash_drugs", "prob": 25 },
+      { "group": "gear_survival", "prob": 15 },
+      { "group": "mil_food", "prob": 10 },
+      { "group": "mil_food_nodrugs", "prob": 10 },
+      { "group": "shelter", "prob": 3 },
+      { "group": "mil_surplus", "prob": 15 },
+      { "group": "default_zombie_items_bags", "prob": 15 },
+      { "group": "default_zombie_items_pockets", "prob": 15 },
       { "item": "cash_card", "charges-min": 25000, "charges-max": 100000 },
       {
         "distribution": [ { "group": "full_survival_kit", "damage": [ 1, 4 ] }, { "group": "used_survival_kit", "damage": [ 1, 4 ] } ],
-        "prob": 15
+        "prob": 5
       },
       {
         "distribution": [
-          { "group": "guns_pistol_common_everyday_carry", "damage": [ 1, 2 ], "prob": 1 },
-          { "collection": [ { "item": "holster" }, { "group": "guns_pistol_common_everyday_carry" } ], "prob": 80 }
+          { "item": "teargas_sprayer", "prob": 10, "charges-min": 0, "charges-max": 7 },
+          { "group": "guns_pistol_common_everyday_carry", "damage": [ 1, 4 ], "prob": 5 },
+          {
+            "collection": [ { "item": "holster" }, { "group": "guns_pistol_common_everyday_carry", "damage": [ 0, 2 ] } ],
+            "prob": 5
+          },
+          {
+            "collection": [ { "item": "holster" }, { "item": "tazer", "damage": [ 0, 2 ], "charges-min": 0, "charges-max": 100 } ],
+            "prob": 5
+          }
         ],
-        "prob": 80
+        "prob": 35
       }
     ]
   },

--- a/data/json/monsterdrops/zombie_survivor.json
+++ b/data/json/monsterdrops/zombie_survivor.json
@@ -36,11 +36,10 @@
       },
       {
         "distribution": [
-          { "item": "teargas_sprayer", "prob": 10, "charges-min": 0, "charges-max": 7 },
-          { "group": "guns_pistol_common_everyday_carry", "damage": [ 1, 4 ], "prob": 5 },
+          { "item": "teargas_sprayer", "prob": 10, "charges-min": 0, "charges-max": 5 },
           {
             "collection": [ { "item": "holster" }, { "group": "guns_pistol_common_everyday_carry", "damage": [ 0, 2 ] } ],
-            "prob": 5
+            "prob": 10
           },
           {
             "collection": [ { "item": "holster" }, { "item": "tazer", "damage": [ 0, 2 ], "charges-min": 0, "charges-max": 100 } ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "partially undo buffs to survivor z loot"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Survivor zombies felt too much like loot piñatas too frequently. Even though the player could easily die with hundreds of items the survivor zombies led to too much easy loot too quickly despite their rarity. After testing and fighting quite a few I more or less feel I buffed them too much.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Lower probabilities of most loot heavily. They're still considerably more stacked than the average zombie but less than before. They still use their new armor system though.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
remove survivor zombies
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->