### PR TITLE
adjust zombie food to be more often perishables

### DIFF
--- a/data/json/monsterdrops/zombie_default.json
+++ b/data/json/monsterdrops/zombie_default.json
@@ -249,7 +249,7 @@
       { "group": "softdrugs", "prob": 10 },
       { "group": "harddrugs", "prob": 5 },
       { "group": "phones", "prob": 85 },
-      { "group": "vending_food_items", "prob": 5 }
+      { "group": "zombie_pocket_food", "prob": 5 }
     ]
   },
   {
@@ -308,6 +308,20 @@
           }
         ]
       }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "//": "pocket sized food items a person could have looted or kept with them.",
+    "id": "zombie_pocket_food",
+    "entries": [
+      { "group": "vending_food_items", "prob": 20 },
+      { "group": "sandwiches", "prob": 20 },
+      { "group": "fresh_produce", "prob": 15 },
+      { "group": "food_vendor_cart_kitchen", "prob": 15 },
+      { "group": "fridgesnacks", "prob": 15 },
+      { "group": "fast_food", "prob": 5 },
     ]
   }
 ]

--- a/data/json/monsterdrops/zombie_default.json
+++ b/data/json/monsterdrops/zombie_default.json
@@ -321,7 +321,7 @@
       { "group": "fresh_produce", "prob": 15 },
       { "group": "food_vendor_cart_kitchen", "prob": 15 },
       { "group": "fridgesnacks", "prob": 15 },
-      { "group": "fast_food", "prob": 5 },
+      { "group": "fast_food", "prob": 5 }
     ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "When zombies drop food, it's more frequently perishable"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Zombies only ever carried shelf stable foods with them, but not everyone in a disaster would grab something that would last a long time.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make the zombie food drop (5% chance of a vending machine food) instead a 5% chance of a larger variety of food which includes vending machine food, but also sandwiches, stuff from their fridge, etc. Much of which will spoil quickly.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Unsure if zombies should carry that much food with them but this should at least have a gameplay effect of zombie-based food delivery becoming less potent as the days creep on. It might be worth applying these to bugout bags too.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->