### PR TITLE
Fix map memory not cleared when dragging

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -301,7 +301,7 @@ void avatar::memorize_symbol( const tripoint &p, char32_t symbol )
 
 void avatar::memorize_clear_vehicles( const tripoint &p )
 {
-    player_map_memory->clear_tile_vehicles( p );
+    player_map_memory->clear_tile_decoration( p, /* prefix = */ "vp_" );
 }
 
 std::vector<mission *> avatar::get_active_missions() const
@@ -678,7 +678,7 @@ bool avatar::read( item_location &book, item_location ereader )
     return true;
 }
 
-void avatar::grab( object_type grab_type, const tripoint &grab_point )
+void avatar::grab( object_type grab_type_new, const tripoint &grab_point_new )
 {
     const auto update_memory =
     [this]( const object_type gtype, const tripoint & gpoint, const bool erase ) {
@@ -694,20 +694,20 @@ void avatar::grab( object_type grab_type, const tripoint &grab_point )
             }
         } else if( gtype != object_type::NONE ) {
             if( erase ) {
-                memorize_clear_vehicles( m.getabs( pos() + gpoint ) );
+                player_map_memory->clear_tile_decoration( m.getabs( pos() + gpoint ) );
             }
             m.set_memory_seen_cache_dirty( pos() + gpoint );
         }
     };
     // Mark the area covered by the previous vehicle/furniture/etc for re-memorizing.
-    update_memory( this->grab_type, this->grab_point, false );
+    update_memory( grab_type, grab_point, /* erase = */ false );
+
+    grab_type = grab_type_new;
+    grab_point = grab_point_new;
+
     // Clear the map memory for the area covered by the vehicle/furniture/etc to
     // eliminate ghost vehicles/furnitures/etc.
-    // FIXME: change map memory to memorize all memorizable objects and only erase vehicle part memory.
-    update_memory( grab_type, grab_point, true );
-
-    this->grab_type = grab_type;
-    this->grab_point = grab_point;
+    update_memory( grab_type, grab_point, /* erase = */ true );
 
     path_settings->avoid_rough_terrain = grab_type != object_type::NONE;
 }

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -235,7 +235,7 @@ void map_memory::set_tile_symbol( const tripoint &pos, char32_t symbol )
     sm.set_tile( p.loc, mt );
 }
 
-void map_memory::clear_tile_vehicles( const tripoint &pos )
+void map_memory::clear_tile_decoration( const tripoint &pos, std::string_view prefix )
 {
     const coord_pair p( pos );
     mm_submap &sm = get_submap( p.sm );
@@ -243,7 +243,7 @@ void map_memory::clear_tile_vehicles( const tripoint &pos )
         return;
     }
     memorized_tile mt = sm.get_tile( p.loc );
-    if( string_starts_with( mt.get_dec_id(), "vp_" ) ) {
+    if( string_starts_with( mt.get_dec_id(), prefix ) ) {
         mt.set_dec_id( "" );
         mt.set_dec_rotation( 0 );
         mt.set_dec_subtile( 0 );

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -152,10 +152,11 @@ class map_memory
         void set_tile_symbol( const tripoint &pos, char32_t symbol );
 
         /**
-         * Clears memorized vehicles and symbol.
+         * Clears memorized decorations and symbol.
          * @param pos tile position, in global ms coords.
+         * @param prefix if non-empty only clears if decoration starts with this prefix
          */
-        void clear_tile_vehicles( const tripoint &pos );
+        void clear_tile_decoration( const tripoint &pos, std::string_view prefix = "" );
 
     private:
         std::map<tripoint, shared_ptr_fast<mm_submap>> submaps;

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -112,7 +112,7 @@ TEST_CASE( "map_memory_forgets", "[map_memory]" )
     CHECK( mt.get_dec_rotation() == 3 );
     memory.set_tile_symbol( p1, 1 );
     CHECK( mt.symbol == 1 );
-    memory.clear_tile_vehicles( p1 );
+    memory.clear_tile_decoration( p1, /* prefix = */ "vp_" );
     CHECK( mt.symbol == 0 );
     CHECK( mt.get_ter_id() == "t_foo" );
     CHECK( mt.get_ter_subtile() == 43 );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix dragging furniture with no vision leaving memory mark trails

#### Describe the solution

Should clear any decoration id when dragging non-vehicles, oops

#### Describe alternatives you've considered

#### Testing

Drag furniture around without blindfold, then with, in both cases old memory should be cleared

#### Additional context

https://discord.com/channels/598523535169945603/642349261320880128/1120331594595565598