### PR TITLE
Fix large sprites not displaying correctly

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1611,7 +1611,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         }
     };
 
-    const int height_3d_mult = is_isometric() ? 10 : 0;
+    //const int height_3d_mult = is_isometric() ? 10 : 0;
     if( max_draw_depth <= 0 ) {
         // Legacy draw mode
         for( int row = min_row; row < max_row; row ++ ) {
@@ -1626,7 +1626,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         // Start drawing from the bottom-most z-level
         int cur_zlevel = -OVERMAP_DEPTH;
         do {
-            int cur_height_3d = ( cur_zlevel - center.z ) * height_3d_mult;
+            //int cur_height_3d = ( cur_zlevel - center.z ) * height_3d_mult;
             // For each row
             for( int row = min_row; row < max_row; row ++ ) {
                 // For each layer
@@ -1641,7 +1641,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         tripoint draw_loc = p.pos;
                         draw_loc.z = cur_zlevel;
                         // Draw
-                        ( this->*f )( draw_loc, p.ll, cur_height_3d, p.invisible );
+                        ( this->*f )( draw_loc, p.ll, p.height_3d, p.invisible );
                     }
                 }
             }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1615,8 +1615,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     if( max_draw_depth <= 0 ) {
         // Legacy draw mode
         for( int row = min_row; row < max_row; row ++ ) {
-        for( tile_render_info &p : draw_points[row] ) {
             for( auto f : drawing_layers_legacy ) {
+        for( tile_render_info &p : draw_points[row] ) {
                 ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible );
             }
         }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1627,15 +1627,14 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         int cur_zlevel = -OVERMAP_DEPTH;
         do {
             int cur_height_3d = ( cur_zlevel - center.z ) * height_3d_mult;
+                    for( auto f : drawing_layers ) {
                 for( tile_render_info &p : draw_points ) {
                 	if( cur_zlevel < p.draw_min_z ) { continue; }
                     tripoint draw_loc = p.pos;
                     draw_loc.z = cur_zlevel;
-                    // Draw each layer
-                    for( auto f : drawing_layers ) {
                         ( this->*f )( draw_loc, p.ll, cur_height_3d, p.invisible );
-                    }
                 }
+                    }
             cur_zlevel += 1;
         } while( cur_zlevel <= center.z );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix large sprites not displaying correctly"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #66280
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Correct the order in which sprites are drawn.  Row and draw depth data are now stored with `draw_points` and `tile_render_info` respectively to accommodate for this.  Care had been taken to avoid the reintroduction of other draw order related bugs.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Builds ok.
Large sprites now display correctly.
Fog is drawn on top of large sprites correctly.
Creatures are drawn behind tall sprites in front of them as they should.
No detectable increase in draw time.
Screenshot below uses debug clairvoyance.

![Spathi Pkeloucht _2023-06-20T12-21-24](https://github.com/CleverRaven/Cataclysm-DDA/assets/129854247/c6ec4289-0200-46ec-81b8-3b0711cde19b)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->