### PR TITLE
Various perf improvements

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -619,7 +619,7 @@ bool can_butcher_at( const tripoint &p )
 {
     map_stack items = get_map().i_at( p );
     // Early exit when there's definitely nothing to butcher
-    if( items.size() == 0 ) {
+    if( items.empty() ) {
         return false;
     }
     Character &player_character = get_player_character();

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -617,11 +617,15 @@ std::optional<input_event> hotkey_for_action( const action_id action,
 
 bool can_butcher_at( const tripoint &p )
 {
+    map_stack items = get_map().i_at( p );
+    // Early exit when there's definitely nothing to butcher
+    if( items.size() == 0 ) {
+        return false;
+    }
     Character &player_character = get_player_character();
     // TODO: unify this with game::butcher
     const int factor = player_character.max_quality( qual_BUTCHER, PICKUP_RANGE );
     const int factorD = player_character.max_quality( qual_CUT_FINE, PICKUP_RANGE );
-    map_stack items = get_map().i_at( p );
     bool has_item = false;
     bool has_corpse = false;
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3569,6 +3569,7 @@ void vehicle::deserialize( const JsonObject &data )
 void vehicle::deserialize_parts( const JsonArray &data )
 {
     parts.clear();
+    parts.reserve( data.size() );
     for( const JsonValue jv : data ) {
         try {
             vehicle_part part;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6049,7 +6049,7 @@ void vehicle::refresh( const bool remove_fakes )
             fake_parts.push_back( fake_index );
             relative_parts[ part_fake.mount ].push_back( fake_index );
             edges.emplace( real_mount, edge_info );
-            parts.push_back( part_fake );
+            parts.push_back( std::move( part_fake ) );
         }
     };
     // re-install fake parts - this could be done in a separate function, but we want to


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Faster, faster, faster.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. When deserializing the vehicle parts of a given vehicle, reserve `parts` to avoid  emplace-reallocation.
2. When refreshing the vehicle, when generating fake parts, move the temporary vparts instead of copying them to avoid deconstruction and copy-construction.
3. Early exit when there's definitely nothing to butcher to avoid checking all items nearby for tools.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
none
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
CI should tell.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

When generating fake parts, the item colonies of the real parts are also copied. This becomes an issue for Blaze Industry mod, because there's a 2000L cargo space vp that is also obstacle, so the copy overhead becomes large. Should we implement a dedicated copy-ctor that does not copy the item colony to generate fake parts?

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->