### PR TITLE
Exclude tools/spell_checker/dictionary.txt from auto-request-review config

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -39,7 +39,7 @@ files:
     - KorGgenT
   '**/magic*.h':
     - KorGgenT
-  'tools/**':
+  'tools/!(spell_checker){,/**}':
     - jbytheway
     - int-ua
   'src/widget.cpp':

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -39,7 +39,7 @@ files:
     - KorGgenT
   '**/magic*.h':
     - KorGgenT
-  'tools/!(spell_checker){,/**}':
+  'tools/{spell_checker/!(dictionary.txt){,/**},!(spell_checker){,/**}}':
     - jbytheway
     - int-ua
   'src/widget.cpp':


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
@jbytheway @int-ua probably did not intend to be alerted of changes to the spell checker dictionary.

#### Describe the solution
Exclude `tools/spell_checker/dictionary.txt`.

#### Describe alternatives you've considered
None

#### Testing
Tested with an [online sandbox](https://codesandbox.io/s/minimatch-forked-75gyzx?file=/src/index.tsx:358-426). It now matches `tools/foo`, `tools/foo/bar` etc but not `tools/spell_checker/dictionary.txt`.

#### Additional context
None