### PR TITLE
Fix NPC putting items in open air when fetching items during an activity when 3D FOV is on

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2809,8 +2809,8 @@ static requirement_check_result generic_multi_activity_check_requirement(
                         local_src_set.push_back( here.bub_from_abs( elem ) );
                     }
                     std::vector<tripoint_bub_ms> candidates;
-                    for( const tripoint_bub_ms &point_elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1,
-                            PICKUP_RANGE - 1 ) ) {
+                    for( const tripoint_bub_ms &point_elem :
+                         here.points_in_radius( src_loc, /*radius=*/PICKUP_RANGE - 1, /*radiusz=*/0 ) ) {
                         // we don't want to place the components where they could interfere with our ( or someone else's ) construction spots
                         if( !you.sees( point_elem ) || ( std::find( local_src_set.begin(), local_src_set.end(),
                                                          point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix NPC putting items in open air when fetching items during an activity when 3D FOV is on"

#### Purpose of change
Once our ~slaves~ builders discover the sky they invent juggling and throw items into the air instead of placing them on the same z-level as the target tile. This PR makes NPCs do the latter instead.

#### Describe the solution
Only check tiles on the same z-level as the target tile when looking for tile to place items.

#### Describe alternatives you've considered
None

#### Testing
1. Enable 3D FOV
2. Create construction zone one tile south of the player
3. Create unsorted loot zone 13 tiles north of the player and place needed construction materials and tools there
4. Teleport an follower to the player's location and let them do construction
5. Before this change, NPC walks to the loot zone and places items in an open air tile above the construction zone
6. Before this change, the unit test hangs when testing construction activity
7. After this change, NPC places items near the construction zone on the same z-level
8. After this change, the unit test no long hangs (although it still fails due to another error)

#### Additional context
None