### PR TITLE
Remove BLADED_FARMING weapon category. Replace with SHORT_SWORDS where applicable. Fix scythe to-hit.

### DIFF
--- a/data/json/items/melee/spears_and_polearms.json
+++ b/data/json/items/melee/spears_and_polearms.json
@@ -15,7 +15,7 @@
     "to_hit": { "grip": "solid", "length": "long", "surface": "point", "balance": "neutral" },
     "qualities": [ [ "COOK", 1 ] ],
     "flags": [ "SPEAR", "REACH_ATTACK", "NONCONDUCTIVE", "SHEATH_SPEAR" ],
-    "weapon_category": [ "BLADED_FARMING", "POLEARMS", "SPEARS" ],
+    "weapon_category": [ "POLEARMS", "SPEARS" ],
     "price": 2000,
     "price_postapoc": 500,
     "melee_damage": { "bash": 5, "stab": 18 }
@@ -125,7 +125,7 @@
     "techniques": [ "WIDE", "BRUTAL" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -22 ] ],
     "flags": [ "FRAGILE_MELEE", "NONCONDUCTIVE", "POLEARM", "SHEATH_SPEAR", "REACH_ATTACK", "ALWAYS_TWOHAND" ],
-    "weapon_category": [ "BLADED_FARMING", "HOOKING_WEAPONRY", "POLEARMS" ],
+    "weapon_category": [ "HOOKING_WEAPONRY", "POLEARMS" ],
     "melee_damage": { "bash": 16, "cut": 40 }
   },
   {
@@ -758,7 +758,7 @@
     "techniques": [ "WIDE", "BRUTAL" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -22 ] ],
     "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "POLEARM", "SHEATH_SPEAR", "REACH_ATTACK", "ALWAYS_TWOHAND" ],
-    "weapon_category": [ "BLADED_FARMING", "HOOKING_WEAPONRY", "POLEARMS" ],
+    "weapon_category": [ "HOOKING_WEAPONRY", "POLEARMS" ],
     "melee_damage": { "bash": 17, "cut": 42 }
   },
   {

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -507,7 +507,7 @@
     "qualities": [ [ "CUT", 2 ], [ "GRASS_CUT", 1 ], [ "BUTCHER", -27 ] ],
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "SHEATH_SWORD" ],
-    "weapon_category": [ "BLADED_FARMING" ],
+    "weapon_category": [ "SHORT_SWORDS" ],
     "melee_damage": { "bash": 5, "cut": 16 }
   },
   {
@@ -528,7 +528,7 @@
     "techniques": [ "WBLOCK_2" ],
     "qualities": [ [ "CUT", 2 ], [ "GRASS_CUT", 1 ], [ "BUTCHER", 15 ] ],
     "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
-    "weapon_category": [ "BLADED_FARMING" ],
+    "weapon_category": [ "SHORT_SWORDS" ],
     "melee_damage": { "bash": 5, "cut": 21 }
   },
   {
@@ -547,7 +547,7 @@
     "material": [ "steel" ],
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 8 ], [ "SAW_W", 1 ], [ "DIG", 1 ], [ "PRY", 1 ] ],
     "flags": [ "SHEATH_SWORD", "FRAGILE_MELEE" ],
-    "weapon_category": [ "BLADED_FARMING" ],
+    "weapon_category": [ "SHORT_SWORDS" ],
     "melee_damage": { "bash": 5, "cut": 15 }
   },
   {
@@ -1462,7 +1462,7 @@
     "techniques": [ "WBLOCK_2", "DEF_DISARM" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
     "flags": [ "DURABLE_MELEE" ],
-    "weapon_category": [ "BLADED_FARMING" ],
+    "weapon_category": [ "SHORT_SWORDS" ],
     "melee_damage": { "bash": 9, "cut": 27 }
   },
   {
@@ -1526,7 +1526,7 @@
     "techniques": [ "WBLOCK_2", "RAPID" ],
     "qualities": [ [ "CUT", 2 ], [ "GRASS_CUT", 1 ], [ "BUTCHER", 10 ] ],
     "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
-    "weapon_category": [ "BLADED_FARMING", "CONSTRUCTED_SWORDS" ],
+    "weapon_category": [ "SHORT_SWORDS", "CONSTRUCTED_SWORDS" ],
     "melee_damage": { "bash": 6, "cut": 23 }
   },
   {
@@ -1565,7 +1565,7 @@
     "techniques": [ "WBLOCK_2", "RAPID" ],
     "qualities": [ [ "CUT", 2 ], [ "GRASS_CUT", 1 ], [ "BUTCHER", 14 ] ],
     "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
-    "weapon_category": [ "BLADED_FARMING", "CONSTRUCTED_SWORDS" ],
+    "weapon_category": [ "SHORT_SWORDS", "CONSTRUCTED_SWORDS" ],
     "looks_like": "survivor_machete",
     "melee_damage": { "bash": 6, "cut": 28 }
   },

--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -52,7 +52,7 @@
     "qualities": [ [ "DIG", 1 ], [ "SAW_W", 1 ] ],
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "NONCONDUCTIVE", "NO_SALVAGE" ],
-    "weapon_category": [ "BLADED_FARMING", "HOOKING_WEAPONRY" ],
+    "weapon_category": [ "HOOKING_WEAPONRY" ],
     "use_action": [ "MAKEMOUND" ],
     "melee_damage": { "bash": 10, "cut": 6 }
   },
@@ -74,7 +74,7 @@
     "qualities": [ [ "DIG", 1 ], [ "SAW_W", 1 ] ],
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "NONCONDUCTIVE" ],
-    "weapon_category": [ "BLADED_FARMING", "HOOKING_WEAPONRY" ],
+    "weapon_category": [ "HOOKING_WEAPONRY" ],
     "use_action": [ "MAKEMOUND" ],
     "melee_damage": { "bash": 10, "cut": 5 }
   },
@@ -135,14 +135,14 @@
     "longest_side": "140 cm",
     "price": 8000,
     "price_postapoc": 250,
-    "to_hit": -6,
+    "to_hit": { "grip": "solid", "length": "long", "surface": "point", "balance": "uneven" },
     "material": [ "steel", "wood" ],
     "symbol": "/",
     "color": "light_gray",
     "techniques": [ "WIDE", "BRUTAL" ],
     "qualities": [ [ "CUT", 1 ], [ "GRASS_CUT", 2 ], [ "BUTCHER", -22 ] ],
     "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE" ],
-    "weapon_category": [ "BLADED_FARMING", "HOOKING_WEAPONRY", "POLEARMS" ],
+    "weapon_category": [ "HOOKING_WEAPONRY", "POLEARMS" ],
     "melee_damage": { "bash": 6, "cut": 14 }
   },
   {
@@ -173,11 +173,11 @@
     "longest_side": "150 cm",
     "price": 3000,
     "price_postapoc": 10,
-    "to_hit": -6,
+    "to_hit": { "grip": "solid", "length": "long", "surface": "any", "balance": "uneven" },
     "material": [ "plastic" ],
     "techniques": [ "WIDE", "BRUTAL" ],
     "flags": [ "NONCONDUCTIVE", "FRAGILE_MELEE", "POLEARM", "SHEATH_SPEAR", "REACH_ATTACK", "ALWAYS_TWOHAND" ],
-    "weapon_category": [ "BLADED_FARMING", "HOOKING_WEAPONRY", "POLEARMS" ],
+    "weapon_category": [ "HOOKING_WEAPONRY", "POLEARMS" ],
     "melee_damage": { "bash": 7 }
   },
   {
@@ -255,7 +255,7 @@
     "qualities": [ [ "CUT", 1 ], [ "GRASS_CUT", 1 ], [ "BUTCHER", 2 ] ],
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "NONCONDUCTIVE", "FRAGILE_MELEE" ],
-    "weapon_category": [ "BLADED_FARMING" ],
+    "weapon_category": [ "BSHORT_SWORDS" ],
     "melee_damage": { "bash": 3, "cut": 10 }
   },
   {
@@ -275,7 +275,7 @@
     "qualities": [ [ "CUT", 1 ], [ "GRASS_CUT", 2 ], [ "BUTCHER", 7 ] ],
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "DURABLE_MELEE" ],
-    "weapon_category": [ "BLADED_FARMING" ],
+    "weapon_category": [ "SHORT_SWORDS" ],
     "melee_damage": { "bash": 3, "cut": 20 }
   },
   {
@@ -295,7 +295,7 @@
     "looks_like": "sickle",
     "qualities": [ [ "CUT", 1 ], [ "GRASS_CUT", 2 ], [ "BUTCHER", 7 ] ],
     "techniques": [ "WBLOCK_1" ],
-    "weapon_category": [ "BLADED_FARMING" ],
+    "weapon_category": [ "SHORT_SWORDS" ],
     "melee_damage": { "bash": 3, "cut": 12 }
   },
   {

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -516,7 +516,7 @@
       "tec_eskrima_low",
       "tec_eskrima_combination"
     ],
-    "weapon_category": [ "KNIVES", "BATONS", "BLADED_FARMING", "CLAWS", "SHIVS" ]
+    "weapon_category": [ "KNIVES", "BATONS", "SHORT_SWORDS", "CLAWS", "SHIVS" ]
   },
   {
     "type": "martial_art",
@@ -976,7 +976,7 @@
       }
     ],
     "techniques": [ "tec_ninjutsu_swift", "tec_ninjutsu_swift_crit", "tec_ninjutsu_takedown", "tec_ninjutsu_precise" ],
-    "weapon_category": [ "MEDIUM_SWORDS", "LONG_SWORDS", "SHORT_SWORDS", "KNIVES", "QUARTERSTAVES", "BLADED_FARMING", "CLAWS" ]
+    "weapon_category": [ "MEDIUM_SWORDS", "LONG_SWORDS", "SHORT_SWORDS", "KNIVES", "QUARTERSTAVES", "CLAWS" ]
   },
   {
     "type": "martial_art",
@@ -1143,7 +1143,7 @@
       }
     ],
     "techniques": [ "tec_silat_hamstring", "tec_silat_precise", "tec_silat_brutal", "tec_silat_dirty" ],
-    "weapon_category": [ "KNIVES", "BATONS", "QUARTERSTAVES", "BLADED_FARMING", "POLEARMS" ]
+    "weapon_category": [ "KNIVES", "BATONS", "QUARTERSTAVES", "SHORT_SWORDS", "POLEARMS" ]
   },
   {
     "type": "martial_art",

--- a/data/json/weapon_categories.json
+++ b/data/json/weapon_categories.json
@@ -51,11 +51,6 @@
   },
   {
     "type": "weapon_category",
-    "id": "BLADED_FARMING",
-    "name": "BLADED FARMING"
-  },
-  {
-    "type": "weapon_category",
     "id": "CLAWS",
     "name": "CLAWS"
   },


### PR DESCRIPTION
#### Summary
Balance "Remove BLADED_FARMING weapon category and fix scythe to-hit."

#### Purpose of change

Weapon categories are meant to conglomerate similarly-shaped and balanced weapons into categories for the purposes of martial arts. BLADED_FARMING was a nonsensical category with everything from machetes to sickles to hoes and scythes and pitchforks, with the only running theme being "these be farming tools." Except, for some reason, also containing the war scythe and khopesh. This is not a useful category for the purposes of martial arts, and causes the bizarre behavior where martial arts using it (notably Eskrima) is capable of skillfully using a pitchfork but not a spear, or a war scythe but not a glaive.

#### Describe the solution

Yote "BLADED_FARMING" entirely. For sickles and machetes, replaced with SHORT_SWORDS as a category; for all the other items like the hoe, pitchfork, etc. no replacement since they're already polearms or hooking weaponry where applicable. Eskrima and Silat were also given SHORT_SWORDS (previously only used by Ninjutsu) as viable weapon categories so they can still use machetes. This does buff them somewhat since they now have access to other weapons in the category such as the cutlass, cavalry saber, and wakizashi, but I'm willing to say they're "close enough" to be compatible.

While I was fiddling in there I gave scythes proper to-hit modifiers on par with the design doc; "solid" grip, "point" angle of attack (which specifies scythes due to the cutting edge being towards the user), "long" length, "uneven" balance. Grim reaper's scythe (since it's a toy) has "any" angle of attack since it's blunt and basically a long plastic stick. This brings their to-hit from -6 to-2 (0 for the grim reaper scythe).

#### Describe alternatives you've considered

Making a new weapon category just for machetes and sickles. "MACHETES" or "EVEN_SHORTER_SWORDS" or something I guess, but it felt like it overlapped too much with "SHORT_SWORDS".

#### Testing

Game runs with no errors, weapons are usable in relevant martial arts.

#### Additional context

Scythes are still poor weapons despite the buff, but at least they're no longer worse than punching. Ninjutsu and Eskrima lost access to the few polearms it had (justifiably), while Silat has built-in polearm support anyway, though Ninjutsu still has a fairly large weapon list including staves. Eskrima's new access to short_swords is a buff, but the best weapon there (tempered wakizashi) isn't a huge improvement over the tempered combat machete.