### PR TITLE
Hound afterimages also copy their host nicknames

### DIFF
--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -5190,6 +5190,7 @@ bool mattack::tindalos_teleport( monster *z )
                                         1 ) ) {
             z->moves -= 140;
             afterimage->make_ally( *z );
+            afterimage->nickname = z->nickname;
             add_msg_if_player_sees( *z, m_warning,
                                     _( "The hound's movements chaotically rewind as a living afterimage splits from it!" ) );
         }


### PR DESCRIPTION
#### Summary
Balance "Hound afterimages also copy their host nicknames"

#### Purpose of change
Giving a nickname to the main hound so you can easily tell it apart is an exploit, this fixes it.

#### Describe the solution
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/5290912/2c5a7a1d-8d70-4685-8399-f59a0b023c55)

#### Testing
See image