### PR TITLE
Add Great Beaked Toad

### DIFF
--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -428,7 +428,7 @@
           { "damage_type": "cut", "amount": 26, "armor_multiplier": 0.2 },
           { "damage_type": "bash", "amount": 14, "armor_multiplier": 0.2 }
         ],
-		"effects": [ { "id": "paralyzepoison", "duration": 20, "affect_hit_bp": true } ]
+        "effects": [ { "id": "paralyzepoison", "duration": 20, "affect_hit_bp": true } ]
       },
       { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 }
     ],

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -425,7 +425,7 @@
         "id": "bite_grab",
         "cooldown": 10,
         "accuracy": 6,
-        "damage_max_instance": [ { "damage_type": "cut", "amount": 16, "armor_multiplier": 0.3 }, { "damage_type": "bash", "amount": 8, "armor_multiplier": 0.3 } ],
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 16, "armor_multiplier": 0.3 }, { "damage_type": "bash", "amount": 8, "armor_multiplier": 0.3 } ]
       },
       { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 },
     ],

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -341,8 +341,9 @@
     "id": "mon_toad",
     "type": "MONSTER",
     "name": { "str": "toad" },
-    "description": "Toads are a diverse and varied family of amphibians sister to frogs.  Very distinguishable for their warty and dry skin.",
+    "description": "Toads are a largely colloquial grouping of frogs.  Distinguished by their warty and dry skin.",
     "copy-from": "mon_frog",
+    "upgrades": { "half_life": 34, "into": "mon_toad_small" },
     "reproduction": { "baby_egg": "egg_toad", "baby_count": 8, "baby_timer": 26 }
   },
   {
@@ -392,5 +393,43 @@
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "PLAYER_CLOSE" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "SWIMS" ],
     "armor": { "bash": 4 }
+    "upgrades": { "half_life": 65, "into": "mon_toad_beak" }
+  },
+  {
+    "id": "mon_toad_beak",
+    "type": "MONSTER",
+    "name": { "str": "great beaked toad" },
+    "description": "This massive toad's jawbones have grown out from its lips into a powerful beak, large enough to snap a bicycle in two. A pale fluid oozes from the creatures face and mouth. The swollen lumps behind its large eyes hint at this fluid's toxic nature.",
+    "default_faction": "frog",
+    "bodytype": "frog",
+    "categories": [ "WILDLIFE" ],
+    "species": [ "AMPHIBIAN" ],
+    "volume": "150 L",
+    "weight": "200 kg",
+    "hp": 200,
+    "speed": 80,
+    "symbol": "B",
+    "color": "brown"
+    "aggression": 10,
+    "morale": 100,
+    "melee_skill": 5,
+    "melee_dice": 2,
+    "melee_dice_sides": 12,
+    "melee_damage": [ { "damage_type": "cut", "amount": 2, "armor_multiplier": 0.5 } ],
+    "dodge": 1,
+    "harvest": "mutant_animal_large_noskin",
+    "path_settings": { "max_dist": 5 },
+    "special_attacks": [
+      {
+        "id": "bite_grab",
+        "cooldown": 10,
+        "accuracy": 6,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 16, "armor_multiplier": 0.3 }, { "damage_type": "bash", "amount": 8, "armor_multiplier": 0.3 } ]
+      },
+      { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 } 
+    ],
+    "anger_triggers": [ "STALK", "PLAYER_WEAK", "PLAYER_CLOSE" ],
+    "flags": [ "SEES", "SMELLS", "HEARS", "SWIMS", "GRABS", "VENOM" ],
+    "armor": { "bash": 6 }
   }
 ]

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -427,7 +427,7 @@
         "accuracy": 6,
         "damage_max_instance": [ { "damage_type": "cut", "amount": 16, "armor_multiplier": 0.3 }, { "damage_type": "bash", "amount": 8, "armor_multiplier": 0.3 } ]
       },
-      { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 },
+      { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 }
     ],
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "PLAYER_CLOSE" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "SWIMS", "GRABS", "VENOM" ],

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -413,26 +413,27 @@
     "aggression": 10,
     "morale": 100,
     "melee_skill": 5,
-    "melee_dice": 2,
+    "melee_dice": 1,
     "melee_dice_sides": 12,
-    "melee_damage": [ { "damage_type": "cut", "amount": 2, "armor_multiplier": 0.5 } ],
+    "melee_damage": [ { "damage_type": "cut", "amount": 1 } ],
     "dodge": 1,
     "harvest": "mutant_animal_large_noskin",
     "path_settings": { "max_dist": 5 },
     "special_attacks": [
       {
         "id": "bite_grab",
-        "cooldown": 10,
+        "cooldown": 6,
         "accuracy": 6,
         "damage_max_instance": [
-          { "damage_type": "cut", "amount": 16, "armor_multiplier": 0.3 },
-          { "damage_type": "bash", "amount": 8, "armor_multiplier": 0.3 }
-        ]
+          { "damage_type": "cut", "amount": 26, "armor_multiplier": 0.2 },
+          { "damage_type": "bash", "amount": 14, "armor_multiplier": 0.2 }
+        ],
+		"effects": [ { "id": "paralyzepoison", "duration": 20, "affect_hit_bp": true } ]
       },
       { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 }
     ],
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "SWIMS", "GRABS", "VENOM" ],
+    "flags": [ "SEES", "SMELLS", "HEARS", "SWIMS", "GRABS" ],
     "armor": { "bash": 6 }
   }
 ]

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -419,13 +419,15 @@
     "dodge": 1,
     "harvest": "mutant_animal_large_noskin",
     "path_settings": { "max_dist": 5 },
-    "special_attacks":
-	[
+    "special_attacks": [
       {
         "id": "bite_grab",
         "cooldown": 10,
         "accuracy": 6,
-        "damage_max_instance": [ { "damage_type": "cut", "amount": 16, "armor_multiplier": 0.3 }, { "damage_type": "bash", "amount": 8, "armor_multiplier": 0.3 } ]
+        "damage_max_instance": [
+          { "damage_type": "cut", "amount": 16, "armor_multiplier": 0.3 },
+          { "damage_type": "bash", "amount": 8, "armor_multiplier": 0.3 }
+        ]
       },
       { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 }
     ],

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -419,14 +419,15 @@
     "dodge": 1,
     "harvest": "mutant_animal_large_noskin",
     "path_settings": { "max_dist": 5 },
-    "special_attacks": [
+    "special_attacks":
+	[
       {
         "id": "bite_grab",
         "cooldown": 10,
         "accuracy": 6,
-        "damage_max_instance": [ { "damage_type": "cut", "amount": 16, "armor_multiplier": 0.3 }, { "damage_type": "bash", "amount": 8, "armor_multiplier": 0.3 } ]
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 16, "armor_multiplier": 0.3 }, { "damage_type": "bash", "amount": 8, "armor_multiplier": 0.3 } ],
       },
-      { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 } 
+      { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 },
     ],
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "PLAYER_CLOSE" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "SWIMS", "GRABS", "VENOM" ],

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -409,7 +409,7 @@
     "hp": 200,
     "speed": 80,
     "symbol": "B",
-    "color": "brown"
+    "color": "brown",
     "aggression": 10,
     "morale": 100,
     "melee_skill": 5,

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -414,7 +414,7 @@
     "species": [ "AMPHIBIAN" ],
     "volume": "150 L",
     "weight": "200 kg",
-    "hp": 200,
+    "hp": 250,
     "speed": 80,
     "symbol": "B",
     "color": "brown",
@@ -430,8 +430,8 @@
     "special_attacks": [
       {
         "id": "bite_grab",
-        "cooldown": 6,
-        "accuracy": 6,
+        "cooldown": 5,
+        "accuracy": 5,
         "damage_max_instance": [
           { "damage_type": "cut", "amount": 26, "armor_multiplier": 0.2 },
           { "damage_type": "bash", "amount": 14, "armor_multiplier": 0.2 }
@@ -440,7 +440,7 @@
       },
       { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 }
     ],
-    "armor": { "bash": 6 },
+    "armor": { "bash": 12, "cut": 8, "bullet": 6 },
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "PLAYER_CLOSE" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "SWIMS", "GRABS" ],
     "reproduction": { "baby_egg": "egg_toad", "baby_count": 24, "baby_timer": 54 },

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -392,7 +392,7 @@
     "special_attacks": [ { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 } ],
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "PLAYER_CLOSE" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "SWIMS" ],
-    "armor": { "bash": 4 }
+    "armor": { "bash": 4 },
     "upgrades": { "half_life": 65, "into": "mon_toad_beak" }
   },
   {

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -22,7 +22,7 @@
     "dissect": "dissect_batrachian_sample_single",
     "special_attacks": [ { "type": "leap", "cooldown": 4, "max_range": 5, "allow_no_target": true } ],
     "fear_triggers": [ "PLAYER_CLOSE" ],
-    "upgrades": { "half_life": 34, "into": "mon_frog_small" },
+    "upgrades": { "age_grow": 34, "into": "mon_frog_small" },
     "flags": [ "SEES", "SMELLS", "HEARS", "SWIMS", "WATER_CAMOUFLAGE" ]
   },
   {
@@ -44,7 +44,7 @@
     "color": "green",
     "aggression": -60,
     "morale": -5,
-    "upgrades": { "age_grow": 365, "into": "mon_frog" },
+    "upgrades": { "age_grow": 100, "into": "mon_frog" },
     "fear_triggers": [ "PLAYER_CLOSE", "SOUND" ],
     "harvest": "mammal_tiny",
     "flags": [ "FISHABLE", "SEES", "SMELLS", "HEARS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
@@ -58,7 +58,8 @@
     "proportional": { "hp": 0.67, "speed": 1.1, "morale": 0.67, "melee_dice_sides": 0.67 },
     "volume": "62500 ml",
     "weight": "81500 g",
-    "upgrades": { "half_life": 34, "into": "mon_frog_giant" }
+    "reproduction": { "baby_egg": "egg_frog", "baby_count": 12, "baby_timer": 36 },
+    "upgrades": { "age_grow": 34, "into": "mon_frog_giant" }
   },
   {
     "id": "mon_frog_giant",
@@ -86,7 +87,8 @@
     "harvest": "mutant_animal_large_noskin",
     "dissect": "dissect_batrachian_sample_small",
     "path_settings": { "max_dist": 5 },
-    "upgrades": { "half_life": 60, "into": "mon_frog_mega" },
+    "reproduction": { "baby_egg": "egg_frog", "baby_count": 18, "baby_timer": 54 },
+    "upgrades": { "age_grow": 60, "into": "mon_frog_mega" },
     "zombify_into": "mon_zombullfrog",
     "special_attacks": [ { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 } ],
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "PLAYER_CLOSE" ],
@@ -121,6 +123,7 @@
     "harvest": "mutant_animal_large_noskin",
     "dissect": "dissect_batrachian_sample_huge",
     "path_settings": { "max_dist": 5 },
+    "reproduction": { "baby_egg": "egg_frog", "baby_count": 24, "baby_timer": 54 },
     "zombify_into": "mon_frog_mother",
     "grab_strength": 50,
     "special_attacks": [
@@ -343,7 +346,7 @@
     "name": { "str": "toad" },
     "description": "Toads are a largely colloquial grouping of frogs.  Distinguished by their warty and dry skin.",
     "copy-from": "mon_frog",
-    "upgrades": { "half_life": 34, "into": "mon_toad_small" },
+    "upgrades": { "age_grow": 34, "into": "mon_toad_small" },
     "reproduction": { "baby_egg": "egg_toad", "baby_count": 8, "baby_timer": 26 }
   },
   {
@@ -353,15 +356,19 @@
     "description": "Toad tadpoles looks exactly like a frog tadpoles at birth.  The main difference is that they keep this color during their whole larval stage.",
     "copy-from": "mon_tadpole",
     "color": "brown",
-    "upgrades": { "age_grow": 365, "into": "mon_toad" }
+    "upgrades": { "age_grow": 100, "into": "mon_toad" }
   },
   {
     "id": "mon_toad_small",
     "type": "MONSTER",
     "name": { "str": "huge toad" },
     "description": "This toad seems to have been mutated to absurd size by the Cataclysm.",
-    "copy-from": "mon_frog_small",
-    "upgrades": { "half_life": 34, "into": "mon_toad_giant" }
+    "copy-from": "mon_toad_giant",
+    "proportional": { "hp": 0.67, "speed": 1.1, "morale": 0.67, "melee_dice_sides": 0.67 },
+    "volume": "62500 ml",
+    "weight": "81500 g",
+    "reproduction": { "baby_egg": "egg_toad", "baby_count": 12, "baby_timer": 36 },
+    "upgrades": { "age_grow": 34, "into": "mon_toad_giant" }
   },
   {
     "id": "mon_toad_giant",
@@ -370,7 +377,6 @@
     "description": "This toad has grown bigger than a human.  It looks uninterested in eating you but you better not give it a chance.",
     "default_faction": "frog",
     "bodytype": "frog",
-    "looks_like": "mon_frog_giant",
     "categories": [ "WILDLIFE" ],
     "species": [ "AMPHIBIAN" ],
     "volume": "92500 ml",
@@ -393,7 +399,9 @@
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "PLAYER_CLOSE" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "SWIMS" ],
     "armor": { "bash": 4 },
-    "upgrades": { "half_life": 65, "into": "mon_toad_beak" }
+    "reproduction": { "baby_egg": "egg_toad", "baby_count": 18, "baby_timer": 54 },
+    "upgrades": { "age_grow": 60, "into": "mon_toad_beak" },
+    "zombify_into": "mon_gastro_bufo"
   },
   {
     "id": "mon_toad_beak",
@@ -432,8 +440,10 @@
       },
       { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 10, "min_consider_range": 2 }
     ],
+    "armor": { "bash": 6 },
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "PLAYER_CLOSE" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "SWIMS", "GRABS" ],
-    "armor": { "bash": 6 }
+    "reproduction": { "baby_egg": "egg_toad", "baby_count": 24, "baby_timer": 54 },
+    "zombify_into": "mon_gastro_bufo"
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Adds an evolution of giant toads with an armor-piercing and venomous bite."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
To add more distinct monsters to the amphibian grouping. The great beaked toads are a tougher, slower giant toad with an armor-piercing and venomous bite.
Currently they appear by growing from mutant toads and zombify into gastro bufo, though I intend to add a unique zombie version in a future PR.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I have spawned the creature both through debug spawning and advancing time on naturally spawned toads.
Instigated several test fights between it and other creatures, NPCs, and PCs.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->