### PR TITLE
Added power consumption for generator UPS

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8838,7 +8838,12 @@ units::energy Character::consume_ups( units::energy qty, const int radius )
     if( qty != 0_kJ ) {
         std::vector<const item *> ups_items = all_items_with_flag( flag_IS_UPS );
         for( const item *i : ups_items ) {
-            qty -= const_cast<item *>( i )->energy_consume( qty, tripoint_zero, nullptr );
+            if( i->is_tool() && i->type->tool->fuel_efficiency >= 0 ) {
+                qty -= const_cast<item *>( i )->energy_consume( qty, tripoint_zero, nullptr,
+                        i->type->tool->fuel_efficiency );
+            } else {
+                qty -= const_cast<item *>( i )->energy_consume( qty, tripoint_zero, nullptr );
+            }
         }
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10551,7 +10551,7 @@ units::energy item::energy_consume( units::energy qty, const tripoint &pos, Char
     const units::energy wanted_energy = qty;
 
     // Consume battery(ammo) and other fuel (if allowed)
-    if( is_battery() ) {
+    if( is_battery() || fuel_efficiency >= 0 ) {
         int consumed_kj = contents.ammo_consume( units::to_kilojoule( qty ), pos, fuel_efficiency );
         qty -= units::from_kilojoule( consumed_kj );
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10554,6 +10554,10 @@ units::energy item::energy_consume( units::energy qty, const tripoint &pos, Char
     if( is_battery() || fuel_efficiency >= 0 ) {
         int consumed_kj = contents.ammo_consume( units::to_kilojoule( qty ), pos, fuel_efficiency );
         qty -= units::from_kilojoule( consumed_kj );
+        // fix negative quantity
+        if( qty < 0_J ) {
+            qty = 0_J;
+        }
     }
 
     // Consume energy from contained magazine

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10540,7 +10540,8 @@ int item::ammo_consume( int qty, const tripoint &pos, Character *carrier )
     return wanted_qty - qty;
 }
 
-units::energy item::energy_consume( units::energy qty, const tripoint &pos, Character *carrier )
+units::energy item::energy_consume( units::energy qty, const tripoint &pos, Character *carrier,
+                                    float fuel_efficiency )
 {
     if( qty < 0_kJ ) {
         debugmsg( "Cannot consume negative quantity of energy for %s", tname() );
@@ -10549,9 +10550,9 @@ units::energy item::energy_consume( units::energy qty, const tripoint &pos, Char
 
     const units::energy wanted_energy = qty;
 
-    // Consume battery(ammo)
+    // Consume battery(ammo) and other fuel (if allowed)
     if( is_battery() ) {
-        int consumed_kj = contents.ammo_consume( units::to_kilojoule( qty ), pos );
+        int consumed_kj = contents.ammo_consume( units::to_kilojoule( qty ), pos, fuel_efficiency );
         qty -= units::from_kilojoule( consumed_kj );
     }
 

--- a/src/item.h
+++ b/src/item.h
@@ -2354,6 +2354,7 @@ class item : public visitable
          * @param qty maximum amount of ammo that should be consumed
          * @param pos current location of item, used for ejecting magazines and similar effects
          * @param carrier holder of the item, used for getting UPS and bionic power
+         * @param fuel_efficiency if this is a generator of some kind the efficiency at which it consumes fuel
          * @return amount of ammo consumed which will be between 0 and qty
          */
         int ammo_consume( int qty, const tripoint &pos, Character *carrier );
@@ -2367,7 +2368,8 @@ class item : public visitable
          * @param carrier holder of the item, used for getting UPS and bionic power
          * @return amount of energy consumed which will be between 0 kJ and qty+1 kJ
          */
-        units::energy energy_consume( units::energy qty, const tripoint &pos, Character *carrier );
+        units::energy energy_consume( units::energy qty, const tripoint &pos, Character *carrier,
+                                      float fuel_efficiency = -1.0 );
 
         /**
          * Consume ammo to activate item qty times (if available) and return the amount of ammo that was consumed

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1149,7 +1149,7 @@ void item_contents::heat_up()
     }
 }
 
-int item_contents::ammo_consume( int qty, const tripoint &pos )
+int item_contents::ammo_consume( int qty, const tripoint &pos, float fuel_efficiency )
 {
     int consumed = 0;
     for( item_pocket &pocket : contents ) {
@@ -1172,9 +1172,27 @@ int item_contents::ammo_consume( int qty, const tripoint &pos )
             qty -= res;
             consumed += res;
         } else if( pocket.is_type( item_pocket::pocket_type::MAGAZINE ) ) {
-            const int res = pocket.ammo_consume( qty );
-            consumed += res;
-            qty -= res;
+            if( pocket.front().is_fuel() && fuel_efficiency >= 0 ) {
+                // if using fuel instead of battery, everything is in kJ
+                // charges is going to be the energy needed over the energy in 1 unit of fuel * the efficiency of the generator
+                int charges_used = roll_remainder( static_cast<float>( units::from_kilojoule( qty ).value() ) / (
+                                                       static_cast<float>( pocket.front().fuel_energy().value() ) * fuel_efficiency ) );
+                const int res = pocket.ammo_consume( charges_used );
+                if( res == charges_used ) {
+                    // avoid rounding weirdness, if we used all the charges we wanted to, count that as good enough
+                    consumed += qty;
+                    qty = 0;
+                } else {
+                    // otherwise calculate the ammount of energy generated
+                    int energy_generated = res * units::to_kilojoule( pocket.front().fuel_energy() );
+                    consumed += energy_generated;
+                    qty -= energy_generated;
+                }
+            } else {
+                const int res = pocket.ammo_consume( qty );
+                consumed += res;
+                qty -= res;
+            }
         }
     }
     return consumed;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1172,22 +1172,18 @@ int item_contents::ammo_consume( int qty, const tripoint &pos, float fuel_effici
             qty -= res;
             consumed += res;
         } else if( pocket.is_type( item_pocket::pocket_type::MAGAZINE ) ) {
-            if( pocket.front().is_fuel() && fuel_efficiency >= 0 ) {
+            if( !pocket.empty() && pocket.front().is_fuel() && fuel_efficiency >= 0 ) {
                 // if using fuel instead of battery, everything is in kJ
                 // charges is going to be the energy needed over the energy in 1 unit of fuel * the efficiency of the generator
-                int charges_used = roll_remainder( static_cast<float>( units::from_kilojoule( qty ).value() ) / (
-                                                       static_cast<float>( pocket.front().fuel_energy().value() ) * fuel_efficiency ) );
+                int charges_used = ceil( static_cast<float>( units::from_kilojoule( qty ).value() ) / (
+                                             static_cast<float>( pocket.front().fuel_energy().value() ) * fuel_efficiency ) );
+
                 const int res = pocket.ammo_consume( charges_used );
-                if( res == charges_used ) {
-                    // avoid rounding weirdness, if we used all the charges we wanted to, count that as good enough
-                    consumed += qty;
-                    qty = 0;
-                } else {
-                    // otherwise calculate the ammount of energy generated
-                    int energy_generated = res * units::to_kilojoule( pocket.front().fuel_energy() );
-                    consumed += energy_generated;
-                    qty -= energy_generated;
-                }
+                //calculate the ammount of energy generated
+                int energy_generated = res * units::to_kilojoule( pocket.front().fuel_energy() );
+                consumed += energy_generated;
+                qty -= energy_generated;
+                qty = std::max( 0, qty );
             } else {
                 const int res = pocket.ammo_consume( qty );
                 consumed += res;

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -289,7 +289,7 @@ class item_contents
         // heats up the contents if they have temperature
         void heat_up();
         // returns amount of ammo consumed
-        int ammo_consume( int qty, const tripoint &pos );
+        int ammo_consume( int qty, const tripoint &pos, float fuel_efficiency = -1.0 );
         item *magazine_current();
         std::set<ammotype> ammo_types() const;
         int ammo_capacity( const ammotype &ammo ) const;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2971,6 +2971,7 @@ void Item_factory::load( islot_tool &slot, const JsonObject &jo, const std::stri
     assign( jo, "charges_per_use", slot.charges_per_use, strict, 0 );
     assign( jo, "charge_factor", slot.charge_factor, strict, 1 );
     assign( jo, "turns_per_charge", slot.turns_per_charge, strict, 0 );
+    assign( jo, "fuel_efficiency", slot.fuel_efficiency, strict, -1.0f );
     assign( jo, "power_draw", slot.power_draw, strict, 0_W );
     assign( jo, "revert_msg", slot.revert_msg, strict );
     assign( jo, "sub", slot.subtype, strict );

--- a/src/itype.h
+++ b/src/itype.h
@@ -108,6 +108,8 @@ struct islot_tool {
     int turns_per_charge = 0;
     units::power power_draw = 0_W;
 
+    float fuel_efficiency = -1.0f;
+
     std::vector<int> rand_charges;
 };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
fixes #60613
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds fuel efficiency
When checking UPS's if they have efficiency and fuel then pass that info to contents::consume_ammo
in consume_ammo do the math for how much energy the fuel makes.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Still WIP
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->