### PR TITLE
Disable the Bionic Professions mod by default

### DIFF
--- a/data/mods/default.json
+++ b/data/mods/default.json
@@ -4,6 +4,6 @@
     "id": "dev:default",
     "name": "default",
     "description": "contains all the mods recommended by the developers",
-    "dependencies": [ "dda", "no_npc_food", "personal_portal_storms", "no_fungal_growth", "package_bionic_professions", "No_Rail_Stations" ]
+    "dependencies": [ "dda", "no_npc_food", "personal_portal_storms", "no_fungal_growth", "No_Rail_Stations" ]
   }
 ]

--- a/data/mods/package_bionic_professions/modinfo.json
+++ b/data/mods/package_bionic_professions/modinfo.json
@@ -4,7 +4,7 @@
     "id": "package_bionic_professions",
     "name": "Bionic Professions",
     "authors": [ "Erk/Everyone" ],
-    "description": "Numerous bionic starting professions.  Disable for a more real-world experience.",
+    "description": "Numerous bionic starting professions.  Enable for the classic old CDDA bionic starting professions.",
     "category": "content",
     "dependencies": [ "dda" ]
   }

--- a/data/mods/package_bionic_professions/modinfo.json
+++ b/data/mods/package_bionic_professions/modinfo.json
@@ -4,7 +4,7 @@
     "id": "package_bionic_professions",
     "name": "Bionic Professions",
     "authors": [ "Erk/Everyone" ],
-    "description": "Numerous bionic starting professions.  Enable for the classic old CDDA bionic starting professions.",
+    "description": "Numerous bionic starting professions.",
     "category": "content",
     "dependencies": [ "dda" ]
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Disable the Bionic Professions mod by default"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The fact that the Bionic Professions mod was enabled by default despite our lore change regarding CBMs has been a topic of plenty of confusion on the devcord. People attempted to use this as an argument against the already established lore that CBMs are NOT Earth technology.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Disabled the mod by default. This changes exactly nothing for existing savegames or, for that matter, for anyone. If someone still wishes to play with it they can enable it when creating the world - the mod is still there, it just isn't enabled by default anymore.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->