### PR TITLE
Burning down forests for fun and profit (and wood ash)

### DIFF
--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1563,7 +1563,7 @@ static void burned_ground_parser( map &m, const tripoint &loc )
     if( iter != dies_into.end() ) {
         if( one_in( 6 ) ) {
             m.ter_set( loc, t_dirt );
-            m.spawn_item( loc, itype_ash, 1, rng( 1, 5 ) );
+            m.spawn_item( loc, itype_ash, 1, rng( 10, 50 ) );
         } else if( one_in( 10 ) ) {
             // do nothing, save some spots from fire
         } else {
@@ -1580,7 +1580,7 @@ static void burned_ground_parser( map &m, const tripoint &loc )
     if( tr.has_flag( ter_furn_flag::TFLAG_FUNGUS ) ) {
         m.ter_set( loc, t_dirt );
         if( one_in( 5 ) ) {
-            m.spawn_item( loc, itype_ash, 1, rng( 1, 5 ) );
+            m.spawn_item( loc, itype_ash, 1, rng( 10, 50 ) );
         }
     }
     // destruction of trees is not absolute
@@ -1594,7 +1594,7 @@ static void burned_ground_parser( map &m, const tripoint &loc )
         } else {
             m.ter_set( loc, ter_t_dirt );
             m.furn_set( loc, f_ash );
-            m.spawn_item( loc, itype_ash, 1, rng( 1, 100 ) );
+            m.spawn_item( loc, itype_ash, 1, rng( 10, 1000 ) );
         }
         // everything else is destroyed, ash is added
     } else if( ter_furn_has_flag( tr, fid, ter_furn_flag::TFLAG_FLAMMABLE ) ||
@@ -1603,6 +1603,7 @@ static void burned_ground_parser( map &m, const tripoint &loc )
             m.destroy( loc, true );
         }
         if( one_in( 5 ) && !tr.has_flag( ter_furn_flag::TFLAG_LIQUID ) ) {
+            // This gives very little *wood* ash because the terrain is not flagged as flammable
             m.spawn_item( loc, itype_ash, 1, rng( 1, 10 ) );
         }
     } else if( ter_furn_has_flag( tr, fid, ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {
@@ -1612,7 +1613,7 @@ static void burned_ground_parser( map &m, const tripoint &loc )
         if( !m.is_open_air( loc ) ) {
             m.furn_set( loc, f_ash );
             if( !tr.has_flag( ter_furn_flag::TFLAG_LIQUID ) ) {
-                m.spawn_item( loc, itype_ash, 1, rng( 1, 100 ) );
+                m.spawn_item( loc, itype_ash, 1, rng( 10, 1000 ) );
             }
         }
     }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1046,10 +1046,17 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 200 - cur.get_field_intensity() * 50 ) ) {
+                here.spawn_item( p, "ash", 1, rng( 10, 1000 ) );
                 if( p.z > 0 ) {
-                    // We're in the air
+                    // We're in the air. Need to invalidate the furniture otherwise it'll cause problems
+                    here.furn_set( p, f_null );
                     here.ter_set( p, t_open_air );
+                } else if( p.z < -1 ) {
+                    // We're deep underground, in bedrock. Whatever terrain was here is burned to the ground, leaving only the carved out rock (including ceiling)
+                    here.ter_set( p, t_rock_floor );
                 } else {
+                    // Need to invalidate the furniture otherwise it'll cause problems when supporting terrain collapses
+                    here.furn_set( p, f_null );
                     here.ter_set( p, t_dirt );
                 }
             }


### PR DESCRIPTION
#### Summary
Bugfixes "Trees and other FLAMMABLE_ASH terrain leaves behind ash when burned down"

#### Purpose of change
* Fixes #56242
* Fixes #65041

#### Describe the solution
-Tell fires to actually leave ash for FLAMMABLE_ASH terrain. RNG from 10-1000 charges, or approximately 16-1640mL.

-**Increased most ash left by the burned ground map extra by a factor of 10**. This still leaves... probably not enough ash, but it leaves *more*. Previously it would spawn only a maximum of 100 charges of wood ash(~164mL) for an entire tree.

-Add a terrain transformation to rock when terrain is burned on Z -2 or lower (previously turned into dirt, bit of a 🤔)

-Delete furniture before applying terrain transformation to avoid floating furniture & related errors (#56242)

#### Describe alternatives you've considered
field_processor_fd_fire should probably process furniture burning *before* terrain burning, to avoid instances where flammable terrain in a fire is set to null, but it's a very minor edge case that only applies on the turn of destruction

I decided not to mess with that as it could create more bugs and would result in some churn without any real benefit

#### Testing
Ran around burning down forests and homes like some sort of pyromaniac. Confirmed that previously burning down the forests left nothing, confirmed that after changes it left ash. Burn down the same home repeatedly pre changes, got errors about setting furniture (rubble) on open air, burned them down afterwards without a peep.

#### Additional context