### PR TITLE
Revert "Use unordered_set to deduplicate active items (#66310)"

### DIFF
--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -6,6 +6,19 @@
 #include "item.h"
 #include "safe_reference.h"
 
+namespace
+{
+
+void _remove_if( std::list<item_reference> &active_items, item const *it )
+{
+    active_items.remove_if( [it]( const item_reference & active_item ) {
+        item *const target = active_item.item_ref.get();
+        return !target || target == it;
+    } );
+}
+
+} // namespace
+
 float item_reference::spoil_multiplier()
 {
     return std::accumulate(
@@ -13,6 +26,27 @@ float item_reference::spoil_multiplier()
     []( float a, item_pocket const * pk ) {
         return a * pk->spoil_multiplier();
     } );
+}
+
+void active_item_cache::remove( const item *it )
+{
+    for( item const *iter : it->all_items_ptr() ) {
+        _remove_if( active_items[iter->processing_speed()], iter );
+    }
+    _remove_if( active_items[it->processing_speed()], it );
+    if( it->can_revive() ) {
+        special_items[ special_item_type::corpse ].remove_if( [it]( const item_reference & active_item ) {
+            item *const target = active_item.item_ref.get();
+            return !target || target == it;
+        } );
+    }
+    if( it->get_use( "explosion" ) ) {
+        special_items[ special_item_type::explosive ].remove_if( [it]( const item_reference &
+        active_item ) {
+            item *const target = active_item.item_ref.get();
+            return !target || target == it;
+        } );
+    }
 }
 
 bool active_item_cache::add( item &it, point location, item *parent,
@@ -26,21 +60,15 @@ bool active_item_cache::add( item &it, point location, item *parent,
             ret |= add( *pkit, location, &it, pockets );
         }
     }
-
-    int speed = it.processing_speed();
-    if( speed == item::NO_PROCESSING ) {
+    if( it.processing_speed() == item::NO_PROCESSING ) {
         return ret;
     }
-    std::unordered_set<safe_reference<item>> &target_index = active_items_index[speed];
-    std::list<item_reference> &target_list = active_items[speed];
-    if( target_index.empty() ) {
-        // If the index has been cleared, rebuild it first.
-        for( item_reference &iter : target_list ) {
-            target_index.emplace( iter.item_ref );
-        }
-    }
+    std::list<item_reference> &target_list = active_items[it.processing_speed()];
     // If the item is already in the cache for some reason, don't add a second reference
-    if( target_index.find( it.get_safe_reference() ) != target_index.end() ) {
+    if( std::find_if( target_list.begin(),
+    target_list.end(), [&it]( const item_reference & active_item_ref ) {
+    return &it == active_item_ref.item_ref.get();
+    } ) != target_list.end() ) {
         return true;
     }
     item_reference ref{ location, it.get_safe_reference(), parent, pocket_chain };
@@ -51,7 +79,6 @@ bool active_item_cache::add( item &it, point location, item *parent,
         special_items[special_item_type::explosive].emplace_back( ref );
     }
     target_list.emplace_back( std::move( ref ) );
-    target_index.emplace( it.get_safe_reference() );
     return true;
 }
 
@@ -71,7 +98,6 @@ std::vector<item_reference> active_item_cache::get()
                 all_cached_items.emplace_back( *it );
                 ++it;
             } else {
-                active_items_index[kv.first].clear();
                 it = kv.second.erase( it );
             }
         }
@@ -97,8 +123,6 @@ std::vector<item_reference> active_item_cache::get_for_processing()
                 ++it;
             } else {
                 // The item has been destroyed, so remove the reference from the cache
-                // Also invalidate the index
-                active_items_index[kv.first].clear();
                 it = kv.second.erase( it );
             }
         }

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <list>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "point.h"
@@ -39,13 +38,6 @@ struct hash<special_item_type> {
         return static_cast<size_t>( k );
     }
 };
-
-template<>
-struct hash<safe_reference<item>> {
-    std::size_t operator()( safe_reference<item > const &s ) const noexcept {
-        return hash<item * > {}( s.get() );
-    }
-};
 } // namespace std
 
 class active_item_cache
@@ -53,9 +45,15 @@ class active_item_cache
     private:
         std::unordered_map<int, std::list<item_reference>> active_items;
         std::unordered_map<special_item_type, std::list<item_reference>> special_items;
-        std::unordered_map<int, std::unordered_set<safe_reference<item>>> active_items_index;
 
     public:
+        /**
+         * Removes the item if it is in the cache. Does nothing if the item is not in the cache.
+         * Relies on the fact that item::processing_speed() is a constant.
+         * Also removes any items that have been destroyed in the list containing it
+         */
+        void remove( const item *it );
+
         /**
          * Adds the reference to the cache. Does nothing if the reference is already in the cache.
          * Relies on the fact that item::processing_speed() is a constant.

--- a/src/safe_reference.h
+++ b/src/safe_reference.h
@@ -53,12 +53,6 @@ class safe_reference
         std::weak_ptr<T> impl;
 };
 
-template<typename T>
-constexpr bool operator==( safe_reference<T> const &lhs, safe_reference<T> const &rhs )
-{
-    return lhs && rhs && lhs.get() == rhs.get();
-}
-
 class safe_reference_anchor
 {
     public:


### PR DESCRIPTION
This reverts commit 49b2acbda66ee722df380ff7a54af3864e70c0f3.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

#66310 is bug-prone, and introduced instability, which led to those Windows CI tests crash.

See discussion on that thread for details.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Revert it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Patch it. Eventually there should be some sort of cache, but it turns out that properly caching is pretty hard. Let's stabilize the game first.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->