### PR TITLE
Minor bird description tweaks

### DIFF
--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -701,7 +701,7 @@
     "id": "mon_hummingbird",
     "type": "MONSTER",
     "name": { "str": "hummingbird" },
-    "description": "A very small bird of varied colored feathers depending on species.  It flies at incredible speeds while seeking nectar among flowers.",
+    "description": "A very small ruby-throated hummingbird of varied colored feathers.  It flies at incredible speeds while seeking nectar among flowers.",
     "bodytype": "bird",
     "default_faction": "small_animal",
     "categories": [ "WILDLIFE" ],

--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -281,7 +281,7 @@
     "type": "MONSTER",
     "copy-from": "mon_duck",
     "name": { "str": "goose", "str_pl": "geese" },
-    "description": "A Canadian goose, a common waterfowl that regrets leaving Canada.",
+    "description": "A Canada goose; a common waterfowl that regrets leaving Canada.",
     "volume": "5 L",
     "weight": "3750 g",
     "hp": 15,

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -2874,6 +2874,7 @@ thorned
 thornothurian
 thosun
 threateningly
+throated
 throating
 throwable
 thru


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make some bird descriptions slightly more accurate for the region.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Don't call a Canada goose a "Canadian goose". The former is much more common, and the common name used by probably just about any ornithology database.
- Make the hummingbird just be a ruby-throated hummingbird, due to the extreme rarity of any other species.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not being a pedant and ignoring my upbringing in a family of birders.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Nothing seems wrong.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->