### PR TITLE
Increase default mountable weight ratio

### DIFF
--- a/src/mtype.h
+++ b/src/mtype.h
@@ -399,8 +399,8 @@ struct mtype {
 
         // Number of hitpoints regenerated per turn.
         int regenerates = 0;
-        // mountable ratio for rider weight vs. mount weight, default 0.2
-        float mountable_weight_ratio = 0.2f;
+        // mountable ratio for rider weight vs. mount weight, default 0.35
+        float mountable_weight_ratio = 0.35f;
 
         int attack_cost = 100;  /** moves per regular attack */
         int melee_skill = 0;    /** melee hit skill, 20 is superhuman hitting abilities */


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Increases default mountable weight ratio"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Default mountable_weight_ratio at 20% is very low and represents "the safe maximum" that was relevant in pre-apoc world, but the good times are already past and I doubt the survivor would have much concern for recommendations and safety when zombies are near.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Increases the default mountable_weight_ratio to 0.35.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Leaving stuff as is.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

None for now.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Sources:

https://www.helpfulhorsehints.com/how-much-weight-can-a-pony-carry/

Quote: "Many modern studies have indicated that any load heavier than 30% of the animal’s body weight is likely detrimental in the long run". Survivor has totally different priorities than pre-Cataclysm horse breeders/riders/racers, mind you, most likely caring more about his survivor even at the expense of wellbeing of his mount.

https://www.napoleon-series.org/military-info/organization/France/Artillery/c_artilleryhorses.html

Quote: "...a horse carrying 75.6 kg  and drawing 315 kg  could travel on average 20 miles a day". The artillery wheel horses (ones with the most load) were at least 15.2 hands high, and weigh about 905 to 1,215 pounds (410.5 – 551 kg) at the listed height. Horses can draw about 1.5 times their weight, and for horse weight of 500 kg the pull weight is about 750 kg. That means 75 kg of carried weight is about equal to 300 kg of draft for a horse of 500 kg -> horse effectively carries about 150 kg of weight, giving us the 0.3 load-to-weight ratio.

Then there is this: https://en.wikipedia.org/wiki/Common_ostrich#Racing

Common ostrich weighs up to 140 kg, but usually less. That gives more than 50% load if a 70 kg human rides a large one, racing into 70% if ostrich is not of the largest variety. The race happens over somewhat short distance, though.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->