### PR TITLE
[Aftershock] recipe for processed lichen fix

### DIFF
--- a/data/mods/Aftershock/recipes/comestible_recipes.json
+++ b/data/mods/Aftershock/recipes/comestible_recipes.json
@@ -75,7 +75,7 @@
     "batch_time_factors": [ 99, 1 ],
     "book_learn": [ [ "recipe_lichenlog", 2 ] ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 60, "LIST" ] ], [ [ "pressure_cooker", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 60, "LIST" ] ], [ [ "pressure_cooker", -1 ], [ "makeshift_pressure_cooker", -1 ] ] ],
     "components": [ [ [ "yum_lichen", 4 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

The recipe for the chunk of processed lichen was not updated to include the makeshift pressure cooker & this PR does that

#### Describe the solution

adds `makeshift_pressure_cooker` as an alternate tool for the recipe
