### PR TITLE
[CR]Properly index active items

### DIFF
--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -6,19 +6,6 @@
 #include "item.h"
 #include "safe_reference.h"
 
-namespace
-{
-
-void _remove_if( std::list<item_reference> &active_items, item const *it )
-{
-    active_items.remove_if( [it]( const item_reference & active_item ) {
-        item *const target = active_item.item_ref.get();
-        return !target || target == it;
-    } );
-}
-
-} // namespace
-
 float item_reference::spoil_multiplier()
 {
     return std::accumulate(
@@ -26,27 +13,6 @@ float item_reference::spoil_multiplier()
     []( float a, item_pocket const * pk ) {
         return a * pk->spoil_multiplier();
     } );
-}
-
-void active_item_cache::remove( const item *it )
-{
-    for( item const *iter : it->all_items_ptr() ) {
-        _remove_if( active_items[iter->processing_speed()], iter );
-    }
-    _remove_if( active_items[it->processing_speed()], it );
-    if( it->can_revive() ) {
-        special_items[ special_item_type::corpse ].remove_if( [it]( const item_reference & active_item ) {
-            item *const target = active_item.item_ref.get();
-            return !target || target == it;
-        } );
-    }
-    if( it->get_use( "explosion" ) ) {
-        special_items[ special_item_type::explosive ].remove_if( [it]( const item_reference &
-        active_item ) {
-            item *const target = active_item.item_ref.get();
-            return !target || target == it;
-        } );
-    }
 }
 
 bool active_item_cache::add( item &it, point location, item *parent,

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -30,6 +30,13 @@ enum class special_item_type : int {
     explosive
 };
 
+template<typename T>
+constexpr bool operator==( safe_reference<T> const &lhs, safe_reference<T> const &rhs )
+{
+    // To ensure they hasn't expired
+    return !!lhs && !!rhs && lhs.get() == rhs.get();
+}
+
 namespace std
 {
 template <>
@@ -45,7 +52,7 @@ class active_item_cache
     private:
         std::unordered_map<int, std::list<item_reference>> active_items;
         std::unordered_map<special_item_type, std::list<item_reference>> special_items;
-
+        std::unordered_map<int, std::unordered_map<item *, safe_reference<item>>> active_items_index;
     public:
         /**
          * Removes the item if it is in the cache. Does nothing if the item is not in the cache.

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -55,13 +55,6 @@ class active_item_cache
         std::unordered_map<int, std::unordered_map<item *, safe_reference<item>>> active_items_index;
     public:
         /**
-         * Removes the item if it is in the cache. Does nothing if the item is not in the cache.
-         * Relies on the fact that item::processing_speed() is a constant.
-         * Also removes any items that have been destroyed in the list containing it
-         */
-        void remove( const item *it );
-
-        /**
          * Adds the reference to the cache. Does nothing if the reference is already in the cache.
          * Relies on the fact that item::processing_speed() is a constant.
          */


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Supersede #66310.

Reduce the time complexity of refreshing the active items cache from O(n^2) to O(n).
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Index whether the item has been cached using `unordered_map`.
The reasons are:
1. One key can only be associated to one object. This is true for item pointers. If a new item to be indexed has the same memory address of an indexed item, the old item has been deleted, and it's safe to override that key-value pair.
2. As long as the items are not expired, their addresses should remain the same, so rebuilding the map through iterating over the list is fine.

The points that I've thought of:

1. use `!!lhs && !!rhs` to check if the safe_reference has expired. So two expired safe_references won't appear to be equal.
2. Only hash the item* pointer. This avoids the expiry check of hashing safe_reference.
3. If there's a collision of memory address, the index will be checked to hold the very item, and has not expired.
4. When rebuilding the map, those expired safe_references in the list will not be indexed, to minimize the possibility of null item* pointers and invalid safe_references in the index.
5. The expiry of item_reference stored by the list is equivalent to the expiry of safe_reference stored by index. ( As they are basically both weak_ptr. )
6. There will be more memory consumption, but the overall overhead shouldn't be large, as these objects mostly just hold pointers.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I've built and run the test suite for tens of times. No crash or related failure.
The performance improvement is still valid.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Thanks for @andrei8l building the infrastructure to make this possible.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->