### PR TITLE
Add a doctor/autodoc to the Ancilla bar

### DIFF
--- a/data/json/mapgen/robofaq_locs/EOC_robofac_hq_updater.json
+++ b/data/json/mapgen/robofaq_locs/EOC_robofac_hq_updater.json
@@ -10,7 +10,6 @@
     "type": "effect_on_condition",
     "id": "EOC_ROBOFAC_HQ_UPDATE_EVENT",
     "global": true,
-    "//": "This sets up all the variables for the start of an early portal storm.",
     "condition": {
       "and": [
         { "u_near_om_location": "robofachq_surface_road1", "range": 30 },
@@ -44,21 +43,34 @@
         },
         {
           "id": "EOC_ROBOFAC_HQ_PLACE_ANCILLA_BAR",
-          "condition": {
-            "and": [
-              { "compare_num": [ { "global_val": "var", "var_name": "ancilla_bar_placed" }, "!=", { "const": 1 } ] },
-              { "days_since_cataclysm": 60 }
-            ]
-          },
+          "condition": { "and": [ { "math": [ "ancilla_bar_placed", "!=", "1" ] }, { "days_since_cataclysm": 60 } ] },
           "effect": [
             { "mapgen_update": "robofachq_ancilla_bar_basic", "om_terrain": "robofachq_subcc_a2" },
             {
               "u_location_variable": { "global_val": "ancilla_bar_loc" },
               "target_params": { "om_terrain": "robofachq_subcc_a2" }
             },
-            { "arithmetic": [ { "global_val": "var", "var_name": "ancilla_bar_exists" }, "=", { "const": 1 } ] },
-            { "arithmetic": [ { "global_val": "var", "var_name": "ancilla_bar_placed" }, "=", { "const": 1 } ] },
+            { "math": [ "ancilla_bar_exists", "=", "1" ] },
+            { "math": [ "ancilla_bar_placed", "=", "1" ] },
             { "run_eocs": [ "EOC_reroll_bar_mercs" ] }
+          ]
+        },
+        {
+          "id": "EOC_ROBOFAC_HQ_PLACE_ANCILLA_AUTODOC",
+          "condition": {
+            "and": [
+              { "math": [ "ancilla_bar_exists", "==", "1" ] },
+              { "math": [ "ancilla_autodoc_placed", "!=", "1" ] },
+              { "days_since_cataclysm": 80 }
+            ]
+          },
+          "effect": [
+            { "mapgen_update": "robofachq_ancilla_bar_autodoc", "om_terrain": "robofachq_subcc_a1" },
+            {
+              "u_location_variable": { "global_val": "ancilla_autodoc_loc" },
+              "target_params": { "om_terrain": "robofachq_subcc_a1" }
+            },
+            { "math": [ "ancilla_autodoc_placed", "=", "1" ] }
           ]
         }
       ]

--- a/data/json/mapgen/robofaq_locs/ancillia_bar_updater.json
+++ b/data/json/mapgen/robofaq_locs/ancillia_bar_updater.json
@@ -7,7 +7,7 @@
     "condition": {
       "and": [
         { "not": { "u_near_om_location": "robofachq_subcc_a2", "range": 1 } },
-        { "compare_num": [ { "global_val": "var", "var_name": "ancilla_bar_exists" }, "==", { "const": 1 } ] }
+        { "math": [ "ancilla_bar_exists", "==", "1" ] }
       ]
     },
     "effect": [

--- a/data/json/mapgen/robofaq_locs/robofac_hq_chunks.json
+++ b/data/json/mapgen/robofaq_locs/robofac_hq_chunks.json
@@ -268,6 +268,50 @@
   {
     "type": "mapgen",
     "method": "json",
+    "update_mapgen_id": "robofachq_ancilla_bar_autodoc",
+    "//": "Spawns by itself at the moment, spawning should be triggered by missions later on.",
+    "object": {
+      "rows": [
+        "########################",
+        "########################",
+        "||||||||||||||||||||||||",
+        "''''''''''''''''''''''''",
+        "''''''''''''''''''''''''",
+        "''''''''''''''''''''''''",
+        "''''''''''''''''''''''''",
+        "=======|||||========:::|",
+        "         |      =   :71A",
+        "         |      =   :.YA",
+        "         |      =   :h..",
+        "         |==[=====[=::[:",
+        "^        2              ",
+        "=======|||||===========|",
+        "''''''''''''''''''''''''",
+        "''''''''''''''''''''''''",
+        "''''''''''''''''''''''''",
+        "''''''''''''''''''''''''",
+        "''''''''''''''''''''''''",
+        "||||||||||||||||||||||||",
+        "########################",
+        "########################",
+        "########################",
+        "########################"
+      ],
+      "palettes": [ "robofachq" ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "remove_all": { "7": {  }, "1": {  }, "A": {  }, "h": {  } },
+      "terrain": { "'": "t_open_air", "Y": "t_metal_floor_olight", ":": "t_wall_metal_corrugated", "#": "t_rock" },
+      "furniture": { "7": "f_autodoc_couch", "1": "f_autodoc", "A": "f_rack", "h": "f_chair" },
+      "npcs": { "h": { "class": "ancilla_doctor" } },
+      "place_zones": [
+        { "type": "LOOT_UNSORTED", "faction": "no_faction", "x": 23, "y": 8 },
+        { "type": "LOOT_CURRENCY", "faction": "no_faction", "x": 23, "y": 9 }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "nested_mapgen_id": "BEM_hireable",
     "object": {
       "faction_owner": [ { "id": "robofac_auxiliaries", "x": [ 0, 0 ], "y": [ 0, 0 ] } ],

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -1,0 +1,184 @@
+[
+  {
+    "type": "npc",
+    "id": "ancilla_doctor",
+    "name_unique": "Doc. Blanks",
+    "gender": "male",
+    "class": "NC_ANCILLA_DOCTOR",
+    "attitude": 0,
+    "mission": 3,
+    "chat": "TALK_ANCILLA_DOCTOR",
+    "faction": "no_faction"
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_ANCILLA_DOCTOR",
+    "name": { "str": "Ancilla Doctor" },
+    "job_description": "I try to keep this gang in one piece.  It's a full time job.",
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "common": false,
+    "bonus_int": { "rng": [ 3, 5 ] },
+    "worn_override": "NC_ANCILLA_DOCTOR_worn",
+    "carry_override": "NC_ANCILLA_BARKEEP_carry",
+    "weapon_override": "NC_ANCILLA_BARKEEP_wield",
+    "shopkeeper_item_group": [ { "group": "NC_ANCILLA_DOCTOR_stock", "rigid": true } ],
+    "shopkeeper_price_rules": [
+      { "group": "NC_ANCILLA_DOCTOR_stock", "premium": 2.0 },
+      { "group": "NC_ANCILLA_DOCTOR_EXPENSIVE_ITEMS", "premium": 6.0 },
+      { "item": "RobofacCoin", "price": 5000, "fixed_adj": 0 }
+    ],
+    "skills": [
+      {
+        "skill": "ALL",
+        "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "constant": -2 }, { "one_in": 4 } ] } ] }
+      },
+      { "skill": "firstaid", "bonus": 7 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_ANCILLA_DOCTOR_worn",
+    "subtype": "collection",
+    "items": [
+      { "item": "jeans" },
+      { "item": "boots_combat" },
+      { "item": "boxer_briefs" },
+      { "item": "tshirt" },
+      { "item": "apron_leather" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_ANCILLA_DOCTOR_stock",
+    "subtype": "collection",
+    "entries": [
+      { "item": "RobofacCoin", "prob": 100, "count": [ 8, 10 ] },
+      { "item": "disinfectant", "prob": 100, "count": [ 2, 10 ] },
+      { "item": "bandages", "prob": 100, "count": [ 3, 10 ] },
+      { "item": "saline", "prob": 100, "count": [ 1, 2 ] },
+      { "group": "drugs_emergency", "prob": 100, "count": [ 4, 6 ] },
+      { "group": "drugs_analgesic", "prob": 100, "count": [ 2, 4 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_ANCILLA_DOCTOR_EXPENSIVE_ITEMS",
+    "subtype": "collection",
+    "entries": [
+      { "item": "morphine", "prob": 100 },
+      { "item": "antibiotics", "prob": 100 },
+      { "item": "strong_antibiotic", "prob": 100 },
+      { "item": "anesthetic", "prob": 100 },
+      { "item": "oxycodone", "prob": 100 },
+      { "item": "codeine", "prob": 100 }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ANCILLA_DOCTOR",
+    "dynamic_line": {
+      "u_has_faction_trust": 10,
+      "yes": [ "Oh, what can I do for you today?" ],
+      "no": {
+        "u_has_var": "first_meet",
+        "type": "dialogue",
+        "context": "ancilla_doctor",
+        "value": "yes",
+        "yes": [
+          "Try not to touch anything.  Keeping this place clean is a full time job.",
+          "I'm free at the moment if you need something.",
+          "Did you know you can loose a medical license over tax fraud?  Couldn't be me.",
+          "You try to use the autodoc alone and I'll let it carve you up.  I'm not kidding."
+        ],
+        "no": "Clinic is open, yes.  If you need medical assistance, I'm your man."
+      }
+    },
+    "speaker_effect": {
+      "effect": [ { "u_add_var": "first_meet", "type": "dialogue", "context": "ancilla_doctor", "value": "yes" } ],
+      "sentinel": "ancilla_doctor_meet"
+    },
+    "responses": [
+      { "text": "Could you help me with some bionics?", "topic": "TALK_ANCILLA_DOCTOR_BIONICS" },
+      { "text": "I could use your medical assistance.", "topic": "TALK_ANCILLA_DOCTOR_AID" },
+      { "text": "I need to trade some medical supplies.", "topic": "TALK_ANCILLA_DOCTOR", "effect": "start_trade" },
+      { "text": "Is there anything I can help you with?", "topic": "TALK_ANCILLA_DOCTOR_WORK" },
+      { "text": "…", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_ANCILLA_DOCTOR_AID",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "npc_has_effect": "currently_busy",
+      "yes": "Come back later, I need to take care of a few things first.",
+      "no": "I can take a look at you or your companions if you have any injuries.  It'll cost you, of course."
+    },
+    "responses": [
+      {
+        "text": "[4 HGC, 30m] I need you to patch me up.",
+        "topic": "TALK_ANCILLA_DOCTOR_AID_DONE",
+        "effect": [ { "u_spend_cash": 20000, "true_eocs": { "id": "give_aid", "effect": "give_aid" } } ],
+        "condition": { "npc_service": true }
+      },
+      {
+        "text": "[8 HGC, 1h] I need you to patch my friends up.",
+        "topic": "TALK_ANCILLA_DOCTOR_AID_DONE",
+        "effect": { "u_spend_cash": 40000, "true_eocs": { "id": "give_all_aid", "effect": "give_all_aid" } },
+        "condition": { "npc_service": true }
+      },
+      { "text": "I should be fine.", "topic": "TALK_ANCILLA_DOCTOR" }
+    ]
+  },
+  {
+    "id": "TALK_ANCILLA_DOCTOR_BIONICS",
+    "type": "talk_topic",
+    "dynamic_line": "Sure, what are you looking for?",
+    "responses": [
+      {
+        "text": "I was wondering if you could install a cybernetic implant…",
+        "topic": "TALK_DONE",
+        "effect": "bionic_install",
+        "condition": { "npc_service": true }
+      },
+      {
+        "text": "I need help removing an implant…",
+        "topic": "TALK_DONE",
+        "effect": "bionic_remove",
+        "condition": { "npc_service": true }
+      },
+      { "text": "Oh no, I was wondering if you knew where to get some.", "topic": "TALK_ANCILLA_DOCTOR_FIND_BIONICS" },
+      { "text": "Never mind.", "topic": "TALK_NONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ANCILLA_DOCTOR_BIONICS_DONE",
+    "dynamic_line": [
+      "Now some protocol tests for brain damage. Please stare at the light over there…",
+      "It might take some days for your nervous system to adapt.  Come back if you experience any concerning symptoms like…",
+      "I suggest you take it easy for a few days now."
+    ],
+    "responses": [ { "text": "…", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ANCILLA_DOCTOR_AID_DONE",
+    "dynamic_line": [
+      "Take it easy now, or come back soon.  All the same to me.",
+      "Now try not to do whatever you did again.  No, dont tell me more."
+    ],
+    "responses": [ { "text": "…", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ANCILLA_DOCTOR_FIND_BIONICS",
+    "dynamic_line": "If you want to carve up cyborg corpses, find someone at the bar, not me.",
+    "responses": [ { "text": "…", "topic": "TALK_ANCILLA_DOCTOR" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ANCILLA_DOCTOR_WORK",
+    "dynamic_line": "It takes resources to keep this show running: disinfectant, antibiotics, anesthetics, so on.  I'll give you a great price if you bring any of those.",
+    "responses": [ { "text": "I'll keep that in mind.", "topic": "TALK_ANCILLA_DOCTOR" } ]
+  }
+]

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -2,7 +2,7 @@
   {
     "type": "npc",
     "id": "ancilla_doctor",
-    "name_unique": "Doc. Blanks",
+    "name_unique": "Doc.  Stevens",
     "gender": "male",
     "class": "NC_ANCILLA_DOCTOR",
     "attitude": 0,
@@ -154,7 +154,7 @@
     "type": "talk_topic",
     "id": "TALK_ANCILLA_DOCTOR_BIONICS_DONE",
     "dynamic_line": [
-      "Now some protocol tests for brain damage. Please stare at the light over there…",
+      "Now some protocol tests for brain damage.  Please stare at the light over there…",
       "It might take some days for your nervous system to adapt.  Come back if you experience any concerning symptoms like…",
       "I suggest you take it easy for a few days now."
     ],


### PR DESCRIPTION
#### Summary
Content "Add a doctor/autodoc to the Ancilla bar"

#### Purpose of change

For a long time Hub 01 has been intended to serve as a secondary source of CBMs and their installation, among other features. This is a basic implementation of the feature set demanded by such role. 

#### Describe the solution

Since CBMs arent exactly central to the faction identity, I thought it'd be interesting to have the clinic spawn as part of the Mercenary bar instead of inside the faction bunker, giving the idea that this is a service that the Ancilla mostly runs for itself (with some tech support from Hub 01 every now and then).

Atm the autodoc spawns by itself at day 90 (this is 30 days after the whole bar is set up) this is of course part of the accelerated timeframe used by the bar itself, and open to change once the game can more easily simulate the passage of larger periods of time. Accelerating the spawn of the clinic based on player-exodii interactions would be nice, but is left to future expansions.

The doctor that spawns here also provides healing services, much like the Tacoma ranch doctor.

Its important to note that the doctor doesn't sell CBMs, I'll later add some bar visitors that do that later on (Hub 01 shouldnt be super convenient when it comes to bionics).

#### Describe alternatives you've considered

Lots of stuff, like spawning this inside Hub 01 (which would greatly delay its implementation).

#### Testing

Spawned and visited the bar and clinic