### PR TITLE
Fixed the issue of not properly handling pre existing items in the bag after installing it on the pet.

### DIFF
--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -188,7 +188,7 @@ void attach_bag_to( monster &z )
     }
     item &it = *loc;
     if( !it.is_container_empty() ) {
-        for ( item *top_item : it.all_items_top() ) {
+        for( item *top_item : it.all_items_top() ) {
             item &i = *top_item;
             z.add_item( i );
             it.remove_item( i );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -186,7 +186,6 @@ void attach_bag_to( monster &z )
         add_msg( _( "The %1$s is too heavy for the %2$s to carry." ), it.tname(), pet_name );
         return;
     }
-    item &it = *loc;
     if( !it.is_container_empty() ) {
         for( item *top_item : it.all_items_top() ) {
             item &i = *top_item;

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -186,6 +186,14 @@ void attach_bag_to( monster &z )
         add_msg( _( "The %1$s is too heavy for the %2$s to carry." ), it.tname(), pet_name );
         return;
     }
+    item &it = *loc;
+    if( !it.is_container_empty() ) {
+        for ( item *top_item : it.all_items_top() ) {
+            item &i = *top_item;
+            z.add_item( i );
+            it.remove_item( i );
+        }
+    }
     z.storage_item = cata::make_value<item>( it );
     add_msg( _( "You mount the %1$s on your %2$s." ), it.display_name(), pet_name );
     player_character.i_rem( &it );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixed the issue of not properly handling pre existing items in the backpack after installing it on the pet."
There are currently the following issues with the game and they are related to interaction with pet menu.If there are items in the bag you installed, the 'remove all items' command will not be displayed the first time unless you actively add something through the pet menu. And the 'remove all items' command cannot remove pre existing items in the bag that you install . You can only execute the 'remove bag' command to truly remove all items.
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix it.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
If the bag to be installed is not empty, we will handle it accordingly and proactively execute `z.add_item ( i )` . The `it.remove_item ( i )` avoids the possibility of duplicate items when removing the bag from pet.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Put items in a bag beforehand, and then install the bag on the pet. The items in the bag have been correctly added.And "remove all items", "give items", and "remove backpack" can proceed normally.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->