### PR TITLE
3D vision for isometric tilesets

### DIFF
--- a/gfx/SmashButton_iso/tile_config.json
+++ b/gfx/SmashButton_iso/tile_config.json
@@ -1,6 +1,6 @@
 {
   "tile_info": [
-    { "pixelscale": 2, "width": 16, "height": 20, "iso": true, "retract_dist_min": -1.0, "retract_dist_max": 1.0 }
+    { "pixelscale": 2, "width": 16, "height": 20, "zlevel_height": 10, "iso": true, "retract_dist_min": -1.0, "retract_dist_max": 1.0 }
   ],
   "tiles-new": [
     {

--- a/gfx/Ultica_iso/tile_config.json
+++ b/gfx/Ultica_iso/tile_config.json
@@ -1,6 +1,6 @@
 {
   "tile_info": [
-    { "pixelscale": 1, "width": 48, "height": 24, "zlevel_height": 120, "iso": true, "retract_dist_min": 2.5, "retract_dist_max": 6.0 }
+    { "pixelscale": 1, "width": 48, "height": 24, "zlevel_height": 96, "iso": true, "retract_dist_min": 2.5, "retract_dist_max": 6.0 }
   ],
   "tiles-new": [
     {

--- a/gfx/Ultica_iso/tile_config.json
+++ b/gfx/Ultica_iso/tile_config.json
@@ -1,6 +1,6 @@
 {
   "tile_info": [
-    { "pixelscale": 1, "width": 48, "height": 24, "iso": true, "retract_dist_min": 2.5, "retract_dist_max": 6.0 }
+    { "pixelscale": 1, "width": 48, "height": 24, "zlevel_height": 120, "iso": true, "retract_dist_min": 2.5, "retract_dist_max": 6.0 }
   ],
   "tiles-new": [
     {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1629,9 +1629,9 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         do {
             // For each row
             for( int row = min_row; row < max_row; row ++ ) {
-            	// Set base height for each tile
+                // Set base height for each tile
                 for( tile_render_info &p : draw_points[row] ) {
-                	p.height_3d = ( cur_zlevel - center.z ) * zlevel_height;
+                    p.height_3d = ( cur_zlevel - center.z ) * zlevel_height;
                 }
                 // For each layer
                 for( auto f : drawing_layers ) {
@@ -1645,14 +1645,14 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         tripoint draw_loc = p.pos;
                         draw_loc.z = cur_zlevel;
                         if( f == &cata_tiles::draw_vpart_no_roof || f == &cata_tiles::draw_vpart_roof ) {
-                        	int temp_height_3d = p.height_3d;
+                            int temp_height_3d = p.height_3d;
                             // Reset height_3d to base when drawing vehicles
-                        	p.height_3d = ( cur_zlevel - center.z ) * zlevel_height;
+                            p.height_3d = ( cur_zlevel - center.z ) * zlevel_height;
                             // Draw
-                        	if(!( this->*f )( draw_loc, p.ll, p.height_3d, p.invisible )) {
-                        		// If no vpart drawn, revert height_3d changes
-                        		p.height_3d = temp_height_3d;
-                        	}
+                            if( !( this->*f )( draw_loc, p.ll, p.height_3d, p.invisible ) ) {
+                                // If no vpart drawn, revert height_3d changes
+                                p.height_3d = temp_height_3d;
+                            }
                         } else {
                             // Draw
                             ( this->*f )( draw_loc, p.ll, p.height_3d, p.invisible );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1360,7 +1360,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     std::map<int, std::vector<tile_render_info>> draw_points;
     // Limit draw depth to vertical vision setting
     // Disable multi z-level display on isometric tilesets until height_3d issues resolved
-    const int max_draw_depth = is_isometric() ? 0 : fov_3d_z_range;
+    const int max_draw_depth = fov_3d_z_range;
     for( int row = min_row; row < max_row; row ++ ) {
         draw_points[row].reserve( max_col );
         for( int col = min_col; col < max_col; col ++ ) {
@@ -1611,7 +1611,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         }
     };
 
-    //const int height_3d_mult = is_isometric() ? 10 : 0;
+    const int height_3d_mult = is_isometric() ? 10 : 0;
     if( max_draw_depth <= 0 ) {
         // Legacy draw mode
         for( int row = min_row; row < max_row; row ++ ) {
@@ -1626,7 +1626,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         // Start drawing from the bottom-most z-level
         int cur_zlevel = -OVERMAP_DEPTH;
         do {
-            //int cur_height_3d = ( cur_zlevel - center.z ) * height_3d_mult;
+            int cur_height_3d = ( cur_zlevel - center.z ) * height_3d_mult;
             // For each row
             for( int row = min_row; row < max_row; row ++ ) {
                 // For each layer
@@ -1641,7 +1641,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         tripoint draw_loc = p.pos;
                         draw_loc.z = cur_zlevel;
                         // Draw
-                        ( this->*f )( draw_loc, p.ll, p.height_3d, p.invisible );
+                        ( this->*f )( draw_loc, p.ll, cur_height_3d, p.invisible );
                     }
                 }
             }
@@ -3804,9 +3804,6 @@ bool cata_tiles::draw_zombie_revival_indicators( const tripoint &pos, const lit_
 
 void cata_tiles::draw_zlevel_overlay( const tripoint &p, const lit_level ll, int &height_3d )
 {
-    if( is_isometric() ) {
-        return;
-    }
     // Draws zlevel fog using geometry renderer
     // Slower than sprites so only use as fallback when sprite missing
     const point screen = player_to_screen( p.xy() );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3840,7 +3840,8 @@ void cata_tiles::draw_zlevel_overlay( const tripoint &p, const lit_level ll, int
         fog_color = curses_color_to_SDL( c_dark_gray );
     }
     // Setting for fog transparency
-    fog_color.a = 100;
+    // On isometric tilesets, fog intensity scales with zlevel_height in tile_config.json
+    fog_color.a = is_isometric() ? 50 + zlevel_height / 2 : 100;
 
     // Change blend mode for transparency to work
     // Disable after to avoid visual bugs

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3234,7 +3234,6 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
 
                 //get field intensity
                 int intensity = fd_pr.second.get_field_intensity();
-                int nullint = 0;
 
                 bool has_drawn = false;
 
@@ -3262,7 +3261,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
 
                             // if we have found info on the item go through and draw its stuff
                             ret_draw_field = draw_from_id_string( sprite_to_draw, TILE_CATEGORY::FIELD, empty_string, p,
-                                                                  subtile, rotation, lit, nv, nullint, intensity, "", layer_var.offset );
+                                                                  subtile, rotation, lit, nv, height_3d, intensity, "", layer_var.offset );
                             has_drawn = true;
                             break;
                         }
@@ -3290,7 +3289,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
 
                                 // if we have found info on the item go through and draw its stuff
                                 ret_draw_field = draw_from_id_string( sprite_to_draw, TILE_CATEGORY::FIELD, empty_string, p,
-                                                                      subtile, rotation, lit, nv, nullint, intensity, "", layer_var.offset );
+                                                                      subtile, rotation, lit, nv, height_3d, intensity, "", layer_var.offset );
                                 has_drawn = true;
                                 break;
                             }
@@ -3301,7 +3300,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                 // draw the default sprite
                 if( !has_drawn ) {
                     ret_draw_field = draw_from_id_string( fld.id().str(), TILE_CATEGORY::FIELD, empty_string,
-                                                          p, subtile, rotation, lit, nv, nullint, intensity );
+                                                          p, subtile, rotation, lit, nv, height_3d, intensity );
                 }
 
             }
@@ -3332,9 +3331,8 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
 
             //get field intensity
             int intensity = fld_overridden ? 0 : here.field_at( p ).displayed_intensity();
-            int nullint = 0;
             ret_draw_field = draw_from_id_string( fld.id().str(), TILE_CATEGORY::FIELD, empty_string,
-                                                  p, subtile, rotation, lit, nv, nullint, intensity );
+                                                  p, subtile, rotation, lit, nv, height_3d, intensity );
         }
     }
 
@@ -3802,7 +3800,7 @@ bool cata_tiles::draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d
 }
 
 bool cata_tiles::draw_zombie_revival_indicators( const tripoint &pos, const lit_level /*ll*/,
-        int &/*height_3d*/, const std::array<bool, 5> &invisible )
+        int &height_3d, const std::array<bool, 5> &invisible )
 {
     map &here = get_map();
     if( tileset_ptr->find_tile_type( ZOMBIE_REVIVAL_INDICATOR ) && !invisible[0] &&
@@ -3811,7 +3809,7 @@ bool cata_tiles::draw_zombie_revival_indicators( const tripoint &pos, const lit_
         for( item &i : here.i_at( pos ) ) {
             if( i.can_revive() ) {
                 return draw_from_id_string( ZOMBIE_REVIVAL_INDICATOR, TILE_CATEGORY::NONE,
-                                            empty_string, pos, 0, 0, lit_level::LIT, false );
+                                            empty_string, pos, 0, 0, lit_level::LIT, false, height_3d );
             }
         }
     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2931,7 +2931,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             get_terrain_orientation( p, rotation, subtile, {}, invisible, rotate_group );
             // do something to get other terrain orientation values
         }
-        if( here.check_seen_cache( p ) ) {
+        if( here.check_seen_cache( p ) && p.z == get_avatar().pos().z ) {
             get_avatar().memorize_terrain( here.getabs( p ), tname, subtile, rotation );
         }
         // draw the actual terrain if there's no override
@@ -3014,7 +3014,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         const std::string &fname = f.id().str();
         if( !( you.get_grab_type() == object_type::FURNITURE
                && p == you.pos() + you.grab_point )
-            && here.check_seen_cache( p ) ) {
+            && here.check_seen_cache( p ) && p.z == get_avatar().pos().z ) {
             you.memorize_decoration( here.getabs( p ), fname, subtile, rotation );
         }
         // draw the actual furniture if there's no override
@@ -3101,7 +3101,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
         int rotation = 0;
         get_tile_values( tr.loadid.to_i(), neighborhood, subtile, rotation, 0 );
         const std::string trname = tr.loadid.id().str();
-        if( here.check_seen_cache( p ) ) {
+        if( here.check_seen_cache( p ) && p.z == get_avatar().pos().z ) {
             you.memorize_decoration( here.getabs( p ), trname, subtile, rotation );
         }
         // draw the actual trap if there's no override
@@ -3159,7 +3159,7 @@ bool cata_tiles::draw_part_con( const tripoint &p, const lit_level ll, int &heig
     if( here.partial_con_at( tripoint_bub_ms( p ) ) != nullptr && !invisible[0] ) {
         avatar &you = get_avatar();
         std::string const &trname = tr_unfinished_construction.str();;
-        if( here.check_seen_cache( p ) ) {
+        if( here.check_seen_cache( p ) && p.z == get_avatar().pos().z ) {
             you.memorize_decoration( here.getabs( p ), trname, 0, 0 );
         }
         return draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, 0,
@@ -3533,7 +3533,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             if( !veh.forward_velocity() && !veh.player_in_control( you )
                 && !( you.get_grab_type() == object_type::VEHICLE
                       && veh.get_points().count( you.pos() + you.grab_point ) )
-                && here.check_seen_cache( p ) ) {
+                && here.check_seen_cache( p ) && p.z == get_avatar().pos().z ) {
                 you.memorize_decoration( here.getabs( p ), vd.get_tileset_id(), subtile, rotation );
             }
             if( !overridden ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2913,8 +2913,8 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
     // first memorize the actual terrain
     const ter_id &t = here.ter( p );
     const std::string &tname = t.id().str();
-    // Non-isometric legacy mode does not draw fog sprites
-    if( !is_isometric() && fov_3d_z_range == 0 && tname == "t_open_air" ) {
+    // Legacy mode does not draw fog sprites
+    if( fov_3d_z_range == 0 && tname == "t_open_air" ) {
         return false;
     }
     if( t && !invisible[0] ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -334,6 +334,11 @@ void cata_tiles::load_tileset( const std::string &tileset_id, const bool prechec
     tileset_ptr = cache.load_tileset( tileset_id, renderer, precheck, force, pump_events );
 
     set_draw_scale( 16 );
+
+    // Precalculate fog transparency
+    // On isometric tilesets, fog intensity scales with zlevel_height in tile_config.json
+    fog_alpha = is_isometric() ? std::min( std::max( int( 255.0f - 255.0f * pow( 155.0f / 255.0f,
+                                           zlevel_height / 100.0f ) ), 40 ), 150 ) : 100;
 }
 
 void cata_tiles::reinit()
@@ -3839,7 +3844,7 @@ void cata_tiles::draw_zlevel_overlay( const tripoint &p, const lit_level ll, int
     }
     // Setting for fog transparency
     // On isometric tilesets, fog intensity scales with zlevel_height in tile_config.json
-    fog_color.a = is_isometric() ? 50 + zlevel_height / 2 : 100;
+    fog_color.a = fog_alpha;
 
     // Change blend mode for transparency to work
     // Disable after to avoid visual bugs

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -706,6 +706,8 @@ class cata_tiles
         float tile_ratiox = 0.0f;
         float tile_ratioy = 0.0f;
 
+        int fog_alpha = 0;
+
         bool in_animation = false;
 
         bool do_draw_explosion = false;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -142,6 +142,7 @@ class tileset
         bool tile_isometric = false;
         int tile_width = 0;
         int tile_height = 0;
+        int zlevel_height = 0;
 
         float prevent_occlusion_min_dist = 0.0;
         float prevent_occlusion_max_dist = 0.0;
@@ -185,6 +186,9 @@ class tileset
         }
         int get_tile_height() const {
             return tile_height;
+        }
+        int get_zlevel_height() const {
+            return zlevel_height;
         }
         float get_tile_pixelscale() const {
             return tile_pixelscale;
@@ -694,6 +698,7 @@ class cata_tiles
 
         int tile_height = 0;
         int tile_width = 0;
+        int zlevel_height = 0;
         // The width and height of the area we can draw in,
         // measured in map coordinates, *not* in pixels.
         int screentile_width = 0;

--- a/tools/gfx_tools/compose.py
+++ b/tools/gfx_tools/compose.py
@@ -273,7 +273,8 @@ class Tileset:
             self.info = json.load(file)
             self.sprite_width = self.info[0].get('width', self.sprite_width)
             self.sprite_height = self.info[0].get('height', self.sprite_height)
-            self.zlevel_height = self.info[0].get('zlevel_height', self.zlevel_height)
+            self.zlevel_height = self.info[0].get('zlevel_height',
+                                                  self.zlevel_height)
             self.pixelscale = self.info[0].get('pixelscale', self.pixelscale)
             self.retract_dist_min = self.info[0].get('retract_dist_min',
                                                      self.retract_dist_min)

--- a/tools/gfx_tools/compose.py
+++ b/tools/gfx_tools/compose.py
@@ -471,6 +471,7 @@ class Tileset:
                 'pixelscale': self.pixelscale,
                 'width': self.sprite_width,
                 'height': self.sprite_height,
+                'zlevel_height': self.sprite_height,
                 'iso': self.iso,
                 'retract_dist_min': self.retract_dist_min,
                 'retract_dist_max': self.retract_dist_max

--- a/tools/gfx_tools/compose.py
+++ b/tools/gfx_tools/compose.py
@@ -259,6 +259,7 @@ class Tileset:
         info_path = self.source_dir.joinpath('tile_info.json')
         self.sprite_width = 16
         self.sprite_height = 16
+        self.zlevel_height = 0
         self.pixelscale = 1
         self.iso = False
         self.retract_dist_min = -1.0
@@ -272,6 +273,7 @@ class Tileset:
             self.info = json.load(file)
             self.sprite_width = self.info[0].get('width', self.sprite_width)
             self.sprite_height = self.info[0].get('height', self.sprite_height)
+            self.zlevel_height = self.info[0].get('zlevel_height', self.zlevel_height)
             self.pixelscale = self.info[0].get('pixelscale', self.pixelscale)
             self.retract_dist_min = self.info[0].get('retract_dist_min',
                                                      self.retract_dist_min)
@@ -471,7 +473,7 @@ class Tileset:
                 'pixelscale': self.pixelscale,
                 'width': self.sprite_width,
                 'height': self.sprite_height,
-                'zlevel_height': self.sprite_height,
+                'zlevel_height': self.zlevel_height,
                 'iso': self.iso,
                 'retract_dist_min': self.retract_dist_min,
                 'retract_dist_max': self.retract_dist_max


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "3D vision for isometric tilesets"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
In #65738, 3D vision was disabled for isometric tilesets because of several visual bugs, mostly involving height_3d.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
**Update**: This PR has been merged but the feature will not be fully functional until https://github.com/I-am-Erk/CDDA-Tilesets/pull/2036 is merged as well and the next tileset update takes place.

This fixes said issues and enables 3D vision for all tilesets.  The height_3d feature should now be fully compatible with 3D vision.  The apparent height of each z-level can be tweaked by changing the `zlevel_height` property in the tile_info.json / tile_config.json of the target tileset. Cross z-level map memory still does not work properly so I have disabled it for now.  That will be worked on next.
![iso1](https://github.com/CleverRaven/Cataclysm-DDA/assets/129854247/1608c5c1-a00c-473f-81cf-827c5da4486c)
![iso2](https://github.com/CleverRaven/Cataclysm-DDA/assets/129854247/0ee17593-ade1-4e87-8579-da32d710ce63)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Builds ok.
Tested with various scenarios involving different elevations using both HitButton_iso and Ultica_iso tilesets.  Renders fine so far.
Map memory for the same z-level works as expected.
Updated compose.py built new tilesets successfully.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->