### PR TITLE
Fix dodge training

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1104,7 +1104,7 @@ void Character::consume_dodge_attempts()
     }
 }
 
-ret_val<void> Character::can_try_doge() const
+ret_val<void> Character::can_try_doge( bool ignore_dodges_left ) const
 {
     //If we're asleep or busy we can't dodge
     if( in_sleep_state() || has_effect( effect_narcosis ) ||
@@ -1121,7 +1121,7 @@ ret_val<void> Character::can_try_doge() const
                                             _( "<npcname>'s stamina is too low to attempt to dodge." ) );;
     }
     // Ensure no attempt to dodge without sources of extra dodges, eg martial arts
-    if( get_dodges_left() <= 0 ) {
+    if( get_dodges_left() <= 0 && !ignore_dodges_left ) {
         add_msg_debug( debugmode::DF_MELEE, "No remaining dodge attempts" );
         return ret_val<void>::make_failure();
     }
@@ -1793,7 +1793,8 @@ void Character::on_try_dodge()
 void Character::on_dodge( Creature *source, float difficulty )
 {
     // Make sure we're not practicing dodge in situation where we can't dodge
-    if( !can_try_doge().success() ) {
+    // We can ignore dodges_left because it was already checked in get_dodge()
+    if( !can_try_doge( true ).success() ) {
         return;
     }
 

--- a/src/character.h
+++ b/src/character.h
@@ -697,7 +697,7 @@ class Character : public Creature, public visitable
         void set_dodges_left( int dodges );
         void mod_dodges_left( int mod );
         void consume_dodge_attempts();
-        ret_val<void> can_try_doge() const;
+        ret_val<void> can_try_doge( bool ignore_dodges_left = false ) const;
 
         float get_stamina_dodge_modifier() const;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

#### Purpose of change
Fixes #66098

#### Describe the solution
Ignore the dodge_left counter inside on_dodge
#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Get a slime
get invincible but 0 dodge
Wait
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41293484/4571003b-0c02-40f9-80e6-a401ca972d08)

#### Additional context

This feels like an ugly solution, it's weird to check can_try_doge both in on_try_dodge and then again in on_dodge


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->