### PR TITLE
recruiting static NPCs makes them lose their static traits

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8327,7 +8327,7 @@
     "name": { "str": "Ignores Sounds" },
     "points": 99,
     "valid": false,
-    "description": "NPC ignores sounds and does not investigate them.",
+    "description": "NPC ignores sounds and does not investigate them.  If you see this, it's is a bug.",
     "purifiable": false
   },
   {
@@ -8336,7 +8336,7 @@
     "name": { "str": "Will Not Bash" },
     "points": 99,
     "valid": false,
-    "description": "NPC will not bash to reach things.",
+    "description": "NPC will not bash to reach things.  If you see this, it's a bug.",
     "purifiable": false
   },
   {

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8327,7 +8327,6 @@
     "name": { "str": "Ignores Sounds" },
     "points": 99,
     "valid": false,
-    "player_display": false,
     "description": "NPC ignores sounds and does not investigate them.",
     "purifiable": false
   },
@@ -8337,7 +8336,6 @@
     "name": { "str": "Will Not Bash" },
     "points": 99,
     "valid": false,
-    "player_display": false,
     "description": "NPC will not bash to reach things.",
     "purifiable": false
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8327,6 +8327,7 @@
     "name": { "str": "Ignores Sounds" },
     "points": 99,
     "valid": false,
+    "player_display": false,
     "description": "NPC ignores sounds and does not investigate them.",
     "purifiable": false
   },
@@ -8336,6 +8337,7 @@
     "name": { "str": "Will Not Bash" },
     "points": 99,
     "valid": false,
+    "player_display": false,
     "description": "NPC will not bash to reach things.",
     "purifiable": false
   },

--- a/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
@@ -124,7 +124,16 @@
           "difficulty": 0,
           "mod": [ [ "ALTRUISM", 6 ], [ "POS_FEAR", -6 ], [ "BRAVERY", 2 ], [ "ANGER", -6 ], [ "VALUE", 2 ] ]
         },
-        "success": { "topic": "TALK_AGREE_FOLLOW", "effect": "follow", "opinion": { "value": -1 } },
+        "success": {
+          "topic": "TALK_AGREE_FOLLOW",
+          "effect": [
+            "follow",
+            { "npc_lose_trait": "RETURN_TO_START_POS" },
+            { "npc_lose_trait": "NO_BASH" },
+            { "npc_lose_trait": "IGNORE_SOUND" }
+          ],
+          "opinion": { "value": -1 }
+        },
         "failure": { "topic": "TALK_DENY_FOLLOW", "effect": "deny_follow", "opinion": { "fear": -1, "value": -1, "anger": 1 } }
       },
       {
@@ -132,7 +141,16 @@
         "default": true,
         "text": "We're friends, aren't we?",
         "trial": { "type": "PERSUADE", "difficulty": 0, "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ] ] },
-        "success": { "topic": "TALK_AGREE_FOLLOW", "effect": "follow", "opinion": { "trust": 2, "anger": -1 } },
+        "success": {
+          "topic": "TALK_AGREE_FOLLOW",
+          "effect": [
+            "follow",
+            { "npc_lose_trait": "RETURN_TO_START_POS" },
+            { "npc_lose_trait": "NO_BASH" },
+            { "npc_lose_trait": "IGNORE_SOUND" }
+          ],
+          "opinion": { "trust": 2, "anger": -1 }
+        },
         "failure": { "topic": "TALK_DENY_FOLLOW", "effect": "deny_follow", "opinion": { "trust": 1, "fear": -2, "value": -1, "anger": 1 } }
       },
       {
@@ -140,7 +158,16 @@
         "default": true,
         "text": "I'll kill you if you don't.",
         "trial": { "type": "INTIMIDATE", "difficulty": 20, "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ] },
-        "success": { "topic": "TALK_AGREE_FOLLOW", "effect": "follow", "opinion": { "trust": -4, "fear": 3, "value": -1, "anger": 4 } },
+        "success": {
+          "topic": "TALK_AGREE_FOLLOW",
+          "effect": [
+            "follow",
+            { "npc_lose_trait": "RETURN_TO_START_POS" },
+            { "npc_lose_trait": "NO_BASH" },
+            { "npc_lose_trait": "IGNORE_SOUND" }
+          ],
+          "opinion": { "trust": -4, "fear": 3, "value": -1, "anger": 4 }
+        },
         "failure": { "topic": "TALK_DENY_FOLLOW", "effect": "deny_follow", "opinion": { "trust": 4, "value": -5, "anger": 10 } }
       },
       { "switch": true, "default": true, "text": "Nevermind.", "topic": "TALK_NONE" }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

The NPC traits "ignore sounds" and "will not bash" were not set to be invisible in the traits menu, meaning NPCs with them that could be recruited (Meteorologist mostly) would display them if you asked to know about them.

#### Describe the solution

~~added `player_display: false` to both traits~~ Maleclypse suggested I have the NPCs lose said traits once they're recruited.
