### PR TITLE
Dirty cache / clear memory map on furn/trap removal

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -299,9 +299,9 @@ void avatar::memorize_symbol( const tripoint &p, char32_t symbol )
     player_map_memory->set_tile_symbol( p, symbol );
 }
 
-void avatar::memorize_clear_vehicles( const tripoint &p )
+void avatar::memorize_clear_decoration( const tripoint &p, std::string_view prefix )
 {
-    player_map_memory->clear_tile_decoration( p, /* prefix = */ "vp_" );
+    player_map_memory->clear_tile_decoration( p, prefix );
 }
 
 std::vector<mission *> avatar::get_active_missions() const
@@ -687,14 +687,14 @@ void avatar::grab( object_type grab_type_new, const tripoint &grab_point_new )
             if( const optional_vpart_position ovp = m.veh_at( pos() + gpoint ) ) {
                 for( const tripoint &target : ovp->vehicle().get_points() ) {
                     if( erase ) {
-                        memorize_clear_vehicles( m.getabs( target ) );
+                        memorize_clear_decoration( m.getabs( target ), /* prefix = */ "vp_" );
                     }
                     m.set_memory_seen_cache_dirty( target );
                 }
             }
         } else if( gtype != object_type::NONE ) {
             if( erase ) {
-                player_map_memory->clear_tile_decoration( m.getabs( pos() + gpoint ) );
+                memorize_clear_decoration( m.getabs( pos() + gpoint ) );
             }
             m.set_memory_seen_cache_dirty( pos() + gpoint );
         }

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -144,7 +144,7 @@ class avatar : public Character
         void memorize_terrain( const tripoint &p, std::string_view id, int subtile, int rotation );
         void memorize_decoration( const tripoint &p, std::string_view id, int subtile, int rotation );
         void memorize_symbol( const tripoint &p, char32_t symbol );
-        void memorize_clear_vehicles( const tripoint &p );
+        void memorize_clear_decoration( const tripoint &p, std::string_view prefix = "" );
 
         nc_color basic_symbol_color() const override;
         int print_info( const catacurses::window &w, int vStart, int vLines, int column ) const override;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5749,7 +5749,7 @@ void game::control_vehicle()
         // If we reached here, we gained control of a vehicle.
         // Clear the map memory for the area covered by the vehicle to eliminate ghost vehicles.
         for( const tripoint &target : veh->get_points() ) {
-            u.memorize_clear_vehicles( m.getabs( target ) );
+            u.memorize_clear_decoration( m.getabs( target ), "vp_" );
             m.set_memory_seen_cache_dirty( target );
         }
         veh->is_following = false;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/66396

Seems this is bugged from 0.G or earlier

#### Describe the solution

Dirty memory_seen cache when traps(/partial_con)/furniture is getting removed/reset and clear decoration memory if avatar sees the spot

#### Describe alternatives you've considered

#### Testing

Smash/deconstruct some benches in shelter, move outside

#### Additional context
