### PR TITLE
Cleanup legacy character template loading

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -700,8 +700,6 @@ bool avatar::create( character_type type, const std::string &tempname )
             if( !load_template( tempname, /*out*/ pool ) ) {
                 return false;
             }
-            // TEMPORARY until 0.F
-            set_all_parts_hp_to_max();
 
             // We want to prevent recipes known by the template from being applied to the
             // new character. The recipe list will be rebuilt when entering the game.


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I saw the code that said "TEMPORARY until 0.F" and removed it. It is no longer necessary, right?
<!-- 
#### Describe the solution

How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

#### Describe alternatives you've considered

Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
None

#### Additional context

ref: https://github.com/CleverRaven/Cataclysm-DDA/pull/41623


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->