### PR TITLE
Mapgen weight as a function of time since cata

### DIFF
--- a/data/json/weight_functions.json
+++ b/data/json/weight_functions.json
@@ -47,26 +47,27 @@
 	"//": "Use completing the square to generalise",
 	"//": "Usage weight_quadratic_pos( days until max weight ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed.",
     "num_args": 1,
-	"return": { "u_val('time_since_cataclysm: days') < _0 ? 0.1 + ( ( 13 / 400 ) * u_val('time_since_cataclysm: days') ) - ( ( 19 / 72000 ) * ( u_val('time_since_cataclysm: days') ^ 2 ) ) : 0.1" }
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) : 1" }
   },
   {
     "type": "jmath_function",
     "id": "weight_quadratic_neg",
-	"//": "Usage weight_quadratic_pos( days until max weight ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until max weight' have passed.",
+	"//": "Usage weight_quadratic_neg( days until 0 weight ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until 0 weight' have passed.",
     "num_args": 1,
-	"return": { "u_val('time_since_cataclysm: days') < _0 ? 0.1 + ( ( 13 / 400 ) * u_val('time_since_cataclysm: days') ) - ( ( 19 / 72000 ) * ( u_val('time_since_cataclysm: days') ^ 2 ) ) : 0.1" }
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? 1 - ( ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) : 0" }
   }
   {
     "type": "jmath_function",
     "id": "weight_quadratic_pos_from",
-	"//": "Usage weight_quadratic_pos( days until max weight, minimum multiplier ).  Quadratically varies weight from 'weight' to 'minimum multiplier' * 'weight' and back to 'weight' until 'days until max weight' have passed.",
+	"//": "Usage weight_quadratic_pos_from( days until max weight, minimum multiplier ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier' * 'weight'.",
     "num_args": 2,
-	"return": { "u_val('time_since_cataclysm: days') < _0 ? 0.1 + ( ( 13 / 400 ) * u_val('time_since_cataclysm: days') ) - ( ( 19 / 72000 ) * ( u_val('time_since_cataclysm: days') ^ 2 ) ) : 0.1" }
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? max( _1, ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) : 1" }
   }
   {
     "type": "jmath_function",
     "id": "weight_quadratic_neg_until",
+	"//": "Usage weight_quadratic_neg_until( days until 0 weight, minimum multiplier ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier' * 'weight'.",
     "num_args": 2,
-	"return": { "u_val('time_since_cataclysm: days') < _0 ? 0.1 + ( ( 13 / 400 ) * u_val('time_since_cataclysm: days') ) - ( ( 19 / 72000 ) * ( u_val('time_since_cataclysm: days') ^ 2 ) ) : 0.1" }
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? max( _1, 1 - ( ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) ) : _1" }
   }
 ]

--- a/data/json/weight_functions.json
+++ b/data/json/weight_functions.json
@@ -1,0 +1,58 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "weight_start_14",
+    "condition": { "math": [ "u_dayssincestart", "<", "14" ] },
+    "effect": { "math": [ "u_weight", "=", 0 ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "weight_end_14",
+    "condition": { "math": [ "u_dayssincestart", ">=", "14" ] },
+    "effect": { "math": [ "u_weight", "=", 0 ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "weight_linear_pos_14",
+    "condition": { "math": [ "u_dayssincestart", "<", "14" ] },
+    "effect": { "math": [ "u_weight", "*=", "u_dayssincestart / 14" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "weight_linear_neg_14",
+    "run_eocs": [
+      {
+        "id": "weight_linear_neg_14_first",
+        "condition": { "math": [ "u_dayssincestart", "<", "14" ] },
+        "effect": { "math": [ "u_weight", "*=", "1 - ( u_dayssincestart / 14 )" ] }
+      },
+      {
+        "id": "weight_linear_neg_14_last",
+        "condition": { "math": [ "u_dayssincestart", ">=", "14" ] },
+        "effect": { "math": [ "u_weight", "=", 0 ] }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "weight_unlooted_120",
+    "effect": { "math": [ "u_weight", "*=", "u_dayssincestart < 120 ? 1 - ( ( 9 / 1200 ) * u_dayssincestart ) : 0.1" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "weight_partlooted_120",
+    "effect": {
+      "math": [
+        "u_weight",
+        "*=",
+        "u_dayssincestart < 120 ? 0.1 + ( ( 13 / 400 ) * u_dayssincestart ) - ( ( 19 / 72000 ) * ( u_dayssincestart ^ 2 ) ) : 0.1"
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "weight_looted_120",
+    "condition": { "math": [ "u_dayssincestart", "<", "120" ] },
+    "effect": { "math": [ "u_weight", "*=", "u_dayssincestart / 120" ] }
+  }
+]

--- a/data/json/weight_functions.json
+++ b/data/json/weight_functions.json
@@ -59,28 +59,57 @@
     "type": "jmath_function",
     "id": "weight_quadratic_pos",
 	"//": "Use completing the square to generalise",
-	"//": "Usage weight_quadratic_pos( days until max weight ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed.",
+	"//": "Usage weight_quadratic_u_pos( days until max weight ).  Quadratically varies weight from to 0 to 'weight' until 'days until max weight' have passed.",
+    "num_args": 1,
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? ( u_val('time_since_cataclysm: days') / _0 ) ^ 2 : 1" }
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_neg",
+	"//": "Usage weight_quadratic_u_neg( days until 0 weight ).  Quadratically varies weight from 'weight' to 0 until 'days until 0 weight' have passed.",
+    "num_args": 1,
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? 1 - ( ( u_val('time_since_cataclysm: days') / _0 ) ^ 2 ) : 0" }
+  }
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_pos_min",
+	"//": "Usage weight_quadratic_u_pos_min( days until max weight, minimum multiplier ).  Quadratically varies weight from 0 to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier'.",
+    "num_args": 2,
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? max( _1, ( u_val('time_since_cataclysm: days') / _0 ) ^ 2 ) : 1" }
+  }
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_neg_min",
+	"//": "Usage weight_quadratic_neg_min( days until 0 weight, minimum multiplier ).  Quadratically varies weight from 'weight' to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
+    "num_args": 2,
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? max( _1, 1 - ( ( u_val('time_since_cataclysm: days') / _0 ) ^ 2 ) ) : _1" }
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_u_pos",
+	"//": "Use completing the square to generalise",
+	"//": "Usage weight_quadratic_u_pos( days until max weight ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed.",
     "num_args": 1,
 	"return": { "u_val('time_since_cataclysm: days') < _0 ? ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) : 1" }
   },
   {
     "type": "jmath_function",
-    "id": "weight_quadratic_neg",
-	"//": "Usage weight_quadratic_neg( days until 0 weight ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until 0 weight' have passed.",
+    "id": "weight_quadratic_u_neg",
+	"//": "Usage weight_quadratic_u_neg( days until 0 weight ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until 0 weight' have passed.",
     "num_args": 1,
 	"return": { "u_val('time_since_cataclysm: days') < _0 ? 1 - ( ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) : 0" }
   }
   {
     "type": "jmath_function",
-    "id": "weight_quadratic_pos_min",
-	"//": "Usage weight_quadratic_pos_min( days until max weight, minimum multiplier ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier'.",
+    "id": "weight_quadratic_u_pos_min",
+	"//": "Usage weight_quadratic_u_pos_min( days until max weight, minimum multiplier ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier'.",
     "num_args": 2,
 	"return": { "u_val('time_since_cataclysm: days') < _0 ? max( _1, ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) : 1" }
   }
   {
     "type": "jmath_function",
-    "id": "weight_quadratic_neg_min",
-	"//": "Usage weight_quadratic_neg_min( days until 0 weight, minimum multiplier ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
+    "id": "weight_quadratic_u_neg_min",
+	"//": "Usage weight_quadratic_u_neg_min( days until 0 weight, minimum multiplier ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
     "num_args": 2,
 	"return": { "u_val('time_since_cataclysm: days') < _0 ? max( _1, 1 - ( ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) ) : _1" }
   }

--- a/data/json/weight_functions.json
+++ b/data/json/weight_functions.json
@@ -15,6 +15,20 @@
   },
   {
     "type": "jmath_function",
+    "id": "weight_start_min",
+	"//": "Usage weight_start_min( days of 0 weight, minimum multiplier ).  Sets weight from 0 to 'weight' after 'days of 0 weight' have passed but never returns less than 'minimum multiplier'.",
+    "num_args": 2,
+    "return": { " u_val('time_since_cataclysm: days') < _0 ? _1 : 1" }
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_end_min",
+	"//": "Usage weight_end_min( days until 0 weight, minimum multiplier ).  Sets weight from 'weight' to 0 after 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
+    "num_args": 2,
+    "return": { "u_val('time_since_cataclysm: days') < _0 ? 1 : _1" }
+  },
+  {
+    "type": "jmath_function",
     "id": "weight_linear_pos",
 	"//": "Usage weight_linear_pos( days until max weight ).  Linearly increases weight from 0 to 'weight' until 'days until max weight' have passed.",
     "num_args": 1,
@@ -29,15 +43,15 @@
   },
   {
     "type": "jmath_function",
-    "id": "weight_linear_pos_from",
-	"//": "Usage weight_linear_pos_from( days until max weight, minimum multiplier ).  Linearly increases weight to 'weight' until 'days until max weight' such that it would start from 0 but starts at a flat 'minimum multiplier' * 'weight'.",
+    "id": "weight_linear_pos_min",
+	"//": "Usage weight_linear_pos_min( days until max weight, minimum multiplier ).  Linearly increases weight from 0 to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier'.",
     "num_args": 2,
 	"return": { " u_val('time_since_cataclysm: days') < _0 ? max( u_val('time_since_cataclysm: days') / _0, _1 ) : 1" }
   }
   {
     "type": "jmath_function",
-    "id": "weight_linear_neg_until",
-	"//": "Usage weight_linear_neg_until( days until 0 weight, minimum multiplier ).  Linearly decreases weight from 'weight' such that it would reach 0 at 'days until 0 weight' but stops at 'minimum multiplier' * 'weight'.",
+    "id": "weight_linear_neg_min",
+	"//": "Usage weight_linear_neg_min( days until 0 weight, minimum multiplier ).  Linearly decreases weight from 'weight' to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
     "num_args": 2,
 	"return": { "u_val('time_since_cataclysm: days') < _0 ? max( 1 - ( u_val('time_since_cataclysm: days') / _0 ), _1 ) : _1" }
   },
@@ -58,15 +72,15 @@
   }
   {
     "type": "jmath_function",
-    "id": "weight_quadratic_pos_from",
-	"//": "Usage weight_quadratic_pos_from( days until max weight, minimum multiplier ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier' * 'weight'.",
+    "id": "weight_quadratic_pos_min",
+	"//": "Usage weight_quadratic_pos_min( days until max weight, minimum multiplier ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier'.",
     "num_args": 2,
 	"return": { "u_val('time_since_cataclysm: days') < _0 ? max( _1, ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) : 1" }
   }
   {
     "type": "jmath_function",
-    "id": "weight_quadratic_neg_until",
-	"//": "Usage weight_quadratic_neg_until( days until 0 weight, minimum multiplier ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier' * 'weight'.",
+    "id": "weight_quadratic_neg_min",
+	"//": "Usage weight_quadratic_neg_min( days until 0 weight, minimum multiplier ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
     "num_args": 2,
 	"return": { "u_val('time_since_cataclysm: days') < _0 ? max( _1, 1 - ( ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) ) : _1" }
   }

--- a/data/json/weight_functions.json
+++ b/data/json/weight_functions.json
@@ -1,58 +1,72 @@
 [
   {
-    "type": "effect_on_condition",
-    "id": "weight_start_14",
-    "condition": { "math": [ "u_dayssincestart", "<", "14" ] },
-    "effect": { "math": [ "u_weight", "=", 0 ] }
+    "type": "jmath_function",
+    "id": "weight_start",
+	"//": "These functions return a value between 0 and 1 to be multiplied with mapgen weights and hopefully in the future specials occurances and for use in mapgen value conditionals.  Usage weight_start( days of 0 weight ).  Sets weight from 0 to 'weight' after 'days of 0 weight' have passed.",
+    "num_args": 1,
+    "return": { " u_val('time_since_cataclysm: days') < _0 ? 0 : 1" }
   },
   {
-    "type": "effect_on_condition",
-    "id": "weight_end_14",
-    "condition": { "math": [ "u_dayssincestart", ">=", "14" ] },
-    "effect": { "math": [ "u_weight", "=", 0 ] }
+    "type": "jmath_function",
+    "id": "weight_end",
+	"//": "Usage weight_end( days until 0 weight ).  Sets weight from 'weight' to 0 after 'days until 0 weight' have passed.",
+    "num_args": 1,
+    "return": { "u_val('time_since_cataclysm: days') < _0 ? 1 : 0" }
   },
   {
-    "type": "effect_on_condition",
-    "id": "weight_linear_pos_14",
-    "condition": { "math": [ "u_dayssincestart", "<", "14" ] },
-    "effect": { "math": [ "u_weight", "*=", "u_dayssincestart / 14" ] }
+    "type": "jmath_function",
+    "id": "weight_linear_pos",
+	"//": "Usage weight_linear_pos( days until max weight ).  Linearly increases weight from 0 to 'weight' until 'days until max weight' have passed.",
+    "num_args": 1,
+    "return": { "u_val('time_since_cataclysm: days') < _0 ? u_val('time_since_cataclysm: days') / _0 : 1" }
   },
   {
-    "type": "effect_on_condition",
-    "id": "weight_linear_neg_14",
-    "run_eocs": [
-      {
-        "id": "weight_linear_neg_14_first",
-        "condition": { "math": [ "u_dayssincestart", "<", "14" ] },
-        "effect": { "math": [ "u_weight", "*=", "1 - ( u_dayssincestart / 14 )" ] }
-      },
-      {
-        "id": "weight_linear_neg_14_last",
-        "condition": { "math": [ "u_dayssincestart", ">=", "14" ] },
-        "effect": { "math": [ "u_weight", "=", 0 ] }
-      }
-    ]
+    "type": "jmath_function",
+    "id": "weight_linear_neg",
+	"//": "Usage weight_linear_neg( days until 0 weight ).  Linearly decreases weight from 'weight' to 0 until 'days until 0 weight' have passed.",
+    "num_args": 1,
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? 1 - ( u_val('time_since_cataclysm: days') / _0 ) : 0" }
   },
   {
-    "type": "effect_on_condition",
-    "id": "weight_unlooted_120",
-    "effect": { "math": [ "u_weight", "*=", "u_dayssincestart < 120 ? 1 - ( ( 9 / 1200 ) * u_dayssincestart ) : 0.1" ] }
+    "type": "jmath_function",
+    "id": "weight_linear_pos_from",
+	"//": "Usage weight_linear_pos_from( days until max weight, minimum multiplier ).  Linearly increases weight to 'weight' until 'days until max weight' such that it would start from 0 but starts at a flat 'minimum multiplier' * 'weight'.",
+    "num_args": 2,
+	"return": { " u_val('time_since_cataclysm: days') < _0 ? max( u_val('time_since_cataclysm: days') / _0, _1 ) : 1" }
+  }
+  {
+    "type": "jmath_function",
+    "id": "weight_linear_neg_until",
+	"//": "Usage weight_linear_neg_until( days until 0 weight, minimum multiplier ).  Linearly decreases weight from 'weight' such that it would reach 0 at 'days until 0 weight' but stops at 'minimum multiplier' * 'weight'.",
+    "num_args": 2,
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? max( 1 - ( u_val('time_since_cataclysm: days') / _0 ), _1 ) : _1" }
   },
   {
-    "type": "effect_on_condition",
-    "id": "weight_partlooted_120",
-    "effect": {
-      "math": [
-        "u_weight",
-        "*=",
-        "u_dayssincestart < 120 ? 0.1 + ( ( 13 / 400 ) * u_dayssincestart ) - ( ( 19 / 72000 ) * ( u_dayssincestart ^ 2 ) ) : 0.1"
-      ]
-    }
+    "type": "jmath_function",
+    "id": "weight_quadratic_pos",
+	"//": "Use completing the square to generalise",
+	"//": "Usage weight_quadratic_pos( days until max weight ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed.",
+    "num_args": 1,
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? 0.1 + ( ( 13 / 400 ) * u_val('time_since_cataclysm: days') ) - ( ( 19 / 72000 ) * ( u_val('time_since_cataclysm: days') ^ 2 ) ) : 0.1" }
   },
   {
-    "type": "effect_on_condition",
-    "id": "weight_looted_120",
-    "condition": { "math": [ "u_dayssincestart", "<", "120" ] },
-    "effect": { "math": [ "u_weight", "*=", "u_dayssincestart / 120" ] }
+    "type": "jmath_function",
+    "id": "weight_quadratic_neg",
+	"//": "Usage weight_quadratic_pos( days until max weight ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until max weight' have passed.",
+    "num_args": 1,
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? 0.1 + ( ( 13 / 400 ) * u_val('time_since_cataclysm: days') ) - ( ( 19 / 72000 ) * ( u_val('time_since_cataclysm: days') ^ 2 ) ) : 0.1" }
+  }
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_pos_from",
+	"//": "Usage weight_quadratic_pos( days until max weight, minimum multiplier ).  Quadratically varies weight from 'weight' to 'minimum multiplier' * 'weight' and back to 'weight' until 'days until max weight' have passed.",
+    "num_args": 2,
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? 0.1 + ( ( 13 / 400 ) * u_val('time_since_cataclysm: days') ) - ( ( 19 / 72000 ) * ( u_val('time_since_cataclysm: days') ^ 2 ) ) : 0.1" }
+  }
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_neg_until",
+    "num_args": 2,
+	"return": { "u_val('time_since_cataclysm: days') < _0 ? 0.1 + ( ( 13 / 400 ) * u_val('time_since_cataclysm: days') ) - ( ( 19 / 72000 ) * ( u_val('time_since_cataclysm: days') ^ 2 ) ) : 0.1" }
   }
 ]

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -625,11 +625,10 @@ load_mapgen_function( const JsonObject &jio, const std::string &id_base, const p
         return nullptr; // nothing
     }
     const std::string mgtype = jio.get_string( "method" );
-    if ( mgtype == "builtin" ) {
-        if (const building_gen_pointer ptr = get_mapgen_cfunction( jio.get_string( "name" ) ) ) {
+    if( mgtype == "builtin" ) {
+        if( const building_gen_pointer ptr = get_mapgen_cfunction( jio.get_string( "name" ) ) ) {
             return std::make_shared<mapgen_function_builtin>( ptr, mgweight );
-        }
-        else {
+        } else {
             jio.throw_error_at( "name", "function does not exist" );
         }
     } else if( mgtype == "json" ) {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -357,21 +357,6 @@ class mapgen_basic_container
                 rng( 1, weights_.get_weight() + hardcoded_weight ) > weights_.get_weight() ) {
                 return false;
             }
-            for (/*hell knows*/) {
-                if (/*weight func exists*/) {
-                    switch (/*weight func name*/) {
-                    case "weight_start":
-                        /*stored weight*/ *= jmath_func_weight_start->eval(/*weight func arguments*/)
-                            break;
-                    case "weight_end":
-                        /*stored weight*/ *= jmath_func_weight_end->eval(/*weight func arguments*/)
-                            break;
-                    /*...*/
-                    default:
-                        /*error*/
-                    }
-                }
-            }
             const std::shared_ptr<mapgen_function> *const ptr = weights_.pick();
             if( !ptr ) {
                 return false;
@@ -388,6 +373,20 @@ class mapgen_basic_container
         void setup() {
             for( const std::shared_ptr<mapgen_function> &ptr : mapgens_ ) {
                 const int weight = ptr->weight;
+                if (/*weight func exists*/) {
+                        switch (/*weight func name*/) {
+                        case "weight_start":
+                            weight *= jmath_func_weight_start->eval(/*weight func arguments*/)
+                                break;
+                        case "weight_end":
+                            weight *= jmath_func_weight_end->eval(/*weight func arguments*/)
+                                break;
+                            /*The rest*/
+                        default:
+                            /*error*/
+                        }
+                    }
+                }
                 if( weight < 1 ) {
                     continue; // rejected!
                 }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -624,19 +624,18 @@ load_mapgen_function( const JsonObject &jio, const std::string &id_base, const p
         jio.allow_omitted_members();
         return nullptr; // nothing
     }
-    const std::string mgtype = jio.get_string("method");
-    if (mgtype == "builtin") {
-        if (const building_gen_pointer ptr = get_mapgen_cfunction(jio.get_string("name"))) {
-            return std::make_shared<mapgen_function_builtin>(ptr, mgweight);
+    const std::string mgtype = jio.get_string( "method" );
+    if ( mgtype == "builtin" ) {
+        if (const building_gen_pointer ptr = get_mapgen_cfunction( jio.get_string( "name" ) ) ) {
+            return std::make_shared<mapgen_function_builtin>( ptr, mgweight );
         }
         else {
-            jio.throw_error_at("name", "function does not exist");
+            jio.throw_error_at( "name", "function does not exist" );
         }
     } else if( mgtype == "json" ) {
         if( !jio.has_object( "object" ) ) {
             jio.throw_error( R"(mapgen with method "json" must define key "object")" );
         }
-        JsonObject weightfunc;
         JsonObject jo = jio.get_object( "object" );
         jo.allow_omitted_members();
         return std::make_shared<mapgen_function_json>(

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -618,6 +618,14 @@ load_mapgen_function( const JsonObject &jio, const std::string &id_base, const p
         jio.allow_omitted_members();
         return nullptr; // nothing
     }
+	if(jio.has_member( "starts" ) ) {
+		time_duration starts = read_from_json_string<time_duration>( jio.get_member( "starts" ), time_duration::units );
+		mgweight *= calendar::turn < calendar::start_of_cataclysm + starts ? 0 : 1;
+	}
+	if(jio.has_member( "ends" ) ) {
+		time_duration ends = read_from_json_string<time_duration>( jio.get_member( "ends" ), time_duration::units );
+		mgweight *= calendar::turn >= calendar::start_of_cataclysm + ends ? 0 : 1;
+	}
     const std::string mgtype = jio.get_string( "method" );
     if( mgtype == "builtin" ) {
         if( const building_gen_pointer ptr = get_mapgen_cfunction( jio.get_string( "name" ) ) ) {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -626,35 +626,37 @@ load_mapgen_function( const JsonObject &jio, const std::string &id_base, const p
 			jio.throw_error_at( "name", "function does not exist" );
 		}
     } else if( mgtype == "json" ) {
+        if (!jio.has_object("object")) {
+            jio.throw_error(R"(mapgen with method "json" must define key "object")");
+        }
+        JsonObject jo = jio.get_object("object");
+        jo.allow_omitted_members();
 		if( jio.has_member( "weight_func" ) ) {
-			if( jio.has_member( "weight" ) {
+			if( jio.has_member( "weight" ) ) {
 				jio.throw_error( "weight and weight_func are mutually exclusive" );
 			}
 			JsonObject mgweight = jio.get_object( "weight_func" ); // Object should contain the 'name' of the jmath function found in weight_functions.json to be called, 'arguments' to be passed to the function in an array and the basic 'weight' it multiplies.
 			// Add better checks to make sure this is valid before runtime
-			if( !mgweight.has_member( "name" ) {
+			if( !mgweight.has_member( "name" ) ) {
 				mgweight.throw_error( "no weight function name found" );
 			}
-			if( !mgweight.has_member( "arguments" ) {
+			if( !mgweight.has_member( "arguments" ) ) {
 				mgweight.throw_error( "no weight function arguements found" );
 			}
-			if( !mgweight.has_member( "weight" ) {
+			if( !mgweight.has_member( "weight" ) ) {
 				mgweight.throw_error( "no weight function weight found" );
 			}
+            return std::make_shared<mapgen_function_json>(
+                jo, mgweight, "mapgen " + id_base, offset, total);
 		} else {
 			int mgweight = jio.get_int( "weight", 1000 );
 			if( mgweight <= 0 || jio.get_bool( "disabled", false ) ) {
 				jio.allow_omitted_members();
 				return nullptr; // nothing
 			}
-	    }
-        if( !jio.has_object( "object" ) ) {
-            jio.throw_error( R"(mapgen with method "json" must define key "object")" );
-        }
-        JsonObject jo = jio.get_object( "object" );
-        jo.allow_omitted_members();
-        return std::make_shared<mapgen_function_json>(
-                   jo, mgweight, "mapgen " + id_base, offset, total );
+            return std::make_shared<mapgen_function_json>(
+                jo, mgweight, "mapgen " + id_base, offset, total);
+	    }        
     } else {
         jio.throw_error_at( "method", R"(invalid value: must be "builtin" or "json")" );
     }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -358,9 +358,9 @@ class mapgen_basic_container
         void setup() {
             for( const std::shared_ptr<mapgen_function> &ptr : mapgens_ ) {
                 const dbl_or_var weight = ptr->weight;
-                if (/*weight func exists*/) {
-                    jmath_func_id func = jmath_func_id(/*weight func id*/)
-                    weight *= func->eval(/*weight func arguments*/);
+                if( /*weight func exists*/ ) {
+                    jmath_func_id func = jmath_func_id( /*weight func id*/ )
+                                         weight *= func->eval( /*weight func arguments*/ );
                 }
                 if( weight < 1 ) {
                     continue; // rejected!
@@ -615,11 +615,12 @@ static void set_mapgen_defer( const JsonObject &jsi, const std::string &member,
  * load a single mapgen json structure; this can be inside an overmap_terrain, or on it's own.
  */
 std::shared_ptr<mapgen_function>
-load_mapgen_function(const JsonObject& jio, const std::string& id_base, const point& offset,
-    const point& total)
+load_mapgen_function( const JsonObject &jio, const std::string &id_base, const point &offset,
+                      const point &total )
 {
-    dbl_or_var mgweight = jio.get_dbl_or_var( this, "weight", false, 1000); // Should either be an double or an object containing an int "weight" that gets multiplied by the result of the jmath function, the 'id' of the jmath function found in weight_functions.json to be called and 'arguments' to be passed to the function in an array.
-    if (mgweight <= 0 || jio.get_bool("disabled", false)) {
+    dbl_or_var mgweight = jio.get_dbl_or_var( this, "weight", false,
+                          1000 ); // Should either be an double or an object containing an int "weight" that gets multiplied by the result of the jmath function, the 'id' of the jmath function found in weight_functions.json to be called and 'arguments' to be passed to the function in an array.
+    if( mgweight <= 0 || jio.get_bool( "disabled", false ) ) {
         jio.allow_omitted_members();
         return nullptr; // nothing
     }
@@ -631,19 +632,17 @@ load_mapgen_function(const JsonObject& jio, const std::string& id_base, const po
         else {
             jio.throw_error_at("name", "function does not exist");
         }
-    }
-    else if (mgtype == "json") {
-        if (!jio.has_object("object")) {
-            jio.throw_error(R"(mapgen with method "json" must define key "object")");
+    } else if( mgtype == "json" ) {
+        if( !jio.has_object( "object" ) ) {
+            jio.throw_error( R"(mapgen with method "json" must define key "object")" );
         }
         JsonObject weightfunc;
-        JsonObject jo = jio.get_object("object");
+        JsonObject jo = jio.get_object( "object" );
         jo.allow_omitted_members();
         return std::make_shared<mapgen_function_json>(
-            jo, mgweight, "mapgen " + id_base, offset, total);
-    }
-    else {
-        jio.throw_error_at("method", R"(invalid value: must be "builtin" or "json")");
+                   jo, mgweight, "mapgen " + id_base, offset, total );
+    } else {
+        jio.throw_error_at( "method", R"(invalid value: must be "builtin" or "json")" );
     }
 }
 
@@ -823,7 +822,7 @@ mapgen_function_json_base::mapgen_function_json_base(
 mapgen_function_json_base::~mapgen_function_json_base() = default;
 
 mapgen_function_json::mapgen_function_json( const JsonObject &jsobj, const dbl_or_var w,
-    const std::string& context, const point& grid_offset, const point& grid_total, const JsonObject &weightfunc )
+        const std::string &context, const point &grid_offset, const point &grid_total )
     : mapgen_function( w )
     , mapgen_function_json_base( jsobj, context )
     , fill_ter( t_null )

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -482,7 +482,7 @@ class mapgen_function_json : public mapgen_function_json_base, public virtual ma
         void generate( mapgendata & ) override;
         mapgen_parameters get_mapgen_params( mapgen_parameter_scope ) const override;
         mapgen_function_json( const JsonObject &jsobj, int w, const std::string &context,
-                              const point &grid_offset, const point &grid_total );
+                              const point &grid_offset, const point &grid_total, const JsonObject &weightfunc );
         ~mapgen_function_json() override = default;
 
         ter_id fill_ter;

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -26,6 +26,7 @@ class map;
 template <typename Id> class mapgen_value;
 class mapgendata;
 class mission;
+struct dbl_or_var;
 struct mapgen_arguments;
 
 using building_gen_pointer = void ( * )( mapgendata & );
@@ -481,8 +482,8 @@ class mapgen_function_json : public mapgen_function_json_base, public virtual ma
         bool expects_predecessor() const override;
         void generate( mapgendata & ) override;
         mapgen_parameters get_mapgen_params( mapgen_parameter_scope ) const override;
-        mapgen_function_json( const JsonObject &jsobj, int w, const std::string &context,
-                              const point &grid_offset, const point &grid_total, const JsonObject &weightfunc );
+        mapgen_function_json( const JsonObject &jsobj, dbl_or_var w, const std::string &context,
+                              const point &grid_offset, const point &grid_total );
         ~mapgen_function_json() override = default;
 
         ter_id fill_ter;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Just putting this here but I don't get what I'm doing so this probably won't get done at least soon.
(Just astlying it at least then I'll close)

Aims to add the ability to use a weight function from a json defined list alongside the weight of a map to allow the weight to change at runtime dependant on variables (just time since cata to begin with), allowing different maps to only spawn after a certain time or to stop spawning after a certain time or less simplistic functions like making the map gradually decrease in weight to a minimum quadratically. Could be used in initial implementation to say have "untouched" variants of buildings decline over time, heavily looted/destroyed variants to increase over time and partially looted/destroyed variants to increase then decrease. Could also be used in the future to include other values to say increase the likelihood of running into the faction you've helped the most.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
What solution?
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Sticking to json stuff
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->