### PR TITLE
JSON formatter html build

### DIFF
--- a/.github/workflows/format_emscripten.yml
+++ b/.github/workflows/format_emscripten.yml
@@ -1,0 +1,63 @@
+name: JSON Formatter in HTML
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+    - 'tools/format/**'
+    - 'tools/format_emscripten/**'
+    - '.github/workflows/format_emscripten.yml'
+
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v3
+
+    - name: install dependencies (ubuntu)
+      run: |
+          sudo apt-get update
+          sudo apt-get install emscripten
+
+    - name: Build with emcc (emscripten)
+      run: tools/format_emscripten/build.sh
+
+    - name: Display files
+      run: ls -Rah
+
+    - name: Upload zipped html as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: formatter
+        path: formatter.html
+
+    - uses: actions/checkout@v3
+      with:
+        ref: gh-pages
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: formatter
+
+    - name: Display files
+      run: ls -Rah
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.TX_PR_CREATOR_JSON_LINTER }}
+        commit-message: JSON linter gh-pages file update
+        base: gh-pages
+        branch: gh-pages-json-linter-update
+        branch-suffix: short-commit-hash
+        delete-branch: true
+        add-paths: formatter.html
+        title: Update Github Pages JSON linter page
+        body: "#### Summary\nNone\n\n#### Additional context\nAutomatically generated PR from emscripten compile output"
+        labels: Organization,<Documentation>
+        # create as a draft to allow maintainers to cull the changes before merging
+        draft: true

--- a/tools/format_emscripten/build.sh
+++ b/tools/format_emscripten/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+emcc -std=c++17 -Oz -flto -I src/ -isystem src/third-party/ \
+    -s SINGLE_FILE --shell-file tools/format_emscripten/shell.html -s WASM=1 \
+    -s ENVIRONMENT=web -s MODULARIZE=1 -s 'EXPORT_NAME=json_formatter' -s NO\_FILESYSTEM=1 \
+    -s LLD_REPORT_UNDEFINED -s MINIFY_HTML=0 -s NO_DISABLE_EXCEPTION_CATCHING \
+    -s EXPORTED_FUNCTIONS=_json_format -s EXPORTED_RUNTIME_METHODS=cwrap \
+    src/json.cpp tools/format/format.cpp tools/format_emscripten/format_emscripten.cpp \
+    -o formatter.html

--- a/tools/format_emscripten/format_emscripten.cpp
+++ b/tools/format_emscripten/format_emscripten.cpp
@@ -1,0 +1,35 @@
+enum class error_log_format_t { human_readable };
+extern constexpr error_log_format_t error_log_format = error_log_format_t::human_readable;
+
+#include "../../src/json.h"
+#include "../../tools/format/format.h"
+
+extern "C" {
+    const char *json_format( const char *input )
+    {
+        // we can do the malloc/free game with emscripten
+        // or just leave the buffer in place and realloc
+        // to make sure the strings fit
+        static char *ret = nullptr;
+
+        std::stringstream ss_out;
+        std::stringstream ss_in( input );
+        std::string ret_tmp;
+
+        try {
+            TextJsonIn jsin( ss_in );
+            JsonOut jsout( ss_out, true );
+            formatter::format( jsin, jsout );
+            ret_tmp = ss_out.str();
+        } catch( const std::exception &ex ) {
+            ret_tmp = std::string( ex.what() );
+        }
+
+        const char *ret_ctmp = ret_tmp.c_str();
+        const int len = strlen( ret_ctmp );
+        ret = static_cast<char *>( realloc( ret, len + 1 ) );
+        ret[0] = 0;
+        strncat( ret, ret_ctmp, len );
+        return ret;
+    }
+}

--- a/tools/format_emscripten/shell.html
+++ b/tools/format_emscripten/shell.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en-us">
+
+<head>
+    <meta charset="utf-8">
+    <title>Cataclysm DDA JSON formatter</title>
+    <style>
+        @media (prefers-color-scheme: dark) {
+            :root {
+                color-scheme: dark;
+                --bg: #333;
+                --text: #eee;
+                --textarea: #222;
+                --bad-json-alert: #c30;
+            }
+        }
+
+        @media (prefers-color-scheme: light) {
+            :root {
+                color-scheme: light;
+                --bg: #888;
+                --text: #111;
+                --textarea: #aaa;
+                --bad-json-alert: #c30;
+            }
+        }
+
+        html,
+        body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            color: var(--text);
+            background-color: var(--bg);
+            font-family: sans-serif;
+        }
+
+        body {
+            display: flex;
+            flex-flow: column;
+        }
+
+        .row {
+            flex: 1;
+            display: flex;
+            flex-flow: row;
+        }
+
+        .col {
+            flex: 1;
+            display: flex;
+            flex-flow: column;
+            margin: 4px;
+        }
+
+        label {
+            font-weight: bold;
+            padding: 1em 2em;
+        }
+
+        textarea {
+            flex: 1;
+            display: block;
+            margin: 0;
+            padding: 4px;
+            border: 1px solid;
+            resize: none;
+            font-family: monospace;
+            background-color: var(--textarea);
+            white-space: pre;
+            overflow-wrap: normal;
+            overflow-x: scroll;
+        }
+
+        #json_error_alert {
+            font-size: larger;
+            font-weight: bold;
+            text-align: center;
+            background-color: var(--bad-json-alert);
+            padding: 16px;
+            display: none;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="row">
+        <div class="col">
+            <label for="json_input">Paste unformatted JSON on left side</label>
+            <textarea id="json_input" placeholder="Paste unformatted JSON on left side"></textarea>
+            <span id="json_error_alert">JSON has errors, can't format!</span>
+        </div>
+        <div class="col">
+            <label for="json_output">Copy formatted JSON from right side</label>
+            <textarea id="json_output" readonly onClick="this.select()"></textarea>
+        </div>
+    </div>
+    {{{ SCRIPT }}}
+    <script>
+
+        let json_input = document.getElementById("json_input");
+        let json_output = document.getElementById("json_output");
+        let json_error_alert = document.getElementById("json_error_alert");
+
+        json_input.placeholder =
+            "\n    Paste your unformatted json into this area, and" +
+            "\n    it will be formatted on the right side." +
+            "\n" +
+            "\n    If there is an error you need to fix it first.";
+
+        json_output.placeholder = "\n    Formatter is loading." +
+            "\n    This tool needs javascript enabled, " +
+            "\n    and a modern browser.";
+
+        json_formatter().then(function (module) {
+            let json_format = module.cwrap("json_format", "string", ["string"]);
+
+            json_output.placeholder =
+                "\n\n    Formatter ready."
+                + "\n    Paste into panel on the left to format.";
+
+            json_input.oninput = function () {
+                if (json_input.value.length < 1) {
+                    json_error_alert.style.display = "none";
+                    json_output.value = "";
+                    return;
+                }
+                // not all invalid json is rejected by the cata formatter,
+                // filter early using the browser's parser instead
+                try {
+                    // https://stackoverflow.com/a/20392392
+                    let o = JSON.parse(json_input.value);
+                    if (o && typeof o === "object") {
+                        let formatted = json_format(json_input.value);
+                        json_error_alert.style.display =
+                            (formatted.startsWith("Json error")
+                                ? "block" : "none");
+                        json_output.value = formatted;
+                        return;
+                    }
+                } catch (e) {
+                    json_error_alert.style.display = "block";
+                    json_output.value = e.message;
+                    return;
+                }
+                json_error_alert.style.display = "block";
+                json_output.value =
+                    "Cataclysm JSON must start with array or object";
+            };
+        });
+
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Toyed with emscripten a bit - made a non-cgi formatter for one-file-at-a-time json formatter flow

https://irwiss.github.io/Cataclysm-DDA/formatter.html

#### Describe the solution

Compiles the formatter with emscripten, sprinkles some html/js and the static page can lint in the format cata wants (example above)

It's a bit bigger (~120kB gzipped vs a few kB) than the narc.ro but I think it's worth the tradeoffs: it doesn't hit a cgi server with a large json trout and client side can be snappier if network isn't great. I didn't go into polyfills and the rest of js shenanigans, likely stuff requires es6 - but testing on up to date chromium/firefox it works including mobile

Also uses browser's JSON.parse to early detect some errors cata formatter barfs on (e.g. type in 12345 on narc.ro)

The automated PR maker job needs a personal access token in TX_PR_CREATOR_JSON_LINTER, fine grained worked for me with permissions for "Content" read/write, "Metadata" read-only, "Pull Requests" read/write, not sure if there's a better way to auto PR to gh-pages, stole the action from weekly changelog, although weirdly it starts unshallowing and churning GBs of deltas for just 1 file PR...

#### Describe alternatives you've considered

#### Testing

The PR creation likely won't work until someone with permissions adds a key and reruns actions, not 100% solid on how it works, although considering the amount of hassle with this action  just manually PRing to gh-pages starts to sound more and more attractive

#### Additional context
