### PR TITLE
Reduce hangtime of shocker sparks

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -808,7 +808,7 @@
     "description_affix": "illuminated_by",
     "has_elec": true,
     "priority": 4,
-    "half_life": "4 turns",
+    "half_life": "1 turn",
     "phase": "plasma",
     "display_items": false,
     "display_field": true
@@ -1625,7 +1625,7 @@
     "description_affix": "illuminated_by",
     "has_elec": true,
     "priority": 4,
-    "half_life": "4 turns",
+    "half_life": "1 turn",
     "phase": "plasma",
     "display_items": false,
     "display_field": false,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Reduce hangtime of shocker sparks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Shockers are ubiquitous in the world and basically force survivors to wear activity suits, get the capacitance CBM, or perish. While gear checks are well and good, this one is extremely punishing, partially because the sparks hang in the air for such a long time, resulting in the player being struck many times by a single bolt of lightning that can somehow hang around for several seconds.

Real-life electrical arcs do not hover in midair like a gas. They jump instantaneously from one surface toward another and then blip out of existence. This isn't completely possible with how we've modeled electricity in this game, but it can be better.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

This PR reduces the half-life of both types of spark fields from 4 to 1. The result is that it is just as easy to get hit by a shocker's initial attack or the odd stray bolt, but you are less likely to get spammed with hits from the same source unless you decide to just stand there and take it. Even if you do, it will result in fewer overall hits.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

The spark field is partially hardcoded and I considered messing with that, but it may not be necessary for a small nerf like this. A more comprehensive fix might be to make it so that if a field spreads to a tile which already contains a field, it should not refresh that tile's lifespan.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

I made a test character and spawned a shocker, an incandescent husk, and a shocker brute, and made sure their attacks all looked and acted correctly. I observed that the lightning looks a bit more like lightning now, in a bolt with forks, rather than a big blue and white cloud of death.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->