### PR TITLE
Remove redundant read

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -767,8 +767,6 @@ void Character::load( const JsonObject &data )
 
     data.read( "magic", magic );
 
-    data.read( "underwater", underwater );
-
     data.read( "traits", my_traits );
     // If a trait has been migrated, we'll need to add it.
     // Queue them up to add at the end, because adding and removing at the same time is hard


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

`underwater` is a member of Creature. Creature::load already reads it. Character::load calls Creature::load. No need to read it again.
<!-- 
#### Describe the solution

How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

#### Describe alternatives you've considered

Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

None
<!-- 
#### Additional context

Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->