### PR TITLE
Check map bounds before checking Character::sees()

### DIFF
--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -782,6 +782,11 @@ lit_level map::apparent_light_at( const tripoint &p, const visibility_variables 
     }
 }
 
+bool tinymap::pl_sees( const tripoint &, int ) const
+{
+    return false;
+}
+
 bool map::pl_sees( const tripoint &t, const int max_range ) const
 {
     if( !inbounds( t ) ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1709,7 +1709,7 @@ bool map::furn_set( const tripoint &p, const furn_id &new_furniture, const bool 
     invalidate_max_populated_zlev( p.z );
 
     set_memory_seen_cache_dirty( p );
-    if( player_character.sees( p ) ) {
+    if( pl_sees( p, player_character.sight_max ) ) {
         player_character.memorize_clear_decoration( getabs( p ), "f_" );
     }
 
@@ -2153,7 +2153,7 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_crea
 
     set_memory_seen_cache_dirty( p );
     avatar &player_character = get_avatar();
-    if( player_character.sees( p ) ) {
+    if( pl_sees( p, player_character.sight_max ) ) {
         player_character.memorize_clear_decoration( getabs( p ), "t_" );
     }
 
@@ -5917,7 +5917,7 @@ void map::partial_con_remove( const tripoint_bub_ms &p )
     current_submap->partial_constructions.erase( tripoint_sm_ms( l, p.z() ) );
     set_memory_seen_cache_dirty( p.raw() );
     avatar &player_character = get_avatar();
-    if( player_character.sees( p ) ) {
+    if( pl_sees( p.raw(), player_character.sight_max ) ) {
         player_character.memorize_clear_decoration( getabs( p ), "tr_" );
     }
 }
@@ -5960,7 +5960,7 @@ void map::trap_set( const tripoint &p, const trap_id &type )
 
     set_memory_seen_cache_dirty( p );
     avatar &player_character = get_avatar();
-    if( player_character.sees( p ) ) {
+    if( pl_sees( p, player_character.sight_max ) ) {
         player_character.memorize_clear_decoration( getabs( p ), "tr_" );
     }
     // If there was already a trap here, remove it.
@@ -5997,7 +5997,7 @@ void map::remove_trap( const tripoint &p )
         if( g != nullptr && this == &get_map() ) {
             set_memory_seen_cache_dirty( p );
             avatar &player_character = get_avatar();
-            if( player_character.sees( p ) ) {
+            if( pl_sees( p, player_character.sight_max ) ) {
                 player_character.memorize_clear_decoration( getabs( p ), "tr_" );
             }
             player_character.add_known_trap( p, tr_null.obj() );

--- a/src/map.h
+++ b/src/map.h
@@ -1755,7 +1755,7 @@ class map
          * @param max_range All squares that are further away than this are invisible.
          * Ignored if smaller than 0.
          */
-        bool pl_sees( const tripoint &t, int max_range ) const;
+        virtual bool pl_sees( const tripoint &t, int max_range ) const;
         /**
          * Uses the map cache to tell if the player could see the given square.
          * pl_sees implies pl_line_of_sight
@@ -2293,6 +2293,8 @@ class tinymap : public map
     public:
         tinymap() : map( 2, false ) {}
         bool inbounds( const tripoint &p ) const override;
+        // @returns false
+        bool pl_sees( const tripoint &t, int max_range ) const override;
 };
 
 class fake_map : public tinymap


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/66427

#### Describe the solution

Makes pl_sees overload on tinymap/fake_map return false without accessing lightmap

Doesn't solve the issue completely - the out of bounds read can still be reached just not from this chunk of code, but this will stop the random crash.

#### Describe alternatives you've considered

#### Testing

Mapgen is triggering it randomly, spawning default evacuee in shelter a few times triggers this bug on MSVC

#### Additional context
