### PR TITLE
Pre-strip comment members before deciding whether to create TextJson

### DIFF
--- a/src/flexbuffer_json.cpp
+++ b/src/flexbuffer_json.cpp
@@ -279,7 +279,16 @@ void JsonObject::report_unvisited() const
             mask >>= 1;
         }
 
-        error_skipped_members( skipped_members );
+        // Don't error on skipped comments.
+        skipped_members.erase( std::remove_if( skipped_members.begin(),
+        skipped_members.end(), [this]( size_t idx ) {
+            flexbuffers::String name = keys_[idx].AsString();
+            return strncmp( "//", name.c_str(), 2 ) == 0;
+        } ), skipped_members.end() );
+
+        if( !skipped_members.empty() ) {
+            error_skipped_members( skipped_members );
+        }
         visited_fields_bitset_.set_all();
     }
 #endif
@@ -324,14 +333,12 @@ void JsonObject::error_skipped_members( const std::vector<size_t> &skipped_membe
     jo.allow_omitted_members();
     for( size_t skipped_member_idx : skipped_members ) {
         flexbuffers::String name = keys_[skipped_member_idx].AsString();
-        if( strncmp( "//", name.c_str(), 2 ) != 0 ) {
-            try {
-                jo.throw_error_at( name.c_str(),
-                                   string_format( "Invalid or misplaced field name \"%s\" in JSON data",
-                                                  name.c_str() ) );
-            } catch( const JsonError &e ) {
-                debugmsg( "(json-error)\n%s", e.what() );
-            }
+        try {
+            jo.throw_error_at( name.c_str(),
+                               string_format( "Invalid or misplaced field name \"%s\" in JSON data",
+                                              name.c_str() ) );
+        } catch( const JsonError &e ) {
+            debugmsg( "(json-error)\n%s", e.what() );
         }
         mark_visited( skipped_member_idx );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Re-enabling skipped member checking was a good idea. It also exposed the fact that not erroring on comments worked... but only after the expensive part of the flow already happened. Creating the TextJsonIn and advancing it to the erroring location consumed 1/3 the cpu used in my test case of loading a save, a full 10+s. Lets, uh, fix that.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
After parsing the visited member bitmask into indices, remove indices that map to comment type members (start with `//`). Then don't call the expensive function if there are no indices left.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Perf test the same save. Profiler is a little bunk right now but, left is before right is after. `basic_istream` self cpu usage no longer top of functions.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/0a7a348e-55ee-4353-ac17-0e56fd1bf5ab)

 `JsonObject::report_unvisited` total cpu zeroes out after.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/771d4a29-23a8-428a-97fd-8de3a36677aa)

Introduce a new random member in an object and verified game still fires on it.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/604826fe-68cd-42a0-be89-76ffb8663faf)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->