### PR TITLE
Remove `welding_components` item

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -3584,21 +3584,6 @@
   },
   {
     "type": "GENERIC",
-    "id": "welding_components",
-    "category": "spare_parts",
-    "material": [ "steel" ],
-    "symbol": ";",
-    "color": "red",
-    "name": { "str": "welding component kit" },
-    "description": "A set of components useful for constructing a full-featured welding station, complete with soldering capability.",
-    "price": 9000,
-    "price_postapoc": 2500,
-    "weight": "4500 g",
-    "volume": "3 L",
-    "melee_damage": { "bash": 8 }
-  },
-  {
-    "type": "GENERIC",
     "id": "amplifier_head",
     "symbol": ";",
     "color": "blue",

--- a/data/json/obsoletion/migrate_to_VEH_TOOLS.json
+++ b/data/json/obsoletion/migrate_to_VEH_TOOLS.json
@@ -20,6 +20,12 @@
     "replace": "veh_tools_kitchen"
   },
   {
+    "id": "welding_components",
+    "type": "MIGRATION",
+    "replace": "bag_plastic",
+    "contents": [ { "id": "welder", "count": 1 }, { "id": "soldering_iron", "count": 1 } ]
+  },
+  {
     "type": "vehicle_part_migration",
     "from": "ap_weldkit",
     "to": "veh_tools_workshop",

--- a/data/json/obsoletion/migrate_to_VEH_TOOLS.json
+++ b/data/json/obsoletion/migrate_to_VEH_TOOLS.json
@@ -24,7 +24,7 @@
     "type": "MIGRATION",
     "replace": "bag_plastic",
     "contents": [ { "id": "welder", "count": 1 }, { "id": "soldering_iron", "count": 1 } ]
-  }
+  },
   {
     "type": "vehicle_part_migration",
     "from": "ap_weldkit",

--- a/data/json/obsoletion/migrate_to_VEH_TOOLS.json
+++ b/data/json/obsoletion/migrate_to_VEH_TOOLS.json
@@ -24,7 +24,7 @@
     "type": "MIGRATION",
     "replace": "bag_plastic",
     "contents": [ { "id": "welder", "count": 1 }, { "id": "soldering_iron", "count": 1 } ]
-  },
+  }
   {
     "type": "vehicle_part_migration",
     "from": "ap_weldkit",

--- a/data/json/recipes/other/parts.json
+++ b/data/json/recipes/other/parts.json
@@ -666,22 +666,6 @@
   },
   {
     "type": "recipe",
-    "activity_level": "MODERATE_EXERCISE",
-    "result": "welding_components",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_PARTS",
-    "skill_used": "mechanics",
-    "skills_required": [ "electronics", 4 ],
-    "difficulty": 4,
-    "time": "10 m",
-    "reversible": true,
-    "decomp_learn": 4,
-    "book_learn": [ [ "textbook_mechanics", 6 ], [ "textbook_electronics", 8 ], [ "textbook_fabrication", 8 ], [ "welding_book", 5 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
-    "components": [ [ [ "soldering_iron", 1 ] ], [ [ "welder", 1 ], [ "welder_crude", 2 ] ] ]
-  },
-  {
-    "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "electrolysis_kit",
     "category": "CC_ELECTRONIC",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Remove not used `welding component kit` item"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Cleanup. #65112 removed all items that `welding component kit` was used in, so this item is useless now.

#### Describe the solution

Remove crafting recipe for `welding_components`
Add migration to convert existing `welding_components` into its parts: arc welder and soldering iron.

#### Describe alternatives you've considered

N/A

#### Testing

1. Check that `welding component kit` recipe is no longer available.
2. Spawn `welding component kit`.
3. Update json with migration.
4. Check that `welding component kit` is replaced with a plastic bag that contains arc welder and soldering iron.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->