### PR TITLE
Autostyle on save for VSC

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
-    "recommendations": [
-        "ms-vscode-remote.remote-containers",
-        "ms-azuretools.vscode-docker"
-    ]
+  "recommendations": [
+    "ms-vscode-remote.remote-containers",
+    "ms-azuretools.vscode-docker",
+    "emeraldwalk.runonsave"
+  ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
   "recommendations": [
     "ms-vscode-remote.remote-containers",
     "ms-azuretools.vscode-docker",
-    "emeraldwalk.runonsave"
+    "cdda-toys.cdda-json-formatter"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,7 +34,12 @@
             {
                 "match": "\\.json$",
                 "isAsync": true,
-                "cmd": "${workspaceFolder}/tools/format/json_formatter ${file}"
+                "cmd": "${workspaceFolder}/tools/format/json_formatter ${file}",
+            },
+            {
+                "match": "\\.json$",
+                "isAsync": true,
+                "cmd": "${workspaceFolder}/tools/format/json_formatter.cgi ${file}",
             },
         ]
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,18 +29,4 @@
     "github-actions.remote-name": "upstream",
     // NOTE: This disable the plugins formatting so astyle is used.
     "C_Cpp.formatting": "disabled",
-    "emeraldwalk.runonsave": {
-        "commands": [
-            {
-                "match": "\\.json$",
-                "isAsync": true,
-                "cmd": "${workspaceFolder}/tools/format/json_formatter ${file}",
-            },
-            {
-                "match": "\\.json$",
-                "isAsync": true,
-                "cmd": "${workspaceFolder}/tools/format/json_formatter.cgi ${file}",
-            },
-        ]
-    },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,4 +29,13 @@
     "github-actions.remote-name": "upstream",
     // NOTE: This disable the plugins formatting so astyle is used.
     "C_Cpp.formatting": "disabled",
+    "emeraldwalk.runonsave": {
+        "commands": [
+            {
+                "match": "\\.json$",
+                "isAsync": true,
+                "cmd": "${workspaceFolder}/tools/format/json_formatter ${file}"
+            },
+        ]
+    },
 }

--- a/doc/JSON_STYLE.md
+++ b/doc/JSON_STYLE.md
@@ -91,4 +91,4 @@ position of your command in the list (e.g. `Tools.ExternalCommand1` if it's the
 top item in the list) and then assign shortcut keys to it.
 
 ### Visual Studio Code
-**If you have compiled the json formatter** you can set up styling on auto save by installing the recommended extension `emeraldwalk.runonsave`. After install any json file you save should style correctly.
+If you install the recommended extensions you should have access to the the cdda-toys.cdda-json-formatter which will auto format your json.

--- a/doc/JSON_STYLE.md
+++ b/doc/JSON_STYLE.md
@@ -89,3 +89,6 @@ Additionally, you can configure a keybinding for this command by navigating to
 containing `Tools.ExternalCommand` and pick the one that corresponds to the
 position of your command in the list (e.g. `Tools.ExternalCommand1` if it's the
 top item in the list) and then assign shortcut keys to it.
+
+### Visual Studio Code
+**If you have compiled the json formatter** you can set up styling on auto save by installing the recommended extension `emeraldwalk.runonsave`. After install any json file you save should style correctly.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Something I've wanted for a while, autostyling in VSC.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Irwiss actually set up a plugin for VSC that does this, so I just added it to the recommended plugins.


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->