### PR TITLE
EOC Run Until

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -15,6 +15,19 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_run_until_test",
+    "effect": [
+      { "set_condition": "to_test", "condition": { "math": [ "u_context", "<", "10" ] } },
+      { "run_eoc_until": "EOC_until_nested", "condition": "to_test" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_until_nested",
+    "effect": [ { "math": [ "u_context", "++" ] }, { "math": [ "key1", "=", "u_context" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_stored_condition_test",
     "effect": [
       { "set_condition": "to_test", "condition": { "math": [ "_context", ">", "0" ] } },

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -54,107 +54,108 @@ EVENT EOCs trigger on in game events specified in the event_type enum in `event.
 Every event EOC passes context vars with each of their key value pairs that the event has in C++.  They are all converted to strings when made context variables but their original types are included for reference below.  At some point this documentation may go out of sync, The up to date info for each event can be found in event.h
 
 ## Event EOC Types:
-EVENT            | Description | Context Variables |
---------------------- | --------- | ----------- |
-activates_artifact | Triggers when the player activates an artifact | { "character", `character_id` }, { "item_name", `string` }, |
-activates_mininuke |  | { "character", `character_id` } |
-administers_mutagen |  | { "character", `character_id` }, { "technique", `mutagen_technique` }, |
-angers_amigara_horrors |  | NONE |
-avatar_enters_omt |  | { "pos", `tripoint` }, { "oter_id", `oter_id` }, |
-avatar_moves |  | { "mount", `mtype_id` }, { "terrain", `ter_id` }, { "movement_mode", `move_mode_id` }, { "underwater", `bool` }, { "z", `int` }, |
-avatar_dies |  | NONE |
-awakes_dark_wyrms |  | NONE |
-becomes_wanted |  | { "character", `character_id` } |
-broken_bone |  | { "character", `character_id` }, { "part", `body_part` }, |
-broken_bone_mends |  | { "character", `character_id` }, { "part", `body_part` }, |
-buries_corpse |  | { "character", `character_id` }, { "corpse_type", `mtype_id` }, { "corpse_name", `string` }, |
-causes_resonance_cascade |  | NONE |
-character_consumes_item |  | { "character", `character_id` }, { "itype", `itype_id` }, |
-character_eats_item |  | { "character", `character_id` }, { "itype", `itype_id` }, |
-character_forgets_spell |  | { "character", `character_id` }, { "spell", `spell_id` } |
-character_gains_effect |  | { "character", `character_id` }, { "effect", `efftype_id` }, |
-character_gets_headshot |  | { "character", `character_id` } |
-character_heals_damage |  | { "character", `character_id` }, { "damage", `int` }, |
-character_kills_character |  | { "killer", `character_id` }, { "victim", `character_id` }, { "victim_name", `string` }, |
-character_kills_monster |  | { "killer", `character_id` }, { "victim_type", `mtype_id` }, |
-character_learns_spell |  | { "character", `character_id` }, { "spell", `spell_id` } |
-character_loses_effect |  | { "character", `character_id` }, { "effect", `efftype_id` }, |
-character_melee_attacks_character |  | { "attacker", `character_id` }, { "weapon", `itype_id` }, { "hits", `bool` }, { "victim", `character_id` }, { "victim_name", `string` }, |
-character_melee_attacks_monster | | { "attacker", `character_id` }, { "weapon", `itype_id` }, { "hits", `bool` }, { "victim_type", `mtype_id` },|
-character_ranged_attacks_character | |  { "attacker", `character_id` },  { "weapon", `itype_id` }, { "victim", `character_id` }, { "victim_name", `string` }, |
-character_ranged_attacks_monster | | { "attacker", `character_id` }, { "weapon", `itype_id` }, { "victim_type", `mtype_id` }, |
-character_smashes_tile | | { "character", `character_id` },  { "terrain", `ter_str_id` },  { "furniture", `furn_str_id` }, |
-character_takes_damage | | { "character", `character_id` }, { "damage", `int` }, |
-character_triggers_trap | | { "character", `character_id` }, { "trap", `trap_str_id` }, |
-character_wakes_up | | { "character", `character_id` }, |
-character_wields_item | | { "character", `character_id` }, { "itype", `itype_id` }, |
-character_wears_item | | { "character", `character_id` }, { "itype", `itype_id` }, |
-consumes_marloss_item | | { "character", `character_id` }, { "itype", `itype_id` }, |
-crosses_marloss_threshold | | { "character", `character_id` } |
-crosses_mutation_threshold | | { "character", `character_id` }, { "category", `mutation_category_id` }, |
-crosses_mycus_threshold | | { "character", `character_id` } |
-cuts_tree | | { "character", `character_id` } |
-dermatik_eggs_hatch | | { "character", `character_id` } |
-dermatik_eggs_injected | | { "character", `character_id` } |
-destroys_triffid_grove | | NONE |
-dies_from_asthma_attack | | { "character", `character_id` } |
-dies_from_drug_overdose | | { "character", `character_id` }, { "effect", `efftype_id` }, |
-dies_from_bleeding | | { "character", `character_id` }  |
-dies_from_hypovolemia | | { "character", `character_id` }  |
-dies_from_redcells_loss | | { "character", `character_id` }  |
-dies_of_infection | | { "character", `character_id` }  |
-dies_of_starvation | | { "character", `character_id` }  |
-dies_of_thirst | | { "character", `character_id` }  |
-digs_into_lava | | NONE  |
-disarms_nuke | | NONE  |
-eats_sewage | | NONE  |
-evolves_mutation | | { "character", `character_id` }, { "from_trait", `trait_id` }, { "to_trait", `trait_id` }, |
-exhumes_grave | | { "character", `character_id` } |
-fails_to_install_cbm | | { "character", `character_id` }, { "bionic", `bionic_id` }, |
-fails_to_remove_cbm | | { "character", `character_id` }, { "bionic", `bionic_id` }, |
-falls_asleep_from_exhaustion | | { "character", `character_id` } |
-fuel_tank_explodes | | { "vehicle_name", `string` }, |
-gains_addiction | |  { "character", `character_id` }, { "add_type", `addiction_id` }, |
-gains_mutation | |  { "character", `character_id` }, { "trait", `trait_id` }, |
-gains_skill_level | | { "character", `character_id` }, { "skill", `skill_id` }, { "new_level", `int` }, |
-game_avatar_death | | { "avatar_id", `character_id` }, { "avatar_name", `string` }, { "avatar_is_male", `bool` }, { "is_suicide", `bool` }, { "last_words", `string` }, |
-game_avatar_new | | { "is_new_game", `bool` }, { "is_debug", `bool` }, { "avatar_id", `character_id` }, { "avatar_name", `string` }, { "avatar_is_male", `bool` }, { "avatar_profession", `profession_id` }, { "avatar_custom_profession", `string` }, |
-game_load | | { "cdda_version", `string` }, |
-game_begin | | { "cdda_version", `string` }, |
-game_over | | { "total_time_played", `chrono_seconds` }, |
-game_save | | { "time_since_load", `chrono_seconds` }, { "total_time_played", `chrono_seconds` }, |
-game_start | | { "game_version", `string` }, |
-installs_cbm | | { "character", `character_id` }, { "bionic", `bionic_id` }, |
-installs_faulty_cbm | | { "character", `character_id` }, { "bionic", `bionic_id` }, |
-learns_martial_art | |  { "character", `character_id` }, { "martial_art", `matype_id` }, |
-loses_addiction | | { "character", `character_id` }, { "add_type", `addiction_id` }, |
-npc_becomes_hostile | | { "npc", `character_id` }, { "npc_name", `string` }, |
-opens_portal | | NONE |
-opens_spellbook | | { "character", `character_id` } |
-opens_temple | | NONE |
-player_fails_conduct | | { "conduct", `achievement_id` }, { "achievements_enabled", `bool` }, |
-player_gets_achievement | | { "achievement", `achievement_id` }, { "achievements_enabled", `bool` }, |
-player_levels_spell | | { "character", `character_id` }, { "spell", `spell_id` }, { "new_level", `int` }, |
-reads_book | | { "character", `character_id` } |
-releases_subspace_specimens | | NONE |
-removes_cbm | |  { "character", `character_id` }, { "bionic", `bionic_id` }, |
-seals_hazardous_material_sarcophagus | | NONE |
-spellcasting_finish | | { "character", `character_id` }, { "spell", `spell_id` }, { "school", `trait_id` }  |
-telefrags_creature | | { "character", `character_id` }, { "victim_name", `string` }, |
-teleglow_teleports | | { "character", `character_id` } |
-teleports_into_wall | | { "character", `character_id` }, { "obstacle_name", `string` }, |
-terminates_subspace_specimens | | NONE |
-throws_up | | { "character", `character_id` } |
-triggers_alarm | | { "character", `character_id` } | 
-uses_debug_menu | | { "debug_menu_option", `debug_menu_index` }, | 
-u_var_changed | | { "var", `string` }, { "value", `string` }, |
-vehicle_moves | | { "avatar_on_board", `bool` }, { "avatar_is_driving", `bool` }, { "avatar_remote_control", `bool` }, { "is_flying_aircraft", `bool` }, { "is_floating_watercraft", `bool` }, { "is_on_rails", `bool` }, { "is_falling", `bool` }, { "is_sinking", `bool` }, { "is_skidding", `bool` }, { "velocity", `int` }, // vehicle current velocity, mph * 100 { "z", `int` }, |
+
+| EVENT            | Description | Context Variables |
+| --------------------- | --------- | ----------- |
+| activates_artifact | Triggers when the player activates an artifact | { "character", `character_id` }, { "item_name", `string` }, |
+| activates_mininuke |  | { "character", `character_id` } |
+| administers_mutagen |  | { "character", `character_id` }, { "technique", `mutagen_technique` }, |
+| angers_amigara_horrors |  | NONE |
+| avatar_enters_omt |  | { "pos", `tripoint` }, { "oter_id", `oter_id` }, |
+| avatar_moves |  | { "mount", `mtype_id` }, { "terrain", `ter_id` }, { "movement_mode", `move_mode_id` }, { "underwater", `bool` }, { "z", `int` }, |
+| avatar_dies |  | NONE |
+| awakes_dark_wyrms |  | NONE |
+| becomes_wanted |  | { "character", `character_id` } |
+| broken_bone |  | { "character", `character_id` }, { "part", `body_part` }, |
+| broken_bone_mends |  | { "character", `character_id` }, { "part", `body_part` }, |
+| buries_corpse |  | { "character", `character_id` }, { "corpse_type", `mtype_id` }, { "corpse_name", `string` }, |
+| causes_resonance_cascade |  | NONE |
+| character_consumes_item |  | { "character", `character_id` }, { "itype", `itype_id` }, |
+| character_eats_item |  | { "character", `character_id` }, { "itype", `itype_id` }, |
+| character_forgets_spell |  | { "character", `character_id` }, { "spell", `spell_id` } |
+| character_gains_effect |  | { "character", `character_id` }, { "effect", `efftype_id` }, |
+| character_gets_headshot |  | { "character", `character_id` } |
+| character_heals_damage |  | { "character", `character_id` }, { "damage", `int` }, |
+| character_kills_character |  | { "killer", `character_id` }, { "victim", `character_id` }, { "victim_name", `string` }, |
+| character_kills_monster |  | { "killer", `character_id` }, { "victim_type", `mtype_id` }, |
+| character_learns_spell |  | { "character", `character_id` }, { "spell", `spell_id` } |
+| character_loses_effect |  | { "character", `character_id` }, { "effect", `efftype_id` }, |
+| character_melee_attacks_character |  | { "attacker", `character_id` }, { "weapon", `itype_id` }, { "hits", `bool` }, { "victim", `character_id` }, { "victim_name", `string` }, |
+| character_melee_attacks_monster | | { "attacker", `character_id` }, { "weapon", `itype_id` }, { "hits", `bool` }, { "victim_type", `mtype_id` },|
+| character_ranged_attacks_character | |  { "attacker", `character_id` },  { "weapon", `itype_id` }, { "victim", `character_id` }, { "victim_name", `string` }, |
+| character_ranged_attacks_monster | | { "attacker", `character_id` }, { "weapon", `itype_id` }, { "victim_type", `mtype_id` }, |
+| character_smashes_tile | | { "character", `character_id` },  { "terrain", `ter_str_id` },  { "furniture", `furn_str_id` }, |
+| character_takes_damage | | { "character", `character_id` }, { "damage", `int` }, |
+| character_triggers_trap | | { "character", `character_id` }, { "trap", `trap_str_id` }, |
+| character_wakes_up | | { "character", `character_id` }, |
+| character_wields_item | | { "character", `character_id` }, { "itype", `itype_id` }, |
+| character_wears_item | | { "character", `character_id` }, { "itype", `itype_id` }, |
+| consumes_marloss_item | | { "character", `character_id` }, { "itype", `itype_id` }, |
+| crosses_marloss_threshold | | { "character", `character_id` } |
+| crosses_mutation_threshold | | { "character", `character_id` }, { "category", `mutation_category_id` }, |
+| crosses_mycus_threshold | | { "character", `character_id` } |
+| cuts_tree | | { "character", `character_id` } |
+| dermatik_eggs_hatch | | { "character", `character_id` } |
+| dermatik_eggs_injected | | { "character", `character_id` } |
+| destroys_triffid_grove | | NONE |
+| dies_from_asthma_attack | | { "character", `character_id` } |
+| dies_from_drug_overdose | | { "character", `character_id` }, { "effect", `efftype_id` }, |
+| dies_from_bleeding | | { "character", `character_id` }  |
+| dies_from_hypovolemia | | { "character", `character_id` }  |
+| dies_from_redcells_loss | | { "character", `character_id` }  |
+| dies_of_infection | | { "character", `character_id` }  |
+| dies_of_starvation | | { "character", `character_id` }  |
+| dies_of_thirst | | { "character", `character_id` }  |
+| digs_into_lava | | NONE  |
+| disarms_nuke | | NONE  |
+| eats_sewage | | NONE  |
+| evolves_mutation | | { "character", `character_id` }, { "from_trait", `trait_id` }, { "to_trait", `trait_id` }, |
+| exhumes_grave | | { "character", `character_id` } |
+| fails_to_install_cbm | | { "character", `character_id` }, { "bionic", `bionic_id` }, |
+| fails_to_remove_cbm | | { "character", `character_id` }, { "bionic", `bionic_id` }, |
+| falls_asleep_from_exhaustion | | { "character", `character_id` } |
+| fuel_tank_explodes | | { "vehicle_name", `string` }, |
+| gains_addiction | |  { "character", `character_id` }, { "add_type", `addiction_id` }, |
+| gains_mutation | |  { "character", `character_id` }, { "trait", `trait_id` }, |
+| gains_skill_level | | { "character", `character_id` }, { "skill", `skill_id` }, { "new_level", `int` }, |
+| game_avatar_death | | { "avatar_id", `character_id` }, { "avatar_name", `string` }, { "avatar_is_male", `bool` }, { "is_suicide", `bool` }, { "last_words", `string` }, |
+| game_avatar_new | | { "is_new_game", `bool` }, { "is_debug", `bool` }, { "avatar_id", `character_id` }, { "avatar_name", `string` }, { "avatar_is_male", `bool` }, { "avatar_profession", `profession_id` }, { "avatar_custom_profession", `string` }, |
+| game_load | | { "cdda_version", `string` }, |
+| game_begin | | { "cdda_version", `string` }, |
+| game_over | | { "total_time_played", `chrono_seconds` }, |
+| game_save | | { "time_since_load", `chrono_seconds` }, { "total_time_played", `chrono_seconds` }, |
+| game_start | | { "game_version", `string` }, |
+| installs_cbm | | { "character", `character_id` }, { "bionic", `bionic_id` }, |
+| installs_faulty_cbm | | { "character", `character_id` }, { "bionic", `bionic_id` }, |
+| learns_martial_art | |  { "character", `character_id` }, { "martial_art", `matype_id` }, |
+| loses_addiction | | { "character", `character_id` }, { "add_type", `addiction_id` }, |
+| npc_becomes_hostile | | { "npc", `character_id` }, { "npc_name", `string` }, |
+| opens_portal | | NONE |
+| opens_spellbook | | { "character", `character_id` } |
+| opens_temple | | NONE |
+| player_fails_conduct | | { "conduct", `achievement_id` }, { "achievements_enabled", `bool` }, |
+| player_gets_achievement | | { "achievement", `achievement_id` }, { "achievements_enabled", `bool` }, |
+| player_levels_spell | | { "character", `character_id` }, { "spell", `spell_id` }, { "new_level", `int` }, |
+| reads_book | | { "character", `character_id` } |
+| releases_subspace_specimens | | NONE |
+| removes_cbm | |  { "character", `character_id` }, { "bionic", `bionic_id` }, |
+| seals_hazardous_material_sarcophagus | | NONE |
+| spellcasting_finish | | { "character", `character_id` }, { "spell", `spell_id` }, { "school", `trait_id` }  |
+| telefrags_creature | | { "character", `character_id` }, { "victim_name", `string` }, |
+| teleglow_teleports | | { "character", `character_id` } |
+| teleports_into_wall | | { "character", `character_id` }, { "obstacle_name", `string` }, |
+| terminates_subspace_specimens | | NONE |
+| throws_up | | { "character", `character_id` } |
+| triggers_alarm | | { "character", `character_id` } | 
+| uses_debug_menu | | { "debug_menu_option", `debug_menu_index` }, | 
+| u_var_changed | | { "var", `string` }, { "value", `string` }, |
+| vehicle_moves | | { "avatar_on_board", `bool` }, { "avatar_is_driving", `bool` }, { "avatar_remote_control", `bool` }, { "is_flying_aircraft", `bool` }, { "is_floating_watercraft", `bool` }, { "is_on_rails", `bool` }, { "is_falling", `bool` }, { "is_sinking", `bool` }, { "is_skidding", `bool` }, { "velocity", `int` }, // vehicle current velocity, mph * 100 { "z", `int` }, |
 
 ## Context Variables For Other EOCs
 Other EOCs have some variables as well that they have access to, they are as follows:
 
-EOC            | Context Variables |
---------------------- | ----------- |
-mutation: "activated_eocs" | { "this", `mutation_id` }
-mutation: "processed_eocs" | { "this", `mutation_id` }
-mutation: "deactivated_eocs" | { "this", `mutation_id` }
+| EOC            | Context Variables |
+| --------------------- | ----------- |
+| mutation: "activated_eocs" | { "this", `mutation_id` }
+| mutation: "processed_eocs" | { "this", `mutation_id` }
+| mutation: "deactivated_eocs" | { "this", `mutation_id` }

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -954,7 +954,7 @@ New EOC effects that are documented should be in the format below.
 | Effect                 | Options            | Description   |
 | ---------------------- | ------- | --- |
 | `u_attack, npc_attack` | `u_attack`: string or [variable object](#variable-object) The technique ID to use, if you don't want a specific tech provide "tec_none" </br> `allow_special: ` bool, **default true**, whether or not a special attack should be selected. </br> `allow_unarmed: ` bool **default true** if unarmed techs should be considered </br> `forced_movecost: ` double or [variable object](#variable-object) **default -1.0** the attack will take a fixed amount of moves, any negative value will be ignored (giving the moves standard cost) | the selected talker attacks the other talker with a melee attack. |
-| `run_eoc_until`        | `run_eoc_until`: EOC or inline EOC The eoc to run multiple times </br> `condition` string or [variable object](#variable-object) The name of the condition from the current context to evaluate to see if execution should continue  | The provided EOC is run until the condition given is false. |
+| `run_eoc_until`        | `run_eoc_until`: EOC or inline EOC The eoc to run multiple times </br> `condition` string or [variable object](#variable-object) The name of the condition from the current context to evaluate to see if execution should continue </br> `iteration` double or [variable object](#variable-object) The number of iterations this loop is allowed to go for before throwing an error, **default 100**  | The provided EOC is run until the condition given is false. |
 
 
 #### Deprecated

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -927,12 +927,12 @@ Effect | Description
 
 #### General
 
-Effect | Description
----|---
-`sound_effect: `string or [variable object](#variable-object), (*optional* `sound_effect_variant: `string or [variable object](#variable-object)), (*optional* `outdoor_event: outdoor_event`), (*optional* `volume: `int or [variable object](#variable-object))  | Will play a sound effect of id `sound_effect` and variant `sound_effect_variant`. If `volume` is defined it will be used otherwise 80 is the default. If `outdoor_event`(defaults to false) is true this will be less likely to play if the player is underground.
-`open_dialogue`, (*optional* `topic: `string or [variable object](#variable-object)), (*optional* `true_eocs: eocs_array`), (*optional* `false_eocs: eocs_array`). | Opens up a dialog between the participants. This should only be used in effect_on_conditions. If the dialog is opened, then all of the effect_on_conditions in `true_eocs` are run, otherwise all the effect_on_conditions in `false_eocs` are run. If `topic` is supplied than a conversation with an empty talker starting with the topic `topic` will be opened.
-`take_control`, (*optional* `true_eocs: eocs_array`), (*optional* `false_eocs: eocs_array`) | If the npc is a character then take control of them and then all of the effect_on_conditions in `true_eocs` are run, otherwise all the effect_on_conditions in `false_eocs` are run.
-`give_achievement` string or [variable object](#variable-object), Marks the given achievement as complete.
+| Effect | Description                                                                                                                                                                                                                                                        |
+| ---- | ---- |
+| `sound_effect: `string or [variable object](#variable-object), (*optional* `sound_effect_variant: `string or [variable object](#variable-object)), (*optional* `outdoor_event: outdoor_event`), (*optional* `volume: `int or [variable object](#variable-object)) | Will play a sound effect of id `sound_effect` and variant `sound_effect_variant`. If `volume` is defined it will be used otherwise 80 is the default. If `outdoor_event`(defaults to false) is true this will be less likely to play if the player is underground. |
+| `open_dialogue`, (*optional* `topic: `string or [variable object](#variable-object)), (*optional* `true_eocs: eocs_array`), (*optional* `false_eocs: eocs_array`). | Opens up a dialog between the participants. This should only be used in effect_on_conditions. If the dialog is opened, then all of the effect_on_conditions in `true_eocs` are run, otherwise all the effect_on_conditions in `false_eocs` are run. If `topic` is supplied than a conversation with an empty talker starting with the topic `topic` will be opened.
+| `take_control`, (*optional* `true_eocs: eocs_array`), (*optional* `false_eocs: eocs_array`) | If the npc is a character then take control of them and then all of the effect_on_conditions in `true_eocs` are run, otherwise all the effect_on_conditions in `false_eocs` are run.
+| `give_achievement` string or [variable object](#variable-object), | Marks the given achievement as complete.
 `take_control_menu` | Opens up a menu to choose a follower to take control of.
 `assign_mission: `string or [variable object](#variable-object) | Will assign mission to the player.
 `remove_active_mission: `string or [variable object](#variable-object) | Will remove mission from the player's active mission list without failing it.
@@ -950,9 +950,11 @@ Effect | Description
 
 #### Detailed Info
 New EOC effects that are documented should be in the format below.
-| Effect | Options | Description |
-| ----- | ------ | ------ |
-`u_attack, npc_attack` | `u_attack`: string or [variable object](#variable-object) The technique ID to use, if you don't want a specific tech provide "tec_none" </br> `allow_special: ` bool, **default true**, whether or not a special attack should be selected. </br> `allow_unarmed: ` bool **default true** if unarmed techs should be considered </br> `forced_movecost: ` double or [variable object](#variable-object) **default -1.0** the attack will take a fixed amount of moves, any negative value will be ignored (giving the moves standard cost) | the selected talker attacks the other talker with a melee attack. 
+
+| Effect                 | Options            | Description   |
+| ---------------------- | ------- | --- |
+| `u_attack, npc_attack` | `u_attack`: string or [variable object](#variable-object) The technique ID to use, if you don't want a specific tech provide "tec_none" </br> `allow_special: ` bool, **default true**, whether or not a special attack should be selected. </br> `allow_unarmed: ` bool **default true** if unarmed techs should be considered </br> `forced_movecost: ` double or [variable object](#variable-object) **default -1.0** the attack will take a fixed amount of moves, any negative value will be ignored (giving the moves standard cost) | the selected talker attacks the other talker with a melee attack. |
+| `run_eoc_until`        | `run_eoc_until`: EOC or inline EOC The eoc to run multiple times </br> `condition` string or [variable object](#variable-object) The name of the condition from the current context to evaluate to see if execution should continue  | The provided EOC is run until the condition given is false. |
 
 
 #### Deprecated

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -51,6 +51,7 @@ struct talk_effect_fun_t {
         void set_make_sound( const JsonObject &jo, const std::string &member, bool is_npc );
         void set_run_eocs( const JsonObject &jo, std::string_view member );
         void set_run_eoc_with( const JsonObject &jo, std::string_view member );
+        void set_run_eoc_until( const JsonObject &jo, std::string_view member );
         void set_run_eoc_selector( const JsonObject &jo, const std::string &member );
         void set_run_npc_eocs( const JsonObject &jo, std::string_view member, bool is_npc );
         void set_queue_eocs( const JsonObject &jo, std::string_view member );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4136,14 +4136,34 @@ void talk_effect_fun_t::set_run_eoc_until( const JsonObject &jo, const std::stri
 
     str_or_var condition = get_str_or_var( jo.get_member( "condition" ), "condition" );
 
+    dbl_or_var itteration_count;
+    if( jo.has_member( "itteration_count" ) ) {
+        itteration_count = get_dbl_or_var( jo.get_member( "itteration_count" ), "itteration_count" );
+    }
 
-    function = [eoc, condition]( dialogue & d ) {
+
+    function = [eoc, condition, itteration_count]( dialogue & d ) {
         auto itt = d.get_conditionals().find( condition.evaluate( d ) );
         if( itt == d.get_conditionals().end() ) {
             debugmsg( string_format( "No condition with the name %s", condition.evaluate( d ) ) );
             return;
         }
+        int max_itteration = 100;
+        int given_itteration = itteration_count.evaluate( d );
+
+        if( given_itteration > 0 ) {
+            max_itteration = given_itteration;
+        }
+
+        int curr_itteration = 0;
+
         while( itt->second( d ) ) {
+            curr_itteration++;
+            if( curr_itteration > max_itteration ) {
+                debugmsg( string_format( "EOC loop ran for more instances than the max allowed: %d. Exiting loop.",
+                                         max_itteration ) );
+                break;
+            }
             eoc->activate( d );
         }
     };

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4136,10 +4136,7 @@ void talk_effect_fun_t::set_run_eoc_until( const JsonObject &jo, const std::stri
 
     str_or_var condition = get_str_or_var( jo.get_member( "condition" ), "condition" );
 
-    dbl_or_var iteration_count;
-    if( jo.has_member( "iteration_count" ) ) {
-        iteration_count = get_dbl_or_var( jo.get_member( "iteration_count" ), "iteration_count" );
-    }
+    dbl_or_var iteration_count = get_dbl_or_var( jo, "iteration_count", false, 100 );
 
 
     function = [eoc, condition, iteration_count]( dialogue & d ) {
@@ -4148,12 +4145,8 @@ void talk_effect_fun_t::set_run_eoc_until( const JsonObject &jo, const std::stri
             debugmsg( string_format( "No condition with the name %s", condition.evaluate( d ) ) );
             return;
         }
-        int max_iteration = 100;
-        int given_iteration = iteration_count.evaluate( d );
 
-        if( given_iteration > 0 ) {
-            max_iteration = given_iteration;
-        }
+        int max_iteration = iteration_count.evaluate( d );
 
         int curr_iteration = 0;
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4130,6 +4130,25 @@ void talk_effect_fun_t::set_run_eocs( const JsonObject &jo, const std::string_vi
     };
 }
 
+void talk_effect_fun_t::set_run_eoc_until( const JsonObject &jo, const std::string_view member )
+{
+    effect_on_condition_id eoc = effect_on_conditions::load_inline_eoc( jo.get_member( member ), "" );
+
+    str_or_var condition = get_str_or_var( jo.get_member( "condition" ), "condition" );
+
+
+    function = [eoc, condition]( dialogue & d ) {
+        auto itt = d.get_conditionals().find( condition.evaluate( d ) );
+        if( itt == d.get_conditionals().end() ) {
+            debugmsg( string_format( "No condition with the name %s", condition.evaluate( d ) ) );
+            return;
+        }
+        while( itt->second( d ) ) {
+            eoc->activate( d );
+        }
+    };
+}
+
 void talk_effect_fun_t::set_run_eoc_selector( const JsonObject &jo, const std::string &member )
 {
     std::vector<str_or_var> eocs;
@@ -5238,6 +5257,8 @@ void talk_effect_t::parse_sub_effect( const JsonObject &jo )
             subeffect_fun.set_make_sound( jo, "npc_make_sound", true );
         } else if( jo.has_array( "run_eocs" ) || jo.has_member( "run_eocs" ) ) {
             subeffect_fun.set_run_eocs( jo, "run_eocs" );
+        } else if( jo.has_member( "run_eoc_until" ) ) {
+            subeffect_fun.set_run_eoc_until( jo, "run_eoc_until" );
         } else if( jo.has_member( "run_eoc_with" ) ) {
             subeffect_fun.set_run_eoc_with( jo, "run_eoc_with" );
         } else if( jo.has_member( "run_eoc_selector" ) ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4136,32 +4136,32 @@ void talk_effect_fun_t::set_run_eoc_until( const JsonObject &jo, const std::stri
 
     str_or_var condition = get_str_or_var( jo.get_member( "condition" ), "condition" );
 
-    dbl_or_var itteration_count;
-    if( jo.has_member( "itteration_count" ) ) {
-        itteration_count = get_dbl_or_var( jo.get_member( "itteration_count" ), "itteration_count" );
+    dbl_or_var iteration_count;
+    if( jo.has_member( "iteration_count" ) ) {
+        iteration_count = get_dbl_or_var( jo.get_member( "iteration_count" ), "iteration_count" );
     }
 
 
-    function = [eoc, condition, itteration_count]( dialogue & d ) {
+    function = [eoc, condition, iteration_count]( dialogue & d ) {
         auto itt = d.get_conditionals().find( condition.evaluate( d ) );
         if( itt == d.get_conditionals().end() ) {
             debugmsg( string_format( "No condition with the name %s", condition.evaluate( d ) ) );
             return;
         }
-        int max_itteration = 100;
-        int given_itteration = itteration_count.evaluate( d );
+        int max_iteration = 100;
+        int given_iteration = iteration_count.evaluate( d );
 
-        if( given_itteration > 0 ) {
-            max_itteration = given_itteration;
+        if( given_iteration > 0 ) {
+            max_iteration = given_iteration;
         }
 
-        int curr_itteration = 0;
+        int curr_iteration = 0;
 
         while( itt->second( d ) ) {
-            curr_itteration++;
-            if( curr_itteration > max_itteration ) {
+            curr_iteration++;
+            if( curr_iteration > max_iteration ) {
                 debugmsg( string_format( "EOC loop ran for more instances than the max allowed: %d. Exiting loop.",
-                                         max_itteration ) );
+                                         max_iteration ) );
                 break;
             }
             eoc->activate( d );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -52,6 +52,7 @@ static const effect_on_condition_id effect_on_condition_EOC_mutator_test( "EOC_m
 static const effect_on_condition_id effect_on_condition_EOC_options_tests( "EOC_options_tests" );
 static const effect_on_condition_id effect_on_condition_EOC_recipe_test_1( "EOC_recipe_test_1" );
 static const effect_on_condition_id effect_on_condition_EOC_recipe_test_2( "EOC_recipe_test_2" );
+static const effect_on_condition_id effect_on_condition_EOC_run_until_test( "EOC_run_until_test" );
 static const effect_on_condition_id effect_on_condition_EOC_run_with_test( "EOC_run_with_test" );
 static const effect_on_condition_id
 effect_on_condition_EOC_run_with_test_expects_fail( "EOC_run_with_test_expects_fail" );
@@ -598,6 +599,21 @@ TEST_CASE( "EOC_run_with_test", "[eoc]" )
     CHECK( d.get_value( "npctalk_var_key" ).empty() );
     CHECK( d.get_value( "npctalk_var_key2" ).empty() );
     CHECK( d.get_value( "npctalk_var_key3" ).empty() );
+}
+
+TEST_CASE( "EOC_run_until_test", "[eoc]" )
+{
+    clear_avatar();
+    clear_map();
+
+    dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
+    global_variables &globvars = get_globals();
+    globvars.clear_global_values();
+
+    REQUIRE( globvars.get_global_value( "npctalk_var_key1" ).empty() );
+
+    CHECK( effect_on_condition_EOC_run_until_test->activate( d ) );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_key1" ) ) == Approx( 10 ) );
 }
 
 TEST_CASE( "EOC_run_with_test_expects", "[eoc]" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "EOC run until"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Wanted to be able to call an EOC multiple times without creating a massive call stack, seemed messy and inefficient.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds new call eoc_run_until
you provide the name of a condition in the current context and an EOC and it runs it until the condition is false.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Unit test included. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->