### PR TITLE
Various Down Bed Fixes

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2418,12 +2418,7 @@
     "required_skills": [ [ "fabrication", 4 ] ],
     "time": "70 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 1 } ] ],
-    "components": [
-      [ [ "2x4", 16 ], [ "wood_panel", 4 ] ],
-      [ [ "2x4", 2 ] ],
-      [ [ "nail", 20 ] ],
-      [ [ "mattress", 1 ] ]
-    ],
+    "components": [ [ [ "2x4", 16 ], [ "wood_panel", 4 ] ], [ [ "2x4", 2 ] ], [ [ "nail", 20 ] ], [ [ "mattress", 1 ] ] ],
     "pre_terrain": "f_bed",
     "post_terrain": "f_bunkbed"
   },
@@ -2458,12 +2453,7 @@
     "required_skills": [ [ "fabrication", 4 ] ],
     "time": "70 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 1 } ] ],
-    "components": [
-      [ [ "2x4", 16 ], [ "wood_panel", 4 ] ],
-      [ [ "2x4", 2 ] ],
-      [ [ "nail", 20 ] ],
-      [ [ "down_mattress", 1 ] ]
-    ],
+    "components": [ [ [ "2x4", 16 ], [ "wood_panel", 4 ] ], [ [ "2x4", 2 ] ], [ [ "nail", 20 ] ], [ [ "down_mattress", 1 ] ] ],
     "pre_terrain": "f_bed_down",
     "post_terrain": "f_bunkbed_down"
   },

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2406,7 +2406,7 @@
     "category": "FURN",
     "required_skills": [ [ "fabrication", 0 ] ],
     "time": "5 m",
-    "components": [ [ [ "mattress", 1 ], [ "down_mattress", 1 ] ] ],
+    "components": [ [ [ "mattress", 1 ] ] ],
     "pre_terrain": "f_bed_frame",
     "post_terrain": "f_bed"
   },
@@ -2422,10 +2422,50 @@
       [ [ "2x4", 16 ], [ "wood_panel", 4 ] ],
       [ [ "2x4", 2 ] ],
       [ [ "nail", 20 ] ],
-      [ [ "mattress", 1 ], [ "down_mattress", 1 ] ]
+      [ [ "mattress", 1 ] ]
     ],
     "pre_terrain": "f_bed",
     "post_terrain": "f_bunkbed"
+  },
+  {
+    "type": "construction",
+    "id": "constr_down_bed_frame",
+    "group": "build_down_bed",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 4 ] ],
+    "time": "55 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 1 } ] ],
+    "components": [ [ [ "2x4", 12 ] ], [ [ "nail", 10 ] ] ],
+    "pre_special": "check_empty",
+    "post_terrain": "f_bed_frame"
+  },
+  {
+    "type": "construction",
+    "id": "constr_finish_down_bed",
+    "group": "build_down_bed",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "5 m",
+    "components": [ [ [ "down_mattress", 1 ] ] ],
+    "pre_terrain": "f_bed_frame",
+    "post_terrain": "f_bed_down"
+  },
+  {
+    "type": "construction",
+    "id": "constr_down_bunkbed",
+    "group": "build_down_bed",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 4 ] ],
+    "time": "70 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 1 } ] ],
+    "components": [
+      [ [ "2x4", 16 ], [ "wood_panel", 4 ] ],
+      [ [ "2x4", 2 ] ],
+      [ [ "nail", 20 ] ],
+      [ [ "down_mattress", 1 ] ]
+    ],
+    "pre_terrain": "f_bed_down",
+    "post_terrain": "f_bunkbed_down"
   },
   {
     "type": "construction",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -66,6 +66,11 @@
   },
   {
     "type": "construction_group",
+    "id": "build_down_bed",
+    "name": "Build Down Bed/Bunk bed"
+  },
+  {
+    "type": "construction_group",
     "id": "build_bookcase",
     "name": "Build Bookcase"
   },

--- a/data/json/furniture_and_terrain/furniture-sleep.json
+++ b/data/json/furniture_and_terrain/furniture-sleep.json
@@ -61,6 +61,68 @@
   },
   {
     "type": "furniture",
+    "id": "f_bed_down",
+    "name": "down bed",
+    "symbol": "0",
+    "description": "A down mattress on a sturdy wooden frame.  Even without blankets or pillows, and despite being a completely ordinary mattress, it's a sight for sore, tired eyes.",
+    "color": "magenta",
+    "move_cost_mod": 3,
+    "coverage": 40,
+    "comfort": 5,
+    "floor_bedding_warmth": 1000,
+    "required_str": -1,
+    "deconstruct": { "items": [ { "item": "down_mattress", "count": 1 } ], "furn_set": "f_bed_frame" },
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "PLACE_ITEM", "ORGANIC", "MOUNTABLE", "CAN_SIT", "EASY_DECONSTRUCT" ],
+    "bash": {
+      "str_min": 12,
+      "str_max": 40,
+      "sound": "crunch!",
+      "sound_fail": "whump.",
+      "items": [
+        { "item": "2x4", "count": [ 5, 8 ] },
+        { "item": "nail", "charges": [ 6, 8 ] },
+        { "item": "splinter", "count": [ 3, 6 ] },
+        { "item": "cotton_patchwork", "count": [ 10, 15 ] },
+        { "item": "down_feather", "count": [ 45, 55 ] },
+        { "item": "scrap", "count": [ 10, 20 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_bunkbed_down",
+    "name": "down bunkbed",
+    "symbol": "0",
+    "looks_like": "f_bed_down",
+    "description": "A bunk bed with a sturdy wooden frame built to hold two single-person mattresses above one another.  While these usually mean sleeping closer than you'd like to somebody you wouldn't normally want to share a mattress with, a bed's a bed. This one has two down mattresses.",
+    "color": "magenta",
+    "move_cost_mod": 6,
+    "coverage": 40,
+    "comfort": 5,
+    "floor_bedding_warmth": 1000,
+    "required_str": -1,
+    "deconstruct": {
+      "items": [ { "item": "down_mattress", "count": 1 }, { "item": "2x4", "count": 16 }, { "item": "nail", "charges": [ 10, 20 ] } ],
+      "furn_set": "f_bed_down"
+    },
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "CAN_SIT" ],
+    "bash": {
+      "str_min": 12,
+      "str_max": 40,
+      "sound": "crunch!",
+      "sound_fail": "whump.",
+      "items": [
+        { "item": "2x4", "count": [ 8, 15 ] },
+        { "item": "nail", "charges": [ 15, 20 ] },
+        { "item": "splinter", "count": [ 8, 15 ] },
+        { "item": "cotton_patchwork", "count": [ 20, 30 ] },
+        { "item": "down_feather", "count": [ 90, 110 ] },
+        { "item": "scrap", "count": [ 20, 40 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_triple_bunkbed",
     "name": "triple berth",
     "symbol": "#",
@@ -163,7 +225,7 @@
       "str_max": 30,
       "sound": "rrrrip!",
       "sound_fail": "whump.",
-      "items": [ { "item": "cotton_patchwork", "count": [ 40, 55 ] }, { "item": "down_feather", "count": [ 900, 1100 ] } ]
+      "items": [ { "item": "cotton_patchwork", "count": [ 10, 15 ] }, { "item": "down_feather", "count": [ 45, 55 ] } ]
     }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-sleep.json
+++ b/data/json/furniture_and_terrain/furniture-sleep.json
@@ -94,7 +94,7 @@
     "name": "down bunkbed",
     "symbol": "0",
     "looks_like": "f_bed_down",
-    "description": "A bunk bed with a sturdy wooden frame built to hold two single-person mattresses above one another.  While these usually mean sleeping closer than you'd like to somebody you wouldn't normally want to share a mattress with, a bed's a bed. This one has two down mattresses.",
+    "description": "A bunk bed with a sturdy wooden frame built to hold two single-person mattresses above one another.  While these usually mean sleeping closer than you'd like to somebody you wouldn't normally want to share a mattress with, a bed's a bed.  This one has two down mattresses.",
     "color": "magenta",
     "move_cost_mod": 6,
     "coverage": 40,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix Down Mattress interactions with smashing, construction, and deconstructing beds"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Down mattresses have weird interactions with bed construction. Creating a bed from a down mattress creates a generic "bed" which then deconstructs into a regular mattress. Down mattresses also do not smash into the correct amount of down feathers when deployed (numbers did not account for down feathers being sets of 20) and give too much cotton (equivalent to regular beds).

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Create new construction options for making "down beds" and "down bunkbeds"
Remove down mattresses from the options for making "beds" and "bunkbeds"
When smashing, lower the amount of down feathers acquired by 20x and cotton by ~75%.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Considered trying to have beds "remember" their material, but that seems like a much larger issue to tackle for furniture in general.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

1. Spawned planks, nails, and two down mattresses. Constructed Bed Frame -> Down Bed -> Down bunkbed correctly.

2. Deconstructing Down Bunkbed and Down Bed gave down mattresses.

3. Spawned planks, nails, and two regular mattresses. Constructed Bed Frame -> Bed -> Bunkbed correctly. (i.e. did not break regular bed making)

4. Spawned and deployed down mattress. Smashed with combat knife, correct # of down feathers spawned.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

I'd like to add down beds to some regular house spawns (at lower % chance), but I want to make sure this works first.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->