### PR TITLE
[Magiclysm] Fixes runes' duration

### DIFF
--- a/data/mods/Magiclysm/Spells/animist.json
+++ b/data/mods/Magiclysm/Spells/animist.json
@@ -423,7 +423,7 @@
     "max_duration": 2,
     "duration_increment": 1,
     "difficulty": 0,
-    "max_level": 2,
+    "max_level": 0,
     "spell_class": "ANIMIST",
     "energy_source": "HP",
     "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]

--- a/data/mods/Magiclysm/Spells/biomancer.json
+++ b/data/mods/Magiclysm/Spells/biomancer.json
@@ -226,7 +226,7 @@
     "max_duration": 2,
     "duration_increment": 1,
     "difficulty": 0,
-    "max_level": 2,
+    "max_level": 0,
     "spell_class": "BIOMANCER",
     "energy_source": "MANA",
     "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]

--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -259,7 +259,7 @@
     "max_duration": 2,
     "duration_increment": 1,
     "difficulty": 0,
-    "max_level": 2,
+    "max_level": 0,
     "spell_class": "DRUID",
     "energy_source": "MANA",
     "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]

--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -242,7 +242,7 @@
     "max_duration": 2,
     "duration_increment": 1,
     "difficulty": 0,
-    "max_level": 2,
+    "max_level": 0,
     "spell_class": "EARTHSHAPER",
     "energy_source": "MANA",
     "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]

--- a/data/mods/Magiclysm/Spells/kelvinist.json
+++ b/data/mods/Magiclysm/Spells/kelvinist.json
@@ -417,7 +417,7 @@
     "max_duration": 2,
     "duration_increment": 1,
     "difficulty": 0,
-    "max_level": 2,
+    "max_level": 0,
     "spell_class": "KELVINIST",
     "energy_source": "MANA",
     "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]

--- a/data/mods/Magiclysm/Spells/magus.json
+++ b/data/mods/Magiclysm/Spells/magus.json
@@ -281,7 +281,7 @@
     "max_duration": 2,
     "duration_increment": 1,
     "difficulty": 0,
-    "max_level": 2,
+    "max_level": 0,
     "spell_class": "MAGUS",
     "energy_source": "MANA",
     "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]

--- a/data/mods/Magiclysm/Spells/stormshaper.json
+++ b/data/mods/Magiclysm/Spells/stormshaper.json
@@ -230,7 +230,7 @@
     "max_duration": 2,
     "duration_increment": 1,
     "difficulty": 0,
-    "max_level": 2,
+    "max_level": 0,
     "spell_class": "STORMSHAPER",
     "energy_source": "MANA",
     "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]

--- a/data/mods/Magiclysm/Spells/technomancer.json
+++ b/data/mods/Magiclysm/Spells/technomancer.json
@@ -213,7 +213,7 @@
     "max_duration": 2,
     "duration_increment": 1,
     "difficulty": 0,
-    "max_level": 2,
+    "max_level": 0,
     "spell_class": "TECHNOMANCER",
     "energy_source": "MANA",
     "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]

--- a/data/mods/Magiclysm/traits/classes.json
+++ b/data/mods/Magiclysm/traits/classes.json
@@ -9,7 +9,7 @@
     "purifiable": false,
     "valid": false,
     "cancels": [ "ANIMIST" ],
-    "spells_learned": [ [ "create_rune_magus", 1 ] ]
+    "spells_learned": [ [ "create_rune_magus", 0 ] ]
   },
   {
     "type": "mutation",
@@ -21,7 +21,7 @@
     "purifiable": false,
     "valid": false,
     "cancels": [ "MAGUS" ],
-    "spells_learned": [ [ "create_rune_animist", 1 ] ]
+    "spells_learned": [ [ "create_rune_animist", 0 ] ]
   },
   {
     "type": "mutation",
@@ -34,7 +34,7 @@
     "valid": false,
     "enchantments": [ "KELVINIST" ],
     "cancels": [ "STORMSHAPER" ],
-    "spells_learned": [ [ "create_rune_kelvinist", 1 ] ]
+    "spells_learned": [ [ "create_rune_kelvinist", 0 ] ]
   },
   {
     "type": "mutation",
@@ -47,7 +47,7 @@
     "valid": false,
     "enchantments": [ "STORMSHAPER" ],
     "cancels": [ "KELVINIST" ],
-    "spells_learned": [ [ "create_rune_stormshaper", 1 ] ]
+    "spells_learned": [ [ "create_rune_stormshaper", 0 ] ]
   },
   {
     "type": "mutation",
@@ -59,7 +59,7 @@
     "purifiable": false,
     "valid": false,
     "cancels": [ "EARTHSHAPER" ],
-    "spells_learned": [ [ "create_rune_technomancer", 1 ] ]
+    "spells_learned": [ [ "create_rune_technomancer", 0 ] ]
   },
   {
     "type": "mutation",
@@ -71,7 +71,7 @@
     "purifiable": false,
     "valid": false,
     "cancels": [ "TECHNOMANCER" ],
-    "spells_learned": [ [ "create_rune_earthshaper", 1 ] ]
+    "spells_learned": [ [ "create_rune_earthshaper", 0 ] ]
   },
   {
     "type": "mutation",
@@ -83,7 +83,7 @@
     "purifiable": false,
     "valid": false,
     "cancels": [ "DRUID" ],
-    "spells_learned": [ [ "create_rune_biomancer", 1 ] ]
+    "spells_learned": [ [ "create_rune_biomancer", 0 ] ]
   },
   {
     "type": "mutation",
@@ -95,6 +95,6 @@
     "purifiable": false,
     "valid": false,
     "cancels": [ "BIOMANCER" ],
-    "spells_learned": [ [ "create_rune_druid", 1 ] ]
+    "spells_learned": [ [ "create_rune_druid", 0 ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[Magiclysm] Fixes runes' duration"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #66459
Fixes #65417
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Sets runes to be gained at level 0, and sets maximum caster level of runes back to 0
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Figure out how I managed to get the spells at level 2 when the mutation says they should be gained at level 1, and they have a maximum caster level of 0
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I tested becoming an animist. The create rune spell is correctly at level 0 (MAX), and the rune is permanent. So it seems to work as intended.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->