### PR TITLE
Implement export&import of the protagonist and follower NPCs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 /src/prefix.h
 /sound/
 /templates/
+/export_dir/
 /tools/format/json_formatter.cgi
 CataclysmWin.cscope_file_list
 CataclysmWin.depend

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -166,12 +166,6 @@ void avatar::control_npc( npc &np, const bool debug )
         debugmsg( "control_npc() called on non-allied npc %s", np.name );
         return;
     }
-    if( !shadow_npc ) {
-        shadow_npc = std::make_unique<npc>();
-        shadow_npc->op_of_u.trust = 10;
-        shadow_npc->op_of_u.value = 10;
-        shadow_npc->set_attitude( NPCATT_FOLLOW );
-    }
     character_id new_character = np.getID();
     const std::function<void( npc & )> update_npc = [new_character]( npc & guy ) {
         guy.update_missions_target( get_avatar().getID(), new_character );
@@ -179,11 +173,11 @@ void avatar::control_npc( npc &np, const bool debug )
     overmap_buffer.foreach_npc( update_npc );
     mission().update_world_missions_character( get_avatar().getID(), new_character );
     // move avatar character data into shadow npc
-    swap_character( *shadow_npc );
+    swap_character( get_shadow_npc() );
     // swap target npc with shadow npc
-    std::swap( *shadow_npc, np );
+    std::swap( get_shadow_npc(), np );
     // move shadow npc character data into avatar
-    swap_character( *shadow_npc );
+    swap_character( get_shadow_npc() );
     // the avatar character is no longer a follower NPC
     g->remove_npc_follower( getID() );
     // the previous avatar character is now a follower
@@ -2073,6 +2067,18 @@ void avatar::set_location( const tripoint_abs_ms &loc )
 {
     Creature::set_location( loc );
 }
+
+npc &avatar::get_shadow_npc()
+{
+    if( !shadow_npc ) {
+        shadow_npc = std::make_unique<npc>();
+        shadow_npc->op_of_u.trust = 10;
+        shadow_npc->op_of_u.value = 10;
+        shadow_npc->set_attitude( NPCATT_FOLLOW );
+    }
+    return *shadow_npc;
+}
+
 
 void monster_visible_info::remove_npc( npc *n )
 {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -160,13 +160,6 @@ avatar::avatar( avatar && ) = default;
 // NOLINTNEXTLINE(performance-noexcept-move-constructor)
 avatar &avatar::operator=( avatar && ) = default;
 
-static void swap_npc( npc &one, npc &two, npc &tmp )
-{
-    tmp = std::move( one );
-    one = std::move( two );
-    two = std::move( tmp );
-}
-
 void avatar::control_npc( npc &np, const bool debug )
 {
     if( !np.is_player_ally() ) {
@@ -185,13 +178,12 @@ void avatar::control_npc( npc &np, const bool debug )
     };
     overmap_buffer.foreach_npc( update_npc );
     mission().update_world_missions_character( get_avatar().getID(), new_character );
-    npc tmp;
     // move avatar character data into shadow npc
-    swap_character( *shadow_npc, tmp );
+    swap_character( *shadow_npc );
     // swap target npc with shadow npc
-    swap_npc( *shadow_npc, np, tmp );
+    std::swap( *shadow_npc, np );
     // move shadow npc character data into avatar
-    swap_character( *shadow_npc, tmp );
+    swap_character( *shadow_npc );
     // the avatar character is no longer a follower NPC
     g->remove_npc_follower( getID() );
     // the previous avatar character is now a follower

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -2079,6 +2079,12 @@ npc &avatar::get_shadow_npc()
     return *shadow_npc;
 }
 
+void avatar::export_as_npc( const cata_path &path )
+{
+    swap_character( get_shadow_npc() );
+    get_shadow_npc().export_to( path );
+    swap_character( get_shadow_npc() );
+}
 
 void monster_visible_info::remove_npc( npc *n )
 {

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -364,6 +364,7 @@ class avatar : public Character
         const mood_face_id &character_mood_face( bool clear_cache = false ) const;
 
     private:
+        npc &get_shadow_npc();
 
         // The name used to generate save filenames for this avatar. Not serialized in json.
         std::string save_id;

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -25,6 +25,7 @@
 class advanced_inv_area;
 class advanced_inv_listitem;
 class advanced_inventory_pane;
+class cata_path;
 class diary;
 class faction;
 class item;
@@ -91,6 +92,7 @@ class avatar : public Character
 
         void store( JsonOut &json ) const;
         void load( const JsonObject &data );
+        void export_as_npc( const cata_path &path );
         void serialize( JsonOut &json ) const override;
         void deserialize( const JsonObject &data ) override;
         bool save_map_memory();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -612,8 +612,10 @@ character_id Character::getID() const
     return this->id;
 }
 
-void Character::swap_character( Character &other, Character &tmp )
+void Character::swap_character( Character &other )
 {
+    npc tmp_npc;
+    Character &tmp = tmp_npc;
     tmp = std::move( other );
     other = std::move( *this );
     *this = std::move( tmp );

--- a/src/character.h
+++ b/src/character.h
@@ -3447,9 +3447,7 @@ class Character : public Creature, public visitable
         Character();
         Character( Character && ) noexcept( map_is_noexcept );
         Character &operator=( Character && ) noexcept( list_is_noexcept );
-        // Swaps the data of this Character and "other" using "tmp" for temporary storage.
-        // Leaves "tmp" in an undefined state.
-        void swap_character( Character &other, Character &tmp );
+        void swap_character( Character &other );
     public:
         struct trait_data {
             /** Whether the mutation is activated. */

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3486,7 +3486,7 @@ void debug()
             uilist filemenu;
             int filenum = 0;
             for( cata_path path : npc_files ) {
-                filemenu.addentry( filenum++, true, MENU_AUTOASSIGN, path.get_unrelative_path().stem() );
+                filemenu.addentry( filenum++, true, MENU_AUTOASSIGN, path.get_unrelative_path().stem().string() );
             }
             filemenu.w_y_setup = 0;
             filemenu.query();

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3493,17 +3493,14 @@ void debug()
             if( filemenu.ret < 0 || static_cast<size_t>( filemenu.ret ) >= npc_files.size() ) {
                 break;
             }
-            read_from_file_json( npc_files[filemenu.ret], [&]( const JsonValue & jv ) {
-                JsonObject npc_json = jv;
-                shared_ptr_fast<npc> temp = make_shared_fast<npc>();
-                temp->import_and_clean( npc_json );
-                g->add_npc_follower( temp->getID() );
-                temp->set_attitude( NPCATT_FOLLOW );
-                temp->set_fac( faction_your_followers );
-                temp->spawn_at_precise( player_character.get_location() + point( -4, -4 ) );
-                overmap_buffer.insert_npc( temp );
-                g->load_npcs();
-            } );
+            shared_ptr_fast<npc> temp = make_shared_fast<npc>();
+            temp->import_and_clean( npc_files[filemenu.ret] );
+            g->add_npc_follower( temp->getID() );
+            temp->set_attitude( NPCATT_FOLLOW );
+            temp->set_fac( faction_your_followers );
+            temp->spawn_at_precise( player_character.get_location() + point( -4, -4 ) );
+            overmap_buffer.insert_npc( temp );
+            g->load_npcs();
             break;
         }
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3493,14 +3493,18 @@ void debug()
             if( filemenu.ret < 0 || static_cast<size_t>( filemenu.ret ) >= npc_files.size() ) {
                 break;
             }
-            shared_ptr_fast<npc> temp = make_shared_fast<npc>();
-            temp->import_and_clean( npc_files[filemenu.ret] );
-            g->add_npc_follower( temp->getID() );
-            temp->set_attitude( NPCATT_FOLLOW );
-            temp->set_fac( faction_your_followers );
-            temp->spawn_at_precise( player_character.get_location() + point( -4, -4 ) );
-            overmap_buffer.insert_npc( temp );
-            g->load_npcs();
+            try {
+                shared_ptr_fast<npc> temp = make_shared_fast<npc>();
+                temp->import_and_clean( npc_files[filemenu.ret] );
+                g->add_npc_follower( temp->getID() );
+                temp->set_attitude( NPCATT_FOLLOW );
+                temp->set_fac( faction_your_followers );
+                temp->spawn_at_precise( player_character.get_location() + point( -4, -4 ) );
+                overmap_buffer.insert_npc( temp );
+                g->load_npcs();
+            } catch( const std::exception &err ) {
+                debugmsg( _( "Failed to read NPC: %s" ), err.what() );
+            }
             break;
         }
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -33,6 +33,7 @@
 #include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"
+#include "cata_path.h"
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "character.h"
@@ -127,6 +128,7 @@ static const efftype_id effect_asthma( "asthma" );
 static const efftype_id effect_bleed( "bleed" );
 
 static const faction_id faction_no_faction( "no_faction" );
+static const faction_id faction_your_followers( "your_followers" );
 
 static const matype_id style_none( "style_none" );
 
@@ -230,6 +232,9 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::VEHICLE_BATTERY_CHARGE: return "VEHICLE_BATTERY_CHARGE";
         case debug_menu::debug_menu_index::GENERATE_EFFECT_LIST: return "GENERATE_EFFECT_LIST";
         case debug_menu::debug_menu_index::ACTIVATE_EOC: return "ACTIVATE_EOC";
+        case debug_menu::debug_menu_index::IMPORT_FOLLOWER: return "IMPORT_FOLLOWER";
+        case debug_menu::debug_menu_index::EXPORT_FOLLOWER: return "EXPORT_FOLLOWER";
+        case debug_menu::debug_menu_index::EXPORT_SELF: return "EXPORT_SELF";
         // *INDENT-ON*
         case debug_menu::debug_menu_index::last:
             break;
@@ -563,6 +568,25 @@ static int map_uilist()
     return uilist( _( "Map…" ), uilist_initializer );
 }
 
+static int import_uilist()
+{
+    const std::vector<uilist_entry> uilist_initializer = {
+        { uilist_entry( debug_menu_index::IMPORT_FOLLOWER, true, 'f', _( "Import follower" ) ) },
+    };
+
+    return uilist( _( "Import…" ), uilist_initializer );
+}
+
+static int export_uilist()
+{
+    const std::vector<uilist_entry> uilist_initializer = {
+        { uilist_entry( debug_menu_index::EXPORT_SELF, true, 's', _( "Export self" ) ) },
+        { uilist_entry( debug_menu_index::EXPORT_FOLLOWER, true, 'f', _( "Export follower" ) ) },
+    };
+
+    return uilist( _( "Expot…" ), uilist_initializer );
+}
+
 /**
  * Create the debug menu UI list.
  * @param display_all_entries: `true` if all entries should be displayed, `false` is some entries should be hidden (for ex. when the debug menu is called from the main menu).
@@ -583,6 +607,8 @@ static std::optional<debug_menu_index> debug_menu_uilist( bool display_all_entri
             { uilist_entry( 7, true, 'v', _( "Vehicle…" ) ) },
             { uilist_entry( 4, true, 't', _( "Teleport…" ) ) },
             { uilist_entry( 5, true, 'm', _( "Map…" ) ) },
+            { uilist_entry( 8, true, 'i', _( "Import…" ) ) },
+            { uilist_entry( 9, true, 'e', _( "Export…" ) ) },
         };
 
         // insert debug-only menu right after "Info".
@@ -622,6 +648,12 @@ static std::optional<debug_menu_index> debug_menu_uilist( bool display_all_entri
                 break;
             case 7:
                 action = vehicle_uilist();
+                break;
+            case 8:
+                action = import_uilist();
+                break;
+            case 9:
+                action = export_uilist();
                 break;
 
             default:
@@ -2623,6 +2655,44 @@ static void debug_menu_force_temperature()
     }
 }
 
+static npc *select_follower_to_export()
+{
+    std::vector<npc *> followers;
+    uilist charmenu;
+    int charnum = 0;
+    for( const character_id &elem : g->get_follower_list() ) {
+        shared_ptr_fast<npc> follower = overmap_buffer.find_npc( elem );
+        if( follower ) {
+            followers.emplace_back( follower.get() );
+            charmenu.addentry( charnum++, true, MENU_AUTOASSIGN, follower->get_name() );
+        }
+    }
+    if( followers.empty() ) {
+        popup( _( "There's no one to export!" ) );
+        return nullptr;
+    }
+    charmenu.w_y_setup = 0;
+    charmenu.query();
+    if( charmenu.ret < 0 || static_cast<size_t>( charmenu.ret ) >= followers.size() ) {
+        return nullptr;
+    }
+    return followers[charmenu.ret];
+}
+
+
+static cata_path prepare_export_dir_and_find_unused_name( std::string character_name )
+{
+    cata_path export_dir{ cata_path::root_path::user,  "export_dir" };
+    assure_dir_exist( export_dir );
+    cata_path ret = export_dir / ( character_name + ".npc" );
+    int try_next = 1;
+    while( file_exist( ret ) ) {
+        ret = export_dir / ( character_name + " " + std::to_string( try_next ) + ".npc" );
+        try_next++;
+    }
+    return ret;
+}
+
 void debug()
 {
     bool debug_menu_has_hotkey = hotkey_for_action( ACTION_DEBUG,
@@ -2640,7 +2710,9 @@ void debug()
         debug_menu_index::BENCHMARK,
         debug_menu_index::SHOW_MSG,
         debug_menu_index::QUICKLOAD,
-        debug_menu_index::QUIT_NOSAVE
+        debug_menu_index::QUIT_NOSAVE,
+        debug_menu_index::EXPORT_FOLLOWER,
+        debug_menu_index::EXPORT_SELF
     };
     const bool should_disable_achievements = action && !is_debug_character() &&
             !non_cheaty_options.count( *action );
@@ -3400,6 +3472,57 @@ void debug()
                            your_faction->food_supply ) ) {
                 your_faction->food_supply = larder;
             }
+            break;
+        }
+
+        case debug_menu_index::IMPORT_FOLLOWER: {
+            cata_path export_dir{ cata_path::root_path::user,  "export_dir" };
+            std::vector<cata_path> npc_files = get_files_from_path( ".npc",
+                                               export_dir, /* recursive_search */ false, /* match_extension */ true );
+            if( npc_files.empty() ) {
+                popup( _( "There's no NPCs to import!" ) );
+                break;
+            }
+            uilist filemenu;
+            int filenum = 0;
+            for( cata_path path : npc_files ) {
+                filemenu.addentry( filenum++, true, MENU_AUTOASSIGN, path.get_unrelative_path().stem() );
+            }
+            filemenu.w_y_setup = 0;
+            filemenu.query();
+            if( filemenu.ret < 0 || static_cast<size_t>( filemenu.ret ) >= npc_files.size() ) {
+                break;
+            }
+            read_from_file_json( npc_files[filemenu.ret], [&]( const JsonValue & jv ) {
+                JsonObject npc_json = jv;
+                shared_ptr_fast<npc> temp = make_shared_fast<npc>();
+                temp->deserialize( npc_json );
+                temp->setID( g->assign_npc_id(), /* force */ true );
+                g->add_npc_follower( temp->getID() );
+                temp->set_attitude( NPCATT_FOLLOW );
+                temp->set_fac( faction_your_followers );
+                temp->spawn_at_precise( player_character.get_location() + point( -4, -4 ) );
+                overmap_buffer.insert_npc( temp );
+                g->load_npcs();
+            } );
+            break;
+        }
+
+        case debug_menu_index::EXPORT_FOLLOWER: {
+            npc *export_me = select_follower_to_export();
+            if( !export_me ) {
+                break;
+            }
+            cata_path export_name = prepare_export_dir_and_find_unused_name( export_me->name );
+            export_me->export_to( export_name );
+            popup( _( "Written: %s" ), export_name.get_unrelative_path().string() );
+            break;
+        }
+
+        case debug_menu_index::EXPORT_SELF: {
+            cata_path export_name = prepare_export_dir_and_find_unused_name( get_avatar().name );
+            get_avatar().export_as_npc( export_name );
+            popup( _( "Written: %s" ), export_name.get_unrelative_path().string() );
             break;
         }
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3496,8 +3496,7 @@ void debug()
             read_from_file_json( npc_files[filemenu.ret], [&]( const JsonValue & jv ) {
                 JsonObject npc_json = jv;
                 shared_ptr_fast<npc> temp = make_shared_fast<npc>();
-                temp->deserialize( npc_json );
-                temp->setID( g->assign_npc_id(), /* force */ true );
+                temp->import_and_clean( npc_json );
                 g->add_npc_follower( temp->getID() );
                 temp->set_attitude( NPCATT_FOLLOW );
                 temp->set_fac( faction_your_followers );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2680,7 +2680,7 @@ static npc *select_follower_to_export()
 }
 
 
-static cata_path prepare_export_dir_and_find_unused_name( std::string character_name )
+static cata_path prepare_export_dir_and_find_unused_name( const std::string &character_name )
 {
     cata_path export_dir{ cata_path::root_path::user,  "export_dir" };
     assure_dir_exist( export_dir );
@@ -3485,7 +3485,7 @@ void debug()
             }
             uilist filemenu;
             int filenum = 0;
-            for( cata_path path : npc_files ) {
+            for( const cata_path &path : npc_files ) {
                 filemenu.addentry( filenum++, true, MENU_AUTOASSIGN, path.get_unrelative_path().stem().string() );
             }
             filemenu.w_y_setup = 0;

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -103,6 +103,9 @@ enum class debug_menu_index : int {
     ACTIVATE_EOC,
     WRITE_TIMED_EVENTS,
     QUICKLOAD,
+    IMPORT_FOLLOWER,
+    EXPORT_FOLLOWER,
+    EXPORT_SELF,
     last
 };
 

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -84,14 +84,16 @@ mission *mission::reserve_new( const mission_type_id &type, const character_id &
     return &miss;
 }
 
-mission *mission::find( int id )
+mission *mission::find( int id, bool ok_missing )
 {
     const auto iter = world_missions.find( id );
     if( iter != world_missions.end() ) {
         return &iter->second;
     }
-    dbg( D_ERROR ) << "requested mission with uid " << id << " does not exist";
-    debugmsg( "requested mission with uid %d does not exist", id );
+    if( !ok_missing ) {
+        dbg( D_ERROR ) << "requested mission with uid " << id << " does not exist";
+        debugmsg( "requested mission with uid %d does not exist", id );
+    }
     return nullptr;
 }
 
@@ -128,11 +130,11 @@ void mission::process_all()
     }
 }
 
-std::vector<mission *> mission::to_ptr_vector( const std::vector<int> &vec )
+std::vector<mission *> mission::to_ptr_vector( const std::vector<int> &vec, bool ok_missing )
 {
     std::vector<mission *> result;
     for( const int &id : vec ) {
-        mission *miss = find( id );
+        mission *miss = find( id, ok_missing );
         if( miss != nullptr ) {
             result.push_back( miss );
         }

--- a/src/mission.h
+++ b/src/mission.h
@@ -411,7 +411,7 @@ class mission
          * Returns the mission with the matching id (@ref uid). Returns NULL if no mission with that
          * id exists.
          */
-        static mission *find( int id );
+        static mission *find( int id, bool ok_missing = false );
         /**
          * Remove all active missions, used to cleanup on exit and before reloading a new game.
          */
@@ -434,7 +434,7 @@ class mission
         static void serialize_all( JsonOut &json );
         static void unserialize_all( const JsonArray &ja );
         /** Converts a vector mission ids to a vector of mission pointers. Invalid ids are skipped! */
-        static std::vector<mission *> to_ptr_vector( const std::vector<int> &vec );
+        static std::vector<mission *> to_ptr_vector( const std::vector<int> &vec, bool ok_missing = false );
         static std::vector<int> to_uid_vector( const std::vector<mission *> &vec );
 
         // For save/load

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3910,14 +3910,6 @@ void npc::update_missions_target( character_id old_character, character_id new_c
     }
 }
 
-void npc::export_to( const cata_path &path ) const
-{
-    write_to_file( path, [&]( std::ostream & fout ) {
-        JsonOut jsout( fout );
-        serialize( jsout );
-    } );
-}
-
 std::unique_ptr<talker> get_talker_for( npc &guy )
 {
     return std::make_unique<talker_npc>( &guy );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -14,8 +14,6 @@
 #include "auto_pickup.h"
 #include "basecamp.h"
 #include "bodypart.h"
-#include "cata_path.h"
-#include "cata_utility.h"
 #include "catacharset.h"
 #include "character.h"
 #include "character_id.h"

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -14,6 +14,8 @@
 #include "auto_pickup.h"
 #include "basecamp.h"
 #include "bodypart.h"
+#include "cata_path.h"
+#include "cata_utility.h"
 #include "catacharset.h"
 #include "character.h"
 #include "character_id.h"
@@ -3906,6 +3908,14 @@ void npc::update_missions_target( character_id old_character, character_id new_c
             temp->set_assigned_player_id( new_character );
         }
     }
+}
+
+void npc::export_to( const cata_path &path ) const
+{
+    write_to_file( path, [&]( std::ostream & fout ) {
+        JsonOut jsout( fout );
+        serialize( jsout );
+    } );
 }
 
 std::unique_ptr<talker> get_talker_for( npc &guy )

--- a/src/npc.h
+++ b/src/npc.h
@@ -805,6 +805,7 @@ class npc : public Character
         // Save & load
         void deserialize( const JsonObject &data ) override;
         void serialize( JsonOut &json ) const override;
+        void export_to( const cata_path &path ) const;
 
         // Display
         nc_color basic_symbol_color() const override;

--- a/src/npc.h
+++ b/src/npc.h
@@ -806,6 +806,8 @@ class npc : public Character
         void deserialize( const JsonObject &data ) override;
         void serialize( JsonOut &json ) const override;
         void export_to( const cata_path &path ) const;
+        /// Read json and apply post-import cleanup
+        void import_and_clean( const JsonObject &data );
 
         // Display
         nc_color basic_symbol_color() const override;

--- a/src/npc.h
+++ b/src/npc.h
@@ -807,8 +807,12 @@ class npc : public Character
         void serialize( JsonOut &json ) const override;
         void export_to( const cata_path &path ) const;
         /// Read json and apply post-import cleanup
+        void import_and_clean( const cata_path &path );
+
+    private:
         void import_and_clean( const JsonObject &data );
 
+    public:
         // Display
         nc_color basic_symbol_color() const override;
         int print_info( const catacurses::window &w, int line, int vLines, int column ) const override;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1609,3 +1609,63 @@ void overmapbuffer::deserialize_placed_unique_specials( const JsonValue &jsin )
         placed_unique_specials.emplace( special.get_string() );
     }
 }
+
+void npc::import_and_clean( const JsonObject &data )
+{
+    deserialize( data );
+
+    npc defaults;  // to avoid hardcoding defaults here
+
+    // avoid duplicate id
+    setID( g->assign_npc_id(), /* force */ true );
+
+    // timestamps are irrelevant if importing into a different world
+    last_updated = defaults.last_updated;
+    lifespan_end = defaults.lifespan_end;
+    effects->clear();
+    consumption_history = defaults.consumption_history;
+    last_sleep_check = defaults.last_sleep_check;
+    queued_effect_on_conditions = defaults.queued_effect_on_conditions;
+
+    // space coordinates are irrelevant if importing into a different world
+    set_location( defaults.get_location() );
+    omt_path = defaults.omt_path;
+    known_traps.clear();
+    camps = defaults.camps;
+    last_player_seen_pos = defaults.last_player_seen_pos;
+    guard_pos = defaults.guard_pos;
+    pulp_location = defaults.pulp_location;
+    chair_pos = defaults.chair_pos;
+    wander_pos = defaults.wander_pos;
+    goal = defaults.goal;
+    assigned_camp = defaults.assigned_camp;
+    job = defaults.job;
+
+    // mission related
+    mission = defaults.mission;
+    previous_mission = defaults.previous_mission;
+    reset_companion_mission();
+    companion_mission_role_id = defaults.companion_mission_role_id;
+    companion_mission_points = defaults.companion_mission_points;
+    companion_mission_time = defaults.companion_mission_time;
+    companion_mission_time_ret = defaults.companion_mission_time_ret;
+    companion_mission_inv.clear();
+    chatbin.missions.clear();
+    chatbin.missions_assigned.clear();
+    chatbin.mission_selected = nullptr;
+
+    // activity related
+    activity = defaults.activity;
+    backlog = defaults.backlog;
+    clear_destination();
+    stashed_outbounds_activity = defaults.stashed_outbounds_activity;
+    stashed_outbounds_backlog = defaults.stashed_outbounds_backlog;
+    activity_vehicle_part_index = defaults.activity_vehicle_part_index;
+    current_activity_id = defaults.current_activity_id;
+
+    // miscellaneous
+    in_vehicle = defaults.in_vehicle;
+    warning_record = defaults.warning_record;
+    complaints = defaults.complaints;
+    unique_id = defaults.unique_id;
+}

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2045,15 +2045,15 @@ void dialogue_chatbin::deserialize( const JsonObject &data )
 
     std::vector<int> tmpmissions;
     data.read( "missions", tmpmissions );
-    missions = mission::to_ptr_vector( tmpmissions );
+    missions = mission::to_ptr_vector( tmpmissions, /* ok_missing */ true );
     std::vector<int> tmpmissions_assigned;
     data.read( "missions_assigned", tmpmissions_assigned );
-    missions_assigned = mission::to_ptr_vector( tmpmissions_assigned );
+    missions_assigned = mission::to_ptr_vector( tmpmissions_assigned, /* ok_missing */ true );
 
     int tmpmission_selected = 0;
     mission_selected = nullptr;
     if( data.read( "mission_selected", tmpmission_selected ) && tmpmission_selected != -1 ) {
-        mission_selected = mission::find( tmpmission_selected );
+        mission_selected = mission::find( tmpmission_selected, /* ok_missing */ true );
     }
 }
 


### PR DESCRIPTION
#### Summary

Features "Implement export&import of the protagonist and follower NPCs"

#### Purpose of change

This is intended as a replacement for the "character to template" feature as described here #55094. Note: the "character to template" feature will **not** be removed until it is confirmed that this is a satisfactory replacement.

#### Describe the solution

Implement 3 new debug commands:

- Export a follower - exports an NPC from your faction
- Import a follower - spawns a new NPC based on a file and adds her or him to your faction
- Export self - a shortcut to export the protagonist if you don't have a follower to switch to

#### Describe alternatives you've considered

1. I did not add an "Import self" command as it appears to be redundant: the same effect can be achieved with "Import a follower" followed by "Control NPC follower"
2. Export&import of followers is not required to replace the "character to template" feature, but the extra features are useful to me personally (original motivation for this PR). I hope other players will find them useful too
3. I have considered not hiding this in the debug menu, but I can not imagine any way to replace the "character to template" feature that would not be some form of "cheating"

#### Testing

Tried exporting and importing characters - appears to work.

#### Additional context

Please reopen #55094. The button is unavailable to me. :(

This is still raw-ish. There are likely edge cases I have not considered. As we know, devs make poor testers. It would be great if someone who was not involved in writing this tried to break it.