### PR TITLE
Fix inverted visitied member conditional for large Json objects.

### DIFF
--- a/src/flexbuffer_json.cpp
+++ b/src/flexbuffer_json.cpp
@@ -262,7 +262,7 @@ void JsonObject::report_unvisited() const
             tiny_bitset::block_t block = bits[block_idx];
             tiny_bitset::block_t mask = tiny_bitset::kLowBit << ( tiny_bitset::kBitsPerBlock - 1 );
             for( size_t bit_idx = 0; bit_idx < tiny_bitset::kBitsPerBlock; ++bit_idx ) {
-                if( block & mask ) {
+                if( !( block & mask ) ) {
                     skipped_members.emplace_back( block_idx * tiny_bitset::kBitsPerBlock + bit_idx );
                 }
                 mask >>= 1;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #65162.

# Primary issue
This boolean check is inverted https://github.com/CleverRaven/Cataclysm-DDA/blob/f13d34ade880ad7b8f291a7e7dbd6103e6b86f4e/src/flexbuffer_json.cpp#L265

It should be `if( !( block & mask ) ) {` like down here https://github.com/CleverRaven/Cataclysm-DDA/blob/f13d34ade880ad7b8f291a7e7dbd6103e6b86f4e/src/flexbuffer_json.cpp#L276

Because it is inverted it will add every visited member to the unvisited members vector. The block bits are 1 if the member was visited, the mask is a single bit set mask to test each in sequence.

# Why does it only happen on 32 bit
Many things must be true to hit the problem code.
1) There must be at least one unvisited member in Json instance. Typically this happens from comment members in objects. Arrays do not have comment members.
2) There must be more than `uintptr_t` bits worth of members in the object. On 32 bit arches that's 32, 64 for 64 bit arches. There are two separate loops for iterating through 'whole blocks' of the bitset and through 'partial blocks' of the bitset. If there's more than 32 or 64 members, then there's going to be more than 1 block in the bitset, so there's at least one whole block. The inverted check is in the 'whole block' loop.
3) There are no objects with more than 64 members that have comment members, so the whole block loop is never entered on 64 bit platforms.

# Why does removing comments fix it
If the entire bitset is filled, then the entire function is skipped from this check https://github.com/CleverRaven/Cataclysm-DDA/blob/f13d34ade880ad7b8f291a7e7dbd6103e6b86f4e/src/flexbuffer_json.cpp#L255 where it tests `!visited_fields_bitset_.all()`. Since comment members are typically the only unvisited members in objects, this avoids the bad code.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fix the conditional.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Refactor the visited members test code to use a single loop to DRY / avoid duplicate code bugs like this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Reproduced the error. Applied the fix. Created & loaded a new game in a 32 bit build successfully.
Used code in the JsonObject constructor to test for if size > 64 && any member has comments, to throw an exception. Does not fire, validating the assumption above about why 64 bit builds don't hit this.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->