### PR TITLE
Camps display required calories for crafting and building upgrades

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -783,12 +783,16 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
             if( npc_list.empty() ) {
                 std::string display_name = name_display_of( miss_id );
                 const recipe &making = *recipe_id( miss_id.parameters );
+                const int foodcost = time_to_food( base_camps::to_workdays( time_duration::from_moves(
+                                                       making.blueprint_build_reqs().reqs_by_parameters.find( miss_id.mapgen_args )->second.time ) ),
+                                                   BRISK_EXERCISE );
+                bool can_upgrade = upgrade.avail;
                 entry = om_upgrade_description( upgrade.bldg, upgrade.args );
-                entry += string_format( _( "Total calorie cost: %s\n" ),
-                                        time_to_food( base_camps::to_workdays( time_duration::from_moves(
-                                                making.blueprint_build_reqs().reqs_by_parameters.find( miss_id.mapgen_args )->second.time ) ),
-                                                      BRISK_EXERCISE ) );
-                mission_key.add_start( miss_id, display_name, entry, upgrade.avail );
+                entry += string_format( _( "Total calorie cost: %s\n" ), foodcost );
+                if( foodcost > camp_food_supply( 0, false ) ) {
+                    can_upgrade = false;
+                }
+                mission_key.add_start( miss_id, display_name, entry, can_upgrade );
             } else {
                 entry = action_of( miss_id.id );
                 bool avail = update_time_left( entry, npc_list );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -791,13 +791,13 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
                 entry = om_upgrade_description( upgrade.bldg, upgrade.args );
                 if( foodcost > available_calories ) {
                     can_upgrade = false;
-                    entry += string_format( _( "Total calorie cost: " ) ) +
-                             string_format( colorize( std::to_string( foodcost ), c_red ) ) +
-                             string_format( _( "(have %s)" ), available_calories );
+                    entry += string_format( _( "Total calorie cost: %s (have %d)" ),
+                                            colorize( std::to_string( foodcost ), c_red ),
+                                            available_calories );
                 } else {
-                    entry += string_format( _( "Total calorie cost: " ) ) +
-                             string_format( colorize( std::to_string( foodcost ), c_green ) ) +
-                             string_format( _( "(have %s)" ), available_calories );
+                    entry += string_format( _( "Total calorie cost: %s (have %d)" ),
+                                            colorize( std::to_string( foodcost ), c_green ),
+                                            available_calories );
                 }
                 mission_key.add_start( miss_id, display_name, entry, can_upgrade );
             } else {

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -782,7 +782,12 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
 
             if( npc_list.empty() ) {
                 std::string display_name = name_display_of( miss_id );
+                const recipe &making = *recipe_id( miss_id.parameters );
                 entry = om_upgrade_description( upgrade.bldg, upgrade.args );
+                entry += string_format( _( "Total calorie cost: %s\n" ),
+                                        time_to_food( base_camps::to_workdays( time_duration::from_moves(
+                                                making.blueprint_build_reqs().reqs_by_parameters.find( miss_id.mapgen_args )->second.time ) ),
+                                                      BRISK_EXERCISE ) );
                 mission_key.add_start( miss_id, display_name, entry, upgrade.avail );
             } else {
                 entry = action_of( miss_id.id );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -786,13 +786,18 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
                 const int foodcost = time_to_food( base_camps::to_workdays( time_duration::from_moves(
                                                        making.blueprint_build_reqs().reqs_by_parameters.find( miss_id.mapgen_args )->second.time ) ),
                                                    BRISK_EXERCISE );
+                const int available_calories = camp_food_supply( 0, false );
                 bool can_upgrade = upgrade.avail;
                 entry = om_upgrade_description( upgrade.bldg, upgrade.args );
-                if( foodcost > camp_food_supply( 0, false ) ) {
+                if( foodcost > available_calories ) {
                     can_upgrade = false;
-                    entry += string_format( "%s %s\n", colorize( _( "Total calorie cost:" ), c_red ), foodcost );
+                    entry += string_format( _( "Total calorie cost: " ) ) +
+                             string_format( colorize( std::to_string( foodcost ), c_red ) ) +
+                             string_format( _( "(have %s)" ), available_calories );
                 } else {
-                    entry += string_format( _( "Total calorie cost: %s\n" ), foodcost );
+                    entry += string_format( _( "Total calorie cost: " ) ) +
+                             string_format( colorize( std::to_string( foodcost ), c_green ) ) +
+                             string_format( _( "(have %s)" ), available_calories );
                 }
                 mission_key.add_start( miss_id, display_name, entry, can_upgrade );
             } else {

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -788,9 +788,11 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
                                                    BRISK_EXERCISE );
                 bool can_upgrade = upgrade.avail;
                 entry = om_upgrade_description( upgrade.bldg, upgrade.args );
-                entry += string_format( _( "Total calorie cost: %s\n" ), foodcost );
                 if( foodcost > camp_food_supply( 0, false ) ) {
                     can_upgrade = false;
+                    entry += string_format( "%s %s\n", colorize( _( "Total calorie cost:" ), c_red ), foodcost );
+                } else {
+                    entry += string_format( _( "Total calorie cost: %s\n" ), foodcost );
                 }
                 mission_key.add_start( miss_id, display_name, entry, can_upgrade );
             } else {

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -4779,9 +4779,11 @@ std::string basecamp::craft_description( const recipe_id &itm )
     for( auto &elem : component_print_buffer ) {
         str_append( comp, elem, "\n" );
     }
-    comp = string_format( _( "Skill used: %s\nDifficulty: %d\n%s\nTime: %s\n" ),
+    comp = string_format( _( "Skill used: %s\nDifficulty: %d\n%s\nTime: %s\nCalories per craft: %s\n" ),
                           making.skill_used.obj().name(), making.difficulty, comp,
-                          to_string( base_camps::to_workdays( making.batch_duration( get_player_character() ) ) ) );
+                          to_string( base_camps::to_workdays( making.batch_duration( get_player_character() ) ) ),
+                          time_to_food( base_camps::to_workdays( making.batch_duration( get_player_character() ) ),
+                                        itm.obj().exertion_level() ) );
     return comp;
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Camps properly display required calories for building and crafting"

#### Purpose of change
* Fixes #66144

#### Describe the solution
Since calories are no longer 2500 per workday but variable depending on exertion level, the display needs to reflect that. Now it does.

#### Describe alternatives you've considered
~~I'd like to colorize the calorie display depending on whether or not you have enough, but shoving even more conditions into basecamp::get_available_missions_by_dir seems unnecessary. Ideally it'd go into basecamp::om_upgrade_description but~~ ~~basecamp doesn't have access to time_to_food and dealing with all that seems very unnecessary (https://discord.com/channels/598523535169945603/598529174302490644/1122957912550146238)~~
Implemented that! 


#### Testing
<details>
 <summary>Screenshots of it at work</summary>

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/9857d8da-1b30-42e1-9164-ee56842dcf15)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/48ef4847-6cc5-44f0-af58-d3ab334cec87)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/fd1a8d3c-052f-4df4-9e66-5427a39ffc3c)
[increase stored calories to 65000]
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/ca52772b-c337-48e0-b3e0-8272679633a6)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/a5734975-6f42-4b25-8e75-492e343d8a7e)

</details>

#### Additional context
Known issues:
-*Crafting*(not building) display sometimes displays as 0, this is due to the use of `fake` activity levels for NPC-only recipes. (Yes, I will eventually make a *third* PR to resolve that)

-Calories may not actually be consumed when crafting. Unrelated to this PR, will be resolved separately.

~~-Display does not properly dim possible upgrades if you don't have enough calories. Will be resolved before undrafting.~~