### PR TITLE
Move mansion bookcase memorial items out of the mansion_books item group

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/mansion.json
+++ b/data/json/itemgroups/Locations_MapExtras/mansion.json
@@ -438,7 +438,8 @@
     "subtype": "collection",
     "items": [
       { "group": "novels", "prob": 40 },
-      { "group": "mansion_books", "prob": 50 },
+      { "group": "mansion_books", "prob": 48 },
+      { "group": "memorial_mansion", "prob": 2 },
       { "group": "homebooks", "prob": 30 },
       { "group": "manuals", "prob": 10 },
       { "group": "textbooks", "prob": 5 },

--- a/data/json/itemgroups/books.json
+++ b/data/json/itemgroups/books.json
@@ -573,8 +573,7 @@
       { "item": "vacuum_sealing", "prob": 15 },
       { "item": "baking_book", "prob": 190 },
       { "item": "book_pneumatics", "prob": 8 },
-      { "item": "cookbook_bloodforgood", "prob": 50 },
-      { "group": "memorial_mansion", "prob": 10 }
+      { "item": "cookbook_bloodforgood", "prob": 50 }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Bugfixes "No more memorial items spawning in bookstore shelves, only books!"

#### Purpose of change
* Fixes #65450
* Supersedes #65710

Bookstore shelves contained mansion_books, which itself contained memorial_mansion. The intention was that these spawn on mansion bookshelves, but *commercial* book stores were accidentally using the mansion_books group while unaware of this.

#### Describe the solution
Remove memorial_mansion from the mansion_books group, place it into mansion_bookcase group. Adjust spawn probabilities slightly to account for differences, trying to keep roughly the same old spawns while preventing ashes and urns from appearing in bookstores.

#### Describe alternatives you've considered
As explained by my comment in #65710 this could be inlined to better preserve the existing spawn chance but it's a veeeery slight change.

#### Testing
Github tests guide my hand...

#### Additional context
