### PR TITLE
reduce impact of bmi on healthiness

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4538,10 +4538,8 @@ void Character::update_health()
 {
     // Limit daily_health to [-200, 200].
     // This also sets approximate bounds for the character's health.
-    // if( get_daily_health() > 200 ) {
-
-    if( get_daily_health() > get_max_healthy() ) {
-        set_daily_health( get_max_healthy() );
+    if( get_daily_health() > 200 ) {
+        set_daily_health( 200 );
     } else if( get_daily_health() < -200 ) {
         set_daily_health( -200 );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3943,7 +3943,7 @@ int Character::get_lifestyle() const
                                             5 * ( bmi - character_weight_category::obese ) ) );
     int under_factor = std::round( std::max( 0.0f,
                                    50 * ( character_weight_category::normal - bmi ) ) );
-    return std::max( lifestyle - over_factor - under_factor, -200 );
+    return std::max( lifestyle - ( over_factor + under_factor ), -200 );
 }
 
 int Character::get_daily_health() const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3952,7 +3952,7 @@ int Character::get_health_tally() const
                                             5 * ( bmi - character_weight_category::obese ) ) );
     int under_factor = std::round( std::max( 0.0f,
                                    50 * ( character_weight_category::normal - bmi ) ) );
-    return std::max( health_tally - over_factor - under_factor, -200);
+    return std::max( health_tally - over_factor - under_factor, -200 );
 }
 
 /*

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3928,8 +3928,24 @@ int Character::ranged_per_mod() const
 
 int Character::get_lifestyle() const
 {
-    return lifestyle;
+    // gets your health_tally variable + the factor of your bmi on your healthiness.
+
+    // being over or underweight makes your "effective healthiness" lower.
+    // for example, you have a lifestyle of 0 and a bmi_fat of 15 (border between obese and very obese)
+    // 0 - 25 - 0 = -25. So your "effective lifestyle" is -25 (feel a little cruddy)
+    // ex2 you have a lifestyle of 50 and a bmi_fat of 15 because you get exercise and eat well
+    // 50 - 25 - 0 = 25. So your "effective lifestyle" is 25 (feel decent despite being obese)
+    // ex3 you have a lifestyle of -50 and a bmi_fat of 15 because you eat candy and don't exercise
+    // -50 - 25 - 0 = -75. So your "effective lifestyle" is -75 (you'd feel crappy normally but because of your weight you feel worse)
+
+    const float bmi = get_bmi_fat();
+    int over_factor = std::round( std::max( 0.0f,
+                                            5 * ( bmi - character_weight_category::obese ) ) );
+    int under_factor = std::round( std::max( 0.0f,
+                                   50 * ( character_weight_category::normal - bmi ) ) );
+    return std::max( lifestyle - over_factor - under_factor, -200 );
 }
+
 int Character::get_daily_health() const
 {
     return daily_health;
@@ -3937,22 +3953,7 @@ int Character::get_daily_health() const
 
 int Character::get_health_tally() const
 {
-    // gets your health_tally variable + the factor of your bmi on your healthiness.
-
-    // being over or underweight makes your "effective healthiness" lower.
-    // for example, you have a healthy tally of 0 and a bmi_fat of 15 (border between obese and very obese)
-    // 0 - 25 - 0 = -25. So your "effective health tally" is -25 (feel a little cruddy)
-    // ex2 you have a healthy tally of 50 and a bmi_fat of 15 because you get exercise and eat well
-    // 50 - 25 - 0 = 25. So your "effective health tally" is 25 (feel decent despite being obese)
-    // ex3 you have a healthy tally of -50 and a bmi_fat of 15 because you eat candy and don't exercise
-    // -50 - 25 - 0 = -75. So your "effective health tally" is -75 (you'd feel crappy normally but because of your weight you feel worse)
-
-    const float bmi = get_bmi_fat();
-    int over_factor = std::round( std::max( 0.0f,
-                                            5 * ( bmi - character_weight_category::obese ) ) );
-    int under_factor = std::round( std::max( 0.0f,
-                                   50 * ( character_weight_category::normal - bmi ) ) );
-    return std::max( health_tally - over_factor - under_factor, -200 );
+    return health_tally;
 }
 
 /*

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3941,18 +3941,18 @@ int Character::get_health_tally() const
 
     // being over or underweight makes your "effective healthiness" lower.
     // for example, you have a healthy tally of 0 and a bmi_fat of 15 (border between obese and very obese)
-    // 0 - 25 - 0 = -25, -200 - 0 = -200. So your "effective health tally" is -25 (feel a little cruddy)
+    // 0 - 25 - 0 = -25. So your "effective health tally" is -25 (feel a little cruddy)
     // ex2 you have a healthy tally of 50 and a bmi_fat of 15 because you get exercise and eat well
-    // 50 - 25 - 0 = -25, -200 - 50 = -250. So your "effective health tally" is 25 (feel decent despite being obese)
+    // 50 - 25 - 0 = 25. So your "effective health tally" is 25 (feel decent despite being obese)
     // ex3 you have a healthy tally of -50 and a bmi_fat of 15 because you eat candy and don't exercise
-    // -50 - 25 - 0 = -25, -200 - -50 = -200. So your "effective health tally" is -75 (you'd feel crappy normally but because of your weight you feel worse)
+    // -50 - 25 - 0 = -75. So your "effective health tally" is -75 (you'd feel crappy normally but because of your weight you feel worse)
 
     const float bmi = get_bmi_fat();
     int over_factor = std::round( std::max( 0.0f,
                                             5 * ( bmi - character_weight_category::obese ) ) );
     int under_factor = std::round( std::max( 0.0f,
                                    50 * ( character_weight_category::normal - bmi ) ) );
-    return std::max( health_tally - over_factor - under_factor, -200 - health_tally );
+    return std::max( health_tally - over_factor - under_factor, -200);
 }
 
 /*
@@ -4471,7 +4471,6 @@ int Character::get_max_healthy() const
                                    200 * ( character_weight_category::normal - bmi ) ) );
     return std::max( 200 - over_factor - under_factor, -200 );
 }
-
 
 void Character::regen( int rate_multiplier )
 {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4538,8 +4538,10 @@ void Character::update_health()
 {
     // Limit daily_health to [-200, 200].
     // This also sets approximate bounds for the character's health.
-    if( get_daily_health() > 200 ) {
-        set_daily_health( 200 );
+    // if( get_daily_health() > 200 ) {
+
+    if( get_daily_health() > get_max_healthy() ) {
+        set_daily_health( get_max_healthy() );
     } else if( get_daily_health() < -200 ) {
         set_daily_health( -200 );
     }

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -276,6 +276,7 @@ static float untreated_rate( const std::string &bp_name, const float rest_qualit
 static float bandaged_rate( const std::string &bp_name, const float rest_quality )
 {
     avatar dummy;
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
     const bodypart_id &bp = bodypart_id( bp_name );
     dummy.add_effect( effect_bandaged, 1_turns, bp );
     return dummy.healing_rate_medicine( rest_quality, bp );

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -64,7 +64,8 @@ TEST_CASE( "baseline_healing_rate_with_no_healing_traits", "[heal][baseline]" )
 
     GIVEN( "character with no healing traits" ) {
         dummy.clear_mutations();
-        dummy.set_stored_kcal( dummy.get_healthy_kcal() ); // just in case we mutated into something of a different size
+        // just in case we mutated into something of a different size
+        dummy.set_stored_kcal( dummy.get_healthy_kcal() );
         // Ensure there are no healing modifiers from traits/mutations
         REQUIRE( dummy.mutation_value( "healing_multiplier" ) == 1.0f );
         REQUIRE( dummy.mutation_value( "healing_awake" ) == 0.0f );

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -268,6 +268,7 @@ TEST_CASE( "health_effects_on_healing_rate", "[heal][health]" )
 static float untreated_rate( const std::string &bp_name, const float rest_quality )
 {
     avatar dummy;
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
     return dummy.healing_rate_medicine( rest_quality, bodypart_id( bp_name ) );
 }
 
@@ -284,6 +285,7 @@ static float bandaged_rate( const std::string &bp_name, const float rest_quality
 static float disinfected_rate( const std::string &bp_name, const float rest_quality )
 {
     avatar dummy;
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
     const bodypart_id &bp = bodypart_id( bp_name );
     dummy.add_effect( effect_disinfected, 1_turns, bp );
     return dummy.healing_rate_medicine( rest_quality, bp );
@@ -293,6 +295,7 @@ static float disinfected_rate( const std::string &bp_name, const float rest_qual
 static float together_rate( const std::string &bp_name, const float rest_quality )
 {
     avatar dummy;
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
     const bodypart_id &bp = bodypart_id( bp_name );
     dummy.add_effect( effect_bandaged, 1_turns, bp );
     dummy.add_effect( effect_disinfected, 1_turns, bp );
@@ -304,6 +307,7 @@ static float together_rate_with_extras( const std::string &bp_name,
                                         const std::vector<std::string> &extra_bps, const float rest_quality )
 {
     avatar dummy;
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
     const bodypart_id &bp = bodypart_id( bp_name );
     dummy.add_effect( effect_bandaged, 1_turns, bp );
     dummy.add_effect( effect_disinfected, 1_turns, bp );

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -85,6 +85,7 @@ TEST_CASE( "baseline_healing_rate_with_no_healing_traits", "[heal][baseline]" )
 TEST_CASE( "traits_and_mutations_affecting_healing_rate", "[heal][trait][mutation]" )
 {
     avatar dummy;
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
 
     // TODO: Include `healing_rate_medicine` for trait-related healing effects, since many of these
     // affect healing while awake (which can only happen there), or have such small effects as to be
@@ -214,6 +215,7 @@ TEST_CASE( "traits_and_mutations_affecting_healing_rate", "[heal][trait][mutatio
 TEST_CASE( "health_effects_on_healing_rate", "[heal][health]" )
 {
     avatar dummy;
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
 
     // Normal healing rate from game_balance.json
     const float normal = get_option<float>( "PLAYER_HEALING_RATE" );

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -45,6 +45,7 @@ static void give_one_trait( Character &dummy, const std::string &trait_name )
 static float healing_rate_at_health( Character &dummy, const int healthy_value,
                                      const float rest_quality )
 {
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
     dummy.set_lifestyle( healthy_value );
     return dummy.healing_rate( rest_quality );
 }

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -54,7 +54,7 @@ static float healing_rate_at_health( Character &dummy, const int healthy_value,
 TEST_CASE( "baseline_healing_rate_with_no_healing_traits", "[heal][baseline]" )
 {
     avatar dummy;
-
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
     // What is considered normal baseline healing rate comes from game_balance.json.
     const float normal = get_option<float>( "PLAYER_HEALING_RATE" );
     REQUIRE( normal > 1.0f * hp_per_day );
@@ -64,6 +64,7 @@ TEST_CASE( "baseline_healing_rate_with_no_healing_traits", "[heal][baseline]" )
 
     GIVEN( "character with no healing traits" ) {
         dummy.clear_mutations();
+        dummy.set_stored_kcal( dummy.get_healthy_kcal() ); // just in case we mutated into something of a different size
         // Ensure there are no healing modifiers from traits/mutations
         REQUIRE( dummy.mutation_value( "healing_multiplier" ) == 1.0f );
         REQUIRE( dummy.mutation_value( "healing_awake" ) == 0.0f );

--- a/tests/health_test.cpp
+++ b/tests/health_test.cpp
@@ -60,6 +60,7 @@ static void daily_routine( npc &dude, int numb_stam_burn, int vitamin_amount,
 TEST_CASE( "healthy_lifestyle", "[health]" )
 {
     standard_npc dude( "healthy lifestyle" );
+    dude.set_stored_kcal( dude.get_healthy_kcal() );
 
     int init_lifestyle = dude.get_lifestyle();
 
@@ -75,6 +76,7 @@ TEST_CASE( "healthy_lifestyle", "[health]" )
 TEST_CASE( "unhealthy_lifestyle", "[health]" )
 {
     standard_npc dude( "unhealthy lifestyle" );
+    dude.set_stored_kcal( dude.get_healthy_kcal() );
 
     int init_lifestyle = dude.get_lifestyle();
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "BMI has a less all consuming impact on how healthy you are"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
BMI influence on healthiness was broken by the lifestyle system. If you had a BMI in an unhealthy range, it caused your daily healthiness to be lowered by that much each day (in many cases this was like -100 healthiness per day) which was extreme (fat people don't heal from injuries 90% slower and get out of bed every day feeling like they're dying) and also made your lifestyle basically meaningless. If you were mildly obese you may have had an unhealthiness factor of like -25 which means unless you can get more than 25 points of healthiness per day (basically impossible without chugging panaceii) your health would slowly tick down to -200. So being healthy didn't even matter, because no matter what you did you would become as unhealthy as possible very quickly. Since you were already at minimum healthiness, you can do all the mutagens, candy, hard drugs, etc you want with no consequences because it can't get any worse, and nothing you can do except losing weight would make it better.

"Feels awful" should basically only come from eating lots of mutant meat or abusing mutagens. Unless you're so fat that you're literally dying (800+ lbs) you shouldn't "feel awful" unless you're living a garbage lifestyle on top of that.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
No longer limit daily_health to your BMI factor.
Your health tally (the net result of your daily healthiness compounding over days to weeks) is "effectively" lower due to BMI factor, this is -5 points per BMI over Obese. There are comments documenting this in the code but in summary being fat means you "feel" worse than you would be otherwise, but with enough exercise and healthy eating you can still be healthy, it is just harder. Your daily healthiness (the summary of your activities, vitamin consumption, etc) is unaffected by BMI. 
So if you have an XXL char you're about 50 points of healthiness lower than usual. This makes your range of healthiness -200 -> 150 (your absolute best healthiness isn't as high as a thin person). Technically goes down to -250 as it's always a 400 point scale but it is capped at -200. Upon starting the game you have -50 healthiness but if you're healthy you can feel good, it just takes more effort.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Different scaling for the formula.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled and tested and confirmed it's working as I want now.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This also fixes obesity health not impacting you until Midnight #1. You start the game unhealthy now.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->