### PR TITLE
Fix and re-enable 3D map memory

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2936,7 +2936,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             get_terrain_orientation( p, rotation, subtile, {}, invisible, rotate_group );
             // do something to get other terrain orientation values
         }
-        if( here.check_seen_cache( p ) && p.z == get_avatar().pos().z ) {
+        if( here.check_seen_cache( p ) ) {
             get_avatar().memorize_terrain( here.getabs( p ), tname, subtile, rotation );
         }
         // draw the actual terrain if there's no override
@@ -3019,7 +3019,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         const std::string &fname = f.id().str();
         if( !( you.get_grab_type() == object_type::FURNITURE
                && p == you.pos() + you.grab_point )
-            && here.check_seen_cache( p ) && p.z == get_avatar().pos().z ) {
+            && here.check_seen_cache( p ) ) {
             you.memorize_decoration( here.getabs( p ), fname, subtile, rotation );
         }
         // draw the actual furniture if there's no override
@@ -3106,7 +3106,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
         int rotation = 0;
         get_tile_values( tr.loadid.to_i(), neighborhood, subtile, rotation, 0 );
         const std::string trname = tr.loadid.id().str();
-        if( here.check_seen_cache( p ) && p.z == get_avatar().pos().z ) {
+        if( here.check_seen_cache( p ) ) {
             you.memorize_decoration( here.getabs( p ), trname, subtile, rotation );
         }
         // draw the actual trap if there's no override
@@ -3164,7 +3164,7 @@ bool cata_tiles::draw_part_con( const tripoint &p, const lit_level ll, int &heig
     if( here.partial_con_at( tripoint_bub_ms( p ) ) != nullptr && !invisible[0] ) {
         avatar &you = get_avatar();
         std::string const &trname = tr_unfinished_construction.str();;
-        if( here.check_seen_cache( p ) && p.z == get_avatar().pos().z ) {
+        if( here.check_seen_cache( p ) ) {
             you.memorize_decoration( here.getabs( p ), trname, 0, 0 );
         }
         return draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, 0,
@@ -3538,7 +3538,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             if( !veh.forward_velocity() && !veh.player_in_control( you )
                 && !( you.get_grab_type() == object_type::VEHICLE
                       && veh.get_points().count( you.pos() + you.grab_point ) )
-                && here.check_seen_cache( p ) && p.z == get_avatar().pos().z ) {
+                && here.check_seen_cache( p ) ) {
                 you.memorize_decoration( here.getabs( p ), vd.get_tileset_id(), subtile, rotation );
             }
             if( !overridden ) {

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -390,7 +390,7 @@ const mm_submap &map_memory::get_submap( const tripoint &sm_pos ) const
     }
     const point idx = ( sm_pos - cache_pos ).xy();
     if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y &&
-        cached[sm_pos.z].size() > 0 ) {
+        !cached[sm_pos.z].empty() ) {
         return *cached[sm_pos.z][idx.y * cache_size.x + idx.x];
     } else {
         return null_mz_submap;
@@ -404,7 +404,7 @@ mm_submap &map_memory::get_submap( const tripoint &sm_pos )
     }
     const point idx = ( sm_pos - cache_pos ).xy();
     if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y &&
-        cached[sm_pos.z].size() > 0 ) {
+        !cached[sm_pos.z].empty() ) {
         return *cached[sm_pos.z][idx.y * cache_size.x + idx.x];
     } else {
         return null_mz_submap;

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -275,10 +275,13 @@ bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )
     cache_pos = sm_pos;
     cache_size = sm_size;
     cached.clear();
-    cached.reserve( static_cast<std::size_t>( cache_size.x ) * cache_size.y );
-    for( int dy = 0; dy < cache_size.y; dy++ ) {
-        for( int dx = 0; dx < cache_size.x; dx++ ) {
-            cached.push_back( fetch_submap( cache_pos + point( dx, dy ) ) );
+    for( int z = -OVERMAP_DEPTH; z < OVERMAP_HEIGHT; z++ ) { //optimize this
+        cache_pos.z = z;
+        cached[z].reserve( static_cast<std::size_t>( cache_size.x ) * cache_size.y );
+        for( int dy = 0; dy < cache_size.y; dy++ ) {
+            for( int dx = 0; dx < cache_size.x; dx++ ) {
+                    cached[z].push_back( fetch_submap( cache_pos + point( dx, dy ) ) );
+            }
         }
     }
     return true;
@@ -384,7 +387,7 @@ const mm_submap &map_memory::get_submap( const tripoint &sm_pos ) const
     }
     const point idx = ( sm_pos - cache_pos ).xy();
     if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y ) {
-        return *cached[idx.y * cache_size.x + idx.x];
+        return *cached[sm_pos.z][idx.y * cache_size.x + idx.x];
     } else {
         return null_mz_submap;
     }
@@ -397,7 +400,7 @@ mm_submap &map_memory::get_submap( const tripoint &sm_pos )
     }
     const point idx = ( sm_pos - cache_pos ).xy();
     if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y ) {
-        return *cached[idx.y * cache_size.x + idx.x];
+        return *cached[sm_pos.z][idx.y * cache_size.x + idx.x];
     } else {
         return null_mz_submap;
     }

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -278,12 +278,11 @@ bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )
     // Loop through each z-level in vision range
     for( int z = std::max( sm_pos.z - fov_3d_z_range, -OVERMAP_DEPTH );
          z <= std::min( sm_pos.z + fov_3d_z_range, OVERMAP_HEIGHT ); z++ ) {
-        cache_pos.z = z;
         cached[z].reserve( static_cast<std::size_t>( cache_size.x ) * cache_size.y );
         for( int dy = 0; dy < cache_size.y; dy++ ) {
             for( int dx = 0; dx < cache_size.x; dx++ ) {
                 // Store submap pointer in cache, categorized by z-level
-                cached[z].push_back( fetch_submap( cache_pos + point( dx, dy ) ) );
+                cached[z].push_back( fetch_submap( tripoint( cache_pos.xy(), z ) + point( dx, dy ) ) );
             }
         }
     }

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -275,12 +275,15 @@ bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )
     cache_pos = sm_pos;
     cache_size = sm_size;
     cached.clear();
-    for( int z = std::max( sm_pos.z - fov_3d_z_range, -OVERMAP_DEPTH ); z <= std::min( sm_pos.z + fov_3d_z_range, OVERMAP_HEIGHT ); z++ ) {
+    // Loop through each z-level in vision range
+    for( int z = std::max( sm_pos.z - fov_3d_z_range, -OVERMAP_DEPTH );
+         z <= std::min( sm_pos.z + fov_3d_z_range, OVERMAP_HEIGHT ); z++ ) {
         cache_pos.z = z;
         cached[z].reserve( static_cast<std::size_t>( cache_size.x ) * cache_size.y );
         for( int dy = 0; dy < cache_size.y; dy++ ) {
             for( int dx = 0; dx < cache_size.x; dx++ ) {
-                    cached[z].push_back( fetch_submap( cache_pos + point( dx, dy ) ) );
+                // Store submap pointer in cache, categorized by z-level
+                cached[z].push_back( fetch_submap( cache_pos + point( dx, dy ) ) );
             }
         }
     }
@@ -386,7 +389,8 @@ const mm_submap &map_memory::get_submap( const tripoint &sm_pos ) const
         return invalid_mz_submap;
     }
     const point idx = ( sm_pos - cache_pos ).xy();
-    if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y && cached[sm_pos.z].size() > 0 ) {
+    if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y &&
+        cached[sm_pos.z].size() > 0 ) {
         return *cached[sm_pos.z][idx.y * cache_size.x + idx.x];
     } else {
         return null_mz_submap;
@@ -399,7 +403,8 @@ mm_submap &map_memory::get_submap( const tripoint &sm_pos )
         return invalid_mz_submap;
     }
     const point idx = ( sm_pos - cache_pos ).xy();
-    if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y && cached[sm_pos.z].size() > 0 ) {
+    if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y &&
+        cached[sm_pos.z].size() > 0 ) {
         return *cached[sm_pos.z][idx.y * cache_size.x + idx.x];
     } else {
         return null_mz_submap;

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -275,7 +275,7 @@ bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )
     cache_pos = sm_pos;
     cache_size = sm_size;
     cached.clear();
-    for( int z = -OVERMAP_DEPTH; z < OVERMAP_HEIGHT; z++ ) { //optimize this
+    for( int z = std::max( sm_pos.z - fov_3d_z_range, -OVERMAP_DEPTH ); z <= std::min( sm_pos.z + fov_3d_z_range, OVERMAP_HEIGHT ); z++ ) {
         cache_pos.z = z;
         cached[z].reserve( static_cast<std::size_t>( cache_size.x ) * cache_size.y );
         for( int dy = 0; dy < cache_size.y; dy++ ) {
@@ -386,7 +386,7 @@ const mm_submap &map_memory::get_submap( const tripoint &sm_pos ) const
         return invalid_mz_submap;
     }
     const point idx = ( sm_pos - cache_pos ).xy();
-    if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y ) {
+    if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y && cached[sm_pos.z].size() > 0 ) {
         return *cached[sm_pos.z][idx.y * cache_size.x + idx.x];
     } else {
         return null_mz_submap;
@@ -399,7 +399,7 @@ mm_submap &map_memory::get_submap( const tripoint &sm_pos )
         return invalid_mz_submap;
     }
     const point idx = ( sm_pos - cache_pos ).xy();
-    if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y ) {
+    if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y && cached[sm_pos.z].size() > 0 ) {
         return *cached[sm_pos.z][idx.y * cache_size.x + idx.x];
     } else {
         return null_mz_submap;

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -161,7 +161,7 @@ class map_memory
     private:
         std::map<tripoint, shared_ptr_fast<mm_submap>> submaps;
 
-        std::vector<shared_ptr_fast<mm_submap>> cached;
+        mutable std::map<int, std::vector<shared_ptr_fast<mm_submap>>> cached;
         tripoint cache_pos;
         point cache_size;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix and re-enable 3D map memory"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Map memory always had buggy interactions with 3D vision since #65738.  Cross z-level map memory was disabled in #66383 due to memory tiles being drawn on the wrong z-levels being more prominent on isometric tilesets.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Map memory itself is stored in 3D, but the caching and retrieval of submaps are performed on a single z-level.  The relevant code was revised and cross z-level map memory is re-enabled.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Builds ok
Map memory now works as expected
Memory tiles are drawn on the correct z-level on isometric tilesets
Tested on various tilesets and 3D settings
![Chiquita Waters _2023-06-28T11-40-44](https://github.com/CleverRaven/Cataclysm-DDA/assets/129854247/3e0611eb-4087-454e-92d7-85dc7b252fe5)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->