### PR TITLE
make welding practice less resource intensive

### DIFF
--- a/data/json/recipes/practice/fabrication.json
+++ b/data/json/recipes/practice/fabrication.json
@@ -73,12 +73,12 @@
       { "proficiency": "prof_welding_basic", "time_multiplier": 1, "skill_penalty": 0 }
     ],
     "time": "1 h",
-    "//": "240cm of welding",
-    "components": [ [ [ "sheet_metal_small", 24 ] ] ],
-    "byproducts": [ [ "scrap", 6 ] ],
-    "using": [ [ "welding_standard", 240 ] ],
-    "autolearn": [ [ "fabrication", 3 ] ],
-    "book_learn": [ [ "textbook_fabrication", 2 ] ]
+    "//": "40cm of welding, you're taking it slow and probably referencing a manual",
+    "components": [ [ [ "sheet_metal_small", 4 ] ] ],
+    "byproducts": [ [ "scrap", 4 ] ],
+    "using": [ [ "welding_standard", 40 ] ],
+    "autolearn": [ [ "fabrication", 4 ] ],
+    "book_learn": [ [ "textbook_fabrication", 2 ], [ "welding_book", 2 ] ]
   },
   {
     "id": "prac_welding_adv",
@@ -96,11 +96,11 @@
       { "proficiency": "prof_welding", "time_multiplier": 1, "skill_penalty": 0 }
     ],
     "time": "1 h",
-    "//": "300cm of welding",
-    "components": [ [ [ "sheet_metal_small", 30 ] ] ],
-    "byproducts": [ [ "scrap", 9 ] ],
-    "using": [ [ "welding_standard", 300 ] ],
-    "autolearn": [ [ "fabrication", 5 ] ],
+    "//": "60cm of welding, you're taking it slow and probably referencing a manual",
+    "components": [ [ [ "sheet_metal_small", 6 ] ] ],
+    "byproducts": [ [ "scrap", 6 ] ],
+    "using": [ [ "welding_standard", 60 ] ],
+    "autolearn": [ [ "fabrication", 6 ] ],
     "book_learn": [ [ "welding_book", 4 ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "welding practice uses less materials"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Welding practice recipes ended up being useless because they needed too many parts and you were better off finding a non-practice recipe with welding that used less materials.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Buff them, they use about 20% of the resources as before.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Buff them more, they might still be too weak.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->