### PR TITLE
No debug_mode when npc starts looping

### DIFF
--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -326,15 +326,8 @@ void monmove()
             // It has to be done before the last turn, otherwise
             // there will be no meaningful debug output.
             if( turns == 9 ) {
-                debugmsg( "NPC %s entered infinite loop.  Turning on debug mode",
-                          guy.get_name() );
-                debug_mode = true;
-                // make sure the filter is active
-                if( std::find(
-                        debugmode::enabled_filters.begin(), debugmode::enabled_filters.end(),
-                        debugmode::DF_NPC ) == debugmode::enabled_filters.end() ) {
-                    debugmode::enabled_filters.emplace_back( debugmode::DF_NPC );
-                }
+                debugmsg( "NPC '%s' entered infinite loop, npc activity id: '%s'",
+                          guy.get_name(), guy.activity.id().str() );
             }
         }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/51593
Stops players being confused https://discord.com/channels/598523535169945603/642349261320880128/1122867232532344933

#### Describe the solution

Debug mode shouldn't be player facing, remove the debug mode auto-toggle

#### Describe alternatives you've considered

Leaving the filter enabling code in, but all filters are already enabled by default

#### Testing

Don't think there's active reproduction case available, but the change is trivial and I crossed fingers on both hands

#### Additional context
