### PR TITLE
Remove redundant json in vehicleparts/doors.json and vehicleparts/vehicle_parts.json

### DIFF
--- a/data/json/vehicleparts/doors.json
+++ b/data/json/vehicleparts/doors.json
@@ -103,7 +103,6 @@
     "copy-from": "hddoor",
     "description": "A strong door.  Solid construction means you can't see through it when closed.",
     "durability": 660,
-    "location": "center",
     "looks_like": "door_opaque",
     "name": { "str": "heavy-duty opaque door" },
     "extend": { "flags": [ "OPAQUE" ] },

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2195,7 +2195,6 @@
     "name": { "str": "heavy-duty trunk door" },
     "variants": [ { "symbols": "+", "symbols_broken": "&" } ],
     "categories": [ "hull" ],
-    "color": "light_gray",
     "looks_like": "door_trunk",
     "broken_color": "light_gray",
     "damage_modifier": 80,

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2196,7 +2196,6 @@
     "variants": [ { "symbols": "+", "symbols_broken": "&" } ],
     "categories": [ "hull" ],
     "looks_like": "door_trunk",
-    "broken_color": "light_gray",
     "damage_modifier": 80,
     "durability": 750,
     "description": "A strong, short door.  You can always see over it, open or closed.",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -3247,7 +3247,6 @@
     "variants": [ { "symbols": "*", "symbols_broken": "*" } ],
     "categories": [ "other" ],
     "color": "light_blue",
-    "broken_color": "light_gray",
     "durability": 25,
     "description": "A lock and latching mechanism.  If installed on a door, this can be used to lock it.",
     "folded_volume": "250 ml",


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

It appears that #66450 forgot to remove some redundant json entries. This was causing debug warnings.

#### Describe the solution

Remove redundant `location`, `color` and `broken_color`

<!-- 
#### Describe alternatives you've considered

Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

The game loads successfully

<!-- 

#### Additional context

Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->