### PR TITLE
Enable mod tracker for vpart_info

### DIFF
--- a/data/json/vehicleparts/doors.json
+++ b/data/json/vehicleparts/doors.json
@@ -59,7 +59,7 @@
       "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "5 m", "using": [ [ "adhesive", 2 ] ] }
     },
     "damage_reduction": { "all": 0, "bash": 3 },
-    "delete": { "flags": [ "WINDOW" ] }
+    "delete": { "flags": [ "LOCKABLE_DOOR", "WINDOW" ] }
   },
   {
     "copy-from": "cloth_flap_door",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2191,83 +2191,6 @@
   },
   {
     "type": "vehicle_part",
-    "id": "hddoor_trunk",
-    "name": { "str": "heavy-duty trunk door" },
-    "variants": [ { "symbols": "+", "symbols_broken": "&" } ],
-    "categories": [ "hull" ],
-    "looks_like": "door_trunk",
-    "damage_modifier": 80,
-    "durability": 750,
-    "description": "A strong, short door.  You can always see over it, open or closed.",
-    "item": "hdframe",
-    "location": "center",
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "repair_welding_standard", 4 ] ] }
-    },
-    "flags": [
-      "OBSTACLE",
-      "OPENABLE",
-      "MULTISQUARE",
-      "BOARDABLE",
-      "LOW_FINAL_AIR_DRAG",
-      "WINDOW",
-      "SIMPLE_PART",
-      "DOOR",
-      "LOCKABLE_DOOR"
-    ],
-    "breaks_into": "ig_vp_hdframe",
-    "damage_reduction": { "all": 30 }
-  },
-  {
-    "type": "vehicle_part",
-    "id": "door_shutter",
-    "name": { "str": "shutter door" },
-    "looks_like": "hatch",
-    "variants": [ { "symbols": "+", "symbols_broken": "&" } ],
-    "categories": [ "hull" ],
-    "color": "white",
-    "broken_color": "white",
-    "damage_modifier": 80,
-    "durability": 95,
-    "description": "A strong door.  Solid construction means you can't see through it when closed.",
-    "item": "sheet_metal",
-    "location": "center",
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "repair_welding_standard", 2 ] ] }
-    },
-    "flags": [ "OPAQUE", "OBSTACLE", "OPENABLE", "MULTISQUARE", "BOARDABLE", "SIMPLE_PART", "DOOR", "LOCKABLE_DOOR" ],
-    "breaks_into": "ig_vp_sheet_metal",
-    "damage_reduction": { "all": 7 }
-  },
-  {
-    "type": "vehicle_part",
-    "id": "door_sliding",
-    "name": { "str": "sliding door" },
-    "variants": [ { "symbols": "+", "symbols_broken": "&" } ],
-    "looks_like": "door",
-    "categories": [ "hull" ],
-    "color": "light_cyan",
-    "broken_color": "light_cyan",
-    "damage_modifier": 80,
-    "durability": 150,
-    "description": "A door.  A window lets you see through it when closed.",
-    "item": "frame",
-    "location": "center",
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "repair_welding_standard", 2 ] ] }
-    },
-    "flags": [ "OBSTACLE", "OPENABLE", "MULTISQUARE", "BOARDABLE", "SIMPLE_PART", "DOOR", "LOCKABLE_DOOR" ],
-    "breaks_into": "ig_vp_frame",
-    "damage_reduction": { "all": 20 }
-  },
-  {
-    "type": "vehicle_part",
     "id": "cargo_space",
     "name": { "str": "cargo space" },
     "looks_like": "box",
@@ -2601,28 +2524,6 @@
     "copy-from": "seat_wood",
     "durability": 150,
     "description": "A benchlike place to sit."
-  },
-  {
-    "type": "vehicle_part",
-    "id": "spike_wood",
-    "name": { "str": "wooden spike" },
-    "variants": [ { "symbols": ".", "symbols_broken": "x" } ],
-    "categories": [ "warfare" ],
-    "color": "brown",
-    "broken_color": "brown",
-    "damage_modifier": 115,
-    "durability": 150,
-    "description": "A wooden spike, attached to the vehicle, to increase injury when crashing into things.",
-    "item": "pointy_stick",
-    "folded_volume": "1250 ml",
-    "location": "structure",
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
-    },
-    "flags": [ "SHARP", "PROTRUSION" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 3, 7 ] } ]
   },
   {
     "type": "vehicle_part",

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -465,7 +465,9 @@ class vpart_info
         int list_order = 0;
     private:
         bool was_loaded = false; // used by generic_factory
+        std::vector<std::pair<vpart_id, mod_id>> src;
         friend class generic_factory<vpart_info>;
+        friend struct mod_tracker;
 };
 
 struct vehicle_item_spawn {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Check for duplicate vpart definition ids

#### Describe the solution

Enable mod_tracker

Remove some duplicate vpart defs, they were moved to doors.json and accidentally resurrected in #61087, mod_tracker will now raise errors for this

Remove LOCKABLE_DOOR from cloth doors

#### Describe alternatives you've considered

#### Testing

Tests should pass

#### Additional context
