### PR TITLE
Made Slingshot more Tacticool

### DIFF
--- a/data/json/items/gunmod/mount.json
+++ b/data/json/items/gunmod/mount.json
@@ -109,7 +109,7 @@
     "symbol": ":",
     "color": "light_gray",
     "location": "stock mount",
-    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "launcher" ],
+    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "slingshot", "crossbow", "launcher" ],
     "install_time": "20 m",
     "min_skills": [ [ "gun", 5 ] ],
     "add_mod": [ [ "stock", 1 ] ],

--- a/data/json/items/gunmod/stock.json
+++ b/data/json/items/gunmod/stock.json
@@ -273,7 +273,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "stock",
-    "mod_targets": [ "smg", "pistol" ],
+    "mod_targets": [ "smg", "pistol", "slingshot" ],
     "install_time": "5 m",
     "dispersion_modifier": -20,
     "handling_modifier": 4,

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -370,7 +370,7 @@
     "sight_dispersion": 30,
     "field_of_view": 3000,
     "aim_speed_modifier": 15,
-    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "bow", "launcher" ],
+    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "bow", "slingshot", "launcher" ],
     "min_skills": [ [ "weapon", 2 ], [ "gun", 1 ] ],
     "flags": [ "PUMP_RAIL_COMPATIBLE", "LASER_SIGHT" ]
   },

--- a/data/json/items/ranged/slings.json
+++ b/data/json/items/ranged/slings.json
@@ -49,7 +49,7 @@
     "dispersion": 75,
     "durability": 6,
     "clip_size": 1,
-    "valid_mod_locations": [ [ "grip mount", 1 ], [ "underbarrel mount", 1 ] ],
+    "valid_mod_locations": [ [ "underbarrel mount", 1 ], [ "stock mount", 1 ] ],
     "reload": 50,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "pebble": 1 } } ]
   },
@@ -117,7 +117,7 @@
     "dispersion": 45,
     "durability": 7,
     "clip_size": 1,
-    "valid_mod_locations": [ [ "grip mount", 1 ], [ "underbarrel mount", 1 ] ],
+    "valid_mod_locations": [ [ "underbarrel mount", 1 ] ],
     "reload": 50,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "pebble": 1 } } ]
   }


### PR DESCRIPTION
#### Summary
Content "Made Slingshots more Tacticool"


#### Purpose of change
Since the wrist rocket slingshot has a wrist brace, but isn't craftable, I wanted the one you can craft to have an optional wrist brace, too. 


#### Describe the solution

I added the brace through the replacement stock mount and the tail hook stock. It improves the slingshot, but even paired with the underbarrel laser sight it's still weaker than the wrist rocket in every regard.

#### Describe alternatives you've considered

I could make the wrist rocket craftable, but I think it would be difficult to make one as good as modern manufacture can.


#### Testing

I spawned the mods and applied them, then compared their stats with unmodded slingshots. The mods went on like normal and changed the weapon's stats


#### Additional context

This started because I wanted to see a laser sight on a slingshot that actually helped it work better. I didn't realize that it was already possible, it just required the addition of a bottom mount. Now that I understand that system it's what I used to expand access to the tail hook stock. I also removed the grip mount mod slot from the slingshot and wrist rocket. It seemed unnecessary, as the ergonomic grip does literally nothing for slingshots but make them heavier. I'd hoped it would do something like reduce the stamina cost of shooting, but no dice yet. Maybe I can add that in eventually.