### PR TITLE
Bypass variant picking on install if there's only one choice

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3173,7 +3173,9 @@ void veh_interact::complete_vehicle( Character &you )
                 break;
             }
             ::vehicle_part &vp_new = veh->part( partnum );
-            do_change_shape_menu( vp_new );
+            if( vp_new.info().variants.size() > 1 ) {
+                do_change_shape_menu( vp_new );
+            }
 
             // Need map-relative coordinates to compare to output of look_around.
             // Need to call coord_translate() directly since it's a new part.


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Don't nag player with a choice menu if there's only one choice

#### Describe the solution

Skip it

#### Describe alternatives you've considered

#### Testing

Install some part with one variant - mounted spare tire for example, no menu should pop up

#### Additional context