### PR TITLE
No more adobe brick stadiums

### DIFF
--- a/data/json/mapgen_palettes/stadium_palette.json
+++ b/data/json/mapgen_palettes/stadium_palette.json
@@ -19,9 +19,7 @@
       },
       "e_wall_type": {
         "type": "ter_str_id",
-        "default": {
-          "distribution": [ [ "t_brick_wall", 6 ], [ "t_adobe_brick_wall", 2 ], [ "t_concrete_wall", 3 ], [ "t_strconc_wall", 5 ] ]
-        }
+        "default": { "distribution": [ [ "t_brick_wall", 6 ], [ "t_concrete_wall", 3 ], [ "t_strconc_wall", 5 ] ] }
       },
       "bush": {
         "type": "ter_str_id",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Realism. There is only a single stadium left standing (and one defunct one) that is made of adobe bricks and it is far from New England. https://www.kpbs.org/news/2013/04/25/bisbee-ballpark-history-bricks
Also given that we are a bit more in the future, the probability declines even further.
Yes, this appears to only apply to baseball stadiums but I can not find any other sources.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Have a 1% or lower chance for an adobe brick stadium.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

None needed. Although this "unbalances" the existing array.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->