### PR TITLE
Fish size cleanup

### DIFF
--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -579,7 +579,7 @@
     "copy-from": "mon_fish_tiny",
     "name": { "str": "brown bullhead" },
     "description": "A brown bullhead, a type of catfish.  Delicious when battered and fried.",
-    "volume": "500 ml",
+    "volume": "340 ml",
     "weight": "650 g",
     "reproduction": { "baby_egg": "egg_bullhead", "baby_count": 2, "baby_timer": 17 }
   },
@@ -597,7 +597,7 @@
     "name": { "str_sp": "channel catfish" },
     "looks_like": "mon_fish_bullhead",
     "description": "A channel catfish.  It has a forked tail and long whiskers.",
-    "volume": "5 L",
+    "volume": "4040 ml",
     "weight": "7 kg",
     "reproduction": { "baby_egg": "egg_channel_catfish", "baby_count": 2, "baby_timer": 17 }
   },
@@ -615,7 +615,7 @@
     "name": { "str_sp": "white catfish" },
     "looks_like": "mon_fish_bullhead",
     "description": "A white catfish.  A small whiskered fish with a broad head.",
-    "volume": "750 ml",
+    "volume": "620 ml",
     "weight": "950 g",
     "reproduction": { "baby_egg": "egg_white_catfish", "baby_count": 2, "baby_timer": 17 }
   },
@@ -632,7 +632,7 @@
     "copy-from": "mon_fish_medium",
     "name": { "ctxt": "fish", "str": "northern pike" },
     "description": "A northern pike.  Pike can be pretty aggressive fish, careful around those teeth.",
-    "volume": "3500 ml",
+    "volume": "3630 ml",
     "weight": "1750 g",
     "reproduction": { "baby_egg": "egg_pike", "baby_count": 2, "baby_timer": 17 }
   },
@@ -647,9 +647,9 @@
     "id": "mon_fish_pickerel",
     "type": "MONSTER",
     "copy-from": "mon_fish_medium",
-    "name": { "str": "pickerel" },
-    "description": "A pickerel.  It looks like a pike, but slightly smaller.",
-    "volume": "2750 ml",
+    "name": { "str": "chain pickerel" },
+    "description": "A chain pickerel.  It looks like a pike, but slightly smaller.",
+    "volume": "1620 ml",
     "weight": "1150 g",
     "reproduction": { "baby_egg": "egg_pickerel", "baby_count": 2, "baby_timer": 17 }
   },
@@ -667,7 +667,7 @@
     "name": { "str": "muskellunge" },
     "looks_like": "mon_fish_pike",
     "description": "A muskellunge.  Closely related to pike but even larger, it shares the same aggression and sharp teeth.",
-    "volume": "20 L",
+    "volume": "18700 ml",
     "weight": "10 kg",
     "reproduction": { "baby_egg": "egg_muskellunge", "baby_count": 2, "baby_timer": 17 }
   },

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -437,7 +437,7 @@
     "copy-from": "mon_fish_tiny",
     "name": { "str_sp": "banded sunfish" },
     "description": "A banded sunfish.  A small fish related to bass and bluegill.",
-    "volume": "50 ml",
+    "volume": "20 ml",
     "weight": "20 g",
     "reproduction": { "baby_egg": "egg_sunfish", "baby_count": 2, "baby_timer": 17 }
   },
@@ -455,7 +455,7 @@
     "name": { "str": "pumpkinseed" },
     "looks_like": "mon_fish_sunfish",
     "description": "A pumpkinseed sunfish.  A small fish related to bass and bluegill.",
-    "volume": "375 ml",
+    "volume": "80 ml",
     "weight": "175 g",
     "reproduction": { "baby_egg": "egg_pumpkinseed", "baby_count": 2, "baby_timer": 17 }
   },
@@ -472,6 +472,7 @@
     "copy-from": "mon_fish_tiny",
     "name": { "str": "bluegill" },
     "description": "A bluegill, an invasive species in Japan.  Commonly gutted and cooked whole.",
+    "volume": "290 ml",
     "weight": "280 g",
     "reproduction": { "baby_egg": "egg_bluegill", "baby_count": 2, "baby_timer": 17 }
   },
@@ -489,8 +490,8 @@
     "name": { "str_sp": "redbreast sunfish" },
     "looks_like": "mon_fish_sunfish",
     "description": "A redbreast sunfish.  A small fish related to bass and bluegill.",
-    "volume": "115 ml",
-    "weight": "55 g",
+    "volume": "110 ml",
+    "weight": "106 g",
     "reproduction": { "baby_egg": "egg_redbreast", "baby_count": 2, "baby_timer": 17 }
   },
   {
@@ -507,6 +508,7 @@
     "name": { "str_sp": "green sunfish" },
     "looks_like": "mon_fish_sunfish",
     "description": "A green sunfish.  A small fish related to bass and bluegill.",
+    "volume": "290 ml",
     "weight": "280 g",
     "reproduction": { "baby_egg": "egg_green_sunfish", "baby_count": 2, "baby_timer": 17 }
   },
@@ -524,8 +526,8 @@
     "name": { "str_sp": "rock bass" },
     "looks_like": "mon_fish_sunfish",
     "description": "A rock bass.  Related to sunfish, this tiny fish has a camouflage-like patterning and red eyes.",
-    "volume": "375 ml",
-    "weight": "175 g",
+    "volume": "750 ml",
+    "weight": "350 g",
     "reproduction": { "baby_egg": "egg_rock_bass", "baby_count": 2, "baby_timer": 17 }
   },
   {
@@ -542,8 +544,8 @@
     "name": { "str_sp": "black crappie" },
     "looks_like": "mon_fish_pbass",
     "description": "A black crappie.  A medium-sized fish also known as a 'calico bass'.",
-    "volume": "2300 ml",
-    "weight": "850 g",
+    "volume": "900 ml",
+    "weight": "400 g",
     "reproduction": { "baby_egg": "egg_calico_bass", "baby_count": 2, "baby_timer": 17 }
   },
   {
@@ -560,8 +562,8 @@
     "name": { "str": "warmouth" },
     "looks_like": "mon_fish_sunfish",
     "description": "A warmouth, similar to a rock bass.  This small fish is related to the sunfish.",
-    "volume": "375 ml",
-    "weight": "175 g",
+    "volume": "290 ml",
+    "weight": "280 g",
     "reproduction": { "baby_egg": "egg_warmouth", "baby_count": 2, "baby_timer": 17 }
   },
   {

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -228,6 +228,7 @@
     "name": { "str": "brown trout" },
     "looks_like": "mon_fish_salmon",
     "description": "A brown trout.  A fish made popular by father-son fishing trips, except for the part where you have to gut it.",
+    "volume": "18320 ml",
     "weight": "3 kg",
     "reproduction": { "baby_egg": "egg_brown_trout", "baby_count": 2, "baby_timer": 17 }
   },
@@ -245,7 +246,7 @@
     "name": { "str": "brook trout" },
     "looks_like": "mon_fish_salmon",
     "description": "A brook trout.  A fish made popular by father-son fishing trips, except for the part where you have to gut it.",
-    "volume": "3500 ml",
+    "volume": "900 ml",
     "weight": "1650 g",
     "reproduction": { "baby_egg": "egg_brook_trout", "baby_count": 2, "baby_timer": 17 }
   },
@@ -263,6 +264,7 @@
     "name": { "str": "lake trout" },
     "looks_like": "mon_fish_salmon",
     "description": "A lake trout.  A fish made popular by father-son fishing trips, except for the part where you have to gut it.",
+    "volume": "6140 ml",
     "weight": "4 kg",
     "reproduction": { "baby_egg": "egg_lake_trout", "baby_count": 2, "baby_timer": 17 }
   },
@@ -280,7 +282,7 @@
     "name": { "str": "rainbow trout" },
     "looks_like": "mon_fish_salmon",
     "description": "A rainbow trout.  A fish made popular by father-son fishing trips, except for the part where you have to gut it.",
-    "volume": "12 L",
+    "volume": "10600 ml",
     "weight": "3 kg",
     "reproduction": { "baby_egg": "egg_rainbow_trout", "baby_count": 2, "baby_timer": 17 }
   },
@@ -297,6 +299,7 @@
     "copy-from": "mon_fish_large",
     "name": { "str_sp": "atlantic salmon" },
     "description": "An Atlantic salmon.  A very fatty, nutritious fish.  Tastes great smoked.",
+    "volume": "10600 ml",
     "weight": "4 kg",
     "reproduction": { "baby_egg": "egg_salmon", "baby_count": 2, "baby_timer": 17 }
   },
@@ -314,7 +317,7 @@
     "name": { "str_sp": "kokanee salmon" },
     "looks_like": "mon_fish_salmon",
     "description": "A Kokanee salmon.  A very fatty, nutritious fish.  Tastes great smoked.",
-    "volume": "6 L",
+    "volume": "4470 ml",
     "weight": "3500 g",
     "reproduction": { "baby_egg": "egg_kokanee_salmon", "baby_count": 2, "baby_timer": 17 }
   },
@@ -331,7 +334,7 @@
     "copy-from": "mon_fish_medium",
     "name": { "str_sp": "lake whitefish" },
     "description": "A lake whitefish, closely related to salmon.  One can assume they taste just as nice when smoked.",
-    "volume": "5 L",
+    "volume": "7730 ml",
     "weight": "2 kg",
     "reproduction": { "baby_egg": "egg_whitefish", "baby_count": 2, "baby_timer": 17 }
   },

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -351,7 +351,7 @@
     "copy-from": "mon_fish_medium",
     "name": { "str_sp": "largemouth bass" },
     "description": "A largemouth bass.  Very popular with sport fishermen.",
-    "volume": "6 L",
+    "volume": "3140 ml",
     "reproduction": { "baby_egg": "egg_lbass", "baby_count": 2, "baby_timer": 17 }
   },
   {
@@ -367,7 +367,7 @@
     "copy-from": "mon_fish_medium",
     "name": { "str_sp": "smallmouth bass" },
     "description": "A smallmouth bass.  Infamously intolerant to pollution, the presence of smallmouth bass is a good indicator of how clean a body of water is.",
-    "volume": "4 L",
+    "volume": "3140 ml",
     "weight": "3 kg",
     "reproduction": { "baby_egg": "egg_sbass", "baby_count": 2, "baby_timer": 17 }
   },
@@ -384,7 +384,7 @@
     "copy-from": "mon_fish_medium",
     "name": { "str_sp": "striped bass" },
     "description": "A striped bass.  Mostly a saltwater fish, they migrate to fresher water to spawn.",
-    "volume": "13500 ml",
+    "volume": "16080 ml",
     "weight": "6500 g",
     "reproduction": { "baby_egg": "egg_pbass", "baby_count": 2, "baby_timer": 17 }
   },
@@ -402,7 +402,7 @@
     "name": { "str": "yellow perch", "str_pl": "yellow perches" },
     "looks_like": "mon_fish_pickerel",
     "description": "A small, sprightly perch.  It is a very bony fish, still has some tasty meat on it though.",
-    "volume": "500 ml",
+    "volume": "220 ml",
     "weight": "150 g",
     "reproduction": { "baby_egg": "egg_perch", "baby_count": 2, "baby_timer": 17 }
   },
@@ -420,7 +420,7 @@
     "name": { "str": "walleye" },
     "looks_like": "mon_fish_pbass",
     "description": "A walleye.  A green-brown medium-sized fish with a white belly.",
-    "volume": "4500 ml",
+    "volume": "4950 ml",
     "weight": "3 kg",
     "reproduction": { "baby_egg": "egg_walleye", "baby_count": 2, "baby_timer": 17 }
   },

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -685,7 +685,7 @@
     "name": { "str": "white sucker" },
     "looks_like": "mon_fish_pbass",
     "description": "A white sucker.  It has a streamlined body with a round mouth.",
-    "volume": "2500 ml",
+    "volume": "2120 ml",
     "weight": "660 g",
     "reproduction": { "baby_egg": "egg_white_sucker", "baby_count": 2, "baby_timer": 17 }
   },
@@ -702,7 +702,7 @@
     "copy-from": "mon_fish_medium",
     "name": { "str_sp": "European carp" },
     "description": "A golden-yellow common carp.  Some people think they don't taste great, but you can't afford to be choosy in the Cataclysm.",
-    "volume": "3000 ml",
+    "volume": "2010 ml",
     "weight": "1 kg",
     "reproduction": { "baby_egg": "egg_carp", "baby_count": 2, "baby_timer": 17 }
   },
@@ -720,7 +720,7 @@
     "name": { "str": "grass carp" },
     "looks_like": "mon_fish_carp",
     "description": "A huge grass carp.  A golden, herbivorous fish.",
-    "volume": "20 L",
+    "volume": "16080 ml",
     "weight": "15 kg",
     "reproduction": { "baby_egg": "egg_grass_carp", "baby_count": 2, "baby_timer": 17 }
   },
@@ -737,8 +737,8 @@
     "copy-from": "mon_fish_medium",
     "name": { "str": "bowfin" },
     "description": "A bowfin.  These fish are related to gar but without the huge teeth, skin-rending scales, and aggression.",
-    "volume": "3500 ml",
-    "weight": "1 kg",
+    "volume": "4780 ml",
+    "weight": "1300 g",
     "reproduction": { "baby_egg": "egg_bowfin", "baby_count": 2, "baby_timer": 17 }
   },
   {
@@ -755,7 +755,7 @@
     "name": { "str_sp": "fallfish" },
     "looks_like": "mon_fish_pbass",
     "description": "A fallfish.  These fish are small cyprinids, related to carp.",
-    "volume": "250 ml",
+    "volume": "160 ml",
     "weight": "120 g",
     "reproduction": { "baby_egg": "egg_fallfish", "baby_count": 2, "baby_timer": 17 }
   },
@@ -803,7 +803,7 @@
     "bodytype": "crab",
     "categories": [ "WILDLIFE" ],
     "species": [ "FISH" ],
-    "volume": "192 ml",
+    "volume": "90 ml",
     "weight": "52 g",
     "hp": 3,
     "speed": 150,
@@ -842,7 +842,7 @@
     "bodytype": "snake",
     "categories": [ "WILDLIFE" ],
     "species": [ "FISH" ],
-    "volume": "10 L",
+    "volume": "2160 ml",
     "weight": "2150 g",
     "hp": 10,
     "speed": 150,

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -333,7 +333,7 @@ bodkin
 bodyglove
 bodymesh
 bodypart
-bodyweight 
+bodyweight
 bokken
 bolas
 bolded
@@ -788,7 +788,7 @@ doesnt
 doffing
 dogbane
 doggo
-doglike 
+doglike
 domestica
 dongle
 doomseer
@@ -941,9 +941,9 @@ excreta
 excretions
 exhorts
 existentialists
-exoplanet
 exobay
 exodii
+exoplanet
 exosuit
 exosuits
 expansionary
@@ -1587,7 +1587,7 @@ lbs
 leache
 leatherbacked
 leatherbound
-leathercrafters 
+leathercrafters
 leatherworking
 leavening
 lectern
@@ -1763,7 +1763,7 @@ midden
 mideast
 mideastern
 midgame
-midground 
+midground
 midrange
 midsentence
 migo
@@ -2026,7 +2026,7 @@ overclock
 overclocks
 overdosage
 overdrinking
-overengineered 
+overengineered
 overexertion
 overgrowth
 overmap
@@ -2131,6 +2131,7 @@ phyle
 physicochemical
 pickelhaube
 pickerel
+pickerels
 pickhead
 pickin
 pickins
@@ -2523,8 +2524,8 @@ screwdriving
 scrrrash
 scruffs
 scutcher
-scutellosaurus
 scute
+scutellosaurus
 scutes
 scuttles
 sealab
@@ -2863,7 +2864,7 @@ testbed
 tetradrachm
 tetrahedron
 th
-thaumaturgical 
+thaumaturgical
 thawb
 themm
 therizinosaurus
@@ -2989,7 +2990,7 @@ uggo
 uistate
 ultracapacitor
 ultralight
-ultras 
+ultras
 ultratech
 unarmored
 unawareness
@@ -3041,7 +3042,6 @@ unlively
 unlives
 unlooted
 unlubricated
-unspooled
 unmalted
 unmark
 unmarred
@@ -3066,6 +3066,7 @@ unsiatable
 unskillfully
 unsorted
 unspecialized
+unspooled
 unsteadily
 unstocked
 unstrained
@@ -3256,7 +3257,7 @@ ynn
 yoroi
 youre
 yourselves
-youthful 
+youthful
 yowl
 yoyos
 yugg


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
In #61614 I audited fish sizes. And like an absolute moron, I calculated them as CUBES. We all know fish are cylinders and not cubes. This is unacceptable. My immersion is ruined.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Recalculated all the fish as cylinders and not cubes - most now have lower volume, except a few where I miscalculated it in the original PR. A few have changed weights since back then I didn't pick out the correct average weights. Pickerel renamed to Chain pickerel since I forgot to do it the last time.

Also apparently threw the dictionary through a tool to make it alphabetical. Smh people.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->