### PR TITLE
Active backup generator ---> Functional generator appliance, useable in player grids

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -5508,6 +5508,19 @@
   },
   {
     "type": "construction",
+    "id": "app_active_backup_generator",
+    "group": "place_active_backup_generator",
+    "category": "APPLIANCE",
+    "required_skills": [ [ "mechanics", 1 ] ],
+    "time": "5 m",
+    "qualities": [ [ { "id": "WRENCH", "level": 1 } ] ],
+    "components": [ [ [ "active_backup_generator", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_special": "done_appliance",
+    "activity_level": "LIGHT_EXERCISE"
+  },
+  {
+    "type": "construction",
     "id": "constr_pontoon_dp",
     "group": "build_pontoon_bridge",
     "//": "Set up pontoon bridge",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1711,6 +1711,11 @@
   },
   {
     "type": "construction_group",
+    "id": "place_active_backup_generator",
+    "name": "Place backup generator"
+  },
+  {
+    "type": "construction_group",
     "id": "build_rope_hoist",
     "name": "Hang Simple Rope Hoist"
   },

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -979,7 +979,7 @@
     "location": "structure",
     "damage_modifier": 80,
     "durability": 400,
-    "description": "FIXME",
+    "description": "A ubiquitous piece of compact machinery meant for running anything from the bathroom lights to electric stoves and other necessities when grid electricity is unavailable.",
     "//1": "BIZARRE FIELD NAMES HERE! Weird stuff happening! Epower determines how fast it is converted, power determines the ratio of diesel(mL) to battery charges output. In other words, *power* is *fuel efficiency*.",
     "//2": "On a normal vehicle 250mL of diesel in an I4 with a truck alternator (what the active backup gen uses) should provide ~1692 charges (kW?) of power in about 24 minutes based on a test setup. That's a little less than 7W power, rounded up as I assume a larger dedicated generator is more efficient.",
     "power": "7 W",

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -969,6 +969,44 @@
     "variants": [ { "symbols": "0", "symbols_broken": "#" } ]
   },
   {
+    "type": "vehicle_part",
+    "id": "ap_active_backup_generator",
+    "name": { "str": "active backup generator" },
+    "looks_like": "f_active_backup_generator",
+    "categories": [ "energy" ],
+    "color": "green_white",
+    "broken_color": "blue",
+    "location": "structure",
+    "damage_modifier": 80,
+    "durability": 400,
+    "description": "FIXME",
+    "//1": "BIZARRE FIELD NAMES HERE! Weird stuff happening! Epower determines how fast it is converted, power determines the ratio of diesel(mL) to battery charges output. In other words, *power* is *fuel efficiency*.",
+    "//2": "On a normal vehicle 250mL of diesel in an I4 with a truck alternator (what the active backup gen uses) should provide ~1692 charges (kW?) of power in about 24 minutes based on a test setup. That's a little less than 7W power, rounded up as I assume a larger dedicated generator is more efficient.",
+    "power": "7 W",
+    "//3": "Truck alternator value",
+    "epower": "1320 W",
+    "//4": "This value doesn't seem to do anything for the appliance version? Let's keep it commented out for future reference.",
+    "//energy_consumption": "1000 W",
+    "m2c": 5,
+    "//5": "Actually accepts any diesel-type fuel but does NOT account for their relative fuel values! For diesel this is not a huge deal, only a few % inaccuracy, but for e.g. gas turbines this would be very bad!",
+    "fuel_type": "diesel",
+    "//6": "Appliance engine does NOT accept having these fields.",
+    "//fuel_options": [ "diesel", "biodiesel", "lamp_oil", "motor_oil", "jp8" ],
+    "//damaged_power_factor": 0.25,
+    "item": "active_backup_generator",
+    "requirements": {
+      "repair": {
+        "skills": [ [ "mechanics", 4 ] ],
+        "time": "60 m",
+        "using": [ [ "repair_welding_standard", 5 ], [ "soldering_standard", 5 ] ]
+      }
+    },
+    "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "REACTOR", "FLUIDTANK" ],
+    "breaks_into": [ { "item": "scrap", "count": [ 4, 16 ] }, { "item": "steel_chunk", "count": [ 1, 6 ] } ],
+    "damage_reduction": { "all": 60 },
+    "variants": [ { "symbols": "0", "symbols_broken": "#" } ]
+  },
+  {
     "id": "app_microwave",
     "type": "vehicle_part",
     "name": { "str": "grid microwave" },

--- a/data/json/furniture_and_terrain/furniture-industrial.json
+++ b/data/json/furniture_and_terrain/furniture-industrial.json
@@ -578,6 +578,7 @@
     "move_cost_mod": -1,
     "coverage": 80,
     "required_str": 8,
+    "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "active_backup_generator" },
     "flags": [ "NOITEM", "SEALED", "REDUCE_SCENT", "PERMEABLE", "ACTIVE_GENERATOR" ],
     "bash": {
       "str_min": 5,

--- a/data/json/furniture_and_terrain/furniture-industrial.json
+++ b/data/json/furniture_and_terrain/furniture-industrial.json
@@ -579,7 +579,7 @@
     "coverage": 80,
     "required_str": 8,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "active_backup_generator" },
-    "flags": [ "NOITEM", "SEALED", "REDUCE_SCENT", "PERMEABLE", "ACTIVE_GENERATOR" ],
+    "flags": [ "NOITEM", "SEALED", "REDUCE_SCENT", "PERMEABLE", "ACTIVE_GENERATOR", "EASY_DECONSTRUCT" ],
     "bash": {
       "str_min": 5,
       "str_max": 40,
@@ -595,14 +595,6 @@
         { "item": "bearing", "charges": [ 5, 60 ] }
       ]
     },
-    "deconstruct": {
-      "items": [
-        { "item": "scrap", "count": [ 5, 15 ] },
-        { "item": "sheet_metal", "count": [ 4, 6 ] },
-        { "item": "jp8", "charges": [ 1000, 10000 ], "container-item": "jerrycan_big" },
-        { "item": "i4_diesel" },
-        { "item": "bearing", "charges": [ 5, 40 ] }
-      ]
-    }
+    "deconstruct": { "items": [ { "item": "active_backup_generator" } ] }
   }
 ]

--- a/data/json/itemgroups/Locations_MapExtras/airdrop.json
+++ b/data/json/itemgroups/Locations_MapExtras/airdrop.json
@@ -107,7 +107,7 @@
     "//": "This is a small diesel generator, outputting ~1.3kW. It is not military spec, but it is the only generator we have. Should be replaced with milspec 5kW generator item in the future",
     "//2": "yes, they should be 50-75% full, according to FM 10-535.",
     "entries": [
-      { "item": "jp8", "charges": [ 5000, 7500 ], "container-item": "active_backup_generator" },
+      { "item": "jp8", "charges": [ 10000, 15000 ], "container-item": "active_backup_generator" },
       { "item": "standing_directed_floodlight" },
       { "item": "jp8", "charges": [ 19000, 20000 ], "container-item": "jerrycan_big", "count": 5 },
       { "item": "cardboard", "count": [ 1200, 1700 ] }

--- a/data/json/itemgroups/Locations_MapExtras/airdrop.json
+++ b/data/json/itemgroups/Locations_MapExtras/airdrop.json
@@ -104,14 +104,11 @@
     "id": "airdrop_generator",
     "type": "item_group",
     "subtype": "collection",
-    "//": "should be replaced with 5kW generator item in the future.",
+    "//": "This is a small diesel generator, outputting ~1.3kW. It is not military spec, but it is the only generator we have. Should be replaced with milspec 5kW generator item in the future",
     "//2": "yes, they should be 50-75% full, according to FM 10-535.",
     "entries": [
-      { "item": "scrap", "count": [ 5, 15 ] },
-      { "item": "sheet_metal", "count": [ 4, 6 ] },
-      { "item": "jp8", "charges": [ 10000, 15000 ], "container-item": "jerrycan_big" },
-      { "item": "i4_diesel" },
-      { "item": "bearing", "charges": [ 5, 40 ] },
+      { "item": "jp8", "charges": [ 5000, 7500 ], "container-item": "active_backup_generator" },
+      { "item": "standing_directed_floodlight" },
       { "item": "jp8", "charges": [ 19000, 20000 ], "container-item": "jerrycan_big", "count": 5 },
       { "item": "cardboard", "count": [ 1200, 1700 ] }
     ]

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -369,6 +369,36 @@
   {
     "type": "GENERIC",
     "category": "other",
+    "id": "active_backup_generator",
+    "name": { "str_sp": "backup generator" },
+    "looks_like": "f_active_backup_generator",
+    "description": "A ubiquitous piece of compact machinery meant for running anything from the bathroom lights to electric stoves and other necessities when grid electricity is unavailable.  It just needs to be plugged in, fueled up, and then turned on.",
+    "weight": "200 kg",
+    "to_hit": -10,
+    "material": [ "steel" ],
+    "volume": "200 L",
+    "longest_side": "80 cm",
+    "price": "350 USD",
+    "price_postapoc": "25 USD",
+    "//1": "Plastic jerrycan values. Must have this pocket, otherwise will not have any fuel capacity as an appliance.",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "watertight": true,
+        "max_contains_volume": "10 L",
+        "max_item_volume": "32 ml",
+        "max_contains_weight": "15 kg"
+      }
+    ],
+    "symbol": "O",
+    "color": "green_white",
+    "//2": "Prevent loading items into the generator while it's not in appliance form.",
+    "flags": [ "NO_RELOAD" ]
+  },
+  {
+    "type": "GENERIC",
+    "category": "other",
     "id": "oxygen_concentrator",
     "name": { "str_sp": "oxygen concentrator" },
     "description": "A machine capable of generating pure oxygen from the air.  Can be placed and plugged into a power source.",

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -380,15 +380,15 @@
     "longest_side": "80 cm",
     "price": "350 USD",
     "price_postapoc": "25 USD",
-    "//1": "Plastic jerrycan values. Must have this pocket, otherwise will not have any fuel capacity as an appliance.",
+    "//1": "Steel jerrycan (jerrycan_big) values. Must have this pocket, otherwise will not have any fuel capacity as an appliance.",
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
-        "max_contains_volume": "10 L",
+        "max_contains_volume": "20 L",
         "max_item_volume": "32 ml",
-        "max_contains_weight": "15 kg"
+        "max_contains_weight": "25 kg"
       }
     ],
     "symbol": "O",

--- a/data/json/recipes/recipe_appliance.json
+++ b/data/json/recipes/recipe_appliance.json
@@ -191,5 +191,20 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "proficiencies": [ { "proficiency": "prof_elec_soldering" }, { "proficiency": "prof_appliance_repair" } ],
     "components": [ [ [ "frame_wood", 1 ] ], [ [ "battery_charger", 1 ] ] ]
+  },
+  {
+    "result": "active_backup_generator",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "reversible": true,
+    "skill_used": "mechanics",
+    "difficulty": 3,
+    "//": "combined install requirements for placing frame+alternator+engine as if you were putting together a vehicle with these 3 parts",
+    "time": "90 m",
+    "autolearn": true,
+    "category": "CC_APPLIANCE",
+    "subcategory": "CSC_APPLIANCE_UTILITY",
+    "using": [ [ "vehicle_wrench_2", 1 ] ],
+    "components": [ [ [ "alternator_truck", 1 ] ], [ [ "i4_diesel", 1 ] ], [ [ "frame", 1 ] ], [ [ "jerrycan_big", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -7583,7 +7583,7 @@
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",
     "time": "45 m",
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
-    "components": [ [ [ "alternator_truck", 1 ] ], [ [ "i4_diesel", 1 ] ], [ [ "frame", 1 ] ] ]
+    "qualities": [ { "id": "WRENCH", "level": 2 } ],
+    "components": [ [ [ "alternator_truck", 1 ] ], [ [ "i4_diesel", 1 ] ], [ [ "frame", 1 ] ], [ [ "jerrycan_big", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -7577,5 +7577,13 @@
     "time": "15 m",
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
     "components": [ [ [ "steel_chunk", 4 ] ] ]
+  },
+  {
+    "result": "active_backup_generator",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "45 m",
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
+    "components": [ [ [ "alternator_truck", 1 ] ], [ [ "i4_diesel", 1 ] ], [ [ "frame", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
#### Summary
Content "Active backup generator can now be transformed into an appliance"

#### Purpose of change
~~Fixes several issues (WIP on links)~~
Apparently resolves no feature requests that I can find! But this has been repeatedly brought up in the development discord, and has provided a good deal of confusion. It's a generator. It *should* work as one!

#### Describe the solution
Make generator into appliance, mirror the energy output and fuel consumption of an actual vehicle with constituent parts attached. Specifically we are emulating a vehicle which is simply a steel frame, an I4 diesel engine, and a truck alternator.

Add recipe to construct your own (it's just frame+engine+alternator)

Add deconstruct recipe and clean up interactions with the furniture version now that it has an item form

#### Describe alternatives you've considered


#### Testing
Appliance is fully functional, recipe and disassembly work as written.

Save provided with all parts spawned/available: 
[Asharoken-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/11918824/Asharoken-trimmed.tar.gz)

Includes nearby bicycle with I4 diesel engine and truck alternator (which generator is based off of) for comparison.

#### Additional context
This should NOT be backported to 0.G - the vehicle code has changed significantly since then and I sincerely doubt it will work on that version