### PR TITLE
[Alternative Map Key] Building alternatives now show correctly on the map

### DIFF
--- a/data/mods/alt_map_key/overmap_terrain.json
+++ b/data/mods/alt_map_key/overmap_terrain.json
@@ -320,7 +320,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_pharm",
+    "id": [ "s_pharm", "s_pharm_1" ],
     "copy-from": "s_pharm",
     "name": "pharmacy",
     "sym": "p",
@@ -328,7 +328,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "office_doctor",
+    "id": [ "office_doctor", "office_doctor_1", "office_doctor_2" ],
     "copy-from": "office_doctor",
     "name": "doctor's office",
     "sym": "d",
@@ -528,7 +528,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_grocery",
+    "id": [ "s_grocery", "s_grocery_1" ],
     "copy-from": "s_grocery",
     "name": "grocery store",
     "sym": "g",
@@ -536,7 +536,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_hardware",
+    "id": [ "s_hardware", "s_hardware_1", "s_hardware_2", "s_hardware_3" ],
     "copy-from": "s_hardware",
     "name": "hardware store",
     "sym": "h",
@@ -544,7 +544,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_electronics",
+    "id": [ "s_electronics", "s_electronics_1", "s_electronicstore" ],
     "copy-from": "s_electronics",
     "name": "electronics store",
     "sym": "e",
@@ -568,7 +568,18 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_gun",
+    "id": [
+      "s_gun",
+      "s_gun_looted",
+      "s_gun_1",
+      "s_gun_2",
+      "s_gun_3",
+      "s_gun_3_looted",
+      "s_gun_4",
+      "s_gun_4_looted",
+      "s_gunstore",
+      "s_gunstore_looted"
+    ],
     "copy-from": "s_gun",
     "name": "gun store",
     "sym": "g",
@@ -576,7 +587,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_clothes",
+    "id": [ "s_clothes", "s_clothes_1", "s_clothes_2", "s_clothes_3", "s_clothes_4", "s_clothes_5", "s_clothes_6" ],
     "copy-from": "s_clothes",
     "name": "clothing store",
     "sym": "c",
@@ -592,7 +603,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_bookstore",
+    "id": [ "s_bookstore", "s_bookstore_1", "s_bookstore_2" ],
     "copy-from": "s_bookstore",
     "name": "bookstore",
     "sym": "b",
@@ -600,7 +611,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_restaurant",
+    "id": [ "s_restaurant_foodplace", "s_restaurant", "s_restaurant_1", "s_restaurant_2", "s_restaurant_3" ],
     "copy-from": "s_restaurant",
     "name": "restaurant",
     "sym": "r",
@@ -608,7 +619,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_restaurant_fast",
+    "id": [ "s_restaurant_fast", "s_restaurant_fast_1" ],
     "copy-from": "s_restaurant_fast",
     "name": "fast food restaurant",
     "sym": "f",
@@ -616,7 +627,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_restaurant_coffee",
+    "id": [ "s_restaurant_coffee", "s_restaurant_coffee_1", "s_restaurant_coffee_2" ],
     "copy-from": "s_restaurant_coffee",
     "name": "coffee shop",
     "sym": "c",
@@ -624,7 +635,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_teashop",
+    "id": [ "s_teashop", "s_teashop_1" ],
     "copy-from": "s_teashop",
     "name": "teashop",
     "sym": "t",
@@ -632,7 +643,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "bar",
+    "id": [ "bar", "bar_1" ],
     "copy-from": "bar",
     "name": "bar",
     "sym": "b",
@@ -640,7 +651,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_pizza_parlor",
+    "id": [ "s_pizza_parlor", "s_pizza_parlor_1" ],
     "copy-from": "s_pizza_parlor",
     "name": "pizza parlor",
     "sym": "p",
@@ -768,7 +779,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "bank",
+    "id": [ "bank", "bank_1" ],
     "copy-from": "bank",
     "name": "bank",
     "sym": "b",
@@ -776,7 +787,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "pawn",
+    "id": [ "pawn", "pawn_1", "pawn_pf", "pawn_pf_under" ],
     "copy-from": "pawn",
     "name": "pawn shop",
     "sym": "p",
@@ -784,7 +795,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "mil_surplus",
+    "id": [ "mil_surplus", "mil_surplus_1", "mil_surplus_2" ],
     "copy-from": "mil_surplus",
     "name": { "str": "mil. surplus", "//NOLINT(cata-text-style)": "not a period" },
     "sym": "m",
@@ -4003,7 +4014,7 @@
     "color": "green"
   },
   {
-    "id": "dispensary",
+    "id": [ "dispensary", "dispensary_1", "dispensary_2" ],
     "copy-from": "dispensary",
     "type": "overmap_terrain",
     "name": "dispensary",
@@ -4512,7 +4523,7 @@
     "color": "blue"
   },
   {
-    "id": "s_laundromat",
+    "id": [ "s_laundromat", "s_laundromat_1" ],
     "copy-from": "s_laundromat",
     "type": "overmap_terrain",
     "name": "laundromat",
@@ -4577,7 +4588,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "candy_shop",
+    "id": [ "candy_shop", "candy_shop_1" ],
     "copy-from": "candy_shop",
     "name": "candy shop",
     "sym": "c",
@@ -4625,7 +4636,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_butcher",
+    "id": [ "s_butcher", "s_butcher_1", "s_butcher_2" ],
     "copy-from": "s_butcher",
     "name": "butcher shop",
     "sym": "b",
@@ -4633,7 +4644,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "dollarstore",
+    "id": [ "dollarstore", "dollarstore_1" ],
     "copy-from": "dollarstore",
     "name": "dollar store",
     "sym": "d",
@@ -5001,7 +5012,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_petstore",
+    "id": [ "s_petstore", "s_petstore_1", "s_petstore_2" ],
     "copy-from": "s_petstore",
     "name": "pet supply store",
     "sym": "p",
@@ -5153,7 +5164,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "s_bike_shop",
+    "id": [ "s_bike_shop", "s_bike_shop_1" ],
     "copy-from": "s_bike_shop",
     "name": "bike shop",
     "color": "light_blue",

--- a/data/mods/alt_map_key/overmap_terrain.json
+++ b/data/mods/alt_map_key/overmap_terrain.json
@@ -208,7 +208,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "park",
+    "id": [ "park", "park_roof", "park_2", "park_3", "park_4", "park_5", "park_5_roof", "park_6", "park_7", "park_7_roof" ],
     "copy-from": "park",
     "name": "park",
     "sym": "p",
@@ -4467,7 +4467,7 @@
     "color": "brown"
   },
   {
-    "id": "gym_fitness",
+    "id": [ "gym_fitness", "gym_fitness_1", "gym_fitness_2ndFloor_1" ],
     "copy-from": "gym_fitness",
     "type": "overmap_terrain",
     "name": "fitness gym",
@@ -4515,7 +4515,7 @@
     "color": "magenta"
   },
   {
-    "id": "dojo",
+    "id": [ "dojo", "dojo_1" ],
     "copy-from": "dojo",
     "type": "overmap_terrain",
     "name": "dojo",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Alternative Map Key] Building alternatives now show correctly on the map"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Partially fixes #66142 where, when using the Alternative Map Key mod, it would not show proper map symbols on the map, and instead it would show the "old" symbols, i.e. symbols from the base game.

#### Describe the solution
I have added the building alternatives, as included in the base game, to the mod itself. So now it includes alternatives for the few fixed building.
https://github.com/CleverRaven/Cataclysm-DDA/blob/e40864f9989a843c7f6525084e0ec87a9c30c674/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json#L250-L258

Specifically, I have added alternatives for these buildings:
- hardware
- clothing store
- restaurant
- tea shop
- fast food
- bar
- coffee shop
- bookstore
- electronics store
- pizza parlor
- gun store
- bank
- pawn shop
- mil. surplus
- butcher shop
- bike shop
- grocery store
- pharmacy
- doctor's office
- laundromat
- dispensary
- pet supply
- dollar store
- candy shop

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
There is an alternative described in #66545 however I dont know whether it is possible, nor how long it would take to implement. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. Update the Alternative Map Key mod locally
2. Start the game
3. Create new world
4. Reveal map > teleport to an adjacent overmap > reveal map > repeat 20 times > view map
5. Didn't throw any errors, and I saw the correct tiles on the map
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
The screenshots show the whole map just in case, but the red square is the most obvious change.

NOTE! I did not fix every incorrect building. There are loads of them that are still missing, however I would like to add them in increments as some have "special cases", and some have to be added as completely new entities into the mod, which requires discussion on what symbols, and colors they should have. Plus, majority of them were from two files `overmap_terrain_recreational.json` and `overmap_terrain_commercial.json`, so I wanted to keep it to those two files for now only. More will follow if this PR is accepted.

Before:
![before1](https://github.com/CleverRaven/Cataclysm-DDA/assets/28529900/92c8f215-efc3-4c0d-b210-5460807ff5ea)

After:
![after1](https://github.com/CleverRaven/Cataclysm-DDA/assets/28529900/83897f08-be52-40ce-8fef-26984e5a3f8e)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->