### PR TITLE
Add autopilot test

### DIFF
--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1286,17 +1286,9 @@ monster *vehicle::get_harnessed_animal() const
 
 void vehicle::selfdrive( const point &p )
 {
-    if( !is_towed() && !magic ) {
-        for( size_t e = 0; e < parts.size(); e++ ) {
-            const vehicle_part &vp = parts[ e ];
-            if( vp.info().fuel_type == fuel_type_animal ) {
-                monster *mon = get_monster( e );
-                if( !mon || !mon->has_effect( effect_harnessed ) || !mon->has_effect( effect_pet ) ) {
-                    is_following = false;
-                    return;
-                }
-            }
-        }
+    if( !is_towed() && !magic && !get_harnessed_animal() && !has_part( "AUTOPILOT" ) ) {
+        is_following = false;
+        return;
     }
     if( p.x != 0 ) {
         if( steering_effectiveness() <= 0 ) {

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -31,6 +31,7 @@ static const itype_id itype_test_power_cord( "test_power_cord" );
 
 static const vpart_id vpart_ap_test_standing_lamp( "ap_test_standing_lamp" );
 static const vpart_id vpart_bike_rack( "bike_rack" );
+static const vpart_id vpart_programmable_autopilot( "programmable_autopilot" );
 
 static const vproto_id vehicle_prototype_bicycle( "bicycle" );
 static const vproto_id vehicle_prototype_car( "car" );
@@ -744,4 +745,56 @@ TEST_CASE( "Racking_and_unracking_tests", "[vehicle][bikerack]" )
     }
 
     clear_vehicles( &get_map() );
+}
+
+static int test_autopilot_moving( const vproto_id &veh_id, const vpart_id &extra_part )
+{
+    clear_avatar();
+    clear_map();
+    Character &player_character = get_player_character();
+    // Move player somewhere safe
+    REQUIRE_FALSE( player_character.in_vehicle );
+    player_character.setpos( tripoint_zero );
+
+    const tripoint map_starting_point( 60, 60, 0 );
+    map &here = get_map();
+    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, -90_degrees, 100, 0, false );
+
+    REQUIRE( veh_ptr != nullptr );
+
+    vehicle &veh = *veh_ptr;
+    if( !extra_part.is_null() ) {
+        vehicle_part vp( extra_part, item( extra_part->base_item ) );
+        const int part_index = veh.install_part( point_zero, std::move( vp ) );
+        REQUIRE( part_index >= 0 );
+    }
+
+    veh.autopilot_on = true;
+    veh.is_following = true;
+    veh.is_patrolling = false;
+    veh.engine_on = true;
+    veh.refresh();
+
+    int turns_left = 10;
+    int tiles_travelled = 0;
+    const tripoint starting_point = veh.global_pos3();
+    while( veh.engine_on && turns_left > 0 ) {
+        turns_left--;
+        here.vehmove();
+        veh.idle( true );
+        // How much it moved
+        tiles_travelled += square_dist( starting_point, veh.global_pos3() );
+        // Bring it back to starting point to prevent it from leaving the map
+        const tripoint displacement = starting_point - veh.global_pos3();
+        here.displace_vehicle( veh, displacement );
+    }
+    return tiles_travelled;
+}
+
+TEST_CASE( "autopilot_tests", "[vehicle][autopilot]" )
+{
+    // spawns vehicle, installs the extra part if it's not null, activates follow and
+    // checks if it moves, most of the test is a cutout from vehicle_efficiency_test.cpp
+    CHECK( test_autopilot_moving( vehicle_prototype_car, vpart_id::NULL_ID() ) == 0 );
+    CHECK( test_autopilot_moving( vehicle_prototype_car, vpart_programmable_autopilot ) == 9 );
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Adds autopilot test, restores reverted chunk of code

#### Describe the solution

The reverted check should check for autopilot method existing, assuming no animal controls to mean autopilot part existing only works by happenstance of current UI access and doesn't handle any variance like the part breaking

#### Describe alternatives you've considered

#### Testing

Test should now test some autopilot paths

#### Additional context
