### PR TITLE
Partially reduce coverage of gambesons

### DIFF
--- a/data/json/items/armor/gambesons.json
+++ b/data/json/items/armor/gambesons.json
@@ -236,13 +236,19 @@
     "flags": [ "VARSIZE", "STURDY", "WATERPROOF" ],
     "armor": [
       {
-        "material": [ { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 3.5 } ],
+        "material": [
+          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 2.5 }
+        ],
         "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 10
       },
       {
-        "material": [ { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [
+          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 2.0 }
+        ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
         "encumbrance": 15
@@ -288,7 +294,10 @@
     "flags": [ "VARSIZE", "STURDY", "WATERPROOF" ],
     "armor": [
       {
-        "material": [ { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 3.5 } ],
+        "material": [
+          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 2.5 }
+        ],
         "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 10
@@ -334,7 +343,10 @@
     "flags": [ "VARSIZE", "STURDY", "WATERPROOF" ],
     "armor": [
       {
-        "material": [ { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [
+          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 2.0 }
+        ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 100,
         "encumbrance": 15
@@ -380,7 +392,10 @@
     "flags": [ "VARSIZE", "STURDY", "SKINTIGHT", "WATERPROOF" ],
     "armor": [
       {
-        "material": [ { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "material": [
+          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 1.0 }
+        ],
         "covers": [ "head" ],
         "specifically_covers": [ "head_throat", "head_ear_l", "head_ear_r", "head_forehead", "head_crown", "head_nape" ],
         "coverage": 100,
@@ -427,7 +442,10 @@
     "flags": [ "VARSIZE", "STURDY" ],
     "armor": [
       {
-        "material": [ { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "material": [
+          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 1.0 }
+        ],
         "covers": [ "hand_l", "hand_r" ],
         "coverage": 100,
         "encumbrance": 20
@@ -478,8 +496,8 @@
     "armor": [
       {
         "material": [
-          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 3.5 },
-          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
+          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 5.5 }
         ],
         "covers": [ "torso" ],
         "coverage": 100,
@@ -487,8 +505,8 @@
       },
       {
         "material": [
-          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 3.0 },
-          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 3.0 }
+          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
@@ -550,15 +568,18 @@
     "armor": [
       {
         "material": [
-          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 3.5 },
-          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
+          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 5.5 }
         ],
         "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 20
       },
       {
-        "material": [ { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [
+          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 2.0 }
+        ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
         "encumbrance": 15,
@@ -618,8 +639,8 @@
     "armor": [
       {
         "material": [
-          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 3.5 },
-          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
+          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 5.5 }
         ],
         "covers": [ "torso" ],
         "coverage": 100,
@@ -676,8 +697,8 @@
     "armor": [
       {
         "material": [
-          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 3.0 },
-          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 3.0 }
+          { "type": "canvas_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "canvas_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 100,
@@ -794,13 +815,19 @@
     "flags": [ "VARSIZE", "STURDY", "WATERPROOF" ],
     "armor": [
       {
-        "material": [ { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 3.5 } ],
+        "material": [
+          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 2.5 }
+        ],
         "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 7
       },
       {
-        "material": [ { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [
+          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 2.0 }
+        ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
         "encumbrance": 10
@@ -846,7 +873,10 @@
     "flags": [ "VARSIZE", "STURDY", "WATERPROOF" ],
     "armor": [
       {
-        "material": [ { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 3.5 } ],
+        "material": [
+          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 2.5 }
+        ],
         "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 7
@@ -892,7 +922,10 @@
     "flags": [ "VARSIZE", "STURDY", "WATERPROOF" ],
     "armor": [
       {
-        "material": [ { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [
+          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 2.0 }
+        ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 100,
         "encumbrance": 10
@@ -938,7 +971,10 @@
     "flags": [ "VARSIZE", "STURDY", "SKINTIGHT" ],
     "armor": [
       {
-        "material": [ { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "material": [
+          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 1.0 }
+        ],
         "covers": [ "head" ],
         "specifically_covers": [ "head_throat", "head_ear_l", "head_ear_r", "head_forehead", "head_crown", "head_nape" ],
         "coverage": 100,
@@ -985,7 +1021,10 @@
     "flags": [ "VARSIZE", "STURDY" ],
     "armor": [
       {
-        "material": [ { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "material": [
+          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 1.0 }
+        ],
         "covers": [ "hand_l", "hand_r" ],
         "coverage": 100,
         "encumbrance": 15
@@ -1036,8 +1075,8 @@
     "armor": [
       {
         "material": [
-          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 3.5 },
-          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
+          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 5.5 }
         ],
         "covers": [ "torso" ],
         "coverage": 100,
@@ -1045,8 +1084,8 @@
       },
       {
         "material": [
-          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 3.0 },
-          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 3.0 }
+          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
@@ -1108,15 +1147,18 @@
     "armor": [
       {
         "material": [
-          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 3.5 },
-          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
+          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 5.5 }
         ],
         "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 15
       },
       {
-        "material": [ { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [
+          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 2.0 }
+        ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
         "encumbrance": 10,
@@ -1176,8 +1218,8 @@
     "armor": [
       {
         "material": [
-          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 3.5 },
-          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
+          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 5.5 }
         ],
         "covers": [ "torso" ],
         "coverage": 100,
@@ -1234,8 +1276,8 @@
     "armor": [
       {
         "material": [
-          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 3.0 },
-          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 3.0 }
+          { "type": "nylon_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "nylon_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 100,
@@ -1353,13 +1395,19 @@
     "flags": [ "VARSIZE", "STURDY" ],
     "armor": [
       {
-        "material": [ { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 3.5 } ],
+        "material": [
+          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 2.5 }
+        ],
         "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 9
       },
       {
-        "material": [ { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [
+          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 2.0 }
+        ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
         "encumbrance": 13
@@ -1406,7 +1454,10 @@
     "flags": [ "VARSIZE", "STURDY" ],
     "armor": [
       {
-        "material": [ { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 3.5 } ],
+        "material": [
+          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 2.5 }
+        ],
         "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 9
@@ -1452,7 +1503,10 @@
     "flags": [ "VARSIZE", "STURDY" ],
     "armor": [
       {
-        "material": [ { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [
+          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 2.0 }
+        ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 100,
         "encumbrance": 13
@@ -1499,7 +1553,10 @@
     "flags": [ "VARSIZE", "STURDY", "SKINTIGHT" ],
     "armor": [
       {
-        "material": [ { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "material": [
+          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 1.0 }
+        ],
         "covers": [ "head" ],
         "specifically_covers": [ "head_throat", "head_ear_l", "head_ear_r", "head_forehead", "head_crown", "head_nape" ],
         "coverage": 100,
@@ -1547,7 +1604,10 @@
     "flags": [ "VARSIZE", "STURDY" ],
     "armor": [
       {
-        "material": [ { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "material": [
+          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 1.0 }
+        ],
         "covers": [ "hand_l", "hand_r" ],
         "coverage": 100,
         "encumbrance": 18
@@ -1599,8 +1659,8 @@
     "armor": [
       {
         "material": [
-          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 3.5 },
-          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
+          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 5.5 }
         ],
         "covers": [ "torso" ],
         "coverage": 100,
@@ -1608,8 +1668,8 @@
       },
       {
         "material": [
-          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 3.0 },
-          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 3.0 }
+          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
@@ -1672,15 +1732,18 @@
     "armor": [
       {
         "material": [
-          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 3.5 },
-          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
+          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 5.5 }
         ],
         "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 18
       },
       {
-        "material": [ { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [
+          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 2.0 }
+        ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
         "encumbrance": 23,
@@ -1741,8 +1804,8 @@
     "armor": [
       {
         "material": [
-          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 3.5 },
-          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
+          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 5.5 }
         ],
         "covers": [ "torso" ],
         "coverage": 100,
@@ -1800,8 +1863,8 @@
     "armor": [
       {
         "material": [
-          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 3.0 },
-          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 3.0 }
+          { "type": "wool_quilted", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "wool_quilted_2", "covered_by_mat": 95, "thickness": 4.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 100,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Less of aketons/gambesons coverage is 100%"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Aketons/gambesons were pretty strong due to surefire 100% coverage values. This makes the game boring. IRL the garments are not probably not of entirely uniform thickness, they are a bit thinner around joints and whatnot which may be rarely hit but it's worth simulating those cases. IRL these are extremely protective, there's no doubt about that, and the mm thickness is pretty accurate, but balance wise they should probably not be wholly flawless.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Aketons went from 3mm @ 100% to 1mm % 100% + 2mm @ 95%. Gambesons went from 3mm @ 100% + 3mm @ 95% to 2mm @ 100% + 4mm @ 100%. This is a minor nerf but it will probably make a big difference as 1/20 hits will likely go from "no damage" to "less, but still some damage". 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Adjust weights/material input of them too. I don't know if this is necessary because the material calculations do not account for the slightly increased surface area required to layer multiple sheets on top of existing sheets, so it seems reasonable to keep those more or less the same.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->