### PR TITLE
Update clear_character to remove mutation categories

### DIFF
--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -206,8 +206,6 @@ TEST_CASE( "Generated_character_with_category_mutations", "[mutation]" )
     REQUIRE( !trait_TAIL_FLUFFY.obj().category.empty() );
     avatar &u = get_avatar();
     clear_avatar();
-    u.clear_mutations();
-    u.mutation_category_level.clear();
     REQUIRE( u.get_mutations().empty() );
     REQUIRE( u.get_base_traits().empty() );
     REQUIRE( u.mutation_category_level.empty() );

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -78,6 +78,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.inv->clear();
     dummy.remove_weapon();
     dummy.clear_mutations();
+    dummy.mutation_category_level.clear();
     dummy.clear_bionics();
 
     // Clear stomach and then eat a nutritious meal to normalize stomach


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Followup on https://github.com/CleverRaven/Cataclysm-DDA/pull/65732#discussion_r1204629324

#### Describe the solution
Move the act of clearing from the test to clear_character
Shake the testing tree, see what falls out

#### Describe alternatives you've considered
This could be put into Character::clear_mutations instead?

#### Testing
Github tests

#### Additional context
