### PR TITLE
Use flags recognized by Artistic Style 3.3

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -26,7 +26,7 @@
 
 # indent later lines of multi-line preprocessor directives
 # to be deprecated by --indent-preproc-define
---indent-preprocessor
+--indent-preproc-define
 
 # indent comments on column 1 to match the code block they are in
 --indent-col1-comments
@@ -38,7 +38,7 @@
 --pad-oper
 
 # add brackets to unbracketed one line conditional statements
---add-brackets
+--add-braces
 
 # replaces tabs with spaces in non-indent sections, except in strings
 --convert-tabs

--- a/.astylerc
+++ b/.astylerc
@@ -25,7 +25,6 @@
 --indent-switches
 
 # indent later lines of multi-line preprocessor directives
-# to be deprecated by --indent-preproc-define
 --indent-preproc-define
 
 # indent comments on column 1 to match the code block they are in


### PR DESCRIPTION
#### Summary
Infrastructure "Updated .astylerc to use flags recognized by Artistic Style 3.3"

#### Purpose of change

To fix #66566 in which astyle doesn't recognize some of the flags in .astylerc

#### Describe the solution

Change the two flags to versions recognized by astyle 3.3:
- `--indent-preprocessor` changed to `--indent-preproc-define`
- `--add-brackets` changed to `--add-braces`

#### Describe alternatives you've considered

N/A

#### Testing

Run the following command (which can be found in doc/DEVELOPER_TOOLING.md):

```
astyle --options=.astylerc --recursive src/*.cpp,*.h tests/*.cpp,*.h
```

#### Additional context

N/A


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->