### PR TITLE
added flesh property to snail_garden

### DIFF
--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -1055,6 +1055,7 @@
     "use_action": [ "POISON" ],
     "comestible_type": "FOOD",
     "symbol": "%",
+    "material": [ "flesh" ],
     "calories": 15,
     "spoils_in": "15 days",
     "rot_spawn": "GROUP_MUTATION_SNAIL",

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -223,7 +223,6 @@
       "chem_formaldehyde",
       "sandwich_deluxe",
       "robofac_test_data",
-      "snail_garden",
       "irradiated_cranberries",
       "hallula",
       "chem_chloroform",


### PR DESCRIPTION
#### Summary
Content "Characters with Meat Intolerance are now allergic to raw snails"

#### Purpose of change
`snail` should be considered as `flesh` when eating since it's an animal. See #66190 for more.

#### Describe the solution
Adding `"material": [ "flesh" ],`  field to `snail_garden`

#### Describe alternatives you've considered
None

#### Testing
Get `Meat Intolerance` mutation and acquire a `snail`. The `snail` should provide an allergy warning.