### PR TITLE
Makes founders’ leg bags much, much, much rarer.

### DIFF
--- a/data/json/items/armor/hats.json
+++ b/data/json/items/armor/hats.json
@@ -174,7 +174,8 @@
         "id": "flag_cowboy_hat",
         "name": { "str_sp": "American cowboy hat" },
         "description": "This hat has traded its original classic looks for a red, white, and blue pattern with a band of golden stars embossed about its lip; suitable headwear for only the most serious of patriots.",
-        "append": true
+        "append": true,
+        "weight": 1
       }
     ],
     "weight": "390 g",

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -610,13 +610,6 @@
         "weight": 10
       },
       {
-        "id": "pants_flag",
-        "name": { "str": "liberty’s pants", "str_pl": "pairs of liberty’s pants" },
-        "description": "These pair of sky blue pants are resplendent with a pair of stitched American flags, their flag poles running down each leg, and a standard flanking the trousers’ front and rear.  \"Freedom\" is boldly stitched across the fly and enclosed by a ring of golden stars, while the back bears the legend, \"Liberbooty!\"",
-        "color": "light_blue",
-        "weight": 2
-      },
-      {
         "id": "pants_cream",
         "name": { "str": "cream pants", "str_pl": "pairs of cream pants" },
         "description": "A pair of milky, off-white pants dyed a shade of soft cream.  They're slightly warmer than jeans.",
@@ -978,6 +971,13 @@
         "name": { "str": "canary-yellow pants", "str_pl": "pairs of canary-yellow pants" },
         "description": "Much like the bird from which the hue of this pair of pants derives its name, this set of trousers is dyed a warm and extremely vibrant hue of yellow.  Equipped with deep pockets and warmer than regular jeans, you feel relatively sure that wearing this would let you be seen by any survivors, zombies, or even the ISS, if it’s still in orbit.",
         "color": "yellow",
+        "weight": 2
+      },
+      {
+        "id": "pants_flag",
+        "name": { "str": "liberty’s pants", "str_pl": "pairs of liberty’s pants" },
+        "description": "These pair of sky blue pants are resplendent with a pair of stitched American flags, their flag poles running down each leg, and a standard flanking the trousers’ front and rear.  \"Freedom\" is boldly stitched across the fly and enclosed by a ring of golden stars, while the back bears the legend, \"Liberbooty!\"",
+        "color": "light_blue",
         "weight": 2
       }
     ]

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -1457,7 +1457,7 @@
         "id": "flag_leg_bag",
         "name": { "str": "founders' leg bag" },
         "description": "A garishly colored red, white, and blue bag that can be worn on the thighs and hips using adjustable buckled straps, with the stylized depiction of George Washington’s face gazing sternly from the side.  Perfect for carrying the dreams of the founding fathers wherever you go.",
-        "weight": 50
+        "weight": 1
       }
     ]
   },

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -214,7 +214,8 @@
         "id": "flag_boxer_shorts",
         "name": { "str_sp": "star-spangled boxer shorts" },
         "description": "This pair has been printed with the pattern of an American flag, with stars and miniature eagles embroidered at strategic positions.",
-        "append": true
+        "append": true,
+        "weight": 1
       }
     ],
     "weight": "42 g",
@@ -270,7 +271,8 @@
         "id": "flag_boy_shorts",
         "name": { "str_sp": "star-spangled boy shorts" },
         "description": "This pair has been printed with the pattern of an American flag, with stars and miniature eagles embroidered at strategic positions.",
-        "append": true
+        "append": true,
+        "weight": 1
       }
     ],
     "weight": "42 g",


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes the spawn rates for the founders’ leg bag, and also adds spawn weights for the American/ patriotic items which lacked them."
#### Purpose of change
When making #64934 , a few oversights slipped in with respect to the patriotic items I added in that PR, namely that the founder’s leg bag was just as common as the base generic leg bag. Considering that this is a game breaking bug of intense proportions, leading to far too much patriotism within the cdda world, this PR addresses that issue.
#### Describe the solution
Punching my keyboard and pressing buttons until “weight”: “50”, turned into “weight”: “1”. This also adds weights to the other American gear that were added and lacked such an entry.
#### Describe alternatives you've considered
Being  a jackwagon and ignoring my own bugs, or setting up an extreme marketing campaign to inflate the commonality of my joke items in the real world.
#### Testing
#### Additional context
