### PR TITLE
Add ability to cull more farmed/bred animals

### DIFF
--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -640,7 +640,7 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS", "CANPLAY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS", "CANPLAY", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_goose",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -219,7 +219,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s lets out a happy squeak as you give its head a small scritch."
     },
-    "flags": [ "SEES", "SMELLS", "HEARS", "KEENNOSE", "CANPLAY", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "KEENNOSE", "CANPLAY", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER_1", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_boar_wild_piglet",
@@ -400,7 +400,8 @@
       "CLIMBS",
       "PATH_AVOID_DANGER_1",
       "WARM",
-      "HIT_AND_RUN"
+      "HIT_AND_RUN",
+      "CAN_BE_CULLED"
     ],
     "armor": { "cold": 2 }
   },
@@ -964,6 +965,7 @@
       "ANIMAL",
       "DOGFOOD",
       "CANPLAY",
+      "CAN_BE_CULLED",
       "GROUP_MORALE",
       "HEARS",
       "PET_MOUNTABLE",
@@ -2018,7 +2020,7 @@
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 10 },
     "special_attacks": [ [ "EAT_CROP", 100 ] ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PATH_AVOID_DANGER_1", "WARM", "NO_BREED" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PATH_AVOID_DANGER_1", "WARM", "NO_BREED", "CAN_BE_CULLED" ],
     "armor": { "bash": 2, "electric": 1 }
   },
   {
@@ -2459,7 +2461,7 @@
     "families": [ "prof_intro_biology" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "PET_WONT_FOLLOW", "WARM" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "PET_WONT_FOLLOW", "WARM", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_raccoon",
@@ -2933,7 +2935,7 @@
     "families": [ "prof_intro_biology" ],
     "reproduction": { "baby_monster": "mon_ferret_kit", "baby_count": 5, "baby_timer": 100 },
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM", "CANPLAY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM", "CANPLAY", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_ferret_kit",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2627,7 +2627,18 @@
     "baby_flags": [ "SPRING" ],
     "special_attacks": [ [ "EAT_CROP", 100 ] ],
     "zombify_into": "mon_zombie_goat",
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE", "CLIMBS", "CAN_BE_CULLED" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "WARM",
+      "PET_WONT_FOLLOW",
+      "MILKABLE",
+      "CLIMBS",
+      "CAN_BE_CULLED"
+    ]
   },
   {
     "id": "mon_squirrel",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2556,7 +2556,7 @@
     "upgrades": { "age_grow": 240, "into": "mon_sheep" },
     "//": "Puberty reached in 6-9 months.",
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_sheep",
@@ -2627,7 +2627,7 @@
     "baby_flags": [ "SPRING" ],
     "special_attacks": [ [ "EAT_CROP", 100 ] ],
     "zombify_into": "mon_zombie_goat",
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE", "CLIMBS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE", "CLIMBS", "CAN_BE_CULLED" ]
   },
   {
     "id": "mon_squirrel",


### PR DESCRIPTION
#### Summary
Balance "Most friendly breedable animals can now be culled without having to attack them"

#### Purpose of change
There exists many animals which can be tamed and bred, but not culled, even if that is reasonably possible.

#### Describe the solution
Add culling to the following animals:
-rat
-rabbit
-pigeon
-cat (and anything inheriting from cat)
-dog (and anything inheriting from dog)
-horse (foal/child only. Adults remain unable to be culled)
-ferrets
-Sheep(children, adults could already be culled)
-Goats(both children and adults)

#### Describe alternatives you've considered


#### Testing
Linted

#### Additional context
I believe this leaves only adult horses as a tameable that's not also cullable. I left them out on purpose, as they are very difficult animals to work with. (i.e. I don't know if it's appropriate to be able to cull them)