### PR TITLE
Fix misplaced NOT in game::walk_move

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10358,7 +10358,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     const bool slowed = ( ( !u.has_proficiency( proficiency_prof_parkour ) && ( mcost_to > 2 ||
                             mcost_from > 2 ) ) ||
                           mcost_to > 4 || mcost_from > 4 ) &&
-                        !( u.has_trait( trait_M_IMMUNE ) && fungus );
+                        ( !u.has_trait( trait_M_IMMUNE ) && fungus );
     if( slowed && !u.is_mounted() ) {
         // Unless u.pos() has a higher movecost than dest_loc, state that dest_loc is the cause
         if( mcost_to >= mcost_from ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #39710

#### Describe the solution
Slowed is a simple boolean used to display a variety of messages and play sounds, having no game function and calculating its stuff outside of the actual determined move cost. 
The simplified form of the check is: slowed = NOT ( immune to fungus AND terrain is fungus ) = NOT (false) = true

The corrected form is: slowed = (NOT immune to fungus) AND terrain is fungus = true AND false = false

#### Describe alternatives you've considered
I do not know why parkour makes you move faster over tall grass but whatever...

#### Testing

https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/efd994fb-7f46-4945-a92a-49e34765c2e9



#### Additional context
This boolean is an abomination 