### PR TITLE
A bunch of random item reworks: 7

### DIFF
--- a/data/json/items/generic/bedding.json
+++ b/data/json/items/generic/bedding.json
@@ -77,11 +77,11 @@
     "type": "ARMOR",
     "name": { "str": "blanket" },
     "description": "Hiding under here will not protect you from the monsters.",
-    "weight": "1123 g",
-    "volume": "15 L",
-    "price": 5500,
+    "weight": "848 g",
+    "volume": "15500 ml",
+    "price": "15 USD",
     "price_postapoc": 50,
-    "to_hit": -1,
+    "to_hit": { "grip": "none", "length": "long", "surface": "any", "balance": "clumsy" },
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "towel",
@@ -96,7 +96,8 @@
         "coverage": 100,
         "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
       }
-    ]
+    ],
+    "//": "Based on https://www.amazon.com/Utopia-Bedding-Summer-Blanket-Breathable/dp/B091DZVHX7/ref=sr_1_6?crid=11FB1U0I1340M&keywords=blanket%2Bcotton&qid=1688242264&sprefix=blanket%2Bcotton%2Caps%2C280&sr=8-6&th=1 with the assumed material thickness of 0.8cm"
   },
   {
     "id": "down_blanket",

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -742,7 +742,13 @@
     "name": { "str": "can opener" },
     "description": "A tool for opening cans that lack pull-tabs.  Now that you think about it, you haven't seen any of those around lately.",
     "looks_like": "hand_crank_charger",
-    "copy-from": "base_utensil"
+    "copy-from": "base_utensil",
+    "price": "9 USD",
+    "weight": "204 g",
+    "volume": "364 ml",
+    "longest_side": "21 cm",
+    "to_hit": { "grip": "none", "length": "hand", "surface": "any", "balance": "neutral" },
+    "//": "Based on https://www.amazon.com/AmazonCommercial-Stainless-Steel-Can-Opener/dp/B087MSWH65/ref=sr_1_36?crid=15C7UP9YX6W0E&keywords=can+opener&qid=1688240425&sprefix=can+opener%2Caps%2C610&sr=8-36 with the volume multiplied by 0.85 - otherwise the volume is way higher than it should be since Amazon lists package volume"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -981,14 +981,15 @@
     "copy-from": "base_cookpot",
     "material": [ "iron" ],
     "color": "dark_gray",
-    "weight": "2628 g",
-    "volume": "1335 ml",
-    "longest_side": "36 cm",
-    "to_hit": -3,
+    "weight": "2427 g",
+    "volume": "2940 ml",
+    "longest_side": "41 cm",
+    "price": "20 USD",
+    "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "clumsy" },
     "pocket_data": [
       {
-        "max_contains_volume": "1 L",
-        "max_contains_weight": "1 kg",
+        "max_contains_volume": "168 ml",
+        "max_contains_weight": "500 g",
         "watertight": true,
         "open_container": true,
         "rigid": true
@@ -996,7 +997,8 @@
     ],
     "delete": { "qualities": [ [ "COOK", 3 ] ] },
     "extend": { "qualities": [ [ "HAMMER", 1 ], [ "COOK", 2 ] ] },
-    "melee_damage": { "bash": 12 }
+    "melee_damage": { "bash": 12 },
+    "//": "Based on https://www.amazon.com/Lodge-Skillet-Pre-Seasoned-Ready-Stove/dp/B00006JSUA/ref=sr_1_5?crid=SPLV6RIP18RL&keywords=cast%2Biron%2Bfrying%2Bpan&qid=1688243417&sprefix=cast%2Biron%2Bfrying%2Bp%2Caps%2C491&sr=8-5&th=1 BUT volume calculated as a cylinder - 2 inches height x 10.68 inches diameter"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -747,7 +747,7 @@
     "weight": "204 g",
     "volume": "364 ml",
     "longest_side": "21 cm",
-    "to_hit": { "grip": "none", "length": "hand", "surface": "any", "balance": "neutral" },
+    "to_hit": { "grip": "solid", "length": "hand", "surface": "any", "balance": "neutral" },
     "//": "Based on https://www.amazon.com/AmazonCommercial-Stainless-Steel-Can-Opener/dp/B087MSWH65/ref=sr_1_36?crid=15C7UP9YX6W0E&keywords=can+opener&qid=1688240425&sprefix=can+opener%2Caps%2C610&sr=8-36 with the volume multiplied by 0.85 - otherwise the volume is way higher than it should be since Amazon lists package volume"
   },
   {

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -988,7 +988,7 @@
     "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "clumsy" },
     "pocket_data": [
       {
-        "max_contains_volume": "168 ml",
+        "max_contains_volume": "500 ml",
         "max_contains_weight": "500 g",
         "watertight": true,
         "open_container": true,

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -330,22 +330,26 @@
     "type": "GENERIC",
     "category": "container",
     "id": "wine_glass",
-    "volume": "262 ml",
+    "volume": "420 ml",
+    "weight": "130 g",
+    "longest_side": "20 cm",
+    "price": "13 USD",
     "name": { "str": "wine glass", "str_pl": "wine glasses" },
-    "proportional": { "weight": 0.5 },
     "symbol": "Y",
     "description": "A stemmed drinking glass that makes you feel very fancy when you drink from it.",
     "copy-from": "base_glass_dish",
     "pocket_data": [
       {
         "max_contains_volume": "250 ml",
-        "max_contains_weight": "1 kg",
+        "max_contains_weight": "500 g",
         "watertight": true,
         "open_container": true,
         "rigid": true
       }
     ],
-    "qualities": [ [ "CONTAIN", 1 ] ]
+    "qualities": [ [ "CONTAIN", 1 ] ],
+    "to_hit": { "grip": "bad", "length": "hand", "surface": "any", "balance": "clumsy" },
+    "//": "Based on https://www.amazon.com/ADERIA-8612-Glass-IPT-Plaisir-Japan/dp/B01M4OEU65/ref=sr_1_5?crid=K7O7AHRUN33T&keywords=250ml%2Bwine%2Bglass&qid=1688217534&sprefix=250ml%2Bwine%2Bglass%2Caps%2C426&sr=8-5&th=1"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -38,7 +38,7 @@
   {
     "id": "dish_towel",
     "type": "TOOL",
-    "category": "spare_parts",
+    "category": "other",
     "name": { "str": "dish towel" },
     "description": "A dish towel, useful for cleaning hard surfaces.",
     "weight": "65600 mg",

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -213,9 +213,9 @@
     "type": "TOOL",
     "name": { "str": "sponge" },
     "description": "A cleaning aid made of soft, porous material.  Typically used for cleaning hard objects.",
-    "weight": "40 g",
-    "volume": "150 ml",
-    "price": 0,
+    "weight": "17 g",
+    "volume": "156 ml",
+    "price": 66,
     "price_postapoc": 10,
     "material": [ "plastic" ],
     "symbol": "s",
@@ -225,13 +225,13 @@
     "snippet_category": [
       { "id": "spng1", "text": "A round smiley-face sponge." },
       { "id": "spng2", "text": "A rectangular sponge with a green abrasive back." },
-      { "id": "spng3", "text": "A natural sea sponge.  It looks kind of lumpy." },
       { "id": "spng4", "text": "A dolphin-shaped sponge.  It looks at home in the water." },
       { "id": "spng5", "text": "A rectangular sponge." },
       { "id": "spng6", "text": "A sponge cake-shaped sponge, the abrasive pad looks like frosting." },
       { "id": "spng7", "text": "A sponge in the shape of a beloved character from a children's cartoon." },
       { "id": "spng8", "text": "A cat-shaped sponge." }
-    ]
+    ],
+    "//": "Based on https://www.amazon.com/Amazon-Brand-Solimo-Non-Scratch-Sponges/dp/B08RFC3VH7/ref=sr_1_7?crid=1JSW6KQKVQKBK&keywords=sponge&qid=1688239591&sprefix=250ml%2Bwine%2Bglass%2Caps%2C726&sr=8-7&th=1"
   },
   {
     "id": "survivor_hairtrimmer",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -4353,7 +4353,8 @@
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
     "time": "1 s",
-    "components": [ [ [ "glass_shard", 2 ] ] ]
+    "components": [ [ [ "glass_shard", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "peanut",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -69,7 +69,7 @@
     "result": "can_opener",
     "time": "30 s",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "scrap", 3 ] ] ]
+    "components": [ [ [ "scrap", 4 ] ] ]
   },
   {
     "type": "uncraft",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -5004,7 +5004,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "time": "3 m",
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
-    "components": [ [ [ "chunk_cast_iron", 6 ] ], [ [ "lump_cast_iron", 1 ] ] ]
+    "components": [ [ [ "chunk_cast_iron", 5 ] ], [ [ "lump_cast_iron", 1 ] ], [ [ "scrap_cast_iron", 3 ] ] ]
   },
   {
     "result": "pot",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -585,7 +585,8 @@
     "activity_level": "LIGHT_EXERCISE",
     "time": "10 m",
     "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_cotton", 30 ] ], [ [ "thread", 150 ] ] ]
+    "components": [ [ [ "sheet_cotton", 20 ] ], [ [ "thread", 150 ] ] ],
+    "//": "This recipe somehow manages to lose cotton while creating mass out of thin air. Honestly remarkable, but for me it means I have to look into the weight for thread later on"
   },
   {
     "result": "crackpipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<details>
<summary>BLANKET</summary>

- Weight: 1123g -> 848g
- Volume: 15l -> 15.5l
- ``price_preapoc``: 55$ -> 15$
- ``to_hit`` values now use modifiers
- Disassembly yield decreased to account for weight decrease - still generates mass, will need to be addressed in a separate PR later on when I double check the weight of thread

</details>

<details>
<summary>WINE GLASS</summary>

- Weight: 161g -> 130g
- Volume: 262ml -> 420ml
- Longest side: N/A -> 20cm
- ``price_preapoc``: 14$ -> 13$
- ``to_hit`` values now use modifiers
- Disassembly yield decreased to account for weight decrease 
- Pocket max weight decreased from 1kg to 500g

</details>

<details>
<summary>CAN OPENER</summary>

- Weight: 158g -> 204g
- Volume: 75ml -> 364ml
- Longest side: N/A -> 21cm
- ``price_preapoc``: 2$ -> 9$
- ``to_hit`` values now use modifiers
- Disassembly yield increased to account for weight increase

</details>

<details>
<summary>CAST-IRON FRYING PAN</summary>

- Weight: 2628g -> 2427g
- Volume: 1335ml -> 2940ml
- Longest side: 36cm -> 41cm
- ``price_preapoc``: 45$ -> 20$
- ``to_hit`` values now use modifiers
- Disassembly yield decreased to account for weight decrease 
- Pocket max weight decreased from 1kg to 500g
- Pocket max volume decreased from 1l to 500ml

</details>

<details>
<summary>SPONGE</summary>

- Weight: 40g -> 17g
- Volume: 150ml -> 156ml
- ``price_preapoc``: 0$ -> 0.66$
- Removed the snippet referencing sea sponges - not only are sponges made of those very rare, they're also definitely not plastic by material - not material for a snippet

</details>

<details>
<summary>DISH TOWEL</summary>

- Category changed to ``other`` from ``spare parts``
</details>

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->