### PR TITLE
Half chausses

### DIFF
--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -2702,7 +2702,7 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str": "pair of mild steel chainmail half-chausses", "str_pl": "pairs of mild steel chainmail half-chausses" },
-    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot, leaving the back and sole unprotected.",
+    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot and are maintained in place by a zigzaging leather lace on the unprotected back.",
     "weight": "1505 g",
     "volume": "375 ml",
     "price": 3508,
@@ -2725,6 +2725,7 @@
       },
       {
         "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
         "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.0 } ],
         "coverage": 75
       }
@@ -2753,7 +2754,7 @@
     "copy-from": "lc_half_chainmail_feet",
     "material": [ "mc_steel_chain" ],
     "name": { "str": "pair of medium steel chainmail half-chausses", "str_pl": "pairs of medium steel chainmail half-chausses" },
-    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot, leaving the back and sole unprotected.",
+    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot and are maintained in place by a zigzaging leather lace on the unprotected back.",
     "armor": [
       {
         "covers": [ "foot_l", "foot_r" ],
@@ -2767,6 +2768,7 @@
       },
       {
         "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
         "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.0 } ],
         "coverage": 75
       }
@@ -2801,7 +2803,7 @@
     "copy-from": "lc_half_chainmail_feet",
     "material": [ "hc_steel_chain" ],
     "name": { "str": "pair of high steel chainmail half-chausses", "str_pl": "pairs of high steel chainmail half-chausses" },
-    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot, leaving the back and sole unprotected.",
+    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot and are maintained in place by a zigzaging leather lace on the unprotected back.",
     "armor": [
       {
         "covers": [ "foot_l", "foot_r" ],
@@ -2815,6 +2817,7 @@
       },
       {
         "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
         "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.0 } ],
         "coverage": 75
       }
@@ -2842,7 +2845,7 @@
     "copy-from": "lc_half_chainmail_feet",
     "material": [ "ch_steel_chain" ],
     "name": { "str": "pair of hardened steel chainmail half-chausses", "str_pl": "pairs of hardened steel chainmail half-chausses" },
-    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot, leaving the back and sole unprotected.",
+    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot and are maintained in place by a zigzaging leather lace on the unprotected back.",
     "armor": [
       {
         "covers": [ "foot_l", "foot_r" ],
@@ -2856,6 +2859,7 @@
       },
       {
         "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
         "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.0 } ],
         "coverage": 75
       }
@@ -2889,7 +2893,7 @@
     "copy-from": "lc_half_chainmail_feet",
     "material": [ "qt_steel_chain" ],
     "name": { "str": "pair of tempered steel chainmail half-chausses", "str_pl": "pairs of tempered steel chainmail half-chausses" },
-    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot, leaving the back and sole unprotected.",
+    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot and are maintained in place by a zigzaging leather lace on the unprotected back.",
     "armor": [
       {
         "covers": [ "foot_l", "foot_r" ],
@@ -2903,6 +2907,7 @@
       },
       {
         "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
         "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.0 } ],
         "coverage": 75
       }

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -2698,6 +2698,239 @@
     "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
+    "id": "lc_half_chainmail_feet",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "pair of mild steel chainmail half-chausses", "str_pl": "pairs of mild steel chainmail half-chausses" },
+    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot, leaving the back and sole unprotected.",
+    "weight": "1505 g",
+    "volume": "375 ml",
+    "price": 3508,
+    "price_postapoc": 1400,
+    "to_hit": -1,
+    "material": [ "lc_steel_chain" ],
+    "symbol": "[",
+    "color": "light_red",
+    "flags": [ "VARSIZE", "STURDY", "OUTER" ],
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_ankle_r", "foot_ankle_l" ],
+        "material": [
+          { "type": "leather", "covered_by_mat": 75, "thickness": 2.0 },
+          { "type": "lc_steel_chain", "covered_by_mat": 75, "thickness": 1.2 }
+        ],
+        "encumbrance": 15,
+        "coverage": 75
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "material": [ { "type": "leather", "covered_by_mat": 75, "thickness": 4.0 } ],
+        "coverage": 75
+      }
+    ]
+  },
+  {
+    "id": "xl_lc_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "lc_half_chainmail_feet",
+    "name": { "str": "pair of XL mild steel chainmail half-chausses", "str_pl": "pairs of XL mild steel chainmail half-chausses" },
+    "proportional": { "weight": 2, "volume": 2 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_lc_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "lc_half_chainmail_feet",
+    "looks_like": "half_chainmail_feet",
+    "name": { "str": "pair of XS mild steel chainmail half-chausses", "str_pl": "pairs of XS mild steel chainmail half-chausses" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "mc_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "lc_half_chainmail_feet",
+    "material": [ "mc_steel_chain" ],
+    "name": { "str": "pair of medium steel chainmail half-chausses", "str_pl": "pairs of medium steel chainmail half-chausses" },
+    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot, leaving the back and sole unprotected.",
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_ankle_r", "foot_ankle_l" ],
+        "material": [
+          { "type": "leather", "covered_by_mat": 75, "thickness": 2.0 },
+          { "type": "mc_steel_chain", "covered_by_mat": 75, "thickness": 1.2 }
+        ],
+        "encumbrance": 15,
+        "coverage": 75
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "material": [ { "type": "leather", "covered_by_mat": 75, "thickness": 4.0 } ],
+        "coverage": 75
+      }
+    ]
+  },
+  {
+    "id": "xl_mc_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "mc_half_chainmail_feet",
+    "name": {
+      "str": "pair of XL medium steel chainmail half-chausses",
+      "str_pl": "pairs of XL medium steel chainmail half-chausses"
+    },
+    "proportional": { "weight": 2, "volume": 2 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_mc_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "mc_half_chainmail_feet",
+    "looks_like": "half_chainmail_feet",
+    "name": {
+      "str": "pair of XS medium steel chainmail half-chausses",
+      "str_pl": "pairs of XS medium steel chainmail half-chausses"
+    },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "hc_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "lc_half_chainmail_feet",
+    "material": [ "hc_steel_chain" ],
+    "name": { "str": "pair of high steel chainmail half-chausses", "str_pl": "pairs of high steel chainmail half-chausses" },
+    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot, leaving the back and sole unprotected.",
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_ankle_r", "foot_ankle_l" ],
+        "material": [
+          { "type": "leather", "covered_by_mat": 75, "thickness": 2.0 },
+          { "type": "hc_steel_chain", "covered_by_mat": 75, "thickness": 1.2 }
+        ],
+        "encumbrance": 15,
+        "coverage": 75
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "material": [ { "type": "leather", "covered_by_mat": 75, "thickness": 4.0 } ],
+        "coverage": 75
+      }
+    ]
+  },
+  {
+    "id": "xl_hc_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "hc_half_chainmail_feet",
+    "name": { "str": "pair of XL high steel chainmail half-chausses", "str_pl": "pairs of XL high steel chainmail half-chausses" },
+    "proportional": { "weight": 2, "volume": 2 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_hc_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "hc_half_chainmail_feet",
+    "name": { "str": "pair of XS high steel chainmail half-chausses", "str_pl": "pairs of XS high steel chainmail half-chausses" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "ch_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "lc_half_chainmail_feet",
+    "material": [ "ch_steel_chain" ],
+    "name": { "str": "pair of hardened steel chainmail half-chausses", "str_pl": "pairs of hardened steel chainmail half-chausses" },
+    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot, leaving the back and sole unprotected.",
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_ankle_r", "foot_ankle_l" ],
+        "material": [
+          { "type": "leather", "covered_by_mat": 75, "thickness": 2.0 },
+          { "type": "ch_steel_chain", "covered_by_mat": 75, "thickness": 1.2 }
+        ],
+        "encumbrance": 15,
+        "coverage": 75
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "material": [ { "type": "leather", "covered_by_mat": 75, "thickness": 4.0 } ],
+        "coverage": 75
+      }
+    ]
+  },
+  {
+    "id": "xl_ch_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "ch_half_chainmail_feet",
+    "name": {
+      "str": "pair of XL hardened steel chainmail half-chausses",
+      "str_pl": "pairs of XL hardened steel chainmail half-chausses"
+    },
+    "proportional": { "weight": 2, "volume": 2 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_ch_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "ch_half_chainmail_feet",
+    "name": {
+      "str": "pair of XS hardened steel chainmail half-chausses",
+      "str_pl": "pairs of XS hardened steel chainmail half-chausses"
+    },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "qt_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "lc_half_chainmail_feet",
+    "material": [ "qt_steel_chain" ],
+    "name": { "str": "pair of tempered steel chainmail half-chausses", "str_pl": "pairs of tempered steel chainmail half-chausses" },
+    "description": "Customized chainmail half-chausses that only cover the front and sides of the foot, leaving the back and sole unprotected.",
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_ankle_r", "foot_ankle_l" ],
+        "material": [
+          { "type": "leather", "covered_by_mat": 75, "thickness": 2.0 },
+          { "type": "qt_steel_chain", "covered_by_mat": 75, "thickness": 1.2 }
+        ],
+        "encumbrance": 15,
+        "coverage": 75
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "material": [ { "type": "leather", "covered_by_mat": 75, "thickness": 4.0 } ],
+        "coverage": 75
+      }
+    ]
+  },
+  {
+    "id": "xl_qt_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "qt_half_chainmail_feet",
+    "name": {
+      "str": "pair of XL tempered steel chainmail half-chausses",
+      "str_pl": "pairs of XL tempered steel chainmail half-chausses"
+    },
+    "proportional": { "weight": 2, "volume": 2 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_qt_half_chainmail_feet",
+    "type": "ARMOR",
+    "copy-from": "qt_half_chainmail_feet",
+    "name": {
+      "str": "pair of XS tempered steel chainmail half-chausses",
+      "str_pl": "pairs of XS tempered steel chainmail half-chausses"
+    },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
     "id": "nomex_socks",
     "type": "ARMOR",
     "name": { "str": "pair of flame-resistant socks", "str_pl": "pairs of flame-resistant socks" },

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -737,7 +737,7 @@
           "foot_arch_l"
         ],
         "material": [
-          { "type": "budget_steel", "covered_by_mat": 75, "thickness": 1.5 },
+          { "type": "budget_steel", "covered_by_mat": 100, "thickness": 1.5 },
           { "type": "cotton", "covered_by_mat": 100, "thickness": 1.0 }
         ],
         "encumbrance": 6,
@@ -747,7 +747,7 @@
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
         "material": [
-          { "type": "budget_steel", "covered_by_mat": 75, "thickness": 1.5 },
+          { "type": "budget_steel", "covered_by_mat": 100, "thickness": 1.5 },
           { "type": "cotton", "covered_by_mat": 100, "thickness": 1.0 }
         ],
         "coverage": 80
@@ -2717,15 +2717,15 @@
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_ankle_r", "foot_ankle_l" ],
         "material": [
-          { "type": "leather", "covered_by_mat": 75, "thickness": 2.0 },
-          { "type": "lc_steel_chain", "covered_by_mat": 75, "thickness": 1.2 }
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 }
         ],
         "encumbrance": 15,
         "coverage": 75
       },
       {
         "covers": [ "foot_l", "foot_r" ],
-        "material": [ { "type": "leather", "covered_by_mat": 75, "thickness": 4.0 } ],
+        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.0 } ],
         "coverage": 75
       }
     ]
@@ -2759,15 +2759,15 @@
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_ankle_r", "foot_ankle_l" ],
         "material": [
-          { "type": "leather", "covered_by_mat": 75, "thickness": 2.0 },
-          { "type": "mc_steel_chain", "covered_by_mat": 75, "thickness": 1.2 }
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "mc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 }
         ],
         "encumbrance": 15,
         "coverage": 75
       },
       {
         "covers": [ "foot_l", "foot_r" ],
-        "material": [ { "type": "leather", "covered_by_mat": 75, "thickness": 4.0 } ],
+        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.0 } ],
         "coverage": 75
       }
     ]
@@ -2807,15 +2807,15 @@
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_ankle_r", "foot_ankle_l" ],
         "material": [
-          { "type": "leather", "covered_by_mat": 75, "thickness": 2.0 },
-          { "type": "hc_steel_chain", "covered_by_mat": 75, "thickness": 1.2 }
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "hc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 }
         ],
         "encumbrance": 15,
         "coverage": 75
       },
       {
         "covers": [ "foot_l", "foot_r" ],
-        "material": [ { "type": "leather", "covered_by_mat": 75, "thickness": 4.0 } ],
+        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.0 } ],
         "coverage": 75
       }
     ]
@@ -2848,15 +2848,15 @@
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_ankle_r", "foot_ankle_l" ],
         "material": [
-          { "type": "leather", "covered_by_mat": 75, "thickness": 2.0 },
-          { "type": "ch_steel_chain", "covered_by_mat": 75, "thickness": 1.2 }
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "ch_steel_chain", "covered_by_mat": 100, "thickness": 1.2 }
         ],
         "encumbrance": 15,
         "coverage": 75
       },
       {
         "covers": [ "foot_l", "foot_r" ],
-        "material": [ { "type": "leather", "covered_by_mat": 75, "thickness": 4.0 } ],
+        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.0 } ],
         "coverage": 75
       }
     ]
@@ -2895,15 +2895,15 @@
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_ankle_r", "foot_ankle_l" ],
         "material": [
-          { "type": "leather", "covered_by_mat": 75, "thickness": 2.0 },
-          { "type": "qt_steel_chain", "covered_by_mat": 75, "thickness": 1.2 }
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 }
         ],
         "encumbrance": 15,
         "coverage": 75
       },
       {
         "covers": [ "foot_l", "foot_r" ],
-        "material": [ { "type": "leather", "covered_by_mat": 75, "thickness": 4.0 } ],
+        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.0 } ],
         "coverage": 75
       }
     ]

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -1363,6 +1363,141 @@
     "using": [ [ "armor_qt_chainmail_assembling", 4 ], [ "strap_small", 2 ] ]
   },
   {
+    "result": "lc_half_chainmail_feet",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "time": "2 h 15 m",
+    "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
+    "proficiencies": [ { "proficiency": "prof_cobbling" }, { "proficiency": "prof_chain_armour" } ],
+    "using": [ [ "armor_lc_chainmail_assembling", 2 ], [ "strap_small", 3 ] ]
+  },
+  {
+    "result": "xs_lc_half_chainmail_feet",
+    "type": "recipe",
+    "copy-from": "lc_half_chainmail_feet",
+    "time": "2 h 15 m",
+    "using": [ [ "armor_lc_chainmail_assembling", 1 ], [ "strap_small", 2 ] ]
+  },
+  {
+    "result": "xl_lc_half_chainmail_feet",
+    "type": "recipe",
+    "copy-from": "lc_half_chainmail_feet",
+    "time": "3 h 45 m",
+    "using": [ [ "armor_lc_chainmail_assembling", 3 ], [ "strap_small", 3 ] ]
+  },
+  {
+    "result": "mc_half_chainmail_feet",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "time": "2 h 15 m",
+    "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
+    "proficiencies": [ { "proficiency": "prof_cobbling" }, { "proficiency": "prof_chain_armour" } ],
+    "using": [ [ "armor_mc_chainmail_assembling", 2 ], [ "strap_small", 3 ] ]
+  },
+  {
+    "result": "xs_mc_half_chainmail_feet",
+    "type": "recipe",
+    "copy-from": "mc_half_chainmail_feet",
+    "time": "2 h 15 m",
+    "using": [ [ "armor_mc_chainmail_assembling", 1 ], [ "strap_small", 2 ] ]
+  },
+  {
+    "result": "xl_mc_half_chainmail_feet",
+    "type": "recipe",
+    "copy-from": "mc_half_chainmail_feet",
+    "time": "3 h 45 m",
+    "using": [ [ "armor_mc_chainmail_assembling", 3 ], [ "strap_small", 3 ] ]
+  },
+  {
+    "result": "hc_half_chainmail_feet",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "time": "2 h 15 m",
+    "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
+    "proficiencies": [ { "proficiency": "prof_cobbling" }, { "proficiency": "prof_chain_armour" } ],
+    "using": [ [ "armor_hc_chainmail_assembling", 2 ], [ "strap_small", 3 ] ]
+  },
+  {
+    "result": "xs_hc_half_chainmail_feet",
+    "type": "recipe",
+    "copy-from": "hc_half_chainmail_feet",
+    "time": "2 h 15 m",
+    "using": [ [ "armor_hc_chainmail_assembling", 1 ], [ "strap_small", 2 ] ]
+  },
+  {
+    "result": "xl_hc_half_chainmail_feet",
+    "type": "recipe",
+    "copy-from": "hc_half_chainmail_feet",
+    "time": "3 h 45 m",
+    "using": [ [ "armor_hc_chainmail_assembling", 3 ], [ "strap_small", 3 ] ]
+  },
+  {
+    "result": "ch_half_chainmail_feet",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "time": "2 h 15 m",
+    "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
+    "proficiencies": [ { "proficiency": "prof_cobbling" }, { "proficiency": "prof_chain_armour" } ],
+    "using": [ [ "armor_ch_chainmail_assembling", 2 ], [ "strap_small", 3 ] ]
+  },
+  {
+    "result": "xs_ch_half_chainmail_feet",
+    "type": "recipe",
+    "copy-from": "ch_half_chainmail_feet",
+    "time": "2 h 15 m",
+    "using": [ [ "armor_ch_chainmail_assembling", 1 ], [ "strap_small", 2 ] ]
+  },
+  {
+    "result": "xl_ch_half_chainmail_feet",
+    "type": "recipe",
+    "copy-from": "ch_half_chainmail_feet",
+    "time": "3 h 45 m",
+    "using": [ [ "armor_ch_chainmail_assembling", 3 ], [ "strap_small", 3 ] ]
+  },
+  {
+    "result": "qt_half_chainmail_feet",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "time": "2 h 15 m",
+    "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
+    "proficiencies": [ { "proficiency": "prof_cobbling" }, { "proficiency": "prof_chain_armour" } ],
+    "using": [ [ "armor_qt_chainmail_assembling", 2 ], [ "strap_small", 3 ] ]
+  },
+  {
+    "result": "xs_qt_half_chainmail_feet",
+    "type": "recipe",
+    "copy-from": "qt_half_chainmail_feet",
+    "time": "2 h 15 m",
+    "using": [ [ "armor_qt_chainmail_assembling", 1 ], [ "strap_small", 2 ] ]
+  },
+  {
+    "result": "xl_qt_half_chainmail_feet",
+    "type": "recipe",
+    "copy-from": "qt_half_chainmail_feet",
+    "time": "3 h 45 m",
+    "using": [ [ "armor_qt_chainmail_assembling", 3 ], [ "strap_small", 3 ] ]
+  },
+  {
     "result": "roller_blades",
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -3654,6 +3654,84 @@
     "difficulty": 7
   },
   {
+    "id": "nested_lc_half_chainmail_feet",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "name": "mild steel chain half-chausses",
+    "description": "Recipes related to constructing various sizes of chainmail half-chausses.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "lc_half_chainmail_feet", "xs_lc_half_chainmail_feet", "xl_lc_half_chainmail_feet" ],
+    "difficulty": 1
+  },
+  {
+    "id": "nested_mc_half_chainmail_feet",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "name": "medium steel chain half-chausses",
+    "description": "Recipes related to constructing various sizes of chainmail half-chausses.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "mc_half_chainmail_feet", "xs_mc_half_chainmail_feet", "xl_mc_half_chainmail_feet" ],
+    "difficulty": 2
+  },
+  {
+    "id": "nested_hc_half_chainmail_feet",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "name": "high steel chain half-chausses",
+    "description": "Recipes related to constructing various sizes of chainmail half-chausses.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "hc_half_chainmail_feet", "xs_hc_half_chainmail_feet", "xl_hc_half_chainmail_feet" ],
+    "difficulty": 3
+  },
+  {
+    "id": "nested_ch_half_chainmail_feet",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "name": "hardened steel chain half-chausses",
+    "description": "Recipes related to constructing various sizes of chainmail half-chausses.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "ch_half_chainmail_feet", "xs_ch_half_chainmail_feet", "xl_ch_half_chainmail_feet" ],
+    "difficulty": 4
+  },
+  {
+    "id": "nested_qt_half_chainmail_feet",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "name": "tempered steel chain half-chausses",
+    "description": "Recipes related to constructing various sizes of chainmail half-chausses.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "qt_half_chainmail_feet", "xs_qt_half_chainmail_feet", "xl_qt_half_chainmail_feet" ],
+    "difficulty": 5
+  },
+  {
+    "id": "nested_all_half_chainmail_feet",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_FEET",
+    "name": "steel chain half-chausses",
+    "description": "Recipes related to constructing various types and sizes of chainmail half-chausses.",
+    "skill_used": "fabrication",
+    "nested_category_data": [
+      "nested_lc_half_chainmail_feet",
+      "nested_mc_half_chainmail_feet",
+      "nested_hc_half_chainmail_feet",
+      "nested_ch_half_chainmail_feet",
+      "nested_qt_half_chainmail_feet"
+    ],
+    "difficulty": 7
+  },
+  {
     "id": "nested_sling_ready_explosives",
     "type": "nested_category",
     "activity_level": "fake",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Added a lighter, less costly but less protective alternative to chainmail chausses"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adding a new chainmail armor type for feet along with XS/XL versions and all 5 grades, as well as adding them to new nested groups.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added the items, recipes and nested groups for these new armor pieces, I am however still too new to contributing to find out how to make it so that the items require the leather lace these require to be kept in place and not just drop off from your foot, 2 short laces (1 for each individual half-chausse) would probably be enough seeing as those are supposed to be 15cm long.
As I bumped up the "strap_small" ingredient for all the recipes by one to reflect higher leather requirement the lace would involve while being unaware the laces existed, anyone who wishes to fix my work by adding the lace(s) should probably make all those identical to the normal chausses again.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Not adding the chausses.
- Choosing other weight/coverage values instead of settling on overall removing 25% on most values from the full chausses.
- Considered making a new, larger nested group they would occupy together with the groups for the normal chausses, but didn't feel confident enough to not mess it up.
- I think the current sublimbs put in there are not ideal to properly simulate how this would be useless to protect from attacks hitting the back of the foot, so there may be something to improve there.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned the items in game, checked their values, used the recipes, checked that the nested groups were working correctly, asked for feedback on the coverage errors I was getting and after fixing those am no longer getting any error message while loading the game.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This manga page was what mainly prompted me to add them, I'm under the impression our chausses do not go as far up as those, but the potential was there to make them so I made them.
![inspiration](https://github.com/CleverRaven/Cataclysm-DDA/assets/16321433/b4c02984-3186-4656-a1d6-e82b774ec173)
Ironskin (an online merchant site for chainmail armor) also seems to agree that such early chausses did exist historically.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->