### PR TITLE
Zombie runners can't climb stairs now

### DIFF
--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1106,7 +1106,7 @@
     "weakpoint_sets": [ "wps_humanoid_body" ],
     "families": [ "prof_intro_biology", "prof_wp_zombie" ],
     "harvest": "zombie",
-    "path_settings": { "max_dist": 4 },
+    "path_settings": { "max_dist": 4, "allow_climb_stairs": false },
     "grab_strength": 20,
     "special_attacks": [
       { "id": "grab" },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Zombie runners shouldn't have an ability to climb stairs
#### Describe the solution
add `"allow_climb_stairs": false`
#### Additional context
So, if `path_settings` is not defined, all its parameters are `false`, but once it added to monster, `allow_climb_stairs` turn into default value, which is `true`. Super confusing