### PR TITLE
[Bombastic Perks] Fix for perk_olde_guns

### DIFF
--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -541,13 +541,13 @@
         "condition": { "not": { "u_has_trait": "perk_olde_guns" } },
         "text": "Gain [<trait_name:perk_olde_guns>]",
         "effect": [
-          { "set_string_var": "<trait_name:perk_olde_guns>", "target_var": { "global_val": "trait_name" } },
+          { "set_string_var": "<trait_name:perk_olde_guns>", "target_var": { "context_val": "trait_name" } },
           {
             "set_string_var": "<trait_description:perk_olde_guns>",
-            "target_var": { "global_val": "trait_description" }
+            "target_var": { "context_val": "trait_description" }
           },
-          { "set_string_var": "perk_olde_guns", "target_var": { "global_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "global_val": "trait_requirement_description" } },
+          { "set_string_var": "perk_olde_guns", "target_var": { "context_val": "trait_id" } },
+          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
`perk_olde_guns` accidentally used `global_val` instead of `context_val`, which make it impossible to read the description of the trait
#### Describe the solution
replace `global_val` with `context_val`
#### Additional context
If you read the descriptions from another perks, their context variables would be used
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/4dabb93a-7a95-4cfa-a006-75d3e1fef20e)
If you did not, nothing would be written
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/45e451ea-7e72-4b42-adf8-185fbca2d99a)