### PR TITLE
Further accessories obsoletion

### DIFF
--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -21,15 +21,7 @@
     "durability": 7,
     "default_mods": [ "retool_ar15_223rem" ],
     "min_cycle_recoil": 1350,
-    "valid_mod_locations": [
-      [ "accessories", 4 ],
-      [ "bore", 1 ],
-      [ "grip", 1 ],
-      [ "mechanism", 4 ],
-      [ "sling", 1 ],
-      [ "stock accessory", 2 ],
-      [ "stock", 1 ]
-    ],
+    "valid_mod_locations": [ [ "bore", 1 ], [ "grip", 1 ], [ "mechanism", 4 ], [ "sling", 1 ], [ "stock accessory", 2 ], [ "stock", 1 ] ],
     "flags": [ "NO_TURRET" ],
     "//3": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "pocket_data": [
@@ -321,15 +313,7 @@
     "min_cycle_recoil": 1350,
     "default_mods": [ "retool_ar15_223rem" ],
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
-    "valid_mod_locations": [
-      [ "accessories", 4 ],
-      [ "bore", 1 ],
-      [ "grip", 1 ],
-      [ "mechanism", 4 ],
-      [ "sling", 1 ],
-      [ "stock accessory", 2 ],
-      [ "stock", 1 ]
-    ],
+    "valid_mod_locations": [ [ "bore", 1 ], [ "grip", 1 ], [ "mechanism", 4 ], [ "sling", 1 ], [ "stock accessory", 2 ], [ "stock", 1 ] ],
     "flags": [ "NO_TURRET" ],
     "//3": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "pocket_data": [
@@ -559,15 +543,7 @@
     "min_cycle_recoil": 1350,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
     "default_mods": [ "retool_ar15_223rem_medium" ],
-    "valid_mod_locations": [
-      [ "accessories", 4 ],
-      [ "bore", 1 ],
-      [ "grip", 1 ],
-      [ "mechanism", 4 ],
-      [ "sling", 1 ],
-      [ "stock accessory", 2 ],
-      [ "stock", 1 ]
-    ],
+    "valid_mod_locations": [ [ "bore", 1 ], [ "grip", 1 ], [ "mechanism", 4 ], [ "sling", 1 ], [ "stock accessory", 2 ], [ "stock", 1 ] ],
     "flags": [ "NO_TURRET" ],
     "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "pocket_data": [
@@ -639,15 +615,7 @@
     "min_cycle_recoil": 1350,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
     "default_mods": [ "pistol_grip", "retool_ar15_223rem_short", "suppressor", "adjustable_stock" ],
-    "valid_mod_locations": [
-      [ "accessories", 4 ],
-      [ "bore", 1 ],
-      [ "grip", 1 ],
-      [ "mechanism", 4 ],
-      [ "sling", 1 ],
-      [ "stock accessory", 2 ],
-      [ "stock", 1 ]
-    ],
+    "valid_mod_locations": [ [ "bore", 1 ], [ "grip", 1 ], [ "mechanism", 4 ], [ "sling", 1 ], [ "stock accessory", 2 ], [ "stock", 1 ] ],
     "flags": [ "NO_TURRET" ],
     "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "pocket_data": [
@@ -719,15 +687,7 @@
     "durability": 7,
     "min_cycle_recoil": 1350,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "3 rd.", 3 ] ],
-    "valid_mod_locations": [
-      [ "accessories", 4 ],
-      [ "bore", 1 ],
-      [ "grip", 1 ],
-      [ "mechanism", 4 ],
-      [ "sling", 1 ],
-      [ "stock accessory", 2 ],
-      [ "stock", 1 ]
-    ],
+    "valid_mod_locations": [ [ "bore", 1 ], [ "grip", 1 ], [ "mechanism", 4 ], [ "sling", 1 ], [ "stock accessory", 2 ], [ "stock", 1 ] ],
     "flags": [ "NO_TURRET" ],
     "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "pocket_data": [
@@ -1202,7 +1162,6 @@
     "default_mods": [ "retool_mdrx_223rem_medium" ],
     "min_cycle_recoil": 1250,
     "valid_mod_locations": [
-      [ "accessories", 4 ],
       [ "bore", 1 ],
       [ "grip", 1 ],
       [ "mechanism", 4 ],
@@ -1276,7 +1235,6 @@
     "durability": 8,
     "default_mods": [ "folding_stock", "muzzle_brake" ],
     "valid_mod_locations": [
-      [ "accessories", 4 ],
       [ "barrel", 1 ],
       [ "bore", 1 ],
       [ "brass catcher", 1 ],
@@ -1349,7 +1307,6 @@
     "built_in_mods": [ "adjustable_stock" ],
     "default_mods": [ "retool_cz600_223rem" ],
     "valid_mod_locations": [
-      [ "accessories", 4 ],
       [ "bore", 1 ],
       [ "grip", 1 ],
       [ "mechanism", 4 ],

--- a/data/json/items/gun/300.json
+++ b/data/json/items/gun/300.json
@@ -126,7 +126,6 @@
     "default_mods": [ "match_trigger", "high_end_folding_stock", "muzzle_brake" ],
     "barrel_volume": "456 ml",
     "valid_mod_locations": [
-      [ "accessories", 4 ],
       [ "barrel", 1 ],
       [ "bore", 1 ],
       [ "brass catcher", 1 ],

--- a/data/json/items/gun/3006.json
+++ b/data/json/items/gun/3006.json
@@ -223,7 +223,6 @@
     "durability": 8,
     "clip_size": 4,
     "valid_mod_locations": [
-      [ "accessories", 4 ],
       [ "barrel", 1 ],
       [ "bore", 1 ],
       [ "grip", 1 ],

--- a/data/json/items/gun/303.json
+++ b/data/json/items/gun/303.json
@@ -31,7 +31,6 @@
     "blackpowder_tolerance": 40,
     "flags": [ "EASY_CLEAN" ],
     "valid_mod_locations": [
-      [ "accessories", 4 ],
       [ "barrel", 1 ],
       [ "bore", 1 ],
       [ "brass catcher", 1 ],
@@ -79,7 +78,6 @@
     "blackpowder_tolerance": 40,
     "flags": [ "EASY_CLEAN" ],
     "valid_mod_locations": [
-      [ "accessories", 4 ],
       [ "barrel", 1 ],
       [ "bore", 1 ],
       [ "brass catcher", 1 ],

--- a/data/json/items/gun/338lapua.json
+++ b/data/json/items/gun/338lapua.json
@@ -65,7 +65,6 @@
     "clip_size": 1,
     "default_mods": [ "match_trigger", "muzzle_brake" ],
     "valid_mod_locations": [
-      [ "accessories", 4 ],
       [ "barrel", 1 ],
       [ "bore", 1 ],
       [ "brass catcher", 1 ],
@@ -114,7 +113,6 @@
     "//": "Cheek pad required for holding the buttstock in place and keep it from folding.",
     "default_mods": [ "match_trigger", "muzzle_brake" ],
     "valid_mod_locations": [
-      [ "accessories", 4 ],
       [ "barrel", 1 ],
       [ "grip", 1 ],
       [ "mechanism", 4 ],
@@ -160,7 +158,6 @@
     "blackpowder_tolerance": 24,
     "default_mods": [ "match_trigger", "high_end_folding_stock", "retool_axmc_338lapua", "muzzle_brake" ],
     "valid_mod_locations": [
-      [ "accessories", 4 ],
       [ "grip", 1 ],
       [ "bore", 1 ],
       [ "mechanism", 4 ],

--- a/data/json/items/gun/450bushmaster.json
+++ b/data/json/items/gun/450bushmaster.json
@@ -19,7 +19,6 @@
     "durability": 8,
     "flags": [ "NEVER_JAMS", "EASY_CLEAN" ],
     "valid_mod_locations": [
-      [ "accessories", 4 ],
       [ "barrel", 1 ],
       [ "bore", 1 ],
       [ "brass catcher", 1 ],

--- a/data/json/items/gun/762.json
+++ b/data/json/items/gun/762.json
@@ -340,7 +340,6 @@
     "barrel_volume": "175 ml",
     "default_mods": [ "folding_stock", "muzzle_brake" ],
     "valid_mod_locations": [
-      [ "accessories", 4 ],
       [ "barrel", 1 ],
       [ "bore", 1 ],
       [ "brass catcher", 1 ],


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Continue #65300
#### Describe the solution
Remove the rest of `accessories` slots, that was accidentally reintroduced in #64934