### PR TITLE
item::set_degradation sets value of 0 on items with degradation disabled

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -873,7 +873,11 @@ void item::set_damage( int qty )
 
 void item::set_degradation( int qty )
 {
-    degradation_ = std::clamp( qty, 0, max_damage() );
+    if( type->degrade_increments() > 0 ) {
+        degradation_ = std::clamp( qty, 0, max_damage() );
+    } else {
+        degradation_ = 0;
+    }
     set_damage( damage_ );
 }
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3998,7 +3998,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     float degrade_mult = 1.0f;
     optional( jo, false, "degradation_multiplier", degrade_mult, 1.0f );
     // TODO: remove condition once degradation is ready to be applied to all items
-    if( def.category_force != item_category_veh_parts ) {
+    if( def.count_by_charges() || def.category_force != item_category_veh_parts ) {
         degrade_mult = 0.0f;
     }
     if( ( degrade_mult * itype::damage_max_ ) <= 0.5f ) {

--- a/src/itype.h
+++ b/src/itype.h
@@ -1384,7 +1384,7 @@ struct itype {
         }
         /** Number of degradation increments before the item is destroyed */
         int degrade_increments() const {
-            return count_by_charges() ? 0 : degrade_increments_;
+            return degrade_increments_;
         }
 
         /**

--- a/tests/degradation_test.cpp
+++ b/tests/degradation_test.cpp
@@ -85,6 +85,17 @@ TEST_CASE( "Damage_indicator_thresholds", "[item][damage_level]" )
     }
 }
 
+TEST_CASE( "only_degrade_items_with_defined_degradation", "[item][degradation]" )
+{
+    // can be removed once all items degrade
+    item no_degradation_item( itype_tailors_kit );
+    CHECK( no_degradation_item.degradation() == 0 );
+    no_degradation_item.set_degradation( 1000 );
+    CHECK( no_degradation_item.degradation() == 0 );
+    no_degradation_item.rand_degradation();
+    CHECK( no_degradation_item.degradation() == 0 );
+}
+
 TEST_CASE( "Degradation_on_spawned_items", "[item][degradation]" )
 {
     clear_map();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/66587

#### Describe the solution

item::set_degradation no longer sets degradation on items without it enabled
vehicle folding test had to be adjusted a bit

Existing items can have degradation cleared by installing/removing on a vehicle or via debug

#### Describe alternatives you've considered

#### Testing

Added a test case for it

#### Additional context
