### PR TITLE
Make lanterns plug-in-able

### DIFF
--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -149,14 +149,14 @@
     "ammo": [ "battery" ],
     "use_action": [
       {
-      "type": "transform",
-      "target": "electric_lantern_on",
-      "active": true,
-      "msg": "You turn the lamp on.",
-      "need_charges": 1,
-      "need_charges_msg": "The lantern has no batteries."
-    },
-    {
+        "type": "transform",
+        "target": "electric_lantern_on",
+        "active": true,
+        "msg": "You turn the lamp on.",
+        "need_charges": 1,
+        "need_charges_msg": "The lantern has no batteries."
+      },
+      {
         "type": "link_up",
         "menu_text": "Plug in / Unplug",
         "ammo_scale": 0,
@@ -164,8 +164,6 @@
         "charge_rate": "20 W"
       }
     ],
-
-
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "ALLOWS_REMOTE_USE", "WATER_BREAK" ],
     "pocket_data": [
       {
@@ -185,8 +183,7 @@
     "power_draw": "1 W",
     "revert_to": "electric_lantern",
     "use_action": [
-      { 
-      "menu_text": "Turn off", "type": "transform", "target": "electric_lantern", "msg": "You turn the lamp off." },
+      { "menu_text": "Turn off", "type": "transform", "target": "electric_lantern", "msg": "You turn the lamp off." },
       {
         "type": "link_up",
         "menu_text": "Plug in / Unplug",

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -147,7 +147,8 @@
     "color": "green",
     "charges_per_use": 1,
     "ammo": [ "battery" ],
-    "use_action": {
+    "use_action": [
+      {
       "type": "transform",
       "target": "electric_lantern_on",
       "active": true,
@@ -155,6 +156,16 @@
       "need_charges": 1,
       "need_charges_msg": "The lantern has no batteries."
     },
+    {
+        "type": "link_up",
+        "menu_text": "Plug in / Unplug",
+        "ammo_scale": 0,
+        "cable_length": 2,
+        "charge_rate": "20 W"
+      }
+    ],
+
+
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "ALLOWS_REMOTE_USE", "WATER_BREAK" ],
     "pocket_data": [
       {
@@ -173,7 +184,17 @@
     "name": { "str": "electric lantern (on)", "str_pl": "electric lanterns (on)" },
     "power_draw": "1 W",
     "revert_to": "electric_lantern",
-    "use_action": { "menu_text": "Turn off", "type": "transform", "target": "electric_lantern", "msg": "You turn the lamp off." },
+    "use_action": [
+      { 
+      "menu_text": "Turn off", "type": "transform", "target": "electric_lantern", "msg": "You turn the lamp off." },
+      {
+        "type": "link_up",
+        "menu_text": "Plug in / Unplug",
+        "ammo_scale": 0,
+        "cable_length": 2,
+        "charge_rate": "20 W"
+      }
+    ],
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "LIGHT_15", "TRADER_AVOID", "ALLOWS_REMOTE_USE" ]
   },
   {


### PR DESCRIPTION
#### Summary
Features "Give electric lanterns power cords"


#### Purpose of change
I adore the way some electronics can be plugged into a power grid, but not being able to do it to ALL of them makes me sad.

#### Describe the solution
Turns out, it's not super duper hard to give cords to items! So I did. Proof of concept I guess. Planning to do more, but I wanted to get this passed first.

#### Describe alternatives you've considered
Waiting for someone else to do it? It seems bound to happen eventually.

#### Testing
Made a new save. Spawned in a large battery. Set it up as an appliance. Spawned an electric lantern without a battery. Tried to turn it on. Doesn't work, but plug in is an option in the menu. Selected plug in and plugged into the lamp. Turns on! Dropped the lantern, still on.

#### Additional context
More items should be updated this way, but it looks like there's some issues to figure out regarding items that use up charges being plugged in: #66286 
