### PR TITLE
Wetsuit and diving gear rework

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -376,6 +376,30 @@
     "restriction": "Item must be some kind of chainmail veil"
   },
   {
+    "id": "BOOT_FINS",
+    "type": "json_flag",
+    "info": "This item is attachable to commercial diving boots as fins.",
+    "restriction": "Item must be some kind of fins"
+  },
+  {
+    "id": "BOOT_FINS_CUSTOM",
+    "type": "json_flag",
+    "info": "This item is attachable to custom diving boots as fins.",
+    "restriction": "Item must be some kind of custom fins"
+  },
+  {
+    "id": "HEAD_STRAP_MOUNT",
+    "type": "json_flag",
+    "info": "This item is attachable to straps and mountings on some masks and hoods.",
+    "restriction": "Item must be some kind of item that can be attached to straps on masks and hoods."
+  },
+  {
+    "id": "WRIST_MOUNT_ATTACHMENT",
+    "type": "json_flag",
+    "info": "This item is attachable to a proprietary wrist mount.",
+    "restriction": "Item must be some kind of item that can be attached to a proprietary wrist mount."
+  },
+  {
     "id": "EXTRA_PLATING",
     "type": "json_flag",
     "info": "This item is wearable over some armors as an extra layer of plating.",

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -197,6 +197,7 @@
       { "item": "flashlight", "prob": 20, "charges": [ 0, 300 ] },
       { "item": "heavy_flashlight", "prob": 15, "charges": [ 0, 300 ] },
       { "item": "goggles_nv", "prob": 5, "charges": [ 0, 100 ] },
+      { "item": "goggles_ir", "prob": 2, "charges": [ 0, 100 ] },
       [ "hand_crank_charger", 15 ],
       { "item": "handflare", "prob": 20, "charges": 300 },
       [ "hatchet", 10 ],

--- a/data/json/items/armor/bespoke_armor/custom_bodysuits.json
+++ b/data/json/items/armor/bespoke_armor/custom_bodysuits.json
@@ -436,6 +436,7 @@
     "armor": [
       {
         "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
           { "type": "neoprene", "covered_by_mat": 100, "thickness": 3.5 },
           { "type": "kevlar", "covered_by_mat": 100, "thickness": 1.5 }
         ],
@@ -444,27 +445,48 @@
         "encumbrance": [ 19, 19 ]
       }
     ],
+    "//": "Pockets are half in size of those found on technical shorts and without a pocket in the flap.",
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "500 ml",
-        "max_contains_weight": "2 kg",
-        "moves": 80,
+        "max_contains_weight": "1 kg",
+        "moves": 130,
         "max_item_length": "11 cm",
-        "description": "Pants pocket."
+        "watertight": true,
+        "description": "Back pocket."
       },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "500 ml",
-        "max_contains_weight": "2 kg",
-        "moves": 80,
+        "max_contains_weight": "1 kg",
+        "moves": 130,
         "max_item_length": "11 cm",
-        "description": "Pants pocket."
+        "watertight": true,
+        "description": "Back pocket."
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1650 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "32 cm",
+        "description": "Pants pocket.",
+        "volume_encumber_modifier": 0.25,
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1650 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "32 cm",
+        "description": "Pants pocket.",
+        "volume_encumber_modifier": 0.25,
+        "moves": 80
       }
     ],
     "warmth": 41,
-    "environmental_protection": 8,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "POCKETS", "HOOD", "RAINPROOF", "STURDY", "SKINTIGHT", "NORMAL" ],
+    "environmental_protection": 12,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "STURDY", "SKINTIGHT", "NORMAL" ],
     "melee_damage": { "bash": 6 }
   },
   {
@@ -480,6 +502,92 @@
     "type": "ARMOR",
     "name": { "str": "XL Kevlar wetsuit" },
     "copy-from": "h20survivor_jumpsuit",
+    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "h20survivor_jumpsuit_light",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "light Kevlar wetsuit oversuit" },
+    "description": "A hand-built light combination armor made from an expanded and lightened wetsuit padded with layers of Kevlar.  Protects from the elements as well as from harm.",
+    "weight": "6400 g",
+    "volume": "7000 ml",
+    "price_postapoc": 5000,
+    "material": [ "neoprene", "kevlar" ],
+    "symbol": "[",
+    "to_hit": -3,
+    "looks_like": "wetsuit",
+    "color": "dark_gray",
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 1.5 }
+        ],
+        "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 11, 11 ]
+      }
+    ],
+    "//": "Pockets are half in size of those found on technical shorts and without a pocket in the flap.",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "500 ml",
+        "max_contains_weight": "1 kg",
+        "moves": 130,
+        "max_item_length": "11 cm",
+        "watertight": true,
+        "description": "Back pocket."
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "500 ml",
+        "max_contains_weight": "1 kg",
+        "moves": 130,
+        "max_item_length": "11 cm",
+        "watertight": true,
+        "description": "Back pocket."
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1650 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "32 cm",
+        "description": "Pants pocket.",
+        "volume_encumber_modifier": 0.2,
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1650 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "32 cm",
+        "description": "Pants pocket.",
+        "volume_encumber_modifier": 0.2,
+        "moves": 80
+      }
+    ],
+    "warmth": 30,
+    "environmental_protection": 10,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "STURDY" ],
+    "melee_damage": { "bash": 6 }
+  },
+  {
+    "id": "xs_h20survivor_jumpsuit_light",
+    "type": "ARMOR",
+    "name": { "str": "XS light Kevlar wetsuit oversuit" },
+    "copy-from": "h20survivor_jumpsuit_light",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "xl_h20survivor_jumpsuit_light",
+    "type": "ARMOR",
+    "name": { "str": "XL light Kevlar wetsuit oversuit" },
+    "copy-from": "h20survivor_jumpsuit_light",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "extend": { "flags": [ "OVERSIZE" ] }
   },
@@ -500,8 +608,8 @@
     "armor": [
       {
         "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.4 },
           { "type": "neoprene", "covered_by_mat": 100, "thickness": 5.0 },
-          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.5 },
           { "type": "kevlar", "covered_by_mat": 100, "thickness": 3.0 }
         ],
         "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
@@ -509,27 +617,48 @@
         "encumbrance": [ 26, 26 ]
       }
     ],
+    "//": "Pockets are from normal thick wetsuit with back pockets added on.",
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "500 ml",
-        "max_contains_weight": "2 kg",
-        "moves": 80,
+        "max_contains_weight": "1 kg",
+        "moves": 130,
         "max_item_length": "11 cm",
-        "description": "Pants pocket."
+        "watertight": true,
+        "description": "Back pocket."
       },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "500 ml",
-        "max_contains_weight": "2 kg",
-        "moves": 80,
+        "max_contains_weight": "1 kg",
+        "moves": 130,
         "max_item_length": "11 cm",
-        "description": "Pants pocket."
+        "watertight": true,
+        "description": "Back pocket."
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1000 ml",
+        "max_contains_weight": "1500 g",
+        "moves": 130,
+        "max_item_length": "20 cm",
+        "watertight": true,
+        "description": "Hip pocket."
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1000 ml",
+        "max_contains_weight": "1500 g",
+        "moves": 130,
+        "max_item_length": "20 cm",
+        "watertight": true,
+        "description": "Hip pocket."
       }
     ],
     "warmth": 70,
-    "environmental_protection": 8,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "POCKETS", "HOOD", "RAINPROOF", "STURDY", "SKINTIGHT", "NORMAL" ],
+    "environmental_protection": 14,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "STURDY", "SKINTIGHT", "NORMAL" ],
     "melee_damage": { "bash": 6 }
   },
   {

--- a/data/json/items/armor/bespoke_armor/custom_boots.json
+++ b/data/json/items/armor/bespoke_armor/custom_boots.json
@@ -296,22 +296,284 @@
     "id": "boots_h20survivor",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "pair of survivor wetsuit boots", "str_pl": "pairs of survivor wetsuit boots" },
+    "name": { "str": "pair of Kevlar diving boots", "str_pl": "pairs of Kevlar diving boots" },
     "description": "A pair of customized, Kevlar-armored neoprene boots.  These will keep you dry and alive, come hell or high water.",
     "weight": "1180 g",
     "volume": "1500 ml",
     "price": 24000,
     "price_postapoc": 6000,
     "to_hit": -1,
-    "material": [ "kevlar", "plastic", "neoprene" ],
+    "material": [ "kevlar", "neoprene", "rubber", "nylon" ],
     "symbol": "[",
     "looks_like": "boots_bunker",
     "color": "dark_gray",
-    "warmth": 15,
-    "material_thickness": 3,
-    "environmental_protection": 10,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY" ],
-    "armor": [ { "encumbrance": 32, "coverage": 100, "covers": [ "foot_l", "foot_r" ] } ],
+    "warmth": 41,
+    "environmental_protection": 12,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "WATERPROOF", "SKINTIGHT", "NORMAL" ],
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [
+          "foot_toes_r",
+          "foot_toes_l",
+          "foot_ankle_r",
+          "foot_ankle_l",
+          "foot_heel_r",
+          "foot_heel_l",
+          "foot_arch_r",
+          "foot_arch_l"
+        ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 3.0 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 1.5 }
+        ],
+        "encumbrance": 19,
+        "coverage": 100
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 3.5 },
+          { "type": "rubber", "covered_by_mat": 100, "thickness": 4.0 }
+        ],
+        "coverage": 100
+      }
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "ablative": true,
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "1000 ml",
+        "max_contains_weight": "500 g",
+        "moves": 100,
+        "description": "mounting for a pair of custom fins.",
+        "flag_restriction": [ "BOOT_FINS_CUSTOM" ]
+      }
+    ],
     "melee_damage": { "bash": 1 }
+  },
+  {
+    "id": "xl_boots_h20survivor",
+    "type": "ARMOR",
+    "copy-from": "boots_h20survivor",
+    "looks_like": "boots_h20survivor",
+    "name": { "str": "pair of XL Kevlar diving boots", "str_pl": "pairs of XL Kevlar diving boots" },
+    "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_boots_h20survivor",
+    "type": "ARMOR",
+    "copy-from": "boots_h20survivor",
+    "looks_like": "boots_h20survivor",
+    "name": { "str": "pair of XS Kevlar diving boots", "str_pl": "pairs of XS Kevlar diving boots" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "boots_h20survivor_light",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "pair of light Kevlar diving overboots", "str_pl": "pairs of light Kevlar diving overboots" },
+    "description": "A pair of customized, Kevlar-armored light neoprene boots.  These will keep you dry and alive, come hell or high water.",
+    "//": "Survivor took the booties, expanded them, decreased the thickness and thickened the sole, then added some light Kevlar armor.",
+    "weight": "900 g",
+    "volume": "1200 ml",
+    "price": 24000,
+    "price_postapoc": 6000,
+    "to_hit": -1,
+    "material": [ "kevlar", "neoprene", "rubber", "nylon" ],
+    "symbol": "[",
+    "looks_like": "boots_h20survivor",
+    "color": "dark_gray",
+    "warmth": 30,
+    "environmental_protection": 10,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "WATERPROOF" ],
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [
+          "foot_toes_r",
+          "foot_toes_l",
+          "foot_ankle_r",
+          "foot_ankle_l",
+          "foot_heel_r",
+          "foot_heel_l",
+          "foot_arch_r",
+          "foot_arch_l"
+        ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 1.5 }
+        ],
+        "encumbrance": 11,
+        "coverage": 100
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "rubber", "covered_by_mat": 100, "thickness": 4.0 }
+        ],
+        "coverage": 100
+      }
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "ablative": true,
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "1000 ml",
+        "max_contains_weight": "500 g",
+        "moves": 100,
+        "description": "mounting for a pair of custom fins.",
+        "flag_restriction": [ "BOOT_FINS_CUSTOM" ]
+      }
+    ],
+    "melee_damage": { "bash": 1 }
+  },
+  {
+    "id": "xl_boots_h20survivor_light",
+    "type": "ARMOR",
+    "copy-from": "boots_h20survivor_light",
+    "looks_like": "boots_h20survivor_light",
+    "name": { "str": "pair of XL Kevlar diving overboots", "str_pl": "pairs of XL light Kevlar diving overboots" },
+    "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_boots_h20survivor_light",
+    "type": "ARMOR",
+    "copy-from": "boots_h20survivor_light",
+    "looks_like": "boots_h20survivor_light",
+    "name": { "str": "pair of XS light Kevlar diving overboots", "str_pl": "pairs of XS light Kevlar diving overboots" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "boots_h20survivor_thick",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "pair of thick Kevlar diving boots", "str_pl": "pairs of thick Kevlar diving boots" },
+    "description": "A pair of customized, Kevlar-armored thick neoprene boots.  These will keep you dry and alive, come hell or high water.",
+    "weight": "1180 g",
+    "volume": "1500 ml",
+    "price": 24000,
+    "price_postapoc": 6000,
+    "to_hit": -1,
+    "material": [ "kevlar", "neoprene", "rubber", "nylon" ],
+    "symbol": "[",
+    "looks_like": "boots_h20survivor",
+    "color": "dark_gray",
+    "warmth": 70,
+    "environmental_protection": 14,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "WATERPROOF", "SKINTIGHT", "NORMAL" ],
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [
+          "foot_toes_r",
+          "foot_toes_l",
+          "foot_ankle_r",
+          "foot_ankle_l",
+          "foot_heel_r",
+          "foot_heel_l",
+          "foot_arch_r",
+          "foot_arch_l"
+        ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.4 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 5.0 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "encumbrance": 26,
+        "coverage": 100
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.4 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 5.0 },
+          { "type": "rubber", "covered_by_mat": 100, "thickness": 6.0 }
+        ],
+        "coverage": 100
+      }
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "ablative": true,
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "1000 ml",
+        "max_contains_weight": "500 g",
+        "moves": 100,
+        "description": "mounting for a pair of custom fins.",
+        "flag_restriction": [ "BOOT_FINS_CUSTOM" ]
+      }
+    ],
+    "melee_damage": { "bash": 1 }
+  },
+  {
+    "id": "xl_boots_h20survivor_thick",
+    "type": "ARMOR",
+    "copy-from": "boots_h20survivor_thick",
+    "looks_like": "boots_h20survivor_thick",
+    "name": { "str": "pair of XL thick Kevlar diving boots", "str_pl": "pairs of XL thick Kevlar diving boots" },
+    "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_boots_h20survivor_thick",
+    "type": "ARMOR",
+    "copy-from": "boots_h20survivor_thick",
+    "looks_like": "boots_h20survivor_thick",
+    "name": { "str": "pair of XS thick Kevlar diving boots", "str_pl": "pairs of XS thick Kevlar diving boots" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "swim_fins_custom",
+    "type": "ARMOR",
+    "name": { "str_sp": "custom swim fin boot attachments" },
+    "description": "A pair of rubber flippers worn on the feet, which improve swimming speed while greatly impeding the wearer's ability to walk.  This pair was reduced in volume and weight and has to be attached to diving boots with necessary attachment points.",
+    "weight": "420 g",
+    "volume": "850 ml",
+    "price": 2000,
+    "price_postapoc": 250,
+    "material": [ "rubber" ],
+    "symbol": "[",
+    "looks_like": "swim_fins",
+    "color": "dark_gray",
+    "warmth": 5,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "FIN", "BOOT_FINS_CUSTOM", "CANT_WEAR", "OVERSIZE" ],
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_toes_r", "foot_toes_l" ],
+        "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "encumbrance": 20,
+        "coverage": 100
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_heel_r", "foot_heel_l" ],
+        "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "coverage": 30
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_arch_r", "foot_arch_l" ],
+        "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "coverage": 50
+      }
+    ]
   }
 ]

--- a/data/json/items/armor/bespoke_armor/custom_gloves.json
+++ b/data/json/items/armor/bespoke_armor/custom_gloves.json
@@ -266,21 +266,148 @@
     "id": "gloves_h20survivor",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "pair of survivor wetsuit gloves", "str_pl": "pairs of survivor wetsuit gloves" },
-    "description": "A pair of customized, Kevlar armored neoprene gloves, modified to be easy to wear while providing maximum protection under extreme conditions.",
+    "name": { "str": "pair of Kevlar wetsuit gloves", "str_pl": "pairs of Kevlar wetsuit gloves" },
+    "description": "A pair of customized, Kevlar-armored neoprene gloves, modified to be easy to wear while providing maximum protection under extreme conditions.",
     "weight": "390 g",
     "volume": "750 ml",
     "price": 18000,
     "price_postapoc": 2000,
-    "to_hit": 2,
-    "material": [ "kevlar", "plastic", "neoprene" ],
+    "to_hit": -1,
+    "material": [ "kevlar", "neoprene", "nylon" ],
     "symbol": "[",
     "looks_like": "gloves_rubber",
     "color": "dark_gray",
-    "warmth": 15,
-    "material_thickness": 1,
+    "warmth": 41,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY" ],
-    "armor": [ { "encumbrance": 25, "coverage": 100, "covers": [ "hand_l", "hand_r" ] } ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "WATERPROOF", "SKINTIGHT", "NORMAL" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 3.5 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 1.5 }
+        ],
+        "covers": [ "hand_l", "hand_r" ],
+        "coverage": 100,
+        "encumbrance": 19
+      }
+    ]
+  },
+  {
+    "id": "xl_gloves_h20survivor",
+    "type": "ARMOR",
+    "copy-from": "gloves_h20survivor",
+    "looks_like": "gloves_h20survivor",
+    "name": { "str": "pair of XL Kevlar wetsuit gloves", "str_pl": "pairs of XL Kevlar wetsuit gloves" },
+    "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_gloves_h20survivor",
+    "type": "ARMOR",
+    "copy-from": "gloves_h20survivor",
+    "looks_like": "gloves_h20survivor",
+    "name": { "str": "pair of XS Kevlar wetsuit gloves", "str_pl": "pairs of XS Kevlar wetsuit gloves" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "gloves_h20survivor_light",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "pair of light Kevlar wetsuit overgloves", "str_pl": "pairs of light Kevlar wetsuit gloves" },
+    "description": "A pair of customized, Kevlar-armored light neoprene gloves, modified to be easy to wear while providing significant protection under extreme conditions.",
+    "//": "Cut down in thickness yet expanded in size wetsuit gloves, armored with Kevlar.",
+    "weight": "390 g",
+    "volume": "750 ml",
+    "price": 18000,
+    "price_postapoc": 2000,
+    "to_hit": -1,
+    "material": [ "kevlar", "neoprene", "nylon" ],
+    "symbol": "[",
+    "looks_like": "gloves_h20survivor",
+    "color": "dark_gray",
+    "warmth": 30,
+    "environmental_protection": 10,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "WATERPROOF" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 1.5 }
+        ],
+        "covers": [ "hand_l", "hand_r" ],
+        "coverage": 100,
+        "encumbrance": 11
+      }
+    ]
+  },
+  {
+    "id": "xl_gloves_h20survivor_light",
+    "type": "ARMOR",
+    "copy-from": "gloves_h20survivor_light",
+    "looks_like": "gloves_h20survivor_light",
+    "name": { "str": "pair of XL light Kevlar wetsuit overgloves", "str_pl": "pairs of XL light Kevlar wetsuit overgloves" },
+    "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_gloves_h20survivor_light",
+    "type": "ARMOR",
+    "copy-from": "gloves_h20survivor_light",
+    "looks_like": "gloves_h20survivor_light",
+    "name": { "str": "pair of XS light Kevlar wetsuit overgloves", "str_pl": "pairs of XS light Kevlar wetsuit overgloves" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "gloves_h20survivor_thick",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "pair of Kevlar wetsuit gloves", "str_pl": "pairs of Kevlar wetsuit gloves" },
+    "description": "A pair of customized, Kevlar-armored neoprene gloves, modified to provide maximum protection under extreme conditions.",
+    "weight": "390 g",
+    "volume": "750 ml",
+    "price": 18000,
+    "price_postapoc": 2000,
+    "to_hit": -1,
+    "material": [ "kevlar", "neoprene", "nylon" ],
+    "symbol": "[",
+    "looks_like": "gloves_h20survivor",
+    "color": "dark_gray",
+    "warmth": 70,
+    "environmental_protection": 14,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "WATERPROOF", "SKINTIGHT", "NORMAL" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.4 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 5.0 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "covers": [ "hand_l", "hand_r" ],
+        "coverage": 100,
+        "encumbrance": 26
+      }
+    ]
+  },
+  {
+    "id": "xl_gloves_h20survivor_thick",
+    "type": "ARMOR",
+    "copy-from": "gloves_h20survivor_thick",
+    "looks_like": "gloves_h20survivor_thick",
+    "name": { "str": "pair of XL Kevlar wetsuit gloves", "str_pl": "pairs of XL Kevlar wetsuit gloves" },
+    "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_gloves_h20survivor_thick",
+    "type": "ARMOR",
+    "copy-from": "gloves_h20survivor_thick",
+    "looks_like": "gloves_h20survivor_thick",
+    "name": { "str": "pair of XS Kevlar wetsuit gloves", "str_pl": "pairs of XS Kevlar wetsuit gloves" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   }
 ]

--- a/data/json/items/armor/bespoke_armor/custom_headgear.json
+++ b/data/json/items/armor/bespoke_armor/custom_headgear.json
@@ -230,23 +230,242 @@
     "id": "hood_h20survivor",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "survivor wetsuit hood" },
+    "name": { "str": "Kevlar wetsuit hood" },
     "description": "A customized armored neoprene and Kevlar hood, very strong and durable.",
+    "//": "When/if new head clothing layering system will be implemented, move this to normal and skintight layers.",
     "weight": "860 g",
     "volume": "1500 ml",
     "price": 58000,
     "price_postapoc": 1500,
     "to_hit": -1,
-    "material": [ "kevlar", "plastic", "neoprene" ],
+    "material": [ "kevlar", "neoprene", "nylon" ],
     "symbol": "[",
     "looks_like": "wetsuit_hood",
     "color": "dark_gray",
-    "warmth": 15,
-    "material_thickness": 3,
+    "warmth": 41,
+    "environmental_protection": 12,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "OUTER" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 3.5 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 1.5 }
+        ],
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 100,
+        "covers": [ "head" ]
+      }
+    ],
+    "melee_damage": { "bash": 10 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "1000 g",
+        "moves": 150,
+        "description": "Outer strap mount.",
+        "flag_restriction": [ "HEAD_STRAP_MOUNT" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "1000 g",
+        "moves": 150,
+        "description": "Outer strap mount.",
+        "flag_restriction": [ "HEAD_STRAP_MOUNT" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "1000 g",
+        "moves": 150,
+        "description": "Outer strap mount.",
+        "flag_restriction": [ "HEAD_STRAP_MOUNT" ]
+      }
+    ]
+  },
+  {
+    "id": "xl_hood_h20survivor",
+    "type": "ARMOR",
+    "copy-from": "hood_h20survivor",
+    "looks_like": "hood_h20survivor",
+    "name": { "str": "XL Kevlar wetsuit hood" },
+    "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_hood_h20survivor",
+    "type": "ARMOR",
+    "copy-from": "hood_h20survivor",
+    "looks_like": "hood_h20survivor",
+    "name": { "str": "XS Kevlar wetsuit hood" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "hood_h20survivor_light",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "light Kevlar wetsuit overhood" },
+    "description": "A customized light armored neoprene and Kevlar overhood, very strong and durable.",
+    "//": "When/if new head clothing layering system will be implemented, move this to normal layer.",
+    "//2": "Basically a reduced in weight and thickness wetsuit hood with a layer of Kevlar attached.",
+    "weight": "860 g",
+    "volume": "1500 ml",
+    "price": 58000,
+    "price_postapoc": 1500,
+    "to_hit": -1,
+    "material": [ "kevlar", "neoprene", "nylon" ],
+    "symbol": "[",
+    "looks_like": "wetsuit_hood",
+    "color": "dark_gray",
+    "warmth": 30,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "OUTER", "SOFT" ],
-    "armor": [ { "encumbrance_modifiers": [ "NONE" ], "coverage": 100, "covers": [ "head" ] } ],
-    "melee_damage": { "bash": 10 }
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "OUTER" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 1.5 }
+        ],
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 100,
+        "covers": [ "head" ]
+      }
+    ],
+    "melee_damage": { "bash": 10 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "1000 g",
+        "moves": 150,
+        "description": "Outer strap mount.",
+        "flag_restriction": [ "HEAD_STRAP_MOUNT" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "1000 g",
+        "moves": 150,
+        "description": "Outer strap mount.",
+        "flag_restriction": [ "HEAD_STRAP_MOUNT" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "1000 g",
+        "moves": 150,
+        "description": "Outer strap mount.",
+        "flag_restriction": [ "HEAD_STRAP_MOUNT" ]
+      }
+    ]
+  },
+  {
+    "id": "xl_hood_h20survivor_light",
+    "type": "ARMOR",
+    "copy-from": "hood_h20survivor_light",
+    "looks_like": "hood_h20survivor_light",
+    "name": { "str": "XL light Kevlar wetsuit overhood" },
+    "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_hood_h20survivor_light",
+    "type": "ARMOR",
+    "copy-from": "hood_h20survivor_light",
+    "looks_like": "hood_h20survivor_light",
+    "name": { "str": "XS light Kevlar wetsuit overhood" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "hood_h20survivor_thick",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "thick Kevlar wetsuit hood" },
+    "description": "A customized thick armored neoprene and Kevlar hood, very strong and durable.",
+    "//": "When/if new head clothing layering system will be implemented, move this to skintight and normal layers.",
+    "weight": "860 g",
+    "volume": "1500 ml",
+    "price": 58000,
+    "price_postapoc": 1500,
+    "to_hit": -1,
+    "material": [ "kevlar", "neoprene", "nylon" ],
+    "symbol": "[",
+    "looks_like": "wetsuit_hood",
+    "color": "dark_gray",
+    "warmth": 70,
+    "environmental_protection": 14,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "OUTER" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 5.0 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ],
+        "coverage": 100,
+        "covers": [ "head" ]
+      }
+    ],
+    "melee_damage": { "bash": 10 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "1000 g",
+        "moves": 150,
+        "description": "Outer strap mount.",
+        "flag_restriction": [ "HEAD_STRAP_MOUNT" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "1000 g",
+        "moves": 150,
+        "description": "Outer strap mount.",
+        "flag_restriction": [ "HEAD_STRAP_MOUNT" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "1000 g",
+        "moves": 150,
+        "description": "Outer strap mount.",
+        "flag_restriction": [ "HEAD_STRAP_MOUNT" ]
+      }
+    ]
+  },
+  {
+    "id": "xl_hood_h20survivor_thick",
+    "type": "ARMOR",
+    "copy-from": "hood_h20survivor_thick",
+    "looks_like": "hood_h20survivor_thick",
+    "name": { "str": "XL thick Kevlar wetsuit hood" },
+    "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_hood_h20survivor_thick",
+    "type": "ARMOR",
+    "copy-from": "hood_h20survivor_thick",
+    "looks_like": "hood_h20survivor_thick",
+    "name": { "str": "XS thick Kevlar wetsuit hood" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "helmet_scavenger",

--- a/data/json/items/armor/bespoke_armor/custom_storage.json
+++ b/data/json/items/armor/bespoke_armor/custom_storage.json
@@ -10,7 +10,7 @@
     "price_postapoc": 3250,
     "material": [ "leather", "canvas" ],
     "symbol": "[",
-    "looks_like": "rucksack",
+    "looks_like": "duffelbag",
     "color": "dark_gray",
     "pocket_data": [
       {
@@ -70,14 +70,14 @@
     "id": "survivor_dry_duffelbag",
     "type": "ARMOR",
     "name": { "str": "survivor dry duffel bag" },
-    "description": "A custom-built heavy watertight duffel bag.  Durable and carefully crafted to hold as much stuff as possible.  Capable of floating.  Provides plenty of storage, but is severely encumbering.",
+    "description": "A modified large watertight duffel bag.  Durable and carefully crafted to hold as much stuff as possible.  Capable of floating.  Provides plenty of storage, but is severely encumbering.",
     "weight": "1400 g",
     "volume": "10800 ml",
     "price": 30000,
     "price_postapoc": 3500,
     "material": [ "plastic" ],
     "symbol": "[",
-    "looks_like": "rucksack",
+    "looks_like": "duffelbag",
     "color": "blue",
     "pocket_data": [
       {
@@ -131,7 +131,7 @@
     ],
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "FLOTATION", "BELTED", "WATER_FRIENDLY" ],
+    "flags": [ "FLOTATION", "BELTED", "WATER_FRIENDLY", "OVERSIZE" ],
     "armor": [
       {
         "encumbrance": 10,
@@ -352,14 +352,14 @@
     "type": "ARMOR",
     "//": "custom-made, but the design is inspired by GVANCA Waterproof Dry Bag Backpack and Lee Valley Waterproof Dry Bag Backpack",
     "name": { "str": "survivor dry bag" },
-    "description": "A custom-built lightweight watertight backpack.  Durable and carefully crafted to hold as much stuff as possible.",
+    "description": "A modified lightweight watertight backpack.  Durable and carefully crafted to hold as much stuff as possible.",
     "weight": "620 g",
     "volume": "1850 ml",
     "price": 30000,
     "price_postapoc": 1500,
     "material": [ "nylon", "plastic" ],
     "symbol": "[",
-    "looks_like": "backpack",
+    "looks_like": "dry_bag",
     "color": "blue",
     "pocket_data": [
       {
@@ -430,7 +430,7 @@
       }
     ],
     "material_thickness": 2,
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED" ],
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE" ],
     "armor": [
       {
         "encumbrance": 2,

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -2180,50 +2180,6 @@
     ]
   },
   {
-    "id": "swim_fins",
-    "type": "ARMOR",
-    "name": { "str": "pair of swim fins", "str_pl": "pairs of swim fins" },
-    "description": "A pair of rubber flippers worn on the feet, which improve swimming speed while greatly impeding the wearer's ability to walk.",
-    "weight": "680 g",
-    "volume": "1250 ml",
-    "price": 2000,
-    "price_postapoc": 250,
-    "material": [ "rubber" ],
-    "symbol": "[",
-    "looks_like": "clownshoes",
-    "color": "dark_gray",
-    "warmth": 5,
-    "material_thickness": 2.5,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "FIN" ],
-    "armor": [
-      {
-        "covers": [ "foot_l", "foot_r" ],
-        "specifically_covers": [ "foot_toes_r", "foot_toes_l" ],
-        "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 2.5 } ],
-        "encumbrance": 25,
-        "coverage": 100
-      },
-      {
-        "covers": [ "foot_l", "foot_r" ],
-        "specifically_covers": [ "foot_heel_r", "foot_heel_l" ],
-        "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 2.5 } ],
-        "coverage": 60
-      },
-      {
-        "covers": [ "foot_l", "foot_r" ],
-        "specifically_covers": [ "foot_arch_r", "foot_arch_l" ],
-        "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 2.5 } ],
-        "coverage": 80
-      },
-      {
-        "covers": [ "foot_l", "foot_r" ],
-        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
-        "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 2.5 } ],
-        "coverage": 100
-      }
-    ]
-  },
-  {
     "id": "thigh_high_boots",
     "type": "ARMOR",
     "name": { "str": "pair of thigh-high boots", "str_pl": "pairs of thigh-high boots" },

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -918,7 +918,7 @@
       }
     ],
     "material_thickness": 1,
-    "flags": [ "WATER_FRIENDLY", "BELTED" ],
+    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE" ],
     "armor": [
       {
         "encumbrance": 2,
@@ -942,7 +942,7 @@
     "price_postapoc": 1000,
     "material": [ "plastic" ],
     "symbol": "[",
-    "looks_like": "backpack",
+    "looks_like": "dive_bag",
     "color": "blue",
     "pocket_data": [
       {
@@ -955,7 +955,7 @@
       }
     ],
     "material_thickness": 1,
-    "flags": [ "WATER_FRIENDLY", "BELTED" ],
+    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE" ],
     "armor": [
       {
         "encumbrance": 2,
@@ -1027,7 +1027,7 @@
     "price_postapoc": 1000,
     "material": [ "plastic" ],
     "symbol": "[",
-    "looks_like": "rucksack",
+    "looks_like": "duffelbag",
     "color": "blue",
     "pocket_data": [
       {
@@ -1055,7 +1055,7 @@
     ],
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "FLOTATION", "BELTED", "WATER_FRIENDLY" ],
+    "flags": [ "FLOTATION", "BELTED", "WATER_FRIENDLY", "OVERSIZE" ],
     "armor": [
       {
         "encumbrance": 10,
@@ -1366,6 +1366,129 @@
         "coverage": 50,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_r", "leg_upper_l" ]
+      }
+    ]
+  },
+  {
+    "id": "legrig_wetsuit",
+    "type": "ARMOR",
+    "name": { "str": "pair of diving pouches", "str_pl": "pairs of diving pouches" },
+    "description": "A set of pouches that can be worn on the thighs using buckled neoprene rig.  This variety is favored by the divers.",
+    "//": "Based on skeletonized version of these https://fourthelement.com/product/technical-shorts/ with added lower buckles like here https://www.divegarage.com/neoprene-tech-shorts.html",
+    "weight": "305 g",
+    "volume": "1150 ml",
+    "price": 3000,
+    "price_postapoc": 250,
+    "material": [ "neoprene", "nylon", "nylon_2" ],
+    "symbol": "[",
+    "color": "dark_gray",
+    "//3": "Two large pockets separated into four, two small zipper pockets on flaps, four bungee loops.",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1650 ml",
+        "max_contains_weight": "1500 g",
+        "max_item_length": "32 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1650 ml",
+        "max_contains_weight": "1500 g",
+        "max_item_length": "32 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1650 ml",
+        "max_contains_weight": "1500 g",
+        "max_item_length": "32 cm",
+        "moves": 100
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1650 ml",
+        "max_contains_weight": "1500 g",
+        "max_item_length": "32 cm",
+        "moves": 100
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "500 ml",
+        "max_contains_weight": "500 g",
+        "max_item_length": "19 cm",
+        "moves": 130
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "500 ml",
+        "max_contains_weight": "500 g",
+        "max_item_length": "19 cm",
+        "moves": 130
+      },
+      {
+        "holster": true,
+        "min_item_volume": "50 ml",
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1000 g",
+        "max_item_length": "70 cm",
+        "extra_encumbrance": 2,
+        "moves": 50,
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+      },
+      {
+        "holster": true,
+        "min_item_volume": "50 ml",
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1000 g",
+        "max_item_length": "70 cm",
+        "extra_encumbrance": 2,
+        "moves": 50,
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+      },
+      {
+        "holster": true,
+        "min_item_volume": "50 ml",
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1000 g",
+        "max_item_length": "70 cm",
+        "extra_encumbrance": 2,
+        "moves": 50,
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+      },
+      {
+        "holster": true,
+        "min_item_volume": "50 ml",
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1000 g",
+        "max_item_length": "70 cm",
+        "extra_encumbrance": 2,
+        "moves": 50,
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+      }
+    ],
+    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "BELTED" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 100,
+        "encumbrance": 2,
+        "volume_encumber_modifier": 0.2,
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
+      },
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "nylon_2", "covered_by_mat": 50, "thickness": 1.5 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 40,
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ]
       }
     ]
   },

--- a/data/json/items/armor/swimming.json
+++ b/data/json/items/armor/swimming.json
@@ -1804,7 +1804,6 @@
     "looks_like": "goggles_welding",
     "color": "light_blue",
     "warmth": 10,
-    "material_thickness": 1,
     "environmental_protection": 16,
     "flags": [ "WATER_FRIENDLY", "WATERPROOF", "SWIM_GOGGLES", "SKINTIGHT", "OVERSIZE" ],
     "armor": [
@@ -1906,5 +1905,99 @@
     "description": "A pair of thick neoprene-silicone rubber gloves, suitable for underwater use.  These fit very small hands.",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
     "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "divemask_full_scuba_notready",
+    "type": "ARMOR",
+    "name": { "str": "full-face diving mask" },
+    "description": "A full-face diving mask that covers the face and eyes.  Can be equipped with any common scuba regulator to protect from drowning and other dangers, though the process needs some time and knowledge.",
+    "//": "Based on OTS Spectrum mask",
+    "weight": "1040 g",
+    "volume": "1500 ml",
+    "price": 40000,
+    "price_postapoc": 2000,
+    "to_hit": -2,
+    "material": [ "plastic", "rubber", "thermo_resin" ],
+    "symbol": "[",
+    "looks_like": "mask_h20survivor",
+    "color": "blue",
+    "warmth": 10,
+    "environmental_protection": 4,
+    "flags": [ "WATER_FRIENDLY", "RAINPROOF", "SWIM_GOGGLES" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "rubber", "covered_by_mat": 20, "thickness": 1.0 },
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 3.0 },
+          { "type": "thermo_resin", "covered_by_mat": 20, "thickness": 2.0 }
+        ],
+        "covers": [ "eyes" ],
+        "coverage": 100,
+        "encumbrance": 10,
+        "rigid_layer_only": true
+      },
+      {
+        "material": [
+          { "type": "rubber", "covered_by_mat": 100, "thickness": 3.0 },
+          { "type": "plastic", "covered_by_mat": 20, "thickness": 2.0 }
+        ],
+        "covers": [ "mouth" ],
+        "coverage": 100,
+        "encumbrance": 10,
+        "specifically_covers": [ "mouth_cheeks", "mouth_chin", "mouth_nose" ],
+        "rigid_layer_only": true
+      }
+    ]
+  },
+  {
+    "id": "divemask_full_modular",
+    "type": "ARMOR",
+    "name": { "str": "modular full-face diving mask" },
+    "description": "A high-end modular full-face diving mask that covers the face and eyes.  Can be equipped with proprietary adapters for scuba tanks or rebreather cartridges to protect from drowning and other dangers.",
+    "//": "Based on Kirby Morgan M-48 MOD-1 mask",
+    "weight": "830 g",
+    "volume": "1500 ml",
+    "price": 40000,
+    "price_postapoc": 2000,
+    "to_hit": -2,
+    "material": [ "plastic", "rubber", "thermo_resin" ],
+    "symbol": "[",
+    "looks_like": "mask_h20survivor",
+    "color": "dark_gray",
+    "warmth": 10,
+    "environmental_protection": 16,
+    "flags": [ "WATER_FRIENDLY", "WATERPROOF", "SWIM_GOGGLES" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "rubber", "covered_by_mat": 20, "thickness": 1.0 },
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 3.0 },
+          { "type": "thermo_resin", "covered_by_mat": 25, "thickness": 3.0 }
+        ],
+        "covers": [ "eyes" ],
+        "coverage": 100,
+        "encumbrance": 10,
+        "rigid_layer_only": true
+      },
+      {
+        "material": [
+          { "type": "rubber", "covered_by_mat": 100, "thickness": 3.0 },
+          { "type": "thermo_resin", "covered_by_mat": 40, "thickness": 3.0 }
+        ],
+        "covers": [ "mouth" ],
+        "specifically_covers": [ "mouth_nose" ],
+        "coverage": 100
+      },
+      {
+        "material": [
+          { "type": "rubber", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "thermo_resin", "covered_by_mat": 50, "thickness": 3.0 }
+        ],
+        "covers": [ "mouth" ],
+        "specifically_covers": [ "mouth_cheeks", "mouth_chin" ],
+        "coverage": 100,
+        "encumbrance": 10
+      }
+    ]
   }
 ]

--- a/data/json/items/armor/swimming.json
+++ b/data/json/items/armor/swimming.json
@@ -584,20 +584,19 @@
   {
     "id": "wetsuit_booties",
     "type": "ARMOR",
-    "name": { "str": "pair of swimming booties", "str_pl": "pairs of swimming booties" },
-    "description": "A pair of neoprene swimming booties, with individual toes.",
+    "name": { "str": "pair of diving socks", "str_pl": "pairs of diving socks" },
+    "description": "A pair of 3mm split-toe neoprene diving socks with thin rubber soles.",
     "weight": "130 g",
     "volume": "1 L",
     "price": 6800,
     "price_postapoc": 250,
-    "material": [ "neoprene" ],
+    "material": [ "neoprene", "nylon", "rubber" ],
     "symbol": "[",
     "looks_like": "boots_rubber",
     "color": "dark_gray",
     "warmth": 30,
-    "material_thickness": 3,
-    "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ],
+    "environmental_protection": 10,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT", "TOUGH_FEET", "SOFT" ],
     "armor": [
       {
         "covers": [ "foot_l", "foot_r" ],
@@ -609,27 +608,57 @@
           "foot_heel_r",
           "foot_heel_l",
           "foot_arch_r",
-          "foot_arch_l",
-          "foot_sole_r",
-          "foot_sole_l"
+          "foot_arch_l"
         ],
-        "material": [ { "type": "neoprene", "covered_by_mat": 100, "thickness": 3.0 } ],
-        "encumbrance": 15,
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "encumbrance": 10,
+        "coverage": 100
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 3.0 },
+          { "type": "rubber", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
         "coverage": 100
       }
     ]
   },
   {
+    "id": "xl_wetsuit_booties",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_booties",
+    "name": { "str": "pair of XL diving socks", "str_pl": "pairs of XL diving socks" },
+    "description": "A pair of 3mm split-toe neoprene diving socks with thin rubber soles.  These fit very large feet.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_booties",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_booties",
+    "name": { "str": "pair of XS diving socks", "str_pl": "pairs of XS diving socks" },
+    "description": "A pair of 3mm split-toe neoprene diving socks with thin rubber soles.  These fit very small feet.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
     "id": "wetsuit_booties_thick",
     "type": "ARMOR",
     "copy-from": "wetsuit_booties",
-    "name": { "str": "pair of thick swimming booties", "str_pl": "pairs of thick swimming booties" },
-    "description": "A pair of thick neoprene swimming booties, with individual toes.",
+    "name": { "str": "pair of thick diving boots", "str_pl": "pairs of thick diving boots" },
+    "description": "A pair of 5mm thick neoprene diving boots with thick soles.",
+    "//": "These will have an ablative armor slot for fins, as diving boots are designed to be worn with those.",
     "weight": "160 g",
     "warmth": 50,
-    "material_thickness": 5,
-    "environmental_protection": 4,
+    "environmental_protection": 12,
     "extend": { "flags": [ "NORMAL" ] },
+    "delete": { "flags": [ "TOUGH_FEET", "SOFT" ] },
     "armor": [
       {
         "covers": [ "foot_l", "foot_r" ],
@@ -641,12 +670,98 @@
           "foot_heel_r",
           "foot_heel_l",
           "foot_arch_r",
-          "foot_arch_l",
-          "foot_sole_r",
-          "foot_sole_l"
+          "foot_arch_l"
         ],
-        "material": [ { "type": "neoprene", "covered_by_mat": 100, "thickness": 5.0 } ],
-        "encumbrance": 24,
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.4 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 5.0 }
+        ],
+        "encumbrance": 20,
+        "coverage": 100
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.4 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 5.0 },
+          { "type": "rubber", "covered_by_mat": 100, "thickness": 4.0 }
+        ],
+        "coverage": 100
+      }
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "ablative": true,
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "1300 ml",
+        "max_contains_weight": "1000 g",
+        "moves": 150,
+        "description": "mounting for a pair of fins.",
+        "flag_restriction": [ "BOOT_FINS" ]
+      }
+    ]
+  },
+  {
+    "id": "xl_wetsuit_booties_thick",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_booties_thick",
+    "name": { "str": "pair of XL diving socks", "str_pl": "pairs of XL diving socks" },
+    "description": "A pair of 5mm thick neoprene diving boots with thick soles.  These fit very large feet.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_booties_thick",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_booties_thick",
+    "name": { "str": "pair of XS diving socks", "str_pl": "pairs of XS diving socks" },
+    "description": "A pair of 5mm thick neoprene diving boots with thick soles.  These fit very small feet.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "swim_fins",
+    "type": "ARMOR",
+    "name": { "str": "pair of swim fins", "str_pl": "pairs of swim fins" },
+    "description": "A pair of rubber flippers worn on the feet, which improve swimming speed while greatly impeding the wearer's ability to walk.",
+    "weight": "680 g",
+    "volume": "1250 ml",
+    "price": 2000,
+    "price_postapoc": 250,
+    "material": [ "rubber" ],
+    "symbol": "[",
+    "looks_like": "clownshoes",
+    "color": "dark_gray",
+    "warmth": 5,
+    "material_thickness": 2.5,
+    "//": "Most fins have some way of adjustment as of now, so OVERSIZE flag.",
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "FIN", "BOOT_FINS", "OVERSIZE" ],
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_toes_r", "foot_toes_l" ],
+        "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "encumbrance": 25,
+        "coverage": 100
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_heel_r", "foot_heel_l" ],
+        "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "coverage": 60
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_arch_r", "foot_arch_l" ],
+        "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "coverage": 80
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
+        "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 2.5 } ],
         "coverage": 100
       }
     ]
@@ -655,110 +770,222 @@
     "id": "wetsuit",
     "type": "ARMOR",
     "name": { "str": "wetsuit" },
-    "description": "A full-body neoprene wetsuit.",
+    "description": "A full-body 3mm thick neoprene wetsuit with nylon lining.",
     "weight": "825 g",
     "volume": "5 L",
     "price": 12000,
     "price_postapoc": 500,
     "to_hit": -3,
-    "material": [ "neoprene" ],
+    "material": [ "neoprene", "nylon" ],
     "symbol": "[",
     "color": "dark_gray",
     "armor": [
       {
-        "material": [ { "type": "neoprene", "covered_by_mat": 100, "thickness": 3 } ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
         "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
         "coverage": 100,
-        "encumbrance": [ 15, 15 ]
+        "encumbrance": [ 10, 10 ]
       }
     ],
+    "//": "Pockets like here: https://mytriathlon.co.uk/zone3-versa-womens-wetsuit---ex-rental-cat-1/",
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "500 ml",
-        "max_contains_weight": "2 kg",
+        "max_contains_weight": "1 kg",
+        "moves": 130,
         "max_item_length": "11 cm",
-        "moves": 130
+        "watertight": true,
+        "description": "Back pocket."
       },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "500 ml",
-        "max_contains_weight": "2 kg",
+        "max_contains_weight": "1 kg",
+        "moves": 130,
         "max_item_length": "11 cm",
-        "moves": 130
+        "watertight": true,
+        "description": "Back pocket."
       }
     ],
     "warmth": 30,
-    "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ]
+    "environmental_protection": 10,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT" ]
+  },
+  {
+    "id": "xl_wetsuit",
+    "type": "ARMOR",
+    "copy-from": "wetsuit",
+    "name": { "str": "XL wetsuit" },
+    "description": "A full-body 3mm thick neoprene wetsuit with nylon lining.  This one is made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit",
+    "type": "ARMOR",
+    "copy-from": "wetsuit",
+    "name": { "str": "XS wetsuit" },
+    "description": "A full-body 3mm thick neoprene wetsuit with nylon lining.  This one is made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "wetsuit_thick",
     "type": "ARMOR",
     "name": { "str": "thick wetsuit" },
-    "description": "A full-body 5mm thick neoprene and nylon wetsuit.",
+    "description": "A full-body 5mm thick neoprene wetsuit with nylon lining.",
     "weight": "2200 g",
     "volume": "6 L",
     "price": 10000,
     "price_postapoc": 500,
     "to_hit": -3,
-    "material": [ { "type": "neoprene", "portion": 9 }, { "type": "nylon", "portion": 1 } ],
-    "material_thickness": 5,
+    "material": [ "neoprene", "nylon" ],
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "wetsuit",
-    "armor": [ { "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 24, 24 ] } ],
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.4 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 5.0 }
+        ],
+        "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 20, 20 ]
+      }
+    ],
+    "//": "Pockets like here: https://waterproof.eu/products/wetsuits/w7/",
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "500 ml",
-        "max_contains_weight": "2 kg",
-        "max_item_length": "11 cm",
-        "moves": 130
+        "max_contains_volume": "1000 ml",
+        "max_contains_weight": "1500 g",
+        "moves": 130,
+        "max_item_length": "20 cm",
+        "watertight": true,
+        "description": "Hip pocket."
       },
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "500 ml",
-        "max_contains_weight": "2 kg",
-        "max_item_length": "11 cm",
-        "moves": 130
+        "max_contains_volume": "1000 ml",
+        "max_contains_weight": "1500 g",
+        "moves": 130,
+        "max_item_length": "20 cm",
+        "watertight": true,
+        "description": "Hip pocket."
       }
     ],
     "warmth": 50,
-    "environmental_protection": 4,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "NORMAL" ]
+    "environmental_protection": 12,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT", "NORMAL" ]
+  },
+  {
+    "id": "xl_wetsuit_thick",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_thick",
+    "name": { "str": "XL thick wetsuit" },
+    "description": "A full-body 5mm thick neoprene wetsuit with nylon lining.  This one is made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_thick",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_thick",
+    "name": { "str": "XS thick wetsuit" },
+    "description": "A full-body 5mm thick neoprene wetsuit with nylon lining.  This one is made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "wetsuit_hood",
     "type": "ARMOR",
     "name": { "str": "wetsuit hood" },
-    "description": "A neoprene hood, commonly worn by divers.",
+    "description": "A 3mm neoprene hood, commonly worn by divers.",
     "weight": "160 g",
     "volume": "1 L",
     "price": 4500,
     "price_postapoc": 250,
-    "material": [ "neoprene" ],
+    "material": [ "neoprene", "nylon" ],
     "symbol": "[",
     "looks_like": "hood_rain",
     "color": "dark_gray",
     "warmth": 30,
-    "material_thickness": 3,
-    "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ],
-    "armor": [ { "encumbrance_modifiers": [ "NONE" ], "coverage": 100, "covers": [ "head" ] } ]
+    "environmental_protection": 10,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 100,
+        "covers": [ "head" ]
+      }
+    ]
+  },
+  {
+    "id": "xl_wetsuit_hood",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_hood",
+    "name": { "str": "XL wetsuit hood" },
+    "description": "A 3mm thick neoprene hood, commonly worn by divers.  This one is made to fit a very large head.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_hood",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_hood",
+    "name": { "str": "XS wetsuit hood" },
+    "description": "A 3mm thick neoprene hood, commonly worn by divers.  This one is made to fit a very small head.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "wetsuit_hood_thick",
     "type": "ARMOR",
     "copy-from": "wetsuit_hood",
     "name": { "str": "thick wetsuit hood" },
-    "description": "A 5mm thick neoprene hood, commonly worn by divers.",
+    "description": "A 5mm thick neoprene hood, commonly worn by divers in cold weather.",
     "weight": "180 g",
     "warmth": 50,
-    "material_thickness": 5,
-    "environmental_protection": 4,
+    "environmental_protection": 12,
     "extend": { "flags": [ "NORMAL" ] },
-    "armor": [ { "encumbrance_modifiers": [ "RESTRICTS_NECK" ], "coverage": 100, "covers": [ "head" ] } ]
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.4 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 5.0 }
+        ],
+        "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ],
+        "coverage": 100,
+        "covers": [ "head" ]
+      }
+    ]
+  },
+  {
+    "id": "xl_wetsuit_hood_thick",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_hood_thick",
+    "name": { "str": "XL thick wetsuit hood" },
+    "description": "A 5mm thick neoprene hood, commonly worn by divers in cold weather.  This one is made to fit a very large head.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_hood_thick",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_hood_thick",
+    "name": { "str": "XS thick wetsuit hood" },
+    "description": "A 5mm thick neoprene hood, commonly worn by divers in cold weather.  This one is made to fit a very small head.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "wetsuit_jacket",
@@ -770,18 +997,51 @@
     "price": 7500,
     "price_postapoc": 350,
     "to_hit": -2,
-    "material": [ "neoprene" ],
+    "material": [ "neoprene", "nylon" ],
     "symbol": "[",
     "looks_like": "jacket_light",
     "color": "dark_gray",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": 10 },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": 10 }
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 }
+        ],
+        "encumbrance": 8,
+        "coverage": 100,
+        "covers": [ "torso" ]
+      },
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 }
+        ],
+        "encumbrance": 8,
+        "coverage": 100,
+        "covers": [ "arm_l", "arm_r" ]
+      }
     ],
     "warmth": 20,
-    "material_thickness": 2,
-    "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY" ]
+    "environmental_protection": 8,
+    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY" ]
+  },
+  {
+    "id": "xl_wetsuit_jacket",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_jacket",
+    "name": { "str": "XL wetsuit jacket" },
+    "description": "A long-sleeved neoprene jacket.  Keeps you warm and protected from the elements.  This one is made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_jacket",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_jacket",
+    "name": { "str": "XS wetsuit jacket" },
+    "description": "A long-sleeved neoprene jacket.  Keeps you warm and protected from the elements.  This one is made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "wetsuit_top",
@@ -792,67 +1052,255 @@
     "volume": "1500 ml",
     "price": 6500,
     "price_postapoc": 250,
-    "material": [ "neoprene" ],
+    "material": [ "neoprene", "nylon" ],
     "symbol": "[",
     "looks_like": "tshirt",
     "color": "dark_gray",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 95, "encumbrance": 6 },
       {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
+        "encumbrance": 5,
+        "coverage": 95,
+        "covers": [ "torso" ]
+      },
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ],
         "encumbrance": 2
       },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 95, "specifically_covers": [ "arm_upper_l", "arm_upper_r" ] }
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
+        "coverage": 95,
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_upper_l", "arm_upper_r" ]
+      }
     ],
     "warmth": 15,
-    "material_thickness": 1,
-    "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ]
+    "environmental_protection": 6,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT" ]
+  },
+  {
+    "id": "xl_wetsuit_top",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_top",
+    "name": { "str": "XL wetsuit shirt" },
+    "description": "A short-sleeved neoprene shirt.  Good for use on the beach.  This one is made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_top",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_top",
+    "name": { "str": "XS wetsuit shirt" },
+    "description": "A short-sleeved neoprene shirt.  Good for use on the beach.  This one is made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "wetsuit_top_sleeved_thin",
+    "type": "ARMOR",
+    "name": { "str": "thin wetsuit long-sleeved shirt" },
+    "copy-from": "wetsuit_top_sleeved",
+    "description": "A thin long-sleeved neoprene shirt.  Good for surfing and other water sports.",
+    "weight": "350 g",
+    "volume": "2 L",
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
+        "encumbrance": 5,
+        "coverage": 100,
+        "covers": [ "torso" ]
+      },
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
+        "covers": [ "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": 5
+      }
+    ],
+    "warmth": 15,
+    "environmental_protection": 6,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT" ]
+  },
+  {
+    "id": "xl_wetsuit_top_sleeved_thin",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_top_sleeved_thin",
+    "name": { "str": "XL thin wetsuit long-sleeved shirt" },
+    "description": "A thin long-sleeved neoprene shirt.  Good for surfing and other water sports.  This one is made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_top_sleeved_thin",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_top_sleeved_thin",
+    "name": { "str": "XS thin wetsuit long-sleeved shirt" },
+    "description": "A thin long-sleeved neoprene shirt.  Good for surfing and other water sports.  This one is made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "wetsuit_top_sleeved",
     "type": "ARMOR",
     "name": { "str": "wetsuit long-sleeved shirt" },
     "description": "A long-sleeved neoprene shirt.  Good for surfing and other water sports.",
-    "weight": "350 g",
-    "volume": "2 L",
+    "weight": "500 g",
+    "volume": "4 L",
     "price": 6500,
     "price_postapoc": 250,
     "to_hit": -2,
-    "material": [ "neoprene" ],
+    "material": [ "neoprene", "nylon" ],
     "symbol": "[",
     "looks_like": "longshirt",
     "color": "dark_gray",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": 6 },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": 6 }
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 }
+        ],
+        "encumbrance": 7,
+        "coverage": 100,
+        "covers": [ "torso" ]
+      },
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 }
+        ],
+        "covers": [ "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": 7
+      }
+    ],
+    "warmth": 20,
+    "environmental_protection": 8,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT" ]
+  },
+  {
+    "id": "xl_wetsuit_top_sleeved",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_top_sleeved",
+    "name": { "str": "XL wetsuit long-sleeved shirt" },
+    "description": "A long-sleeved neoprene shirt.  Good for surfing and other water sports.  This one is made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_top_sleeved",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_top_sleeved",
+    "name": { "str": "XS wetsuit long-sleeved shirt" },
+    "description": "A long-sleeved neoprene shirt.  Good for surfing and other water sports.  This one is made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "wetsuit_pants_thin",
+    "type": "ARMOR",
+    "name": { "str_sp": "thin wetsuit pants" },
+    "copy-from": "wetsuit_pants",
+    "description": "A pair of light and stretchy thin neoprene pants.  Good for surfing and other water sports.",
+    "weight": "325 g",
+    "volume": "2 L",
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 100,
+        "encumbrance": 5
+      }
     ],
     "warmth": 15,
-    "material_thickness": 1,
-    "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ]
+    "environmental_protection": 6,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT" ]
+  },
+  {
+    "id": "xl_wetsuit_pants_thin",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_pants_thin",
+    "name": { "str_sp": "XL thin wetsuit pants" },
+    "description": "A pair of light and stretchy thin neoprene pants.  Good for surfing and other water sports.  These are made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_pants_thin",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_pants_thin",
+    "name": { "str_sp": "XS thin wetsuit pants" },
+    "description": "A pair of light and stretchy thin neoprene pants.  Good for surfing and other water sports.  These are made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "wetsuit_pants",
     "type": "ARMOR",
     "name": { "str_sp": "wetsuit pants" },
     "description": "A pair of light and stretchy neoprene pants.  Good for surfing and other water sports.",
-    "weight": "325 g",
-    "volume": "2 L",
+    "weight": "450 g",
+    "volume": "4 L",
     "price": 6500,
     "price_postapoc": 250,
     "to_hit": -3,
-    "material": [ "neoprene" ],
+    "material": [ "neoprene", "nylon" ],
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "pants",
-    "armor": [ { "covers": [ "leg_l", "leg_r" ], "coverage": 100, "encumbrance": 6 } ],
-    "warmth": 15,
-    "material_thickness": 1,
-    "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ]
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 100,
+        "encumbrance": 7
+      }
+    ],
+    "warmth": 20,
+    "environmental_protection": 8,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT" ]
+  },
+  {
+    "id": "xl_wetsuit_pants",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_pants",
+    "name": { "str_sp": "XL wetsuit pants" },
+    "description": "A pair of light and stretchy neoprene pants.  Good for surfing and other water sports.  These are made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_pants",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_pants",
+    "name": { "str_sp": "XS wetsuit pants" },
+    "description": "A pair of light and stretchy neoprene pants.  Good for surfing and other water sports.  These are made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "wetsuit_shorts",
@@ -863,23 +1311,237 @@
     "volume": "1 L",
     "price": 6500,
     "price_postapoc": 150,
-    "material": [ "neoprene" ],
+    "material": [ "neoprene", "nylon" ],
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "shorts",
     "armor": [
       {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 100,
         "encumbrance": 2,
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
-      { "coverage": 50, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 50,
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ]
+      }
     ],
     "warmth": 8,
-    "material_thickness": 1,
-    "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ]
+    "environmental_protection": 6,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT" ]
+  },
+  {
+    "id": "xl_wetsuit_shorts",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_shorts",
+    "name": { "str_sp": "XL wetsuit shorts" },
+    "description": "A pair of light and stretchy neoprene shorts.  Good for use on the beach.  These are made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_shorts",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_shorts",
+    "name": { "str_sp": "XS wetsuit shorts" },
+    "description": "A pair of light and stretchy neoprene shorts.  Good for use on the beach.  These are made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "wetsuit_shorts_technical",
+    "type": "ARMOR",
+    "name": { "str_sp": "wetsuit technical shorts" },
+    "description": "A pair of stretchy neoprene shorts with large pockets.  Can be worn alone or adjusted to be worn over a wetsuit.",
+    "//": "Based on these: https://fourthelement.com/product/technical-shorts/",
+    "//2": "A recipe to make these into leg pouches?",
+    "weight": "500 g",
+    "volume": "1500 ml",
+    "price": 6500,
+    "price_postapoc": 150,
+    "material": [ "neoprene", "nylon", "nylon_2" ],
+    "symbol": "[",
+    "color": "dark_gray",
+    "looks_like": "wetsuit_shorts",
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 100,
+        "encumbrance": 4,
+        "volume_encumber_modifier": 0.25,
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
+      },
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "nylon_2", "covered_by_mat": 20, "thickness": 1.5 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 50,
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ]
+      }
+    ],
+    "//3": "Two large pockets separated into four, two small zipper pockets on flaps, four bungee loops.",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1650 ml",
+        "max_contains_weight": "1500 g",
+        "max_item_length": "32 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1650 ml",
+        "max_contains_weight": "1500 g",
+        "max_item_length": "32 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1650 ml",
+        "max_contains_weight": "1500 g",
+        "max_item_length": "32 cm",
+        "moves": 100
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1650 ml",
+        "max_contains_weight": "1500 g",
+        "max_item_length": "32 cm",
+        "moves": 100
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "500 ml",
+        "max_contains_weight": "500 g",
+        "max_item_length": "19 cm",
+        "moves": 130
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "500 ml",
+        "max_contains_weight": "500 g",
+        "max_item_length": "19 cm",
+        "moves": 130
+      },
+      {
+        "holster": true,
+        "min_item_volume": "50 ml",
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1000 g",
+        "max_item_length": "70 cm",
+        "extra_encumbrance": 2,
+        "moves": 50,
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+      },
+      {
+        "holster": true,
+        "min_item_volume": "50 ml",
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1000 g",
+        "max_item_length": "70 cm",
+        "extra_encumbrance": 2,
+        "moves": 50,
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+      },
+      {
+        "holster": true,
+        "min_item_volume": "50 ml",
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1000 g",
+        "max_item_length": "70 cm",
+        "extra_encumbrance": 2,
+        "moves": 50,
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+      },
+      {
+        "holster": true,
+        "min_item_volume": "50 ml",
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1000 g",
+        "max_item_length": "70 cm",
+        "extra_encumbrance": 2,
+        "moves": 50,
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+      }
+    ],
+    "use_action": { "type": "transform", "msg": "You loosen your %s.", "target": "wetsuit_shorts_technical_loose", "menu_text": "Loosen" },
+    "warmth": 11,
+    "environmental_protection": 8,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT" ]
+  },
+  {
+    "id": "xl_wetsuit_shorts_technical",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_shorts_technical",
+    "name": { "str_sp": "XL wetsuit technical shorts" },
+    "description": "A pair of stretchy neoprene shorts with large pockets.  Can be worn alone or adjusted to be worn over a wetsuit.  These are made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "use_action": {
+      "type": "transform",
+      "msg": "You loosen your %s.",
+      "target": "xl_wetsuit_shorts_technical_loose",
+      "menu_text": "Loosen"
+    },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_shorts_technical",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_shorts_technical",
+    "name": { "str_sp": "XS wetsuit technical shorts" },
+    "description": "A pair of stretchy neoprene shorts with large pockets.  Can be worn alone or adjusted to be worn over a wetsuit.  These are made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "use_action": {
+      "type": "transform",
+      "msg": "You loosen your %s.",
+      "target": "xs_wetsuit_shorts_technical_loose",
+      "menu_text": "Loosen"
+    },
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "wetsuit_shorts_technical_loose",
+    "type": "ARMOR",
+    "name": { "str_sp": "wetsuit technical shorts (loose)" },
+    "description": "A pair of stretchy neoprene shorts with large pockets.  Can be worn over a wetsuit or adjusted to be worn alone.",
+    "copy-from": "wetsuit_shorts_technical",
+    "use_action": { "type": "transform", "msg": "You tighten your %s.", "target": "wetsuit_shorts_technical", "menu_text": "Tighten" },
+    "delete": { "flags": [ "SKINTIGHT" ] }
+  },
+  {
+    "id": "xl_wetsuit_shorts_technical_loose",
+    "type": "ARMOR",
+    "copy-from": "xl_wetsuit_shorts_technical",
+    "name": { "str_sp": "XL wetsuit technical shorts (loose)" },
+    "description": "A pair of stretchy neoprene shorts with large pockets.  Can be worn over a wetsuit or adjusted to be worn alone.  These are made to fit a very large body.",
+    "use_action": { "type": "transform", "msg": "You tighten your %s.", "target": "xl_wetsuit_shorts_technical", "menu_text": "Tighten" },
+    "delete": { "flags": [ "SKINTIGHT" ] }
+  },
+  {
+    "id": "xs_wetsuit_shorts_technical_loose",
+    "type": "ARMOR",
+    "copy-from": "xs_wetsuit_shorts_technical",
+    "name": { "str_sp": "XS wetsuit technical shorts" },
+    "description": "A pair of stretchy neoprene shorts with large pockets.  Can be worn over a wetsuit or adjusted to be worn alone.  These are made to fit a very small body.",
+    "use_action": { "type": "transform", "msg": "You tighten your %s.", "target": "xs_wetsuit_shorts_technical", "menu_text": "Tighten" },
+    "delete": { "flags": [ "SKINTIGHT" ] }
   },
   {
     "id": "wetsuit_spring",
@@ -896,9 +1558,30 @@
     "looks_like": "wetsuit",
     "color": "pink",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 95, "encumbrance": 6, "volume_encumber_modifier": 0.25 },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 6, 6 ] },
       {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
+        "covers": [ "torso" ],
+        "coverage": 95,
+        "encumbrance": 5,
+        "volume_encumber_modifier": 0.25
+      },
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
+        "covers": [ "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 5, 5 ]
+      },
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 75,
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
@@ -909,22 +1592,43 @@
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "500 ml",
-        "max_contains_weight": "2 kg",
+        "max_contains_weight": "1 kg",
+        "moves": 130,
         "max_item_length": "11 cm",
-        "moves": 130
+        "watertight": true,
+        "description": "Back pocket."
       },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "500 ml",
-        "max_contains_weight": "2 kg",
+        "max_contains_weight": "1 kg",
+        "moves": 130,
         "max_item_length": "11 cm",
-        "moves": 130
+        "watertight": true,
+        "description": "Back pocket."
       }
     ],
     "warmth": 10,
-    "material_thickness": 1,
-    "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "POCKETS" ]
+    "environmental_protection": 6,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT", "POCKETS" ]
+  },
+  {
+    "id": "xl_wetsuit_spring",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_spring",
+    "name": { "str": "XL spring suit" },
+    "description": "A long-sleeved spring wetsuit with pink color details and cleavage-enhancing, hip-accentuating construction.  Not as protective as a full-body suit, but also less restrictive.  This one is made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_spring",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_spring",
+    "name": { "str": "XS spring suit" },
+    "description": "A long-sleeved spring wetsuit with pink color details and cleavage-enhancing, hip-accentuating construction.  Not as protective as a full-body suit, but also less restrictive.  This one is made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "wetsuit_spring_sleeveless",
@@ -941,8 +1645,20 @@
     "looks_like": "wetsuit_spring",
     "color": "blue",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 90, "encumbrance": 6 },
       {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
+        "covers": [ "torso" ],
+        "coverage": 90,
+        "encumbrance": 5
+      },
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 75,
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
@@ -950,21 +1666,39 @@
       }
     ],
     "warmth": 8,
-    "material_thickness": 1,
-    "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ]
+    "environmental_protection": 6,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT" ]
+  },
+  {
+    "id": "xl_wetsuit_spring_sleeveless",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_spring_sleeveless",
+    "name": { "str": "XL sleeveless spring suit" },
+    "description": "A sleeveless spring wetsuit with an ocean blue color and cleavage-enhancing, hip-accentuating construction.  Not as protective as a full-body suit, but also less restrictive.  This one is made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_spring_sleeveless",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_spring_sleeveless",
+    "name": { "str": "XS sleeveless spring suit" },
+    "description": "A sleeveless spring wetsuit with an ocean blue color and cleavage-enhancing, hip-accentuating construction.  Not as protective as a full-body suit, but also less restrictive.  This one is made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "shark_suit_faraday",
     "type": "ARMOR",
     "name": { "str": "faraday sharksuit" },
     "description": "A one-piece chainmail suit used by SCUBA divers for protection against shark bites.  It has been conductively interconnected, protecting against electricity.",
+    "//": "Will be based on this: https://www.hammacher.com/product/chainmail-sharkproof-suit",
     "weight": "8164 g",
     "volume": "3500 ml",
     "price": 35000,
     "price_postapoc": 6000,
     "to_hit": -1,
-    "material": [ "lc_steel_chain", "plastic" ],
+    "material": [ "lc_steel_chain" ],
     "symbol": "[",
     "looks_like": "chainmail_hauberk",
     "color": "light_red",
@@ -982,21 +1716,40 @@
         "coverage": 100,
         "covers": [ "foot_l", "foot_r", "head" ],
         "encumbrance": 25,
-        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 1 } ]
+        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ]
       }
     ]
+  },
+  {
+    "id": "xl_shark_suit_faraday",
+    "type": "ARMOR",
+    "copy-from": "shark_suit_faraday",
+    "name": { "str": "XL faraday sharksuit" },
+    "description": "A one-piece chainmail suit used by SCUBA divers for protection against shark bites.  It has been conductively interconnected, protecting against electricity.  This one is made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_shark_suit_faraday",
+    "type": "ARMOR",
+    "copy-from": "shark_suit_faraday",
+    "name": { "str": "XS faraday sharksuit" },
+    "description": "A one-piece chainmail suit used by SCUBA divers for protection against shark bites.  It has been conductively interconnected, protecting against electricity.  This one is made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "shark_suit",
     "type": "ARMOR",
     "name": { "str": "sharksuit" },
-    "description": "A-one piece chainmail suit used by SCUBA divers for protection against shark bites.  It comes with attached plastic helmet and booties.",
+    "description": "A-one piece chainmail suit used by SCUBA divers for protection against shark bites.",
+    "//": "Will be based on this: https://www.hammacher.com/product/chainmail-sharkproof-suit, helmet will be a separate piece",
     "weight": "8164 g",
     "volume": "3500 ml",
     "price": 35000,
     "price_postapoc": 5000,
     "to_hit": -1,
-    "material": [ "lc_steel_chain", "plastic" ],
+    "material": [ "lc_steel_chain" ],
     "symbol": "[",
     "looks_like": "chainmail_suit",
     "color": "light_red",
@@ -1014,9 +1767,27 @@
         "coverage": 100,
         "covers": [ "foot_l", "foot_r", "head" ],
         "encumbrance": 25,
-        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 1 } ]
+        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ]
       }
     ]
+  },
+  {
+    "id": "xl_shark_suit",
+    "type": "ARMOR",
+    "copy-from": "shark_suit_faraday",
+    "name": { "str": "XL sharksuit" },
+    "description": "A one-piece chainmail suit used by SCUBA divers for protection against shark bites.  This one is made to fit a very large body.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_shark_suit",
+    "type": "ARMOR",
+    "copy-from": "shark_suit",
+    "name": { "str": "XS sharksuit" },
+    "description": "A one-piece chainmail suit used by SCUBA divers for protection against shark bites.  This one is made to fit a very small body.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "goggles_swim",
@@ -1028,47 +1799,112 @@
     "price": 1100,
     "price_postapoc": 50,
     "to_hit": -2,
-    "material": [ "plastic" ],
+    "material": [ "plastic", "rubber" ],
     "symbol": "[",
     "looks_like": "goggles_welding",
     "color": "light_blue",
     "warmth": 10,
     "material_thickness": 1,
-    "environmental_protection": 4,
-    "flags": [ "WATER_FRIENDLY", "SWIM_GOGGLES", "SKINTIGHT" ],
-    "armor": [ { "encumbrance": 10, "coverage": 100, "covers": [ "eyes" ], "rigid_layer_only": true } ]
+    "environmental_protection": 16,
+    "flags": [ "WATER_FRIENDLY", "WATERPROOF", "SWIM_GOGGLES", "SKINTIGHT", "OVERSIZE" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "rubber", "covered_by_mat": 20, "thickness": 1.0 },
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
+        "covers": [ "eyes" ],
+        "coverage": 100,
+        "encumbrance": 10,
+        "rigid_layer_only": true
+      }
+    ]
   },
   {
     "id": "wetsuit_gloves",
     "type": "ARMOR",
-    "name": { "str": "pair of swimming gloves", "str_pl": "pairs of swimming gloves" },
-    "description": "A pair of very flexible neoprene-silicone rubber gloves, suitable for underwater use.",
+    "name": { "str": "pair of diving gloves", "str_pl": "pairs of diving gloves" },
+    "description": "A pair of flexible neoprene-silicone rubber gloves, suitable for underwater use.",
     "weight": "80 g",
     "volume": "500 ml",
     "price": 3000,
     "price_postapoc": 100,
     "to_hit": 1,
-    "material": [ "neoprene" ],
+    "material": [ "neoprene", "nylon" ],
     "symbol": "[",
     "looks_like": "gloves_tactical",
     "color": "dark_gray",
     "warmth": 30,
-    "material_thickness": 3,
-    "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ],
-    "armor": [ { "encumbrance": 10, "coverage": 100, "covers": [ "hand_l", "hand_r" ] } ]
+    "environmental_protection": 10,
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "covers": [ "hand_l", "hand_r" ],
+        "coverage": 100,
+        "encumbrance": 10
+      }
+    ]
+  },
+  {
+    "id": "xl_wetsuit_gloves",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_gloves",
+    "name": { "str": "pair of XL diving gloves", "str_pl": "pairs of XL diving gloves" },
+    "description": "A pair of flexible neoprene-silicone rubber gloves, suitable for underwater use.  These fit very large hands.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_gloves",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_gloves",
+    "name": { "str": "pair of XS diving gloves", "str_pl": "pairs of XS diving gloves" },
+    "description": "A pair of flexible neoprene-silicone rubber gloves, suitable for underwater use.  These fit very small hands.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
     "id": "wetsuit_gloves_thick",
     "type": "ARMOR",
     "copy-from": "wetsuit_gloves",
-    "name": { "str": "pair of thick swimming gloves", "str_pl": "pairs of thick swimming gloves" },
+    "name": { "str": "pair of thick diving gloves", "str_pl": "pairs of thick diving gloves" },
     "description": "A pair of thick neoprene-silicone rubber gloves, suitable for underwater use.",
     "weight": "90 g",
     "warmth": 50,
-    "material_thickness": 5,
-    "environmental_protection": 4,
+    "environmental_protection": 12,
     "extend": { "flags": [ "NORMAL" ] },
-    "armor": [ { "encumbrance": 16, "coverage": 100, "covers": [ "hand_l", "hand_r" ] } ]
+    "armor": [
+      {
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.4 },
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 5.0 }
+        ],
+        "covers": [ "hand_l", "hand_r" ],
+        "coverage": 100,
+        "encumbrance": 16
+      }
+    ]
+  },
+  {
+    "id": "xl_wetsuit_gloves_thick",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_gloves_thick",
+    "name": { "str": "pair of thick XL diving gloves", "str_pl": "pairs of thick XL diving gloves" },
+    "description": "A pair of thick neoprene-silicone rubber gloves, suitable for underwater use.  These fit very large hands.",
+    "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_wetsuit_gloves_thick",
+    "type": "ARMOR",
+    "copy-from": "wetsuit_gloves_thick",
+    "name": { "str": "pair of thick XS diving gloves", "str_pl": "pairs of thick XS diving gloves" },
+    "description": "A pair of thick neoprene-silicone rubber gloves, suitable for underwater use.  These fit very small hands.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
+    "extend": { "flags": [ "UNDERSIZE" ] }
   }
 ]

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -2854,6 +2854,32 @@
     ]
   },
   {
+    "id": "waterproof_camera_case",
+    "type": "GENERIC",
+    "category": "container",
+    "name": { "str": "waterproof camera case" },
+    "looks_like": "camera",
+    "description": "A waterproof case designed for a standard camera.  Will protect your camera from water damage entirely.",
+    "weight": "50 g",
+    "volume": "275 ml",
+    "price": 1000,
+    "price_postapoc": 100,
+    "material": [ "plastic" ],
+    "symbol": ";",
+    "color": "white",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "250 ml",
+        "max_contains_weight": "907 g",
+        "moves": 100,
+        "watertight": true,
+        "rigid": true,
+        "item_restriction": [ "camera" ]
+      }
+    ]
+  },
+  {
     "id": "waterskin",
     "type": "GENERIC",
     "category": "container",

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -209,7 +209,7 @@
     "price_postapoc": 100,
     "charges_per_use": 1,
     "ammo": [ "battery" ],
-    "flags": [ "BELT_CLIP", "WATER_BREAK_ACTIVE", "HELMET_HEAD_ATTACHMENT" ],
+    "flags": [ "BELT_CLIP", "WATER_BREAK_ACTIVE", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ],
     "use_action": {
       "type": "transform",
       "msg": "You turn the flashlight on.",
@@ -241,7 +241,239 @@
       "target": "flashlight",
       "ammo_scale": 0
     },
-    "flags": [ "LIGHT_300", "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "WATER_BREAK", "HELMET_HEAD_ATTACHMENT" ]
+    "flags": [ "LIGHT_300", "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "WATER_BREAK", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ]
+  },
+  {
+    "id": "diving_flashlight_small",
+    "type": "TOOL",
+    "name": { "str": "mini diving flashlight (off)", "str_pl": "mini diving flashlights (off)" },
+    "description": "A small waterproof flashlight with an aluminum handle, powered by batteries.  Can be attached to some diving masks and hoods.",
+    "//": "Based on this: https://www.amazon.com/ORCATORCH-Underwater-Rotatable-Batteries-Included/dp/B07BDKRFJG?th=1",
+    "material": [ "plastic", "aluminum" ],
+    "looks_like": "flashlight",
+    "symbol": ";",
+    "color": "blue",
+    "weight": "48 g",
+    "volume": "45 ml",
+    "longest_side": "10 cm",
+    "price": 500,
+    "price_postapoc": 100,
+    "charges_per_use": 1,
+    "ammo": [ "battery" ],
+    "flags": [ "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ],
+    "use_action": {
+      "type": "transform",
+      "msg": "You turn the flashlight on.",
+      "target": "diving_flashlight_small_on",
+      "active": true,
+      "need_charges": 1,
+      "need_charges_msg": "The flashlight's batteries are dead."
+    },
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT" ],
+        "default_magazine": "light_disposable_cell"
+      }
+    ]
+  },
+  {
+    "id": "diving_flashlight_small_on",
+    "copy-from": "diving_flashlight_small",
+    "type": "TOOL",
+    "name": { "str": "mini diving flashlight (on)", "str_pl": "mini diving flashlights (on)" },
+    "looks_like": "flashlight_on",
+    "power_draw": "1200 mW",
+    "revert_to": "diving_flashlight_small",
+    "use_action": {
+      "menu_text": "Turn off",
+      "type": "transform",
+      "msg": "You turn the flashlight off.",
+      "target": "diving_flashlight_small",
+      "ammo_scale": 0
+    },
+    "flags": [ "LIGHT_170", "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ]
+  },
+  {
+    "id": "diving_flashlight_small_hipower",
+    "type": "TOOL",
+    "name": { "str": "high-power mini diving flashlight (off)", "str_pl": "high-power mini diving flashlights (off)" },
+    "description": "A small waterproof high-power flashlight with an aluminum handle, powered by batteries.  Can be attached to some diving masks and hoods.",
+    "//": "Based on this: https://www.amazon.com/RAYVENGE-Headlamp-Underwater-Flashlight-Stainless/dp/B0BD6GVJH2",
+    "material": [ "plastic", "aluminum", "lc_steel" ],
+    "looks_like": "flashlight",
+    "symbol": ";",
+    "color": "blue",
+    "weight": "40 g",
+    "volume": "38 ml",
+    "longest_side": "10 cm",
+    "price": 500,
+    "price_postapoc": 100,
+    "charges_per_use": 1,
+    "ammo": [ "battery" ],
+    "flags": [ "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ],
+    "use_action": {
+      "type": "transform",
+      "msg": "You turn the flashlight on.",
+      "target": "diving_flashlight_small_hipower_on",
+      "active": true,
+      "need_charges": 1,
+      "need_charges_msg": "The flashlight's batteries are dead."
+    },
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT" ],
+        "default_magazine": "light_disposable_cell"
+      }
+    ]
+  },
+  {
+    "id": "diving_flashlight_small_hipower_on",
+    "copy-from": "diving_flashlight_small_hipower",
+    "type": "TOOL",
+    "name": { "str": "high-power mini diving flashlight (on)", "str_pl": "high-power mini diving flashlights (on)" },
+    "looks_like": "flashlight_on",
+    "power_draw": "3 W",
+    "revert_to": "diving_flashlight_small_hipower",
+    "use_action": {
+      "menu_text": "Turn off",
+      "type": "transform",
+      "msg": "You turn the flashlight off.",
+      "target": "diving_flashlight_small_hipower",
+      "ammo_scale": 0
+    },
+    "flags": [ "LIGHT_450", "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ]
+  },
+  {
+    "id": "diving_flashlight_variable",
+    "type": "TOOL",
+    "name": { "str": "high-power mini diving flashlight (off)", "str_pl": "high-power mini diving flashlights (off)" },
+    "description": "A waterproof variable power flashlight with a plastic handle, powered by batteries.  Can be attached to some diving masks and hoods and onto a proprietary wrist mount.",
+    "//": "Based on this: https://www.amazon.com/Aqualite-Tauchlampe-schwarz-Lumen-12516/dp/B00DI5GMOM",
+    "material": [ "plastic" ],
+    "looks_like": "flashlight",
+    "symbol": ";",
+    "color": "blue",
+    "weight": "182 g",
+    "volume": "185 ml",
+    "longest_side": "13 cm",
+    "price": 500,
+    "price_postapoc": 100,
+    "charges_per_use": 1,
+    "ammo": [ "battery" ],
+    "flags": [ "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT", "WRIST_MOUNT_ATTACHMENT" ],
+    "use_action": [
+      {
+        "type": "transform",
+        "msg": "You turn the flashlight on.",
+        "target": "diving_flashlight_variable_on_hi",
+        "active": true,
+        "need_charges": 1,
+        "need_charges_msg": "The flashlight's batteries are dead."
+      },
+      {
+        "type": "link_up",
+        "menu_text": "Plug in / Unplug",
+        "ammo_scale": 0,
+        "cable_length": 2,
+        "charge_rate": "20 W"
+      }
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT" ],
+        "default_magazine": "light_battery_cell"
+      }
+    ]
+  },
+  {
+    "id": "diving_flashlight_variable_on_hi",
+    "copy-from": "diving_flashlight_variable",
+    "type": "TOOL",
+    "name": { "str": "variable power diving flashlight (on, high)", "str_pl": "variable power mini diving flashlights (on, high)" },
+    "looks_like": "flashlight_on",
+    "//": "Uses a 3.7 V battery at ~1.73 A at full power = 6.413 W draw.",
+    "power_draw": "6420 mW",
+    "revert_to": "diving_flashlight_variable",
+    "use_action": [
+      {
+        "menu_text": "Lower power",
+        "type": "transform",
+        "msg": "You decrease power of the flashlight.",
+        "target": "diving_flashlight_variable_on_med",
+        "ammo_scale": 0
+      },
+      {
+        "type": "link_up",
+        "menu_text": "Plug in / Unplug",
+        "ammo_scale": 0,
+        "cable_length": 2,
+        "charge_rate": "20 W"
+      }
+    ],
+    "flags": [ "LIGHT_500", "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ]
+  },
+  {
+    "id": "diving_flashlight_variable_on_med",
+    "copy-from": "diving_flashlight_variable",
+    "type": "TOOL",
+    "name": {
+      "str": "variable power diving flashlight (on, medium)",
+      "str_pl": "variable power mini diving flashlights (on, medium)"
+    },
+    "looks_like": "flashlight_on",
+    "//": "Uses a 3.7 V battery at ~0.46 A at medium power = ~1.7 W draw.",
+    "power_draw": "1700 mW",
+    "revert_to": "diving_flashlight_variable",
+    "use_action": [
+      {
+        "menu_text": "Lower power",
+        "type": "transform",
+        "msg": "You decrease power of the flashlight.",
+        "target": "diving_flashlight_variable_on_low",
+        "ammo_scale": 0
+      },
+      {
+        "type": "link_up",
+        "menu_text": "Plug in / Unplug",
+        "ammo_scale": 0,
+        "cable_length": 2,
+        "charge_rate": "20 W"
+      }
+    ],
+    "flags": [ "LIGHT_200", "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ]
+  },
+  {
+    "id": "diving_flashlight_variable_on_low",
+    "copy-from": "diving_flashlight_variable",
+    "type": "TOOL",
+    "name": { "str": "variable power diving flashlight (on, low)", "str_pl": "variable power mini diving flashlights (on, low)" },
+    "looks_like": "flashlight_on",
+    "//": "Uses a 3.7 V battery at ~0.289 A at low power = ~1.07 W draw.",
+    "power_draw": "1070 mW",
+    "revert_to": "diving_flashlight_variable",
+    "use_action": [
+      {
+        "menu_text": "Turn off",
+        "type": "transform",
+        "msg": "You turn the flashlight off.",
+        "target": "diving_flashlight_variable",
+        "ammo_scale": 0
+      },
+      {
+        "type": "link_up",
+        "menu_text": "Plug in / Unplug",
+        "ammo_scale": 0,
+        "cable_length": 2,
+        "charge_rate": "20 W"
+      }
+    ],
+    "flags": [ "LIGHT_80", "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ]
   },
   {
     "id": "gasoline_lantern",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -575,6 +575,47 @@
     "armor": [ { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ] } ]
   },
   {
+    "type": "TOOL_ARMOR",
+    "id": "flashlight_mount_wrist",
+    "name": { "str": "diving flashlight wrist mount" },
+    "category": "clothing",
+    "volume": "150 ml",
+    "description": "A proprietary wrist mount for a flashlight.  Not very useful on its own.",
+    "//": "Based on mount for this: https://www.amazon.com/Aqualite-Tauchlampe-schwarz-Lumen-12516/dp/B00DI5GMOM",
+    "weight": "50 g",
+    "to_hit": -1,
+    "color": "light_gray",
+    "sided": true,
+    "price": 2500,
+    "price_postapoc": 100,
+    "material": [ "rubber", "plastic" ],
+    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
+    "symbol": "[",
+    "armor": [
+      {
+        "material": [
+          { "type": "rubber", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "plastic", "covered_by_mat": 40, "thickness": 4.0 }
+        ],
+        "coverage": 70,
+        "encumbrance": 1,
+        "covers": [ "hand_l", "hand_r" ],
+        "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ]
+      }
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 1.5,
+        "max_contains_volume": "300 ml",
+        "max_contains_weight": "300 g",
+        "moves": 150,
+        "description": "Proprietary mount for a diving flashlight.",
+        "flag_restriction": [ "WRIST_MOUNT_ATTACHMENT" ]
+      }
+    ]
+  },
+  {
     "id": "holo_cloak",
     "type": "TOOL_ARMOR",
     "name": { "str": "hologram cloak" },
@@ -2323,7 +2364,7 @@
     "color": "dark_gray",
     "name": { "str": "pair of light amp goggles", "str_pl": "pairs of light amp goggles" },
     "description": "A pair of battery-powered goggles that amplify ambient light, allowing you to see in the dark.  Use it to turn them on.",
-    "flags": [ "FRAGILE", "OUTER", "WATER_BREAK", "ELECTRONIC" ],
+    "flags": [ "FRAGILE", "OUTER", "ELECTRONIC" ],
     "price": 92000,
     "price_postapoc": 3500,
     "material": [ "plastic", "steel" ],
@@ -2360,7 +2401,7 @@
     "name": { "str_pl": "pairs of light amp goggles (on)", "str": "pair of light amp goggles (on)" },
     "description": "A pair of battery-powered light amplifying goggles with an infrared illuminator, allowing you to see in the dark.  It is turned on, and continually draining batteries.  Use it to turn them off.",
     "material": [ "plastic", "steel" ],
-    "flags": [ "GNV_EFFECT", "FRAGILE", "TRADER_AVOID", "OUTER" ],
+    "flags": [ "GNV_EFFECT", "FRAGILE", "TRADER_AVOID", "OUTER", "ELECTRONIC" ],
     "//": "2019 commercial models can operate at under 0.375W with the IR illuminator on",
     "power_draw": "375 mW",
     "revert_to": "goggles_nv",
@@ -2376,7 +2417,7 @@
     "color": "dark_gray",
     "name": { "str": "pair of infrared goggles", "str_pl": "pairs of infrared goggles" },
     "description": "A pair of battery-powered goggles that grant infrared vision, allowing you to see warm-blooded creatures in the dark.  Use it to turn them on.",
-    "flags": [ "FRAGILE", "OUTER", "WATER_BREAK", "ELECTRONIC" ],
+    "flags": [ "FRAGILE", "OUTER", "ELECTRONIC" ],
     "price": 92000,
     "price_postapoc": 2500,
     "material": [ "plastic", "steel" ],
@@ -2413,7 +2454,7 @@
     "name": { "str": "pair of infrared goggles (on)", "str_pl": "pairs of infrared goggles (on)" },
     "description": "A pair of battery-powered goggles that grant infrared vision, allowing you to see warm-blooded creatures in the dark.  Use it to turn them off.",
     "material": [ "plastic", "steel" ],
-    "flags": [ "IR_EFFECT", "FRAGILE", "TRADER_AVOID", "OUTER" ],
+    "flags": [ "IR_EFFECT", "FRAGILE", "TRADER_AVOID", "OUTER", "ELECTRONIC" ],
     "power_draw": "1 W",
     "revert_to": "goggles_ir",
     "use_action": { "ammo_scale": 0, "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "goggles_ir" },

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -1376,7 +1376,7 @@
       { "fuel": 0.001, "smoke": 3, "burn": 0.002, "volume_per_turn": "5 ml" },
       { "fuel": 0.003, "smoke": 3, "burn": 0.005 }
     ],
-    "resist": { "bash": 2, "cut": 1, "acid": 1, "heat": 2, "bullet": 1 },
+    "resist": { "bash": 3, "cut": 1, "acid": 4, "heat": 3, "bullet": 1 },
     "repair_difficulty": 3
   },
   {
@@ -2097,6 +2097,14 @@
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 9, "heat": 2, "bullet": 3 },
     "repair_difficulty": 2
+  },
+  {
+    "type": "material",
+    "//": "duplicate material used to give technical shorts and diving rigs an extra coverage layer without causing weirdness",
+    "id": "nylon_2",
+    "copy-from": "nylon",
+    "repaired_with": "null",
+    "name": "Synthetic Fabric"
   },
   {
     "type": "material",

--- a/data/json/recipes/armor/bespoke_armor/survivor.json
+++ b/data/json/recipes/armor/bespoke_armor/survivor.json
@@ -144,12 +144,7 @@
     "copy-from": "thick_h20survivor_jumpsuit",
     "activity_level": "LIGHT_EXERCISE",
     "time": "11 h",
-    "using": [
-      [ "tailoring_kevlar_fabric", 300 ],
-      [ "tailoring_neoprene_patchwork", 9 ],
-      [ "fastener_large", 2 ],
-      [ "clasps", 12 ]
-    ],
+    "using": [ [ "tailoring_kevlar_fabric", 300 ], [ "tailoring_neoprene_patchwork", 9 ], [ "fastener_large", 2 ], [ "clasps", 12 ] ],
     "components": [ [ [ "wetsuit_thick", 1 ] ], [ [ "rubber_cement", 3 ] ] ]
   },
   {

--- a/data/json/recipes/armor/bespoke_armor/survivor.json
+++ b/data/json/recipes/armor/bespoke_armor/survivor.json
@@ -51,7 +51,7 @@
     "autolearn": true,
     "using": [
       [ "tailoring_kevlar_fabric", 200 ],
-      [ "tailoring_neoprene_patchwork", 30 ],
+      [ "tailoring_neoprene_patchwork", 12 ],
       [ "fastener_large", 1 ],
       [ "clasps", 8 ],
       [ "tailoring_nylon_patchwork", 10 ]
@@ -70,7 +70,7 @@
     "copy-from": "h20survivor_jumpsuit",
     "activity_level": "LIGHT_EXERCISE",
     "time": "11 h",
-    "using": [ [ "tailoring_kevlar_fabric", 150 ], [ "tailoring_neoprene_patchwork", 20 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 150 ], [ "tailoring_neoprene_patchwork", 9 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
     "components": [ [ [ "wetsuit", 1 ] ], [ [ "rubber_cement", 3 ] ] ]
   },
   {
@@ -79,7 +79,7 @@
     "copy-from": "h20survivor_jumpsuit",
     "activity_level": "LIGHT_EXERCISE",
     "time": "14 h",
-    "using": [ [ "tailoring_kevlar_fabric", 300 ], [ "tailoring_neoprene_patchwork", 45 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 300 ], [ "tailoring_neoprene_patchwork", 18 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
     "components": [ [ [ "wetsuit", 1 ] ], [ [ "rubber_cement", 4 ] ] ]
   },
   {
@@ -89,7 +89,7 @@
     "time": "8 h",
     "using": [
       [ "tailoring_kevlar_fabric", 200 ],
-      [ "tailoring_neoprene_patchwork", 5 ],
+      [ "tailoring_neoprene_patchwork", 2 ],
       [ "fastener_large", 1 ],
       [ "clasps", 8 ],
       [ "tailoring_nylon_patchwork", 10 ]
@@ -102,7 +102,7 @@
     "copy-from": "h20survivor_jumpsuit_light",
     "activity_level": "LIGHT_EXERCISE",
     "time": "6 h",
-    "using": [ [ "tailoring_kevlar_fabric", 150 ], [ "tailoring_neoprene_patchwork", 4 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 150 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
     "components": [ [ [ "wetsuit", 1 ] ], [ [ "rubber_cement", 1 ] ] ]
   },
   {
@@ -111,7 +111,7 @@
     "copy-from": "h20survivor_jumpsuit_light",
     "activity_level": "LIGHT_EXERCISE",
     "time": "12 h",
-    "using": [ [ "tailoring_kevlar_fabric", 300 ], [ "tailoring_neoprene_patchwork", 8 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 300 ], [ "tailoring_neoprene_patchwork", 3 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
     "components": [ [ [ "wetsuit", 1 ] ], [ [ "rubber_cement", 2 ] ] ]
   },
   {
@@ -126,7 +126,7 @@
     "autolearn": true,
     "using": [
       [ "tailoring_kevlar_fabric", 400 ],
-      [ "tailoring_neoprene_patchwork", 42 ],
+      [ "tailoring_neoprene_patchwork", 12 ],
       [ "fastener_large", 2 ],
       [ "clasps", 12 ]
     ],
@@ -146,7 +146,7 @@
     "time": "11 h",
     "using": [
       [ "tailoring_kevlar_fabric", 300 ],
-      [ "tailoring_neoprene_patchwork", 28 ],
+      [ "tailoring_neoprene_patchwork", 9 ],
       [ "fastener_large", 2 ],
       [ "clasps", 12 ]
     ],
@@ -160,7 +160,7 @@
     "time": "14 h",
     "using": [
       [ "tailoring_kevlar_fabric", 600 ],
-      [ "tailoring_neoprene_patchwork", 63 ],
+      [ "tailoring_neoprene_patchwork", 18 ],
       [ "fastener_large", 2 ],
       [ "clasps", 12 ]
     ],

--- a/data/json/recipes/armor/bespoke_armor/survivor.json
+++ b/data/json/recipes/armor/bespoke_armor/survivor.json
@@ -49,7 +49,13 @@
     "difficulty": 7,
     "time": "12 h",
     "autolearn": true,
-    "using": [ [ "tailoring_kevlar_fabric", 200 ], [ "tailoring_neoprene_patchwork", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 200 ],
+      [ "tailoring_neoprene_patchwork", 30 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ],
+      [ "tailoring_nylon_patchwork", 10 ]
+    ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
@@ -75,6 +81,38 @@
     "time": "14 h",
     "using": [ [ "tailoring_kevlar_fabric", 300 ], [ "tailoring_neoprene_patchwork", 45 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
     "components": [ [ [ "wetsuit", 1 ] ], [ [ "rubber_cement", 4 ] ] ]
+  },
+  {
+    "result": "h20survivor_jumpsuit_light",
+    "type": "recipe",
+    "copy-from": "h20survivor_jumpsuit",
+    "time": "8 h",
+    "using": [
+      [ "tailoring_kevlar_fabric", 200 ],
+      [ "tailoring_neoprene_patchwork", 5 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ],
+      [ "tailoring_nylon_patchwork", 10 ]
+    ],
+    "components": [ [ [ "wetsuit", 1 ] ], [ [ "rubber_cement", 1 ] ] ]
+  },
+  {
+    "result": "xs_h20survivor_jumpsuit_light",
+    "type": "recipe",
+    "copy-from": "h20survivor_jumpsuit_light",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "6 h",
+    "using": [ [ "tailoring_kevlar_fabric", 150 ], [ "tailoring_neoprene_patchwork", 4 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "components": [ [ [ "wetsuit", 1 ] ], [ [ "rubber_cement", 1 ] ] ]
+  },
+  {
+    "result": "xl_h20survivor_jumpsuit_light",
+    "type": "recipe",
+    "copy-from": "h20survivor_jumpsuit_light",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "12 h",
+    "using": [ [ "tailoring_kevlar_fabric", 300 ], [ "tailoring_neoprene_patchwork", 8 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "components": [ [ [ "wetsuit", 1 ] ], [ [ "rubber_cement", 2 ] ] ]
   },
   {
     "result": "thick_h20survivor_jumpsuit",

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -389,23 +389,33 @@
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_elastics" }
     ],
-    "components": [
-      [ [ "wetsuit_booties", 1 ] ]
-    ]
+    "components": [ [ [ "wetsuit_booties", 1 ] ] ]
   },
   {
     "result": "xs_boots_h20survivor",
     "type": "recipe",
     "copy-from": "boots_h20survivor",
     "time": "10 h",
-    "using": [ [ "tailoring_kevlar_fabric", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ]
+    "using": [
+      [ "tailoring_kevlar_fabric", 12 ],
+      [ "shoe_rubber", 1 ],
+      [ "adhesive_rubber", 1 ],
+      [ "tailoring_neoprene_patchwork", 2 ],
+      [ "fastener_small", 6 ]
+    ]
   },
   {
     "result": "xl_boots_h20survivor",
     "type": "recipe",
     "copy-from": "boots_h20survivor",
     "time": "16 h",
-    "using": [ [ "tailoring_kevlar_fabric", 17 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 4 ], [ "fastener_small", 6 ] ]
+    "using": [
+      [ "tailoring_kevlar_fabric", 17 ],
+      [ "shoe_rubber", 2 ],
+      [ "adhesive_rubber", 2 ],
+      [ "tailoring_neoprene_patchwork", 4 ],
+      [ "fastener_small", 6 ]
+    ]
   },
   {
     "result": "boots_h20survivor_light",
@@ -418,7 +428,13 @@
     "difficulty": 6,
     "time": "14 h",
     "autolearn": true,
-    "using": [ [ "tailoring_kevlar_fabric", 14 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 14 ],
+      [ "shoe_rubber", 1 ],
+      [ "adhesive_rubber", 1 ],
+      [ "tailoring_neoprene_patchwork", 1 ],
+      [ "fastener_small", 6 ]
+    ],
     "proficiencies": [
       { "proficiency": "prof_cobbling" },
       { "proficiency": "prof_closures" },
@@ -426,23 +442,33 @@
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_elastics" }
     ],
-    "components": [
-      [ [ "wetsuit_booties", 1 ] ]
-    ]
+    "components": [ [ [ "wetsuit_booties", 1 ] ] ]
   },
   {
     "result": "xs_boots_h20survivor_light",
     "type": "recipe",
     "copy-from": "boots_h20survivor_light",
     "time": "11 h",
-    "using": [ [ "tailoring_kevlar_fabric", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ]
+    "using": [
+      [ "tailoring_kevlar_fabric", 12 ],
+      [ "shoe_rubber", 1 ],
+      [ "adhesive_rubber", 1 ],
+      [ "tailoring_neoprene_patchwork", 1 ],
+      [ "fastener_small", 6 ]
+    ]
   },
   {
     "result": "xl_boots_h20survivor_light",
     "type": "recipe",
     "copy-from": "boots_h20survivor_light",
     "time": "18 h",
-    "using": [ [ "tailoring_kevlar_fabric", 17 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ]
+    "using": [
+      [ "tailoring_kevlar_fabric", 17 ],
+      [ "shoe_rubber", 2 ],
+      [ "adhesive_rubber", 2 ],
+      [ "tailoring_neoprene_patchwork", 2 ],
+      [ "fastener_small", 6 ]
+    ]
   },
   {
     "result": "boots_h20survivor_thick",
@@ -455,7 +481,13 @@
     "difficulty": 6,
     "time": "14 h",
     "autolearn": true,
-    "using": [ [ "tailoring_kevlar_fabric", 28 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 28 ],
+      [ "shoe_rubber", 1 ],
+      [ "adhesive_rubber", 1 ],
+      [ "tailoring_neoprene_patchwork", 1 ],
+      [ "fastener_small", 6 ]
+    ],
     "proficiencies": [
       { "proficiency": "prof_cobbling" },
       { "proficiency": "prof_closures" },
@@ -472,14 +504,26 @@
     "type": "recipe",
     "copy-from": "boots_h20survivor_thick",
     "time": "11 h",
-    "using": [ [ "tailoring_kevlar_fabric", 24 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ]
+    "using": [
+      [ "tailoring_kevlar_fabric", 24 ],
+      [ "shoe_rubber", 1 ],
+      [ "adhesive_rubber", 1 ],
+      [ "tailoring_neoprene_patchwork", 1 ],
+      [ "fastener_small", 6 ]
+    ]
   },
   {
     "result": "xl_boots_h20survivor_thick",
     "type": "recipe",
     "copy-from": "boots_h20survivor_thick",
     "time": "18 h",
-    "using": [ [ "tailoring_kevlar_fabric", 36 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ]
+    "using": [
+      [ "tailoring_kevlar_fabric", 36 ],
+      [ "shoe_rubber", 2 ],
+      [ "adhesive_rubber", 2 ],
+      [ "tailoring_neoprene_patchwork", 2 ],
+      [ "fastener_small", 6 ]
+    ]
   },
   {
     "result": "boots_hsurvivor",
@@ -1319,14 +1363,24 @@
     "skill_used": "tailor",
     "difficulty": 4,
     "time": "5 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 6 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 8 ] ]
+    "using": [
+      [ "tailoring_neoprene_patchwork", 6 ],
+      [ "shoe_rubber", 1 ],
+      [ "adhesive_rubber", 1 ],
+      [ "tailoring_nylon_patchwork", 8 ]
+    ]
   },
   {
     "result": "xl_wetsuit_booties",
     "type": "recipe",
     "copy-from": "wetsuit_booties",
     "time": "8 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 9 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_nylon_patchwork", 15 ] ]
+    "using": [
+      [ "tailoring_neoprene_patchwork", 9 ],
+      [ "shoe_rubber", 2 ],
+      [ "adhesive_rubber", 2 ],
+      [ "tailoring_nylon_patchwork", 15 ]
+    ]
   },
   {
     "result": "wetsuit_booties_thick",
@@ -1335,8 +1389,17 @@
     "difficulty": 5,
     "time": "8 h",
     "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures_waterproofing" }, { "proficiency": "prof_elastics" }, { "proficiency": "prof_cobbling" } ],
-    "using": [ [ "tailoring_neoprene_patchwork", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 20 ] ]
+    "proficiencies": [
+      { "proficiency": "prof_closures_waterproofing" },
+      { "proficiency": "prof_elastics" },
+      { "proficiency": "prof_cobbling" }
+    ],
+    "using": [
+      [ "tailoring_neoprene_patchwork", 12 ],
+      [ "shoe_rubber", 1 ],
+      [ "adhesive_rubber", 1 ],
+      [ "tailoring_nylon_patchwork", 20 ]
+    ]
   },
   {
     "result": "xs_wetsuit_booties_thick",
@@ -1345,14 +1408,24 @@
     "skill_used": "tailor",
     "difficulty": 4,
     "time": "6 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 10 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 16 ] ]
+    "using": [
+      [ "tailoring_neoprene_patchwork", 10 ],
+      [ "shoe_rubber", 1 ],
+      [ "adhesive_rubber", 1 ],
+      [ "tailoring_nylon_patchwork", 16 ]
+    ]
   },
   {
     "result": "xl_wetsuit_booties_thick",
     "type": "recipe",
     "copy-from": "wetsuit_booties_thick",
     "time": "12 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 16 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_nylon_patchwork", 30 ] ]
+    "using": [
+      [ "tailoring_neoprene_patchwork", 16 ],
+      [ "shoe_rubber", 2 ],
+      [ "adhesive_rubber", 2 ],
+      [ "tailoring_nylon_patchwork", 30 ]
+    ]
   },
   {
     "result": "lc_chainmail_feet",

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -501,9 +501,7 @@
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_elastics" }
     ],
-    "components": [
-      [ [ "wetsuit_booties_thick", 1 ] ]
-    ]
+    "components": [ [ [ "wetsuit_booties_thick", 1 ] ] ]
   },
   {
     "result": "xs_boots_h20survivor_thick",

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -1319,14 +1319,14 @@
     "skill_used": "tailor",
     "difficulty": 4,
     "time": "5 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 6 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 10 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 6 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 8 ] ]
   },
   {
     "result": "xl_wetsuit_booties",
     "type": "recipe",
     "copy-from": "wetsuit_booties",
     "time": "8 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 9 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_nylon_patchwork", 10 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 9 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_nylon_patchwork", 15 ] ]
   },
   {
     "result": "wetsuit_booties_thick",
@@ -1336,7 +1336,7 @@
     "time": "8 h",
     "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_closures_waterproofing" }, { "proficiency": "prof_elastics" }, { "proficiency": "prof_cobbling" } ],
-    "using": [ [ "tailoring_neoprene_patchwork", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 10 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 20 ] ]
   },
   {
     "result": "xs_wetsuit_booties_thick",
@@ -1345,14 +1345,14 @@
     "skill_used": "tailor",
     "difficulty": 4,
     "time": "6 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 10 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 8 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 10 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 16 ] ]
   },
   {
-    "result": "xl_wetsuit_booties",
+    "result": "xl_wetsuit_booties_thick",
     "type": "recipe",
     "copy-from": "wetsuit_booties_thick",
     "time": "12 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 16 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_nylon_patchwork", 13 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 16 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_nylon_patchwork", 30 ] ]
   },
   {
     "result": "lc_chainmail_feet",

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -381,7 +381,13 @@
     "difficulty": 7,
     "time": "12 h",
     "autolearn": true,
-    "using": [ [ "tailoring_kevlar_fabric", 14 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 3 ], [ "fastener_small", 6 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 14 ],
+      [ "shoe_rubber", 1 ],
+      [ "adhesive_rubber", 1 ],
+      [ "tailoring_neoprene_patchwork", 3 ],
+      [ "fastener_small", 6 ]
+    ],
     "proficiencies": [
       { "proficiency": "prof_cobbling" },
       { "proficiency": "prof_closures" },

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -1359,8 +1359,17 @@
     "difficulty": 4,
     "time": "6 h",
     "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures_waterproofing" }, { "proficiency": "prof_elastics" }, { "proficiency": "prof_cobbling" } ],
-    "using": [ [ "tailoring_neoprene_patchwork", 7 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 10 ] ]
+    "proficiencies": [
+      { "proficiency": "prof_closures_waterproofing" },
+      { "proficiency": "prof_elastics" },
+      { "proficiency": "prof_cobbling" }
+    ],
+    "using": [
+      [ "tailoring_neoprene_patchwork", 7 ],
+      [ "shoe_rubber", 1 ],
+      [ "adhesive_rubber", 1 ],
+      [ "tailoring_nylon_patchwork", 10 ]
+    ]
   },
   {
     "result": "xs_wetsuit_booties",

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -398,14 +398,14 @@
     "type": "recipe",
     "copy-from": "boots_h20survivor",
     "time": "10 h",
-    "using": [ [ "tailoring_kevlar_fabric", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ]
   },
   {
     "result": "xl_boots_h20survivor",
     "type": "recipe",
     "copy-from": "boots_h20survivor",
     "time": "16 h",
-    "using": [ [ "tailoring_kevlar_fabric", 17 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 4 ], [ "fastener_small", 6 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 17 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 4 ], [ "fastener_small", 6 ] ]
   },
   {
     "result": "boots_h20survivor_light",
@@ -435,14 +435,14 @@
     "type": "recipe",
     "copy-from": "boots_h20survivor_light",
     "time": "11 h",
-    "using": [ [ "tailoring_kevlar_fabric", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ]
   },
   {
     "result": "xl_boots_h20survivor_light",
     "type": "recipe",
     "copy-from": "boots_h20survivor_light",
     "time": "18 h",
-    "using": [ [ "tailoring_kevlar_fabric", 17 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 17 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ]
   },
   {
     "result": "boots_h20survivor_thick",
@@ -472,14 +472,14 @@
     "type": "recipe",
     "copy-from": "boots_h20survivor_thick",
     "time": "11 h",
-    "using": [ [ "tailoring_kevlar_fabric", 24 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 24 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ]
   },
   {
     "result": "xl_boots_h20survivor_thick",
     "type": "recipe",
     "copy-from": "boots_h20survivor_thick",
     "time": "18 h",
-    "using": [ [ "tailoring_kevlar_fabric", 36 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 36 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ]
   },
   {
     "result": "boots_hsurvivor",

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -416,7 +416,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "tailor",
     "difficulty": 6,
-    "time": "12 h",
+    "time": "14 h",
     "autolearn": true,
     "using": [ [ "tailoring_kevlar_fabric", 14 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ],
     "proficiencies": [
@@ -434,14 +434,14 @@
     "result": "xs_boots_h20survivor_light",
     "type": "recipe",
     "copy-from": "boots_h20survivor_light",
-    "time": "10 h",
+    "time": "11 h",
     "using": [ [ "tailoring_kevlar_fabric", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ],
   },
   {
     "result": "xl_boots_h20survivor_light",
     "type": "recipe",
     "copy-from": "boots_h20survivor_light",
-    "time": "16 h",
+    "time": "18 h",
     "using": [ [ "tailoring_kevlar_fabric", 17 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ],
   },
   {

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -379,22 +379,107 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "tailor",
     "difficulty": 7,
-    "skills_required": [ "fabrication", 6 ],
-    "time": "24 h",
+    "time": "12 h",
     "autolearn": true,
-    "using": [ [ "tailoring_kevlar_fabric", 4 ], [ "plastic_molding", 4 ], [ "fastener_small", 2 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 14 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 3 ], [ "fastener_small", 6 ] ],
     "proficiencies": [
       { "proficiency": "prof_cobbling" },
-      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
       { "proficiency": "prof_polymerworking" },
-      { "proficiency": "prof_plasticworking" }
+      { "proficiency": "prof_elastics" }
     ],
     "components": [
-      [ [ "duct_tape", 200 ] ],
-      [ [ "wetsuit_booties", 1 ] ],
-      [ [ "boots_combat", 1 ], [ "boots_steel", 1 ], [ "boots_bunker", 1 ] ]
+      [ [ "wetsuit_booties", 1 ] ]
     ]
+  },
+  {
+    "result": "xs_boots_h20survivor",
+    "type": "recipe",
+    "copy-from": "boots_h20survivor",
+    "time": "10 h",
+    "using": [ [ "tailoring_kevlar_fabric", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ],
+  },
+  {
+    "result": "xl_boots_h20survivor",
+    "type": "recipe",
+    "copy-from": "boots_h20survivor",
+    "time": "16 h",
+    "using": [ [ "tailoring_kevlar_fabric", 17 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 4 ], [ "fastener_small", 6 ] ],
+  },
+  {
+    "result": "boots_h20survivor_light",
+    "type": "recipe",
+    "copy-from": "boots_h20survivor",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "tailor",
+    "difficulty": 6,
+    "time": "12 h",
+    "autolearn": true,
+    "using": [ [ "tailoring_kevlar_fabric", 14 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_cobbling" },
+      { "proficiency": "prof_closures" },
+      { "proficiency": "prof_closures_waterproofing" },
+      { "proficiency": "prof_polymerworking" },
+      { "proficiency": "prof_elastics" }
+    ],
+    "components": [
+      [ [ "wetsuit_booties", 1 ] ]
+    ]
+  },
+  {
+    "result": "xs_boots_h20survivor_light",
+    "type": "recipe",
+    "copy-from": "boots_h20survivor_light",
+    "time": "10 h",
+    "using": [ [ "tailoring_kevlar_fabric", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ],
+  },
+  {
+    "result": "xl_boots_h20survivor_light",
+    "type": "recipe",
+    "copy-from": "boots_h20survivor_light",
+    "time": "16 h",
+    "using": [ [ "tailoring_kevlar_fabric", 17 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ],
+  },
+  {
+    "result": "boots_h20survivor_thick",
+    "type": "recipe",
+    "copy-from": "boots_h20survivor",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "tailor",
+    "difficulty": 6,
+    "time": "14 h",
+    "autolearn": true,
+    "using": [ [ "tailoring_kevlar_fabric", 28 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_cobbling" },
+      { "proficiency": "prof_closures" },
+      { "proficiency": "prof_closures_waterproofing" },
+      { "proficiency": "prof_polymerworking" },
+      { "proficiency": "prof_elastics" }
+    ],
+    "components": [
+      [ [ "wetsuit_booties_thick", 1 ] ]
+    ]
+  },
+  {
+    "result": "xs_boots_h20survivor_thick",
+    "type": "recipe",
+    "copy-from": "boots_h20survivor_thick",
+    "time": "11 h",
+    "using": [ [ "tailoring_kevlar_fabric", 24 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "fastener_small", 6 ] ],
+  },
+  {
+    "result": "xl_boots_h20survivor_thick",
+    "type": "recipe",
+    "copy-from": "boots_h20survivor_thick",
+    "time": "18 h",
+    "using": [ [ "tailoring_kevlar_fabric", 36 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_neoprene_patchwork", 2 ], [ "fastener_small", 6 ] ],
   },
   {
     "result": "boots_hsurvivor",
@@ -1222,10 +1307,52 @@
     "subcategory": "CSC_ARMOR_FEET",
     "skill_used": "tailor",
     "difficulty": 4,
-    "time": "3 h",
+    "time": "6 h",
     "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures_waterproofing" }, { "proficiency": "prof_elastics" } ],
-    "using": [ [ "tailoring_neoprene_patchwork", 7 ] ]
+    "proficiencies": [ { "proficiency": "prof_closures_waterproofing" }, { "proficiency": "prof_elastics" }, { "proficiency": "prof_cobbling" } ],
+    "using": [ [ "tailoring_neoprene_patchwork", 7 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 10 ] ]
+  },
+  {
+    "result": "xs_wetsuit_booties",
+    "type": "recipe",
+    "copy-from": "wetsuit_booties",
+    "skill_used": "tailor",
+    "difficulty": 4,
+    "time": "5 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 6 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 10 ] ]
+  },
+  {
+    "result": "xl_wetsuit_booties",
+    "type": "recipe",
+    "copy-from": "wetsuit_booties",
+    "time": "8 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 9 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_nylon_patchwork", 10 ] ]
+  },
+  {
+    "result": "wetsuit_booties_thick",
+    "type": "recipe",
+    "copy-from": "wetsuit_booties",
+    "difficulty": 5,
+    "time": "8 h",
+    "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
+    "proficiencies": [ { "proficiency": "prof_closures_waterproofing" }, { "proficiency": "prof_elastics" }, { "proficiency": "prof_cobbling" } ],
+    "using": [ [ "tailoring_neoprene_patchwork", 12 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 10 ] ]
+  },
+  {
+    "result": "xs_wetsuit_booties_thick",
+    "type": "recipe",
+    "copy-from": "wetsuit_booties_thick",
+    "skill_used": "tailor",
+    "difficulty": 4,
+    "time": "6 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 10 ], [ "shoe_rubber", 1 ], [ "adhesive_rubber", 1 ], [ "tailoring_nylon_patchwork", 8 ] ]
+  },
+  {
+    "result": "xl_wetsuit_booties",
+    "type": "recipe",
+    "copy-from": "wetsuit_booties_thick",
+    "time": "12 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 16 ], [ "shoe_rubber", 2 ], [ "adhesive_rubber", 2 ], [ "tailoring_nylon_patchwork", 13 ] ]
   },
   {
     "result": "lc_chainmail_feet",

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -1015,7 +1015,7 @@
     "difficulty": 4,
     "time": "6 h",
     "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
-    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "sewing_standard", 15 ], [ "tailoring_nylon_patchwork", 5 ] ],
+    "using": [ [ "tailoring_neoprene_patchwork", 3 ], [ "sewing_standard", 15 ], [ "tailoring_nylon_patchwork", 5 ] ],
     "//": "Should use fabric_neoprene when the tailoring recipe audit is done.",
     "proficiencies": [ { "proficiency": "prof_elastics" }, { "proficiency": "prof_closures_waterproofing" } ],
     "components": [ [ [ "rubber_cement", 1 ] ] ]
@@ -1025,14 +1025,14 @@
     "type": "recipe",
     "copy-from": "wetsuit_gloves",
     "time": "9 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 2 ], [ "sewing_standard", 24 ], [ "tailoring_nylon_patchwork", 8 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 5 ], [ "sewing_standard", 24 ], [ "tailoring_nylon_patchwork", 8 ] ]
   },
   {
     "result": "xs_wetsuit_gloves",
     "type": "recipe",
     "copy-from": "wetsuit_gloves",
     "time": "5 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "sewing_standard", 12 ], [ "tailoring_nylon_patchwork", 4 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 3 ], [ "sewing_standard", 12 ], [ "tailoring_nylon_patchwork", 4 ] ]
   },
   {
     "result": "wetsuit_gloves_thick",
@@ -1040,21 +1040,21 @@
     "copy-from": "wetsuit_gloves",
     "difficulty": 5,
     "time": "9 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 2 ], [ "sewing_standard", 24 ], [ "tailoring_nylon_patchwork", 10 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 6 ], [ "sewing_standard", 24 ], [ "tailoring_nylon_patchwork", 10 ] ]
   },
   {
     "result": "xl_wetsuit_gloves_thick",
     "type": "recipe",
     "copy-from": "wetsuit_gloves_thick",
     "time": "14 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 3 ], [ "sewing_standard", 36 ], [ "tailoring_nylon_patchwork", 15 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 8 ], [ "sewing_standard", 36 ], [ "tailoring_nylon_patchwork", 15 ] ]
   },
   {
     "result": "xs_wetsuit_gloves_thick",
     "type": "recipe",
     "copy-from": "wetsuit_gloves_thick",
     "time": "7 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 2 ], [ "sewing_standard", 18 ], [ "tailoring_nylon_patchwork", 8 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 5 ], [ "sewing_standard", 18 ], [ "tailoring_nylon_patchwork", 8 ] ]
   },
   {
     "result": "lc_chainmail_hands",

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -328,7 +328,7 @@
     "skill_used": "tailor",
     "difficulty": 7,
     "skills_required": [ "tailor", 7 ],
-    "time": "12 h",
+    "time": "8 h",
     "autolearn": true,
     "using": [ [ "tailoring_neoprene_patchwork", 5 ], [ "tailoring_kevlar_fabric", 5 ] ],
     "proficiencies": [
@@ -343,21 +343,21 @@
     "result": "xl_gloves_h20survivor",
     "type": "recipe",
     "copy-from": "gloves_h20survivor",
-    "time": "18 h",
+    "time": "12 h",
     "using": [ [ "tailoring_neoprene_patchwork", 8 ], [ "tailoring_kevlar_fabric", 8 ] ]
   },
   {
     "result": "xs_gloves_h20survivor",
     "type": "recipe",
     "copy-from": "gloves_h20survivor",
-    "time": "10 h",
+    "time": "6 h",
     "using": [ [ "tailoring_neoprene_patchwork", 4 ], [ "tailoring_kevlar_fabric", 4 ] ]
   },
   {
     "result": "gloves_h20survivor_light",
     "type": "recipe",
     "copy-from": "gloves_h20survivor",
-    "time": "8 h",
+    "time": "12 h",
     "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 5 ] ],
     "components": [ [ [ "wetsuit_gloves", 1 ] ], [ [ "rubber_cement", 1 ] ] ]
   },
@@ -365,14 +365,14 @@
     "result": "xl_gloves_h20survivor_light",
     "type": "recipe",
     "copy-from": "gloves_h20survivor_light",
-    "time": "12 h",
+    "time": "18 h",
     "using": [ [ "tailoring_neoprene_patchwork", 2 ], [ "tailoring_kevlar_fabric", 8 ] ]
   },
   {
     "result": "xs_gloves_h20survivor_light",
     "type": "recipe",
     "copy-from": "gloves_h20survivor_light",
-    "time": "6 h",
+    "time": "10 h",
     "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 4 ] ]
   },
   {

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -1013,7 +1013,7 @@
     "difficulty": 4,
     "time": "6 h",
     "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
-    "using": [ [ "tailoring_neoprene_patchwork", 3 ], [ "tailoring_nylon_patchwork", 5 ] ],
+    "using": [ [ "tailoring_neoprene_patchwork", 4 ], [ "tailoring_nylon_patchwork", 5 ] ],
     "//": "Should use fabric_neoprene when the tailoring recipe audit is done.",
     "proficiencies": [ { "proficiency": "prof_elastics" }, { "proficiency": "prof_closures_waterproofing" } ],
     "components": [ [ [ "rubber_cement", 1 ] ] ]
@@ -1023,7 +1023,7 @@
     "type": "recipe",
     "copy-from": "wetsuit_gloves",
     "time": "9 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 5 ], [ "tailoring_nylon_patchwork", 8 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 6 ], [ "tailoring_nylon_patchwork", 8 ] ]
   },
   {
     "result": "xs_wetsuit_gloves",

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -358,8 +358,7 @@
     "type": "recipe",
     "copy-from": "gloves_h20survivor",
     "time": "12 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 5 ] ],
-    "components": [ [ [ "wetsuit_gloves", 1 ] ], [ [ "rubber_cement", 1 ] ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 5 ] ]
   },
   {
     "result": "xl_gloves_h20survivor_light",
@@ -396,7 +395,6 @@
     "copy-from": "gloves_h20survivor_thick",
     "time": "8 h",
     "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 8 ] ]
-    ]
   },
   {
     "result": "gloves_hsurvivor",

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -330,7 +330,7 @@
     "skills_required": [ "tailor", 7 ],
     "time": "8 h",
     "autolearn": true,
-    "using": [ [ "tailoring_neoprene_patchwork", 5 ], [ "tailoring_kevlar_fabric", 5 ] ],
+    "using": [ [ "tailoring_neoprene_patchwork", 3 ], [ "tailoring_kevlar_fabric", 5 ] ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
@@ -344,14 +344,14 @@
     "type": "recipe",
     "copy-from": "gloves_h20survivor",
     "time": "12 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 8 ], [ "tailoring_kevlar_fabric", 8 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 4 ], [ "tailoring_kevlar_fabric", 8 ] ]
   },
   {
     "result": "xs_gloves_h20survivor",
     "type": "recipe",
     "copy-from": "gloves_h20survivor",
     "time": "6 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 4 ], [ "tailoring_kevlar_fabric", 4 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 2 ], [ "tailoring_kevlar_fabric", 4 ] ]
   },
   {
     "result": "gloves_h20survivor_light",
@@ -365,7 +365,7 @@
     "type": "recipe",
     "copy-from": "gloves_h20survivor_light",
     "time": "18 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 2 ], [ "tailoring_kevlar_fabric", 8 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 8 ] ]
   },
   {
     "result": "xs_gloves_h20survivor_light",
@@ -387,7 +387,7 @@
     "type": "recipe",
     "copy-from": "gloves_h20survivor_thick",
     "time": "18 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 2 ], [ "tailoring_kevlar_fabric", 16 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 16 ] ]
   },
   {
     "result": "xs_gloves_h20survivor_thick",
@@ -1013,7 +1013,7 @@
     "difficulty": 4,
     "time": "6 h",
     "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
-    "using": [ [ "tailoring_neoprene_patchwork", 3 ], [ "sewing_standard", 15 ], [ "tailoring_nylon_patchwork", 5 ] ],
+    "using": [ [ "tailoring_neoprene_patchwork", 3 ], [ "tailoring_nylon_patchwork", 5 ] ],
     "//": "Should use fabric_neoprene when the tailoring recipe audit is done.",
     "proficiencies": [ { "proficiency": "prof_elastics" }, { "proficiency": "prof_closures_waterproofing" } ],
     "components": [ [ [ "rubber_cement", 1 ] ] ]
@@ -1023,14 +1023,14 @@
     "type": "recipe",
     "copy-from": "wetsuit_gloves",
     "time": "9 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 5 ], [ "sewing_standard", 24 ], [ "tailoring_nylon_patchwork", 8 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 5 ], [ "tailoring_nylon_patchwork", 8 ] ]
   },
   {
     "result": "xs_wetsuit_gloves",
     "type": "recipe",
     "copy-from": "wetsuit_gloves",
     "time": "5 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 3 ], [ "sewing_standard", 12 ], [ "tailoring_nylon_patchwork", 4 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 3 ], [ "tailoring_nylon_patchwork", 4 ] ]
   },
   {
     "result": "wetsuit_gloves_thick",
@@ -1038,21 +1038,21 @@
     "copy-from": "wetsuit_gloves",
     "difficulty": 5,
     "time": "9 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 6 ], [ "sewing_standard", 24 ], [ "tailoring_nylon_patchwork", 10 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 6 ], [ "tailoring_nylon_patchwork", 10 ] ]
   },
   {
     "result": "xl_wetsuit_gloves_thick",
     "type": "recipe",
     "copy-from": "wetsuit_gloves_thick",
     "time": "14 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 8 ], [ "sewing_standard", 36 ], [ "tailoring_nylon_patchwork", 15 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 8 ], [ "tailoring_nylon_patchwork", 15 ] ]
   },
   {
     "result": "xs_wetsuit_gloves_thick",
     "type": "recipe",
     "copy-from": "wetsuit_gloves_thick",
     "time": "7 h",
-    "using": [ [ "tailoring_neoprene_patchwork", 5 ], [ "sewing_standard", 18 ], [ "tailoring_nylon_patchwork", 8 ] ]
+    "using": [ [ "tailoring_neoprene_patchwork", 5 ], [ "tailoring_nylon_patchwork", 8 ] ]
   },
   {
     "result": "lc_chainmail_hands",

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -327,16 +327,77 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "tailor",
     "difficulty": 7,
-    "skills_required": [ "fabrication", 6 ],
-    "time": "20 h",
+    "skills_required": [ "tailor", 7 ],
+    "time": "12 h",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 50 ], [ "plastic_molding", 4 ], [ "tailoring_kevlar_fabric", 1 ] ],
+    "using": [ [ "tailoring_neoprene_patchwork", 5 ], [ "tailoring_kevlar_fabric", 5 ] ],
     "proficiencies": [
+      { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
       { "proficiency": "prof_polymerworking" },
-      { "proficiency": "prof_articulation" }
+      { "proficiency": "prof_elastics" }
     ],
-    "components": [ [ [ "duct_tape", 120 ] ], [ [ "wetsuit_gloves", 1 ] ] ]
+    "components": [ [ [ "wetsuit_gloves", 1 ] ], [ [ "rubber_cement", 1 ] ] ]
+  },
+  {
+    "result": "xl_gloves_h20survivor",
+    "type": "recipe",
+    "copy-from": "gloves_h20survivor",
+    "time": "18 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 8 ], [ "tailoring_kevlar_fabric", 8 ] ]
+  },
+  {
+    "result": "xs_gloves_h20survivor",
+    "type": "recipe",
+    "copy-from": "gloves_h20survivor",
+    "time": "10 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 4 ], [ "tailoring_kevlar_fabric", 4 ] ]
+  },
+  {
+    "result": "gloves_h20survivor_light",
+    "type": "recipe",
+    "copy-from": "gloves_h20survivor",
+    "time": "8 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 5 ] ],
+    "components": [ [ [ "wetsuit_gloves", 1 ] ], [ [ "rubber_cement", 1 ] ] ]
+  },
+  {
+    "result": "xl_gloves_h20survivor_light",
+    "type": "recipe",
+    "copy-from": "gloves_h20survivor_light",
+    "time": "12 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 2 ], [ "tailoring_kevlar_fabric", 8 ] ]
+  },
+  {
+    "result": "xs_gloves_h20survivor_light",
+    "type": "recipe",
+    "copy-from": "gloves_h20survivor_light",
+    "time": "6 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 4 ] ]
+    ]
+  },
+  {
+    "result": "gloves_h20survivor_thick",
+    "type": "recipe",
+    "copy-from": "gloves_h20survivor",
+    "time": "12 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 10 ] ],
+    "components": [ [ [ "wetsuit_gloves_thick", 1 ] ], [ [ "rubber_cement", 1 ] ] ]
+  },
+  {
+    "result": "xl_gloves_h20survivor_thick",
+    "type": "recipe",
+    "copy-from": "gloves_h20survivor_thick",
+    "time": "18 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 2 ], [ "tailoring_kevlar_fabric", 16 ] ]
+  },
+  {
+    "result": "xs_gloves_h20survivor_thick",
+    "type": "recipe",
+    "copy-from": "gloves_h20survivor_thick",
+    "time": "8 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 8 ] ]
+    ]
   },
   {
     "result": "gloves_hsurvivor",
@@ -955,9 +1016,46 @@
     "difficulty": 4,
     "time": "6 h",
     "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
-    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "sewing_standard", 15 ], [ "adhesive", 2 ] ],
+    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "sewing_standard", 15 ], [ "tailoring_nylon_patchwork", 5 ] ],
     "//": "Should use fabric_neoprene when the tailoring recipe audit is done.",
-    "proficiencies": [ { "proficiency": "prof_elastics" }, { "proficiency": "prof_closures_waterproofing" } ]
+    "proficiencies": [ { "proficiency": "prof_elastics" }, { "proficiency": "prof_closures_waterproofing" } ],
+    "components": [ [ [ "rubber_cement", 1 ] ] ]
+  },
+  {
+    "result": "xl_wetsuit_gloves",
+    "type": "recipe",
+    "copy-from": "wetsuit_gloves",
+    "time": "9 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 2 ], [ "sewing_standard", 24 ], [ "tailoring_nylon_patchwork", 8 ] ]
+  },
+  {
+    "result": "xs_wetsuit_gloves",
+    "type": "recipe",
+    "copy-from": "wetsuit_gloves",
+    "time": "5 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "sewing_standard", 12 ], [ "tailoring_nylon_patchwork", 4 ] ]
+  },
+  {
+    "result": "wetsuit_gloves_thick",
+    "type": "recipe",
+    "copy-from": "wetsuit_gloves",
+    "difficulty": 5,
+    "time": "9 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 2 ], [ "sewing_standard", 24 ], [ "tailoring_nylon_patchwork", 10 ] ]
+  },
+  {
+    "result": "xl_wetsuit_gloves_thick",
+    "type": "recipe",
+    "copy-from": "wetsuit_gloves_thick",
+    "time": "14 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 3 ], [ "sewing_standard", 36 ], [ "tailoring_nylon_patchwork", 15 ] ]
+  },
+  {
+    "result": "xs_wetsuit_gloves_thick",
+    "type": "recipe",
+    "copy-from": "wetsuit_gloves_thick",
+    "time": "7 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 2 ], [ "sewing_standard", 18 ], [ "tailoring_nylon_patchwork", 8 ] ]
   },
   {
     "result": "lc_chainmail_hands",

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -374,7 +374,6 @@
     "copy-from": "gloves_h20survivor_light",
     "time": "6 h",
     "using": [ [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 4 ] ]
-    ]
   },
   {
     "result": "gloves_h20survivor_thick",

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -2335,7 +2335,7 @@
     "difficulty": 4,
     "time": "2 h",
     "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
-    "using": [ [ "tailoring_nylon_patchwork", 4 ], [ "tailoring_neoprene_patchwork", 6 ] ],
+    "using": [ [ "tailoring_nylon_patchwork", 10 ], [ "tailoring_neoprene_patchwork", 6 ] ],
     "proficiencies": [ { "proficiency": "prof_elastics" }, { "proficiency": "prof_closures_waterproofing" } ]
   },
   {
@@ -2343,14 +2343,14 @@
     "type": "recipe",
     "copy-from": "wetsuit_hood",
     "time": "3 h",
-    "using": [ [ "tailoring_nylon_patchwork", 6 ], [ "tailoring_neoprene_patchwork", 9 ] ]
+    "using": [ [ "tailoring_nylon_patchwork", 15 ], [ "tailoring_neoprene_patchwork", 9 ] ]
   },
   {
     "result": "xs_wetsuit_hood",
     "type": "recipe",
     "copy-from": "wetsuit_hood",
     "time": "1 h 30 m",
-    "using": [ [ "tailoring_nylon_patchwork", 3 ], [ "tailoring_neoprene_patchwork", 5 ] ]
+    "using": [ [ "tailoring_nylon_patchwork", 8 ], [ "tailoring_neoprene_patchwork", 5 ] ]
   },
   {
     "result": "wetsuit_hood_thick",
@@ -2359,21 +2359,21 @@
     "skill_used": "tailor",
     "difficulty": 5,
     "time": "3 h",
-    "using": [ [ "tailoring_nylon_patchwork", 8 ], [ "tailoring_neoprene_patchwork", 12 ] ]
+    "using": [ [ "tailoring_nylon_patchwork", 20 ], [ "tailoring_neoprene_patchwork", 12 ] ]
   },
   {
     "result": "xl_wetsuit_hood_thick",
     "type": "recipe",
     "copy-from": "wetsuit_hood_thick",
     "time": "4 h 30 m",
-    "using": [ [ "tailoring_nylon_patchwork", 12 ], [ "tailoring_neoprene_patchwork", 18 ] ]
+    "using": [ [ "tailoring_nylon_patchwork", 30 ], [ "tailoring_neoprene_patchwork", 18 ] ]
   },
   {
     "result": "xl_wetsuit_hood_thick",
     "type": "recipe",
     "copy-from": "wetsuit_hood_thick",
     "time": "2 h 15 m",
-    "using": [ [ "tailoring_nylon_patchwork", 6 ], [ "tailoring_neoprene_patchwork", 10 ] ]
+    "using": [ [ "tailoring_nylon_patchwork", 16 ], [ "tailoring_neoprene_patchwork", 10 ] ]
   },
   {
     "result": "lc_chainmail_hood",

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -2346,7 +2346,7 @@
     "using": [ [ "tailoring_nylon_patchwork", 6 ], [ "tailoring_neoprene_patchwork", 9 ] ]
   },
   {
-    "result": "xl_wetsuit_hood",
+    "result": "xs_wetsuit_hood",
     "type": "recipe",
     "copy-from": "wetsuit_hood",
     "time": "1 h 30 m",

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -1054,7 +1054,7 @@
     "difficulty": 7,
     "time": "7 h",
     "autolearn": true,
-    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 10 ], [ "tailoring_kevlar_fabric", 10 ] ],
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 4 ], [ "tailoring_kevlar_fabric", 10 ] ],
     "components": [ [ [ "wetsuit_hood", 1 ] ], [ [ "rubber_cement", 1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_millinery" },
@@ -1069,14 +1069,14 @@
     "type": "recipe",
     "copy-from": "hood_h20survivor",
     "time": "6 h",
-    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 2 ], [ "tailoring_kevlar_fabric", 8 ] ]
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 3 ], [ "tailoring_kevlar_fabric", 8 ] ]
   },
   {
     "result": "xl_hood_h20survivor",
     "type": "recipe",
     "copy-from": "hood_h20survivor",
     "time": "10 h",
-    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 3 ], [ "tailoring_kevlar_fabric", 15 ] ]
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 6 ], [ "tailoring_kevlar_fabric", 15 ] ]
   },
   {
     "result": "hood_h20survivor_light",
@@ -1084,7 +1084,7 @@
     "copy-from": "hood_h20survivor",
     "time": "12 h",
     "autolearn": true,
-    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 2 ], [ "tailoring_kevlar_fabric", 10 ] ]
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 10 ] ]
   },
   {
     "result": "xs_hood_h20survivor_light",

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -1117,7 +1117,7 @@
     "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 15 ] ]
   },
   {
-    "result": "xl_hood_h20survivor_thickt",
+    "result": "xl_hood_h20survivor_thick",
     "type": "recipe",
     "copy-from": "hood_h20survivor_thick",
     "time": "10 h",

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -1052,17 +1052,76 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "tailor",
     "difficulty": 7,
-    "skills_required": [ "fabrication", 6 ],
     "time": "7 h",
     "autolearn": true,
-    "using": [ [ "sewing_aramids", 20 ], [ "plastic_molding", 4 ] ],
-    "qualities": [ { "id": "SEW_CURVED", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_layered", 2 ] ], [ [ "wetsuit_hood", 1 ] ], [ [ "duct_tape", 100 ] ] ],
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 10 ], [ "tailoring_kevlar_fabric", 10 ] ],
+    "components": [ [ [ "wetsuit_hood", 1 ] ], [ [ "rubber_cement", 1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_millinery" },
-      { "proficiency": "prof_plasticworking" },
-      { "proficiency": "prof_polymerworking" }
+      { "proficiency": "prof_closures" },
+      { "proficiency": "prof_closures_waterproofing" },
+      { "proficiency": "prof_polymerworking" },
+      { "proficiency": "prof_elastics" }
     ]
+  },
+  {
+    "result": "xs_hood_h20survivor",
+    "type": "recipe",
+    "copy-from": "hood_h20survivor",
+    "time": "6 h",
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 2 ], [ "tailoring_kevlar_fabric", 8 ] ]
+  },
+  {
+    "result": "xl_hood_h20survivor",
+    "type": "recipe",
+    "copy-from": "hood_h20survivor",
+    "time": "10 h",
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 3 ], [ "tailoring_kevlar_fabric", 15 ] ]
+  },
+  {
+    "result": "hood_h20survivor_light",
+    "type": "recipe",
+    "copy-from": "hood_h20survivor",
+    "time": "12 h",
+    "autolearn": true,
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 2 ], [ "tailoring_kevlar_fabric", 10 ] ]
+  },
+  {
+    "result": "xs_hood_h20survivor_light",
+    "type": "recipe",
+    "copy-from": "hood_h20survivor_light",
+    "time": "6 h",
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 8 ] ]
+  },
+  {
+    "result": "xl_hood_h20survivor_light",
+    "type": "recipe",
+    "copy-from": "hood_h20survivor_light",
+    "time": "10 h",
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 15 ] ]
+  },
+  {
+    "result": "hood_h20survivor_thick",
+    "type": "recipe",
+    "copy-from": "hood_h20survivor",
+    "time": "12 h",
+    "autolearn": true,
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 20 ] ],
+    "components": [ [ [ "wetsuit_hood_thick", 1 ] ], [ [ "rubber_cement", 1 ] ] ],
+  },
+  {
+    "result": "xs_hood_h20survivor_thick",
+    "type": "recipe",
+    "copy-from": "hood_h20survivor_thick",
+    "time": "6 h",
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 15 ] ]
+  },
+  {
+    "result": "xl_hood_h20survivor_thickt",
+    "type": "recipe",
+    "copy-from": "hood_h20survivor_thick",
+    "time": "10 h",
+    "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 30 ] ]
   },
   {
     "result": "hood_lsurvivor",
@@ -2276,10 +2335,45 @@
     "difficulty": 4,
     "time": "2 h",
     "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
-    "using": [ [ "tailoring_cotton_patchwork", 4 ], [ "tailoring_neoprene_patchwork", 3 ] ],
-    "qualities": [ { "id": "SEW_CURVED", "level": 1 } ],
-    "components": [ [ [ "neoprene", 2 ] ], [ [ "cotton_patchwork", 2 ] ] ],
+    "using": [ [ "tailoring_nylon_patchwork", 4 ], [ "tailoring_neoprene_patchwork", 6 ] ],
     "proficiencies": [ { "proficiency": "prof_elastics" }, { "proficiency": "prof_closures_waterproofing" } ]
+  },
+  {
+    "result": "xl_wetsuit_hood",
+    "type": "recipe",
+    "copy-from": "wetsuit_hood",
+    "time": "3 h",
+    "using": [ [ "tailoring_nylon_patchwork", 6 ], [ "tailoring_neoprene_patchwork", 9 ] ]
+  },
+  {
+    "result": "xl_wetsuit_hood",
+    "type": "recipe",
+    "copy-from": "wetsuit_hood",
+    "time": "1 h 30 m",
+    "using": [ [ "tailoring_nylon_patchwork", 3 ], [ "tailoring_neoprene_patchwork", 5 ] ]
+  },
+  {
+    "result": "wetsuit_hood_thick",
+    "type": "recipe",
+    "copy-from": "wetsuit_hood",
+    "skill_used": "tailor",
+    "difficulty": 5,
+    "time": "3 h",
+    "using": [ [ "tailoring_nylon_patchwork", 8 ], [ "tailoring_neoprene_patchwork", 12 ] ]
+  },
+  {
+    "result": "xl_wetsuit_hood_thick",
+    "type": "recipe",
+    "copy-from": "wetsuit_hood_thick",
+    "time": "4 h 30 m",
+    "using": [ [ "tailoring_nylon_patchwork", 12 ], [ "tailoring_neoprene_patchwork", 18 ] ]
+  },
+  {
+    "result": "xl_wetsuit_hood_thick",
+    "type": "recipe",
+    "copy-from": "wetsuit_hood_thick",
+    "time": "2 h 15 m",
+    "using": [ [ "tailoring_nylon_patchwork", 6 ], [ "tailoring_neoprene_patchwork", 10 ] ]
   },
   {
     "result": "lc_chainmail_hood",

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -1107,7 +1107,7 @@
     "time": "12 h",
     "autolearn": true,
     "using": [ [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_neoprene_patchwork", 1 ], [ "tailoring_kevlar_fabric", 20 ] ],
-    "components": [ [ [ "wetsuit_hood_thick", 1 ] ], [ [ "rubber_cement", 1 ] ] ],
+    "components": [ [ [ "wetsuit_hood_thick", 1 ] ], [ [ "rubber_cement", 1 ] ] ]
   },
   {
     "result": "xs_hood_h20survivor_thick",

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -162,17 +162,15 @@
     "reversible": { "time": "35 m" },
     "book_learn": [ [ "plastics_book", 3 ] ],
     "using": [
-      [ "sewing_standard", 100 ],
       [ "tailoring_lycra_patchwork", 20 ],
       [ "clasps", 1 ],
-      [ "waterproofing_plastic_sheets", 10 ]
+      [ "waterproofing_plastic_sheets", 20 ]
     ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
       { "proficiency": "prof_plasticworking" }
-    ],
-    "components": [ [ [ "duct_tape", 200 ] ] ]
+    ]
   },
   {
     "result": "fanny",
@@ -1715,6 +1713,7 @@
   },
   {
     "result": "survivor_dry_duffelbag",
+    "//": "Survivor expands the drybag a bit, reinforces it and adds compression straps to the side, along with making other personal adjustments.",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
@@ -1724,9 +1723,9 @@
     "skills_required": [ "fabrication", 6 ],
     "time": "8 h",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 200 ], [ "tailoring_lycra_patchwork", 30 ], [ "fastener_large", 3 ] ],
+    "using": [ [ "tailoring_lycra_patchwork", 20 ], [ "waterproofing_plastic_sheets", 16 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_closures_waterproofing" } ],
-    "components": [ [ [ "plastic_sheet", 6 ] ], [ [ "dry_duffelbag", 1 ] ], [ [ "duct_tape", 300 ] ] ]
+    "components": [ [ [ "dry_duffelbag", 1 ] ] ]
   },
   {
     "result": "light_load_bearing_vest",

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -161,11 +161,7 @@
     "autolearn": true,
     "reversible": { "time": "35 m" },
     "book_learn": [ [ "plastics_book", 3 ] ],
-    "using": [
-      [ "tailoring_lycra_patchwork", 20 ],
-      [ "clasps", 1 ],
-      [ "waterproofing_plastic_sheets", 20 ]
-    ],
+    "using": [ [ "tailoring_lycra_patchwork", 20 ], [ "clasps", 1 ], [ "waterproofing_plastic_sheets", 20 ] ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -2155,9 +2155,46 @@
     "difficulty": 4,
     "time": "10 h",
     "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
-    "using": [ [ "tailoring_neoprene_patchwork", 33 ] ],
+    "using": [ [ "tailoring_neoprene_patchwork", 33 ], [ "tailoring_nylon_patchwork", 55 ], [ "fastener_small", 6 ] ],
     "components": [ [ [ "zipper_long_plastic", 1 ] ] ],
     "proficiencies": [ { "proficiency": "prof_elastics" }, { "proficiency": "prof_closures_waterproofing" } ]
+  },
+  {
+    "result": "xs_wetsuit",
+    "type": "recipe",
+    "copy-from": "wetsuit",
+    "time": "8 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 25 ], [ "tailoring_nylon_patchwork", 40 ], [ "fastener_small", 6 ] ]
+  },
+  {
+    "result": "xl_wetsuit",
+    "type": "recipe",
+    "copy-from": "wetsuit",
+    "time": "15 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 45 ], [ "tailoring_nylon_patchwork", 75 ], [ "fastener_small", 6 ] ]
+  },
+  {
+    "result": "wetsuit_thick",
+    "type": "recipe",
+    "copy-from": "wetsuit",
+    "difficulty": 5,
+    "time": "20 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 55 ], [ "tailoring_nylon_patchwork", 110 ], [ "fastener_small", 6 ] ],
+    "components": [ [ [ "zipper_long_plastic", 1 ] ] ]
+  },
+  {
+    "result": "xs_wetsuit_thick",
+    "type": "recipe",
+    "copy-from": "wetsuit_thick",
+    "time": "16 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 42 ], [ "tailoring_nylon_patchwork", 85 ], [ "fastener_small", 6 ] ]
+  },
+  {
+    "result": "xl_wetsuit_thick",
+    "type": "recipe",
+    "copy-from": "wetsuit_thick",
+    "time": "30 h",
+    "using": [ [ "tailoring_neoprene_patchwork", 75 ], [ "tailoring_nylon_patchwork", 160 ], [ "fastener_small", 6 ] ]
   },
   {
     "result": "wetsuit_spring",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -2486,6 +2486,9 @@
       "h20survivor_jumpsuit",
       "xs_h20survivor_jumpsuit",
       "xl_h20survivor_jumpsuit",
+      "h20survivor_jumpsuit_light",
+      "xs_h20survivor_jumpsuit_light",
+      "xl_h20survivor_jumpsuit_light",
       "thick_h20survivor_jumpsuit",
       "xs_thick_h20survivor_jumpsuit",
       "xl_thick_h20survivor_jumpsuit"
@@ -2720,7 +2723,17 @@
     "name": "survivor wetsuit hoods",
     "description": "Recipes related to constructing various sizes of specialized hoods designed to protect the wearer from water.",
     "skill_used": "tailor",
-    "nested_category_data": [ "hood_h20survivor" ],
+    "nested_category_data": [ 
+      "hood_h20survivor",
+      "xs_hood_h20survivor",
+      "xl_hood_h20survivor",
+      "hood_h20survivor_light",
+      "xs_hood_h20survivor_light",
+      "xl_hood_h20survivor_light",
+      "hood_h20survivor_thick",
+      "xs_hood_h20survivor_thick",
+      "xl_hood_h20survivor_thick"
+    ],
     "difficulty": 7
   },
   {
@@ -3162,7 +3175,17 @@
     "name": "survivor wetsuit gloves",
     "description": "Recipes related to constructing various sizes of survivor wetsuit gloves.",
     "skill_used": "tailor",
-    "nested_category_data": [ "gloves_h20survivor" ],
+    "nested_category_data": [
+      "gloves_h20survivor",
+      "xs_gloves_h20survivor",
+      "xl_gloves_h20survivor",
+      "gloves_h20survivor_light",
+      "xs_gloves_h20survivor_light",
+      "xl_gloves_h20survivor_light",
+      "gloves_h20survivor_thick",
+      "xs_gloves_h20survivor_thick",
+      "xl_gloves_h20survivor_thick"
+    ],
     "difficulty": 7
   },
   {
@@ -3628,7 +3651,17 @@
     "name": "survivor wetsuit boots",
     "description": "Recipes related to constructing various sizes of survivor wetsuit boots.",
     "skill_used": "tailor",
-    "nested_category_data": [ "boots_h20survivor" ],
+    "nested_category_data": [
+      "boots_h20survivor",
+      "xs_boots_h20survivor",
+      "xl_boots_h20survivor",
+      "boots_h20survivor_light",
+      "xs_boots_h20survivor_light",
+      "xl_boots_h20survivor_light",
+      "boots_h20survivor_thick",
+      "xs_boots_h20survivor_thick",
+      "xl_boots_h20survivor_thick"
+    ],
     "difficulty": 5
   },
   {

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -2723,7 +2723,7 @@
     "name": "survivor wetsuit hoods",
     "description": "Recipes related to constructing various sizes of specialized hoods designed to protect the wearer from water.",
     "skill_used": "tailor",
-    "nested_category_data": [ 
+    "nested_category_data": [
       "hood_h20survivor",
       "xs_hood_h20survivor",
       "xl_hood_h20survivor",

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -382,6 +382,7 @@ Some armor flags, such as `WATCH` and `ALARMCLOCK` are compatible with other ite
 - ```SUPER_FANCY``` Gives an additional moral bonus over `FANCY` if the player has the `Stylish` trait.
 - ```SWIM_GOGGLES``` Allows you to see much further underwater.
 - ```THERMOMETER``` This gear is equipped with an accurate thermometer (which is used to measure temperature).
+- ```TOUGH_FEET``` Character receives no movement penalty for not wearing `NORMAL` layer foot clothing.
 - ```VARSIZE``` Can be made to fit via tailoring.
 - ```WAIST``` Layer for belts other things worn on the waist.
 - ```WATCH``` Acts as a watch and allows the player to see actual time.

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -1878,6 +1878,7 @@ motes
 motorpool
 motorsports
 mountable
+mountings
 mouthgear
 mouthpart
 mouthparts
@@ -2069,6 +2070,7 @@ outgrowths
 outperforms
 outputting
 ovata
+overboots
 overbore
 overbuilt
 overclock
@@ -2077,13 +2079,18 @@ overdosage
 overdrinking
 overengineered
 overexertion
+overgloves
 overgrowth
+overhood
+overhoods
 overmap
 overmaps
 overpenetration
 overpressure
 overqueen
 overshoes
+oversuit
+oversuits
 overswing
 overswinging
 overtaxing
@@ -2616,6 +2623,7 @@ shantak
 shantytowns
 shapechangers
 sharksuit
+sharksuits
 shedded
 shenandoah
 shipside


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Wetsuit and diving gear rework"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Making the wetsuits more realistic, expanding on variety of diving gear, reworking the survivor gear to be more sensible yet unique.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- [x]  Skintight wetsuitlike (neoprene) gear gets WATERPROOF flag (preventing flow of water through the cuffs and leakage of warmth are a big thing in wetsuit design, otherwise they would not need blindstitching);
- [x] Normal wetsuits get the same/thinner Lycra/spandex/Nylon layer as thick wetsuit (all wetsuits have at least one layer of backing to be comfortable to wear);
- [x] New gear like technical neoprene shorts (cargo shorts, but for diving) and custom diving leg rigs (cut-down technical shorts, strapped layer);
- [ ] Add some pockets like on technical neoprene shorts to survivor wetsuits, adjust crafting costs to include buttons and some nylon;
- [ ] More recipes for neoprene gear (wetsuit jackets, shorts, shirts, etc);
- [ ] Add recipes for new gear and variation when appropriate;
- [x] Light Kevlar overwetsuit (2 mm neoprene, ~1 mm Kevlar, middle layer);
- [x] Increase in enviro prot for wetsuits and wetsuit accessories (up to around 10, far from hazmat, but closer to rubber gloves and boots, as neoprene is sort of rubber too and has solid environmental protection IRL);
- [x] Buff to neoprene acid and fire resistance per issue #66139 (again, neoprene is a synthetic rubber, does not breathe and thus does not let harmful stuff in), also a small blunt res buff to make it closer to rubber;
- [x] Size variations where needed to make muties happy (done for non-survivor clothing);
- [x] Waterproof camera case - fits small camera;
- [x] Waterproof small LED light, fittable to mask straps;
- [x] Waterproofing of NVGs (light amps) and IR goggles - most NVGs require hermetic seal to work properly, and most milspec ones are rated for at least 2 hour full submersion, both are often used by hunters and military, and those want their stuff reliable in all circumstances;
- [x] Add IR goggles to hunter shops - while IR scopes are more common among hunters, IR cameras and goggles have a decent demand among hunters;
- [x] Normal survivor diveboots get split into light dive overboots (middle layer, see light Kevlar wetsuit, work like current boots) and medium (middle and skintight, like current Kevlar wetsuit);
- [x] Thick diveboots get a slot for normal fins;
- [x] Survivor diveboots get a slot for fin attachment (like these, but a bit cruder https://newatlas.com/aquabionic-abs-fins/54033/), attachment is crafted out of normal fins and has less volume and weight than normal fins, and attaches faster that the fins can be worn;
- [ ] Survivor swimming gloves get the same treatment as boots, and get a webbed hand attachment (quite some hand encumbrance, bonus to swimming speed);
- [x] Survivor wetsuit hoods get the same treatment as boots, and get a slot for a flashlight and another for a camera case (straps on the outside of hood), when head gear layer changes will come, these will get a slot for the strapped on gas/divemasks (as they are intended to be worn and provide good seal with the full-face masks);
- [ ] Add new variations of lootable diving masks, some modular, some not (like this one: https://www.hollisrebreathers.com/product/mod-1/, a good fit for XEDRA lockers);
- [x] Rebrand survivor stuff into Kevlar-reinforced (?).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

None?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

None for now.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

#66139, #66271 for relevant issues.

Will fill this up when/if needed.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->