### PR TITLE
Add Standing-Storm to Mind over Matter notification list

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -26,6 +26,8 @@ files:
   'data/mods/Xedra_Evolved/**':
     - Maleclypse
     - GuardianDll
+  'data/mods/MindOverMatter/**':
+    - Standing-Storm
   'data/mods/innawood/**':
     - Light-Wave
   'data/mods/MA/**':


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
They asked to
#### Additional context
Planned to make it in the same PR as adding a lable for MoM, but it was merged super fast