### PR TITLE
Improve output for JSON errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -857,9 +857,9 @@ THIRD_PARTY_SOURCES := $(wildcard $(SRC_DIR)/third-party/flatbuffers/*.cpp)
 HEADERS := $(wildcard $(SRC_DIR)/*.h)
 TESTSRC := $(wildcard tests/*.cpp)
 TESTHDR := $(wildcard tests/*.h)
-JSON_FORMATTER_SOURCES := $(wildcard tools/format/*.cpp) src/json.cpp
+JSON_FORMATTER_SOURCES := $(wildcard tools/format/*.cpp) src/wcwidth.cpp src/json.cpp
 JSON_FORMATTER_HEADERS := $(wildcard tools/format/*.h)
-CHKJSON_SOURCES := $(wildcard src/chkjson/*.cpp) src/json.cpp
+CHKJSON_SOURCES := $(wildcard src/chkjson/*.cpp) src/wcwidth.cpp src/json.cpp
 CLANG_TIDY_PLUGIN_SOURCES := \
   $(wildcard tools/clang-tidy-plugin/*.cpp tools/clang-tidy-plugin/*/*.cpp)
 CLANG_TIDY_PLUGIN_HEADERS := \

--- a/src/chkjson/chkjson.cpp
+++ b/src/chkjson/chkjson.cpp
@@ -18,6 +18,12 @@
 #include <string>
 #include <vector>
 
+#if defined(_MSC_VER)
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
 #include "json.h"
 
 // copypasta: file_finder.cpp
@@ -166,6 +172,18 @@ static void load_json_dir( const std::string &dirname )
 
 int main( int, char ** )
 {
+#if defined(_MSC_VER)
+    bool supports_color = _isatty( _fileno( stdout ) );
+#else
+    bool supports_color = isatty( STDOUT_FILENO );
+#endif
+    // formatter stdout in github actions is redirected but still able to handle ANSI colors
+    supports_color |= std::getenv( "CI" ) != nullptr;
+
+    json_error_output_colors = supports_color
+                               ? json_error_output_colors_t::ansi_escapes
+                               : json_error_output_colors_t::no_colors;
+
     char *result = setlocale( LC_ALL, "" );
     if( !result ) {
         std::cerr << "Failed to set locale\n";

--- a/src/chkjson/chkjson.cpp
+++ b/src/chkjson/chkjson.cpp
@@ -180,6 +180,7 @@ int main( int, char ** )
     // formatter stdout in github actions is redirected but still able to handle ANSI colors
     supports_color |= std::getenv( "CI" ) != nullptr;
 
+    // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
     json_error_output_colors = supports_color
                                ? json_error_output_colors_t::ansi_escapes
                                : json_error_output_colors_t::no_colors;

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -2053,6 +2053,14 @@ void TextJsonIn::error( int offset, const std::string &message )
     const int max_context_lines = 3;   // limits context length to this many lines
     const int max_context_chars = 480; // limits context length to this many chars
     stream->seekg( offset, std::istream::cur );
+
+    // if offset points to middle of a codepoint then rewind stream to codepoint start
+    // this is so utf8_width below has correct utf-8 to count length.
+    // pattern of 10xxxxxx means the byte is utf-8 continuation byte.
+    while( ( stream->tellg() > 0 ) && ( ( stream->peek() & 0xC0 ) == 0x80 ) ) {
+        stream->seekg( -1, std::istream::cur );
+    }
+
     // remember positions of several places to print a few lines of context
     const size_t cursor_pos = tell();               // exact position of error
     rewind( 1, max_context_chars );                 // rewind to start of line

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -21,9 +21,12 @@
 #include "cached_options.h"
 #include "cata_scope_helpers.h"
 #include "cata_utility.h"
+#include "wcwidth.h"
 #include "debug.h"
 #include "output.h"
 #include "string_formatter.h"
+
+json_error_output_colors_t json_error_output_colors = json_error_output_colors_t::unset;
 
 // JSON parsing and serialization tools for Cataclysm-DDA.
 // For documentation, see the included header, json.h.
@@ -1890,6 +1893,109 @@ std::string TextJsonIn::line_number( int offset_modifier )
     return ret.str();
 }
 
+// see note at utf8_width_raw(...
+static uint32_t UTF8_getch_raw( const char **src, int *srclen )
+{
+    const unsigned char *p = *reinterpret_cast<const unsigned char **>( src );
+    int left = 0;
+    bool overlong = false;
+    bool underflow = false;
+    uint32_t ch = UNKNOWN_UNICODE;
+
+    if( *srclen == 0 ) {
+        return UNKNOWN_UNICODE;
+    }
+    if( p[0] >= 0xFC ) {
+        if( ( p[0] & 0xFE ) == 0xFC ) {
+            if( p[0] == 0xFC && ( p[1] & 0xFC ) == 0x80 ) {
+                overlong = true;
+            }
+            ch = static_cast<uint32_t>( p[0] & 0x01 );
+            left = 5;
+        }
+    } else if( p[0] >= 0xF8 ) {
+        if( ( p[0] & 0xFC ) == 0xF8 ) {
+            if( p[0] == 0xF8 && ( p[1] & 0xF8 ) == 0x80 ) {
+                overlong = true;
+            }
+            ch = static_cast<uint32_t>( p[0] & 0x03 );
+            left = 4;
+        }
+    } else if( p[0] >= 0xF0 ) {
+        if( ( p[0] & 0xF8 ) == 0xF0 ) {
+            if( p[0] == 0xF0 && ( p[1] & 0xF0 ) == 0x80 ) {
+                overlong = true;
+            }
+            ch = static_cast<uint32_t>( p[0] & 0x07 );
+            left = 3;
+        }
+    } else if( p[0] >= 0xE0 ) {
+        if( ( p[0] & 0xF0 ) == 0xE0 ) {
+            if( p[0] == 0xE0 && ( p[1] & 0xE0 ) == 0x80 ) {
+                overlong = true;
+            }
+            ch = static_cast<uint32_t>( p[0] & 0x0F );
+            left = 2;
+        }
+    } else if( p[0] >= 0xC0 ) {
+        if( ( p[0] & 0xE0 ) == 0xC0 ) {
+            if( ( p[0] & 0xDE ) == 0xC0 ) {
+                overlong = true;
+            }
+            ch = static_cast<uint32_t>( p[0] & 0x1F );
+            left = 1;
+        }
+    } else {
+        if( ( p[0] & 0x80 ) == 0x00 ) {
+            ch = static_cast<uint32_t>( p[0] );
+        }
+    }
+    ++*src;
+    --*srclen;
+    while( left > 0 && *srclen > 0 ) {
+        ++p;
+        if( ( p[0] & 0xC0 ) != 0x80 ) {
+            ch = UNKNOWN_UNICODE;
+            break;
+        }
+        ch <<= 6;
+        ch |= ( p[0] & 0x3F );
+        ++*src;
+        --*srclen;
+        --left;
+    }
+    if( left > 0 ) {
+        underflow = true;
+    }
+    if( overlong || underflow ||
+        ( ch >= 0xD800 && ch <= 0xDFFF ) ||
+        ( ch == 0xFFFE || ch == 0xFFFF ) || ch > 0x10FFFF ) {
+        ch = UNKNOWN_UNICODE;
+    }
+    return ch;
+}
+
+//Calculate width of a Unicode string
+//Latin characters have a width of 1
+//CJK characters have a width of 2, etc
+// This is a copy of the function in catacharset.cpp but without
+// dependencies on catacharset.h => output.h => more dependencies...
+// TODO: untangle the dependencies and remove this copy and UTF8_getch_raw
+static int utf8_width_raw( const std::string_view s )
+{
+    int len = s.size();
+    const char *ptr = s.data();
+    int w = 0;
+    while( len > 0 ) {
+        uint32_t ch = UTF8_getch_raw( &ptr, &len );
+        if( ch == UNKNOWN_UNICODE ) {
+            continue;
+        }
+        w += mk_wcwidth( ch );
+    }
+    return w;
+}
+
 void TextJsonIn::error( const std::string &message )
 {
     error( 0, message );
@@ -1906,6 +2012,32 @@ void TextJsonIn::error( int offset, const std::string &message )
             err_header << "::error " << line_number( offset ) << "::";
             break;
     }
+
+    std::string color_normal;
+    std::string color_error;
+    std::string color_highlight;
+    std::string color_end;
+    switch( json_error_output_colors ) {
+        case json_error_output_colors_t::color_tags:
+            color_normal = "<color_white>";
+            color_error = "<color_light_red>";
+            color_highlight = "<color_cyan>";
+            color_end = "</color>";
+            break;
+        case json_error_output_colors_t::ansi_escapes:
+            color_normal = "\033[0m";
+            color_error = "\033[0;31m";
+            color_highlight = "\033[0;36m";
+            color_end = "\033[0m";
+            break;
+        case json_error_output_colors_t::unset:
+            err_header << "( json_error_output_colors is unset, defaulting to no colors ) ";
+            break;
+        default:
+            // leave color strings empty
+            break;
+    }
+
     // if we can't get more info from the stream don't try
     if( !stream->good() ) {
         throw JsonError( err_header.str() + escape_data( message ) );
@@ -1917,57 +2049,59 @@ void TextJsonIn::error( int offset, const std::string &message )
         stream->seekg( 0, std::istream::end );
     } );
     std::ostringstream err;
-    err << message;
-    // also print surrounding few lines of context, if not too large
-    err << "\n\n";
+    err << color_normal << color_highlight << message << color_end << "\n\n";
+    const int max_context_lines = 3;   // limits context length to this many lines
+    const int max_context_chars = 480; // limits context length to this many chars
     stream->seekg( offset, std::istream::cur );
-    size_t pos = tell();
-    rewind( 3, 240 );
-    size_t startpos = tell();
-    std::string buffer( pos - startpos, '\0' );
-    stream->read( buffer.data(), pos - startpos );
-    auto it = buffer.begin();
-    for( ; it < buffer.end() && ( *it == '\r' || *it == '\n' ); ++it ) {
-        // skip starting newlines
-    }
-    for( ; it < buffer.end(); ++it ) {
-        if( *it == '\r' ) {
-            err << '\n';
-            if( it + 1 < buffer.end() && *( it + 1 ) == '\n' ) {
-                ++it;
+    // remember positions of several places to print a few lines of context
+    const size_t cursor_pos = tell();               // exact position of error
+    rewind( 1, max_context_chars );                 // rewind to start of line
+    const size_t start_of_line = tell();            // start of error line
+    rewind( max_context_lines, max_context_chars ); // rewind a couple lines to show context
+    const size_t start_of_context = tell();         // start of context (couple lines above)
+    size_t end_of_line;                             // end of error line (without \n)
+
+    {
+        // find end of line and store in end_of_line
+        seek( cursor_pos );
+        end_of_line = tell();
+        while( stream->peek() != EOF ) {
+            if( stream->peek() == '\n' ) {
+                break;
             }
-        } else {
-            err << *it;
-        }
-    }
-    if( !is_whitespace( peek() ) && stream->good() ) {
-        err << peek();
-    }
-    // display a pointer to the position
-    rewind( 1, 240 );
-    startpos = tell();
-    err << '\n';
-    if( pos > startpos ) {
-        err << std::string( pos - startpos, ' ' );
-    }
-    err << "^\n";
-    seek( pos );
-    // if that wasn't the end of the line, continue underneath pointer
-    char ch = stream->get();
-    if( ch == '\r' ) {
-        if( peek() == '\n' ) {
             stream->get();
-        }
-    } else if( ch == '\n' ) {
-        // pass
-    } else if( peek() != '\r' && peek() != '\n' && !stream->eof() ) {
-        for( size_t i = 0; i < pos - startpos + 1; ++i ) {
-            err << ' ';
+            end_of_line = tell();
         }
     }
+    {
+        // print context lines to start of error line
+        seek( start_of_context );
+        std::string buffer( start_of_line - start_of_context, '\0' );
+        stream->read( buffer.data(), start_of_line - start_of_context );
+        err << buffer;
+    }
+    {
+        // print error line
+        std::string buffer( end_of_line - start_of_line, '\0' );
+        stream->read( buffer.data(), end_of_line - start_of_line );
+        err << color_error << buffer << color_end << "\n";
+    }
+    {
+        seek( start_of_line );
+        std::string buffer( cursor_pos - start_of_line, '\0' );
+        stream->read( buffer.data(), cursor_pos - start_of_line );
+
+        // display a cursor at the position if possible, or at start of line
+        if( const int padding = std::max( 0, utf8_width_raw( buffer ) - 1 ); padding > 0 ) {
+            err << std::string( padding, ' ' );
+        }
+        err << color_highlight << "▲▲▲" << color_end;
+    }
+    seek( end_of_line );
     // print the next couple lines as well
     int line_count = 0;
-    for( int i = 0; line_count < 3 && stream->good() && i < 240; ++i ) {
+    char ch = 0;
+    for( int i = 0; line_count < max_context_lines && stream->good() && i < max_context_chars; ++i ) {
         stream->get( ch );
         if( !stream->good() ) {
             break;
@@ -1983,11 +2117,8 @@ void TextJsonIn::error( int offset, const std::string &message )
         }
         err << ch;
     }
-    std::string msg = err.str();
-    if( !msg.empty() && msg.back() != '\n' ) {
-        msg.push_back( '\n' );
-    }
-    throw JsonError( err_header.str() + escape_data( msg ) );
+    err << color_end << "\n";
+    throw JsonError( err_header.str() + escape_data( err.str() ) );
 }
 
 void TextJsonIn::string_error( const int offset, const std::string &message )

--- a/src/json.h
+++ b/src/json.h
@@ -94,6 +94,15 @@ struct json_source_location {
     int offset = 0;
 };
 
+enum class json_error_output_colors_t {
+    unset,        // default value, will print a warning
+    no_colors,    // use when error output is a redirected pipe
+    color_tags,   // use when debugmsg will handle the errors in either SDL or curses mode
+    ansi_escapes, // use when error output will end up in stdout: in tooling, formatters or CI
+};
+
+extern json_error_output_colors_t json_error_output_colors;
+
 class TextJsonValue
 {
     private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -634,6 +634,7 @@ int main( int argc, const char *argv[] )
     }
 
     setupDebug( DebugOutput::file );
+    // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
     json_error_output_colors = json_error_output_colors_t::color_tags;
 
     /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -634,6 +634,7 @@ int main( int argc, const char *argv[] )
     }
 
     setupDebug( DebugOutput::file );
+    json_error_output_colors = json_error_output_colors_t::color_tags;
 
     /**
      * OS X does not populate locale env vars correctly (they usually default to

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -719,7 +719,8 @@ void math_exp::math_exp_impl::error( std::string_view str, std::string_view what
                               std::get<var>( output.top().data ).varinfo.name.substr( 12 ) );
     }
 
-    debugmsg( "%s\n\n%.80s\n%*s^\n", mess, str.data(), offset, " " );
+    offset = std::max<std::ptrdiff_t>( 0, offset - 1 );
+    debugmsg( "%s\n\n%.80s\n%*s▲▲▲\n", mess, str.data(), offset, " " );
 }
 
 void math_exp::math_exp_impl::validate_string( std::string_view str, std::string_view label,

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -218,9 +218,12 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     // the text style check itself is tested in the lit test of clang-tidy.
     restore_on_out_of_scope<error_log_format_t> restore_error_log_format( error_log_format );
     restore_on_out_of_scope<check_plural_t> restore_check_plural( check_plural );
+    restore_on_out_of_scope<json_error_output_colors_t> error_colors( json_error_output_colors );
     error_log_format = error_log_format_t::human_readable;
     check_plural = check_plural_t::certain;
+    json_error_output_colors = json_error_output_colors_t::no_colors;
 
+    // NOLINTBEGIN(cata-text-style)
     // string, ascii
     test_translation_text_style_check(
         Catch::Equals(
@@ -230,10 +233,9 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"(    Suggested fix: insert " ")" "\n"
             R"(    At the following position (marked with caret))" "\n"
             R"()" "\n"
-            R"("foo.)" "\n"
-            R"(    ^)" "\n"
-            R"(      bar.")" "\n" ),
-        R"("foo. bar.")" ); // NOLINT(cata-text-style)
+            R"("foo. bar.")" "\n"
+            R"(   ▲▲▲)" "\n" ),
+        R"("foo. bar.")" );
     // string, unicode
     test_translation_text_style_check(
         Catch::Equals(
@@ -243,10 +245,9 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"(    Suggested fix: insert " ")" "\n"
             R"(    At the following position (marked with caret))" "\n"
             R"()" "\n"
-            R"("…foo.)" "\n"
-            R"(       ^)" "\n"
-            R"(         bar.")" "\n" ),
-        R"("…foo. bar.")" ); // NOLINT(cata-text-style)
+            R"("…foo. bar.")" "\n"
+            R"(    ▲▲▲)" "\n" ),
+        R"("…foo. bar.")" );
     // string, escape sequence
     test_translation_text_style_check(
         Catch::Equals(
@@ -256,10 +257,9 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"(    Suggested fix: insert " ")" "\n"
             R"(    At the following position (marked with caret))" "\n"
             R"()" "\n"
-            R"("\u2026foo.)" "\n"
-            R"(          ^)" "\n"
-            R"(            bar.")" "\n" ),
-        R"("\u2026foo. bar.")" ); // NOLINT(cata-text-style)
+            R"("\u2026foo. bar.")" "\n"
+            R"(         ▲▲▲)" "\n" ),
+        R"("\u2026foo. bar.")" );
     // object, ascii
     test_translation_text_style_check(
         Catch::Equals(
@@ -269,10 +269,9 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"(    Suggested fix: insert " ")" "\n"
             R"(    At the following position (marked with caret))" "\n"
             R"()" "\n"
-            R"({"str": "foo.)" "\n"
-            R"(            ^)" "\n"
-            R"(              bar."})" "\n" ),
-        R"({"str": "foo. bar."})" ); // NOLINT(cata-text-style)
+            R"({"str": "foo. bar."})" "\n"
+            R"(           ▲▲▲)" "\n" ),
+        R"({"str": "foo. bar."})" );
     // object, unicode
     test_translation_text_style_check(
         Catch::Equals(
@@ -282,10 +281,9 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"(    Suggested fix: insert " ")" "\n"
             R"(    At the following position (marked with caret))" "\n"
             R"()" "\n"
-            R"({"str": "…foo.)" "\n"
-            R"(               ^)" "\n"
-            R"(                 bar."})" "\n" ),
-        R"({"str": "…foo. bar."})" ); // NOLINT(cata-text-style)
+            R"({"str": "…foo. bar."})" "\n"
+            R"(            ▲▲▲)" "\n" ),
+        R"({"str": "…foo. bar."})" );
     // object, escape sequence
     test_translation_text_style_check(
         Catch::Equals(
@@ -295,10 +293,9 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"(    Suggested fix: insert " ")" "\n"
             R"(    At the following position (marked with caret))" "\n"
             R"()" "\n"
-            R"({"str": "\u2026foo.)" "\n"
-            R"(                  ^)" "\n"
-            R"(                    bar."})" "\n" ),
-        R"({"str": "\u2026foo. bar."})" ); // NOLINT(cata-text-style)
+            R"({"str": "\u2026foo. bar."})" "\n"
+            R"(                 ▲▲▲)" "\n" ),
+        R"({"str": "\u2026foo. bar."})" );
 
     // test unexpected plural forms
     test_translation_text_style_check(
@@ -306,18 +303,16 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"((json-error))" "\n"
             R"(Json error: <unknown source file>:1:11: str_sp not supported here)" "\n"
             R"()" "\n"
-            R"({"str_sp":)" "\n"
-            R"(          ^)" "\n"
-            R"(           "foo"})" "\n" ),
+            R"({"str_sp": "foo"})" "\n"
+            R"(         ▲▲▲)" "\n" ),
         R"({"str_sp": "foo"})" );
     test_translation_text_style_check(
         Catch::Equals(
             R"((json-error))" "\n"
             R"(Json error: <unknown source file>:1:25: str_pl not supported here)" "\n"
             R"()" "\n"
-            R"({"str": "foo", "str_pl":)" "\n"
-            R"(                        ^)" "\n"
-            R"(                         "foo"})" "\n" ),
+            R"({"str": "foo", "str_pl": "foo"})" "\n"
+            R"(                       ▲▲▲)" "\n" ),
         R"({"str": "foo", "str_pl": "foo"})" );
 
     // test plural forms
@@ -350,9 +345,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"('str_pl', or 'str_sp' if the singular and plural forms are the same.)"
             "\n"
             R"()" "\n"
-            R"({"str":)" "\n"
-            R"(       ^)" "\n"
-            R"(        "box"})" "\n" ),
+            R"({"str": "box"})" "\n"
+            R"(      ▲▲▲)" "\n" ),
         R"({"str": "box"})" );
     test_pl_translation_text_style_check(
         Catch::Equals( "" ),
@@ -367,9 +361,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"(Json error: <unknown source file>:1:25: "str_pl" is not necessary here since the plural form can be automatically generated.)"
             "\n"
             R"()" "\n"
-            R"({"str": "bar", "str_pl":)" "\n"
-            R"(                        ^)" "\n"
-            R"(                         "bars"})" "\n" ),
+            R"({"str": "bar", "str_pl": "bars"})" "\n"
+            R"(                       ▲▲▲)" "\n" ),
         R"({"str": "bar", "str_pl": "bars"})" );
     test_pl_translation_text_style_check(
         Catch::Equals(
@@ -377,9 +370,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"(Json error: <unknown source file>:1:25: Please use "str_sp" instead of "str" and "str_pl" for text with identical singular and plural forms)"
             "\n"
             R"()" "\n"
-            R"({"str": "bar", "str_pl":)" "\n"
-            R"(                        ^)" "\n"
-            R"(                         "bar"})" "\n" ),
+            R"({"str": "bar", "str_pl": "bar"})" "\n"
+            R"(                       ▲▲▲)" "\n" ),
         R"({"str": "bar", "str_pl": "bar"})" );
     test_pl_translation_text_style_check(
         Catch::Equals( "" ),
@@ -391,7 +383,6 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     // ensure nolint member suppresses text style check
     test_translation_text_style_check(
         Catch::Equals( "" ),
-        // NOLINTNEXTLINE(cata-text-style)
         R"~({"str": "foo. bar", "//NOLINT(cata-text-style)": "blah"})~" );
     test_pl_translation_text_style_check(
         Catch::Equals( "" ),
@@ -418,9 +409,8 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
                 R"(Json error: <unknown source file>:1:25: "str_pl" is not necessary here )"
                 R"(since the plural form can be automatically generated.)" "\n"
                 R"()" "\n"
-                R"({"str": "bar", "str_pl":)" "\n"
-                R"(                        ^)" "\n"
-                R"(                         "bars"})" "\n" ),
+                R"({"str": "bar", "str_pl": "bars"})" "\n"
+                R"(                       ▲▲▲)" "\n" ),
             R"({"str": "bar", "str_pl": "bars"})" );
         test_pl_translation_text_style_check(
             Catch::Equals(
@@ -428,27 +418,24 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
                 R"(Json error: <unknown source file>:1:25: Please use "str_sp" instead of "str" )"
                 R"(and "str_pl" for text with identical singular and plural forms)" "\n"
                 R"()" "\n"
-                R"({"str": "bar", "str_pl":)" "\n"
-                R"(                        ^)" "\n"
-                R"(                         "bar"})" "\n" ),
+                R"({"str": "bar", "str_pl": "bar"})" "\n"
+                R"(                       ▲▲▲)" "\n" ),
             R"({"str": "bar", "str_pl": "bar"})" );
         test_translation_text_style_check(
             Catch::Equals(
                 R"((json-error))" "\n"
                 R"(Json error: <unknown source file>:1:11: str_sp not supported here)" "\n"
                 R"()" "\n"
-                R"({"str_sp":)" "\n"
-                R"(          ^)" "\n"
-                R"(           "foo"})" "\n" ),
+                R"({"str_sp": "foo"})" "\n"
+                R"(         ▲▲▲)" "\n" ),
             R"({"str_sp": "foo"})" );
         test_translation_text_style_check(
             Catch::Equals(
                 R"((json-error))" "\n"
                 R"(Json error: <unknown source file>:1:25: str_pl not supported here)" "\n"
                 R"()" "\n"
-                R"({"str": "foo", "str_pl":)" "\n"
-                R"(                        ^)" "\n"
-                R"(                         "foo"})" "\n" ),
+                R"({"str": "foo", "str_pl": "foo"})" "\n"
+                R"(                       ▲▲▲)" "\n" ),
             R"({"str": "foo", "str_pl": "foo"})" );
         test_translation_text_style_check(
             Catch::Equals(
@@ -458,36 +445,39 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
                 R"(    Suggested fix: insert " ")" "\n"
                 R"(    At the following position (marked with caret))" "\n"
                 R"()" "\n"
-                R"("foo.)" "\n"
-                R"(    ^)" "\n"
-                R"(      bar.")" "\n" ),
-            R"("foo. bar.")" ); // NOLINT(cata-text-style)
+                R"("foo. bar.")" "\n"
+                R"(   ▲▲▲)" "\n" ),
+            R"("foo. bar.")" );
     }
 
     // ensure sentence text style check is disabled when plural form is enabled
     test_pl_translation_text_style_check(
         Catch::Equals( "" ),
-        R"("foo. bar")" ); // NOLINT(cata-text-style)
+        R"("foo. bar")" );
     test_pl_translation_text_style_check(
         Catch::Equals( "" ),
-        R"({"str": "foo. bar"})" ); // NOLINT(cata-text-style)
+        R"({"str": "foo. bar"})" );
     test_pl_translation_text_style_check(
         Catch::Equals( "" ),
-        R"({"str": "foo. bar", "str_pl": "foo. baz"})" ); // NOLINT(cata-text-style)
+        R"({"str": "foo. bar", "str_pl": "foo. baz"})" );
     test_pl_translation_text_style_check(
         Catch::Equals( "" ),
-        R"({"str_sp": "foo. bar"})" ); // NOLINT(cata-text-style)
+        R"({"str_sp": "foo. bar"})" );
+    // NOLINTEND(cata-text-style)
 }
 
 TEST_CASE( "translation_text_style_check_error_recovery", "[json][translation]" )
 {
     restore_on_out_of_scope<error_log_format_t> restore_error_log_format( error_log_format );
+    restore_on_out_of_scope<json_error_output_colors_t> error_colors( json_error_output_colors );
     error_log_format = error_log_format_t::human_readable;
+    json_error_output_colors = json_error_output_colors_t::no_colors;
 
+    // NOLINTBEGIN(cata-text-style)
     SECTION( "string" ) {
         const std::string json =
             R"([)" "\n"
-            R"(  "foo. bar.",)" "\n" // NOLINT(cata-text-style)
+            R"(  "foo. bar.",)" "\n"
             R"(  "foobar")" "\n"
             R"(])" "\n";
         JsonArray ja = json_loader::from_string( json );
@@ -506,17 +496,16 @@ TEST_CASE( "translation_text_style_check_error_recovery", "[json][translation]" 
                 R"(    At the following position (marked with caret))" "\n"
                 R"()" "\n"
                 R"([)" "\n"
-                R"(  "foo.)" "\n"
-                R"(      ^)" "\n"
-                R"(        bar.",)" "\n"
+                R"(  "foo. bar.",)" "\n"
+                R"(     ▲▲▲)" "\n"
                 R"(  "foobar")" "\n"
-                R"(])" "\n" ) );
+                R"(])" "\n\n" ) );
     }
 
     SECTION( "object" ) {
         const std::string json =
             R"([)" "\n"
-            R"(  { "str": "foo. bar." },)" "\n" // NOLINT(cata-text-style)
+            R"(  { "str": "foo. bar." },)" "\n"
             R"(  "foobar")" "\n"
             R"(])" "\n";
         JsonArray ja = json_loader::from_string( json );
@@ -536,12 +525,12 @@ TEST_CASE( "translation_text_style_check_error_recovery", "[json][translation]" 
                 R"(    At the following position (marked with caret))" "\n"
                 R"()" "\n"
                 R"([)" "\n"
-                R"(  { "str": "foo.)" "\n"
-                R"(               ^)" "\n"
-                R"(                 bar." },)" "\n"
+                R"(  { "str": "foo. bar." },)" "\n"
+                R"(              ▲▲▲)" "\n"
                 R"(  "foobar")" "\n"
-                R"(])" "\n" ) );
+                R"(])" "\n\n" ) );
     }
+    // NOLINTEND(cata-text-style)
 }
 
 static void test_get_string( const std::string &str, const std::string &json )
@@ -574,8 +563,11 @@ static void test_string_error_throws_matches( Matcher &&matcher, const std::stri
 TEST_CASE( "jsonin_get_string", "[json]" )
 {
     restore_on_out_of_scope<error_log_format_t> restore_error_log_format( error_log_format );
+    restore_on_out_of_scope<json_error_output_colors_t> error_colors( json_error_output_colors );
     error_log_format = error_log_format_t::human_readable;
+    json_error_output_colors = json_error_output_colors_t::no_colors;
 
+    // NOLINTBEGIN(cata-text-style)
     // read plain text
     test_get_string( "foo", R"("foo")" );
     // ignore starting spaces
@@ -595,7 +587,6 @@ TEST_CASE( "jsonin_get_string", "[json]" )
     // read slash
     test_get_string( "foo\\bar", R"("foo\\bar")" );
     // read escaped characters
-    // NOLINTNEXTLINE(cata-text-style)
     test_get_string( "\"\\/\b\f\n\r\t\u2581", R"("\"\\\/\b\f\n\r\t\u2581")" );
 
     // empty json
@@ -626,26 +617,23 @@ TEST_CASE( "jsonin_get_string", "[json]" )
         Catch::Message(
             R"(Json error: <unknown source file>:1:3: escape code must be followed by 4 hex digits)" "\n"
             R"()" "\n"
-            R"("\u)" "\n"
-            R"(  ^)" "\n"
-            R"(   12)" "\n" ),
+            R"("\u12)" "\n"
+            R"( ▲▲▲)" "\n" ),
         R"("\u12)" );
     // incorrect escape sequence
     test_get_string_throws_matches(
         Catch::Message(
             R"(Json error: <unknown source file>:1:2: unknown escape code in string constant)" "\n"
             R"()" "\n"
-            R"("\)" "\n"
-            R"( ^)" "\n"
-            R"(  .")" "\n" ),
+            R"("\.")" "\n"
+            R"(▲▲▲)" "\n" ),
         R"("\.")" );
     test_get_string_throws_matches(
         Catch::Message(
             R"(Json error: <unknown source file>:1:3: escape code must be followed by 4 hex digits)" "\n"
             R"()" "\n"
-            R"("\u)" "\n"
-            R"(  ^)" "\n"
-            R"(   DEFG")" "\n" ),
+            R"("\uDEFG")" "\n"
+            R"( ▲▲▲)" "\n" ),
         R"("\uDEFG")" );
     // not a valid utf8 sequence
     test_get_string_throws_matches(
@@ -670,19 +658,15 @@ TEST_CASE( "jsonin_get_string", "[json]" )
             R"(Json error: <unknown source file>:1:2: illegal character in string constant)" "\n"
             R"()" "\n"
             R"("a)" "\n"
-            R"( ^)" "\n"
-            "\n" // Embedded newline inside string
-            R"(")" "\n" ),
+            R"(▲▲▲)" "\n\"\n" ),
         "\"a\n\"" );
     test_get_string_throws_matches(
         Catch::Message(
             R"(Json error: <unknown source file>:1:2: illegal character in string constant)" "\n"
             R"()" "\n"
-            R"("b)" "\n"
-            R"( ^)" "\n"
-            "\n" // \r gets translated to \n?
-            R"(")" "\n" ),
-        "\"b\r\"" ); // NOLINT(cata-text-style)
+            R"("b)" "\r\"\n"
+            R"(▲▲▲)" "\n" ),
+        "\"b\r\"" );
 
     // test throwing error after the given number of unicode characters
     // ascii
@@ -690,60 +674,54 @@ TEST_CASE( "jsonin_get_string", "[json]" )
         Catch::Message(
             R"(Json error: <unknown source file>:1:1: <message>)" "\n"
             R"()" "\n"
-            R"(")" "\n"
-            R"(^)" "\n"
-            R"( foobar")" "\n" ),
+            R"("foobar")" "\n"
+            R"(▲▲▲)" "\n" ),
         R"("foobar")", 0 );
     test_string_error_throws_matches(
         Catch::Message(
             R"(Json error: <unknown source file>:1:4: <message>)" "\n"
             R"()" "\n"
-            R"("foo)" "\n"
-            R"(   ^)" "\n"
-            R"(    bar")" "\n" ),
+            R"("foobar")" "\n"
+            R"(  ▲▲▲)" "\n" ),
         R"("foobar")", 3 );
     // unicode
     test_string_error_throws_matches(
         Catch::Message(
             R"(Json error: <unknown source file>:1:4: <message>)" "\n"
             R"()" "\n"
-            R"("foo)" "\n"
-            R"(   ^)" "\n"
-            R"(    …bar1")" "\n" ),
+            R"("foo…bar1")" "\n"
+            R"(  ▲▲▲)" "\n" ),
         R"("foo…bar1")", 3 );
     test_string_error_throws_matches(
         Catch::Message(
             R"(Json error: <unknown source file>:1:7: <message>)" "\n"
             R"()" "\n"
-            R"("foo…)" "\n"
-            R"(      ^)" "\n"
-            R"(       bar2")" "\n" ),
+            R"("foo…bar2")" "\n"
+            R"(   ▲▲▲)" "\n" ),
         R"("foo…bar2")", 4 );
     test_string_error_throws_matches(
         Catch::Message(
             R"(Json error: <unknown source file>:1:8: <message>)" "\n"
             R"()" "\n"
-            R"("foo…b)" "\n"
-            R"(       ^)" "\n"
-            R"(        ar3")" "\n" ),
+            R"("foo…bar3")" "\n"
+            R"(    ▲▲▲)" "\n" ),
         R"("foo…bar3")", 5 );
     // escape sequence
     test_string_error_throws_matches(
         Catch::Message(
             R"(Json error: <unknown source file>:1:11: <message>)" "\n"
             R"()" "\n"
-            R"("foo\u2026b)" "\n"
-            R"(          ^)" "\n"
-            R"(           ar")" "\n" ),
+            R"("foo\u2026bar")" "\n"
+            R"(         ▲▲▲)" "\n" ),
         R"("foo\u2026bar")", 5 );
     test_string_error_throws_matches(
         Catch::Message(
             R"(Json error: <unknown source file>:1:7: <message>)" "\n"
             R"()" "\n"
-            R"("foo\nb)" "\n"
-            R"(      ^)" "\n"
-            R"(       ar")" "\n" ),
+            R"("foo\nbar")" "\n"
+            R"(     ▲▲▲)" "\n" ),
         R"("foo\nbar")", 5 );
+    // NOLINTEND(cata-text-style)
 }
 
 TEST_CASE( "item_colony_ser_deser", "[json][item]" )

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -19,7 +19,9 @@
 #include "calendar.h"
 #include "cata_catch.h"
 #include "coordinates.h"
-#ifndef _WIN32
+#if defined(_MSC_VER)
+#include <io.h>
+#else
 #include <unistd.h>
 #endif
 
@@ -34,6 +36,7 @@
 #include "filesystem.h"
 #include "game.h"
 #include "help.h"
+#include "json.h"
 #include "loading_ui.h"
 #include "map.h"
 #include "messages.h"
@@ -291,6 +294,18 @@ CATCH_REGISTER_LISTENER( CataListener )
 
 int main( int argc, const char *argv[] )
 {
+#if defined(_MSC_VER)
+    bool supports_color = _isatty( _fileno( stdout ) );
+#else
+    bool supports_color = isatty( STDOUT_FILENO );
+#endif
+    // formatter stdout in github actions is redirected but still able to handle ANSI colors
+    supports_color |= std::getenv( "CI" ) != nullptr;
+
+    json_error_output_colors = supports_color
+                               ? json_error_output_colors_t::ansi_escapes
+                               : json_error_output_colors_t::no_colors;
+
     reset_floating_point_mode();
     on_out_of_scope json_member_reporting_guard{ [] {
             // Disable reporting unvisited members if stack unwinding leaves main early.

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -302,6 +302,7 @@ int main( int argc, const char *argv[] )
     // formatter stdout in github actions is redirected but still able to handle ANSI colors
     supports_color |= std::getenv( "CI" ) != nullptr;
 
+    // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
     json_error_output_colors = supports_color
                                ? json_error_output_colors_t::ansi_escapes
                                : json_error_output_colors_t::no_colors;

--- a/tools/format/format.cpp
+++ b/tools/format/format.cpp
@@ -126,14 +126,6 @@ void formatter::format( TextJsonIn &jsin, JsonOut &jsout, int depth, bool force_
         jsin.skip_null();
         jsout.write_null();
     } else {
-        std::cerr << "Encountered unrecognized TextJson element \"";
-        const int start_pos = jsin.tell();
-        jsin.skip_value();
-        const int end_pos = jsin.tell();
-        for( int i = start_pos; i < end_pos; ++i ) {
-            jsin.seek( i );
-            std::cerr << jsin.peek();
-        }
-        std::cerr << "\"" << std::endl;
+        jsin.skip_value(); // this will throw exception with the invalid element
     }
 }

--- a/tools/format/format_main.cpp
+++ b/tools/format/format_main.cpp
@@ -23,6 +23,18 @@ static void erase_char( std::string &s, const char &c )
 
 int main( int argc, char *argv[] )
 {
+#if defined(_MSC_VER)
+    bool supports_color = _isatty( _fileno( stdout ) );
+#else
+    bool supports_color = isatty( STDOUT_FILENO );
+#endif
+    // formatter stdout in github actions is redirected but still able to handle ANSI colors
+    supports_color |= std::getenv( "CI" ) != nullptr;
+
+    json_error_output_colors = supports_color
+                               ? json_error_output_colors_t::ansi_escapes
+                               : json_error_output_colors_t::no_colors;
+
     std::stringstream in;
     std::stringstream out;
     std::string filename;
@@ -86,11 +98,6 @@ int main( int argc, char *argv[] )
         erase_char( in_str, '\r' );
 #endif
 
-#if defined(_MSC_VER)
-        bool supports_color = _isatty( _fileno( stdout ) );
-#else
-        bool supports_color = isatty( STDOUT_FILENO );
-#endif
         std::string color_bad = supports_color ? "\x1b[31m" : std::string();
         std::string color_end = supports_color ? "\x1b[0m" : std::string();
         if( in_str == out.str() ) {

--- a/tools/format/format_main.cpp
+++ b/tools/format/format_main.cpp
@@ -31,6 +31,7 @@ int main( int argc, char *argv[] )
     // formatter stdout in github actions is redirected but still able to handle ANSI colors
     supports_color |= std::getenv( "CI" ) != nullptr;
 
+    // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
     json_error_output_colors = supports_color
                                ? json_error_output_colors_t::ansi_escapes
                                : json_error_output_colors_t::no_colors;

--- a/tools/format/format_main.cpp
+++ b/tools/format/format_main.cpp
@@ -77,12 +77,11 @@ int main( int argc, char *argv[] )
         exit( EXIT_FAILURE );
     }
     JsonOut jsout( out, true );
-    TextJsonIn jsin( in );
+    TextJsonIn jsin( in, filename.empty() ? "<STDIN>" : filename );
 
     try {
         formatter::format( jsin, jsout );
     } catch( const JsonError &e ) {
-        std::cout << "JSON error in " << ( filename.empty() ? "input" : filename ) << std::endl;
         std::cout << e.what() << std::endl;
         exit( EXIT_FAILURE );
     }

--- a/tools/format_emscripten/build.sh
+++ b/tools/format_emscripten/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-emcc -std=c++17 -Oz -flto -I src/ -isystem src/third-party/ \
+emcc -std=c++17 -Oz -flto -I src/ -I tools/format/ -isystem src/third-party/ \
     -s SINGLE_FILE --shell-file tools/format_emscripten/shell.html -s WASM=1 \
     -s ENVIRONMENT=web -s MODULARIZE=1 -s 'EXPORT_NAME=json_formatter' -s NO\_FILESYSTEM=1 \
     -s LLD_REPORT_UNDEFINED -s MINIFY_HTML=0 -s NO_DISABLE_EXCEPTION_CATCHING \
     -s EXPORTED_FUNCTIONS=_json_format -s EXPORTED_RUNTIME_METHODS=cwrap \
-    src/json.cpp tools/format/format.cpp tools/format_emscripten/format_emscripten.cpp \
+    src/wcwidth.cpp src/json.cpp tools/format/format.cpp tools/format_emscripten/format_emscripten.cpp \
     -o formatter.html

--- a/tools/format_emscripten/format_emscripten.cpp
+++ b/tools/format_emscripten/format_emscripten.cpp
@@ -1,8 +1,8 @@
 enum class error_log_format_t { human_readable };
 extern constexpr error_log_format_t error_log_format = error_log_format_t::human_readable;
 
-#include "../../src/json.h"
-#include "../../tools/format/format.h"
+#include "json.h"
+#include "format.h"
 
 extern "C" {
     const char *json_format( const char *input )


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Json error output is more confusing than it can be(in my opinion); it breaks line at the error position making it harder for humans to correlate the printed output with the actual line in a file, instead this keeps the full line intact.

Most of the "viewers"; game debugmsg in curses or sdl mode, github actions, local terminals for tooling are able to display colors, and since we have the capacity for colors might as well use them.

For before/after examples see screenshots in text folds at bottom.

#### Describe the solution

* Stops breaking the line at cursor - print the full line, then print the cursor underneath, this is similar to how clang or other tooling prints errors ( with a slight discrepancy of empty lines if the line is super long, but I don't wanna complicate it by probing for terminal size, it shows correct column except for the github actions bug described in additional context section ).
* Colorize the output where possible - debugmsg can colorize via `<color_foo>` tags, on stdout unless redirected and in github actions the normal ANSI color escapes work.
* Make the cursor 3 bold arrows, instead of just 1 caret character.
* `make style-all-parallel` is redirecting stdout when running in a github action so `error_log_json_force_color` will force the color on when `CI` env variable is set ([github sets it by default](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)).
* Feed the filename to JsonTextIn in the format_main.cpp  - this replaces `<unknown source file>` with actual filename instead of printing filename separately

Flatbuffers unfortunately doesn't display the error context at all in certain circumstances (doesn't rewind stream? Not sure yet), but that's unrelated to this PR.
<details>
  <summary>Example for flatbuffers erroring out</summary>
  
  ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/69c892ed-6074-46c9-bd02-b8c6a3b1c1c7)
</details>


#### Describe alternatives you've considered

#### Testing

Mostly manual as this needs to have errors in the json to show up.

#### Additional context

Examples under folds

<details>
  <summary>Curses</summary>
  
  ![curses_old](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/7c46edb2-b980-4e8e-9766-c97d23ea9ef6) ![curses_new](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/45192366-d8ba-41c6-bb54-c4e3600b3bd0)
</details>

<details>
  <summary>SDL</summary>
  
  ![tiles_old](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/1e23fade-1bdc-455a-8129-f2775004b67b) ![tiles_new](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/4bfeae39-2768-4822-819c-f096037e5f59)
</details>

<details>
  <summary>make style-all-parallel</summary>
  
  ![style-all-parallel_old](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/c0820316-9192-489e-8366-fa0c1ff9a8da) ![style-all-parallel_new](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/89580737-c43b-4423-9fe9-8d5950cfd863)
</details>

<details>
  <summary>math parser debugmsg</summary>
  
  ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/e0749920-1919-400b-9358-320aa6420489)
</details>



Github actions has an issue with long lines ( see links below ) but this exists in old format as well as new, seems github will trim whitespace even in raw logs, running `make style-all-parallel` locally will show cursor at the correct column

[Buggy output in github actions for old error printout](https://github.com/irwiss/Cataclysm-DDA/actions/runs/5438431534/jobs/9889662343?pr=27)
[Buggy output for new error printout (no change)](https://github.com/irwiss/Cataclysm-DDA/actions/runs/5438428479/jobs/9889657684?pr=25)