### PR TITLE
Make arc welder and co able to plug

### DIFF
--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1243,6 +1243,13 @@
         "tool_quality": 10,
         "cost_scaling": 0.1,
         "move_cost": 500
+      },
+      {
+        "type": "link_up",
+        "menu_text": "Plug in / Unplug",
+        "ammo_scale": 0,
+        "cable_length": 7,
+        "charge_rate": "3000 W"
       }
     ],
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK" ],
@@ -1313,6 +1320,13 @@
         "tool_quality": 5,
         "cost_scaling": 0.1,
         "move_cost": 1000
+      },
+      {
+        "type": "link_up",
+        "menu_text": "Plug in / Unplug",
+        "ammo_scale": 0,
+        "cable_length": 7,
+        "charge_rate": "1500 W"
       }
     ],
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK" ],
@@ -1385,6 +1399,13 @@
         "tool_quality": 10,
         "cost_scaling": 0.1,
         "move_cost": 500
+      },
+      {
+        "type": "link_up",
+        "menu_text": "Plug in / Unplug",
+        "ammo_scale": 0,
+        "cable_length": 7,
+        "charge_rate": "3000 W"
       }
     ],
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK" ],


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I got blessing to make this change
#### Describe the solution
Makes arc welder and similar tools able to be plugged into power grid, using new `link_up` action
#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/7b8a7a0c-dffb-478b-ab78-68c4d80626fc)
#### Additional context
I'm not exactly sure for `charge_rate` - i picked an average of what google me said, and halved it for crude arc welder, but i can change it if someone think the value is too small/too high