### PR TITLE
Remove cata::optional leftovers

### DIFF
--- a/doc/DEVELOPER_TOOLING.md
+++ b/doc/DEVELOPER_TOOLING.md
@@ -364,8 +364,8 @@ diff <(ls src/*.h | sed 's!.*/!!') <(for i in src/*.cpp; do echo $i; sed -n '/^#
   types, which leads to other requirements for `IWYU pragma: keep`.
 
 * IWYU seems to have particular trouble with types used in maps and
-  `cata::optional`.  Have not looked into this in detail, but again worked
-  around it with pragmas.
+  `cata::optional` (NOTE: cata::optional replaced with std::optional around the C++17 migration).
+  Have not looked into this in detail, but again worked around it with pragmas.
 
 ## Python and pyvips on Windows
 

--- a/src/action.h
+++ b/src/action.h
@@ -10,11 +10,6 @@
 #include <string>
 #include <vector>
 
-namespace cata
-{
-template<typename T>
-class optional;
-} // namespace cata
 struct input_event;
 struct point;
 struct tripoint;

--- a/src/assign.h
+++ b/src/assign.h
@@ -17,11 +17,6 @@
 #include "json.h"
 #include "units.h"
 
-namespace cata
-{
-template<typename T>
-class optional;
-} // namespace cata
 namespace detail
 {
 template<typename ...T>
@@ -129,7 +124,7 @@ bool assign( const JsonObject &jo, const std::string_view name, std::pair<T, T> 
     return true;
 }
 
-// Note: is_optional excludes any types based on cata::optional, which is
+// Note: is_optional excludes any types based on std::optional, which is
 // handled below in a separate function.
 template < typename T, typename std::enable_if < std::is_class<T>::value &&!is_optional<T>::value,
            int >::type = 0 >

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -19,12 +19,6 @@ class time_duration;
 class time_point;
 template<typename T> struct enum_traits;
 
-namespace cata
-{
-template<typename T>
-class optional;
-} // namespace cata
-
 /** Real world seasons */
 enum season_type {
     SPRING = 0,

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -235,7 +235,7 @@ class tileset
          * @param id : "raw" tile id (without season suffix)
          * @param season : season suffix encoded as season_type enum
          * @return std::nullopt if no tile is found,
-         *    cata::optional with found id (e.g. "t_tree_apple_season_spring" or "t_tree_apple) and found tile.
+         *    std::optional with found id (e.g. "t_tree_apple_season_spring" or "t_tree_apple) and found tile.
          *
          * Note: this method is guaranteed to return pointers to the keys and values stored inside the
          * `tileset::tile_ids` collection. I.e. result of this method call is invalidated when

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -11,12 +11,6 @@
 struct tripoint;
 template <typename E> struct enum_traits;
 
-namespace cata
-{
-template<typename T>
-class optional;
-} // namespace cata
-
 class Character;
 
 namespace debug_menu

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -14,11 +14,6 @@
 class Character;
 struct tripoint;
 
-namespace cata
-{
-template<typename T>
-class optional;
-} // namespace cata
 class avatar;
 class item;
 class repair_item_actor;

--- a/src/input.h
+++ b/src/input.h
@@ -21,11 +21,6 @@ enum action_id : int;
 class cata_path;
 class hotkey_queue;
 
-namespace cata
-{
-template<typename T>
-class optional;
-} // namespace cata
 namespace catacurses
 {
 class window;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2865,7 +2865,7 @@ static void apply_optional( T &value, const std::optional<T> &applied )
     }
 }
 
-// Gets around the issue that cata::optional doesn't support
+// Gets around the issue that std::optional doesn't support
 // the *= and += operators required for "proportional" and "relative".
 template<typename T>
 static void get_optional( const JsonObject &jo, bool was_loaded, const std::string &member,

--- a/src/json.h
+++ b/src/json.h
@@ -43,12 +43,6 @@ class TextJsonObject;
 class TextJsonValue;
 class item;
 
-namespace cata
-{
-template<typename T>
-class optional;
-} // namespace cata
-
 // Traits class to distinguish sequences which are string like from others
 template< class, class = void >
 struct is_string_like : std::false_type { };

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -113,7 +113,7 @@ class vpart_position
 };
 
 /**
- * Simple wrapper to forward functions that may return a @ref cata::optional
+ * Simple wrapper to forward functions that may return a @ref std::optional
  * to @ref vpart_position. They generally return an empty `optional`, or
  * forward to the same function in `vpart_position`.
  */


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Some `cata::optional` stuff is still lying around

#### Describe the solution

✂️

#### Describe alternatives you've considered

#### Testing

#### Additional context
