### PR TITLE
Assorted tile rendering fixes

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1657,9 +1657,18 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         }
     } else {
         // Multi z-level draw mode
-        // Start drawing from the bottom-most z-level
-        int cur_zlevel = -OVERMAP_DEPTH;
-        do {
+        // Start drawing from the lowest visible z-level
+        int cur_zlevel = center.z + 1;
+        for( const std::pair<const int, std::vector<tile_render_info>> &pts : draw_points ) {
+            for( const tile_render_info &p : pts.second ) {
+                cur_zlevel = std::min( cur_zlevel, p.com.draw_min_z );
+                if( cur_zlevel <= center.z - max_draw_depth
+                    || cur_zlevel <= -OVERMAP_DEPTH ) {
+                    break;
+                }
+            }
+        }
+        while( cur_zlevel <= center.z ) {
             // For each row
             for( int row = min_row; row < max_row; row ++ ) {
                 // Set base height for each tile
@@ -1702,7 +1711,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 }
             }
             cur_zlevel += 1;
-        } while( cur_zlevel <= center.z );
+        }
     }
 
     // display number of monsters to spawn in mapgen preview

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2024,11 +2024,11 @@ std::optional<point> cata_tiles::tile_to_player( const point &colrow ) const
             != modulo( colrow.x - screentile_width / 2, 2 ) ) {
             return std::nullopt;
         }
-        return point {
+        return o + point {
             divide_round_down( colrow.x - colrow.y - screentile_width / 2
-                               + screentile_height / 2, 2 ) + o.x,
+                               + screentile_height / 2, 2 ),
             divide_round_down( colrow.y + colrow.x - screentile_height / 2
-                               - screentile_width / 2, 2 ) + o.y,
+                               - screentile_width / 2, 2 ),
         };
     } else {
         return colrow + o;
@@ -2060,19 +2060,16 @@ point cata_tiles::player_to_screen( const point &pos ) const
     if( is_isometric() ) {
         // To ensure the first fully drawn basic tile (col or row = 1, according
         // to the definition in get_window_full_base_tile_range) starts at 0,
-        return {
-            // left = ( col - 1 ) * ( tw / 2.0 ) + op.x =>
-            divide_round_down( ( colrow.x - 1 ) * tile_width, 2 ) + op.x,
-            // top = ( row - 1 ) * ( tw / 4.0 ) - th + tw / 2.0 + op.y =>
+        return op + point {
+            // left = ( col - 1 ) * ( tw / 2.0 ) =>
+            divide_round_down( ( colrow.x - 1 ) * tile_width, 2 ),
+            // top = ( row - 1 ) * ( tw / 4.0 ) - th + tw / 2.0 =>
             // (shifted so that sprites with default height end at the basic height
             // of `tile_width / 4`)
-            divide_round_down( ( colrow.y + 1 ) * tile_width, 4 ) - tile_height + op.y,
+            divide_round_down( ( colrow.y + 1 ) * tile_width, 4 ) - tile_height,
         };
     } else {
-        return {
-            colrow.x *tile_width + op.x,
-            colrow.y *tile_height + op.y,
-        };
+        return op + point { colrow.x * tile_width, colrow.y * tile_height };
     }
 }
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3584,13 +3584,13 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                 ret_draw_items = draw_from_id_string( disp_id, TILE_CATEGORY::ITEM, it_category, p, 0,
                                                       0, lit, nv, height_3d, 0, variant );
                 if( ret_draw_items && hilite ) {
-                    draw_item_highlight( p );
+                    draw_item_highlight( p, height_3d );
                 }
             }
         }
         // we may still need to draw the highlight
         else if( tile.get_item_count() > 1 && here.sees_some_items( p, get_player_character() ) ) {
-            draw_item_highlight( p );
+            draw_item_highlight( p, height_3d );
         }
     }
     return ret_draw_field && ret_draw_items;
@@ -3657,12 +3657,12 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
                                  : draw_from_id_string( "vp_" + vd.id.str(), TILE_CATEGORY::VEHICLE_PART,
                                                         empty_string, p, subtile, rotation, ll,
                                                         nv_goggles_activated, height_3d_temp, 0, vd.variant.id );
-                // Do not increment height_3d for non-roof vparts
+                if( ret && vd.has_cargo ) {
+                    draw_item_highlight( p, height_3d_temp );
+                }
+                // Do not increment height_3d for roof vparts
                 if( !roof ) {
                     height_3d = height_3d_temp;
-                }
-                if( ret && vd.has_cargo ) {
-                    draw_item_highlight( p );
                 }
                 return ret;
             }
@@ -3684,11 +3684,11 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
                              ? false
                              : draw_from_id_string( vpname, TILE_CATEGORY::VEHICLE_PART, empty_string, p, subtile,
                                                     rotation, lit_level::LIT, false, height_3d_temp );
+            if( ret && draw_highlight ) {
+                draw_item_highlight( p, height_3d_temp );
+            }
             if( !roof ) {
                 height_3d = height_3d_temp;
-            }
-            if( ret && draw_highlight ) {
-                draw_item_highlight( p );
             }
             return ret;
         }
@@ -4019,10 +4019,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
     }
 }
 
-bool cata_tiles::draw_item_highlight( const tripoint &pos )
+bool cata_tiles::draw_item_highlight( const tripoint &pos, int &height_3d )
 {
     return draw_from_id_string( ITEM_HIGHLIGHT, TILE_CATEGORY::NONE, empty_string, pos, 0, 0,
-                                lit_level::LIT, false );
+                                lit_level::LIT, false, height_3d );
 }
 
 std::shared_ptr<const tileset> tileset_cache::load_tileset( const std::string &tileset_id,

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1240,7 +1240,7 @@ struct tile_render_info {
     struct vision_effect {
         visibility_type vis;
 
-        vision_effect( const visibility_type vis )
+        explicit vision_effect( const visibility_type vis )
             : vis( vis ) {}
     };
 
@@ -2002,6 +2002,7 @@ half_open_rectangle<point> cata_tiles::get_window_full_base_tile_range( const po
         // \/
         const int columns = divide_round_down( size.x * 2, tile_width ) - 1;
         const int rows = divide_round_down( size.y * 4, tile_width ) - 1;
+        //NOLINTNEXTLINE(cata-use-named-point-constants)
         return { { 1, 1 }, { columns + 1, rows + 1 } };
     } else {
         // Only the area from (0, 0) to (tile_width, tile_height) is considered
@@ -2023,11 +2024,12 @@ std::optional<point> cata_tiles::tile_to_player( const point &colrow ) const
             != modulo( colrow.x - screentile_width / 2, 2 ) ) {
             return std::nullopt;
         }
-        const int posx = divide_round_down( colrow.x - colrow.y - screentile_width / 2
-                                            + screentile_height / 2, 2 ) + o.x;
-        const int posy = divide_round_down( colrow.y + colrow.x - screentile_height / 2
-                                            - screentile_width / 2, 2 ) + o.y;
-        return point( posx, posy );
+        return point {
+            divide_round_down( colrow.x - colrow.y - screentile_width / 2
+                               + screentile_height / 2, 2 ) + o.x,
+            divide_round_down( colrow.y + colrow.x - screentile_height / 2
+                               - screentile_width / 2, 2 ) + o.y,
+        };
     } else {
         return colrow + o;
     }
@@ -2058,18 +2060,19 @@ point cata_tiles::player_to_screen( const point &pos ) const
     if( is_isometric() ) {
         // To ensure the first fully drawn basic tile (col or row = 1, according
         // to the definition in get_window_full_base_tile_range) starts at 0,
-        //
-        // left = ( col - 1 ) * ( tw / 2.0 ) + op.x =>
-        const int scrx = divide_round_down( ( colrow.x - 1 ) * tile_width, 2 ) + op.x;
-        // top = ( row - 1 ) * ( tw / 4.0 ) - th + tw / 2.0 + op.y =>
-        // (shifted so that sprites with default height end at the basic height
-        // of `tile_width / 4`)
-        const int scry = divide_round_down( ( colrow.y + 1 ) * tile_width, 4 ) - tile_height + op.y;
-        return { scrx, scry };
+        return {
+            // left = ( col - 1 ) * ( tw / 2.0 ) + op.x =>
+            divide_round_down( ( colrow.x - 1 ) * tile_width, 2 ) + op.x,
+            // top = ( row - 1 ) * ( tw / 4.0 ) - th + tw / 2.0 + op.y =>
+            // (shifted so that sprites with default height end at the basic height
+            // of `tile_width / 4`)
+            divide_round_down( ( colrow.y + 1 ) * tile_width, 4 ) - tile_height + op.y,
+        };
     } else {
-        const int scrx = colrow.x * tile_width + op.x;
-        const int scry = colrow.y * tile_height + op.y;
-        return { scrx, scry };
+        return {
+            colrow.x *tile_width + op.x,
+            colrow.y *tile_height + op.y,
+        };
     }
 }
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -502,6 +502,7 @@ class cata_tiles
         /** Drawing Layers */
         bool would_apply_vision_effects( visibility_type visibility ) const;
         bool apply_vision_effects( const tripoint &pos, visibility_type visibility );
+        void draw_square_below( const point &p, const nc_color &col, const int sizefactor );
         bool draw_terrain( const tripoint &p, lit_level ll, int &height_3d,
                            const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_terrain_below( const tripoint &p, lit_level ll, int &height_3d,
@@ -658,7 +659,9 @@ class cata_tiles
             return tile_ratioy;
         }
         void do_tile_loading_report();
-        point player_to_screen( const point & ) const;
+        std::optional<point> tile_to_player( const point &colrow ) const;
+        point player_to_tile( const point &pos ) const;
+        point player_to_screen( const point &pos ) const;
         static std::vector<options_manager::id_and_option> build_renderer_list();
         static std::vector<options_manager::id_and_option> build_display_list();
     private:
@@ -699,8 +702,7 @@ class cata_tiles
         int tile_height = 0;
         int tile_width = 0;
         int zlevel_height = 0;
-        // The width and height of the area we can draw in,
-        // measured in map coordinates, *not* in pixels.
+        // The number of visible tiles in a row or column
         int screentile_width = 0;
         int screentile_height = 0;
         float tile_ratiox = 0.0f;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -503,35 +503,35 @@ class cata_tiles
         bool would_apply_vision_effects( visibility_type visibility ) const;
         bool apply_vision_effects( const tripoint &pos, visibility_type visibility );
         bool draw_terrain( const tripoint &p, lit_level ll, int &height_3d,
-                           const std::array<bool, 5> &invisible );
+                           const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_terrain_below( const tripoint &p, lit_level ll, int &height_3d,
-                                 const std::array<bool, 5> &invisible );
+                                 const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_furniture( const tripoint &p, lit_level ll, int &height_3d,
-                             const std::array<bool, 5> &invisible );
+                             const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_graffiti( const tripoint &p, lit_level ll, int &height_3d,
-                            const std::array<bool, 5> &invisible );
+                            const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_trap( const tripoint &p, lit_level ll, int &height_3d,
-                        const std::array<bool, 5> &invisible );
+                        const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_part_con( const tripoint &p, lit_level ll, int &height_3d,
-                            const std::array<bool, 5> &invisible );
+                            const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_field_or_item( const tripoint &p, lit_level ll, int &height_3d,
-                                 const std::array<bool, 5> &invisible );
+                                 const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
-                         const std::array<bool, 5> &invisible, bool roof );
+                         const std::array<bool, 5> &invisible, bool roof, const bool memorize_only );
         bool draw_vpart_no_roof( const tripoint &p, lit_level ll, int &height_3d,
-                                 const std::array<bool, 5> &invisible );
+                                 const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_vpart_roof( const tripoint &p, lit_level ll, int &height_3d,
-                              const std::array<bool, 5> &invisible );
+                              const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_vpart_below( const tripoint &p, lit_level ll, int &height_3d,
-                               const std::array<bool, 5> &invisible );
+                               const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_critter_at( const tripoint &p, lit_level ll, int &height_3d,
-                              const std::array<bool, 5> &invisible );
+                              const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_critter_at_below( const tripoint &p, lit_level ll, int &height_3d,
-                                    const std::array<bool, 5> &invisible );
+                                    const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d,
-                             const std::array<bool, 5> &invisible );
+                             const std::array<bool, 5> &invisible, const bool memorize_only );
         bool draw_zombie_revival_indicators( const tripoint &pos, lit_level ll, int &height_3d,
-                                             const std::array<bool, 5> &invisible );
+                                             const std::array<bool, 5> &invisible, const bool memorize_only );
         void draw_zlevel_overlay( const tripoint &p, lit_level ll, int &height_3d );
         void draw_entity_with_overlays( const Character &ch, const tripoint &p, lit_level ll,
                                         int &height_3d );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -521,37 +521,37 @@ class cata_tiles
         /** Drawing Layers */
         bool would_apply_vision_effects( visibility_type visibility ) const;
         bool apply_vision_effects( const tripoint &pos, visibility_type visibility, int &height_3d );
-        void draw_square_below( const point &p, const nc_color &col, const int sizefactor );
+        void draw_square_below( const point &p, const nc_color &col, int sizefactor );
         bool draw_terrain( const tripoint &p, lit_level ll, int &height_3d,
-                           const std::array<bool, 5> &invisible, const bool memorize_only );
+                           const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_terrain_below( const tripoint &p, lit_level ll, int &height_3d,
-                                 const std::array<bool, 5> &invisible, const bool memorize_only );
+                                 const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_furniture( const tripoint &p, lit_level ll, int &height_3d,
-                             const std::array<bool, 5> &invisible, const bool memorize_only );
+                             const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_graffiti( const tripoint &p, lit_level ll, int &height_3d,
-                            const std::array<bool, 5> &invisible, const bool memorize_only );
+                            const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_trap( const tripoint &p, lit_level ll, int &height_3d,
-                        const std::array<bool, 5> &invisible, const bool memorize_only );
+                        const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_part_con( const tripoint &p, lit_level ll, int &height_3d,
-                            const std::array<bool, 5> &invisible, const bool memorize_only );
+                            const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_field_or_item( const tripoint &p, lit_level ll, int &height_3d,
-                                 const std::array<bool, 5> &invisible, const bool memorize_only );
+                                 const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
-                         const std::array<bool, 5> &invisible, bool roof, const bool memorize_only );
+                         const std::array<bool, 5> &invisible, bool roof, bool memorize_only );
         bool draw_vpart_no_roof( const tripoint &p, lit_level ll, int &height_3d,
-                                 const std::array<bool, 5> &invisible, const bool memorize_only );
+                                 const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_vpart_roof( const tripoint &p, lit_level ll, int &height_3d,
-                              const std::array<bool, 5> &invisible, const bool memorize_only );
+                              const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_vpart_below( const tripoint &p, lit_level ll, int &height_3d,
-                               const std::array<bool, 5> &invisible, const bool memorize_only );
+                               const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_critter_at( const tripoint &p, lit_level ll, int &height_3d,
-                              const std::array<bool, 5> &invisible, const bool memorize_only );
+                              const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_critter_at_below( const tripoint &p, lit_level ll, int &height_3d,
-                                    const std::array<bool, 5> &invisible, const bool memorize_only );
+                                    const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d,
-                             const std::array<bool, 5> &invisible, const bool memorize_only );
+                             const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_zombie_revival_indicators( const tripoint &pos, lit_level ll, int &height_3d,
-                                             const std::array<bool, 5> &invisible, const bool memorize_only );
+                                             const std::array<bool, 5> &invisible, bool memorize_only );
         void draw_zlevel_overlay( const tripoint &p, lit_level ll, int &height_3d );
         void draw_entity_with_overlays( const Character &ch, const tripoint &p, lit_level ll,
                                         int &height_3d );
@@ -671,7 +671,7 @@ class cata_tiles
         int get_tile_width() const {
             return tile_width;
         }
-        const half_open_rectangle<point> get_max_tile_extent() const {
+        half_open_rectangle<point> get_max_tile_extent() const {
             return max_tile_extent;
         }
         void do_tile_loading_report();

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -501,7 +501,7 @@ class cata_tiles
 
         /** Drawing Layers */
         bool would_apply_vision_effects( visibility_type visibility ) const;
-        bool apply_vision_effects( const tripoint &pos, visibility_type visibility );
+        bool apply_vision_effects( const tripoint &pos, visibility_type visibility, int &height_3d );
         void draw_square_below( const point &p, const nc_color &col, const int sizefactor );
         bool draw_terrain( const tripoint &p, lit_level ll, int &height_3d,
                            const std::array<bool, 5> &invisible, const bool memorize_only );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -409,9 +409,15 @@ class cata_tiles
         void draw_minimap( const point &dest, const tripoint &center, int width, int height );
 
     protected:
-        /** How many rows and columns of tiles fit into given dimensions, fully or partially shown **/
+        /** How many rows and columns of tiles fit into given dimensions, fully
+         ** or partially shown, but disregarding any extra contents outside the
+         ** basic x range of [0, tile_width) and the basic y range of
+         ** [0, tile_width / 2) (isometric) or [0, tile_height) (non-isometric) **/
         point get_window_tile_counts( const point &size ) const;
-        /** How many rows and columns of tiles can be fully shown in the given dimensions **/
+        /** How many rows and columns of tiles can be fully shown in the given
+         ** dimensions, disregarding any extra contents outside the basic x
+         ** range of [0, tile_width] and the basic y range of [0, tile_width / 2)
+         ** (isometric) or [0, tile_height) (non-isometric) **/
         point get_window_full_tile_counts( const point &size ) const;
 
         std::optional<tile_lookup_res> find_tile_with_season( const std::string &id ) const;
@@ -699,6 +705,10 @@ class cata_tiles
         tileset_cache &cache;
         std::shared_ptr<const tileset> tileset_ptr;
 
+        // the scaled default sprite width and height. in non-isometric mode,
+        // the basic tile width and height equal the default sprite width and
+        // height, but in isometric mode, the basic tile height is always
+        // `tile_width / 2`, and `tile_height` is only the default sprite height.
         int tile_height = 0;
         int tile_width = 0;
         int zlevel_height = 0;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -422,11 +422,12 @@ class cata_tiles
          ** basic x range of [0, tile_width) and the basic y range of
          ** [0, tile_width / 2) (isometric) or [0, tile_height) (non-isometric) **/
         point get_window_base_tile_counts( const point &size ) const;
-        /** Coordinate range of tiles that fit into the given dimensions, fully
-         ** or partially shown, according to the maximum tile extent. May be
-         ** negative, and 0 corresponds to the first fully or partially shown
-         ** base tile as defined by get_window_base_tile_counts. **/
-        half_open_rectangle<point> get_window_any_tile_range( const point &size ) const;
+        /** Coordinate range of tiles at the given relative z-level that fit
+         ** into the given dimensions, fully or partially shown, according to
+         ** the maximum tile extent. May be negative, and 0 corresponds to the
+         ** first fully or partially shown base tile at relative z of 0 as
+         ** defined by `get_window_base_tile_counts`. **/
+        half_open_rectangle<point> get_window_any_tile_range( const point &size, int z ) const;
         /** Coordinate range of fully shown tiles that fit into the given
          ** dimensions, disregarding any extra contents outside the basic x
          ** range of [0, tile_width] and the basic y range of [0, tile_width / 2)

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -537,7 +537,7 @@ class cata_tiles
         void draw_entity_with_overlays( const Character &ch, const tripoint &p, lit_level ll,
                                         int &height_3d );
 
-        bool draw_item_highlight( const tripoint &pos );
+        bool draw_item_highlight( const tripoint &pos, int &height_3d );
 
     public:
         // Animation layers

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6505,7 +6505,11 @@ visibility_type map::get_visibility( const lit_level ll,
             return visibility_type::CLEAR;
         case lit_level::BLANK:
         case lit_level::MEMORIZED:
-            return visibility_type::HIDDEN;
+            if( cache.u_is_boomered ) {
+                return visibility_type::BOOMER_DARK;
+            } else {
+                return visibility_type::HIDDEN;
+            }
     }
     return visibility_type::HIDDEN;
 }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -852,9 +852,8 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     const point full_s = get_window_full_tile_counts( point( width, height ) );
 
     op = point( dest.x * fontwidth, dest.y * fontheight );
-    // Rounding up to include incomplete tiles at the bottom/right edges
-    screentile_width = divide_round_up( width, tile_width );
-    screentile_height = divide_round_up( height, tile_height );
+    screentile_width = s.x;
+    screentile_height = s.y;
 
     const int min_col = 0;
     const int max_col = s.x;
@@ -1069,14 +1068,11 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     if( !viewing_weather && uistate.overmap_show_city_labels ) {
 
         const auto abs_sm_to_draw_label = [&]( const tripoint_abs_sm & city_pos, const int label_length ) {
-            const tripoint tile_draw_pos = global_omt_to_draw_position( project_to<coords::omt>
-                                           ( city_pos ) ) - o;
-            point draw_point( tile_draw_pos.x * tile_width + dest.x,
-                              tile_draw_pos.y * tile_height + dest.y );
+            const point omt_pos = global_omt_to_draw_position( project_to<coords::omt>( city_pos ) ).xy();
+            const point draw_point = player_to_screen( omt_pos );
             // center text on the tile
-            draw_point += point( ( tile_width - label_length * fontwidth ) / 2,
-                                 ( tile_height - fontheight ) / 2 );
-            return draw_point;
+            return draw_point + point( ( tile_width - label_length * fontwidth ) / 2,
+                                       ( tile_height - fontheight ) / 2 );
         };
 
         // draws a black rectangle behind a label for visibility and legibility
@@ -1154,10 +1150,8 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         // Find screen coordinates to the right of the center tile
         auto center_sm = project_to<coords::sm>( tripoint_abs_omt( center_abs_omt.x() + 1,
                          center_abs_omt.y(), center_abs_omt.z() ) );
-        const tripoint tile_draw_pos = global_omt_to_draw_position( project_to<coords::omt>
-                                       ( center_sm ) ) - o;
-        point draw_point( tile_draw_pos.x * tile_width + dest.x,
-                          tile_draw_pos.y * tile_height + dest.y );
+        const point omt_pos = global_omt_to_draw_position( project_to<coords::omt>( center_sm ) ).xy();
+        point draw_point = player_to_screen( omt_pos );
         draw_point += point( padding, padding );
 
         // Draw notes header. Very simple label at the moment

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -848,26 +848,29 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         geometry->rect( renderer, clipRect, SDL_Color() );
     }
 
-    const point s = get_window_tile_counts( point( width, height ) );
-    const point full_s = get_window_full_tile_counts( point( width, height ) );
+    const point s = get_window_base_tile_counts( { width, height } );
+    const half_open_rectangle<point> full_base_range = get_window_full_base_tile_range( { width, height } );
 
     op = point( dest.x * fontwidth, dest.y * fontheight );
     screentile_width = s.x;
     screentile_height = s.y;
 
-    const int min_col = 0;
-    const int max_col = s.x;
-    const int min_row = 0;
-    const int max_row = s.y;
+    const half_open_rectangle<point> any_tile_range = get_window_any_tile_range( { width, height } );
+    const int min_col = any_tile_range.p_min.x;
+    const int max_col = any_tile_range.p_max.x;
+    const int min_row = any_tile_range.p_min.y;
+    const int max_row = any_tile_range.p_max.y;
     int height_3d = 0;
     avatar &you = get_avatar();
     const tripoint_abs_omt avatar_pos = you.global_omt_location();
-    const tripoint_abs_omt corner_NW = center_abs_omt - point( max_col / 2, max_row / 2 );
-    const tripoint_abs_omt corner_SE = corner_NW + point( max_col - 1, max_row - 1 );
+    const tripoint_abs_omt origin = center_abs_omt - point( s.x / 2, s.y / 2 );
+    const tripoint_abs_omt corner_NW = origin + any_tile_range.p_min;
+    const tripoint_abs_omt corner_SE = origin + any_tile_range.p_max + point_north_west;
     const inclusive_cuboid<tripoint> overmap_area( corner_NW.raw(), corner_SE.raw() );
     // Area of fully shown tiles
-    const tripoint_abs_omt full_corner_SE = corner_NW + full_s + point_north_west;
-    const inclusive_cuboid<tripoint> full_om_tile_area( corner_NW.raw(), full_corner_SE.raw() );
+    const tripoint_abs_omt full_corner_NW = origin + full_base_range.p_min;
+    const tripoint_abs_omt full_corner_SE = origin + full_base_range.p_max + point_north_west;
+    const inclusive_cuboid<tripoint> full_om_tile_area( full_corner_NW.raw(), full_corner_SE.raw() );
     // Debug vision allows seeing everything
     const bool has_debug_vision = you.has_trait( trait_DEBUG_NIGHTVISION );
     // sight_points is hoisted for speed reasons.
@@ -876,7 +879,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                              100;
     const bool showhordes = uistate.overmap_show_hordes;
     const bool viewing_weather = uistate.overmap_debug_weather || uistate.overmap_visible_weather;
-    o = corner_NW.raw().xy();
+    o = origin.raw().xy();
 
     const auto global_omt_to_draw_position = []( const tripoint_abs_omt & omp ) {
         // z position is hardcoded to 0 because the things this will be used to draw should not be skipped
@@ -885,7 +888,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
     for( int row = min_row; row < max_row; row++ ) {
         for( int col = min_col; col < max_col; col++ ) {
-            const tripoint_abs_omt omp = corner_NW + point( col, row );
+            const tripoint_abs_omt omp = origin + point( col, row );
 
             const bool see = overmap_buffer.seen( omp );
             const bool los = see && you.overmap_los( omp, sight_points );
@@ -1088,7 +1091,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
         // the tiles on the overmap are overmap tiles, so we need to use
         // coordinate conversions to make sure we're in the right place.
-        const int radius = project_to<coords::sm>( tripoint_abs_omt( std::min( max_col, max_row ),
+        const int radius = project_to<coords::sm>( tripoint_abs_omt( std::max( s.x, s.y ),
                            0, 0 ) ).x() / 2;
 
         for( const city_reference &city : overmap_buffer.get_cities_near(

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -855,7 +855,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     screentile_width = s.x;
     screentile_height = s.y;
 
-    const half_open_rectangle<point> any_tile_range = get_window_any_tile_range( { width, height } );
+    const half_open_rectangle<point> any_tile_range = get_window_any_tile_range( { width, height }, 0 );
     const int min_col = any_tile_range.p_min.x;
     const int max_col = any_tile_range.p_max.x;
     const int min_row = any_tile_range.p_min.y;


### PR DESCRIPTION
#### Summary
Bugfixes "Tile rendering fixes"

#### Purpose of change
Fix several issues I noticed about tile rendering. Each commit is explained below.

1. The code was drawing off-screen tiles when memorizing them after all on-screen tiles are drawn, which caused incorrect order of large sprites.
2. Fixing 1 revealed that the drawing range for on-screen tiles was incorrect, so sometimes the last row of sprites in isometric mode were drawn by the memorizing code rather than the main drawing loop, which lacks some of the main drawing loop's layers.
3. Item highlight were drawn without 3d height in isometric mode, so highlights in other z-levels were drawn in the current z-level.
4. Vision effects (the `lighting_xxx` sprites) were drawn along with terrain in the same tile before the 3d vision change, but drawn before all terrain sprites after the 3d vision range, which made the sprites have wrong occlusion orders (which only becomes apparent if you make the `lighting_xxx` sprites have extra height.)
4.1. The code was using the `hidden` sprite for unseen and unmemorized tiles, but `dark` for tiles outside maximum vision range, which caused inconsistent appearance of unseen tiles.
5. The game was using the `hidden` sprite for unseen tiles when boomered, but the `boomered_dark` sprite for tiles outside maximum vision range, which was inconsistent.
6. The code was iterating from the lowest z-level even if the maximum 3d depth is low.
7. Some map memory was not loaded when looking at faraway tiles in the west in isometric mode (i.e. towards the bottom left of screen).
8. None
9. You could not see the upper body of a hulk if its lower body is off-screen, a.k.a. the code did not consider the maximum sprite extent when determining the range of tiles to draw.
10. None
11. None
12. Some top tiles in lower levels are not drawn in isometric mode.

#### Describe the solution
1. Memorize off-screen tiles without actually drawing. This should also improve drawing speed a bit.
2. Unify the mapping between player and screen coordinates into functions and fix errors.
3. Add 3d height to item highlights.
4. Store information required to draw the vision effects and draw them along with terrain in the actual drawing loop.
4.1 See 5 below.
5. Use `hidden` for tiles outisde maximum vision range, and `boomered_dark` for unseen tiles when boomered.
6. Pre-calculate the minimum z-level before the main drawing loop.
7. Calculate the rectangular region containing the on-screen tiles and load map memory from the region, using the unified coordinate mapping code.
8. None.
9. Calculate the maximum sprite extent when loading a tileset, and use this extent to calculate the maximum range of tiles that can possibly be on-screen.
10. None
11. None
12. Calculate range of on-screen tiles for respective z-levels.

#### Describe alternatives you've considered


#### Testing
All changes worked. Tested multiple tilesets in isometric and non-isometric mode and the tiles were correctly drawn.

Also tested framerate benchmarks before and after these changes on three tilesets in a steel mill. The changes improved drawing speed a little bit for the isometric mode, especially when drawing a single level, whereas the speed of non-isometric mode seems unaffected overall apart from some random fluctuations.

| scenario | ultica-iso | ultica | smashbutton-iso |
| -- | -- | -- | -- |
| ground level (1) | 34.435 -> 38.508 | 43.339 -> 43.660 | 33.094 -> 35.786 |
| (2) | 34.283 -> 39.466 | 43.574 -> 42.854 | 33.247 -> 36.356 |
| 3 levels (1) | 24.990 -> 25.304 | 38.177 -> 36.342 | 19.124 -> 20.800 |
| (2) | 25.000 -> 25.289 | 37.725 -> 36.941 | 18.474 -> 20.639 |
| 3 levels & 4x zoom out (1) | 9.408 ->  9.539 | 12.537 -> 12.168 | 6.853 ->  7.671 |
| (2) | 9.198 -> 9.856 | 12.460 -> 12.166 | 6.989 -> 7.571 |

#### Additional context