### PR TITLE
armor penetration gets used up like damage

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8843,6 +8843,8 @@ void item::mitigate_damage( damage_unit &du, const bodypart_id &bp, int roll ) c
 {
     const resistances res = resistances( *this, false, roll, bp );
     const float mitigation = res.get_effective_resist( du );
+    // get_effective_resist subtracts the flat penetration value before multiplying the remaining armor.
+    // therefore, res_pen is reduced by the full value of the item's armor value even though mitigation might be smaller (such as an attack with a 0.5 armor multiplier)
     du.res_pen -= res.type_resist( du.type );
     du.res_pen = std::max( 0.0f, du.res_pen );
     du.amount -= mitigation;
@@ -8853,6 +8855,8 @@ void item::mitigate_damage( damage_unit &du, const sub_bodypart_id &bp, int roll
 {
     const resistances res = resistances( *this, false, roll, bp );
     const float mitigation = res.get_effective_resist( du );
+    // get_effective_resist subtracts the flat penetration value before multiplying the remaining armor.
+    // therefore, res_pen is reduced by the full value of the item's armor value even though mitigation might be smaller (such as an attack with a 0.5 armor multiplier)
     du.res_pen -= res.type_resist( du.type );
     du.res_pen = std::max( 0.0f, du.res_pen );
     du.amount -= mitigation;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8843,6 +8843,8 @@ void item::mitigate_damage( damage_unit &du, const bodypart_id &bp, int roll ) c
 {
     const resistances res = resistances( *this, false, roll, bp );
     const float mitigation = res.get_effective_resist( du );
+    du.res_pen -= res.type_resist( du.type );
+    du.res_pen = std::max( 0.0f, du.res_pen );
     du.amount -= mitigation;
     du.amount = std::max( 0.0f, du.amount );
 }
@@ -8851,6 +8853,8 @@ void item::mitigate_damage( damage_unit &du, const sub_bodypart_id &bp, int roll
 {
     const resistances res = resistances( *this, false, roll, bp );
     const float mitigation = res.get_effective_resist( du );
+    du.res_pen -= res.type_resist( du.type );
+    du.res_pen = std::max( 0.0f, du.res_pen );
     du.amount -= mitigation;
     du.amount = std::max( 0.0f, du.amount );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "flat armor penetration is spread across all armor layers instead of applying its full value to each"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Partially address #65173
Armor penetration is broken, both because it has absurdly high values and also because it renders single armor layers useless (you could wear 20 individual hypothetical 1mm kevlar shirts and still take full damage from a 5.56 nato round, which has 6 armor penetration, but if you had a single 8mm thick kevlar shirt, it would stop the bullet almost entirely)

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Armor penetration is "used up" by the amount it penetrated a single armor layer. If there is a flat armor penetration in addition to a multiplier armor penetration, the actual defense code always applies flat before multiplier, so the same thing is true here (even if the attack has 0.5x armor mult, a 10-armor armor will always reduce the total flat penetration in the attack for the next layer by 10)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I have not thought of any.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled and tested using a special Giant Wasp (mon_wasp) which had its normal attack reduced to 1 damage and its special attacks changed to always do 10 damage instead of a variable amount and wore increasingly large numbers of phelloderms to test its damage. The bite has 20 pen and does cut damage, and the sting has 25 and does stab damage. Phelloderm has 3 cut and 2.4 stab protection.
- At 6 or fewer phelloderms, I took full damage from each attack (10)
- At 7 phelloderms I have 21 cut and 16.8 stab prot. The bite did 9 damage and the sting did 10 damage.
- At 8 phelloderms, I have 24 cut and 19.2 stab prot. The bite did 6 damage and the sting did 10 damage.
- At 9 phelloderms, I have 27 cut and 21.6 stab prot. The bite did 3 damage and the sting did 10 damage.
- At 10 phelloderms, I have 30 cut and 24 stab prot. The bite did 0 damage and the sting did 10 damage.
- At 11 phelloderms, I have 33 cut and 26.4 stab prot. The bite did 0 damage and sting did 9.
- At 13 phelloderms, I have 39 cut and 31.2 stab prot. The bite did 0 damage and the sting did 3.
- At 14 phelloderms, I have 42 cut and 33.6 stab prot. The bite did 0 damage and the sting did 1.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->