### PR TITLE
reign in horse milk yield

### DIFF
--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2040,7 +2040,7 @@
     "material": [ "flesh" ],
     "symbol": "H",
     "color": "brown",
-    "starting_ammo": { "milk_raw": 20 },
+    "starting_ammo": { "milk_raw": 4 },
     "morale": 20,
     "aggro_character": false,
     "melee_skill": 6,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
#66639 was a bit optimistic about milk yield from horses, this reigns it in. 

#### Describe the solution
Drop production to a litre a day.

#### Describe alternatives you've considered
This is still about 4x too high as mares don't produce without a goal which means something like 3 months of production a year. 
Mares also produce a very different milk than cows,  so ideally this would be a different milk.

#### Additional context
https://www.npr.org/sections/thesalt/2018/07/12/627454097/mares-milk-for-health-europeans-look-to-horses-for-ancient-remedy
After some searching I was able to find a source for yield instead of raw production, which indicates about a litre per day. 
