### PR TITLE
Half leggings

### DIFF
--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -732,6 +732,449 @@
     "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
+    "id": "lc_chainmail_half_legs",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "mild steel chainmail half-leggings", "str_pl": "pairs of mild steel chainmail half-leggings" },
+    "description": "Customized mild steel partial chainmail leggings only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "weight": "3159 g",
+    "volume": "1125 ml",
+    "price": 5625,
+    "price_postapoc": 1500,
+    "to_hit": -1,
+    "material": [ "lc_steel_chain" ],
+    "symbol": "[",
+    "looks_like": "legguard_hard",
+    "color": "light_red",
+    "flags": [ "VARSIZE", "STURDY", "OUTER" ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "3300 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1500,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_LEGS" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "900 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1000,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
+      }
+    ],
+    "armor": [
+      {
+        "material": [ { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 75,
+        "encumbrance": 11
+      }
+    ]
+  },
+  {
+    "id": "xl_lc_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "lc_chainmail_half_legs",
+    "name": { "str": "XL mild steel chainmail half-leggings", "str_pl": "pairs of XL mild steel chainmail half-leggings" },
+    "description": "Customized mild steel partial chainmail leggings for the largest of transhumans only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "3800 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1500,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_LEGS" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "1050 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1000,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
+      }
+    ],
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_lc_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "lc_chainmail_half_legs",
+    "name": { "str": "XS mild steel chainmail half-leggings", "str_pl": "pairs of XS mild steel chainmail half-leggings" },
+    "description": "Customized mild steel partial chainmail leggings for the smallest of transhumans only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "2500 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1500,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_LEGS" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1000,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
+      }
+    ],
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "mc_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "lc_chainmail_half_legs",
+    "material": [ "mc_steel_chain" ],
+    "name": { "str": "medium steel chainmail half-leggings", "str_pl": "pairs of medium steel chainmail half-leggings" },
+    "description": "Customized medium steel partial chainmail leggings only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "armor": [
+      {
+        "material": [ { "type": "mc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 75,
+        "encumbrance": 11
+      }
+    ]
+  },
+  {
+    "id": "xl_mc_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "mc_chainmail_half_legs",
+    "name": { "str": "XL medium steel chainmail half-leggings", "str_pl": "pairs of XL medium steel chainmail half-leggings" },
+    "description": "Customized medium steel partial chainmail leggings for the largest of transhumans only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "3800 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1500,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_LEGS" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "1050 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1000,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
+      }
+    ],
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_mc_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "mc_chainmail_half_legs",
+    "name": { "str": "XS medium steel chainmail half-leggings", "str_pl": "pairs of XS medium steel chainmail half-leggings" },
+    "description": "Customized medium steel partial chainmail leggings for the smallest of transhumans only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "2500 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1500,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_LEGS" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1000,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
+      }
+    ],
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "hc_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "lc_chainmail_half_legs",
+    "material": [ "hc_steel_chain" ],
+    "name": { "str": "high steel chainmail half-leggings", "str_pl": "pairs of high steel chainmail half-leggings" },
+    "description": "Customized high steel partial chainmail leggings only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "armor": [
+      {
+        "material": [ { "type": "hc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 75,
+        "encumbrance": 11
+      }
+    ]
+  },
+  {
+    "id": "xl_hc_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "hc_chainmail_half_legs",
+    "name": { "str": "XL high steel chainmail half-leggings", "str_pl": "pairs of XL high steel chainmail half-leggings" },
+    "description": "Customized high steel partial chainmail leggings for the largest of transhumans only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "3800 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1500,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_LEGS" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "1050 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1000,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
+      }
+    ],
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_hc_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "hc_chainmail_half_legs",
+    "name": { "str": "XS high steel chainmail half-leggings", "str_pl": "pairs of XS high steel chainmail half-leggings" },
+    "description": "Customized high steel partial chainmail leggings for the smallest of transhumans only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "2500 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1500,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_LEGS" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1000,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
+      }
+    ],
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "ch_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "lc_chainmail_half_legs",
+    "material": [ "ch_steel_chain" ],
+    "name": { "str": "hardened steel chainmail half-leggings", "str_pl": "pairs of hardened steel chainmail half-leggings" },
+    "description": "Customized hardened steel partial chainmail leggings only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "armor": [
+      {
+        "material": [ { "type": "ch_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 75,
+        "encumbrance": 11
+      }
+    ]
+  },
+  {
+    "id": "xl_ch_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "ch_chainmail_half_legs",
+    "name": { "str": "XL hardened steel chainmail half-leggings", "str_pl": "pairs of XL hardened steel chainmail half-leggings" },
+    "description": "Customized hardened steel partial chainmail leggings for the largest of transhumans only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "3800 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1500,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_LEGS" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "1050 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1000,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
+      }
+    ],
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_ch_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "ch_chainmail_half_legs",
+    "name": { "str": "XS hardened steel chainmail half-leggings", "str_pl": "pairs of XS hardened steel chainmail half-leggings" },
+    "description": "Customized hardened steel partial chainmail leggings for the smallest of transhumans only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "2500 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1500,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_LEGS" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1000,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
+      }
+    ],
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
+    "id": "qt_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "lc_chainmail_half_legs",
+    "material": [ "qt_steel_chain" ],
+    "name": { "str": "tempered steel chainmail half-leggings", "str_pl": "pairs of tempered steel chainmail half-leggings" },
+    "description": "Customized tempered steel partial chainmail leggings only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "armor": [
+      {
+        "material": [ { "type": "qt_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 75,
+        "encumbrance": 11
+      }
+    ]
+  },
+  {
+    "id": "xl_qt_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "qt_chainmail_half_legs",
+    "name": { "str": "XL tempered steel chainmail half-leggings", "str_pl": "pairs of XL tempered steel chainmail half-leggings" },
+    "description": "Customized tempered steel partial chainmail leggings for the largest of transhumans only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "3800 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1500,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_LEGS" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "1050 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1000,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
+      }
+    ],
+    "extend": { "flags": [ "OVERSIZE" ] }
+  },
+  {
+    "id": "xs_qt_chainmail_half_legs",
+    "type": "ARMOR",
+    "copy-from": "qt_chainmail_half_legs",
+    "name": { "str": "XS tempered steel chainmail half-leggings", "str_pl": "pairs of XS tempered steel chainmail half-leggings" },
+    "description": "Customized tempered steel partial chainmail leggings for the smallest of transhumans only covering the front and sides of the legs.  The zigzaging lace at the back keeps everything in place, and the lack of toes and heels allows them to work perfectly well with footwear.",
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "2500 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1500,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_LEGS" ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "volume_encumber_modifier": 0,
+        "ablative": true,
+        "max_contains_volume": "700 ml",
+        "max_contains_weight": "20 kg",
+        "max_item_length": "65 cm",
+        "moves": 1000,
+        "description": "You can wear some armor over chainmail without penalty.",
+        "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
+      }
+    ],
+    "extend": { "flags": [ "UNDERSIZE" ] }
+  },
+  {
     "id": "leggings_thessalonian",
     "type": "ARMOR",
     "category": "armor",

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -1411,7 +1411,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "fabrication",
     "difficulty": 7,
-    "time": "4 h",
+    "time": "3 h",
     "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
     "using": [ [ "armor_lc_chainmail_assembling", 3 ], [ "strap_small", 5 ], [ "clasps", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_chain_armour" } ]
@@ -1420,14 +1420,14 @@
     "result": "xs_lc_chainmail_half_legs",
     "type": "recipe",
     "copy-from": "lc_chainmail_half_legs",
-    "time": "4 h",
+    "time": "3 h",
     "using": [ [ "armor_lc_chainmail_assembling", 3 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
   },
   {
     "result": "xl_lc_chainmail_half_legs",
     "type": "recipe",
     "copy-from": "lc_chainmail_half_legs",
-    "time": "4 h 30 m",
+    "time": "3 h 23 m",
     "using": [ [ "armor_lc_chainmail_assembling", 5 ], [ "strap_small", 5 ], [ "clasps", 3 ] ]
   },
   {
@@ -1438,7 +1438,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "fabrication",
     "difficulty": 7,
-    "time": "4 h",
+    "time": "3 h",
     "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
     "using": [ [ "armor_mc_chainmail_assembling", 3 ], [ "strap_small", 5 ], [ "clasps", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_chain_armour" } ]
@@ -1447,14 +1447,14 @@
     "result": "xs_mc_chainmail_half_legs",
     "type": "recipe",
     "copy-from": "mc_chainmail_half_legs",
-    "time": "4 h",
+    "time": "3 h",
     "using": [ [ "armor_mc_chainmail_assembling", 3 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
   },
   {
     "result": "xl_mc_chainmail_half_legs",
     "type": "recipe",
     "copy-from": "mc_chainmail_half_legs",
-    "time": "4 h 30 m",
+    "time": "3 h 23 m",
     "using": [ [ "armor_mc_chainmail_assembling", 5 ], [ "strap_small", 5 ], [ "clasps", 3 ] ]
   },
   {
@@ -1465,7 +1465,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "fabrication",
     "difficulty": 7,
-    "time": "4 h",
+    "time": "3 h",
     "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
     "using": [ [ "armor_hc_chainmail_assembling", 3 ], [ "strap_small", 5 ], [ "clasps", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_chain_armour" } ]
@@ -1474,14 +1474,14 @@
     "result": "xs_hc_chainmail_half_legs",
     "type": "recipe",
     "copy-from": "hc_chainmail_half_legs",
-    "time": "4 h",
+    "time": "3 h",
     "using": [ [ "armor_hc_chainmail_assembling", 3 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
   },
   {
     "result": "xl_hc_chainmail_half_legs",
     "type": "recipe",
     "copy-from": "hc_chainmail_half_legs",
-    "time": "4 h 30 m",
+    "time": "3 h 23 m",
     "using": [ [ "armor_hc_chainmail_assembling", 5 ], [ "strap_small", 5 ], [ "clasps", 3 ] ]
   },
   {
@@ -1492,7 +1492,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "fabrication",
     "difficulty": 7,
-    "time": "4 h",
+    "time": "3 h",
     "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
     "using": [ [ "armor_ch_chainmail_assembling", 3 ], [ "strap_small", 5 ], [ "clasps", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_chain_armour" } ]
@@ -1501,14 +1501,14 @@
     "result": "xs_ch_chainmail_half_legs",
     "type": "recipe",
     "copy-from": "ch_chainmail_half_legs",
-    "time": "4 h",
+    "time": "3 h",
     "using": [ [ "armor_ch_chainmail_assembling", 3 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
   },
   {
     "result": "xl_ch_chainmail_half_legs",
     "type": "recipe",
     "copy-from": "ch_chainmail_half_legs",
-    "time": "4 h 30 m",
+    "time": "3 h 23 m",
     "using": [ [ "armor_ch_chainmail_assembling", 5 ], [ "strap_small", 5 ], [ "clasps", 3 ] ]
   },
   {
@@ -1519,7 +1519,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "fabrication",
     "difficulty": 7,
-    "time": "4 h",
+    "time": "3 h",
     "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
     "using": [ [ "armor_qt_chainmail_assembling", 3 ], [ "strap_small", 5 ], [ "clasps", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_chain_armour" } ]
@@ -1528,14 +1528,14 @@
     "result": "xs_qt_chainmail_half_legs",
     "type": "recipe",
     "copy-from": "qt_chainmail_half_legs",
-    "time": "4 h",
+    "time": "3 h",
     "using": [ [ "armor_qt_chainmail_assembling", 3 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
   },
   {
     "result": "xl_qt_chainmail_half_legs",
     "type": "recipe",
     "copy-from": "qt_chainmail_half_legs",
-    "time": "4 h 30 m",
+    "time": "3 h 23 m",
     "using": [ [ "armor_qt_chainmail_assembling", 5 ], [ "strap_small", 5 ], [ "clasps", 3 ] ]
   },
   {

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -1404,6 +1404,141 @@
     "using": [ [ "armor_qt_chainmail_assembling", 6 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
+    "result": "lc_chainmail_half_legs",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "time": "4 h",
+    "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
+    "using": [ [ "armor_lc_chainmail_assembling", 3 ], [ "strap_small", 5 ], [ "clasps", 3 ] ],
+    "proficiencies": [ { "proficiency": "prof_chain_armour" } ]
+  },
+  {
+    "result": "xs_lc_chainmail_half_legs",
+    "type": "recipe",
+    "copy-from": "lc_chainmail_half_legs",
+    "time": "4 h",
+    "using": [ [ "armor_lc_chainmail_assembling", 3 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
+  },
+  {
+    "result": "xl_lc_chainmail_half_legs",
+    "type": "recipe",
+    "copy-from": "lc_chainmail_half_legs",
+    "time": "4 h 30 m",
+    "using": [ [ "armor_lc_chainmail_assembling", 5 ], [ "strap_small", 5 ], [ "clasps", 3 ] ]
+  },
+  {
+    "result": "mc_chainmail_half_legs",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "time": "4 h",
+    "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
+    "using": [ [ "armor_mc_chainmail_assembling", 3 ], [ "strap_small", 5 ], [ "clasps", 3 ] ],
+    "proficiencies": [ { "proficiency": "prof_chain_armour" } ]
+  },
+  {
+    "result": "xs_mc_chainmail_half_legs",
+    "type": "recipe",
+    "copy-from": "mc_chainmail_half_legs",
+    "time": "4 h",
+    "using": [ [ "armor_mc_chainmail_assembling", 3 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
+  },
+  {
+    "result": "xl_mc_chainmail_half_legs",
+    "type": "recipe",
+    "copy-from": "mc_chainmail_half_legs",
+    "time": "4 h 30 m",
+    "using": [ [ "armor_mc_chainmail_assembling", 5 ], [ "strap_small", 5 ], [ "clasps", 3 ] ]
+  },
+  {
+    "result": "hc_chainmail_half_legs",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "time": "4 h",
+    "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
+    "using": [ [ "armor_hc_chainmail_assembling", 3 ], [ "strap_small", 5 ], [ "clasps", 3 ] ],
+    "proficiencies": [ { "proficiency": "prof_chain_armour" } ]
+  },
+  {
+    "result": "xs_hc_chainmail_half_legs",
+    "type": "recipe",
+    "copy-from": "hc_chainmail_half_legs",
+    "time": "4 h",
+    "using": [ [ "armor_hc_chainmail_assembling", 3 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
+  },
+  {
+    "result": "xl_hc_chainmail_half_legs",
+    "type": "recipe",
+    "copy-from": "hc_chainmail_half_legs",
+    "time": "4 h 30 m",
+    "using": [ [ "armor_hc_chainmail_assembling", 5 ], [ "strap_small", 5 ], [ "clasps", 3 ] ]
+  },
+  {
+    "result": "ch_chainmail_half_legs",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "time": "4 h",
+    "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
+    "using": [ [ "armor_ch_chainmail_assembling", 3 ], [ "strap_small", 5 ], [ "clasps", 3 ] ],
+    "proficiencies": [ { "proficiency": "prof_chain_armour" } ]
+  },
+  {
+    "result": "xs_ch_chainmail_half_legs",
+    "type": "recipe",
+    "copy-from": "ch_chainmail_half_legs",
+    "time": "4 h",
+    "using": [ [ "armor_ch_chainmail_assembling", 3 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
+  },
+  {
+    "result": "xl_ch_chainmail_half_legs",
+    "type": "recipe",
+    "copy-from": "ch_chainmail_half_legs",
+    "time": "4 h 30 m",
+    "using": [ [ "armor_ch_chainmail_assembling", 5 ], [ "strap_small", 5 ], [ "clasps", 3 ] ]
+  },
+  {
+    "result": "qt_chainmail_half_legs",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 7,
+    "time": "4 h",
+    "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
+    "using": [ [ "armor_qt_chainmail_assembling", 3 ], [ "strap_small", 5 ], [ "clasps", 3 ] ],
+    "proficiencies": [ { "proficiency": "prof_chain_armour" } ]
+  },
+  {
+    "result": "xs_qt_chainmail_half_legs",
+    "type": "recipe",
+    "copy-from": "qt_chainmail_half_legs",
+    "time": "4 h",
+    "using": [ [ "armor_qt_chainmail_assembling", 3 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
+  },
+  {
+    "result": "xl_qt_chainmail_half_legs",
+    "type": "recipe",
+    "copy-from": "qt_chainmail_half_legs",
+    "time": "4 h 30 m",
+    "using": [ [ "armor_qt_chainmail_assembling", 5 ], [ "strap_small", 5 ], [ "clasps", 3 ] ]
+  },
+  {
     "result": "legguard_bronze",
     "type": "recipe",
     "activity_level": "BRISK_EXERCISE",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -3478,6 +3478,84 @@
     "difficulty": 7
   },
   {
+    "id": "nested_lc_chainmail_half_legs",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "name": "mild steel chain half-legs",
+    "description": "Recipes related to constructing various sizes of partial chainmail leggings.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "lc_chainmail_half_legs", "xs_lc_chainmail_half_legs", "xl_lc_chainmail_half_legs" ],
+    "difficulty": 1
+  },
+  {
+    "id": "nested_mc_chainmail_half_legs",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "name": "medium steel chain half-legs",
+    "description": "Recipes related to constructing various sizes of partial chainmail leggings.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "mc_chainmail_half_legs", "xs_mc_chainmail_half_legs", "xl_mc_chainmail_half_legs" ],
+    "difficulty": 2
+  },
+  {
+    "id": "nested_hc_chainmail_half_legs",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "name": "high steel chain half-legs",
+    "description": "Recipes related to constructing various sizes of partial chainmail leggings.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "hc_chainmail_half_legs", "xs_hc_chainmail_half_legs", "xl_hc_chainmail_half_legs" ],
+    "difficulty": 3
+  },
+  {
+    "id": "nested_ch_chainmail_half_legs",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "name": "hardened steel chain half-legs",
+    "description": "Recipes related to constructing various sizes of partial chainmail leggings.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "ch_chainmail_half_legs", "xs_ch_chainmail_half_legs", "xl_ch_chainmail_half_legs" ],
+    "difficulty": 4
+  },
+  {
+    "id": "nested_qt_chainmail_half_legs",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "name": "tempered steel chain half-legs",
+    "description": "Recipes related to constructing various sizes of partial chainmail leggings.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "qt_chainmail_half_legs", "xs_qt_chainmail_half_legs", "xl_qt_chainmail_half_legs" ],
+    "difficulty": 5
+  },
+  {
+    "id": "nested_all_chainmail_half_legs",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_LEGS",
+    "name": "steel chain half-legs",
+    "description": "Recipes related to constructing various sizes and types of partial chainmail leggings.",
+    "skill_used": "fabrication",
+    "nested_category_data": [
+      "nested_lc_chainmail_half_legs",
+      "nested_mc_chainmail_half_legs",
+      "nested_hc_chainmail_half_legs",
+      "nested_ch_chainmail_half_legs",
+      "nested_qt_chainmail_half_legs"
+    ],
+    "difficulty": 7
+  },
+  {
     "id": "nested_boots_fsurvivor",
     "type": "nested_category",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Added a lighter, less costly but less protective alternative to chainmail leggings"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adding a new chainmail armor type for legs along with XS/XL versions and all 5 grades, as well as adding them to new nested groups.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added the items, recipes and nested groups for these new armor pieces. Reduced weight, price, coverage and crafting times, bumped up the strap component requirement to simulate the very long lace required to make it all tight and cozy.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Not adding them.
- First tried adding chausses, realized our chausses were closer to chainmail socks than the chausses that inspired me to add this, decided to redo the PR to make partial leggings instead, as this made more sense than adding chainmail socks without a back.
- Choosing other weight/coverage values instead of settling on overall removing 25% on most values from the full leggings.
- Considered making a new, larger nested group they would occupy together with the groups for the normal leggings, but didn't feel confident enough to not mess it up.
- I do not know if there is a specific sublimb to point out that this would not cover the back of your leg at all, but if there is, please point it out to me.
- Did not fiddle with the full leggings' ablative pockets at all, if somebody who knows more than me about them has any issues with that, I'd be glad to accept criticism and suggestions to fix them.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned the items in game, checked their values, used the recipes, checked that the nested groups were working correctly, all should be getting along swimmingly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This manga page was what mainly prompted me to add the half-chausses, But since our chausses are not historical chausses, I ended up making half-leggings in the end, which I think is the closest thing to this style of armor I could add.
![inspiration](https://github.com/CleverRaven/Cataclysm-DDA/assets/16321433/b4c02984-3186-4656-a1d6-e82b774ec173)
Ironskin (an online merchant site for chainmail armor) also seems to agree that such partial armor with the back exposed did exist historically.
This closes my #66589 Half-Chausses draft.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->