### PR TITLE
Riverside boats

### DIFF
--- a/data/json/mapgen/map_extras/riverside_boats.json
+++ b/data/json/mapgen/map_extras/riverside_boats.json
@@ -1,0 +1,154 @@
+{
+  "type": "mapgen",
+  "method": "json",
+  "update_mapgen_id": "mx_riverside_boat",
+  "object": {
+    "place_nested": [
+      { "chunks": [ "riverside_boat" ], "neighbors": { "west": [ "river_n" ], "east": [ "river_n" ] }, "x": 0, "y": 0 },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_n" ], "east": [ "river_e" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_n" ], "east": [ "river_s" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_n" ], "east": [ "river_w" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_n" ], "east": [ "river_c_" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_e" ], "east": [ "river_e" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_e" ], "east": [ "river_s" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_e" ], "east": [ "river_w" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_e" ], "east": [ "river_n" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_e" ], "east": [ "river_c_" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_s" ], "east": [ "river_s" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_s" ], "east": [ "river_w" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_s" ], "east": [ "river_n" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_s" ], "east": [ "river_e" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_s" ], "east": [ "river_c_" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_w" ], "east": [ "river_w" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_w" ], "east": [ "river_n" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_w" ], "east": [ "river_e" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_w" ], "east": [ "river_s" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_w" ], "east": [ "river_c_" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_c_" ], "east": [ "river_c_" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_c_" ], "east": [ "river_n" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_c_" ], "east": [ "river_e" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_c_" ], "east": [ "river_s" ] },
+        "x": 0,
+        "y": 0
+      },
+      {
+        "chunks": [ "riverside_boat" ],
+        "neighbors": { "west": [ "river_c_" ], "east": [ "river_w" ] },
+        "x": 0,
+        "y": 0
+      }
+    ]
+  }
+}

--- a/data/json/mapgen/nested/riverside_boats_nested.json
+++ b/data/json/mapgen/nested/riverside_boats_nested.json
@@ -1,0 +1,11 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "riverside_boat",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "place_vehicles": [ { "vehicle": "boats_shore", "x": 12, "y": 1, "chance": 100, "rotation": 90, "status": -1 } ]
+    }
+  }
+]

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -584,6 +584,15 @@
     "min_max_zlevel": [ 0, 0 ]
   },
   {
+    "id": "mx_riverside_boat",
+    "type": "map_extra",
+    "name": { "str": "Boat" },
+    "description": "A small boat.",
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_riverside_boat" },
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "MAN_MADE" ]
+  },
+  {
     "id": "mx_toxic_waste",
     "type": "map_extra",
     "name": { "str": "Toxic waste" },

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -828,7 +828,7 @@
           "mx_casings": 30
         }
       },
-      "river": { "chance": 3, "extras": { "mx_reed": 100 } },
+      "river": { "chance": 1, "extras": { "mx_null": 66, "mx_riverside_boat": 1, "mx_reed": 33 } },
       "lake_shore": { "chance": 2, "extras": { "mx_reed": 100 } },
       "sewer": { "chance": 80, "extras": { "mx_null": 100 } },
       "agricultural": {

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -106,6 +106,12 @@
   },
   {
     "type": "vehicle_group",
+    "id": "boats_shore",
+    "//": "boats that locals might leave dragged up on a river / lake shore",
+    "vehicles": [ [ "canoe", 2 ], [ "kayak", 2 ], [ "wood_rowboat_double", 6 ] ]
+  },
+  {
+    "type": "vehicle_group",
     "id": "trains_and_cars",
     "vehicles": [ [ "train_car_passenger", 250 ], [ "train_electrical_loco1300", 500 ] ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add boats to river banks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add boats to riverbanks. Condition varies, with some of the boats still being in regular use, and others having been abandoned there for a long time.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Place boats on river banks as map extras using nests to control what kinds of riverbank tiles boats can spawn on.

This has some downsides: riverbank overmap terrains are hardcoded. There are n/e/s/w rotations and then same for inner and outer corners. These hardcoded variations can't be targeted on regional settings level. Because of that, nested mapgen is used to make sure boats only spawn on straight riverbank segments (tile has riverbank neighbors on both sides). Allowing spawning on all riverbank tiles would result in them showing up in inner and outer riverbank corners off to the water in weird rotations, instead of spawning on the actual bank.

One downside of this approach is that we can't enable autonotes for the boats, because the actual placement on an eligible tile is determined by nested mapgen within the map extra mapgen. If river bank terrains get unhardcoded in the future, and I've been told they will likely be, I will update the mapgen to get proper mapnotes.

If lack of autonotes kills this, let me know and I'll happily re-draft this until river mapgen is unharcoded.

Every river bank tile has 1/100 chance of being considered for boat placement. This is still constrained by the nested mapgen rules, so for example inner and outer corners will never spawn a boat. Actual odds will therefore depend on river wriggliness. I can increase the odds if this feels tuned too low.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Have boats potentially spawn on all riverbank tiles, including the corners where they end up in some unexpected rotation off to the water, but I considered that too wonky looking.

Stuff I left out on purpose to keep scope minimal: making boats spawn together with reeds, adding more/better boat types, boats on lakes, more piers.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Run around as a debug character to expose a lot of shoreline, observe boats being present.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Example of how often boats spawn with the current odds. Both sides of the.river were scouted. Every red circle is a boat:
![boat_likelihood](https://github.com/CleverRaven/Cataclysm-DDA/assets/2456481/cdc593a0-484a-4c68-817a-ccf77abaa3a8)

I has a boat
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/2456481/6f965771-5835-4fe8-a690-1bf598f95cfd)

🤘 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->