### PR TITLE
Fix: show slowed message on slow terrain

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10357,7 +10357,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
                                 dest_loc ); //fungal furniture has no slowing effect on Mycus characters
     const bool slowed = ( ( !u.has_proficiency( proficiency_prof_parkour ) && ( mcost_to > 2 ||
                             mcost_from > 2 ) ) ||
-                          mcost_to > 4 || mcost_from > 4 ) &&
+                          mcost_to > 4 || mcost_from > 4 ) ||
                         ( !u.has_trait( trait_M_IMMUNE ) && fungus );
     if( slowed && !u.is_mounted() ) {
         // Unless u.pos() has a higher movecost than dest_loc, state that dest_loc is the cause


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Someone brought up that the "slow terrain" message was no longer displaying when walking over slow terrain. #66582 tried to fix a logic bug, but in the process made it so that the slow terrain message is only displayed when walking over fungal terrain.

#### Describe the solution
Instead of checking for "slow terrain AND fungal terrain", check for "slow terrain OR fungal terrain".

#### Describe alternatives you've considered

#### Testing

#### Additional context
