### PR TITLE
Move reverse-jointed legs to mod files

### DIFF
--- a/data/json/items/robot_parts.json
+++ b/data/json/items/robot_parts.json
@@ -100,20 +100,6 @@
   },
   {
     "type": "GENERIC",
-    "id": "reverse_jointed_legs",
-    "name": { "str": "set of reverse-jointed legs", "str_pl": "sets of reverse-jointed legs" },
-    "description": "A set of reverse-jointed legs, like the ones found under a chicken walker.",
-    "symbol": "k",
-    "color": "light_gray",
-    "weight": "60000 g",
-    "volume": "20 L",
-    "price": 500000,
-    "price_postapoc": 250,
-    "material": [ "steel" ],
-    "category": "spare_parts"
-  },
-  {
-    "type": "GENERIC",
     "id": "omni_wheel",
     "name": { "str": "set of omni wheels", "str_pl": "sets of omni wheels" },
     "description": "A set of omni wheels, like the ones found under a police bot.",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -1991,17 +1991,6 @@
     "components": [ [ [ "motor_micro", 16 ] ], [ [ "power_supply", 8 ] ], [ [ "cable", 16 ] ], [ [ "scrap", 14 ] ] ]
   },
   {
-    "result": "reverse_jointed_legs",
-    "type": "uncraft",
-    "activity_level": "MODERATE_EXERCISE",
-    "skill_used": "mechanics",
-    "difficulty": 4,
-    "time": "6 h 40 m",
-    "using": [ [ "soldering_standard", 5 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "motor_tiny", 6 ] ], [ [ "power_supply", 6 ] ], [ [ "cable", 12 ] ], [ [ "steel_chunk", 6 ] ] ]
-  },
-  {
     "result": "omni_wheel",
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",

--- a/data/mods/Aftershock/items/robotparts.json
+++ b/data/mods/Aftershock/items/robotparts.json
@@ -137,5 +137,19 @@
     "material": [ "steel" ],
     "category": "spare_parts",
     "color": "red_green"
+  },
+  {
+    "type": "GENERIC",
+    "id": "reverse_jointed_legs",
+    "name": { "str": "set of reverse-jointed legs", "str_pl": "sets of reverse-jointed legs" },
+    "description": "A set of reverse-jointed legs, like the ones found under a chicken walker.",
+    "symbol": "k",
+    "color": "light_gray",
+    "weight": "60000 g",
+    "volume": "20 L",
+    "price": 500000,
+    "price_postapoc": 250,
+    "material": [ "steel" ],
+    "category": "spare_parts"
   }
 ]

--- a/data/mods/Aftershock/recipes/uncraft.json
+++ b/data/mods/Aftershock/recipes/uncraft.json
@@ -486,5 +486,16 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "5x50_hull", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder_rifle", 30 ] ] ]
+  },
+  {
+    "result": "reverse_jointed_legs",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "skill_used": "mechanics",
+    "difficulty": 4,
+    "time": "6 h 40 m",
+    "using": [ [ "soldering_standard", 5 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "motor_tiny", 6 ] ], [ [ "power_supply", 6 ] ], [ [ "cable", 12 ] ], [ [ "steel_chunk", 6 ] ] ]
   }
 ]

--- a/data/mods/No_Hope/items.json
+++ b/data/mods/No_Hope/items.json
@@ -263,5 +263,19 @@
     "name": { "str": "broken laser turret" },
     "weight": "110 kg",
     "copy-from": "broken_turret"
+  },
+  {
+    "type": "GENERIC",
+    "id": "reverse_jointed_legs",
+    "name": { "str": "set of reverse-jointed legs", "str_pl": "sets of reverse-jointed legs" },
+    "description": "A set of reverse-jointed legs, like the ones found under a chicken walker.",
+    "symbol": "k",
+    "color": "light_gray",
+    "weight": "60000 g",
+    "volume": "20 L",
+    "price": 500000,
+    "price_postapoc": 250,
+    "material": [ "steel" ],
+    "category": "spare_parts"
   }
 ]

--- a/data/mods/No_Hope/recipes.json
+++ b/data/mods/No_Hope/recipes.json
@@ -39,5 +39,16 @@
       [ [ "robot_controls", 1 ] ],
       [ [ "turret_chassis", 1 ] ]
     ]
+  },
+  {
+    "result": "reverse_jointed_legs",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "skill_used": "mechanics",
+    "difficulty": 4,
+    "time": "6 h 40 m",
+    "using": [ [ "soldering_standard", 5 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "motor_tiny", 6 ] ], [ [ "power_supply", 6 ] ], [ [ "cable", 12 ] ], [ [ "steel_chunk", 6 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Reverse-jointed legs were an artifact of times when chicken walkers existed. Unused in basegame, they only were used by Aftershock and No Hope.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Moved them from basegame to mod files. Since they haven't been used in basegame for ages, I didn't bother with obsoletion.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->