### PR TITLE
bugfixes for armor bionics

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -59,10 +59,10 @@
     "description": "An advanced protective meshwork has been woven into the flesh on your arms and hands, protecting them from physical trauma.",
     "occupied_bodyparts": [ [ "arm_l", 4 ], [ "arm_r", 4 ], [ "hand_l", 1 ], [ "hand_r", 1 ] ],
     "protec": [
-      [ "arm_l", { "bash": 3, "cut": 3, "bullet": 3 } ],
-      [ "arm_r", { "bash": 3, "cut": 3, "bullet": 3 } ],
-      [ "hand_l", { "bash": 3, "cut": 3, "bullet": 3 } ],
-      [ "hand_r", { "bash": 3, "cut": 3, "bullet": 3 } ]
+      [ "arm_l", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ],
+      [ "arm_r", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ],
+      [ "hand_l", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ],
+      [ "hand_r", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ]
     ],
     "encumbrance": [ [ "arm_l", 1 ], [ "arm_r", 1 ], [ "hand_l", 1 ], [ "hand_r", 1 ] ],
     "//": "cant_remove_reason removed for now as these are presently functionally obsolete and characters should be able to remove them to get with the times.",
@@ -153,7 +153,16 @@
       "FAT",
       "SLIME_SPRAY",
       "MUCUS_SECRETION",
-      "MUCUS_SECRETION2"
+      "MUCUS_SECRETION2",
+      "SKIN_SMOOTH",
+      "SKIN_RASHY",
+      "CHITIN_MOLTED",
+      "CHITIN2_MOLTED",
+      "CHITIN3_MOLTED",
+      "CRUSTACEAN_CARAPACE_MOLTED",
+      "SPARSE_SCALES",
+      "GOOSEBUMPS",
+      "SKIN_PEELING"
     ]
   },
   {
@@ -172,7 +181,7 @@
     "name": { "str": "Head Alloy Plating" },
     "description": "An advanced protective meshwork has been woven into the flesh on your head and jaw region, protecting your skull from physical trauma.",
     "occupied_bodyparts": [ [ "head", 3 ], [ "mouth", 1 ] ],
-    "protec": [ [ "head", { "bash": 3, "cut": 3, "bullet": 3 } ], [ "mouth", { "bash": 3, "cut": 3, "bullet": 3 } ] ],
+    "protec": [ [ "head", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ], [ "mouth", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ] ],
     "encumbrance": [ [ "head", 1 ] ],
     "//": "cant_remove_reason removed for now as these are presently functionally obsolete and characters should be able to remove them to get with the times.",
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ],
@@ -277,7 +286,16 @@
       "SLIME_SPRAY",
       "MUCUS_SECRETION",
       "MUCUS_SECRETION2",
-      "WIDE_MOUTH"
+      "WIDE_MOUTH",
+      "SKIN_SMOOTH",
+      "SKIN_RASHY",
+      "CHITIN_MOLTED",
+      "CHITIN2_MOLTED",
+      "CHITIN3_MOLTED",
+      "CRUSTACEAN_CARAPACE_MOLTED",
+      "SPARSE_SCALES",
+      "GOOSEBUMPS",
+      "SKIN_PEELING"
     ]
   },
   {
@@ -287,10 +305,10 @@
     "description": "An advanced protective meshwork has been woven into the flesh on your legs and feet, protecting them from physical trauma.",
     "occupied_bodyparts": [ [ "leg_l", 6 ], [ "leg_r", 6 ], [ "foot_l", 1 ], [ "foot_r", 1 ] ],
     "protec": [
-      [ "leg_l", { "bash": 3, "cut": 3, "bullet": 3 } ],
-      [ "leg_r", { "bash": 3, "cut": 3, "bullet": 3 } ],
-      [ "foot_l", { "bash": 3, "cut": 3, "bullet": 3 } ],
-      [ "foot_r", { "bash": 3, "cut": 3, "bullet": 3 } ]
+      [ "leg_l", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ],
+      [ "leg_r", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ],
+      [ "foot_l", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ],
+      [ "foot_r", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ]
     ],
     "encumbrance": [ [ "leg_l", 1 ], [ "leg_r", 1 ], [ "foot_l", 1 ], [ "foot_r", 1 ] ],
     "//": "cant_remove_reason removed for now as these are presently functionally obsolete and characters should be able to remove them to get with the times.",
@@ -376,7 +394,16 @@
       "GASTROPOD_FOOT",
       "GASTROPOD_BALANCE",
       "MUCUS_SECRETION",
-      "MUCUS_SECRETION2"
+      "MUCUS_SECRETION2",
+      "SKIN_SMOOTH",
+      "SKIN_RASHY",
+      "CHITIN_MOLTED",
+      "CHITIN2_MOLTED",
+      "CHITIN3_MOLTED",
+      "CRUSTACEAN_CARAPACE_MOLTED",
+      "SPARSE_SCALES",
+      "GOOSEBUMPS",
+      "SKIN_PEELING"
     ]
   },
   {
@@ -385,7 +412,7 @@
     "name": { "str": "Torso Alloy Plating" },
     "description": "An advanced protective meshwork has been woven into the flesh on your torso, protecting it from physical trauma.",
     "occupied_bodyparts": [ [ "torso", 10 ] ],
-    "protec": [ [ "torso", { "bash": 3, "cut": 3, "bullet": 3 } ] ],
+    "protec": [ [ "torso", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ] ],
     "encumbrance": [ [ "torso", 1 ] ],
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ],
     "//": "cant_remove_reason removed for now as these are presently functionally obsolete and characters should be able to remove them to get with the times.",
@@ -461,7 +488,16 @@
       "SLIME_SPRAY",
       "INSECT_RESERVOIR",
       "MUCUS_SECRETION",
-      "MUCUS_SECRETION2"
+      "MUCUS_SECRETION2",
+      "SKIN_SMOOTH",
+      "SKIN_RASHY",
+      "CHITIN_MOLTED",
+      "CHITIN2_MOLTED",
+      "CHITIN3_MOLTED",
+      "CRUSTACEAN_CARAPACE_MOLTED",
+      "SPARSE_SCALES",
+      "GOOSEBUMPS",
+      "SKIN_PEELING"
     ]
   },
   {
@@ -554,17 +590,17 @@
     ],
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ],
     "protec": [
-      [ "torso", { "bash": 2, "cut": 4, "bullet": 4 } ],
-      [ "head", { "bash": 2, "cut": 4, "bullet": 4 } ],
-      [ "mouth", { "bash": 2, "cut": 4, "bullet": 4 } ],
-      [ "arm_l", { "bash": 2, "cut": 4, "bullet": 4 } ],
-      [ "arm_r", { "bash": 2, "cut": 4, "bullet": 4 } ],
-      [ "leg_l", { "bash": 2, "cut": 4, "bullet": 4 } ],
-      [ "leg_r", { "bash": 2, "cut": 4, "bullet": 4 } ],
-      [ "foot_l", { "bash": 2, "cut": 4, "bullet": 4 } ],
-      [ "foot_r", { "bash": 2, "cut": 4, "bullet": 4 } ],
-      [ "hand_l", { "bash": 2, "cut": 4, "bullet": 4 } ],
-      [ "hand_r", { "bash": 2, "cut": 4, "bullet": 4 } ]
+      [ "torso", { "bash": 2, "cut": 4, "bullet": 4, "stab": 4 } ],
+      [ "head", { "bash": 2, "cut": 4, "bullet": 4, "stab": 4 } ],
+      [ "mouth", { "bash": 2, "cut": 4, "bullet": 4, "stab": 4 } ],
+      [ "arm_l", { "bash": 2, "cut": 4, "bullet": 4, "stab": 4 } ],
+      [ "arm_r", { "bash": 2, "cut": 4, "bullet": 4, "stab": 4 } ],
+      [ "leg_l", { "bash": 2, "cut": 4, "bullet": 4, "stab": 4 } ],
+      [ "leg_r", { "bash": 2, "cut": 4, "bullet": 4, "stab": 4 } ],
+      [ "foot_l", { "bash": 2, "cut": 4, "bullet": 4, "stab": 4 } ],
+      [ "foot_r", { "bash": 2, "cut": 4, "bullet": 4, "stab": 4 } ],
+      [ "hand_l", { "bash": 2, "cut": 4, "bullet": 4, "stab": 4 } ],
+      [ "hand_r", { "bash": 2, "cut": 4, "bullet": 4, "stab": 4 } ]
     ]
   },
   {

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -161,7 +161,6 @@
       "CHITIN3_MOLTED",
       "CRUSTACEAN_CARAPACE_MOLTED",
       "SPARSE_SCALES",
-      "GOOSEBUMPS",
       "SKIN_PEELING"
     ]
   },
@@ -297,7 +296,6 @@
       "CHITIN3_MOLTED",
       "CRUSTACEAN_CARAPACE_MOLTED",
       "SPARSE_SCALES",
-      "GOOSEBUMPS",
       "SKIN_PEELING"
     ]
   },
@@ -405,7 +403,6 @@
       "CHITIN3_MOLTED",
       "CRUSTACEAN_CARAPACE_MOLTED",
       "SPARSE_SCALES",
-      "GOOSEBUMPS",
       "SKIN_PEELING"
     ]
   },
@@ -499,7 +496,6 @@
       "CHITIN3_MOLTED",
       "CRUSTACEAN_CARAPACE_MOLTED",
       "SPARSE_SCALES",
-      "GOOSEBUMPS",
       "SKIN_PEELING"
     ]
   },

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -181,7 +181,10 @@
     "name": { "str": "Head Alloy Plating" },
     "description": "An advanced protective meshwork has been woven into the flesh on your head and jaw region, protecting your skull from physical trauma.",
     "occupied_bodyparts": [ [ "head", 3 ], [ "mouth", 1 ] ],
-    "protec": [ [ "head", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ], [ "mouth", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ] ],
+    "protec": [
+      [ "head", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ],
+      [ "mouth", { "bash": 3, "cut": 3, "bullet": 3, "stab": 3 } ]
+    ],
     "encumbrance": [ [ "head", 1 ] ],
     "//": "cant_remove_reason removed for now as these are presently functionally obsolete and characters should be able to remove them to get with the times.",
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "armor bionics conflict with new mutations and protect against stab damage"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #66688
Armor bionics didn't protect against stabbing damage and didn't conflict with some new mutations such as molted chitin.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add conflicts and stab protection.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Do less than 3 stab protection since it's usually 80% of cut. I think I can only do integers for those though (unsure).
I'm not super fond of the way alloy cbms currently conflict with mutations, since having alloy plating on one part of your body prevents changes to the rest of your body due to hardcoded annoying reasons. It could just not conflict with stuff except for like tentacle arms or being a gelatinous slime. These cbms are a little problematic in general, but I just want to maintain parity with the status quo, decisions can be made to overhaul them later.
I think the subdermal carbon filament CBM is overpowered. It should either have encumbrance or not give bash protection. That's a separate issue though.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->