### PR TITLE
Buffed range of .22LR rifles

### DIFF
--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -7,6 +7,7 @@
     "name": { "str": ".22 caliber submachine gun" },
     "description": "A dramatically uncommon automatic weapon, making use of high-capacity pan magazines and firing the low power .22 calibre cartridge: an unusual ammunition choice for a submachine gun.  With negligible recoil on account of its modest cartridge and a suppressively high rate of fire, a burst of .22 LR rounds from this little machine gun can be best likened with a swarm of hornets… an incredibly angry swarm of hornets.",
     "variant_type": "gun",
+    "range": 7,
     "variants": [
       {
         "id": "american_180",
@@ -60,6 +61,7 @@
     "name": { "str": "small game rifle" },
     "description": "A venerable .22 caliber lever-action rifle, with a 19-round tube magazine and a classic design that dates back over a century.  Generally used for the hunting of small game like rabbits, the strict taxonomic classification of zombies as 'small game' is debatable, but this decades-old weapon can still be counted upon to help manage the undead population.",
     "variant_type": "gun",
+    "range": 11,
     "variants": [
       {
         "id": "marlin_9a",
@@ -205,6 +207,7 @@
     "name": { "str": "varmint rifle" },
     "description": "A lightweight and modular pistol caliber hunting carbine, firing the low power .22 LR cartridge.  Before the Cataclysm, a mix of high customizability, cheep ammunition, and low recoil made this a very popular varmint rifle amongst civilian shooters.",
     "variant_type": "gun",
+    "range": 11,
     "variants": [
       {
         "id": "ruger_1022",


### PR DESCRIPTION
Added some extra range to the varmint rifle, small game rifle and the American180


#### Summary

Balance "Buffed range of .22LR rifles"

#### Purpose of change

The two .22LR rifles were hardly usable for anything in my eyes.
Here is a table with the values of 3 weapons. Once with effective range in real life and once with the range in fields in the game.

Wepon_________RL_____Fields
M16___________550m____36
Varmint rifle_____175m____13
CompoundBow___60m____18
Describe the solution

I have given the  .22LR rifles a range bonus.
In my opinion, the rifles should have a better place in the game.

Wepon_________RL_____Fields
M16___________550m____36
Varmint rifle_____175m____“24”
CompoundBow___60m____18


#### Describe the solution

Buffed range of .22LR rifles


#### Describe alternatives you've considered

None


#### Testing

Made a character
Gave him the small game hunting rifle
Tested the shoot distance
Works fine


#### Additional context

None
