### PR TITLE
Added cord to electric blankets

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -3547,14 +3547,23 @@
     "environmental_protection": 2,
     "charges_per_use": 1,
     "ammo": "battery",
-    "use_action": {
-      "type": "transform",
-      "msg": "You turn the blanket's heating elements on.",
-      "target": "electric_blanket_on",
-      "active": true,
-      "need_charges": 1,
-      "need_charges_msg": "The blanket's batteries are dead."
-    },
+    "use_action": [
+      {
+        "type": "transform",
+        "msg": "You turn the blanket's heating elements on.",
+        "target": "electric_blanket_on",
+        "active": true,
+        "need_charges": 1,
+        "need_charges_msg": "The blanket's batteries are dead."
+      },
+      {
+        "type": "link_up",
+        "menu_text": "Plug in / Unplug",
+        "ammo_scale": 0,
+        "cable_length": 3,
+        "charge_rate": "110 W"
+      }
+    ],
     "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "WATER_BREAK" ],
     "pocket_data": [
       {
@@ -3581,12 +3590,21 @@
     "warmth": 90,
     "power_draw": "100 W",
     "revert_to": "electric_blanket",
-    "use_action": {
-      "ammo_scale": 0,
-      "type": "transform",
-      "msg": "You turn the blanket's heating elements off.",
-      "target": "electric_blanket"
-    }
+    "use_action": [
+      {
+        "ammo_scale": 0,
+        "type": "transform",
+        "msg": "You turn the blanket's heating elements off.",
+        "target": "electric_blanket"
+      },
+      {
+        "type": "link_up",
+        "menu_text": "Plug in / Unplug",
+        "ammo_scale": 0,
+        "cable_length": 3,
+        "charge_rate": "110 W"
+      }
+    ]
   },
   {
     "id": "foodperson_mask",


### PR DESCRIPTION
#### Summary
Features "Electric Blanket Power Cords"

#### Purpose of change

You can plug electric blankets into the wall in real life. And it chews through batteries, so why not plug it in instead?
#### Describe the solution

Little copy pasta here, little json edit there, and there it is

#### Describe alternatives you've considered

Though I bet they exist, I've never seen a battery-operated electric blanket before. It just seems like a bad idea. Could make electric blankets ONLY plug-in-able, but I like preserving the flexibility for the sake of gameplay.

#### Testing

I plugged in a spawned in electric blanket. It turned on and drained my deployed car battery's power. I could wear it without unplugging. Mmm, warm.

#### Additional context

This one seemed like a no brainer. Guess I'd overlooked it until now because it's not in the tools section of the json.


