### PR TITLE
Make portal storm ending more apparent to the player

### DIFF
--- a/data/json/npcs/EOC_talkers/portal_storm.json
+++ b/data/json/npcs/EOC_talkers/portal_storm.json
@@ -89,7 +89,7 @@
     "responses": [
       { "text": "No ", "topic": "TALK_PORTAL_STORM_DO_FOR_ME" },
       {
-        "text": "Will it.",
+        "text": "Will it.  (This will end your game.  Do not choose this option if you wish to continue playing.)",
         "topic": "TALK_PORTAL_STORM_WILL_IT",
         "effect": { "give_achievement": "escaped_the_cataclysm" }
       },

--- a/data/json/npcs/EOC_talkers/portal_storm.json
+++ b/data/json/npcs/EOC_talkers/portal_storm.json
@@ -89,7 +89,7 @@
     "responses": [
       { "text": "No ", "topic": "TALK_PORTAL_STORM_DO_FOR_ME" },
       {
-        "text": "Will it.  (This will end your game.  Do not choose this option if you wish to continue playing.)",
+        "text": "Will it.  'Your gut feels like this is jumping out of a plane without a parachute.'",
         "topic": "TALK_PORTAL_STORM_WILL_IT",
         "effect": { "give_achievement": "escaped_the_cataclysm" }
       },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Some people were unaware that accepting the offer from the weird portal storm creature would end your game. 

#### Describe the solution

This PR adds a note to the dialogue option so the player knows what to expect when they choose it.

#### Describe alternatives you've considered

Maybe make it more apparent in the dialogue itself? 

#### Additional context

