### PR TITLE
Fix Central African flag description

### DIFF
--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -460,7 +460,7 @@
       {
         "id": "central_african_flag",
         "name": { "str": "Central African flag" },
-        "description": "A flag with vertical stripes of blue, white, green and yellow coloration and one horizontal red stripe down the middle with a star in the upper left corner.",
+        "description": "A flag with horizontal stripes of blue, white, green and yellow coloration and one vertical red stripe down the middle with a star in the upper left corner.",
         "weight": 10,
         "append": true
       },


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes typo in the description of the CAR flag"

#### Purpose of change

Made a couple of typos in the CAR flag description, I swapped vertical and horizontal by accident.

#### Describe the solution

Fixes the typos.

#### Describe alternatives you've considered

Not fixing the erroneous description.

#### Testing

Just a typo fix.

#### Additional context

Wasn't sure what category to put this under, bugfixing seemed closest.