### PR TITLE
Nerf lycra

### DIFF
--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -1329,7 +1329,7 @@
       { "fuel": 0.05, "smoke": 2, "burn": 0.03 },
       { "fuel": 0.15, "smoke": 5, "burn": 0.5 }
     ],
-    "resist": { "bash": 2, "cut": 2, "acid": 9, "heat": 2, "bullet": 2 },
+    "resist": { "bash": 1, "cut": 1, "acid": 9, "heat": 2, "bullet": 1 },
     "repair_difficulty": 3
   },
   {

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -161,7 +161,7 @@ TEST_CASE( "Infections_from_filthy_clothing", "[coverage]" )
 {
     SECTION( "Full melee and ranged coverage vs. melee attack" ) {
         const float chance = get_avg_melee_dmg( "test_zentai", true );
-        check_near( "Infection chance", chance, 0.42f, 0.05f );
+        check_near( "Infection chance", chance, 0.48f, 0.05f );
     }
 
     SECTION( "No melee coverage vs. melee attack" ) {

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1230,7 +1230,7 @@ static void expected_armor_values( const item &armor, float bash, float cut, flo
 
 TEST_CASE( "armor_stats", "[armor][protection]" )
 {
-    expected_armor_values( item( itype_zentai ), 0.2f, 0.2f, 0.16f, 0.2f );
+    expected_armor_values( item( itype_zentai ), 0.1f, 0.1f, 0.08f, 0.1f );
     expected_armor_values( item( itype_tshirt ), 0.1f, 0.1f, 0.08f, 0.1f );
     expected_armor_values( item( itype_dress_shirt ), 0.1f, 0.1f, 0.08f, 0.1f );
 }

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -411,7 +411,7 @@ TEST_CASE( "Damage_type_effectiveness_vs_monster_resistance", "[melee][damage]" 
 
     SECTION( "Attacking an NPC with no resistance to test_fire" ) {
         check_damage_from_test_fire( std::vector<std::string> { "test_zentai" },
-                                     body_part_torso, 0, false, 13.75f );
+                                     body_part_torso, 0, false, 14.84f );
     }
 
     SECTION( "Attacking an NPC that is resistant to test_fire" ) {
@@ -421,6 +421,6 @@ TEST_CASE( "Damage_type_effectiveness_vs_monster_resistance", "[melee][damage]" 
 
     SECTION( "Attacking an NPC that is immune to test_fire" ) {
         check_damage_from_test_fire( std::vector<std::string> { "test_zentai_immune_test_fire" },
-                                     body_part_torso, 0, true, 5.7f );
+                                     body_part_torso, 0, true, 6.87f );
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "lycra is less protective"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #66433
lycra had too much protection
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Lower to 1/1/1 like cotton. Acid prot unchanged.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Lower acid prot.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->