### PR TITLE
Document more fields for our monsters

### DIFF
--- a/doc/MONSTERS.md
+++ b/doc/MONSTERS.md
@@ -44,7 +44,7 @@ Property                 | Description
 `scents_ignored`         | (array of strings) Monster ignores these scents
 `material`               | (array of strings) Materials the monster is made of
 `phase`                  | (string) Monster's body matter state, ex. SOLID, LIQUID, GAS, PLASMA, NULL
-`attack_cost`            | (integer) Number of moves per regular attack (??)
+`attack_cost`            | (integer) Number of moves per regular attack. If not defined defaults to `100`.
 `diff`                   | (integer) Additional monster difficulty for special and ranged attacks
 `aggression`             | (integer) Starting aggression, the monster will become hostile when it reaches 10
 `morale`                 | (integer) Starting morale, monster will flee when (current aggression + current morale) < 0
@@ -60,6 +60,7 @@ Property                 | Description
 `armor`                  | (object) Monster's protection from different types of damage
 `weakpoints`             | (array of objects) Weakpoints in the monster's protection
 `weakpoint_sets`         | (array of strings) Weakpoint sets to apply to the monster
+`status_chance_multiplier`| (float) Multiplier to chance to apply zapped when electric damage is dealt (no other effects are implemented at this time)
 `families`               | (array of objects or strings) Weakpoint families that the monster belongs to
 `vision_day`             | (integer) Vision range in full daylight, with `50` being the typical maximum
 `vision_night`           | (integer) Vision range in total darkness, ex. coyote `5`, bear `10`, sewer rat `30`, flaming eye `40`
@@ -71,6 +72,7 @@ Property                 | Description
 `emit_field`             | (array of objects) What field the monster emits, and how frequently
 `regenerates`            | (integer) Number of hit points the monster regenerates per turn
 `regenerates_in_dark`    | (boolean) True if monster regenerates quickly in the dark
+`regeneration_modifiers` | (effect id, integer) When monster has this effect, modify regenerates by integer value (i.e. -5 reduces a regen value of 40hp/turn to 35hp/turn).
 `regen_morale`           | (bool) True if monster will stop fleeing at max HP to regenerate anger and morale
 `special_attacks`        | (array of objects) Special attacks the monster has
 `flags`                  | (array of strings) Any number of attributes like SEES, HEARS, SMELLS, STUMBLES, REVIVES
@@ -79,7 +81,11 @@ Property                 | Description
 `placate_triggers`       | (array of strings) Triggers that lower monster aggression (same flags as fear)
 `chat_topics`            | (array of strings) Conversation topics if dialog is opened with the monster
 `revert_to_itype`        | (string) Item monster can be converted to when friendly (ex. to deconstruct turrets)
+`mech_weapon`            | (string) If this monster is a rideable mech with built-in weapons, this is the weapons id
+`mech_str_bonus`         | (integer) If this monster is a rideable mech with enhanced strength, this is the strength it gives to the player when ridden
+`mech_battery`           | (string) If this monster is a rideable mech, this is battery's id. Does not support objects or arrays (i.e. ONE battery id only)
 `starting_ammo`          | (object) Ammo that newly spawned monsters start with
+`mount_items`            | (array of objects) Mount-specific items this monster spawns with. Accepts entries for `tied`, `tack`, `armor`, and `storage`.
 `upgrades`               | (boolean or object) False if monster does not upgrade, or an object do define an upgrade
 `reproduction`           | (object) The monster's reproductive cycle and timing
 `baby_flags`             | (array of strings) Seasons during which this monster is capable of reproduction
@@ -228,7 +234,7 @@ Value           | Description
 ## "attack_cost"
 (integer, optional)
 
-Number of moves per regular attack.
+Number of moves per regular attack. Higher values means the monster attacks less often (e.g. a monster with a speed of 100 and an attack_cost of 1000 attacks about once every 10 seconds).
 
 ## "diff"
 (integer, optional)


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Naughty contributors add json data but don't document their fields

#### Describe the solution
I went through monstergenerator.cpp and added anything that I didn't already find in the docs. Had to look up where some things were used but that wasn't too bad.

Cleaned up the explanation for attack_cost while I was in there since the current one wasn't very helpful.

#### Describe alternatives you've considered
Removing `status_chance_multiplier` because it's just a bit too long to fit in the column and nobody will miss it (it is currently unused)

#### Testing
Docs change only

#### Additional context
