### PR TITLE
Document even more missing fields, across a few more docs

### DIFF
--- a/doc/FACTIONS.md
+++ b/doc/FACTIONS.md
@@ -50,6 +50,7 @@ An NPC faction looks like this:
         "kill on sight": true
       }
     },
+	"epilogues": [ { "power_min": 0, "power_max": 149, "id": "epilogue_faction_your_followers_0" } ],
     "description": "A conglomeration of entrepreneurs and businessmen that stand together to hammer-out an existence through trade and industry."
   },
 ```
@@ -66,12 +67,14 @@ Field                 | Meaning
 `"size"`              | integer, an approximate count of the members of the faction.  Has no effect in play currently.
 `"power"`             | integer, an approximation of the faction's power.  Has no effect in play currently.
 `"food_supply"`       | integer, the number of calories available to the faction.  Has no effect in play currently.
-`"wealth"`            | integer, number of post-apocalyptic currency in cents that that faction has to purchase stuff.
+`"wealth"`            | integer, number of post-apocalyptic currency in cents that that faction has to purchase stuff. Serves as an upper limit on the amount of items restocked by a NPC of this faction with a defined shopkeeper_item_group (see NPCs.md)
 `"currency"`          | string, the item `"id"` of the faction's preferred currency.  Faction shopkeeps will trade faction current at 100% value, for both selling and buying.
 `"price_rules"`       | array, allows defining `premium`, `markup`, `price` and/or `fixed_adj` for an `item`/`category`/`group`.<br/><br/>`premium` is a price multiplier that applies to both sides.<br/> `markup` is only used when an NPC is selling to the avatar and defaults to `1`.<br/>`price` replaces the item's `price_postapoc`.<br/>`fixed_adj` is used instead of adjustment based on social skill and intelligence stat and can be used to define secondary currencies.<br/><br/>Lower entries override higher ones. For conditionals, the avatar is used as alpha and the evaluating npc as beta
 `"relations"`         | dictionary, a description of how the faction sees other factions.  See below
 `"mon_faction"`       | string, optional.  The monster faction `"name"` of the monster faction that this faction counts as.  Defaults to "human" if unspecified.
 `"lone_wolf_faction"` | bool, optional. This is a proto/micro faction template that is used to generate 1-person factions for dynamically spawned NPCs, defaults to "false" if unspecified.
+`"description"`       | string, optional. The player's description of this faction as seen in the faction menu.
+`"epilogues"`         | array of objects, optional. Requires these objects: `power_min` - minimal faction power for epilogue to appear, `power_max` - maximum faction power for epilogue to appear, `id` - id of text snippet containing text of epilogue.
 
 ## Scale of faction values
 Interacting with factions has certain effects on how the faction sees the player. These are reflected in values like `likes_u`, `respects_u` and `trusts_u`. Here's a (non-comprehensive) list to provide some context on how much these values are worth:

--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -27,6 +27,7 @@
   * [Spawn npcs with "place_npcs"](#spawn-npcs-with-place_npcs)
   * [Set variables with "place_variables"](#set-variables-with-place_variables)
   * [Spawn specific items with a "place_item" array](#spawn-specific-items-with-a-place_item-array)
+  * [Set the owner of items in a given area with "faction_owner"](#apply-faction-ownership)
   * [Extra map features with specials](#extra-map-features-with-specials)
     * [Place smoke, gas, or blood with "fields"](#place-smoke-gas-or-blood-with-fields)
     * [Place NPCs with "npcs"](#place-npcs-with-npcs)
@@ -654,6 +655,21 @@ Example:
 | custom-flags | (optional) Value: `[ "flag1", "flag2" ]`. Spawn item with specific flags.
 
 The special custom flag "ACTIVATE_ON_PLACE" causes the item to be activated as it is placed.  This is useful to have noisemakers that are already turned on as the avatar approaches.  It can also be used with explosives with a 1 second countdown to have locations explode as the avatar approaches, creating uniquely ruined terrain.
+
+## Set the owner of items in a given area with "faction_owner"
+**optional** Define an area where mapgen-spawned items will have faction ownership applied
+
+Example:
+```json
+"faction_owner": [ { "id": "exodii", "x": [ 5, 17 ], "y": [ 5, 18 ] } ],
+```
+
+| Field  | Description
+| ---    | ---
+| id     | (required) ID of the faction to apply ownership to.
+| x, y   | (required) Spawn coordinates. Value from `0-23`, or range `[ 0-23, 0-23 ]` for a random value in that range.
+
+This is an array, so multiple entries can be defined.
 
 ## Extra map features with specials
 **optional** Special map features that do more than just placing furniture / terrain.

--- a/doc/PROFICIENCY.md
+++ b/doc/PROFICIENCY.md
@@ -131,6 +131,7 @@ Within these are the standard list of JSON objects having "type": "proficiency".
 | `default_weakpoint_penalty` | Optional  | Float  | Flat penalty to the attacker's skill if they lack the skill.                         |
 | `time_to_learn`             | Optional  | time_duration, as a string | The (optimal) time required to learn this proficiency.           |
 | `required_proficiencies`    | Optional  | Array of strings | The proficiencies that must be obtained before this one can.  You cannot gain experience in a proficiency without the necessary prerequisites. |
+| `ignore_focus`              | Optional  | Bool   | Proficiency exp gain will be as if focus is `100` regardless of actual focus.        |
 | `bonuses`                   | Optional  | Object, with an array of object as values | This member is used to apply bonuses to certain activities given the player has a particular proficiency. The bonuses applied must be hardcoded to the activity in question. (see below) |
 
 ### time multiplier and skill penalty

--- a/doc/VITAMIN.md
+++ b/doc/VITAMIN.md
@@ -26,7 +26,7 @@ Mandatory. The id of the vitamin.
 Mandatory. Must be `vitamin`.
 
 ### `vit_type`
-The type of the vitamin. Valid values are:
+Mandatory. The type of the vitamin. Valid values are:
 
 #### `vitamin`
 When simplified nutrition is enabled, this vitamin will not be added to any items and any time the game attempts to retrieve it from the player it will give 0.

--- a/doc/WEATHER_TYPE.md
+++ b/doc/WEATHER_TYPE.md
@@ -7,6 +7,7 @@ Each weather type is a type of weather that occurs, and what causes it. The only
 |      Identifier      |                                           Description                                            |
 | -------------------- | ------------------------------------------------------------------------------------------------ |
 | `name`               | UI name of weather type.                                                                         |
+| `id`                 | Unique string for this weather type.                                                             |
 | `color`              | UI color of weather type.                                                                        |
 | `map_color`          | Map color of weather type.                                                                       |
 | `sym`                | Map glyph of weather type.                                                                       |
@@ -24,6 +25,7 @@ Each weather type is a type of weather that occurs, and what causes it. The only
 | `duration_min`       | Optional, the lower bound on the amount of time this weather can last. Defaults to 5 minutes.    |
 | `duration_max`       | Optional, the upper bound on the amount of time this weather can last. Defaults to 5 minutes.    |
 | `weather_animation`  | Optional, Information controlling weather animations.  Members: factor, color and glyph          |
+| `sun_multiplier`     | Optional, multiplier to radiation from sun. Affects energy output of solar panels.               |
 | `condition`          | A dialog condition to determine if this weather is happening.  See Dialogue conditions section of [NPCs](NPCs.md) A context variable of `weather_location` contains the location of the current tile checking its weather.  This can be used to have weather be based on location. |
 | `priority`           | An integer.  If the condition of multiple weather types are true the one with higher priority wins. |
 | `required_weathers`  | A string array of possible weathers, it is at this point in the loop. i.e. rain can only happen if the conditions for clouds light drizzle or drizzle are present.  Required weathers need to have lower load orders to be. |


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Naughty contributors add json data but don't document their fields

#### Describe the solution
I went through the docs folder and picked a bunch of them with large lists of optionals, then added things I could find that were missing or that I knew were missing (the mapgen stuff is a bit :eyes:, so I only added what I knew)

#### Describe alternatives you've considered


#### Testing
Docs change only

#### Additional context
This is definitely not comprehensive, even for the files I touched. (Except factions, that should be complete.)