### PR TITLE
sort first time contributors for test approval

### DIFF
--- a/.github/workflows/label-first-time-contributor.yml
+++ b/.github/workflows/label-first-time-contributor.yml
@@ -1,0 +1,30 @@
+name: Sort new contributors for test approval
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  ISSUE_NUMBER: ${{ github.event.issue.number }}
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check if user has any merged PRs in this reposiory
+        id: pr-check
+        run: |
+          author=$(jq -r '.pull_request.user.login' $GITHUB_EVENT_PATH)
+          pr_count=$(gh pr list --state merged --author $author --json number | jq 'length')
+
+          echo "Debug: $author with $pr_count merged PRs."
+          echo "pr_count=$pr_count" >> $GITHUB_OUTPUT
+
+      - name: Label contributors with no merged PRs
+        if: steps.pr-check.outputs.pr_count == 0
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --add-label "new contributor"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
@Maleclypse requested this feature, add a `new contributor` label to first time contributors so their PRs don't get lost

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
```bash
# fetch the number of merged prs of the author that triggered this workflow run
author=$(jq -r '.pull_request.user.login' $GITHUB_EVENT_PATH)
pr_count=$(gh pr list --state merged --author $author --json number | jq 'length'
# set the total count as an output we can later reference
echo "pr_count=$pr_count" >> $GITHUB_OUTPUT

# it the count is 0 aka this pr needs workflow approval from a maintaner label it as 'new contributor'
# not totally acurate from a naming point of view but that's okay
if: steps.pr-check.outputs.pr_count == 0
run: gh issue edit "$ISSUE_NUMBER" --add-label "new contributor"
```
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
this time it's interactive; make a pr to this repo to see this working https://github.com/casswedson/issue-labeling

~~draft cause I'd make the label beforehand (yellow is my favorite color btw) and we could review the label name itself~~

~~how this works: the code checks if you have merged prs in this repo, if not you are a new contributor, slap a label on it - I am the owner of that repo but I do not have any merged prs so I count
https://github.com/casswedson/issue-labeling/pull/25 runs on https://github.com/casswedson/issue-labeling/commit/98e1b9f9bd1d77ac8537b0aac3dae54354ebfa34~~
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->