### PR TITLE
[MoM] Implement jmath, include it in calculations

### DIFF
--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "jmath_function",
+    "id": "int_to_level",
+    "num_args": 1,
+    "return": "(u_val('intelligence') * 1.5) * (_0)"
+  },
+  {
+    "type": "jmath_function",
+    "id": "scaling_factor",
+    "num_args": 1,
+    "return": "( ( _0 + 10) / 20 )"
+  }
+]

--- a/data/mods/MindOverMatter/powers/biokinesis.json
+++ b/data/mods/MindOverMatter/powers/biokinesis.json
@@ -14,19 +14,19 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_two", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 2,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "energy_source": "STAMINA",
     "base_energy_cost": 3500,
     "final_energy_cost": 1250,
     "energy_increment": -175,
     "min_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_physical_enhance') * 1500) + 9000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_physical_enhance') * 1500) + 9000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_physical_enhance') * 2000) + 45000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_physical_enhance') * 2000) + 45000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "base_casting_time": 120,
@@ -49,7 +49,7 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_one", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 1,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": 0,
     "energy_source": "STAMINA",
     "base_energy_cost": 1750,
@@ -57,12 +57,12 @@
     "energy_increment": -75,
     "min_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 30000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 30000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 130000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 130000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "base_casting_time": 125,
@@ -100,12 +100,12 @@
     "min_damage": 0,
     "min_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 30000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 30000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 130000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 130000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -124,12 +124,12 @@
     "min_damage": 0,
     "min_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 60000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 60000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 150000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 150000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -148,12 +148,12 @@
     "min_damage": 0,
     "min_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 90000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 90000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 180000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -172,12 +172,12 @@
     "min_damage": 0,
     "min_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 120000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 120000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 210000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 210000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -196,12 +196,12 @@
     "min_damage": 0,
     "min_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 150000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 150000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 240000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 240000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -220,12 +220,12 @@
     "min_damage": 0,
     "min_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 180000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 270000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_overcome_pain') * 2000) + 270000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -244,7 +244,7 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_three", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 3,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "energy_source": "STAMINA",
     "base_energy_cost": 2500,
     "final_energy_cost": 850,
@@ -271,19 +271,19 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_five", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 5,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "energy_source": "STAMINA",
     "base_energy_cost": 3500,
     "final_energy_cost": 1250,
     "energy_increment": -175,
     "min_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_reflex_enhance') * 1500) + 9000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_reflex_enhance') * 1500) + 9000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_reflex_enhance') * 2000) + 45000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: biokin_reflex_enhance') * 2000) + 45000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "base_casting_time": 175,
@@ -306,16 +306,16 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_four", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 4,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "energy_source": "STAMINA",
     "base_energy_cost": 4000,
     "final_energy_cost": 1750,
     "energy_increment": -200,
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: biokin_armor_skin') * 1000) + 4500) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: biokin_armor_skin') * 1000) + 4500) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: biokin_armor_skin') * 1500) + 30000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: biokin_armor_skin') * 1500) + 30000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "base_casting_time": 150,
     "final_casting_time": 50,
@@ -337,18 +337,16 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_six", "hit_self": false } ],
     "shape": "blast",
     "difficulty": 6,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "energy_source": "STAMINA",
     "base_energy_cost": 5000,
     "final_energy_cost": 2750,
     "energy_increment": -225,
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: biokin_sealed_system') * 800) + 6000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: biokin_sealed_system') * 800) + 6000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_sealed_system') * 800) + 30000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: biokin_sealed_system') * 800) + 30000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "base_casting_time": 200,
     "final_casting_time": 100,
@@ -370,18 +368,16 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_seven", "hit_self": false } ],
     "shape": "blast",
     "difficulty": 7,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "energy_source": "STAMINA",
     "base_energy_cost": 3000,
     "final_energy_cost": 1750,
     "energy_increment": -125,
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: biokin_sealed_system') * 600) + 4000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: biokin_sealed_system') * 600) + 4000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: biokin_sealed_system') * 600) + 20000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: biokin_sealed_system') * 600) + 20000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "base_casting_time": 100,
     "final_casting_time": 40,

--- a/data/mods/MindOverMatter/powers/clairsentience.json
+++ b/data/mods/MindOverMatter/powers/clairsentience.json
@@ -14,19 +14,17 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_one", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 1,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "energy_source": "STAMINA",
     "base_energy_cost": 1000,
     "final_energy_cost": 500,
     "energy_increment": -50,
     "min_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "base_casting_time": 50,
@@ -62,16 +60,14 @@
     "effect": "attack",
     "effect_str": "effect_clair_night_eyes_1",
     "shape": "blast",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": 0,
     "min_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -86,16 +82,14 @@
     "effect": "attack",
     "effect_str": "effect_clair_night_eyes_2",
     "shape": "blast",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": 0,
     "min_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -110,16 +104,14 @@
     "effect": "attack",
     "effect_str": "effect_clair_night_eyes_3",
     "shape": "blast",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": 0,
     "min_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -134,16 +126,14 @@
     "effect": "attack",
     "effect_str": "effect_clair_night_eyes_4",
     "shape": "blast",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": 0,
     "min_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -158,16 +148,14 @@
     "effect": "attack",
     "effect_str": "effect_clair_night_eyes_5",
     "shape": "blast",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": 0,
     "min_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -182,16 +170,14 @@
     "effect": "attack",
     "effect_str": "effect_clair_night_eyes_6",
     "shape": "blast",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": 0,
     "min_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -206,16 +192,14 @@
     "effect": "attack",
     "effect_str": "effect_clair_night_eyes_7",
     "shape": "blast",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": 0,
     "min_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -230,16 +214,14 @@
     "effect": "attack",
     "effect_str": "effect_clair_night_eyes_8",
     "shape": "blast",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": 0,
     "min_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 15000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: clair_night_vision') * 20000) + 180000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     }
   },
@@ -259,15 +241,15 @@
     "shape": "blast",
     "energy_source": "STAMINA",
     "difficulty": 2,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "base_energy_cost": 1500,
     "final_energy_cost": 450,
     "energy_increment": -125,
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_danger_sense') * 6000) + 12000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_danger_sense') * 6000) + 12000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_danger_sense') * 6000) + 90000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_danger_sense') * 6000) + 90000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "base_casting_time": 85,
     "final_casting_time": 25,
@@ -290,19 +272,19 @@
     "shape": "blast",
     "energy_source": "STAMINA",
     "difficulty": 3,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_spot_weakness') * 1.5) + 1) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_spot_weakness') * 1.5) + 1) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 70,
     "base_energy_cost": 2500,
     "final_energy_cost": 500,
     "energy_increment": -125,
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_spot_weakness') * 150) + 1350) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_spot_weakness') * 150) + 1350) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_spot_weakness') * 150) + 3000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_spot_weakness') * 150) + 3000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "base_casting_time": 150,
     "final_casting_time": 75,
@@ -325,15 +307,15 @@
     "shape": "blast",
     "energy_source": "STAMINA",
     "difficulty": 4,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "base_energy_cost": 3500,
     "final_energy_cost": 850,
     "energy_increment": -175,
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_dodge_power') * 1200) + 3000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_dodge_power') * 1200) + 3000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_dodge_power') * 1200) + 45000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_dodge_power') * 1200) + 45000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "base_casting_time": 150,
     "final_casting_time": 70,
@@ -355,13 +337,13 @@
     "shape": "blast",
     "energy_source": "STAMINA",
     "difficulty": 5,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_voyance') * 1.5) + 1.5) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_voyance') * 1.5) + 1.5) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 80,
     "min_aoe": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_voyance') * 1.5) + 1.5) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_voyance') * 1.5) + 1.5) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_aoe": 50,
     "field_id": "fd_clairvoyant",
@@ -371,10 +353,10 @@
     "final_energy_cost": 1500,
     "energy_increment": -250,
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_voyance') * 50) + 250) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_voyance') * 50) + 250) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_voyance') * 50) + 1500) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_voyance') * 50) + 1500) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "base_casting_time": 1000,
     "final_casting_time": 500,
@@ -396,11 +378,9 @@
     "shape": "blast",
     "energy_source": "STAMINA",
     "difficulty": 7,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
-    "min_aoe": { "math": [ "( ( (u_val('spell_level', 'spell: clair_see_map') * 1) + 4) * ( ( u_val('intelligence') + 10) / 20 ) )" ] },
-    "max_aoe": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_see_map') * 1) + 11) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
-    },
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "min_aoe": { "math": [ "( (u_val('spell_level', 'spell: clair_see_map') * 1) + 4) * (scaling_factor(u_val('intelligence') ) )" ] },
+    "max_aoe": { "math": [ "( (u_val('spell_level', 'spell: clair_see_map') * 1) + 11) * (scaling_factor(u_val('intelligence') ) )" ] },
     "base_energy_cost": 9000,
     "base_casting_time": 6000,
     "learn_spells": { "clair_danger_sense": 5 }
@@ -421,12 +401,12 @@
     "shape": "blast",
     "energy_source": "STAMINA",
     "difficulty": 6,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_clear_sight') * 1000) + 8000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_clear_sight') * 1000) + 8000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: clair_clear_sight') * 1000) + 45000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: clair_clear_sight') * 1000) + 45000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "base_energy_cost": 3000,
     "final_energy_cost": 1250,

--- a/data/mods/MindOverMatter/powers/pyrokinesis.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis.json
@@ -49,7 +49,7 @@
     "valid_targets": [ "hostile", "ground" ],
     "spell_class": "PYROKINETIC",
     "skill": "metaphysics",
-    "flags": [ "CONCENTRATE", "NO_HANDS", "NO_PROJECTILE", "NO_LEGS", "RANDOM_DURATION", "RANDOM_AOE" ],
+    "flags": [ "CONCENTRATE", "NO_HANDS", "NO_PROJECTILE", "NO_LEGS", "RANDOM_DURATION" ],
     "effect": "attack",
     "effect_str": "effect_pyrokinetic_flash",
     "extra_effects": [ { "id": "psionic_drained_difficulty_one", "hit_self": true } ],

--- a/data/mods/MindOverMatter/powers/pyrokinesis.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis.json
@@ -14,15 +14,15 @@
     "shape": "blast",
     "damage_type": "heat",
     "difficulty": 2,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_eruption') * 3) + 6) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_eruption') * 3) + 6) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_eruption') * 4.5) + 36) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_eruption') * 3) + 6) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_eruption') * 1.5) + 2) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_eruption') * 3) + 6) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 70,
     "field_id": "fd_fire",
@@ -56,22 +56,22 @@
     "shape": "blast",
     "affected_body_parts": [ "eyes" ],
     "difficulty": 1,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_flash') * 1.5) + 3 ) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_flash') * 1.5) + 3 ) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 75,
     "min_aoe": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_flash') * 0.25) + 1) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_flash') * 0.25) + 1) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_aoe": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_flash') * 0.25) + 4) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_flash') * 0.25) + 4) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_flash') * 150) + 100) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_flash') * 150) + 100) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_flash') * 150) + 800) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_flash') * 150) + 800) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "energy_source": "STAMINA",
     "base_energy_cost": 1750,
@@ -96,17 +96,13 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_three", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 3,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_range": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: pyrokinetic_quell_flames') * 0.8) + 5) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_quell_flames') * 0.8) + 5) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 70,
     "min_aoe": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: pyrokinetic_quell_flames') * 0.5) + 0) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_quell_flames') * 0.5) + 0) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_aoe": 50,
     "field_id": "fd_extinguisher",
@@ -133,7 +129,7 @@
     "effect": "remove_field",
     "effect_str": "fd_hot_air2",
     "shape": "blast",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_aoe": 0
   },
   {
@@ -147,7 +143,7 @@
     "effect": "remove_field",
     "effect_str": "fd_hot_air3",
     "shape": "blast",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_aoe": 0
   },
   {
@@ -161,7 +157,7 @@
     "effect": "remove_field",
     "effect_str": "fd_hot_air4",
     "shape": "blast",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_aoe": 0
   },
   {
@@ -179,26 +175,24 @@
     "shape": "cone",
     "damage_type": "heat",
     "difficulty": 5,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: pyrokinetic_flamethrower') * 1.5) + 15) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: pyrokinetic_flamethrower') * 1.5) + 15) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_damage": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: pyrokinetic_flamethrower') * 2.5) + 40) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: pyrokinetic_flamethrower') * 2.5) + 40) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "min_range": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: pyrokinetic_flamethrower') * 0.2) + 3) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_flamethrower') * 0.2) + 3) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 20,
     "range_increment": 0.2,
     "min_aoe": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_flamethrower') * 3) + 27) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_flamethrower') * 3) + 27) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_aoe": 180,
     "field_id": "fd_fire",
@@ -231,12 +225,12 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_four", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 4,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_cloak') * 2000) + 9000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_cloak') * 2000) + 9000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_cloak') * 2000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_cloak') * 2000) + 180000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "energy_source": "STAMINA",
     "base_energy_cost": 4500,
@@ -262,19 +256,19 @@
     "shape": "blast",
     "damage_type": "heat",
     "difficulty": 7,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_blast') * 3) + 37) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_blast') * 3) + 37) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_blast') * 5) + 115) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_blast') * 5) + 115) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_blast') * 1.2) + 4) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_blast') * 1.2) + 4) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 80,
     "min_aoe": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_blast') * 0.4) + 2) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_blast') * 0.4) + 2) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_aoe": 20,
     "field_id": "fd_fire",
@@ -307,12 +301,12 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_six", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 6,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_aura') * 600) + 4500) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_aura') * 600) + 4500) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: pyrokinetic_aura') * 600) + 30000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_aura') * 600) + 30000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "energy_source": "STAMINA",
     "base_energy_cost": 5500,

--- a/data/mods/MindOverMatter/powers/telekinesis.json
+++ b/data/mods/MindOverMatter/powers/telekinesis.json
@@ -13,15 +13,15 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_one", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 1,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_pull') * -1.5) - 1) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_pull') * -1.5) - 1) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_pull') * -1.5) - 6) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_pull') * -1.5) - 6) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_pull') * 1.2) + 3) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_pull') * 1.2) + 3) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 40,
     "energy_source": "STAMINA",
@@ -47,15 +47,15 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_two", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 2,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_push') * 0.25) + 2) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_push') * 0.25) + 2) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_push') * 0.25) + 6) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_push') * 0.25) + 6) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_push') * 1.2) + 1) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_push') * 1.2) + 1) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 40,
     "energy_source": "STAMINA",
@@ -82,15 +82,13 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_three", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 3,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: telekinetic_momentum') * 1000) + 9000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_momentum') * 1000) + 9000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: telekinetic_momentum') * 1000) + 60000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: telekinetic_momentum') * 1000) + 60000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "energy_source": "STAMINA",
@@ -119,7 +117,7 @@
     ],
     "shape": "blast",
     "difficulty": 4,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "damage_type": "biological",
     "min_damage": 12,
     "max_damage": 12,
@@ -145,12 +143,12 @@
     "effect": "directed_push",
     "shape": "blast",
     "difficulty": 1,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_wave') * 0.25) + 2) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_wave') * 0.25) + 2) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_wave') * 0.25) + 6) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_wave') * 0.25) + 6) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_range": 1,
     "max_range": 1,
@@ -180,15 +178,15 @@
     "shape": "blast",
     "damage_type": "bash",
     "difficulty": 5,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_hammer') * 1.5) + 18) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_hammer') * 1.5) + 18) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_hammer') * 1.5) + 73) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_hammer') * 1.5) + 73) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_hammer') * 1.2) + 3) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_hammer') * 1.2) + 3) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 70,
     "energy_source": "STAMINA",
@@ -213,12 +211,12 @@
     "effect": "bash",
     "shape": "blast",
     "damage_type": "bash",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_hammer') * 1.5) + 18) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_hammer') * 1.5) + 18) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_hammer') * 2) + 73) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_hammer') * 2) + 73) * (scaling_factor(u_val('intelligence') ) )" ]
     }
   },
   {
@@ -236,12 +234,12 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_six", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 6,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_shield') * 1500) + 9000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_shield') * 1500) + 9000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_shield') * 2500) + 90000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_shield') * 2500) + 90000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "energy_source": "STAMINA",
     "base_energy_cost": 7000,
@@ -279,19 +277,19 @@
     "effect": "bash",
     "shape": "blast",
     "difficulty": 7,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_explosion') * 3) + 22) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_explosion') * 3) + 22) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_explosion') * 5) + 100) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_explosion') * 5) + 100) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_explosion') * 1.2) + 4) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_explosion') * 1.2) + 4) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 60,
     "min_aoe": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_explosion') * 0.3) + 2) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_explosion') * 0.3) + 2) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_aoe": 30,
     "energy_source": "STAMINA",
@@ -316,15 +314,15 @@
     "effect": "attack",
     "shape": "blast",
     "damage_type": "bash",
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_explosion') * 3) + 22) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_explosion') * 3) + 22) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_explosion') * 5) + 100) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_explosion') * 5) + 100) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_aoe": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telekinetic_explosion') * 0.3) + 2) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telekinetic_explosion') * 0.3) + 2) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_aoe": 30
   }

--- a/data/mods/MindOverMatter/powers/telepathy.json
+++ b/data/mods/MindOverMatter/powers/telepathy.json
@@ -14,15 +14,15 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_one", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 1,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: telepathic_concentration') * 15000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: telepathic_concentration') * 15000) + 180000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: telepathic_concentration') * 15000) + 720000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: telepathic_concentration') * 15000) + 720000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "energy_source": "STAMINA",
@@ -67,12 +67,12 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_two", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 2,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telepathic_shield') * 1500) + 6000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telepathic_shield') * 1500) + 6000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telepathic_shield') * 1500) + 36000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telepathic_shield') * 1500) + 36000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "energy_source": "STAMINA",
     "base_energy_cost": 2500,
@@ -98,16 +98,12 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_three", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 3,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: telepathic_morale') * 15000) + 180000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: telepathic_morale') * 15000) + 180000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [
-        "( ( (u_val('spell_level', 'spell: telepathic_morale') * 15000) + 720000) * ( ( u_val('intelligence') + 10) / 20 ) )"
-      ]
+      "math": [ "( (u_val('spell_level', 'spell: telepathic_morale') * 15000) + 720000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "energy_source": "STAMINA",
     "base_energy_cost": 4000,
@@ -140,15 +136,15 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_four", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 4,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: telepathic_invisibility') * 200) + 800) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: telepathic_invisibility') * 200) + 800) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: telepathic_invisibility') * 200) + 3000) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: telepathic_invisibility') * 200) + 3000) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "energy_source": "STAMINA",
@@ -171,7 +167,7 @@
     "skill": "metaphysics",
     "flags": [ "CONCENTRATE", "NO_PROJECTILE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION" ],
     "difficulty": 5,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "effect": "attack",
     "effect_str": "stunned",
     "extra_effects": [
@@ -180,13 +176,13 @@
     ],
     "shape": "blast",
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telepathic_confusion') * 100) + 400) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telepathic_confusion') * 100) + 400) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telepathic_confusion') * 100) + 2000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telepathic_confusion') * 100) + 2000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telepathic_confusion') * 2) + 3) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telepathic_confusion') * 2) + 3) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 80,
     "energy_source": "STAMINA",
@@ -209,7 +205,7 @@
     "skill": "metaphysics",
     "flags": [ "CONCENTRATE", "NO_PROJECTILE", "SILENT", "RANDOM_DAMAGE", "NO_HANDS", "NO_LEGS", "PERCENTAGE_DAMAGE" ],
     "difficulty": 6,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "effect": "attack",
     "extra_effects": [ { "id": "psionic_drained_difficulty_six", "hit_self": true } ],
     "shape": "blast",
@@ -218,7 +214,7 @@
     "max_damage": 120,
     "damage_increment": 1,
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telepathic_blast') * 2) + 3) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telepathic_blast') * 2) + 3) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 80,
     "energy_source": "STAMINA",
@@ -240,28 +236,28 @@
     "skill": "metaphysics",
     "flags": [ "CONCENTRATE", "NO_PROJECTILE", "SILENT", "RANDOM_DAMAGE", "RANDOM_DURATION", "NO_HANDS", "NO_LEGS" ],
     "difficulty": 7,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "effect": "charm_monster",
     "extra_effects": [ { "id": "psionic_drained_difficulty_seven", "hit_self": true } ],
     "shape": "blast",
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telepathic_mind_control') * 4) + 30) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telepathic_mind_control') * 4) + 30) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telepathic_mind_control') * 6) + 120) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telepathic_mind_control') * 6) + 120) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: telepathic_mind_control') * 400) + 1200) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: telepathic_mind_control') * 400) + 1200) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_val('spell_level', 'spell: telepathic_mind_control') * 400) + 5200) * ( ( u_val('intelligence') + 10) / 20 ) )"
+        "( (u_val('spell_level', 'spell: telepathic_mind_control') * 400) + 5200) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: telepathic_mind_control') * 1) + 4) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: telepathic_mind_control') * 1) + 4) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 70,
     "energy_source": "STAMINA",

--- a/data/mods/MindOverMatter/powers/teleportation.json
+++ b/data/mods/MindOverMatter/powers/teleportation.json
@@ -13,7 +13,7 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_one", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 1,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_aoe": 1,
     "max_aoe": 5,
     "aoe_increment": 0.25,
@@ -44,19 +44,19 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_two", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 2,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_aoe": 0,
     "max_aoe": 20,
     "aoe_increment": 0.2,
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: teleport_slow') * 1.2) + 3) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: teleport_slow') * 1.2) + 3) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 80,
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: teleport_slow') * 75) + 125) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: teleport_slow') * 75) + 125) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: teleport_slow') * 75) + 1500) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: teleport_slow') * 75) + 1500) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "energy_source": "STAMINA",
     "base_energy_cost": 1200,
@@ -81,9 +81,9 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_three", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 3,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: teleport_transpose') * 2.5) + 1) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: teleport_transpose') * 2.5) + 1) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 80,
     "energy_source": "STAMINA",
@@ -109,12 +109,12 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_five", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 5,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_aoe": 4,
     "max_aoe": 1,
     "aoe_increment": -0.25,
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: teleport_farstep') * 2.5) + 2) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: teleport_farstep') * 2.5) + 2) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 80,
     "energy_source": "STAMINA",
@@ -140,15 +140,15 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_four", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 4,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: teleport_collapse') * -0.15) - 1) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: teleport_collapse') * -0.15) - 1) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: teleport_collapse') * -0.15) - 3) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: teleport_collapse') * -0.15) - 3) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: teleport_collapse') * 1.2) + 5) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: teleport_collapse') * 1.2) + 5) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 80,
     "min_aoe": 3,
@@ -177,7 +177,7 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_six", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 6,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "energy_source": "STAMINA",
     "base_energy_cost": 10000,
     "final_energy_cost": 5000,
@@ -201,15 +201,15 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_seven", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 7,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: teleport_banish') * 15) + 15) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: teleport_banish') * 15) + 15) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: teleport_banish') * 35) + 350) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: teleport_banish') * 35) + 350) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_range": {
-      "math": [ "( ( (u_val('spell_level', 'spell: teleport_banish') * 2) + 1.5) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: teleport_banish') * 2) + 1.5) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_range": 80,
     "energy_source": "STAMINA",

--- a/data/mods/MindOverMatter/powers/vitakinesis.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis.json
@@ -14,7 +14,7 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_two", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 2,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": 1,
     "max_damage": 1,
     "energy_source": "STAMINA",
@@ -43,16 +43,16 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_one", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 1,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "energy_source": "STAMINA",
     "base_energy_cost": 3500,
     "final_energy_cost": 2000,
     "energy_increment": -75,
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: vita_health_power') * 2100) + 18000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: vita_health_power') * 2100) + 18000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: vita_health_power') * 2700) + 145000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: vita_health_power') * 2700) + 145000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "base_casting_time": 100,
     "final_casting_time": 25,
@@ -75,7 +75,7 @@
     "shape": "blast",
     "damage_type": "pure",
     "difficulty": 3,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_dot": 1,
     "max_dot": 2,
     "dot_increment": 0.1,
@@ -84,10 +84,10 @@
     "final_energy_cost": 500,
     "energy_increment": -65,
     "min_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: vita_hurt_touch') * 100) + 400) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: vita_hurt_touch') * 100) + 400) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( (u_val('spell_level', 'spell: vita_hurt_touch') * 100) + 3000) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: vita_hurt_touch') * 100) + 3000) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "min_range": 1,
     "base_casting_time": 85,
@@ -109,7 +109,7 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_five", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 5,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "energy_source": "STAMINA",
     "base_energy_cost": 4500,
     "final_energy_cost": 1250,
@@ -137,12 +137,12 @@
     ],
     "shape": "blast",
     "difficulty": 4,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: vita_sleeping_trance') * 2) + 40) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: vita_sleeping_trance') * 2) + 40) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: vita_sleeping_trance') * 2) + 150) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: vita_sleeping_trance') * 2) + 150) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "energy_source": "STAMINA",
     "base_energy_cost": 1000,
@@ -181,12 +181,12 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_six", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 6,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "min_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: vita_healing_trance') * -1.5) - 6) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: vita_healing_trance') * -1.5) - 6) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( (u_val('spell_level', 'spell: vita_healing_trance') * -2) - 12) * ( ( u_val('intelligence') + 10) / 20 ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: vita_healing_trance') * -2) - 12) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "energy_source": "STAMINA",
     "base_energy_cost": 8000,
@@ -208,7 +208,7 @@
     "extra_effects": [ { "id": "psionic_drained_difficulty_seven", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 7,
-    "max_level": { "math": [ "( u_val('intelligence') * 1.5 )" ] },
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "energy_source": "STAMINA",
     "base_energy_cost": 5000,
     "final_energy_cost": 2500,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Implement jmath, include it in calculations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Saw GuardianDII's comment on https://github.com/CleverRaven/Cataclysm-DDA/pull/66724 while I was prepping for Shabbat. Now that it's after Shabbat, I'm implementing some of his suggestions--moving the standardized "Intelligence * 1.5" used to determine spell level to a  jmath function and also the standardized "(Intelligence + 10) / 20" equation on the end of most powers' damage, range, and duration calculations to a jmath function. That one takes the scaling stat as a parameter in case I ever need to use it to scale something else. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Implemented all the above.

I also noticed that I missed the RANDOM_AOE on the Pyrokinetic power Brilliant Flash when I was taking RANDOM_AOE out, so I removed it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Keeping 150+ separate equations when I could have two.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded the game up and debug changed my intelligence around.  Everything I tested worked as expected. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->