### PR TITLE
A bunch of random item reworks: 8

### DIFF
--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -156,16 +156,23 @@
     "symbol": "u",
     "description": "A light ceramic teacup.  Quite classy.",
     "copy-from": "base_ceramic_dish",
+    "weight": "254 g",
+    "//1": "Weight calculated proportionally from the coffee mug as I couldn't find detailed weight information for the product.",
+    "volume": "380 ml",
+    "longest_side": "12 cm",
+    "price": "5 USD",
+    "to_hit": { "grip": "solid", "length": "hand", "surface": "any", "balance": "clumsy" },
     "pocket_data": [
       {
-        "max_contains_volume": "250 ml",
-        "max_contains_weight": "1 kg",
+        "max_contains_volume": "150 ml",
+        "max_contains_weight": "300 g",
         "watertight": true,
         "open_container": true,
         "rigid": true
       }
     ],
-    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
+    "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
+    "//2": "Based on https://www.dimensions.com/element/ikea-vardagen-coffee-cup-saucer"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -916,7 +916,7 @@
     "material": [ { "type": "steel", "portion": 9 }, { "type": "aluminum", "portion": 1 } ],
     "color": "light_gray",
     "weight": "2500 g",
-    "volume": "12270 ml",
+    "volume": "12700 ml",
     "longest_side": "25 cm",
     "price": "137 USD",
     "pocket_data": [

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -838,13 +838,14 @@
     "copy-from": "base_cookpot",
     "material": [ "iron" ],
     "color": "dark_gray",
-    "weight": "3000 g",
-    "volume": "2375 ml",
-    "longest_side": "24 cm",
+    "weight": "2490 g",
+    "volume": "3980 ml",
+    "longest_side": "25 cm",
+    "price": "29 USD",
     "pocket_data": [
       {
         "max_contains_volume": "2 L",
-        "max_contains_weight": "2 kg",
+        "max_contains_weight": "4 kg",
         "watertight": true,
         "open_container": true,
         "rigid": true

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -907,40 +907,42 @@
     "name": { "str": "stock pot" },
     "description": "A large pot with 20 gauge walls and a thick aluminum bottom, used for making soup stocks.  You could fit a whole turkey in there, with a bit of shoving.",
     "copy-from": "base_cookpot",
-    "material": [ "steel", "aluminum" ],
+    "material": [ { "type": "steel", "portion": 9 }, { "type": "aluminum", "portion": 1 } ],
     "color": "light_gray",
-    "weight": "2490 g",
-    "volume": "12800 ml",
-    "longest_side": "25 cm",
+    "weight": "1 kg",
+    "volume": "11600 ml",
+    "longest_side": "33 cm",
+    "price": "27 USD",
     "pocket_data": [
       {
         "max_contains_volume": "12 L",
-        "max_contains_weight": "12 kg",
+        "max_contains_weight": "24 kg",
         "watertight": true,
         "open_container": true,
         "rigid": true
       }
     ],
-    "melee_damage": { "bash": 8 }
+    "melee_damage": { "bash": 8 },
+    "//": "Based on https://www.amazon.com/IMUSA-L300-40315-Stainless-12-Quart-Silver/dp/B0018KLOCO/ref=sr_1_5?crid=3F8YHF0O1DRWV&keywords=stock%2Bpot&qid=1688900087&sprefix=stock%2B%2Caps%2C276&sr=8-5&th=1"
   },
   {
     "id": "pot_canning",
     "type": "GENERIC",
     "category": "tools",
     "name": { "str": "canning pot" },
-    "description": "A very large 25 liter pot, primarily meant for canning food in glass jars via the water bath method, though it can cook normal foods just as well.  Canning foods with it will require a lot of water.  If you're only canning a couple of jars at a time, you'd fill it up with rocks or something to displace the water above the lids.",
-    "weight": "5540 g",
-    "volume": "32570 ml",
-    "longest_side": "40 cm",
-    "price": "112 USD",
+    "description": "A very large 20 liter pot, primarily meant for canning food in glass jars via the water bath method, though it can cook normal foods just as well.  Canning foods with it will require a lot of water.  If you're only canning a couple of jars at a time, you'd fill it up with rocks or something to displace the water above the lids.",
+    "weight": "4082 g",
+    "volume": "25400 ml",
+    "longest_side": "45 cm",
+    "price": "68 USD",
     "to_hit": { "grip": "bad", "length": "short", "surface": "any", "balance": "clumsy" },
     "material": [ "steel" ],
     "symbol": ")",
     "color": "dark_gray",
     "pocket_data": [
       {
-        "max_contains_volume": "25 L",
-        "max_contains_weight": "50 kg",
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "40 kg",
         "watertight": true,
         "open_container": true,
         "rigid": true
@@ -950,7 +952,7 @@
     "use_action": [ "HEAT_FOOD" ],
     "flags": [ "ALLOWS_REMOTE_USE" ],
     "melee_damage": { "bash": 10 },
-    "//": "Based on https://www.amazon.co.uk/Stainless-Fitted-Tri-Ply-Composite-17Litre/dp/B087X1Y9MN/ref=sr_1_1?crid=17CCGCR5CTO4U&keywords=25l%2Bcanning%2Bpot&qid=1684580110&sprefix=25l%2Bcanning%2Bpo%2Caps%2C92&sr=8-1&th=1"
+    "//": "Based on https://www.amazon.com/Kitchen-Crop-Brands-Canner-Capacity/dp/B0075O2Z34/ref=sr_1_5?crid=28HN2SUYQWFT5&keywords=canning+pot+25l&qid=1688899863&sprefix=canning+pot+25l%2Caps%2C177&sr=8-5"
   },
   {
     "id": "pot_canning_clay",

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -765,9 +765,14 @@
     "description": "A utensil used to hold meat still while you slice it.  It's like a tiny pitchfork, or a very large dinner fork.",
     "looks_like": "fork",
     "copy-from": "base_utensil",
-    "proportional": { "melee_damage": { "stab": 2 } },
+    "weight": "90 g",
+    "volume": "180 ml",
+    "longest_side": "29 cm",
+    "price": "12 USD",
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
-    "melee_damage": { "bash": 3, "stab": 2 }
+    "melee_damage": { "bash": 3, "stab": 2 },
+    "to_hit": { "grip": "solid", "length": "hand", "surface": "point", "balance": "neutral" },
+    "//": "Based on https://www.amazon.com/OXO-Grips-Stainless-Steel-Carving/dp/B083FJXZM5/ref=sr_1_5?crid=RS6T8L8IQF4N&keywords=carving%2Bfork&qid=1688901582&sprefix=carving%2Bfork%2Caps%2C230&sr=8-5&th=1"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -164,7 +164,8 @@
     "to_hit": { "grip": "solid", "length": "hand", "surface": "any", "balance": "clumsy" },
     "pocket_data": [
       {
-        "max_contains_volume": "150 ml",
+        "max_contains_volume": "250 ml",
+        "//2": "This isn't true. It should contain 150ml. But I can't lower it beyond this much because then it won't be able to hold common liquids. I love charges.",
         "max_contains_weight": "300 g",
         "watertight": true,
         "open_container": true,
@@ -172,7 +173,7 @@
       }
     ],
     "qualities": [ [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
-    "//2": "Based on https://www.dimensions.com/element/ikea-vardagen-coffee-cup-saucer"
+    "//3": "Based on https://www.dimensions.com/element/ikea-vardagen-coffee-cup-saucer"
   },
   {
     "type": "GENERIC",
@@ -914,10 +915,10 @@
     "copy-from": "base_cookpot",
     "material": [ { "type": "steel", "portion": 9 }, { "type": "aluminum", "portion": 1 } ],
     "color": "light_gray",
-    "weight": "1 kg",
-    "volume": "11600 ml",
-    "longest_side": "33 cm",
-    "price": "27 USD",
+    "weight": "2500 g",
+    "volume": "12270 ml",
+    "longest_side": "25 cm",
+    "price": "137 USD",
     "pocket_data": [
       {
         "max_contains_volume": "12 L",
@@ -928,7 +929,7 @@
       }
     ],
     "melee_damage": { "bash": 8 },
-    "//": "Based on https://www.amazon.com/IMUSA-L300-40315-Stainless-12-Quart-Silver/dp/B0018KLOCO/ref=sr_1_5?crid=3F8YHF0O1DRWV&keywords=stock%2Bpot&qid=1688900087&sprefix=stock%2B%2Caps%2C276&sr=8-5&th=1"
+    "//": "Based on https://www.amazon.com/Stockpots-Diameter-Height-Litres-Stainless/dp/B08RD3RDYL/ref=sr_1_4?crid=2LB23F5EZM7PV&keywords=12l%2Bstock%2Bpot&qid=1688902380&sprefix=12l%2Bstock%2Bpo%2Caps%2C206&sr=8-4&th=1"
   },
   {
     "id": "pot_canning",

--- a/data/json/items/melee/knives_kitchen.json
+++ b/data/json/items/melee/knives_kitchen.json
@@ -94,16 +94,17 @@
     "ascii_picture": "knife_carving",
     "copy-from": "base_kitchen_knife",
     "looks_like": "knife_butcher",
-    "weight": "280 g",
-    "volume": "200 ml",
+    "weight": "114 g",
+    "volume": "80 ml",
     "longest_side": "30 cm",
-    "price": 1500,
+    "price": "17 USD",
     "price_postapoc": 50,
     "to_hit": { "grip": "weapon", "length": "short", "surface": "point", "balance": "neutral" },
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 22 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "KNIVES" ],
-    "melee_damage": { "bash": 1, "stab": 18 }
+    "melee_damage": { "bash": 1, "stab": 18 },
+    "//": "Based on https://www.amazon.com/Dexter-Russell-Scalloped-Slicer-12-White/dp/B0195V29HG/ref=sr_1_3?crid=1PTJ4T5VL3C86&keywords=carving+knife&qid=1688903048&sprefix=carving+k%2Caps%2C366&sr=8-3"
   },
   {
     "id": "knife_bread",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -3047,11 +3047,11 @@
   },
   {
     "type": "uncraft",
-    "activity_level": "MODERATE_EXERCISE",
+    "activity_level": "LIGHT_EXERCISE",
     "result": "knife_carving",
-    "time": "5 m",
+    "time": "30 s",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "spike", 1 ], [ "scrap", 5 ] ] ]
+    "components": [ [ [ "scrap", 1 ] ] ]
   },
   {
     "type": "uncraft",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -2172,7 +2172,7 @@
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",
     "time": "3 s",
-    "components": [ [ [ "ceramic_shard", 2 ] ] ],
+    "components": [ [ [ "ceramic_shard", 1 ] ] ],
     "flags": [ "BLIND_EASY" ]
   },
   {

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -4096,11 +4096,9 @@
     "result": "stock_pot",
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",
-    "skill_used": "fabrication",
-    "difficulty": 1,
-    "time": "3 m",
-    "qualities": [ { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "sheet_metal_small", 8 ], [ "steel_chunk", 1 ] ] ]
+    "time": "5 m",
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
+    "components": [ [ [ "sheet_metal_small", 3 ], [ "scrap_aluminum", 1 ] ] ]
   },
   {
     "result": "straw_basket",
@@ -5011,8 +5009,8 @@
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",
     "time": "15 m",
-    "qualities": [ { "id": "SAW_M", "level": 2 } ],
-    "components": [ [ [ "steel_lump", 3 ] ], [ [ "steel_chunk", 6 ] ], [ [ "scrap", 10 ] ] ]
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
+    "components": [ [ [ "steel_lump", 3 ] ], [ [ "steel_chunk", 3 ] ], [ [ "scrap", 6 ] ] ]
   },
   {
     "result": "fluid_preserved_brain",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -77,7 +77,7 @@
     "result": "carving_fork",
     "time": "30 s",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "scrap", 3 ] ] ]
+    "components": [ [ [ "scrap", 1 ] ] ]
   },
   {
     "result": "colander_steel",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -4098,7 +4098,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "time": "5 m",
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
-    "components": [ [ [ "sheet_metal_small", 3 ], [ "scrap_aluminum", 1 ] ] ]
+    "components": [ [ [ "sheet_metal_small", 9 ], [ "scrap_aluminum", 1 ] ] ]
   },
   {
     "result": "straw_basket",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -1873,7 +1873,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "time": "2 m",
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
-    "components": [ [ [ "chunk_cast_iron", 8 ] ], [ [ "lump_cast_iron", 1 ] ] ]
+    "components": [ [ [ "chunk_cast_iron", 5 ] ], [ [ "lump_cast_iron", 1 ] ], [ [ "scrap_cast_iron", 4 ] ] ]
   },
   {
     "result": "pathfinding_module",

--- a/data/json/recipes/tools/containers.json
+++ b/data/json/recipes/tools/containers.json
@@ -1321,7 +1321,7 @@
       { "proficiency": "prof_welding" }
     ],
     "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "sheet_metal", 1 ] ] ]
+    "components": [ [ [ "sheet_metal_small", 4 ] ], [ [ "scrap_aluminum", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/tools/containers.json
+++ b/data/json/recipes/tools/containers.json
@@ -1321,7 +1321,7 @@
       { "proficiency": "prof_welding" }
     ],
     "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "sheet_metal_small", 4 ] ], [ [ "scrap_aluminum", 1 ] ] ]
+    "components": [ [ [ "sheet_metal", 1 ] ], [ [ "scrap_aluminum", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<details>
<summary>CERAMIC CUP</summary>

- Weight: 375g -> 254g
- Volume: 375ml -> 380ml
- Longest side: N/A -> 12cm
- ``price_preapoc``: 12$ -> 5$
- Disassembly yield decreased to account for weight decrease 
- Pocket max weight decreased from 1kg to 300g

</details>

<details>
<summary>CAST-IRON POT</summary>

- Weight: 3kg -> 2490g
- Volume: 2375ml -> 3980ml
- Longest side: 24 -> 25cm
- ``price_preapoc``: 45$ -> 29$
- Disassembly yield decreased to account for weight decrease
- Pocket max weight increased from 2kg to 4kg

</details>

<details>
<summary>CANNING POT (again)</summary>

- **I COMPLETELY MESSED UP THE LAST TIME I AUDITED IT AND BASED IT OFF OF A STOCK POT!**
- Weight: 5540g -> 4082g
- Volume:  32570ml -> 25400ml
- Longest side: 40cm -> 45cm
- ``price_preapoc``: 112$ -> 68$
- Disassembly yield decreased to account for weight decrease 
- Pocket max volume decreased from 25l to 20l
- Pocket max weight decreased from 50kg to 40kg

</details>

<details>
<summary>STOCK POT</summary>

- Weight: 2490g -> 2500g
- Volume: 12800ml -> 12700ml
- ``price_preapoc``: 45$ -> 137$
- Changed material proportions from 1:1 steel and aluminum to 9:1 steel and aluminum
- Crafting recipe adjusted to include aluminum
- Disassembly yield decreased to account for weight decrease AND the entire disassembly recipe was brought up to speed with tool qualities, time taken, and to not use skills
- Pocket max weight increased from 12kg to 24kg

</details>

<details>
<summary>CARVING FORK</summary>

- Weight: 158g -> 90g
- Volume: 75ml -> 180ml
- Longest side: N/A -> 29cm
- ``price_preapoc``: 2$ -> 12$
- ``to-hit`` values now use modifiers
- Removed unused ``proportional`` field
- Disassembly yield decreased to account for weight decrease

</details>

<details>
<summary>CARVING KNIFE</summary>

- Weight: 280g -> 114g
- Volume: 200ml -> 80ml
- ``price_preapoc``: 15$ -> 17$
- Disassembly modified to take less time, be less exhausting and always give 1 scrap instead of using the non-working mess that included a spike (and generated mass)

</details>
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Since I'm cleaning up an old oopsie this one will be slightly larger than usual.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->