### PR TITLE
Clear tile map memory on part removal

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -130,7 +130,8 @@ static bool is_sm_tile_over_water( const tripoint &real_global_pos );
 void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
 {
     avatar &player_character = get_avatar();
-    const tripoint part_pos = veh.global_part_pos3( part );
+    const vehicle_part &vp = veh.part( part );
+    const tripoint part_pos = veh.global_part_pos3( vp );
 
     // If the player is currently working on the removed part, stop them as it's futile now.
     const player_activity &act = player_character.activity;
@@ -147,7 +148,7 @@ void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
     // TODO: maybe do this for all the nearby NPCs as well?
     if( player_character.get_grab_type() == object_type::VEHICLE &&
         player_character.pos() + player_character.grab_point == part_pos ) {
-        if( veh.parts_at_relative( veh.part( part ).mount, false ).empty() ) {
+        if( veh.parts_at_relative( vp.mount, false ).empty() ) {
             add_msg( m_info, _( "The vehicle part you were holding has been destroyed!" ) );
             player_character.grab( object_type::NONE );
         }
@@ -156,6 +157,8 @@ void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
     here.dirty_vehicle_list.insert( &veh );
     here.clear_vehicle_point_from_cache( &veh, part_pos );
     here.add_vehicle_to_cache( &veh );
+    here.set_memory_seen_cache_dirty( part_pos );
+    player_character.memorize_clear_decoration( here.getabs( part_pos ), "vp_" + vp.info().id.str() );
 }
 
 // Vehicle stack methods.


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/66747

#### Describe the solution

Clear tile map memory when part on tile gets removed and the memorized decoration string starts with the displayed part id.

Not a perfect solution, for example removing a board, or whatever currently displayed part is but not the last one on tile, makes the vehicle parts on tile disappear until player gains sight on the tile.

#### Describe alternatives you've considered

Could put fd_clairvoyant on the tile if part is removed by a character activity, but the field is buggy and seems to randomly not work at all (or i somehow didn't apply it right)

#### Testing

#### Additional context
