### PR TITLE
Misc maintenance to innawoods

### DIFF
--- a/data/mods/innawood/itemgroups/trash_and_debris.json
+++ b/data/mods/innawood/itemgroups/trash_and_debris.json
@@ -13,7 +13,6 @@
       [ "straw_pile", 80 ],
       [ "tanbark", 80 ],
       [ "rock_large", 70 ],
-      [ "ceramic_shard", 10 ],
       [ "pine_bough", 70 ],
       [ "splinter", 70 ],
       [ "hickory_root", 65 ],

--- a/data/mods/innawood/readme.md
+++ b/data/mods/innawood/readme.md
@@ -12,8 +12,7 @@ The goal of the mod is to create a 'innawood' experience, where the player can e
 - Sand spawns somewhat commonly in plains.
 - Get a lot of withered plants from smashing young trees.
 - Bog iron can be extracted and refined to allow metalworking.
-- The old ammonia recipe is back.
-- Ammonia, glass from sand, cattail jelly, quicklime, cement, and mortar are auto learned.
+- Glass from sand, cattail jelly, quicklime, cement, mortar, and other recipes for a wilderness experience are auto learned.
 - Mortar can be made without a cement mixer, but now requires water.
 - Man made junk found on the ground or though foraging is removed.
 - You can make nails without first needing a nail.

--- a/data/mods/innawood/recipes/medsandchemicals.json
+++ b/data/mods/innawood/recipes/medsandchemicals.json
@@ -249,5 +249,30 @@
     "result_mult": 1,
     "flags": [ "BLIND_EASY" ],
     "components": [ [ [ "cotton_patchwork", 1 ], [ "fibercloth_patchwork", 1 ] ] ]
+  },
+  {
+    "result": "lye",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "id_suffix": "by_electrolysis",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_CHEMICALS",
+    "skill_used": "chemistry",
+    "skills_required": [ "electronics", 2 ],
+    "difficulty": 4,
+    "time": "20 m",
+    "batch_time_factors": [ 80, 4 ],
+    "//": "chloralkali process, same as with bleach except we wont be washing gases",
+    "//2": "This is a copy of the DDA recipe, with autolearn added.",
+    "autolearn": true,
+    "book_learn": [ [ "adv_chemistry", 3 ], [ "textbook_chemistry", 3 ], [ "recipe_labchem", 3 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_intro_chemistry" },
+      { "proficiency": "prof_inorganic_chemistry" },
+      { "proficiency": "prof_intro_chem_synth" }
+    ],
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
+    "tools": [ [ [ "electrolysis_kit", 250 ] ] ],
+    "components": [ [ [ "salt_water", 2 ], [ "saline", 10 ] ] ]
   }
 ]

--- a/data/mods/innawood/recipes/medsandchemicals.json
+++ b/data/mods/innawood/recipes/medsandchemicals.json
@@ -1,22 +1,5 @@
 [
   {
-    "type": "recipe",
-    "result": "ammonia_hydroxide",
-    "category": "CC_CHEM",
-    "subcategory": "CSC_CHEM_CHEMICALS",
-    "skill_used": "chemistry",
-    "difficulty": 5,
-    "time": "36 m",
-    "autolearn": true,
-    "qualities": [ { "id": "CHEM", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
-    "components": [
-      [ [ "water_clean", 1 ], [ "water", 1 ] ],
-      [ [ "scrap", 1 ] ],
-      [ [ "charcoal", 5 ], [ "coal_lump", 5 ], [ "lye_powder", 20 ] ]
-    ]
-  },
-  {
     "result": "cattail_jelly",
     "byproducts": [ [ "plant_fibre" ] ],
     "type": "recipe",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Work towards #65632 in agreeance with @Light-Wave (innawoods maintainer)

#### Describe the solution
Just the uncontroversial json changes which I should've PR'd like a month ago :)

-Removed ceramic shards from foraging results

-Removed recipe for ammonia solution

-**Updated readme** since the ammonia recipe is now well and truly gone. This wasn't mentioned in the topic but I found it while doing a quick grep for the ammonia recipe.

-Made lye_by_electrolysis recipe autolearned in innawoods

#### Describe alternatives you've considered

#### Testing
I made a test save with all recipes learned via debug menu, reloaded after applying changes. No debug messages about missing recipes.
(Not actually sure *why* that is, but sure? Saves the effort of obsoleting it)

#### Additional context
