### PR TITLE
Better scenario worldbuilding by giving PC knowledge of the nearest city on start

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -406,6 +406,7 @@
     "forced_traits": [ "ILLITERATE", "ANTIJUNK", "STRONGSTOMACH", "SPIRITUAL" ],
     "forbidden_traits": [ "FASTREADER", "SLOWREADER" ],
     "requirement": "achievement_witnessed_portal_storm",
+    "reveal_locale": false,
     "flags": [ "CHALLENGE", "LONE_START" ]
   },
   {
@@ -459,6 +460,7 @@
       "ELECTRORECEPTORS"
     ],
     "requirement": "achievement_reach_lab_finale",
+    "reveal_locale": false,
     "flags": [ "CHALLENGE", "CITY_START", "LONE_START" ]
   },
   {
@@ -627,6 +629,7 @@
       "cop"
     ],
     "requirement": "achievement_reach_island_prison",
+    "reveal_locale": false,
     "flags": [ "LONE_START", "CHALLENGE" ]
   },
   {
@@ -639,6 +642,7 @@
     "start_name": "Mi-Go Camp",
     "professions": [ "captive", "rescuer" ],
     "requirement": "achievement_reach_mi-Go_encampment",
+    "reveal_locale": false,
     "flags": [ "LONE_START", "CHALLENGE" ],
     "custom_initial_date": { "season": "winter" }
   },
@@ -917,6 +921,7 @@
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island" ],
     "eoc": [ "scenario_strong_portal_storm" ],
     "requirement": "achievement_reach_lab_finale",
+    "reveal_locale": false,
     "professions": [ "portal_traveler", "churl", "true_foodperson", "unemployed", "naked" ]
   },
   {
@@ -1007,6 +1012,7 @@
       "combat-engineer"
     ],
     "requirement": "achievement_reach_aircraft_carrier",
+    "reveal_locale": false,
     "flags": [ "CHALLENGE", "LONE_START" ]
   },
   {
@@ -1234,7 +1240,8 @@
     "points": 1,
     "description": "During your escape you got lost and ended up at the wrong location.  Get your bearings and make a plan.  You'll need it.",
     "start_name": "Middle of Nowhere",
-    "allowed_locs": [ "sloc_middle_of_nowhere" ]
+    "allowed_locs": [ "sloc_middle_of_nowhere" ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -1243,6 +1250,7 @@
     "points": 1,
     "description": "When the riots came to your home, you ran underground and hid.  Now days later you are lost and hear movement echoing in the dark.",
     "start_name": "Underground",
-    "allowed_locs": [ "sloc_sewer" ]
+    "allowed_locs": [ "sloc_sewer" ],
+    "reveal_locale": false
   }
 ]

--- a/data/mods/Magiclysm/scenarios.json
+++ b/data/mods/Magiclysm/scenarios.json
@@ -45,7 +45,8 @@
       "novice_technomancer",
       "novice_stormshaper",
       "academy_wizard"
-    ]
+    ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -67,7 +68,8 @@
       "wild_druid",
       "archer_druid",
       "magic_grim_reaper"
-    ]
+    ],
+    "reveal_locale": false
   },
   {
     "copy-from": "alcatraz",

--- a/data/mods/innawood/scenarios.json
+++ b/data/mods/innawood/scenarios.json
@@ -36,7 +36,8 @@
       "carpenter",
       "bricklayer"
     ],
-    "flags": [  ]
+    "flags": [  ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -74,7 +75,8 @@
       "trapper",
       "carpenter",
       "bricklayer"
-    ]
+    ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -113,7 +115,8 @@
       "trapper",
       "carpenter",
       "bricklayer"
-    ]
+    ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -153,7 +156,8 @@
       "trapper",
       "carpenter",
       "bricklayer"
-    ]
+    ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -192,7 +196,8 @@
       "trapper",
       "carpenter",
       "bricklayer"
-    ]
+    ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -204,7 +209,8 @@
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island", "sloc_river" ],
     "professions": [ "svictim", "naked", "unemployed", "homeless", "hitchhiker", "musician" ],
     "eoc": [ "scenario_infected", "scenario_bad_day" ],
-    "flags": [ "FIRE_START", "CHALLENGE", "LONE_START" ]
+    "flags": [ "FIRE_START", "CHALLENGE", "LONE_START" ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -242,7 +248,8 @@
       "trapper",
       "carpenter",
       "bricklayer"
-    ]
+    ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -282,7 +289,8 @@
       "trapper",
       "carpenter",
       "bricklayer"
-    ]
+    ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -321,7 +329,8 @@
       "trapper",
       "carpenter",
       "bricklayer"
-    ]
+    ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -334,7 +343,8 @@
     "allowed_locs": [ "sloc_field" ],
     "vehicle": "2seater2_scenario",
     "professions": [ "heli_pilot" ],
-    "flags": [ "LONE_START" ]
+    "flags": [ "LONE_START" ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -372,7 +382,8 @@
       "trapper",
       "carpenter",
       "bricklayer"
-    ]
+    ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -384,7 +395,8 @@
     "allowed_locs": [ "sloc_field" ],
     "start_name": "Crash Site",
     "map_extra": "mx_mayhem",
-    "flags": [ "CHALLENGE", "HELI_CRASH", "LONE_START" ]
+    "flags": [ "CHALLENGE", "HELI_CRASH", "LONE_START" ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",
@@ -398,6 +410,7 @@
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island" ],
     "eoc": [ "scenario_strong_portal_storm" ],
     "requirement": "achievement_witnessed_portal_storm",
+    "reveal_locale": false,
     "professions": [ "portal_traveler", "churl", "true_foodperson", "unemployed", "naked" ]
   },
   {
@@ -411,6 +424,7 @@
     "professions": [ "churl" ],
     "forced_traits": [ "ILLITERATE", "ANTIJUNK", "STRONGSTOMACH", "SPIRITUAL" ],
     "forbidden_traits": [ "FASTREADER", "SLOWREADER" ],
-    "flags": [ "CHALLENGE", "LONE_START" ]
+    "flags": [ "CHALLENGE", "LONE_START" ],
+    "reveal_locale": false
   }
 ]

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -239,6 +239,7 @@ Use the `Home` key to return to the top.
   - [`professions`](#professions)
   - [`map_special`](#map_special)
   - [`requirement`](#requirement-1)
+  - [`reveal_locale`](#reveal_locale)
   - [`eocs`](#eocs)
   - [`missions`](#missions-1)
   - [`custom_initial_date`](#custom_initial_date)
@@ -5179,6 +5180,12 @@ Add a map special to the starting location, see JSON_FLAGS for the possible spec
 (optional, an achievement ID)
 
 The achievement you need to do to access this scenario
+
+## `reveal_locale`
+
+(optional, boolean)
+
+Defaults true. If a road can be found within 3 OMTs of the starting position, reveals a path to the nearest city and that city's center.
 
 ## `eocs`
 (optional, array of strings)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -890,8 +890,8 @@ bool game::start_game()
                            get_option<int>( "DISTANCE_INITIAL_VISIBILITY" ), 0 );
 
     const int city_size = get_option<int>( "CITY_SIZE" );
-    if( scen->reveal_locale && city_size > 0 ) {
-        auto nearest_city = overmap_buffer.closest_city( m.get_abs_sub() );
+    if( get_scenario()->get_reveal_locale() && city_size > 0 ) {
+        city_reference nearest_city = overmap_buffer.closest_city( m.get_abs_sub() );
         const tripoint_abs_omt city_center_omt = project_to<coords::omt>( nearest_city.abs_sm_pos );
         // Very necessary little hack: We look for roads around our start, and path from the closest. Because the most common start(evac shelter) cannot be pathed through...
         const tripoint_abs_omt nearest_road = overmap_buffer.find_closest( omtstart, "road", 3, false );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -899,7 +899,6 @@ bool game::start_game()
         overmap_buffer.reveal_route( nearest_road, city_center_omt, 3 );
         // Reveal destination city (scaling with city size setting)
         overmap_buffer.reveal( city_center_omt, city_size );
-        debugmsg( "test" );
     }
 
     u.moves = 0;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -889,6 +889,19 @@ bool game::start_game()
     overmap_buffer.reveal( u.global_omt_location().xy(),
                            get_option<int>( "DISTANCE_INITIAL_VISIBILITY" ), 0 );
 
+    const int city_size = get_option<int>( "CITY_SIZE" );
+    if( scen->reveal_locale && city_size > 0 ) {
+        auto nearest_city = overmap_buffer.closest_city( m.get_abs_sub() );
+        const tripoint_abs_omt city_center_omt = project_to<coords::omt>( nearest_city.abs_sm_pos );
+        // Very necessary little hack: We look for roads around our start, and path from the closest. Because the most common start(evac shelter) cannot be pathed through...
+        const tripoint_abs_omt nearest_road = overmap_buffer.find_closest( omtstart, "road", 3, false );
+        // Reveal route to closest city and a 3 tile radius around the route
+        overmap_buffer.reveal_route( nearest_road, city_center_omt, 3 );
+        // Reveal destination city (scaling with city size setting)
+        overmap_buffer.reveal( city_center_omt, city_size );
+        debugmsg( "test" );
+    }
+
     u.moves = 0;
     u.process_turn(); // process_turn adds the initial move points
     u.set_stamina( u.get_stamina_max() );

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -498,6 +498,11 @@ bool scenario::custom_start_date() const
     return _custom_start_date;
 }
 
+bool scenario::get_reveal_locale() const
+{
+    return reveal_locale;
+}
+
 void scenario::rerandomize() const
 {
     scenario *hack = const_cast<scenario *>( this );

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -100,6 +100,8 @@ void scenario::load( const JsonObject &jo, const std::string_view )
 
     optional( jo, was_loaded, "requirement", _requirement );
 
+    optional( jo, was_loaded, "reveal_locale", reveal_locale, true );
+
     optional( jo, was_loaded, "eoc", _eoc, auto_flags_reader<effect_on_condition_id> {} );
 
     if( !was_loaded ) {

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -56,6 +56,7 @@ class scenario
         std::optional<achievement_id> _requirement;
 
         bool _custom_start_date = false;
+        bool reveal_locale = true;
         bool _is_random_hour = false;
         int _start_hour = 8;
         bool _is_random_day = false;
@@ -102,6 +103,7 @@ class scenario
         std::optional<achievement_id> get_requirement() const;
 
         bool custom_start_date() const;
+        bool get_reveal_locale() const;
         void rerandomize() const;
         bool is_random_hour() const;
         bool is_random_day() const;
@@ -141,9 +143,6 @@ class scenario
 
         /** Such as a seasonal start, fiery start, surrounded start, etc. */
         bool has_flag( const std::string &flag ) const;
-
-        // Reveal nearest city and path to it?
-        bool reveal_locale = true;
 
         /**
          * Do you have the necessary achievement state

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -142,6 +142,9 @@ class scenario
         /** Such as a seasonal start, fiery start, surrounded start, etc. */
         bool has_flag( const std::string &flag ) const;
 
+        // Reveal nearest city and path to it?
+        bool reveal_locale = true;
+
         /**
          * Do you have the necessary achievement state
          */


### PR DESCRIPTION
#### Summary
Content "Most scenarios now provide vision of the nearest city on start"

#### Purpose of change
Some starts spawn outside of cities, but are not like... ~~innawoods players~~ detached from society. Presumably the PC had a home before the cataclysm, and some sort of education, and at least knew where the mcdonalds down the street was. The game doesn't currently represent that - it only plops down a big (15-tile default) radius of sight around you at the start, and if there's no civilization in sight, too bad, guess your character was living off the grid!

#### Describe the solution
Add a json toggle defined per-scenario (**defaults true** so it doesn't need to be added to 99% of starts) whether this vision should be granted.

Draw a path from the nearest road to the city center, revealing an area around it.

Reveal an area around the city center, scaling with the CITY_SIZE setting.


#### Describe alternatives you've considered
The current method of scaling with city size doesn't seem to be perfect? Sometimes cities are massive, sometimes cities are small, and the vision might either be insufficient or too much. But then again, I wouldn't expect a city's resident to know *the entire* city...


#### Testing

Here is an average evac shelter start:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/8b53716e-0a2d-4b37-9853-503c4b258cb6)

Here is **basically the worst-case scenario**:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/31a9547d-4601-4311-ae89-ced28040c9ba)

#### Additional context
Disabled this for the following scenarios:
Medieval peasant(DDA)
Lab patient(DDA)
Island Prison(DDA)
Mi-Go prisoner(DDA)
Portal dependent(DDA)
Aircraft carrier start(DDA)
Middle of nowhere(DDA)
Lost Underground(DDA)
*All innawoods starts*(just in case)
Wizard's Vacation(Magiclysm)
Exile (Magiclysm)
