### PR TITLE
[MoM] Fix coruscating matrix crystal not draining on use

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_crystal_draining.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_crystal_draining.json
@@ -61,5 +61,14 @@
       { "u_consume_item": "matrix_crystal_vitakinesis", "count": 1 },
       { "u_spawn_item": "matrix_crystal_drained", "suppress_message": true }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CORUSCATING_CRYSTAL_DRAINING",
+    "condition": { "u_has_item": "matrix_crystal_coruscating" },
+    "effect": [
+      { "u_consume_item": "matrix_crystal_coruscating", "count": 1 },
+      { "u_spawn_item": "matrix_crystal_drained", "suppress_message": true }
+    ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_matrix_awakening.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_matrix_awakening.json
@@ -417,16 +417,19 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CORUSCATING_MATRIX",
-    "effect": {
-      "weighted_list_eocs": [
-        [ "EOC_BIOKIN_MATRIX_AWAKENING_3", { "const": 1 } ],
-        [ "EOC_CLAIR_MATRIX_AWAKENING_3", { "const": 1 } ],
-        [ "EOC_PYROKIN_MATRIX_AWAKENING_3", { "const": 1 } ],
-        [ "EOC_TELEKIN_MATRIX_AWAKENING_3", { "const": 1 } ],
-        [ "EOC_TEEP_MATRIX_AWAKENING_3", { "const": 1 } ],
-        [ "EOC_TELEPORT_MATRIX_AWAKENING_3", { "const": 1 } ],
-        [ "EOC_VITAKIN_MATRIX_AWAKENING_3", { "const": 1 } ]
-      ]
-    }
+    "effect": [
+      { "queue_eocs": "EOC_CORUSCATING_CRYSTAL_DRAINING", "time_in_future": "1 seconds" },
+      {
+        "weighted_list_eocs": [
+          [ "EOC_BIOKIN_MATRIX_AWAKENING_3", { "const": 1 } ],
+          [ "EOC_CLAIR_MATRIX_AWAKENING_3", { "const": 1 } ],
+          [ "EOC_PYROKIN_MATRIX_AWAKENING_3", { "const": 1 } ],
+          [ "EOC_TELEKIN_MATRIX_AWAKENING_3", { "const": 1 } ],
+          [ "EOC_TEEP_MATRIX_AWAKENING_3", { "const": 1 } ],
+          [ "EOC_TELEPORT_MATRIX_AWAKENING_3", { "const": 1 } ],
+          [ "EOC_VITAKIN_MATRIX_AWAKENING_3", { "const": 1 } ]
+        ]
+      }
+    ]
   }
 ]

--- a/data/mods/MindOverMatter/items/matrix_crystals.json
+++ b/data/mods/MindOverMatter/items/matrix_crystals.json
@@ -261,7 +261,7 @@
   {
     "type": "TOOL",
     "id": "matrix_crystal_coruscating",
-    "name": { "str_sp": "strange crystal" },
+    "name": { "str_sp": "strange crystal, coruscating" },
     "description": "A strange-looking, surprisingly-heavy crystal.  In total darkness, multicolored lights churn and swirl within its depths.",
     "copy-from": "matrix_crystal_biokinesis",
     "color": "brown",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix coruscating matrix crystal not draining on use"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

When I went through and moved matrix crystal draining to EoCs in https://github.com/CleverRaven/Cataclysm-DDA/pull/66644 I missed adding a drain EoC for coruscating matrix crystals, allowing the Awakening Psion profession and anyone else lucky enough to find one to activate it infinitely until they awaken to every psionic path. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a draining EoC for the coruscating matrix crystal so it can only be used once, as intended. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

"TETSUOOOOOOOOOOOOO"
"KANEDAAAAAAAAAAAAAAA"
*Explosion*
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works properly now. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->