### PR TITLE
Enable clang-tidy check performance-unnecessary-copy-initialization

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -77,7 +77,6 @@ readability-*,\
 -modernize-return-braced-init-list,\
 -modernize-use-default-member-init,\
 -modernize-use-nodiscard,\
--performance-unnecessary-copy-initialization,\
 -readability-container-data-pointer,\
 -readability-convert-member-functions-to-static,\
 -readability-duplicate-include,\

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1018,7 +1018,7 @@ static void draw_speed_tab( ui_adaptor &ui, const catacurses::window &w_speed,
         if( highlight_line ) {
             ui.set_cursor( w_speed, pos );
         }
-        const speedlist_entry entry = speedlist[i];
+        const speedlist_entry &entry = speedlist[i];
 
         // +speed is good, -movecost is good
         const nc_color col = entry.is_speed == ( entry.val > 0 ) ? c_light_green : c_red;


### PR DESCRIPTION

There was just one example it found in our code.
#### Summary
None

#### Purpose of change
More static analysis.

This clang-tidy check looks for opportunities to replace a copy with a captured reference, for a performance improvement.

#### Describe the solution
Enable the check, apply the suggested change.

#### Describe alternatives you've considered
None.

#### Testing
Change is minimal, so I'll rely on the CI for that.

#### Additional context