### PR TITLE
Fix typo in src/third_party/CMakeLists.txt

### DIFF
--- a/src/third-party/CMakeLists.txt
+++ b/src/third-party/CMakeLists.txt
@@ -16,7 +16,7 @@ file(GLOB FLATBUFFERS_SOURCES ${THIRD_PARTY_SOURCE_DIR}/flatbuffers/*.cpp)
 add_library(
         flatbuffers
         STATIC
-        ${FLATBUFFER_HEADERS}
+        ${FLATBUFFERS_HEADERS}
         ${FLATBUFFERS_SOURCES})
 
 target_include_directories(


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fix a typo

#### Describe the solution
Fix the typo

#### Describe alternatives you've considered
Remove the line since it did not cause compilation errors, meaning it might be not needed at all?

#### Testing
Compiled the game without any problem.

#### Additional context
I originally PR'd this to #65709, but that probably needs more work before it is mergeable so I decided to PR this separately.