### PR TITLE
Split Skater profession into one with blades and another with a board

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4153,10 +4153,13 @@
   {
     "type": "profession",
     "id": "skaterkid",
-    "name": { "male": "Skater Boy", "female": "Skater Girl" },
+    "name": { "male": "Skater Boy (Rollerblades)", "female": "Skater Girl (Rollerblades)" },
     "description": "You love to skate!  You've probably spent more time on a pair of blades than off.  Things have gotten pretty bad, but at least the grown-ups aren't telling you where you can't roll.",
     "points": 1,
-    "skills": [ { "level": 1, "name": "dodge" } ],
+    "skills": [
+      { "level": 1, "name": "dodge" },
+      { "level": 2, "name": "swimming" }
+    ],
     "traits": [ "PROF_SKATER" ],
     "items": {
       "both": {
@@ -4169,6 +4172,39 @@
           "gloves_fingerless",
           "helmet_skid",
           "roller_blades",
+          "wristwatch",
+          "sports_drink"
+        ],
+        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+      },
+      "male": [ "briefs" ],
+      "female": [ "boy_shorts" ]
+    }
+  },
+  {
+    "type": "profession",
+    "id": "skaterkid_board",
+    "name": { "male": "Skater Boy (Skateboard)", "female": "Skater Girl (Skateboard)" },
+    "description": "You love to skate!  You've probably spent more time on a skateboard than off.  Things have gotten pretty bad, but at least the grown-ups aren't telling you where you can't roll.",
+    "points": 1,
+    "skills": [
+      { "level": 1, "name": "dodge" },
+      { "level": 2, "name": "driving" },
+      { "level": 2, "name": "swimming" }
+    ],
+    "traits": [ "PROF_SKATER" ],
+    "items": {
+      "both": {
+        "items": [
+          "hoodie",
+          "jeans",
+          "socks",
+          "elbow_pads",
+          "knee_pads",
+          "gloves_fingerless",
+          "helmet_skid",
+          "sneakers",
+          "folded_skateboard_generic",
           "wristwatch",
           "sports_drink"
         ],

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4156,10 +4156,7 @@
     "name": { "male": "Skater Boy (Rollerblades)", "female": "Skater Girl (Rollerblades)" },
     "description": "You love to skate!  You've probably spent more time on a pair of blades than off.  Things have gotten pretty bad, but at least the grown-ups aren't telling you where you can't roll.",
     "points": 1,
-    "skills": [
-      { "level": 1, "name": "dodge" },
-      { "level": 2, "name": "swimming" }
-    ],
+    "skills": [ { "level": 1, "name": "dodge" }, { "level": 2, "name": "swimming" } ],
     "traits": [ "PROF_SKATER" ],
     "items": {
       "both": {
@@ -4187,11 +4184,7 @@
     "name": { "male": "Skater Boy (Skateboard)", "female": "Skater Girl (Skateboard)" },
     "description": "You love to skate!  You've probably spent more time on a skateboard than off.  Things have gotten pretty bad, but at least the grown-ups aren't telling you where you can't roll.",
     "points": 1,
-    "skills": [
-      { "level": 1, "name": "dodge" },
-      { "level": 2, "name": "driving" },
-      { "level": 2, "name": "swimming" }
-    ],
+    "skills": [ { "level": 1, "name": "dodge" }, { "level": 2, "name": "driving" }, { "level": 2, "name": "swimming" } ],
     "traits": [ "PROF_SKATER" ],
     "items": {
       "both": {


### PR DESCRIPTION
#### Summary
Content "Split Skater profession into one with blades and another with a board"

#### Purpose of change
There was a skateboard vehicle added (#66596) and it felt weird to not have a profession that starts with it.

#### Describe the solution
Make a similar profession to Skater Person, but with sneakers instead of rollerblades + a folded skateboard. It has 2 vehicles, and both it and Skater person (Rollerblades) have 2 athletics now.

#### Describe alternatives you've considered
Leaving as is, adding a different flavor.

#### Testing
![изображение](https://github.com/CleverRaven/Cataclysm-DDA/assets/52408044/0ca27575-1e0b-4fd4-9f3c-4b79f6801c14)
![изображение](https://github.com/CleverRaven/Cataclysm-DDA/assets/52408044/78a51b35-864d-4f60-80b5-4aebff618958)

#### Additional context
skamtebord

Hopefully this gets someone to add a sprite for it...