### PR TITLE
No more civilian de-aging

### DIFF
--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -202,7 +202,7 @@
   {
     "type": "monstergroup",
     "name": "GROUP_VANILLA_ONLY_HUMANS",
-    "//": "only human zombies, used in the refugee center and as upgrades for civilians",
+    "//": "only human zombies, used in the refugee center",
     "default": "mon_zombie",
     "monsters": [
       { "monster": "mon_zombie", "weight": 264, "cost_multiplier": 0 },

--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -105,8 +105,12 @@
     "name": "GROUP_CIVILIANS_UPGRADE",
     "type": "monstergroup",
     "monsters": [
-      { "group": "GROUP_VANILLA_ONLY_HUMANS", "weight": 8, "cost_multiplier": 0 },
-      { "group": "GROUP_FERAL", "weight": 2, "cost_multiplier": 0 }
+      { "monster": "mon_zombie", "weight": 16, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_fat", "weight": 16, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_tough", "weight": 16, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_crawler", "weight": 16, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_brainless", "weight": 16, "cost_multiplier": 0 },
+      { "group": "GROUP_FERAL", "weight": 20, "cost_multiplier": 0 }
     ]
   },
   {

--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -105,12 +105,12 @@
     "name": "GROUP_CIVILIANS_UPGRADE",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie", "weight": 16, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_fat", "weight": 16, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_tough", "weight": 16, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_crawler", "weight": 16, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_brainless", "weight": 16, "cost_multiplier": 0 },
-      { "group": "GROUP_FERAL", "weight": 20, "cost_multiplier": 0 }
+      { "monster": "mon_zombie", "weight": 264, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_fat", "weight": 266, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_tough", "weight": 100, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_crawler", "weight": 66, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_brainless", "weight": 30, "cost_multiplier": 0 },
+      { "group": "GROUP_FERAL", "weight": 180, "cost_multiplier": 0 }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevents civilians from evolving into zombie children"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #66547
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Manually allowed specific zombos that the civilians can upgrade to and they include all the previous ones except zombie children and decayed zombies. First, civilians would NOT de-age. Second, 1 day is way too short for a living human to turn into a decaying corpse.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
The ratio of them evolving into zombies vs ferals should be kept intact if my maths was correct
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->