### PR TITLE
Migrate some vehicle code from part indexes to part references pt2

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1045,15 +1045,14 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             std::vector<vehicle_part *> parts =
                 veh->get_parts_at( src_loc.raw(), "", part_status_flag::any );
             for( vehicle_part *part_elem : parts ) {
-                const vpart_info &vpinfo = part_elem->info();
-                int vpindex = veh->index_of_part( part_elem, true );
+                const int vpindex = veh->index_of_part( part_elem, true );
                 // if part is not on this vehicle, or if its attached to another part that needs to be removed first.
-                if( vpindex == -1 || !veh->can_unmount( vpindex ) ) {
+                if( vpindex < 0 || !veh->can_unmount( *part_elem ).success() ) {
                     continue;
                 }
+                const vpart_info &vpinfo = part_elem->info();
                 // If removing this part would make the vehicle non-flyable, avoid it
-                if( veh->would_removal_prevent_flyable( *part_elem,
-                                                        player_character ) ) {
+                if( veh->would_removal_prevent_flyable( *part_elem, player_character ) ) {
                     return activity_reason_info::fail( do_activity_reason::WOULD_PREVENT_VEH_FLYING );
                 }
                 // this is the same part that somebody else wants to work on, or already is.

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -202,8 +202,9 @@ bool game::grabbed_veh_move( const tripoint &dp )
 
     for( int p : wheel_indices ) {
         if( one_in( 2 ) ) {
-            tripoint wheel_p = grabbed_vehicle->global_part_pos3( grabbed_part );
-            grabbed_vehicle->handle_trap( wheel_p, p );
+            vehicle_part &vp_wheel = grabbed_vehicle->part( p );
+            tripoint wheel_p = grabbed_vehicle->global_part_pos3( vp_wheel );
+            grabbed_vehicle->handle_trap( wheel_p, vp_wheel );
         }
     }
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -516,9 +516,10 @@ class item_location::impl::item_on_vehicle : public item_location::impl
 
         void remove_item() override {
             on_contents_changed();
-            item &base = cur.veh.part( cur.part ).base;
+            vehicle_part &vp = cur.veh.part( cur.part );
+            item &base = vp.base;
             if( &base == target() ) {
-                cur.veh.remove_part( cur.part ); // vehicle_part::base
+                cur.veh.remove_part( vp ); // vehicle_part::base
             } else {
                 cur.remove_item( *target() ); // item within CARGO
             }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6735,10 +6735,11 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
                     std::vector<int> parts_in_square = veh_to_add->parts_at_relative( source_point, true );
                     std::set<int> parts_to_check;
                     for( int index = parts_in_square.size() - 1; index >= 0; index-- ) {
+                        vehicle_part &vp = veh_to_add->part( parts_in_square[index] );
                         if( handler_ptr ) {
-                            veh_to_add->remove_part( parts_in_square[index], *handler_ptr );
+                            veh_to_add->remove_part( vp, *handler_ptr );
                         } else {
-                            veh_to_add->remove_part( parts_in_square[index] );
+                            veh_to_add->remove_part( vp );
                         }
                         parts_to_check.insert( parts_in_square[index] );
                     }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -682,7 +682,8 @@ task_reason veh_interact::cant_do( char mode )
             // remove mode
             enough_morale = player_character.has_morale_to_craft();
             valid_target = cpart >= 0;
-            part_free = parts_here.size() > 1 || ( cpart >= 0 && veh->can_unmount( cpart ) );
+            part_free = parts_here.size() > 1 ||
+                        ( cpart >= 0 && veh->can_unmount( veh->part( cpart ) ).success() );
             //tool and skill checks processed later
             has_tools = true;
             has_skill = true;
@@ -1785,10 +1786,10 @@ bool veh_interact::can_remove_part( int idx, const Character &you )
     }
     nmsg += res.second;
 
-    std::string reason;
-    if( !veh->can_unmount( idx, reason ) ) {
+    const ret_val<void> unmount = veh->can_unmount( *sel_vehicle_part );
+    if( !unmount.success() ) {
         //~ %1$s represents the internal color name which shouldn't be translated, %2$s is pre-translated reason
-        nmsg += string_format( _( "> %1$s%2$s</color>" ), status_color( false ), reason ) + "\n";
+        nmsg += string_format( _( "> %1$s%2$s</color>" ), status_color( false ), unmount.str() ) + "\n";
         ok = false;
     }
     const nc_color desc_color = sel_vehicle_part->is_broken() ? c_dark_gray : c_light_gray;

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3274,7 +3274,7 @@ void veh_interact::complete_vehicle( Character &you )
                     return;
                 }
             }
-            const vehicle_part &vp = veh.part( vp_index );
+            vehicle_part &vp = veh.part( vp_index );
             const vpart_info &vpi = vp.info();
             const bool appliance_removal = static_cast<char>( you.activity.index ) == 'O';
             const bool wall_wire_removal = appliance_removal && vpi.id == vpart_ap_wall_wiring;
@@ -3306,7 +3306,7 @@ void veh_interact::complete_vehicle( Character &you )
 
             // Power cables must remove parts from the target vehicle, too.
             if( vpi.has_flag( "POWER_TRANSFER" ) ) {
-                veh.remove_remote_part( vp_index );
+                veh.remove_remote_part( vp );
             }
 
             if( broken ) {
@@ -3353,7 +3353,7 @@ void veh_interact::complete_vehicle( Character &you )
                 here.destroy_vehicle( &veh );
             } else {
                 const tripoint part_pos = veh.global_part_pos3( vp );
-                veh.remove_part( vp_index );
+                veh.remove_part( vp );
                 // part_removal_cleanup calls refresh, so parts_at_relative is valid
                 veh.part_removal_cleanup();
                 if( veh.parts_at_relative( vp.mount, true ).empty() ) {

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -92,7 +92,6 @@ vehicle_part *most_repairable_part( vehicle &veh, Character &who )
 
 bool repair_part( vehicle &veh, vehicle_part &pt, Character &who )
 {
-    int part_index = veh.index_of_part( &pt );
     const vpart_info &vp = pt.info();
 
     const requirement_data reqs = pt.is_broken()
@@ -141,7 +140,7 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who )
         const units::angle direction = pt.direction;
         const std::string variant = pt.variant;
         get_map().spawn_items( who.pos(), pt.pieces_for_broken_part() );
-        veh.remove_part( part_index );
+        veh.remove_part( pt );
         const int partnum = veh.install_part( mount, vpid, std::move( base ) );
         if( partnum >= 0 ) {
             vehicle_part &vp = veh.part( partnum );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -875,11 +875,13 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
             if( p == other_p ) {
                 continue;
             }
-            const vpart_info &p_info = parts[p].info();
-            const vpart_info &other_p_info = parts[other_p].info();
+            vehicle_part &vp1 = parts[p];
+            vehicle_part &vp2 = parts[other_p];
+            const vpart_info &vpi1 = vp1.info();
+            const vpart_info &vpi2 = vp2.info();
 
-            if( p_info.id == other_p_info.id ||
-                ( !p_info.location.empty() && p_info.location == other_p_info.location ) ) {
+            if( vpi1.id == vpi2.id ||
+                ( !vpi1.location.empty() && vpi1.location == vpi2.location ) ) {
                 // Deferred creation of the handler to here so it is only created when actually needed.
                 if( !handler_ptr ) {
                     // This is a heuristic: we just assume the default handler is good enough when called
@@ -892,9 +894,9 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
                     }
                 }
                 if( part.is_fake ) {
-                    remove_part( p, *handler_ptr );
+                    remove_part( vp1, *handler_ptr );
                 } else {
-                    remove_part( other_p, *handler_ptr );
+                    remove_part( vp2, *handler_ptr );
                 }
             }
         }
@@ -1780,28 +1782,19 @@ bool vehicle::merge_vehicle_parts( vehicle *veh )
     return true;
 }
 
-/**
- * Mark a part as removed from the vehicle.
- * @return bool true if the vehicle's 0,0 point shifted.
- */
-bool vehicle::remove_part( const int p )
+bool vehicle::remove_part( vehicle_part &vp )
 {
     DefaultRemovePartHandler handler;
-    return remove_part( p, handler );
+    return remove_part( vp, handler );
 }
 
-bool vehicle::remove_part( const int p, RemovePartHandler &handler )
+bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
 {
     // NOTE: Don't access g or g->m or anything from it directly here.
     // Forward all access to the handler.
     // There are currently two implementations of it:
     // - one for normal game play (vehicle is on the main map g->m),
     // - one for mapgen (vehicle is on a temporary map used only during mapgen).
-    if( p >= static_cast<int>( parts.size() ) ) {
-        debugmsg( "Tried to remove part %d but only %d parts!", p, parts.size() );
-        return false;
-    }
-    vehicle_part &vp = parts[p];
     const vpart_info &vpi = vp.info();
     if( vp.removed ) {
         /* This happens only when we had to remove part, because it was depending on
@@ -1837,9 +1830,9 @@ bool vehicle::remove_part( const int p, RemovePartHandler &handler )
         if( magic || ( dep < 0 ) || !vpi.has_flag( parent_flag ) ) {
             return false;
         }
-        const vehicle_part &vp_dep = parts[dep];
+        vehicle_part &vp_dep = parts[dep];
         handler.add_item_or_charges( part_loc, vp_dep.properties_to_item(), false );
-        remove_part( dep, handler );
+        remove_part( vp_dep, handler );
         return true;
     };
 
@@ -1901,7 +1894,8 @@ bool vehicle::remove_part( const int p, RemovePartHandler &handler )
         parts[vp.fake_part_at].removed = true;
     }
 
-    handler.removed( *this, p );
+    const int vp_idx = index_of_part( &vp, /* include_removed = */ true );
+    handler.removed( *this, vp_idx );
 
     const point &vp_mount = vp.mount;
     const auto iter = labels.find( label( vp_mount ) );
@@ -1909,7 +1903,7 @@ bool vehicle::remove_part( const int p, RemovePartHandler &handler )
         labels.erase( iter );
     }
 
-    for( item &i : get_items( p ) ) {
+    for( item &i : get_items( vp_idx ) ) {
         // Note: this can spawn items on the other side of the wall!
         // TODO: fix this ^^
         if( !magic ) {
@@ -6543,7 +6537,7 @@ void vehicle::invalidate_towing( bool first_vehicle, Character *remover )
             } else {
                 get_map().add_item_or_charges( global_part_pos3( vp ), drop );
             }
-            remove_part( tow_cable_idx );
+            remove_part( vp );
         }
         if( other_veh ) {
             other_veh->invalidate_towing();
@@ -6552,7 +6546,8 @@ void vehicle::invalidate_towing( bool first_vehicle, Character *remover )
     } else {
         const int tow_cable_idx = get_tow_part();
         if( tow_cable_idx > -1 ) {
-            remove_part( tow_cable_idx );
+            vehicle_part &vp = parts[tow_cable_idx];
+            remove_part( vp );
         }
         tow_data.clear_towing();
     }
@@ -6632,7 +6627,7 @@ void vehicle::remove_remote_part( const vehicle_part &vp_local ) const
         for( const int remote_partnum : veh->loose_parts ) {
             vehicle_part &vp_remote = veh->parts[remote_partnum];
             if( vp_remote.info().has_flag( "POWER_TRANSFER" ) && vp_remote.target.first == local_abs ) {
-                veh->remove_part( remote_partnum );
+                veh->remove_part( vp_remote );
                 return;
             }
         }
@@ -6684,7 +6679,7 @@ void vehicle::shed_loose_parts( const tripoint_bub_ms *src, const tripoint_bub_m
             here.add_item_or_charges( global_part_pos3( vp_loose ), drop );
         }
 
-        remove_part( elem );
+        remove_part( vp_loose );
     }
 }
 
@@ -6931,7 +6926,7 @@ bool vehicle::shift_if_needed( map &here )
 
 int vehicle::break_off( map &here, int p, int dmg )
 {
-    const vehicle_part &vp = parts[p];
+    vehicle_part &vp = parts[p];
     const vpart_info &vpi = vp.info();
     /* Already-destroyed part - chance it could be torn off into pieces.
      * Chance increases with damage, and decreases with part max durability
@@ -6990,12 +6985,12 @@ int vehicle::break_off( map &here, int p, int dmg )
                     here.add_item_or_charges( pos, vp_here.properties_to_item() );
                 }
             }
-            remove_part( parts_in_square[index], *handler_ptr );
+            remove_part( vp_here, *handler_ptr );
         }
         // After clearing the frame, remove it.
         add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
         scatter_parts( vp );
-        remove_part( p, *handler_ptr );
+        remove_part( vp, *handler_ptr );
         find_and_split_vehicles( here, { p } );
     } else {
         if( vpi.has_flag( "TOW_CABLE" ) ) {
@@ -7013,7 +7008,7 @@ int vehicle::break_off( map &here, int p, int dmg )
             scatter_parts( vp );
         }
         const point position = vp.mount;
-        remove_part( p, *handler_ptr );
+        remove_part( vp, *handler_ptr );
 
         // remove parts for which required flags are not present anymore
         if( !vpi.get_flags().empty() ) {
@@ -7042,7 +7037,7 @@ int vehicle::break_off( map &here, int p, int dmg )
                             remove_remote_part( vp_here );
                         }
                         here.add_item_or_charges( pos, vp_here.properties_to_item() );
-                        remove_part( part, *handler_ptr );
+                        remove_part( vp_here, *handler_ptr );
                     }
                 }
             }
@@ -7158,9 +7153,9 @@ int vehicle::damage_direct( map &here, int p, int dmg, const damage_type_id &typ
             }
             if( !g || &get_map() != &here ) {
                 MapgenRemovePartHandler handler( here );
-                remove_part( p, handler );
+                remove_part( vp, handler );
             } else {
-                remove_part( p );
+                remove_part( vp );
             }
         }
     }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1062,8 +1062,14 @@ class vehicle
          * on the temporary mapgen map), and when called during normal game play (when items
          * go on the main map g->m).
          */
-        bool remove_part( int p, RemovePartHandler &handler );
-        bool remove_part( int p );
+
+        // Mark a part to be removed from the vehicle.
+        // @returns true if the vehicle's 0,0 point shifted.
+        bool remove_part( vehicle_part &vp );
+        // Mark a part to be removed from the vehicle.
+        // @returns true if the vehicle's 0,0 point shifted.
+        bool remove_part( vehicle_part &vp, RemovePartHandler &handler );
+
         void part_removal_cleanup();
         // inner look for part_removal_cleanup.  returns true if a part is removed
         // also called by remove_fake_parts

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1099,7 +1099,7 @@ class vehicle
          * Remove a part from a targeted remote vehicle. Useful for, e.g. power cables that have
          * a vehicle part on both sides.
          */
-        void remove_remote_part( int part_num );
+        void remove_remote_part( const vehicle_part &vp_local ) const;
         /**
          * Yields a range containing all parts (including broken ones) that can be
          * iterated over.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1016,9 +1016,8 @@ class vehicle
          */
         ret_val<void> can_mount( const point &dp, const vpart_info &vpi ) const;
 
-        // check if certain part can be unmounted
-        bool can_unmount( int p ) const;
-        bool can_unmount( int p, std::string &reason ) const;
+        // @returns true if part \p vp_to_remove can be uninstalled
+        ret_val<void> can_unmount( const vehicle_part &vp_to_remove ) const;
 
         // install a part of type \p type at mount \p dp
         // @return installed part index or -1 if can_mount(...) failed

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -805,13 +805,13 @@ class vehicle
                            const vehicle_part &excluded ) const;
 
         // direct damage to part (armor protection and internals are not counted)
-        // returns damage bypassed
-        int damage_direct( map &here, int p, int dmg,
+        // @returns damage still left to apply
+        int damage_direct( map &here, vehicle_part &vp, int dmg,
                            const damage_type_id &type = damage_type_id( "pure" ) );
         // Removes the part, breaks it into pieces and possibly removes parts attached to it
-        int break_off( map &here, int p, int dmg );
+        int break_off( map &here, vehicle_part &vp, int dmg );
         // Returns if it did actually explode
-        bool explode_fuel( int p, const damage_type_id &type );
+        bool explode_fuel( vehicle_part &vp, const damage_type_id &type );
         //damages vehicle controls and security system
         void smash_security_system();
         // get vpart powerinfo for part number, accounting for variable-sized parts and hps.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1721,7 +1721,7 @@ class vehicle
                                       bool just_detect, bool bash_floor );
 
         // Process the trap beneath
-        void handle_trap( const tripoint &p, int part );
+        void handle_trap( const tripoint &p, vehicle_part &vp_wheel );
         void activate_magical_follow();
         void activate_animal_follow();
         /**

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1201,10 +1201,10 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
     return ret;
 }
 
-void vehicle::handle_trap( const tripoint &p, int part )
+void vehicle::handle_trap( const tripoint &p, vehicle_part &vp_wheel )
 {
-    int pwh = part_with_feature( part, VPFLAG_WHEEL, true );
-    if( pwh < 0 ) {
+    if( !vp_wheel.info().has_flag( VPFLAG_WHEEL ) ) {
+        debugmsg( "vehicle::handle_trap called on non-WHEEL part" );
         return;
     }
     map &here = get_map();
@@ -1214,7 +1214,7 @@ void vehicle::handle_trap( const tripoint &p, int part )
         // If the trap doesn't exist, we can't interact with it, so just return
         return;
     }
-    vehicle_handle_trap_data veh_data = tr.vehicle_data;
+    const vehicle_handle_trap_data &veh_data = tr.vehicle_data;
 
     if( veh_data.is_falling ) {
         return;
@@ -1226,9 +1226,9 @@ void vehicle::handle_trap( const tripoint &p, int part )
     if( seen ) {
         if( known ) {
             //~ %1$s: name of the vehicle; %2$s: name of the related vehicle part; %3$s: trap name
-            add_msg( m_bad, _( "The %1$s's %2$s runs over %3$s." ), name, parts[ part ].name(), tr.name() );
+            add_msg( m_bad, _( "The %1$s's %2$s runs over %3$s." ), name, vp_wheel.name(), tr.name() );
         } else {
-            add_msg( m_bad, _( "The %1$s's %2$s runs over something." ), name, parts[ part ].name() );
+            add_msg( m_bad, _( "The %1$s's %2$s runs over something." ), name, vp_wheel.name() );
         }
     }
 
@@ -1242,7 +1242,6 @@ void vehicle::handle_trap( const tripoint &p, int part )
             explosion_handler::explosion( source, p, veh_data.damage, 0.5f, false, veh_data.shrapnel );
         } else {
             // Hit the wheel directly since it ran right over the trap.
-            vehicle_part &vp_wheel = parts[part];
             damage_direct( here, vp_wheel, veh_data.damage );
         }
         bool still_has_trap = true;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -597,14 +597,14 @@ void vehicle::thrust( int thd, int z )
     // If you are going faster than the animal can handle, harness is damaged
     // Animal may come free ( and possibly hit by vehicle )
     for( size_t e = 0; e < parts.size(); e++ ) {
-        const vehicle_part &vp = parts[ e ];
+        vehicle_part &vp = parts[e];
         if( vp.info().fuel_type == fuel_type_animal && engines.size() != 1 ) {
             monster *mon = get_monster( e );
             if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
                 if( velocity > mon->get_speed() * 12 ) {
                     add_msg( m_bad, _( "Your %s is not fast enough to keep up with the %s" ), mon->get_name(), name );
                     int dmg = rng( 0, 10 );
-                    damage_direct( get_map(), e, dmg );
+                    damage_direct( get_map(), vp, dmg );
                 }
             }
         }
@@ -1242,7 +1242,8 @@ void vehicle::handle_trap( const tripoint &p, int part )
             explosion_handler::explosion( source, p, veh_data.damage, 0.5f, false, veh_data.shrapnel );
         } else {
             // Hit the wheel directly since it ran right over the trap.
-            damage_direct( here, pwh, veh_data.damage );
+            vehicle_part &vp_wheel = parts[part];
+            damage_direct( here, vp_wheel, veh_data.damage );
         }
         bool still_has_trap = true;
         if( veh_data.remove_trap || veh_data.do_explosion ) {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -454,8 +454,8 @@ void vehicle::smash_security_system()
         debugmsg( "No security system found on vehicle." );
         return; // both must be valid parts
     }
-    const vehicle_part &vp_controls = part( idx_controls );
-    const vehicle_part &vp_security = part( idx_security );
+    vehicle_part &vp_controls = part( idx_controls );
+    vehicle_part &vp_security = part( idx_security );
     ///\EFFECT_MECHANICS reduces chance of damaging controls when smashing security system
     const float skill = player_character.get_skill_level( skill_mechanics );
     const int percent_controls = 70 / ( 1 + skill );
@@ -463,7 +463,7 @@ void vehicle::smash_security_system()
     const int rand = rng( 1, 100 );
 
     if( percent_controls > rand ) {
-        damage_direct( here, idx_controls, vp_controls.info().durability / 4 );
+        damage_direct( here, vp_controls, vp_controls.info().durability / 4 );
 
         if( vp_controls.removed || vp_controls.is_broken() ) {
             player_character.controlling_vehicle = false;
@@ -474,7 +474,7 @@ void vehicle::smash_security_system()
         }
     }
     if( percent_alarm > rand ) {
-        damage_direct( here, idx_security, vp_security.info().durability / 5 );
+        damage_direct( here, vp_security, vp_security.info().durability / 5 );
         // chance to disable alarm immediately, or disable on destruction
         if( percent_alarm / 4 > rand || vp_security.is_broken() ) {
             is_alarm_on = false;

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -908,7 +908,7 @@ TEST_CASE( "vision_vehicle_camera_skew", "[shadowcasting][vision][vehicle][vehic
     auto const fiddle_parts = [&]() {
         if( fiddle > 0 ) {
             std::vector<vehicle_part *> const horns = v->get_parts_at( v->global_pos3(), "HORN", {} );
-            v->remove_part( v->index_of_part( horns.front(), true ) );
+            v->remove_part( *horns.front() );
         }
         if( fiddle > 1 ) {
             REQUIRE( v->install_part( point_zero, vpart_inboard_mirror ) != -1 );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Continuation of https://github.com/CleverRaven/Cataclysm-DDA/pull/66796

#### Describe the solution

Make vehicle functions take part references

#### Describe alternatives you've considered

#### Testing

Same as linked issue, also crashed a vehicle a few times

#### Additional context
