### PR TITLE
Fix #66712

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_missions.json
+++ b/data/json/npcs/exodii/exodii_merchant_missions.json
@@ -95,7 +95,7 @@
       {
         "text": "Well, today's your lucky day, my metal friend.  I already know the place quite well.",
         "condition": { "u_has_var": "u_discovered_robofac_intercom", "type": "dialogue", "context": "intercom", "value": "yes" },
-        "topic": "TALK_EXODII_MERCHANT_mission_1_complete"
+        "topic": "TALK_EXODII_MERCHANT_mission_1_met_hub"
       },
       {
         "text": "What exactly do you want me to do?  Scout out this bunker and contact the people in it?",

--- a/data/json/npcs/exodii/exodii_merchant_missions.json
+++ b/data/json/npcs/exodii/exodii_merchant_missions.json
@@ -36,12 +36,7 @@
         "search_range": 2400
       }
     },
-    "end": {
-      "effect": [
-        { "u_add_var": "u_scouted_bunker", "type": "mission", "context": "completed", "value": "yes" },
-        { "arithmetic": [ { "global_val": "var", "var_name": "exodii_knows_hub01" }, "=", { "const": 1 } ] }
-      ]
-    },
+    "end": { "effect": [ { "u_add_var": "u_scouted_bunker", "type": "mission", "context": "completed", "value": "yes" } ] },
     "difficulty": 2,
     "value": 0,
     "origins": [ "ORIGIN_SECONDARY" ],
@@ -100,7 +95,7 @@
       {
         "text": "Well, today's your lucky day, my metal friend.  I already know the place quite well.",
         "condition": { "u_has_var": "u_discovered_robofac_intercom", "type": "dialogue", "context": "intercom", "value": "yes" },
-        "topic": "TALK_EXODII_MERCHANT_mission_1_met_hub"
+        "topic": "TALK_EXODII_MERCHANT_mission_1_complete"
       },
       {
         "text": "What exactly do you want me to do?  Scout out this bunker and contact the people in it?",
@@ -201,6 +196,24 @@
         "topic": "TALK_DONE"
       },
       { "text": "I'm gonna need to think on this one.  I'll see you later, Rubik.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_1_met_hub",
+    "type": "talk_topic",
+    "dynamic_line": "Ah, would ye be willin' ta yark with me about it?",
+    "//~": "Ah, would you be willing to tell me about it?",
+    "responses": [
+      {
+        "text": "*Tell him.",
+        "effect": [
+          { "u_add_faction_trust": 5 },
+          { "arithmetic": [ { "global_val": "var", "var_name": "exodii_knows_hub01" }, "=", { "const": 1 } ] }
+        ],
+        "topic": "TALK_DONE"
+      },
+      { "text": "Maybe later, can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
+      { "text": "Not right now, I have to go.", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -189,7 +189,10 @@
       {
         "text": "I paid a visit to the bunker.",
         "condition": { "and": [ { "u_has_var": "u_scouted_bunker", "type": "mission", "context": "completed", "value": "yes" } ] },
-        "effect": { "u_lose_var": "u_scouted_bunker", "type": "mission", "context": "completed" },
+        "effect": [
+          { "u_lose_var": "u_scouted_bunker", "type": "mission", "context": "completed" },
+          { "arithmetic": [ { "global_val": "var", "var_name": "exodii_knows_hub01" }, "=", { "const": 1 } ] }
+        ],
         "topic": "TALK_EXODII_MERCHANT_mission_1_complete"
       },
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Add missing dialogue to tell Rubik about the Hub."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
You couldn't tell Rubik about the Hub if you'd already met them, and this caused an error. Additionally, the Exodii "learned" of the Hub via variable at a strange time, so I changed that too.  Fix #66712 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Create a new dialogue topic for the response, which successfully completes the mission. This forgoes the reward outside of adding trust, though, but skips a large part of the work. I also changed around when the Exodii-Hub knowledge var is applied to support this.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Keeping the reward available this way, but Erk wanted it to not be so in his planning post.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Made the changes, met the Hub, and successfully completed the mission this way. It all works well.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->