### PR TITLE
fix: update old GRAB_DRAG entry

### DIFF
--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -176,7 +176,8 @@
     "special_attacks": [
       { "type": "leap", "cooldown": 8, "move_cost": 0, "max_range": 8, "min_consider_range": 2 },
       { "id": "ranged_pull", "range": 4 },
-      [ "GRAB_DRAG", 3 ],
+      { "id": "grab_drag", "cooldown": 3 },
+      { "id": "drag_followup" },
       [ "SHRIEK_ALERT", 20 ],
       [ "SHRIEK_STUN", 5 ]
     ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
- Fixes #66838

#### Describe the solution
Updated the old form of `GRAB_DRAG` that [made it in with older tests](https://github.com/CleverRaven/Cataclysm-DDA/pull/65702).

#### Describe alternatives you've considered

#### Testing
The game loads :+1:

#### Additional context
