### PR TITLE
Empty containers are not fuel-air bombs

### DIFF
--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -61,12 +61,6 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "watertight": true, "rigid": true, "ammo_restriction": { "butane": 400 } } ],
     "material": [ "aluminum" ],
     "flags": [ "NO_RELOAD", "GAS_TANK" ],
-    "explosion": {
-      "power": 4503,
-      "distance_factor": 0.1,
-      "fire": true,
-      "shrapnel": { "casing_mass": 50, "fragment_mass": 0.025, "recovery": 0 }
-    },
     "explode_in_fire": true
   },
   {

--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -587,12 +587,6 @@
     ],
     "looks_like": "oxygen_tank",
     "flags": [  ],
-    "explosion": {
-      "power": 90100,
-      "distance_factor": 0.5,
-      "fire": true,
-      "shrapnel": { "casing_mass": 200, "fragment_mass": 0.5, "recovery": 0 }
-    },
     "explode_in_fire": true,
     "melee_damage": { "bash": 10 }
   },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #66760

A full 0.5L can of butane definitely does not have the TNT-equivalence of 4.5kg of TNT(!?)

(In testing, a 0.5L can of butane **destroyed the ground underneath it**, leaving a ~2m tall crater in the ground!!!)

An empty one definitely doesn't have any TNT-equivalence, being that it is a chunk of aluminum (and air)

There is maybe some argument to be made for a container of fuel to become an improvised explosive device but if butane refills were better grenades than military hand grenades you wouldn't be able to buy them at the convenience store. The current behavior also contrasts with every other container (and fuel container) in the game, which do not become improvised explosive devices when set on fire (with or without fuel)

#### Describe the solution
Remove ability for empty fuel cans to explode

(Butane tank is simply the butane can's values scaled up, so removed from there too)

#### Describe alternatives you've considered


#### Testing
I set full cans of butane on fire, they were destroyed in the fire but I did not become shredded by shrapnel.

#### Additional context
