### PR TITLE
Clear character succession cooldown when PC is badly wounded

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -973,5 +973,22 @@
       { "remove_active_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" },
       { "assign_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FACTION_SUCCESSION_IMMEDIATE",
+    "eoc_type": "EVENT",
+    "required_event": "broken_bone",
+    "//1": "Only run EOC if character is currently on succession cooldown!",
+    "condition": { "u_compare_time_since_var": "time_of_last_succession", "type": "timer", "op": "<", "time": "90 d" },
+    "//2": "Remove the mission tracking that you can't change char, push the timer back 90 days so changing is immediately available.",
+    "effect": [
+      { "remove_active_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" },
+      {
+        "u_message": "You've been badly wounded.  It might be better to rest for a while and let someone else scavenge. (Changing characters is now available at any camp board.)",
+        "type": "mixed"
+      },
+      { "u_adjust_var": "time_of_last_succession", "type": "timer", "adjustment": -7776000 }
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary
Balance "Being badly wounded will always allow you to swap characters in camp while you heal"

#### Purpose of change
Suggested by @Maleclypse on discord

More immersion, more fun

#### Describe the solution
When the `broken_bone` event is triggered, check if succession is on cooldown. If so, immediately clear the cooldown (set the time of last succession to 90 days in the past).

#### Describe alternatives you've considered
Some better notification than a log message, but blegh. A popup would be obnoxious, especially when dying.

#### Testing
(This is all the testing I've done)

https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/7ae89288-385d-4ea2-b131-c46beeb304dc



#### Additional context
