### PR TITLE
Tidy vehicle functions for cargo

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -699,16 +699,15 @@ bool can_examine_at( const tripoint &p, bool with_pickup )
 
 static bool can_pickup_at( const tripoint &p )
 {
-    bool veh_has_items = false;
     map &here = get_map();
-    const optional_vpart_position vp = here.veh_at( p );
-    if( vp ) {
-        const int cargo_part = vp->vehicle().part_with_feature( vp->mount(), "CARGO", false );
-        veh_has_items = cargo_part >= 0 && !vp->vehicle().get_items( cargo_part ).empty();
+    if( const std::optional<vpart_reference> ovp = here.veh_at( p ).cargo() ) {
+        if( !ovp->items().empty() ) {
+            return true;
+        }
     }
-
-    return ( !here.has_flag( ter_furn_flag::TFLAG_SEALED, p ) && here.has_items( p ) &&
-             !here.only_liquid_in_liquidcont( p ) ) || veh_has_items;
+    return !here.has_flag( ter_furn_flag::TFLAG_SEALED, p ) &&
+           !here.only_liquid_in_liquidcont( p ) &&
+           here.has_items( p );
 }
 
 bool can_interact_at( action_id action, const tripoint &p )

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6618,10 +6618,8 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
             }
 
             //nothing to sort?
-            const std::optional<vpart_reference> vp = here.veh_at( src_loc ).part_with_feature( "CARGO",
-                    false );
-            if( ( !vp || vp->vehicle().get_items( vp->part_index() ).empty() )
-                && here.i_at( src_loc ).empty() ) {
+            const std::optional<vpart_reference> ovp = here.veh_at( src_loc ).cargo();
+            if( ( !ovp || ovp->items().empty() ) && here.i_at( src_loc ).empty() ) {
                 continue;
             }
 
@@ -6690,11 +6688,10 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
         //Check source for cargo part
         //map_stack and vehicle_stack are different types but inherit from item_stack
         // TODO: use one for loop
-        if( const std::optional<vpart_reference> vp = here.veh_at( src_loc ).part_with_feature( "CARGO",
-                false ) ) {
-            src_veh = &vp->vehicle();
-            src_part = vp->part_index();
-            for( item &it : src_veh->get_items( src_part ) ) {
+        if( const std::optional<vpart_reference> ovp = here.veh_at( src_loc ).cargo() ) {
+            src_veh = &ovp->vehicle();
+            src_part = ovp->part_index();
+            for( item &it : ovp->items() ) {
                 items.emplace_back( &it, true );
             }
         } else {
@@ -6883,8 +6880,8 @@ bool vehicle_folding_activity_actor::fold_vehicle( Character &p, bool check_only
 
     // Drop cargo to ground
     // TODO: make cargo shuffling add time to activity
-    for( const vpart_reference &vp : veh.get_any_parts( "CARGO" ) ) {
-        vehicle_stack cargo = veh.get_items( vp.part_index() );
+    for( const vpart_reference &vpr : veh.get_any_parts( VPFLAG_CARGO ) ) {
+        vehicle_stack cargo = vpr.items();
         for( const item &elem : cargo ) {
             here.add_item_or_charges( veh.pos_bub(), elem );
         }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6509,7 +6509,8 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
         put_into_vehicle_or_drop( you, item_drop_reason::deliberate, { it }, dest );
         // Remove from map or vehicle.
         if( src_veh ) {
-            src_veh->remove_item( src_part, &it );
+            vehicle_part &vp_src = src_veh->part( src_part );
+            src_veh->remove_item( vp_src, &it );
         } else {
             here.i_rem( src, &it );
         }
@@ -6518,7 +6519,8 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
     // If we didn't pick up a whole stack, put the remainder back where it came from.
     if( leftovers.charges > 0 ) {
         if( src_veh ) {
-            if( !src_veh->add_item( src_part, leftovers ) ) {
+            vehicle_part &vp_src = src_veh->part( src_part );
+            if( !src_veh->add_item( vp_src, leftovers ) ) {
                 debugmsg( "SortLoot: Source vehicle failed to receive leftover charges." );
             }
         } else {
@@ -6761,7 +6763,8 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                                 if( it->first->type->magazine->linkage ) {
                                     item link( *it->first->type->magazine->linkage, calendar::turn, contained->count() );
                                     if( this_veh != nullptr ) {
-                                        this_veh->add_item( this_part, link );
+                                        vehicle_part &vp_this = this_veh->part( this_part );
+                                        this_veh->add_item( vp_this, link );
                                     } else {
                                         here.add_item_or_charges( src_loc, link );
                                     }
@@ -6772,7 +6775,8 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
 
                             if( it->first->has_flag( flag_MAG_DESTROY ) && it->first->ammo_remaining() == 0 ) {
                                 if( this_veh != nullptr ) {
-                                    this_veh->remove_item( this_part, it->first );
+                                    vehicle_part &vp_this = this_veh->part( this_part );
+                                    this_veh->remove_item( vp_this, it->first );
                                 } else {
                                     here.i_rem( src_loc, it->first );
                                 }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -620,7 +620,8 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
         put_into_vehicle_or_drop( you, item_drop_reason::deliberate, { it }, dest );
         // Remove from map or vehicle.
         if( src_veh ) {
-            src_veh->remove_item( src_part, &it );
+            vehicle_part &vp_src = src_veh->part( src_part );
+            src_veh->remove_item( vp_src, &it );
         } else {
             here.i_rem( src, &it );
         }
@@ -629,7 +630,8 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
     // If we didn't pick up a whole stack, put the remainder back where it came from.
     if( leftovers.charges > 0 ) {
         if( src_veh ) {
-            if( !src_veh->add_item( src_part, leftovers ) ) {
+            vehicle_part &vp_src = src_veh->part( src_part );
+            if( !src_veh->add_item( vp_src, leftovers ) ) {
                 debugmsg( "SortLoot: Source vehicle failed to receive leftover charges." );
             }
         } else {
@@ -2200,7 +2202,8 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                                     if( it->first->type->magazine->linkage ) {
                                         item link( *it->first->type->magazine->linkage, calendar::turn, contained->count() );
                                         if( this_veh != nullptr ) {
-                                            this_veh->add_item( this_part, link );
+                                            vehicle_part &vp_this = this_veh->part( this_part );
+                                            this_veh->add_item( vp_this, link );
                                         } else {
                                             here.add_item_or_charges( src_loc, link );
                                         }
@@ -2244,7 +2247,8 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                     }
                     if( it->first->has_flag( flag_MAG_DESTROY ) && it->first->ammo_remaining() == 0 ) {
                         if( this_veh != nullptr ) {
-                            this_veh->remove_item( this_part, it->first );
+                            vehicle_part &vp_this = this_veh->part( this_part );
+                            this_veh->remove_item( vp_this, it->first );
                         } else {
                             here.i_rem( src_loc, it->first );
                         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -954,11 +954,8 @@ static bool are_requirements_nearby(
         }
 
         if( !in_loot_zones ) {
-            if( const std::optional<vpart_reference> vp = here.veh_at( elem ).part_with_feature( "CARGO",
-                    false ) ) {
-                vehicle &src_veh = vp->vehicle();
-                int src_part = vp->part_index();
-                for( item &it : src_veh.get_items( src_part ) ) {
+            if( const std::optional<vpart_reference> ovp = here.veh_at( elem ).cargo() ) {
+                for( item &it : ovp->items() ) {
                     temp_inv.add_item_ref( it );
                 }
             }
@@ -1780,13 +1777,9 @@ static bool tidy_activity( Character &you, const tripoint_bub_ms &src_loc,
     if( loot_src_lot == tripoint_bub_ms() ) {
         return false;
     }
-    if( const std::optional<vpart_reference> vp = here.veh_at(
-                src_loc ).part_with_feature( "CARGO",
-                        false ) ) {
-        vehicle *const src_veh = &vp->vehicle();
-        int const src_part = vp->part_index();
-        vehicle_stack stack = src_veh->get_items( src_part );
-        _tidy_move_items( you, stack, src_loc, loot_src_lot, src_veh, src_part,
+    if( const std::optional<vpart_reference> ovp = here.veh_at( src_loc ).cargo() ) {
+        vehicle_stack vs = ovp->items();
+        _tidy_move_items( you, vs, src_loc, loot_src_lot, &ovp->vehicle(), ovp->part_index(),
                           activity_to_restore );
     }
     map_stack stack = here.i_at( src_loc );
@@ -1819,16 +1812,12 @@ static bool fetch_activity(
     map_stack items_there = here.i_at( src_loc );
     vehicle *src_veh = nullptr;
     int src_part = 0;
-    if( const std::optional<vpart_reference> vp = here.veh_at( src_loc ).part_with_feature( "CARGO",
-            false ) ) {
-        src_veh = &vp->vehicle();
-        src_part = vp->part_index();
-    }
     const units::volume volume_allowed = you.volume_capacity() - you.volume_carried();
     const units::mass weight_allowed = you.weight_capacity() - you.weight_carried();
-    // TODO: vehicle_stack and map_stack into one loop.
-    if( src_veh ) {
-        for( item &veh_elem : src_veh->get_items( src_part ) ) {
+    if( const std::optional<vpart_reference> ovp = here.veh_at( src_loc ).cargo() ) {
+        src_veh = &ovp->vehicle();
+        src_part = ovp->part_index();
+        for( item &veh_elem : ovp->items() ) {
             for( auto elem : mental_map_2 ) {
                 if( std::get<0>( elem ) == src_loc && veh_elem.typeId() == std::get<1>( elem ) ) {
                     if( !you.backlog.empty() && you.backlog.front().id() == ACT_MULTIPLE_CONSTRUCTION ) {
@@ -2038,10 +2027,8 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
             }
 
             //nothing to sort?
-            const std::optional<vpart_reference> vp = here.veh_at( src_loc ).part_with_feature( "CARGO",
-                    false );
-            if( ( !vp || vp->vehicle().get_items( vp->part_index() ).empty() )
-                && here.i_at( src_loc ).empty() ) {
+            const std::optional<vpart_reference> vp = here.veh_at( src_loc ).cargo();
+            if( ( !vp || vp->items().empty() ) && here.i_at( src_loc ).empty() ) {
                 continue;
             }
 
@@ -2110,11 +2097,10 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
         //Check source for cargo part
         //map_stack and vehicle_stack are different types but inherit from item_stack
         // TODO: use one for loop
-        if( const std::optional<vpart_reference> vp = here.veh_at( src_loc ).part_with_feature( "CARGO",
-                false ) ) {
+        if( const std::optional<vpart_reference> vp = here.veh_at( src_loc ).cargo() ) {
             src_veh = &vp->vehicle();
             src_part = vp->part_index();
-            for( item &it : src_veh->get_items( src_part ) ) {
+            for( item &it : vp->items() ) {
                 items.emplace_back( &it, true );
             }
         } else {
@@ -3237,17 +3223,13 @@ int get_auto_consume_moves( Character &you, const bool food )
         const optional_vpart_position vp = here.veh_at( here.getlocal( loc ) );
         std::vector<item *> items_here;
         if( vp ) {
-            vehicle &veh = vp->vehicle();
-            int index = veh.part_with_feature( vp->mount(), "CARGO", false );
-            if( index >= 0 ) {
-                vehicle_stack vehitems = veh.get_items( index );
-                for( item &it : vehitems ) {
+            if( const std::optional<vpart_reference> vp_cargo = vp.cargo() ) {
+                for( item &it : vp_cargo->items() ) {
                     items_here.push_back( &it );
                 }
             }
         } else {
-            map_stack mapitems = here.i_at( here.getlocal( loc ) );
-            for( item &it : mapitems ) {
+            for( item &it : here.i_at( here.getlocal( loc ) ) ) {
                 items_here.push_back( &it );
             }
         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -229,7 +229,7 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
         } else {
             if( it.count_by_charges() ) {
                 // Maybe we can add a few charges in the trunk and the rest on the ground.
-                int charges_added = veh.add_charges( part, it );
+                const int charges_added = veh.add_charges( vp, it );
                 it.mod_charges( -charges_added );
                 into_vehicle_count += charges_added;
             }

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1222,7 +1222,7 @@ void advanced_inventory::change_square( aim_location changeSquare,
                 // check item stacks in vehicle and map at said square
                 advanced_inv_area sq = squares[changeSquare];
                 map_stack map_stack = get_map().i_at( sq.pos );
-                vehicle_stack veh_stack = sq.veh->get_items( sq.vstor );
+                vehicle_stack veh_stack = sq.get_vehicle_stack();
                 // auto switch to vehicle storage if vehicle items are there, or neither are there
                 if( !veh_stack.empty() || map_stack.empty() ) {
                     in_vehicle_cargo = true;

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -333,7 +333,7 @@ void advanced_inventory::print_items( const advanced_inventory_pane &pane, bool 
             if( ( pane.get_area() == AIM_CONTAINER || pane.get_area() == AIM_CONTAINER2 ) && pane.container ) {
                 maxvolume = pane.container->get_total_capacity();
             } else if( pane.in_vehicle() ) {
-                maxvolume = s.veh->max_volume( s.vstor );
+                maxvolume = s.get_vehicle_stack().max_volume();
             } else {
                 maxvolume = get_map().max_volume( s.pos );
             }

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -44,7 +44,7 @@ int advanced_inv_area::get_item_count() const
     } else if( id == AIM_ALL ) {
         return 0;
     } else if( id == AIM_DRAGGED ) {
-        return can_store_in_vehicle() ? veh->get_items( vstor ).size() : 0;
+        return can_store_in_vehicle() ? get_vehicle_stack().size() : 0;
     } else {
         return get_map().i_at( pos ).size();
     }

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -90,20 +90,13 @@ void advanced_inv_area::init()
             off = player_character.grab_point;
             // Reset position because offset changed
             pos = player_character.pos() + off;
-            if( const std::optional<vpart_reference> vp = here.veh_at( pos ).part_with_feature( "CARGO",
-                    false ) ) {
+            if( const std::optional<vpart_reference> vp = here.veh_at( pos ).cargo() ) {
                 veh = &vp->vehicle();
                 vstor = vp->part_index();
-            } else {
-                veh = nullptr;
-                vstor = -1;
-            }
-            if( vstor >= 0 ) {
                 desc[0] = veh->name;
                 canputitemsloc = true;
                 max_size = MAX_ITEM_IN_VEHICLE_STORAGE;
             } else {
-                veh = nullptr;
                 canputitemsloc = false;
                 desc[0] = _( "No dragged vehicle!" );
             }
@@ -132,14 +125,10 @@ void advanced_inv_area::init()
         case AIM_NORTHWEST:
         case AIM_NORTH:
         case AIM_NORTHEAST: {
-            const std::optional<vpart_reference> vp =
-                here.veh_at( pos ).part_with_feature( "CARGO", false );
+            const std::optional<vpart_reference> vp = here.veh_at( pos ).cargo();
             if( vp ) {
                 veh = &vp->vehicle();
                 vstor = vp->part_index();
-            } else {
-                veh = nullptr;
-                vstor = -1;
             }
             canputitemsloc = can_store_in_vehicle() || here.can_put_items_ter_furn( pos );
             max_size = MAX_ITEM_IN_SQUARE;
@@ -275,8 +264,7 @@ void advanced_inv_area::set_container_position()
     // update the absolute position
     pos = player_character.pos() + off;
     // update vehicle information
-    if( const std::optional<vpart_reference> vp = get_map().veh_at( pos ).part_with_feature( "CARGO",
-            false ) ) {
+    if( const std::optional<vpart_reference> vp = get_map().veh_at( pos ).cargo() ) {
         veh = &vp->vehicle();
         vstor = vp->part_index();
     } else {

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -306,6 +306,14 @@ bool advanced_inv_area::can_store_in_vehicle() const
     }
 }
 
+vehicle_stack advanced_inv_area::get_vehicle_stack() const
+{
+    if( !can_store_in_vehicle() ) {
+        debugmsg( "advanced_inv_area::get_vehicle_stack when can_store_in_vehicle is false" );
+    }
+    return veh->get_items( veh->part( vstor ) );
+}
+
 template <typename T>
 advanced_inv_area::itemstack advanced_inv_area::i_stacked( T items )
 {

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -197,8 +197,11 @@ units::volume advanced_inv_area::free_volume( bool in_vehicle ) const
     cata_assert( id != AIM_ALL );
     if( id == AIM_INVENTORY || id == AIM_WORN ) {
         return get_player_character().free_space();
+    } else if( in_vehicle ) {
+        return get_vehicle_stack().free_volume();
+    } else {
+        return get_map().free_volume( pos );
     }
-    return in_vehicle ? veh->free_volume( vstor ) : get_map().free_volume( pos );
 }
 
 bool advanced_inv_area::is_same( const advanced_inv_area &other ) const

--- a/src/advanced_inv_area.h
+++ b/src/advanced_inv_area.h
@@ -35,6 +35,7 @@ enum aim_location : char {
 class advanced_inv_listitem;
 class item;
 class vehicle;
+class vehicle_stack;
 
 /**
  * Defines the source of item stacks.
@@ -102,5 +103,7 @@ class advanced_inv_area
         void set_container_position();
         aim_location offset_to_location() const;
         bool can_store_in_vehicle() const;
+        // @return vehicle_stack for this area, call only if can_store_in_vehicle is true
+        vehicle_stack get_vehicle_stack() const;
 };
 #endif // CATA_SRC_ADVANCED_INV_AREA_H

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -62,8 +62,7 @@ void advanced_inventory_pane::load_settings( int saved_area_idx,
     const aim_location location = static_cast<aim_location>( i_location );
     const advanced_inv_area &square = squares[location];
     // determine the square's vehicle/map item presence
-    bool has_veh_items = square.can_store_in_vehicle() ?
-                         !square.veh->get_items( square.vstor ).empty() : false;
+    bool has_veh_items = square.can_store_in_vehicle() && !square.get_vehicle_stack().empty();
     bool has_map_items = !get_map().i_at( square.pos ).empty();
     // determine based on map items and settings to show cargo
     bool show_vehicle = false;
@@ -245,7 +244,7 @@ void advanced_inventory_pane::add_items_from_area( advanced_inv_area &square,
             square.weight = 0_gram;
         }
         const advanced_inv_area::itemstack &stacks = is_in_vehicle ?
-                square.i_stacked( square.veh->get_items( square.vstor ) ) :
+                square.i_stacked( square.get_vehicle_stack() ) :
                 square.i_stacked( m.i_at( square.pos ) );
 
         map_cursor loc_cursor( square.pos );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5276,11 +5276,8 @@ Character::comfort_response_t Character::base_comfort_value( const tripoint &p )
             comfort += 1 + static_cast<int>( comfort_level::slightly_comfortable );
             // Note: shelled individuals can still use sleeping aids!
         } else if( vp ) {
-            const std::optional<vpart_reference> carg = vp.part_with_feature( "CARGO", false );
-            const std::optional<vpart_reference> board = vp.part_with_feature( "BOARDABLE", true );
-            if( carg ) {
-                const vehicle_stack items = vp->vehicle().get_items( carg->part_index() );
-                for( const item &items_it : items ) {
+            if( const std::optional<vpart_reference> cargo = vp.cargo() ) {
+                for( const item &items_it : cargo->items() ) {
                     if( items_it.has_flag( flag_SLEEP_AID ) ) {
                         // Note: BED + SLEEP_AID = 9 pts, or 1 pt below very_comfortable
                         comfort += 1 + static_cast<int>( comfort_level::slightly_comfortable );
@@ -5309,7 +5306,7 @@ Character::comfort_response_t Character::base_comfort_value( const tripoint &p )
                     }
                 }
             }
-            if( board ) {
+            if( const std::optional<vpart_reference> board = vp.part_with_feature( "BOARDABLE", true ) ) {
                 comfort += board->info().comfort;
             } else {
                 comfort -= here.move_cost( p );
@@ -8588,18 +8585,15 @@ void Character::migrate_items_to_storage( bool disintegrate )
 std::string Character::is_snuggling() const
 {
     map &here = get_map();
-    auto begin = here.i_at( pos() ).begin();
-    auto end = here.i_at( pos() ).end();
+    map_stack items_here = here.i_at( pos() );
+    item_stack::const_iterator begin = items_here.begin();
+    item_stack::const_iterator end = items_here.end();
 
     if( in_vehicle ) {
-        if( const std::optional<vpart_reference> vp = here.veh_at( pos() ).part_with_feature( VPFLAG_CARGO,
-                false ) ) {
-            vehicle *const veh = &vp->vehicle();
-            const int cargo = vp->part_index();
-            if( !veh->get_items( cargo ).empty() ) {
-                begin = veh->get_items( cargo ).begin();
-                end = veh->get_items( cargo ).end();
-            }
+        if( const std::optional<vpart_reference> ovp = here.veh_at( pos() ).cargo() ) {
+            const vehicle_stack vs = ovp->items();
+            begin = vs.begin();
+            end = vs.end();
         }
     }
     const item *floor_armor = nullptr;
@@ -8748,18 +8742,13 @@ int Character::floor_item_warmth( const tripoint &pos )
 
     map &here = get_map();
 
-    if( !!here.veh_at( pos ) ) {
-        if( const std::optional<vpart_reference> vp = here.veh_at( pos ).part_with_feature( VPFLAG_CARGO,
-                false ) ) {
-            vehicle *const veh = &vp->vehicle();
-            const int cargo = vp->part_index();
-            vehicle_stack vehicle_items = veh->get_items( cargo );
-            warm( vehicle_items );
+    if( const optional_vpart_position veh_here = here.veh_at( pos ) ) {
+        if( const std::optional<vpart_reference> ovp = veh_here.cargo() ) {
+            warm( ovp->items() );
         }
-        return item_warmth;
+    } else {
+        warm( here.i_at( pos ) );
     }
-    map_stack floor_items = here.i_at( pos );
-    warm( floor_items );
     return item_warmth;
 }
 

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -432,8 +432,7 @@ void Character::drop( const drop_locations &what, const tripoint &target,
         return;
     }
     invalidate_leak_level_cache();
-    const std::optional<vpart_reference> vp = get_map().veh_at(
-                target ).part_with_feature( "CARGO", false );
+    const std::optional<vpart_reference> vp = get_map().veh_at( target ).cargo();
     if( rl_dist( pos(), target ) > 1 || !( stash || get_map().can_put_items( target ) )
         || ( vp.has_value() && vp->part().is_cleaner_on() ) ) {
         add_msg_player_or_npc( m_info, _( "You can't place items here!" ),

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1188,7 +1188,7 @@ void zone_manager::add( const std::string &name, const zone_type_id &type, const
     // only non personal zones can be vehicle zones
     if( !personal ) {
         optional_vpart_position const vp = here.veh_at( here.getlocal( start ) );
-        if( vp && vp->vehicle().get_owner() == fac && vp.part_with_feature( "CARGO", false ) ) {
+        if( vp && vp->vehicle().get_owner() == fac && vp.cargo() ) {
             // TODO:Allow for loot zones on vehicles to be larger than 1x1
             if( start == end &&
                 ( silent || query_yn( _( "Bind this zone to the cargo part here?" ) ) ) ) {
@@ -1557,8 +1557,8 @@ void zone_manager::revert_vzones()
     map &here = get_map();
     for( zone_data zone : removed_vzones ) {
         //Code is copied from add() to avoid yn query
-        if( const std::optional<vpart_reference> vp = here.veh_at( here.getlocal(
-                    zone.get_start_point() ) ).part_with_feature( "CARGO", false ) ) {
+        const tripoint pos = here.getlocal( zone.get_start_point() );
+        if( const std::optional<vpart_reference> vp = here.veh_at( pos ).cargo() ) {
             zone.set_is_vehicle( true );
             vp->vehicle().loot_zones.emplace( vp->mount(), zone );
             here.register_vehicle_zone( &vp->vehicle(), here.get_abs_sub().z() );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -299,7 +299,7 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
                                     cont_not_empty = true;
                                     iname = tmp_i.tname( 1U, true );
                                 }
-                                if( const std::optional<vpart_reference> vp = m.veh_at( p ).part_with_feature( "CARGO", true ) ) {
+                                if( const std::optional<vpart_reference> vp = m.veh_at( p ).cargo() ) {
                                     veh_items.emplace_back( vp.value(), tmp_i );
                                 } else {
                                     map_items.emplace_back( p, tmp_i );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -714,18 +714,16 @@ static item_location set_item_map( const tripoint &loc, item &newit )
 static item_location set_item_map_or_vehicle( const Character &p, const tripoint &loc, item &newit )
 {
     map &here = get_map();
-    if( const std::optional<vpart_reference> vp = here.veh_at( loc ).part_with_feature( "CARGO",
-            false ) ) {
-
-        if( const std::optional<vehicle_stack::iterator> it = vp->vehicle().add_item( vp->part_index(),
-                newit ) ) {
+    if( const std::optional<vpart_reference> vp = here.veh_at( loc ).cargo() ) {
+        vehicle &veh = vp->vehicle();
+        if( const std::optional<vehicle_stack::iterator> it = veh.add_item( vp->part(), newit ) ) {
             p.add_msg_player_or_npc(
                 //~ %1$s: name of item being placed, %2$s: vehicle part name
                 pgettext( "item, furniture", "You put the %1$s on the %2$s." ),
                 pgettext( "item, furniture", "<npcname> puts the %1$s on the %2$s." ),
                 ( *it )->tname(), vp->part().name() );
 
-            return item_location( vehicle_cursor( vp->vehicle(), vp->part_index() ), & **it );
+            return item_location( vehicle_cursor( veh, vp->part_index() ), & **it );
         }
 
         // Couldn't add the in progress craft to the target part, so drop it to the map.

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -518,9 +518,8 @@ std::vector<const item *> Character::get_eligible_containers_for_crafting() cons
             }
         }
 
-        if( const std::optional<vpart_reference> vp = here.veh_at( loc ).part_with_feature( "CARGO",
-                true ) ) {
-            for( const item &it : vp->vehicle().get_items( vp->part_index() ) ) {
+        if( const std::optional<vpart_reference> vp = here.veh_at( loc ).cargo() ) {
+            for( const item &it : vp->items() ) {
                 std::vector<const item *> eligible = get_eligible_containers_recursive( it, true );
                 conts.insert( conts.begin(), eligible.begin(), eligible.end() );
             }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -976,7 +976,7 @@ bool game::start_game()
 
                     // Delete the items that would have spawned here from a "corpse"
                     for( const int sp : v.v->parts_at_relative( vp.mount(), true ) ) {
-                        v.v->get_items( v.v->part( sp ) ).clear();
+                        vpart_reference( *v.v, sp ).items().clear();
                     }
 
                     auto mons = critter_tracker->find( u.get_location() );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -975,12 +975,8 @@ bool game::start_game()
                     u.setpos( pos );
 
                     // Delete the items that would have spawned here from a "corpse"
-                    for( int sp : v.v->parts_at_relative( vp.mount(), true ) ) {
-                        vehicle_stack here = v.v->get_items( sp );
-
-                        for( auto iter = here.begin(); iter != here.end(); ) {
-                            iter = here.erase( iter );
-                        }
+                    for( const int sp : v.v->parts_at_relative( vp.mount(), true ) ) {
+                        v.v->get_items( v.v->part( sp ) ).clear();
                     }
 
                     auto mons = critter_tracker->find( u.get_location() );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9890,9 +9890,9 @@ void game::wield( item_location loc )
                 m.add_item( pos, to_wield );
                 break;
             case item_location::type::vehicle: {
-                const std::optional<vpart_reference> vp = m.veh_at( pos ).part_with_feature( "CARGO", false );
+                const std::optional<vpart_reference> ovp = m.veh_at( pos ).cargo();
                 // If we fail to return the item to the vehicle for some reason, add it to the map instead.
-                if( !vp || !vp->vehicle().add_item( vp->part_index(), to_wield ) ) {
+                if( !ovp || !ovp->vehicle().add_item( ovp->part(), to_wield ) ) {
                     m.add_item( pos, to_wield );
                 }
                 break;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -6513,9 +6513,7 @@ void iexamine::workbench_internal( Character &you, const tripoint &examp,
 
     if( part ) {
         name = part->part().name();
-        vehicle_stack items_at_part = part->vehicle().get_items( part->part_index() );
-
-        for( item &it : items_at_part ) {
+        for( item &it : part->items() ) {
             if( it.is_craft() ) {
                 crafts.emplace_back( vehicle_cursor( part->vehicle(), part->part_index() ), &it );
             }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2047,18 +2047,17 @@ void inventory_selector::add_map_items( const tripoint &target )
 
 void inventory_selector::add_vehicle_items( const tripoint &target )
 {
-    const std::optional<vpart_reference> vp =
-        get_map().veh_at( target ).part_with_feature( "CARGO", true );
-    if( !vp ) {
+    const std::optional<vpart_reference> ovp = get_map().veh_at( target ).cargo();
+    if( !ovp ) {
         return;
     }
-    vehicle *const veh = &vp->vehicle();
-    const int part = vp->part_index();
-    vehicle_stack items = veh->get_items( part );
-    const std::string name = to_upper_case( remove_color_tags( veh->part( part ).name() ) );
+    vehicle_part &vp = ovp->part();
+    vehicle_stack items = ovp->items();
+    const std::string name = to_upper_case( remove_color_tags( vp.name() ) );
     const item_category vehicle_cat( name, no_translation( name ), 200 );
-    _add_map_items( target, vehicle_cat, items, [veh, part]( item & it ) {
-        return item_location( vehicle_cursor( *veh, part ), &it );
+    const vehicle_cursor cursor( ovp->vehicle(), ovp->part_index() );
+    _add_map_items( target, vehicle_cat, items, [&cursor]( item & it ) {
+        return item_location( cursor, &it );
     } );
 }
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -470,12 +470,12 @@ class item_location::impl::item_on_vehicle : public item_location::impl
         }
 
         std::string describe( const Character *ch ) const override {
-            vpart_position part_pos( cur.veh, cur.part );
+            const vpart_position part_pos( cur.veh, cur.part );
             std::string res;
-            if( auto label = part_pos.get_label() ) {
+            if( const std::optional<std::string> label = part_pos.get_label() ) {
                 res = colorize( *label, c_light_blue ) + " ";
             }
-            if( auto cargo_part = part_pos.part_with_feature( "CARGO", true ) ) {
+            if( const std::optional<vpart_reference> cargo_part = part_pos.cargo() ) {
                 res += cargo_part->part().name();
             } else {
                 debugmsg( "item in vehicle part without cargo storage" );

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -535,7 +535,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
         }
 
         units::volume volume_capacity() const override {
-            return cur.veh.free_volume( cur.part );
+            return vpart_reference( cur.veh, cur.part ).items().free_volume();
         }
 
         units::mass weight_capacity() const override {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1125,12 +1125,13 @@ void map::register_vehicle_zone( vehicle *veh, const int zlev )
 
 bool map::deregister_vehicle_zone( zone_data &zone ) const
 {
-    if( const std::optional<vpart_reference> vp = veh_at( getlocal(
-                zone.get_start_point() ) ).part_with_feature( "CARGO", false ) ) {
-        auto bounds = vp->vehicle().loot_zones.equal_range( vp->mount() );
+    const tripoint pos = getlocal( zone.get_start_point() );
+    if( const std::optional<vpart_reference> vp = veh_at( pos ).cargo() ) {
+        vehicle &veh = vp->vehicle();
+        auto bounds = veh.loot_zones.equal_range( vp->mount() );
         for( auto it = bounds.first; it != bounds.second; it++ ) {
             if( &zone == &( it->second ) ) {
-                vp->vehicle().loot_zones.erase( it );
+                veh.loot_zones.erase( it );
                 return true;
             }
         }
@@ -2828,11 +2829,7 @@ bool map::has_flag( const std::string &flag, const tripoint &p ) const
 
 bool map::can_put_items( const tripoint &p ) const
 {
-    if( can_put_items_ter_furn( p ) ) {
-        return true;
-    }
-    const optional_vpart_position vp = veh_at( p );
-    return static_cast<bool>( vp.part_with_feature( "CARGO", true ) );
+    return can_put_items_ter_furn( p ) || veh_at( p ).cargo().has_value();
 }
 
 bool map::can_put_items( const tripoint_bub_ms &p ) const

--- a/src/map.h
+++ b/src/map.h
@@ -2109,8 +2109,7 @@ class map
                               const units::angle &wideangle = 30_degrees );
         void apply_light_ray( cata::mdarray<bool, point_bub_ms, MAPSIZE_X, MAPSIZE_Y> &lit,
                               const tripoint &s, const tripoint &e, float luminance );
-        void add_light_from_items( const tripoint &p, const item_stack::iterator &begin,
-                                   const item_stack::iterator &end );
+        void add_light_from_items( const tripoint &p, const item_stack &items );
         std::unique_ptr<vehicle> add_vehicle_to_map( std::unique_ptr<vehicle> veh, bool merge_wrecks );
 
         // Internal methods used to bash just the selected features

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -327,6 +327,14 @@ static bool mx_house_wasp( map &m, const tripoint &/*loc*/ )
     return true;
 }
 
+static void delete_items_at_mount( vehicle &veh, const point &pt )
+{
+    for( const int idx_cargo : veh.parts_at_relative( pt, /* use_cache = */ true ) ) {
+        vehicle_part &vp_cargo = veh.part( idx_cargo );
+        veh.get_items( vp_cargo ).clear();
+    }
+}
+
 static bool mx_helicopter( map &m, const tripoint &abs_sub )
 {
     point c( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ) );
@@ -417,15 +425,7 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
                     } else {
                         m.place_spawns( GROUP_MIL_PASSENGER, 1, pos.xy(), pos.xy(), 1, true );
                     }
-
-                    // Delete the items that would have spawned here from a "corpse"
-                    for( int sp : wreckage->parts_at_relative( vp.mount(), true ) ) {
-                        vehicle_stack here = wreckage->get_items( sp );
-
-                        for( auto iter = here.begin(); iter != here.end(); ) {
-                            iter = here.erase( iter );
-                        }
-                    }
+                    delete_items_at_mount( *wreckage, vp.mount() ); // delete corpse items
                 }
                 break;
             case 4:
@@ -439,15 +439,7 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
                     } else {
                         m.place_spawns( GROUP_MIL_WEAK, 2, pos.xy(), pos.xy(), 1, true );
                     }
-
-                    // Delete the items that would have spawned here from a "corpse"
-                    for( int sp : wreckage->parts_at_relative( vp.mount(), true ) ) {
-                        vehicle_stack here = wreckage->get_items( sp );
-
-                        for( auto iter = here.begin(); iter != here.end(); ) {
-                            iter = here.erase( iter );
-                        }
-                    }
+                    delete_items_at_mount( *wreckage, vp.mount() ); // delete corpse items
                 }
                 break;
             case 6:
@@ -455,15 +447,7 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
                 for( const vpart_reference &vp : wreckage->get_any_parts( VPFLAG_CONTROLS ) ) {
                     const tripoint pos = vp.pos();
                     m.place_spawns( GROUP_MIL_PILOT, 1, pos.xy(), pos.xy(), 1, true );
-
-                    // Delete the items that would have spawned here from a "corpse"
-                    for( int sp : wreckage->parts_at_relative( vp.mount(), true ) ) {
-                        vehicle_stack here = wreckage->get_items( sp );
-
-                        for( auto iter = here.begin(); iter != here.end(); ) {
-                            iter = here.erase( iter );
-                        }
-                    }
+                    delete_items_at_mount( *wreckage, vp.mount() ); // delete corpse items
                 }
                 break;
             case 7:

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -2081,12 +2081,11 @@ static bool mx_mayhem( map &m, const tripoint &abs_sub )
         case 3: {
             vehicle *veh = m.add_vehicle( vehicle_prototype_car, tripoint( 18, 12, abs_sub.z ), 270_degrees );
 
-            for( const vpart_reference &vp : veh->get_any_parts( "CARGO" ) ) {
-                const size_t p = vp.part_index();
-                for( item &elem : veh->get_items( p ) ) {
+            for( const vpart_reference &vpr : veh->get_any_parts( VPFLAG_CARGO ) ) {
+                for( item &elem : vpr.items() ) {
                     if( elem.typeId() == itype_wheel || elem.typeId() == itype_lug_wrench ||
                         elem.typeId() == itype_jack_small ) {
-                        veh->remove_item( p, &elem );
+                        veh->remove_item( vpr.part(), &elem );
                     }
                 }
             }

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -537,9 +537,8 @@ bool mission::is_complete( const character_id &_npc_id ) const
                     if( here.has_items( p ) && here.accessible_items( p ) ) {
                         count_items( here.i_at( p ) );
                     }
-                    if( const std::optional<vpart_reference> vp =
-                            here.veh_at( p ).part_with_feature( "CARGO", true ) ) {
-                        count_items( vp->vehicle().get_items( vp->part_index() ) );
+                    if( const std::optional<vpart_reference> ovp = here.veh_at( p ).cargo() ) {
+                        count_items( ovp->items() );
                     }
                     if( found_quantity >= item_count ) {
                         break;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2963,8 +2963,8 @@ void npc::find_item()
         int num_items = m_stack.size();
         const optional_vpart_position vp = here.veh_at( p );
         if( vp ) {
-            if( const std::optional<vpart_reference> cargo = vp.cargo() ) {
-                num_items += cargo->items().size();
+            if( const std::optional<vpart_reference> vp_cargo = vp.cargo() ) {
+                num_items += vp_cargo->items().size();
             }
         }
         if( prev_num_items == num_items ) {
@@ -2993,7 +2993,7 @@ void npc::find_item()
             cache_tile();
             continue;
         }
-        const std::optional<vpart_reference> cargo = vp.part_with_feature( VPFLAG_CARGO, true );
+        const std::optional<vpart_reference> cargo = vp.cargo();
         static const std::string locked_string( "LOCKED" );
         // TODO: Let player know what parts are safe from NPC thieves
         if( !cargo || cargo->has_feature( locked_string ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2963,10 +2963,8 @@ void npc::find_item()
         int num_items = m_stack.size();
         const optional_vpart_position vp = here.veh_at( p );
         if( vp ) {
-            const std::optional<vpart_reference> cargo = vp.part_with_feature( VPFLAG_CARGO, true );
-            if( cargo ) {
-                vehicle_stack v_stack = cargo->vehicle().get_items( cargo->part_index() );
-                num_items += v_stack.size();
+            if( const std::optional<vpart_reference> cargo = vp.cargo() ) {
+                num_items += cargo->items().size();
             }
         }
         if( prev_num_items == num_items ) {
@@ -3009,7 +3007,7 @@ void npc::find_item()
             continue;
         }
 
-        for( const item &it : cargo->vehicle().get_items( cargo->part_index() ) ) {
+        for( const item &it : cargo->items() ) {
             consider_item( it, p );
         }
         cache_tile();
@@ -3165,7 +3163,7 @@ std::list<item> npc::pick_up_item_map( const tripoint &where )
 
 std::list<item> npc::pick_up_item_vehicle( vehicle &veh, int part_index )
 {
-    vehicle_stack stack = veh.get_items( part_index );
+    vehicle_stack stack = veh.get_items( veh.part( part_index ) );
     return npc_pickup_from_stack( *this, stack );
 }
 

--- a/src/npctrade_utils.cpp
+++ b/src/npctrade_utils.cpp
@@ -134,8 +134,7 @@ std::list<item> distribute_items_to_npc_zones( std::list<item> &items, npc &guy 
         bool leftover = true;
         for( tripoint_abs_ms const &dpoint : dest ) {
             tripoint const dpoint_here = here.getlocal( dpoint );
-            std::optional<vpart_reference> const vp =
-                here.veh_at( dpoint_here ).part_with_feature( "CARGO", false );
+            std::optional<vpart_reference> const vp = here.veh_at( dpoint_here ).cargo();
             if( vp && vp->vehicle().get_owner() == fac_id ) {
                 leftover = _to_veh( it, vp );
             } else {

--- a/src/npctrade_utils.cpp
+++ b/src/npctrade_utils.cpp
@@ -65,9 +65,8 @@ bool _to_map( item const &it, map &here, tripoint const &dpoint_here )
 
 bool _to_veh( item const &it, std::optional<vpart_reference> const &vp )
 {
-    int const part = static_cast<int>( vp->part_index() );
-    if( vp->vehicle().free_volume( part ) >= it.volume() ) {
-        std::optional<vehicle_stack::iterator> const ret = vp->vehicle().add_item( part, it );
+    if( vp->items().free_volume() >= it.volume() ) {
+        std::optional<vehicle_stack::iterator> const ret = vp->vehicle().add_item( vp->part(), it );
         return !ret.has_value();
     }
     return true;

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3300,7 +3300,7 @@ void veh_interact::complete_vehicle( Character &you )
             std::list<item> resulting_items;
 
             // First we get all the contents of the part
-            vehicle_stack contents = veh.get_items( vp_index );
+            vehicle_stack contents = veh.get_items( vp );
             resulting_items.insert( resulting_items.end(), contents.begin(), contents.end() );
             contents.clear();
 

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2483,10 +2483,10 @@ void veh_interact::display_stats() const
 
     units::volume total_cargo = 0_ml;
     units::volume free_cargo = 0_ml;
-    for( const vpart_reference &vp : veh->get_any_parts( "CARGO" ) ) {
-        const size_t p = vp.part_index();
-        total_cargo += veh->max_volume( p );
-        free_cargo += veh->free_volume( p );
+    for( const vpart_reference &vpr : veh->get_any_parts( VPFLAG_CARGO ) ) {
+        const vehicle_stack vs = vpr.items();
+        total_cargo += vs.max_volume();
+        free_cargo += vs.free_volume();
     }
 
     const int second_column = 33 + ( extraw / 4 );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1518,7 +1518,7 @@ void vehicles::finalize_prototypes()
                 }
             }
 
-            if( pt.part.obj().has_flag( "CARGO" ) ) {
+            if( pt.part.obj().has_flag( VPFLAG_CARGO ) ) {
                 cargo_spots.insert( pt.pos );
             }
         }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5827,8 +5827,9 @@ void vehicle::refresh_active_item_cache()
 {
     // Need to manually backfill the active item cache since the part loader can't call its vehicle.
     for( const vpart_reference &vp : get_any_parts( VPFLAG_CARGO ) ) {
-        auto it = vp.part().items.begin();
-        auto end = vp.part().items.end();
+        vehicle_stack vs = vp.items();
+        auto it = vs.begin();
+        auto end = vs.end();
         for( ; it != end; ++it ) {
             active_items.add( *it, vp.mount() );
         }
@@ -7344,10 +7345,8 @@ std::list<item> vehicle::use_charges( const vpart_position &vp, const itype_id &
     const itype_id veh_tool_type = type.obj().phase > phase_id::SOLID
                                    ? itype_water_faucet
                                    : type;
-    const std::optional<vpart_reference> tool_vp = vp.part_with_tool( veh_tool_type );
-    const std::optional<vpart_reference> cargo_vp = vp.part_with_feature( "CARGO", true );
 
-    if( tool_vp ) { // handle vehicle tools
+    if( const std::optional<vpart_reference> tool_vp = vp.part_with_tool( veh_tool_type ) ) {
         const itype_id &tool_fuel_type = type->tool_slot_first_ammo();
         // use the tool's ammo charges
         const itype_id &fuel_type = tool_fuel_type.is_null() ? type : tool_fuel_type;
@@ -7364,9 +7363,8 @@ std::list<item> vehicle::use_charges( const vpart_position &vp, const itype_id &
         }
     }
 
-    if( cargo_vp ) {
-        vehicle_stack veh_stack = cargo_vp->items();
-        std::list<item> tmp = veh_stack.use_charges( type, quantity, vp.pos(), filter, in_tools );
+    if( const std::optional<vpart_reference> cargo_vp = vp.cargo() ) {
+        std::list<item> tmp = cargo_vp->items().use_charges( type, quantity, vp.pos(), filter, in_tools );
         ret.splice( ret.end(), tmp );
         if( quantity <= 0 ) {
             return ret;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5485,22 +5485,6 @@ void vehicle::disable_smart_controller_if_needed()
     }
 }
 
-// total volume of all the things
-units::volume vehicle::stored_volume( const int part ) const
-{
-    return get_items( part ).stored_volume();
-}
-
-units::volume vehicle::max_volume( const int part ) const
-{
-    return get_items( part ).max_volume();
-}
-
-units::volume vehicle::free_volume( const int part ) const
-{
-    return get_items( part ).free_volume();
-}
-
 void vehicle::make_active( item_location &loc )
 {
     item &target = *loc;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1781,8 +1781,8 @@ class vehicle
         bool remove_item( vehicle_part &vp, item *it );
         vehicle_stack::iterator remove_item( vehicle_part &vp, const vehicle_stack::const_iterator &it );
 
-        vehicle_stack get_items( int part ) const;
-        vehicle_stack get_items( int part );
+        // HACK: callers could modify items through this
+        // TODO: a const version of vehicle_stack is needed
         vehicle_stack get_items( const vehicle_part &vp ) const;
         vehicle_stack get_items( vehicle_part &vp );
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1766,14 +1766,10 @@ class vehicle
         void make_active( item_location &loc );
         /**
          * Try to add an item to part's cargo.
-         *
-         * @returns std::nullopt if it can't be put here (not a cargo part, adding this would violate
-         * the volume limit or item count limit, not all charges can fit, etc.)
-         * Otherwise, returns an iterator to the added item in the vehicle stack
+         * @return iterator to added item or std::nullopt if it can't be put here (not a cargo part, adding
+         * this would violate the volume limit or item count limit, not all charges can fit, etc.)
          */
-        std::optional<vehicle_stack::iterator> add_item( int part, const item &itm );
-        /** Like the above */
-        std::optional<vehicle_stack::iterator> add_item( vehicle_part &pt, const item &obj );
+        std::optional<vehicle_stack::iterator> add_item( vehicle_part &vp, const item &itm );
         /**
          * Add an item counted by charges to the part's cargo.
          *
@@ -1782,9 +1778,7 @@ class vehicle
         int add_charges( vehicle_part &vp, const item &itm );
 
         // remove item from part's cargo
-        bool remove_item( int part, item *it );
         bool remove_item( vehicle_part &vp, item *it );
-        vehicle_stack::iterator remove_item( int part, const vehicle_stack::const_iterator &it );
         vehicle_stack::iterator remove_item( vehicle_part &vp, const vehicle_stack::const_iterator &it );
 
         vehicle_stack get_items( int part ) const;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1738,11 +1738,6 @@ class vehicle
          */
         void pldrive( Character &driver, const point &p, int z = 0 );
 
-        // stub for per-vpart limit
-        units::volume max_volume( int part ) const;
-        units::volume free_volume( int part ) const;
-        units::volume stored_volume( int part ) const;
-
         /**
         * Flags item \p tool with PSEUDO, if it has MOD pocket then a `pseudo_magazine_mod` is
         * installed and a `pseudo_magazine` is inserted into the magazine well pocket with however

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -169,17 +169,13 @@ struct vpart_edge_info {
 class vehicle_stack : public item_stack
 {
     private:
-        point location;
-        vehicle *myorigin;
-        int part_num;
+        vehicle &veh;
+        vehicle_part &vp;
     public:
-        vehicle_stack( cata::colony<item> *newstack, point newloc, vehicle *neworigin, int part ) :
-            item_stack( newstack ), location( newloc ), myorigin( neworigin ), part_num( part ) {}
-        iterator erase( const_iterator it ) override;
+        vehicle_stack( vehicle &veh, vehicle_part &vp );
+        item_stack::iterator erase( item_stack::const_iterator it ) override;
         void insert( const item &newitem ) override;
-        int count_limit() const override {
-            return MAX_ITEM_IN_VEHICLE_STORAGE;
-        }
+        int count_limit() const override;
         units::volume max_volume() const override;
 };
 
@@ -253,6 +249,7 @@ struct vehicle_part {
         friend vehicle;
         friend class veh_interact;
         friend class vehicle_cursor;
+        friend class vehicle_stack;
         friend item_location;
         friend class turret_data;
 
@@ -1787,14 +1784,19 @@ class vehicle
          *
          * @returns The number of charges added.
          */
-        int add_charges( int part, const item &itm );
+        int add_charges( vehicle_part &vp, const item &itm );
 
         // remove item from part's cargo
         bool remove_item( int part, item *it );
+        bool remove_item( vehicle_part &vp, item *it );
         vehicle_stack::iterator remove_item( int part, const vehicle_stack::const_iterator &it );
+        vehicle_stack::iterator remove_item( vehicle_part &vp, const vehicle_stack::const_iterator &it );
 
         vehicle_stack get_items( int part ) const;
         vehicle_stack get_items( int part );
+        vehicle_stack get_items( const vehicle_part &vp ) const;
+        vehicle_stack get_items( vehicle_part &vp );
+
         std::vector<item> &get_tools( vehicle_part &vp );
         const std::vector<item> &get_tools( const vehicle_part &vp ) const;
 

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -121,7 +121,7 @@ vpart_display vehicle::get_display_of_tile( const point &dp, bool rotate, bool i
 
     // if cargo has items color is inverted
     const int cargo_part = part_with_feature( dp, VPFLAG_CARGO, true );
-    if( cargo_part >= 0 && !get_items( cargo_part ).empty() ) {
+    if( cargo_part >= 0 && !get_items( part( cargo_part ) ).empty() ) {
         ret.has_cargo = true;
         ret.color = invert_color( ret.color );
     }

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -180,10 +180,11 @@ int vehicle::print_part_list( const catacurses::window &win, int y1, const int m
         }
 
         if( vpi.has_flag( VPFLAG_CARGO ) ) {
+            const vehicle_stack vs = get_items( vp );
             //~ used/total volume of a cargo vehicle part
             partname += string_format( _( " (vol: %s/%s %s)" ),
-                                       format_volume( stored_volume( pl[i] ) ),
-                                       format_volume( max_volume( pl[i] ) ),
+                                       format_volume( vs.stored_volume() ),
+                                       format_volume( vs.max_volume() ),
                                        volume_units_abbr() );
         }
 

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1088,7 +1088,7 @@ void vehicle::operate_planter()
     for( const vpart_reference &vp : get_enabled_parts( "PLANTER" ) ) {
         const size_t planter_id = vp.part_index();
         const tripoint loc = vp.pos();
-        vehicle_stack v = get_items( planter_id );
+        vehicle_stack v = get_items( vp.part() );
         for( auto i = v.begin(); i != v.end(); i++ ) {
             if( i->is_seed() ) {
                 // If it is an "advanced model" then it will avoid damaging itself or becoming damaged. It's a real feature.
@@ -1382,7 +1382,8 @@ void vehicle::lock_or_unlock( const int part_index, const bool locking )
 
 void vehicle::use_autoclave( int p )
 {
-    vehicle_stack items = get_items( p );
+    vehicle_part &vp = parts[p];
+    vehicle_stack items = get_items( vp );
     bool filthy_items = std::any_of( items.begin(), items.end(), []( const item & i ) {
         return i.has_flag( json_flag_FILTHY );
     } );
@@ -1395,8 +1396,8 @@ void vehicle::use_autoclave( int p )
         return i.is_bionic();
     } );
 
-    if( parts[p].enabled ) {
-        parts[p].enabled = false;
+    if( vp.enabled ) {
+        vp.enabled = false;
         add_msg( m_bad,
                  _( "You turn the autoclave off before it's finished the program, and open its door." ) );
     } else if( items.empty() ) {
@@ -1412,7 +1413,7 @@ void vehicle::use_autoclave( int p )
     } else if( unpacked_items ) {
         add_msg( m_bad, _( "You should put your CBMs in autoclave pouches to keep them sterile." ) );
     } else {
-        parts[p].enabled = true;
+        vp.enabled = true;
         for( item &n : items ) {
             n.set_age( 0_turns );
         }
@@ -1423,13 +1424,13 @@ void vehicle::use_autoclave( int p )
             drain( itype_water_clean, 8 );
         }
 
-        add_msg( m_good,
-                 _( "You turn the autoclave on and it starts its cycle." ) );
+        add_msg( m_good, _( "You turn the autoclave on and it starts its cycle." ) );
     }
 }
 
 void vehicle::use_washing_machine( int p )
 {
+    vehicle_part &vp = parts[p];
     avatar &player_character = get_avatar();
     // Get all the items that can be used as detergent
     const inventory &inv = player_character.crafting_inventory();
@@ -1437,7 +1438,7 @@ void vehicle::use_washing_machine( int p )
         return it.has_flag( STATIC( flag_id( "DETERGENT" ) ) ) && inv.has_charges( it.typeId(), 5 );
     } );
 
-    vehicle_stack items = get_items( p );
+    vehicle_stack items = get_items( vp );
     bool filthy_items = std::all_of( items.begin(), items.end(), []( const item & i ) {
         return i.has_flag( json_flag_FILTHY );
     } );
@@ -1446,25 +1447,22 @@ void vehicle::use_washing_machine( int p )
         return i.is_bionic();
     } );
 
-    if( parts[p].enabled ) {
-        parts[p].enabled = false;
+    if( vp.enabled ) {
+        vp.enabled = false;
         add_msg( m_bad,
                  _( "You turn the washing machine off before it's finished its cycle, and open its lid." ) );
     } else if( items.empty() ) {
-        add_msg( m_bad,
-                 _( "The washing machine is empty; there's no point in starting it." ) );
+        add_msg( m_bad, _( "The washing machine is empty; there's no point in starting it." ) );
     } else if( fuel_left( itype_water ) < 24 && fuel_left( itype_water_clean ) < 24 ) {
         add_msg( m_bad,
-                 _( "You need 24 charges of water in the tanks of the %s to fill the washing machine." ),
-                 name );
+                 _( "You need 24 charges of water in the tanks of the %s to fill the washing machine." ), name );
     } else if( detergents.empty() ) {
         add_msg( m_bad, _( "You need 5 charges of a detergent for the washing machine." ) );
     } else if( !filthy_items ) {
         add_msg( m_bad,
                  _( "You need to remove all non-filthy items from the washing machine to start the washing program." ) );
     } else if( cbms ) {
-        add_msg( m_bad,
-                 _( "CBMs can't be cleaned in a washing machine.  You need to remove them." ) );
+        add_msg( m_bad, _( "CBMs can't be cleaned in a washing machine.  You need to remove them." ) );
     } else {
         uilist detergent_selector;
         detergent_selector.text = _( "Use what detergent?" );
@@ -1494,7 +1492,7 @@ void vehicle::use_washing_machine( int p )
             return;
         }
 
-        parts[p].enabled = true;
+        vp.enabled = true;
         for( item &n : items ) {
             n.set_age( 0_turns );
         }
@@ -1516,9 +1514,10 @@ void vehicle::use_washing_machine( int p )
 
 void vehicle::use_dishwasher( int p )
 {
+    vehicle_part &vp = parts[p];
     avatar &player_character = get_avatar();
     bool detergent_is_enough = player_character.crafting_inventory().has_charges( itype_detergent, 5 );
-    vehicle_stack items = get_items( p );
+    vehicle_stack items = get_items( vp );
     bool filthy_items = std::all_of( items.begin(), items.end(), []( const item & i ) {
         return i.has_flag( json_flag_FILTHY );
     } );
@@ -1533,13 +1532,12 @@ void vehicle::use_dishwasher( int p )
         }
     }
 
-    if( parts[p].enabled ) {
-        parts[p].enabled = false;
+    if( vp.enabled ) {
+        vp.enabled = false;
         add_msg( m_bad,
                  _( "You turn the dishwasher off before it's finished its cycle, and open its lid." ) );
     } else if( items.empty() ) {
-        add_msg( m_bad,
-                 _( "The dishwasher is empty, there's no point in starting it." ) );
+        add_msg( m_bad, _( "The dishwasher is empty, there's no point in starting it." ) );
     } else if( fuel_left( itype_water ) < 24 && fuel_left( itype_water_clean ) < 24 ) {
         add_msg( m_bad, _( "You need 24 charges of water in the tanks of the %s to fill the dishwasher." ),
                  name );
@@ -1551,7 +1549,7 @@ void vehicle::use_dishwasher( int p )
     } else if( soft_items ) {
         add_msg( m_bad, buffer );
     } else {
-        parts[p].enabled = true;
+        vp.enabled = true;
         for( item &n : items ) {
             n.set_age( 0_turns );
         }
@@ -1714,8 +1712,7 @@ void vpart_position::form_inventory( inventory &inv ) const
     const std::optional<vpart_reference> vp_cargo = part_with_feature( "CARGO", true );
 
     if( vp_cargo ) {
-        const vehicle_stack items = vehicle().get_items( vp_cargo->part_index() );
-        for( const item &it : items ) {
+        for( const item &it : vp_cargo->items() ) {
             if( it.empty_container() && it.is_watertight_container() ) {
                 const int count = it.count_by_charges() ? it.charges : 1;
                 inv.update_liq_container_count( it.typeId(), count );
@@ -2114,7 +2111,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
     // Whether vehicle part (cargo) contains items, and whether map tile (ground) has items
     if( with_pickup && (
             get_map().has_items( vp.pos() ) ||
-            ( vp_cargo && !get_items( vp_cargo->part_index() ).empty() ) ) ) {
+            ( vp_cargo && !vp_cargo->items().empty() ) ) ) {
         menu.add( _( "Get items" ) )
         .hotkey( "GET_ITEMS" )
         .skip_locked_check()

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1069,7 +1069,7 @@ void vehicle::operate_reaper()
         }
         sounds::sound( reaper_pos, rng( 10, 25 ), sounds::sound_t::combat, _( "Swish" ), false, "vehicle",
                        "reaper" );
-        if( vp.has_feature( "CARGO" ) ) {
+        if( vp.info().has_flag( VPFLAG_CARGO ) ) {
             for( map_stack::iterator iter = items.begin(); iter != items.end(); ) {
                 if( ( iter->volume() <= max_pickup_volume ) &&
                     add_item( vp.part(), *iter ) ) {
@@ -1708,10 +1708,7 @@ void vehicle::build_bike_rack_menu( veh_menu &menu, int part )
 
 void vpart_position::form_inventory( inventory &inv ) const
 {
-    const std::optional<vpart_reference> vp_faucet = part_with_tool( itype_water_faucet );
-    const std::optional<vpart_reference> vp_cargo = part_with_feature( "CARGO", true );
-
-    if( vp_cargo ) {
+    if( const std::optional<vpart_reference> vp_cargo = part_with_feature( VPFLAG_CARGO, true ) ) {
         for( const item &it : vp_cargo->items() ) {
             if( it.empty_container() && it.is_watertight_container() ) {
                 const int count = it.count_by_charges() ? it.charges : 1;
@@ -1722,6 +1719,7 @@ void vpart_position::form_inventory( inventory &inv ) const
     }
 
     // HACK: water_faucet pseudo tool gives access to liquids in tanks
+    const std::optional<vpart_reference> vp_faucet = part_with_tool( itype_water_faucet );
     if( vp_faucet && inv.provide_pseudo_item( itype_water_faucet ) != nullptr ) {
         for( const item *it : vehicle().fuel_items_left() ) {
             if( it->made_of( phase_id::LIQUID ) ) {
@@ -2107,7 +2105,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         .on_submit( [this, dw_idx] { use_dishwasher( dw_idx ); } );
     }
 
-    const std::optional<vpart_reference> vp_cargo = vp.part_with_feature( "CARGO", false );
+    const std::optional<vpart_reference> vp_cargo = vp.cargo();
     // Whether vehicle part (cargo) contains items, and whether map tile (ground) has items
     if( with_pickup && (
             get_map().has_items( vp.pos() ) ||

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1042,7 +1042,6 @@ void vehicle::operate_reaper()
 {
     map &here = get_map();
     for( const vpart_reference &vp : get_enabled_parts( "REAPER" ) ) {
-        const size_t reaper_id = vp.part_index();
         const tripoint reaper_pos = vp.pos();
         const int plant_produced = rng( 1, vp.info().bonus );
         const int seed_produced = rng( 1, 3 );
@@ -1073,7 +1072,7 @@ void vehicle::operate_reaper()
         if( vp.has_feature( "CARGO" ) ) {
             for( map_stack::iterator iter = items.begin(); iter != items.end(); ) {
                 if( ( iter->volume() <= max_pickup_volume ) &&
-                    add_item( reaper_id, *iter ) ) {
+                    add_item( vp.part(), *iter ) ) {
                     iter = items.erase( iter );
                 } else {
                     ++iter;
@@ -1169,7 +1168,7 @@ void vehicle::operate_scoop()
                                sounds::sound_t::combat, _( "BEEEThump" ), false, "vehicle", "scoop_thump" );
             }
             //This attempts to add the item to the scoop inventory and if successful, removes it from the map.
-            if( add_item( scoop, *that_item_there ) ) {
+            if( add_item( vp.part(), *that_item_there ) ) {
                 here.i_rem( position, that_item_there );
             } else {
                 break;

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -518,7 +518,7 @@ VisitResponse vehicle_cursor::visit_items(
     const vehicle_part &vp = veh.part( part );
     const int idx = veh.part_with_feature( vp.mount, "CARGO", true );
     if( idx >= 0 ) {
-        for( item &e : veh.get_items( idx ) ) {
+        for( item &e : veh.get_items( veh.part( idx ) ) ) {
             if( visit_internal( func, &e ) == VisitResponse::ABORT ) {
                 return VisitResponse::ABORT;
             }

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -17,6 +17,7 @@ struct input_event;
 class inventory;
 class Character;
 class vehicle;
+class vehicle_stack;
 class vpart_info;
 struct vehicle_part;
 
@@ -66,6 +67,8 @@ class vpart_position
          * @returns The label at this part of the vehicle, if there is any.
          */
         std::optional<std::string> get_label() const;
+        // @return reference to unbroken CARGO part at this position or std::nullopt
+        std::optional<vpart_reference> cargo() const;
         /// @see vehicle::part_with_feature
         std::optional<vpart_reference> part_with_feature( const std::string &f, bool unbroken ) const;
         /// @see vehicle::part_with_feature
@@ -126,6 +129,8 @@ class optional_vpart_position : public std::optional<vpart_position>
         std::optional<std::string> get_label() const {
             return has_value() ? value().get_label() : std::nullopt;
         }
+        // @return reference to unbroken CARGO part at this position or std::nullopt
+        std::optional<vpart_reference> cargo() const;
         std::optional<vpart_reference> part_with_feature( const std::string &f, bool unbroken ) const;
         std::optional<vpart_reference> part_with_feature( vpart_bitflags f, bool unbroken ) const;
         std::optional<vpart_reference> avail_part_with_feature( const std::string &f ) const;
@@ -157,6 +162,8 @@ class vpart_reference : public vpart_position
         vehicle_part &part() const;
         /// See @ref vehicle_part::info
         const vpart_info &info() const;
+        // @return vehicle_stack constructed from the part's cargo items
+        vehicle_stack items() const;
         /**
          * Returns whether the part *type* has the given feature.
          * Note that this is different from part flags (which apply to part

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -95,7 +95,7 @@ TEST_CASE( "zone_unloading_ammo_belts", "[zones][items][ammo_belt][activities][u
 
     WHEN( "unloading ammo belts using zone_unload_all " ) {
         if( in_vehicle ) {
-            vp->vehicle().add_item( vp->part_index(), ammo_belt );
+            vp->vehicle().add_item( vp->part(), ammo_belt );
         } else {
             here.add_item_or_charges( tripoint_east, ammo_belt );
         }

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -77,9 +77,8 @@ TEST_CASE( "zone_unloading_ammo_belts", "[zones][items][ammo_belt][activities][u
     dummy.set_location( start );
 
     if( in_vehicle ) {
-        REQUIRE(
-            here.add_vehicle( vehicle_prototype_shopping_cart, tripoint_east, 0_degrees, 0, 0 ) );
-        vp = here.veh_at( start ).part_with_feature( "CARGO", true );
+        REQUIRE( here.add_vehicle( vehicle_prototype_shopping_cart, tripoint_east, 0_degrees, 0, 0 ) );
+        vp = here.veh_at( start ).cargo();
         REQUIRE( vp );
         vp->vehicle().set_owner( dummy );
     }

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -47,7 +47,7 @@ int count_items_or_charges( const tripoint src, const itype_id &id,
                             const std::optional<vpart_reference> &vp )
 {
     if( vp ) {
-        return _count_items_or_charges( vp->vehicle().get_items( vp->part_index() ), id );
+        return _count_items_or_charges( vp->vehicle().get_items( vp->part() ), id );
     }
     return _count_items_or_charges( get_map().i_at( src ), id );
 }

--- a/tests/item_spawn_test.cpp
+++ b/tests/item_spawn_test.cpp
@@ -59,7 +59,7 @@ TEST_CASE( "correct_amounts_of_an_item_spawn_inside_a_container", "[item_spawn]"
                             vehicle *veh = here.get_vehicles()[0].v;
                             int part = veh->avail_part_with_feature( point_zero, "CARGO" );
                             REQUIRE( part >= 0 );
-                            for( item &it : veh->get_items( part ) ) {
+                            for( item &it : veh->get_items( veh->part( part ) ) ) {
                                 items.push_back( it );
                             }
                             break;

--- a/tests/item_spawn_test.cpp
+++ b/tests/item_spawn_test.cpp
@@ -54,12 +54,14 @@ TEST_CASE( "correct_amounts_of_an_item_spawn_inside_a_container", "[item_spawn]"
                         case spawn_type::vehicle: {
                             clear_map();
                             map &here = get_map();
-                            here.add_vehicle( cs_data.vehicle, tripoint( 0, 0, here.get_abs_sub().z() ), 0_degrees, -1, 0 );
+                            const tripoint vehpos( 0, 0, here.get_abs_sub().z() );
+                            vehicle *veh = here.add_vehicle( cs_data.vehicle, vehpos, 0_degrees, 0, 0 );
+                            REQUIRE( veh );
                             REQUIRE( here.get_vehicles().size() == 1 );
-                            vehicle *veh = here.get_vehicles()[0].v;
-                            int part = veh->avail_part_with_feature( point_zero, "CARGO" );
-                            REQUIRE( part >= 0 );
-                            for( item &it : veh->get_items( veh->part( part ) ) ) {
+                            const tripoint pos( point_zero, veh->sm_pos.z );
+                            const std::optional<vpart_reference> ovp_cargo = here.veh_at( pos ).cargo();
+                            REQUIRE( ovp_cargo );
+                            for( item &it : ovp_cargo->items() ) {
                                 items.push_back( it );
                             }
                             break;

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -864,7 +864,7 @@ void test_scenario::run()
     if( cur_container_loc == container_location::vehicle ) {
         REQUIRE( vp.has_value() );
         match( vehicle_cursor( vp->vehicle(), vp->part_index() ),
-               vp->vehicle().get_items( vp->part_index() ), vehicle_results );
+               vp->vehicle().get_items( vp->part() ), vehicle_results );
     } else {
         REQUIRE( !vp.has_value() );
     }

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -59,7 +59,7 @@ static vehicle *setup_drag_test( const vproto_id &veh_id )
     // Remove all items from cargo to normalize weight.
     // turn everything on
     for( const vpart_reference &vp : veh_ptr->get_all_parts() ) {
-        veh_ptr->get_items( vp.part_index() ).clear();
+        veh_ptr->get_items( vp.part() ).clear();
         vp.part().enabled = true;
     }
     // close the doors

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -187,7 +187,7 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
 
     // Remove all items from cargo to normalize weight.
     for( const vpart_reference &vp : veh.get_all_parts() ) {
-        veh_ptr->get_items( vp.part_index() ).clear();
+        veh_ptr->get_items( vp.part() ).clear();
         vp.part().ammo_consume( vp.part().ammo_remaining(), vp.pos() );
     }
     for( const vpart_reference &vp : veh.get_avail_parts( "OPENABLE" ) ) {

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -88,19 +88,17 @@ TEST_CASE( "add_item_to_broken_vehicle_part", "[vehicle]" )
     REQUIRE( veh_ptr != nullptr );
 
     const tripoint pos = vehicle_origin + tripoint_west;
-    auto cargo_parts = veh_ptr->get_parts_at( pos, "CARGO", part_status_flag::any );
-    REQUIRE( !cargo_parts.empty( ) );
-    vehicle_part *cargo_part = cargo_parts.front();
-    REQUIRE( cargo_part != nullptr );
+    const std::optional<vpart_reference> ovp_cargo = get_map().veh_at( pos ).cargo();
+    REQUIRE( ovp_cargo );
     //Must not be broken yet
-    REQUIRE( !cargo_part->is_broken() );
+    REQUIRE( !ovp_cargo->part().is_broken() );
     //For some reason (0 - cargo_part->hp()) is just not enough to destroy a part
-    REQUIRE( veh_ptr->mod_hp( *cargo_part, -( 1 + cargo_part->hp() ) ) );
+    REQUIRE( veh_ptr->mod_hp( ovp_cargo->part(), -( 1 + ovp_cargo->part().hp() ) ) );
     //Now it must be broken
-    REQUIRE( cargo_part->is_broken() );
+    REQUIRE( ovp_cargo->part().is_broken() );
     //Now part is really broken, adding an item should fail
     const item itm2 = item( "jeans" );
-    REQUIRE( !veh_ptr->add_item( *cargo_part, itm2 ) );
+    REQUIRE( !veh_ptr->add_item( ovp_cargo->part(), itm2 ) );
 }
 
 TEST_CASE( "starting_bicycle_damaged_pedal", "[vehicle]" )

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -439,7 +439,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
         const int part = vp->part_index();
         REQUIRE( part >= 0 );
         // Empty the vehicle of any cargo.
-        v->get_items( part ).clear();
+        v->get_items( vp->part() ).clear();
         for( int i = 0; i != count; ++i ) {
             v->add_item( vp->part(), obj );
         }

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -441,7 +441,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
         // Empty the vehicle of any cargo.
         v->get_items( part ).clear();
         for( int i = 0; i != count; ++i ) {
-            v->add_item( part, obj );
+            v->add_item( vp->part(), obj );
         }
 
         vehicle_selector sel( p.pos(), 1 );

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -433,7 +433,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
             return static_cast<bool>( here.veh_at( e ) );
         } ) == 1 );
 
-        const std::optional<vpart_reference> vp = here.veh_at( veh ).part_with_feature( "CARGO", true );
+        const std::optional<vpart_reference> vp = here.veh_at( veh ).cargo();
         REQUIRE( vp );
         vehicle *const v = &vp->vehicle();
         const int part = vp->part_index();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Make more vehicle stuff work via references, tidy up accessing cargo

#### Describe the solution

Added some helpers to vpart_position/vpart_reference to get a `vehicle_stack` with less boilerplate
Remove some duplicated vehicle_stack stuff (vehicle::*_volume)
Converts more code to use vpart references instead of int indexes

There are a couple functional changes; some code ignored broken status of a CARGO part - the added vpart_pos/vpart_ref helpers now always check the part isn't broken before it's considered valid

#### Describe alternatives you've considered

#### Testing

Tests should catch some of these, playing around a bit dropping/picking up items and AIM didn't change

#### Additional context
