### PR TITLE
Map memory tidy and ghost vparts fix

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -675,14 +675,14 @@ void avatar::grab( object_type grab_type_new, const tripoint &grab_point_new )
                     if( erase ) {
                         memorize_clear_decoration( m.getabs( target ), /* prefix = */ "vp_" );
                     }
-                    m.set_memory_seen_cache_dirty( target );
+                    m.memory_cache_dec_set_dirty( target, true );
                 }
             }
         } else if( gtype != object_type::NONE ) {
             if( erase ) {
                 memorize_clear_decoration( m.getabs( pos() + gpoint ) );
             }
-            m.set_memory_seen_cache_dirty( pos() + gpoint );
+            m.memory_cache_dec_set_dirty( pos() + gpoint, true );
         }
     };
     // Mark the area covered by the previous vehicle/furniture/etc for re-memorizing.

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -237,6 +237,11 @@ void avatar::toggle_map_memory()
     show_map_memory = !show_map_memory;
 }
 
+bool avatar::is_map_memory_valid() const
+{
+    return player_map_memory->is_valid();
+}
+
 bool avatar::should_show_map_memory() const
 {
     if( get_timed_events().get( timed_event_type::OVERRIDE_PLACE ) ) {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -247,20 +247,20 @@ bool avatar::should_show_map_memory() const
 
 bool avatar::save_map_memory()
 {
-    return player_map_memory->save( get_map().getabs( pos() ) );
+    return player_map_memory->save( get_map().getglobal( pos() ) );
 }
 
 void avatar::load_map_memory()
 {
-    player_map_memory->load( get_map().getabs( pos() ) );
+    player_map_memory->load( get_map().getglobal( pos() ) );
 }
 
-void avatar::prepare_map_memory_region( const tripoint &p1, const tripoint &p2 )
+void avatar::prepare_map_memory_region( const tripoint_abs_ms &p1, const tripoint_abs_ms &p2 )
 {
     player_map_memory->prepare_region( p1, p2 );
 }
 
-const memorized_tile &avatar::get_memorized_tile( const tripoint &p ) const
+const memorized_tile &avatar::get_memorized_tile( const tripoint_abs_ms &p ) const
 {
     if( should_show_map_memory() ) {
         return player_map_memory->get_tile( p );
@@ -268,24 +268,24 @@ const memorized_tile &avatar::get_memorized_tile( const tripoint &p ) const
     return mm_submap::default_tile;
 }
 
-void avatar::memorize_terrain( const tripoint &p, const std::string_view id,
+void avatar::memorize_terrain( const tripoint_abs_ms &p, const std::string_view id,
                                int subtile, int rotation )
 {
     player_map_memory->set_tile_terrain( p, id, subtile, rotation );
 }
 
-void avatar::memorize_decoration( const tripoint &p, const std::string_view id,
+void avatar::memorize_decoration( const tripoint_abs_ms &p, const std::string_view id,
                                   int subtile, int rotation )
 {
     player_map_memory->set_tile_decoration( p, id, subtile, rotation );
 }
 
-void avatar::memorize_symbol( const tripoint &p, char32_t symbol )
+void avatar::memorize_symbol( const tripoint_abs_ms &p, char32_t symbol )
 {
     player_map_memory->set_tile_symbol( p, symbol );
 }
 
-void avatar::memorize_clear_decoration( const tripoint &p, std::string_view prefix )
+void avatar::memorize_clear_decoration( const tripoint_abs_ms &p, std::string_view prefix )
 {
     player_map_memory->clear_tile_decoration( p, prefix );
 }
@@ -673,14 +673,14 @@ void avatar::grab( object_type grab_type_new, const tripoint &grab_point_new )
             if( const optional_vpart_position ovp = m.veh_at( pos() + gpoint ) ) {
                 for( const tripoint &target : ovp->vehicle().get_points() ) {
                     if( erase ) {
-                        memorize_clear_decoration( m.getabs( target ), /* prefix = */ "vp_" );
+                        memorize_clear_decoration( m.getglobal( target ), /* prefix = */ "vp_" );
                     }
                     m.memory_cache_dec_set_dirty( target, true );
                 }
             }
         } else if( gtype != object_type::NONE ) {
             if( erase ) {
-                memorize_clear_decoration( m.getabs( pos() + gpoint ) );
+                memorize_clear_decoration( m.getglobal( pos() + gpoint ) );
             }
             m.memory_cache_dec_set_dirty( pos() + gpoint, true );
         }

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -140,6 +140,8 @@ class avatar : public Character
         bool query_yn( const std::string &mes ) const override;
 
         void toggle_map_memory();
+        //! @copydoc map_memory::is_valid() const
+        bool is_map_memory_valid() const;
         bool should_show_map_memory() const;
         void prepare_map_memory_region( const tripoint_abs_ms &p1, const tripoint_abs_ms &p2 );
         const memorized_tile &get_memorized_tile( const tripoint_abs_ms &p ) const;

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -141,12 +141,14 @@ class avatar : public Character
 
         void toggle_map_memory();
         bool should_show_map_memory() const;
-        void prepare_map_memory_region( const tripoint &p1, const tripoint &p2 );
-        const memorized_tile &get_memorized_tile( const tripoint &p ) const;
-        void memorize_terrain( const tripoint &p, std::string_view id, int subtile, int rotation );
-        void memorize_decoration( const tripoint &p, std::string_view id, int subtile, int rotation );
-        void memorize_symbol( const tripoint &p, char32_t symbol );
-        void memorize_clear_decoration( const tripoint &p, std::string_view prefix = "" );
+        void prepare_map_memory_region( const tripoint_abs_ms &p1, const tripoint_abs_ms &p2 );
+        const memorized_tile &get_memorized_tile( const tripoint_abs_ms &p ) const;
+        void memorize_terrain( const tripoint_abs_ms &p, std::string_view id,
+                               int subtile, int rotation );
+        void memorize_decoration( const tripoint_abs_ms &p, std::string_view id,
+                                  int subtile, int rotation );
+        void memorize_symbol( const tripoint_abs_ms &p, char32_t symbol );
+        void memorize_clear_decoration( const tripoint_abs_ms &p, std::string_view prefix = "" );
 
         nc_color basic_symbol_color() const override;
         int print_info( const catacurses::window &w, int vStart, int vLines, int column ) const override;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1811,7 +1811,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 }
             }
             if( !var->invisible[0] ) {
-                here.check_and_set_seen_cache( p.com.pos );
+                here.memory_cache_ter_set_dirty( p.com.pos, false );
             }
         }
     }
@@ -1851,13 +1851,13 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             //calling draw to memorize (and only memorize) everything.
             //bypass cache check in case we learn something new about the terrain's connections
             draw_terrain( p, lighting, height_3d, invisible, true );
-            if( here.check_seen_cache( p ) ) {
+            if( here.memory_cache_dec_is_dirty( p ) ) {
                 draw_furniture( p, lighting, height_3d, invisible, true );
                 draw_trap( p, lighting, height_3d, invisible, true );
                 draw_part_con( p, lighting, height_3d, invisible, true );
                 draw_vpart_no_roof( p, lighting, height_3d, invisible, true );
                 draw_vpart_roof( p, lighting, height_3d, invisible, true );
-                here.check_and_set_seen_cache( p );
+                here.memory_cache_dec_set_dirty( p, false );
             }
         }
     }
@@ -3186,12 +3186,12 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
         if( connect_group.any() ) {
             get_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
             // re-memorize previously seen terrain in case new connections have been seen
-            here.set_memory_seen_cache_dirty( p );
+            here.memory_cache_ter_set_dirty( p, true );
         } else {
             get_terrain_orientation( p, rotation, subtile, {}, invisible, rotate_group );
             // do something to get other terrain orientation values
         }
-        if( here.check_seen_cache( p ) ) {
+        if( here.memory_cache_ter_is_dirty( p ) ) {
             get_avatar().memorize_terrain( here.getabs( p ), tname, subtile, rotation );
         }
         // draw the actual terrain if there's no override
@@ -3280,7 +3280,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         const std::string &fname = f.id().str();
         if( !( you.get_grab_type() == object_type::FURNITURE
                && p == you.pos() + you.grab_point )
-            && here.check_seen_cache( p ) ) {
+            && here.memory_cache_dec_is_dirty( p ) ) {
             you.memorize_decoration( here.getabs( p ), fname, subtile, rotation );
         }
         // draw the actual furniture if there's no override
@@ -3373,7 +3373,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
         int rotation = 0;
         get_tile_values( tr.loadid.to_i(), neighborhood, subtile, rotation, 0 );
         const std::string trname = tr.loadid.id().str();
-        if( here.check_seen_cache( p ) ) {
+        if( here.memory_cache_dec_is_dirty( p ) ) {
             you.memorize_decoration( here.getabs( p ), trname, subtile, rotation );
         }
         // draw the actual trap if there's no override
@@ -3437,7 +3437,7 @@ bool cata_tiles::draw_part_con( const tripoint &p, const lit_level ll, int &heig
     if( here.partial_con_at( tripoint_bub_ms( p ) ) != nullptr && !invisible[0] ) {
         avatar &you = get_avatar();
         std::string const &trname = tr_unfinished_construction.str();;
-        if( here.check_seen_cache( p ) ) {
+        if( here.memory_cache_dec_is_dirty( p ) ) {
             you.memorize_decoration( here.getabs( p ), trname, 0, 0 );
         }
         return memorize_only
@@ -3825,7 +3825,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             if( !veh.forward_velocity() && !veh.player_in_control( you )
                 && !( you.get_grab_type() == object_type::VEHICLE
                       && veh.get_points().count( you.pos() + you.grab_point ) )
-                && here.check_seen_cache( p ) ) {
+                && here.memory_cache_dec_is_dirty( p ) ) {
                 you.memorize_decoration( here.getabs( p ), vd.get_tileset_id(), subtile, rotation );
             }
             if( !overridden ) {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -513,11 +513,11 @@ class cata_tiles
         static int get_rotation_edge_ew( char rot_to );
 
         /** Map memory */
-        bool has_memory_at( const tripoint &p ) const;
-        const memorized_tile &get_terrain_memory_at( const tripoint &p ) const;
-        const memorized_tile &get_furniture_memory_at( const tripoint &p ) const;
-        const memorized_tile &get_trap_memory_at( const tripoint &p ) const;
-        const memorized_tile &get_vpart_memory_at( const tripoint &p ) const;
+        bool has_memory_at( const tripoint_abs_ms &p ) const;
+        const memorized_tile &get_terrain_memory_at( const tripoint_abs_ms &p ) const;
+        const memorized_tile &get_furniture_memory_at( const tripoint_abs_ms &p ) const;
+        const memorized_tile &get_trap_memory_at( const tripoint_abs_ms &p ) const;
+        const memorized_tile &get_vpart_memory_at( const tripoint_abs_ms &p ) const;
 
         /** Drawing Layers */
         bool would_apply_vision_effects( visibility_type visibility ) const;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5808,7 +5808,7 @@ void game::control_vehicle()
         // Clear the map memory for the area covered by the vehicle to eliminate ghost vehicles.
         for( const tripoint &target : veh->get_points() ) {
             u.memorize_clear_decoration( m.getabs( target ), "vp_" );
-            m.set_memory_seen_cache_dirty( target );
+            m.memory_cache_dec_set_dirty( target, true );
         }
         veh->is_following = false;
         veh->is_patrolling = false;
@@ -10948,7 +10948,8 @@ void game::place_player_overmap( const tripoint_abs_omt &om_dest, bool move_play
         m.clear_vehicle_list( z );
     }
     m.rebuild_vehicle_level_caches();
-    m.access_cache( m.get_abs_sub().z() ).map_memory_seen_cache.reset();
+    m.access_cache( m.get_abs_sub().z() ).map_memory_cache_dec.reset();
+    m.access_cache( m.get_abs_sub().z() ).map_memory_cache_ter.reset();
     // offset because load_map expects the coordinates of the top left corner, but the
     // player will be centered in the middle of the map.
     const tripoint_abs_sm map_sm_pos =

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5807,7 +5807,7 @@ void game::control_vehicle()
         // If we reached here, we gained control of a vehicle.
         // Clear the map memory for the area covered by the vehicle to eliminate ghost vehicles.
         for( const tripoint &target : veh->get_points() ) {
-            u.memorize_clear_decoration( m.getabs( target ), "vp_" );
+            u.memorize_clear_decoration( m.getglobal( target ), "vp_" );
             m.memory_cache_dec_set_dirty( target, true );
         }
         veh->is_following = false;

--- a/src/level_cache.h
+++ b/src/level_cache.h
@@ -84,7 +84,8 @@ struct level_cache {
 
         // stores resulting apparent brightness to player, calculated by map::apparent_light_at
         cata::mdarray<lit_level, point_bub_ms> visibility_cache;
-        std::bitset<MAPSIZE_X *MAPSIZE_Y> map_memory_seen_cache;
+        std::bitset<MAPSIZE_X *MAPSIZE_Y> map_memory_cache_dec;
+        std::bitset<MAPSIZE_X *MAPSIZE_Y> map_memory_cache_ter;
         std::bitset<MAPSIZE *MAPSIZE> field_cache;
 
         std::set<vehicle *> vehicle_list;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -537,7 +537,7 @@ std::unique_ptr<vehicle> map::detach_vehicle( vehicle *veh )
                 if( inbounds( pt ) ) {
                     memory_cache_dec_set_dirty( pt, true );
                 }
-                get_avatar().memorize_clear_decoration( getabs( pt ), "vp_" );
+                get_avatar().memorize_clear_decoration( getglobal( pt ), "vp_" );
             }
             ch.vehicle_list.erase( veh );
             ch.zone_vehicles.erase( veh );
@@ -1756,7 +1756,7 @@ bool map::furn_set( const tripoint &p, const furn_id &new_furniture, const bool 
 
     memory_cache_dec_set_dirty( p, true );
     if( pl_sees( p, player_character.sight_max ) ) {
-        player_character.memorize_clear_decoration( getabs( p ), "f_" );
+        player_character.memorize_clear_decoration( getglobal( p ), "f_" );
     }
 
     // TODO: Limit to changes that affect move cost, traps and stairs
@@ -1872,13 +1872,13 @@ uint8_t map::get_known_connections( const tripoint &p,
     if( use_tiles ) {
         is_memorized =
         [&]( const tripoint & q ) {
-            return !player_character.get_memorized_tile( getabs( q ) ).get_ter_id().empty();
+            return !player_character.get_memorized_tile( getglobal( q ) ).get_ter_id().empty();
         };
     } else {
 #endif
         is_memorized =
         [&]( const tripoint & q ) {
-            return player_character.get_memorized_tile( getabs( q ) ).symbol != 0;
+            return player_character.get_memorized_tile( getglobal( q ) ).symbol != 0;
         };
 #ifdef TILES
     }
@@ -1957,12 +1957,12 @@ uint8_t map::get_known_connections_f( const tripoint &p,
 #ifdef TILES
     if( use_tiles ) {
         is_memorized = [&]( const tripoint & q ) {
-            return !player_character.get_memorized_tile( getabs( q ) ).get_dec_id().empty();
+            return !player_character.get_memorized_tile( getglobal( q ) ).get_dec_id().empty();
         };
     } else {
 #endif
         is_memorized = [&]( const tripoint & q ) {
-            return player_character.get_memorized_tile( getabs( q ) ).symbol != 0;
+            return player_character.get_memorized_tile( getglobal( q ) ).symbol != 0;
         };
 #ifdef TILES
     }
@@ -2200,7 +2200,7 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_crea
     memory_cache_dec_set_dirty( p, true );
     avatar &player_character = get_avatar();
     if( pl_sees( p, player_character.sight_max ) ) {
-        player_character.memorize_clear_decoration( getabs( p ), "t_" );
+        player_character.memorize_clear_decoration( getglobal( p ), "t_" );
     }
 
     // TODO: Limit to changes that affect move cost, traps and stairs
@@ -5964,7 +5964,7 @@ void map::partial_con_remove( const tripoint_bub_ms &p )
     memory_cache_dec_set_dirty( p.raw(), true );
     avatar &player_character = get_avatar();
     if( pl_sees( p.raw(), player_character.sight_max ) ) {
-        player_character.memorize_clear_decoration( getabs( p ), "tr_" );
+        player_character.memorize_clear_decoration( getglobal( p ), "tr_" );
     }
 }
 
@@ -6007,7 +6007,7 @@ void map::trap_set( const tripoint &p, const trap_id &type )
     memory_cache_dec_set_dirty( p, true );
     avatar &player_character = get_avatar();
     if( pl_sees( p, player_character.sight_max ) ) {
-        player_character.memorize_clear_decoration( getabs( p ), "tr_" );
+        player_character.memorize_clear_decoration( getglobal( p ), "tr_" );
     }
     // If there was already a trap here, remove it.
     if( current_submap->get_trap( l ) != tr_null ) {
@@ -6044,7 +6044,7 @@ void map::remove_trap( const tripoint &p )
             memory_cache_dec_set_dirty( p, true );
             avatar &player_character = get_avatar();
             if( pl_sees( p, player_character.sight_max ) ) {
-                player_character.memorize_clear_decoration( getabs( p ), "tr_" );
+                player_character.memorize_clear_decoration( getglobal( p ), "tr_" );
             }
             player_character.add_known_trap( p, tr_null.obj() );
         }
@@ -6562,7 +6562,7 @@ visibility_type map::get_visibility( const lit_level ll,
 
 static std::optional<char32_t> get_memory_at( const tripoint &p )
 {
-    const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getabs( p ) );
+    const memorized_tile &mt = get_avatar().get_memorized_tile( get_map().getglobal( p ) );
     if( mt.symbol != 0 ) {
         return mt.symbol;
     }
@@ -6600,8 +6600,8 @@ void map::draw( const catacurses::window &w, const tripoint &center )
                              );
     avatar &player_character = get_avatar();
     player_character.prepare_map_memory_region(
-        getabs( tripoint( min_mm_reg, center.z ) ),
-        getabs( tripoint( max_mm_reg, center.z ) )
+        getglobal( tripoint( min_mm_reg, center.z ) ),
+        getglobal( tripoint( max_mm_reg, center.z ) )
     );
 
     const auto draw_background = [&]( const tripoint & p ) {
@@ -6892,7 +6892,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
     }
 
     if( param.memorize() && memory_cache_ter_is_dirty( p ) ) {
-        player_character.memorize_symbol( getabs( p ), memory_sym );
+        player_character.memorize_symbol( getglobal( p ), memory_sym );
         memory_cache_ter_set_dirty( p, false );
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -306,6 +306,18 @@ void map::memory_cache_ter_set_dirty( const tripoint &p, bool value ) const
     get_cache( p.z ).map_memory_cache_ter[p.x + p.y * MAPSIZE_Y] = !value;
 }
 
+void map::memory_clear_vehicle_points( const vehicle &veh ) const
+{
+    avatar &player_character = get_avatar();
+    for( const tripoint &p : veh.get_points() ) {
+        if( !inbounds( p ) ) {
+            continue;
+        }
+        memory_cache_dec_set_dirty( p, true );
+        player_character.memorize_clear_decoration( getglobal( p ), "vp_" );
+    }
+}
+
 void map::invalidate_map_cache( const int zlev )
 {
     if( inbounds_z( zlev ) ) {
@@ -1430,6 +1442,8 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_
                        << dp.x << ", " << dp.y << ", " << dp.z << ")";
         return true;
     }
+
+    memory_clear_vehicle_points( veh );
 
     Character &player_character = get_player_character();
     // Need old coordinates to check for remote control

--- a/src/map.h
+++ b/src/map.h
@@ -359,6 +359,8 @@ class map
         void memory_cache_dec_set_dirty( const tripoint &p, bool value ) const;
         // sets whether map memory terrain should be re/memorized
         void memory_cache_ter_set_dirty( const tripoint &p, bool value ) const;
+        // clears map memory for points occupied by vehicle and marks "dirty" for re-memorizing
+        void memory_clear_vehicle_points( const vehicle &veh ) const;
 
         /**
          * A pre-filter for bresenham LOS.

--- a/src/map.h
+++ b/src/map.h
@@ -349,23 +349,16 @@ class map
         void set_pathfinding_cache_dirty( int zlev );
         /*@}*/
 
-        void set_memory_seen_cache_dirty( const tripoint &p );
         void invalidate_map_cache( int zlev );
 
-        bool check_seen_cache( const tripoint &p ) const {
-            std::bitset<MAPSIZE_X *MAPSIZE_Y> &memory_seen_cache =
-                get_cache( p.z ).map_memory_seen_cache;
-            return !memory_seen_cache[ p.x + p.y * MAPSIZE_Y ];
-        }
-        bool check_and_set_seen_cache( const tripoint &p ) const {
-            std::bitset<MAPSIZE_X *MAPSIZE_Y> &memory_seen_cache =
-                get_cache( p.z ).map_memory_seen_cache;
-            if( !memory_seen_cache[ p.x + p.y * MAPSIZE_Y ] ) {
-                memory_seen_cache.set( p.x + p.y * MAPSIZE_Y );
-                return true;
-            }
-            return false;
-        }
+        // @returns true if map memory decoration should be re/memorized
+        bool memory_cache_dec_is_dirty( const tripoint &p ) const;
+        // @returns true if map memory terrain should be re/memorized
+        bool memory_cache_ter_is_dirty( const tripoint &p ) const;
+        // sets whether map memory decoration should be re/memorized
+        void memory_cache_dec_set_dirty( const tripoint &p, bool value ) const;
+        // sets whether map memory terrain should be re/memorized
+        void memory_cache_ter_set_dirty( const tripoint &p, bool value ) const;
 
         /**
          * A pre-filter for bresenham LOS.

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -35,8 +35,8 @@ struct reg_coord_pair {
     tripoint reg;
     point sm_loc;
 
-    explicit reg_coord_pair( const tripoint &p ) : sm_loc( p.xy() ) {
-        reg = tripoint( sm_to_mmr_remain( sm_loc.x, sm_loc.y ), p.z );
+    explicit reg_coord_pair( const tripoint_abs_sm &p ) : sm_loc( p.xy().raw() ) {
+        reg = tripoint( sm_to_mmr_remain( sm_loc.x, sm_loc.y ), p.z() );
     }
 };
 
@@ -52,22 +52,22 @@ bool mm_submap::is_valid() const
     return valid;
 }
 
-const memorized_tile &mm_submap::get_tile( const point &p ) const
+const memorized_tile &mm_submap::get_tile( const point_sm_ms &p ) const
 {
     if( tiles.empty() ) {
         return default_tile;
     }
-    return tiles[p.y * SEEX + p.x];
+    return tiles[p.y() * SEEX + p.x()];
 }
 
-void mm_submap::set_tile( const point &p, const memorized_tile &value )
+void mm_submap::set_tile( const point_sm_ms &p, const memorized_tile &value )
 {
     if( tiles.empty() ) {
         // call 'reserve' first to force allocation of exact size
         tiles.reserve( SEEX * SEEY );
         tiles.resize( SEEX * SEEY, default_tile );
     }
-    tiles[p.y * SEEX + p.x] = value;
+    tiles[p.y() * SEEX + p.x()] = value;
 }
 
 mm_region::mm_region() : submaps( nullptr ) {}
@@ -176,9 +176,11 @@ bool memorized_tile::operator==( const memorized_tile &rhs ) const
            dec_id == rhs.dec_id;
 }
 
-map_memory::coord_pair::coord_pair( const tripoint &p ) : loc( p.xy() )
+map_memory::coord_pair::coord_pair( const tripoint_abs_ms &p )
 {
-    sm = tripoint( ms_to_sm_remain( loc.x, loc.y ), p.z );
+    loc = point_sm_ms( p.xy().raw() );
+    point pp = ms_to_sm_remain( loc.x(), loc.y() );
+    sm = tripoint_abs_sm( pp.x, pp.y, p.z() );
 }
 
 map_memory::map_memory()
@@ -186,14 +188,14 @@ map_memory::map_memory()
     clear_cache();
 }
 
-const memorized_tile &map_memory::get_tile( const tripoint &pos ) const
+const memorized_tile &map_memory::get_tile( const tripoint_abs_ms &pos ) const
 {
     const coord_pair p( pos );
     const mm_submap &sm = get_submap( p.sm );
     return sm.get_tile( p.loc );
 }
 
-void map_memory::set_tile_terrain( const tripoint &pos, const std::string_view id,
+void map_memory::set_tile_terrain( const tripoint_abs_ms &pos, const std::string_view id,
                                    int subtile, int rotation )
 {
     const coord_pair p( pos );
@@ -208,7 +210,7 @@ void map_memory::set_tile_terrain( const tripoint &pos, const std::string_view i
     sm.set_tile( p.loc, mt );
 }
 
-void map_memory::set_tile_decoration( const tripoint &pos, const std::string_view id,
+void map_memory::set_tile_decoration( const tripoint_abs_ms &pos, const std::string_view id,
                                       int subtile, int rotation )
 {
     const coord_pair p( pos );
@@ -223,7 +225,7 @@ void map_memory::set_tile_decoration( const tripoint &pos, const std::string_vie
     sm.set_tile( p.loc, mt );
 }
 
-void map_memory::set_tile_symbol( const tripoint &pos, char32_t symbol )
+void map_memory::set_tile_symbol( const tripoint_abs_ms &pos, char32_t symbol )
 {
     const coord_pair p( pos );
     mm_submap &sm = get_submap( p.sm );
@@ -235,7 +237,7 @@ void map_memory::set_tile_symbol( const tripoint &pos, char32_t symbol )
     sm.set_tile( p.loc, mt );
 }
 
-void map_memory::clear_tile_decoration( const tripoint &pos, std::string_view prefix )
+void map_memory::clear_tile_decoration( const tripoint_abs_ms &pos, std::string_view prefix )
 {
     const coord_pair p( pos );
     mm_submap &sm = get_submap( p.sm );
@@ -252,19 +254,21 @@ void map_memory::clear_tile_decoration( const tripoint &pos, std::string_view pr
     sm.set_tile( p.loc, mt );
 }
 
-bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )
+bool map_memory::prepare_region( const tripoint_abs_ms &p1, const tripoint_abs_ms &p2 )
 {
-    cata_assert( p1.z == p2.z );
-    cata_assert( p1.x <= p2.x && p1.y <= p2.y );
+    cata_assert( p1.z() == p2.z() );
+    cata_assert( p1.x() <= p2.x() && p1.y() <= p2.y() );
 
-    tripoint sm_p1 = coord_pair( p1 ).sm + point_north_west;
-    tripoint sm_p2 = coord_pair( p2 ).sm + point_south_east;
+    tripoint_abs_sm sm_p1 = coord_pair( p1 ).sm + point_north_west;
+    tripoint_abs_sm sm_p2 = coord_pair( p2 ).sm + point_south_east;
 
-    tripoint sm_pos = sm_p1;
-    point sm_size = sm_p2.xy() - sm_p1.xy();
+    tripoint_abs_sm sm_pos = sm_p1;
+    point_rel_sm sm_size = sm_p2.xy() - sm_p1.xy();
 
-    if( sm_pos.z == cache_pos.z ) {
-        inclusive_rectangle<point> rect( cache_pos.xy(), cache_pos.xy() + cache_size );
+    if( sm_pos.z() == cache_pos.z() ) {
+        inclusive_rectangle<point_abs_sm> rect(
+            point_abs_sm( cache_pos.xy() ),
+            point_abs_sm( cache_pos.xy() + cache_size ) );
         if( rect.contains( sm_p1.xy() ) && rect.contains( sm_p2.xy() ) ) {
             return false;
         }
@@ -273,23 +277,24 @@ bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )
     dbg( D_INFO ) << "Preparing memory map for area: pos: " << sm_pos << " size: " << sm_size;
 
     cache_pos = sm_pos;
-    cache_size = sm_size;
+    cache_size = sm_size.raw();
     cached.clear();
     // Loop through each z-level in vision range
-    for( int z = std::max( sm_pos.z - fov_3d_z_range, -OVERMAP_DEPTH );
-         z <= std::min( sm_pos.z + fov_3d_z_range, OVERMAP_HEIGHT ); z++ ) {
+    for( int z = std::max( sm_pos.z() - fov_3d_z_range, -OVERMAP_DEPTH );
+         z <= std::min( sm_pos.z() + fov_3d_z_range, OVERMAP_HEIGHT ); z++ ) {
         cached[z].reserve( static_cast<std::size_t>( cache_size.x ) * cache_size.y );
         for( int dy = 0; dy < cache_size.y; dy++ ) {
             for( int dx = 0; dx < cache_size.x; dx++ ) {
                 // Store submap pointer in cache, categorized by z-level
-                cached[z].push_back( fetch_submap( tripoint( cache_pos.xy(), z ) + point( dx, dy ) ) );
+                const tripoint_abs_sm smpos( cache_pos.x() + dx, cache_pos.y() + dy, z );
+                cached[z].push_back( fetch_submap( smpos ) );
             }
         }
     }
     return true;
 }
 
-shared_ptr_fast<mm_submap> map_memory::fetch_submap( const tripoint &sm_pos )
+shared_ptr_fast<mm_submap> map_memory::fetch_submap( const tripoint_abs_sm &sm_pos )
 {
     shared_ptr_fast<mm_submap> sm = find_submap( sm_pos );
     if( sm ) {
@@ -302,7 +307,7 @@ shared_ptr_fast<mm_submap> map_memory::fetch_submap( const tripoint &sm_pos )
     return allocate_submap( sm_pos );
 }
 
-shared_ptr_fast<mm_submap> map_memory::allocate_submap( const tripoint &sm_pos )
+shared_ptr_fast<mm_submap> map_memory::allocate_submap( const tripoint_abs_sm &sm_pos )
 {
     // Since all save/load operations are done on regions of submaps,
     // we need to allocate the whole region at once.
@@ -313,7 +318,7 @@ shared_ptr_fast<mm_submap> map_memory::allocate_submap( const tripoint &sm_pos )
 
     for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
         for( size_t x = 0; x < MM_REG_SIZE; x++ ) {
-            tripoint pos = mmr_to_sm_copy( reg ) + tripoint( x, y, 0 );
+            const tripoint_abs_sm pos( mmr_to_sm_copy( reg ) + tripoint( x, y, 0 ) );
             shared_ptr_fast<mm_submap> sm = make_shared_fast<mm_submap>();
             if( pos == sm_pos ) {
                 ret = sm;
@@ -325,7 +330,7 @@ shared_ptr_fast<mm_submap> map_memory::allocate_submap( const tripoint &sm_pos )
     return ret;
 }
 
-shared_ptr_fast<mm_submap> map_memory::find_submap( const tripoint &sm_pos )
+shared_ptr_fast<mm_submap> map_memory::find_submap( const tripoint_abs_sm &sm_pos )
 {
     auto sm = submaps.find( sm_pos );
     if( sm == submaps.end() ) {
@@ -335,7 +340,7 @@ shared_ptr_fast<mm_submap> map_memory::find_submap( const tripoint &sm_pos )
     }
 }
 
-shared_ptr_fast<mm_submap> map_memory::load_submap( const tripoint &sm_pos )
+shared_ptr_fast<mm_submap> map_memory::load_submap( const tripoint_abs_sm &sm_pos )
 {
     if( test_mode ) {
         return nullptr;
@@ -366,7 +371,7 @@ shared_ptr_fast<mm_submap> map_memory::load_submap( const tripoint &sm_pos )
 
     for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
         for( size_t x = 0; x < MM_REG_SIZE; x++ ) {
-            tripoint pos = mmr_to_sm_copy( p.reg ) + tripoint( x, y, 0 );
+            const tripoint_abs_sm pos( mmr_to_sm_copy( p.reg ) + tripoint( x, y, 0 ) );
             shared_ptr_fast<mm_submap> &sm = mmr.submaps[x][y];
             if( pos == sm_pos ) {
                 ret = sm;
@@ -380,54 +385,45 @@ shared_ptr_fast<mm_submap> map_memory::load_submap( const tripoint &sm_pos )
 
 static mm_submap null_mz_submap;
 static mm_submap invalid_mz_submap{ false };
+static const tripoint_abs_sm invalid_cache_pos( tripoint_min );
 
-const mm_submap &map_memory::get_submap( const tripoint &sm_pos ) const
+const mm_submap &map_memory::get_submap( const tripoint_abs_sm &sm_pos ) const
 {
-    if( cache_pos == tripoint_min ) {
-        debugmsg( "Called map_memory with an " );
+    return const_cast<map_memory *>( this )->get_submap( sm_pos );
+}
+
+mm_submap &map_memory::get_submap( const tripoint_abs_sm &sm_pos )
+{
+    if( cache_pos == invalid_cache_pos ) {
         return invalid_mz_submap;
     }
-    const point idx = ( sm_pos - cache_pos ).xy();
-    if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y &&
-        !cached[sm_pos.z].empty() ) {
-        return *cached[sm_pos.z][idx.y * cache_size.x + idx.x];
+    const point_rel_sm idx = ( sm_pos - cache_pos ).xy();
+    if( idx.x() > 0 && idx.y() > 0 && idx.x() < cache_size.x && idx.y() < cache_size.y &&
+        !cached[sm_pos.z()].empty() ) {
+        return *cached[sm_pos.z()][idx.y() * cache_size.x + idx.x()];
     } else {
         return null_mz_submap;
     }
 }
 
-mm_submap &map_memory::get_submap( const tripoint &sm_pos )
-{
-    if( cache_pos == tripoint_min ) {
-        return invalid_mz_submap;
-    }
-    const point idx = ( sm_pos - cache_pos ).xy();
-    if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y &&
-        !cached[sm_pos.z].empty() ) {
-        return *cached[sm_pos.z][idx.y * cache_size.x + idx.x];
-    } else {
-        return null_mz_submap;
-    }
-}
-
-void map_memory::load( const tripoint &pos )
+void map_memory::load( const tripoint_abs_ms &pos )
 {
     const coord_pair p( pos );
-    const tripoint start = p.sm - tripoint( MM_SIZE / 2, MM_SIZE / 2, 0 );
+    const tripoint_abs_sm start = p.sm - tripoint_rel_sm( MM_SIZE / 2, MM_SIZE / 2, 0 );
     dbg( D_INFO ) << "[LOAD] Loading memory map around " << p.sm << ". Loading submaps within " << start
                   << "->" << start + tripoint( MM_SIZE, MM_SIZE, 0 );
     clear_cache();
     for( int dy = 0; dy < MM_SIZE; dy++ ) {
         for( int dx = 0; dx < MM_SIZE; dx++ ) {
-            fetch_submap( start + tripoint( dx, dy, 0 ) );
+            fetch_submap( start + tripoint_rel_sm( dx, dy, 0 ) );
         }
     }
     dbg( D_INFO ) << "[LOAD] Done.";
 }
 
-bool map_memory::save( const tripoint &pos )
+bool map_memory::save( const tripoint_abs_ms &pos )
 {
-    tripoint sm_center = coord_pair( pos ).sm;
+    const tripoint_abs_sm sm_center = coord_pair( pos ).sm;
     const cata_path dirname = find_mm_dir();
     assure_dir_exist( dirname );
 
@@ -445,7 +441,7 @@ bool map_memory::save( const tripoint &pos )
     submaps.clear();
 
     constexpr point MM_HSIZE_P = point( MM_SIZE / 2, MM_SIZE / 2 );
-    rectangle<point> rect_keep( sm_center.xy() - MM_HSIZE_P, sm_center.xy() + MM_HSIZE_P );
+    rectangle<point_abs_sm> rect_keep( sm_center.xy() - MM_HSIZE_P, sm_center.xy() + MM_HSIZE_P );
 
     dbg( D_INFO ) << "[SAVE] Saving memory map around " << sm_center << ". Keeping submaps within " <<
                   rect_keep.p_min << "->" << rect_keep.p_max;
@@ -472,15 +468,17 @@ bool map_memory::save( const tripoint &pos )
             const bool res = write_to_file( path, writer, descr.c_str() );
             result = result & res;
         }
-        tripoint regp_sm = mmr_to_sm_copy( regp );
-        half_open_rectangle<point> rect_reg( regp_sm.xy(), regp_sm.xy() + point( MM_REG_SIZE,
-                                             MM_REG_SIZE ) );
+        const tripoint_abs_sm regp_sm( mmr_to_sm_copy( regp ) );
+        const half_open_rectangle<point_abs_sm> rect_reg(
+            regp_sm.xy(),
+            regp_sm.xy() + point( MM_REG_SIZE, MM_REG_SIZE ) );
+
         if( rect_reg.overlaps( rect_keep ) ) {
             dbg( D_INFO ) << "Keeping mm_region " << regp << " [" << regp_sm << "]";
             // Put submaps back
             for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
                 for( size_t x = 0; x < MM_REG_SIZE; x++ ) {
-                    tripoint p = regp_sm + tripoint( x, y, 0 );
+                    const tripoint_abs_sm p = regp_sm + tripoint( x, y, 0 );
                     shared_ptr_fast<mm_submap> &sm = reg.submaps[x][y];
                     submaps.insert( std::make_pair( p, sm ) );
                 }
@@ -499,6 +497,6 @@ bool map_memory::save( const tripoint &pos )
 void map_memory::clear_cache()
 {
     cached.clear();
-    cache_pos = tripoint_min;
+    cache_pos = invalid_cache_pos;
     cache_size = point_zero;
 }

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -394,7 +394,7 @@ const mm_submap &map_memory::get_submap( const tripoint_abs_sm &sm_pos ) const
 
 mm_submap &map_memory::get_submap( const tripoint_abs_sm &sm_pos )
 {
-    if( cache_pos == invalid_cache_pos ) {
+    if( !is_valid() ) {
         return invalid_mz_submap;
     }
     const point_rel_sm idx = ( sm_pos - cache_pos ).xy();
@@ -404,6 +404,11 @@ mm_submap &map_memory::get_submap( const tripoint_abs_sm &sm_pos )
     } else {
         return null_mz_submap;
     }
+}
+
+bool map_memory::is_valid() const
+{
+    return cache_pos != invalid_cache_pos;
 }
 
 void map_memory::load( const tripoint_abs_ms &pos )

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -63,8 +63,8 @@ struct mm_submap {
         // @returns true if mm_submap is valid, i.e. not returned from an uninitialized region.
         bool is_valid() const;
 
-        const memorized_tile &get_tile( const point &p ) const;
-        void set_tile( const point &p, const memorized_tile &value );
+        const memorized_tile &get_tile( const point_sm_ms &p ) const;
+        void set_tile( const point_sm_ms &p, const memorized_tile &value );
 
         void serialize( JsonOut &jsout ) const;
         void deserialize( int version, const JsonArray &ja );
@@ -103,20 +103,20 @@ class map_memory
          * global sm coord + ms coord within the submap.
          */
         struct coord_pair {
-            tripoint sm;
-            point loc;
+            tripoint_abs_sm sm;
+            point_sm_ms loc;
 
-            explicit coord_pair( const tripoint &p );
+            explicit coord_pair( const tripoint_abs_ms &p );
         };
 
     public:
         map_memory();
 
         /** Load memorized submaps around given global map square pos. */
-        void load( const tripoint &pos );
+        void load( const tripoint_abs_ms &pos );
 
         /** Save memorized submaps to disk, drop ones far from given global map square pos. */
-        bool save( const tripoint &pos );
+        bool save( const tripoint_abs_ms &pos );
 
         /**
          * Prepares map memory for rendering and/or memorization of given region.
@@ -125,59 +125,61 @@ class map_memory
          * Both coords are inclusive and should be on the same Z level.
          * @return whether the region was re-cached
          */
-        bool prepare_region( const tripoint &p1, const tripoint &p2 );
+        bool prepare_region( const tripoint_abs_ms &p1, const tripoint_abs_ms &p2 );
 
         /**
          * Returns memorized tile.
          * @param pos tile position, in global ms coords.
          */
-        const memorized_tile &get_tile( const tripoint &pos ) const;
+        const memorized_tile &get_tile( const tripoint_abs_ms &pos ) const;
 
         /**
          * Memorizes terrain at \p pos, overwriting old terrain values.
          * @param pos tile position, in global ms coords.
          */
-        void set_tile_terrain( const tripoint &pos, std::string_view id, int subtile, int rotation );
+        void set_tile_terrain( const tripoint_abs_ms &pos, std::string_view id,
+                               int subtile, int rotation );
 
         /**
          * Memorizes decoraiton at \p pos, overwriting old decoration values.
          * @param pos tile position, in global ms coords.
          */
-        void set_tile_decoration( const tripoint &pos, std::string_view id, int subtile, int rotation );
+        void set_tile_decoration( const tripoint_abs_ms &pos, std::string_view id,
+                                  int subtile, int rotation );
 
         /**
          * Memorizes symbol at \p pos, overwriting old symbol.
          * @param pos tile position, in global ms coords.
         */
-        void set_tile_symbol( const tripoint &pos, char32_t symbol );
+        void set_tile_symbol( const tripoint_abs_ms &pos, char32_t symbol );
 
         /**
          * Clears memorized decorations and symbol.
          * @param pos tile position, in global ms coords.
          * @param prefix if non-empty only clears if decoration starts with this prefix
          */
-        void clear_tile_decoration( const tripoint &pos, std::string_view prefix = "" );
+        void clear_tile_decoration( const tripoint_abs_ms &pos, std::string_view prefix = "" );
 
     private:
-        std::map<tripoint, shared_ptr_fast<mm_submap>> submaps;
+        std::map<tripoint_abs_sm, shared_ptr_fast<mm_submap>> submaps;
 
         mutable std::map<int, std::vector<shared_ptr_fast<mm_submap>>> cached;
-        tripoint cache_pos;
+        tripoint_abs_sm cache_pos;
         point cache_size;
 
         /** Find, load or allocate a submap. @returns the submap. */
-        shared_ptr_fast<mm_submap> fetch_submap( const tripoint &sm_pos );
+        shared_ptr_fast<mm_submap> fetch_submap( const tripoint_abs_sm &sm_pos );
         /** Find submap amongst the loaded submaps. @returns nullptr if failed. */
-        shared_ptr_fast<mm_submap> find_submap( const tripoint &sm_pos );
+        shared_ptr_fast<mm_submap> find_submap( const tripoint_abs_sm &sm_pos );
         /** Load submap from disk. @returns nullptr if failed. */
-        shared_ptr_fast<mm_submap> load_submap( const tripoint &sm_pos );
+        shared_ptr_fast<mm_submap> load_submap( const tripoint_abs_sm &sm_pos );
         /** Allocate empty submap. @returns the submap. */
-        shared_ptr_fast<mm_submap> allocate_submap( const tripoint &sm_pos );
+        shared_ptr_fast<mm_submap> allocate_submap( const tripoint_abs_sm &sm_pos );
 
         /** Get submap from within the cache */
         //@{
-        const mm_submap &get_submap( const tripoint &sm_pos ) const;
-        mm_submap &get_submap( const tripoint &sm_pos );
+        const mm_submap &get_submap( const tripoint_abs_sm &sm_pos ) const;
+        mm_submap &get_submap( const tripoint_abs_sm &sm_pos );
         //@}
 
         void clear_cache();

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -112,6 +112,9 @@ class map_memory
     public:
         map_memory();
 
+        // @returns true if map memory has been loaded
+        bool is_valid() const;
+
         /** Load memorized submaps around given global map square pos. */
         void load( const tripoint_abs_ms &pos );
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4047,7 +4047,7 @@ void mm_submap::serialize( JsonOut &jsout ) const
 
     for( size_t y = 0; y < SEEY; y++ ) {
         for( size_t x = 0; x < SEEX; x++ ) {
-            const memorized_tile &elem = get_tile( point( x, y ) );
+            const memorized_tile &elem = get_tile( point_sm_ms( x, y ) );
             if( x == 0 && y == 0 ) {
                 last = elem;
                 continue;
@@ -4128,7 +4128,7 @@ void mm_submap::deserialize( int version, const JsonArray &ja )
             }
             // Try to avoid assigning to save up on memory
             if( tile != mm_submap::default_tile ) {
-                set_tile( point( x, y ), tile );
+                set_tile( point_sm_ms( x, y ), tile );
             }
         }
     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -157,7 +157,7 @@ void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
     here.dirty_vehicle_list.insert( &veh );
     here.clear_vehicle_point_from_cache( &veh, part_pos );
     here.add_vehicle_to_cache( &veh );
-    here.set_memory_seen_cache_dirty( part_pos );
+    here.memory_cache_dec_set_dirty( part_pos, true );
     player_character.memorize_clear_decoration( here.getabs( part_pos ), "vp_" + vp.info().id.str() );
 }
 
@@ -7084,7 +7084,7 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
     if( is_autodriving ) {
         stop_autodriving();
     }
-    here.set_memory_seen_cache_dirty( vppos );
+    here.memory_cache_dec_set_dirty( vppos, true );
     if( vp.is_broken() ) {
         return break_off( here, vp, dmg );
     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -158,7 +158,8 @@ void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
     here.clear_vehicle_point_from_cache( &veh, part_pos );
     here.add_vehicle_to_cache( &veh );
     here.memory_cache_dec_set_dirty( part_pos, true );
-    player_character.memorize_clear_decoration( here.getabs( part_pos ), "vp_" + vp.info().id.str() );
+    player_character.memorize_clear_decoration(
+        here.getglobal( part_pos ), "vp_" + vp.info().id.str() );
 }
 
 // Vehicle stack methods.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1809,7 +1809,7 @@ class vehicle
         bool decrement_summon_timer();
 
         // reduces velocity to 0
-        void stop( bool update_cache = true );
+        void stop();
 
         void refresh_insides();
 

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -659,7 +659,13 @@ bool vehicle::autodrive_controller::check_drivable( tripoint pt ) const
         if( !driver.sees( pt ) ) {
             if( !driver.is_avatar() ) {
                 return false;
-            } else if( driver.as_avatar()->get_memorized_tile( pt_abs ) == mm_submap::default_tile ) {
+            }
+            const avatar &avatar = *driver.as_avatar();
+            if( !avatar.is_map_memory_valid() ) {
+                debugmsg( "autodrive querying uninitialized map memory at %s", pt_abs.to_string() );
+                return false;
+            }
+            if( avatar.get_memorized_tile( pt_abs ) == mm_submap::default_tile ) {
                 // apparently open air doesn't get memorized, so pretend it is or else
                 // we can't fly helicopters due to the many unseen tiles behind the driver
                 if( !( data.air_ok && here.ter( pt ) == t_open_air ) ) {

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -650,7 +650,7 @@ bool vehicle::autodrive_controller::check_drivable( tripoint pt ) const
         return &ovp->vehicle() == &driven_veh;
     }
 
-    const tripoint_abs_ms pt_abs( here.getabs( pt ) );
+    const tripoint_abs_ms pt_abs = here.getglobal( pt );
     const tripoint_abs_omt pt_omt = project_to<coords::omt>( pt_abs );
     // only check visibility for the current OMT, we'll check other OMTs when
     // we reach them
@@ -659,7 +659,7 @@ bool vehicle::autodrive_controller::check_drivable( tripoint pt ) const
         if( !driver.sees( pt ) ) {
             if( !driver.is_avatar() ) {
                 return false;
-            } else if( driver.as_avatar()->get_memorized_tile( pt_abs.raw() ) == mm_submap::default_tile ) {
+            } else if( driver.as_avatar()->get_memorized_tile( pt_abs ) == mm_submap::default_tile ) {
                 // apparently open air doesn't get memorized, so pretend it is or else
                 // we can't fly helicopters due to the many unseen tiles behind the driver
                 if( !( data.air_ok && here.ter( pt ) == t_open_air ) ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -664,19 +664,18 @@ void vehicle::turn( units::angle deg )
     turn_dir = round_to_multiple_of( turn_dir, vehicles::steer_increment );
 }
 
-void vehicle::stop( bool update_cache )
+void vehicle::stop()
 {
     velocity = 0;
     skidding = false;
     move = face;
     last_turn = 0_degrees;
     of_turn_carry = 0;
-    if( !update_cache ) {
-        return;
-    }
     map &here = get_map();
     for( const tripoint &p : get_points() ) {
-        here.memory_cache_dec_set_dirty( p, true );
+        if( here.inbounds( p ) ) {
+            here.memory_cache_dec_set_dirty( p, true );
+        }
     }
 }
 
@@ -1756,7 +1755,7 @@ vehicle *vehicle::act_on_map()
     if( !here.inbounds( pt ) ) {
         dbg( D_INFO ) << "stopping out-of-map vehicle.  (x,y,z)=(" << pt.x << "," << pt.y << "," << pt.z <<
                       ")";
-        stop( false );
+        stop();
         of_turn = 0;
         is_falling = false;
         return this;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -676,7 +676,7 @@ void vehicle::stop( bool update_cache )
     }
     map &here = get_map();
     for( const tripoint &p : get_points() ) {
-        here.set_memory_seen_cache_dirty( p );
+        here.memory_cache_dec_set_dirty( p, true );
     }
 }
 

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -11,10 +11,10 @@
 #include "map_memory.h"
 #include "point.h"
 
-static constexpr tripoint p1{ -SEEX - 2, -SEEY - 3, -1 };
-static constexpr tripoint p2{ 5, 7, -1 };
-static constexpr tripoint p3{ SEEX * 2 + 5, SEEY + 7, -1 };
-static constexpr tripoint p4{ SEEX * 3 + 2, SEEY * 7 + 1, -1 };
+static constexpr tripoint_abs_ms p1{ -SEEX - 2, -SEEY - 3, -1 };
+static constexpr tripoint_abs_ms p2{ 5, 7, -1 };
+static constexpr tripoint_abs_ms p3{ SEEX * 2 + 5, SEEY + 7, -1 };
+static constexpr tripoint_abs_ms p4{ SEEX * 3 + 2, SEEY * 7 + 1, -1 };
 
 TEST_CASE( "map_memory_keeps_region", "[map_memory]" )
 {
@@ -29,8 +29,8 @@ TEST_CASE( "map_memory_keeps_region", "[map_memory]" )
     CHECK( memory.prepare_region( p1, p4 ) );
     CHECK( !memory.prepare_region( p2, p3 ) );
     CHECK( memory.prepare_region(
-               tripoint( p2.xy(), -p2.z ),
-               tripoint( p3.xy(), -p3.z )
+               tripoint_abs_ms( p2.xy(), -p2.z() ),
+               tripoint_abs_ms( p3.xy(), -p3.z() )
            ) );
 }
 

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -197,7 +197,7 @@ static void check_quadrants( std::bitset<MAPSIZE *SEEX *MAPSIZE *SEEY> &test_cac
 static constexpr size_t first_twelve = SEEX;
 static constexpr size_t last_twelve = ( SEEX *MAPSIZE ) - SEEX;
 
-TEST_CASE( "shift_map_memory_seen_cache" )
+TEST_CASE( "shift_map_memory_bitset_cache" )
 {
     std::bitset<MAPSIZE *SEEX *MAPSIZE *SEEY> test_cache;
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Clean up map memory bitcache functions
Split map memory bitset caches to separate bitsets for terrain and decorations
Make map_memory.h/cpp use typed points
Fix vehicle part memory not clearing for moving vehicles

#### Describe the solution

Map memory bitset cache function names are a bit of a mess;
* `check_seen_cache` checks the map memory bitcache value, but `set_seen_cache_dirty` is unrelated to map memory.
* `check_and_set_seen_cache` does 2 things at once but doesn't exploit the only possible "optimization" for doing it (saving calculated array offset)
* Bounds checking for these is mixed - some are bounds checked, some aren't
* The tripoints for map_memory are absolute ones but currently untyped

This PR does the following:
* Splits/refactors and renames the memory bitset cache functions into relatively trivial is_dirty/set_dirty.
* Consistent bounds check with debugmsgs for the bitset cache functions - these can later be removed for a tiny perf gain, or left in.
* Refactors map_memory.h/cpp to use typed tripoints, not sure I got all of them right, but should be a bit safer
* Makes `map_memory::get_submap(...) const` call the non-const overload instead of duplicating code - the difference seems to be the debugmsg which sometimes appears with uninitialized map memory related to https://github.com/CleverRaven/Cataclysm-DDA/issues/51288 and https://github.com/CleverRaven/Cataclysm-DDA/issues/63928, but leaving the debugmsg in blows up tests since map memory isn't initialized in tests (not sure why map memory is accessed via avatar, but this PR is too chonky already). Instead this makes the initialized check and debugmsg to be explicit and pulls it out into autodrive code instead.

---
For point 4; When vehicles are moved (in map::displace_vehicle) map memory for their occupied points is now cleared

The point clearing solution might be a bit crude, but the naive alternative is having to render dummy "decorations" when no furniture/vparts exist on a tile just to clear off the map memory (previously the terrain tiles rendered on every tile and replaced map memory), might have to get back to this if I think of a better solution

This leaves a slight bug where non-player caused vehicle movement - for example hulks pushing cars around might cause player memory to change (memory of pushed vehicle disappearing), but it's less intrusive than the current issue of map memory ghosts.

#### Describe alternatives you've considered

#### Testing

Tests should catch some code changes

For the vehicle pushing; Spawn 2 vehicles and push one with the other, set night/blindfold/etc to only see memory; before this patch there'll be ghost vehicle parts left, after this patch the map memory should disappear and no ghosts remain.

Autodrived to a couple spots

#### Additional context
