### PR TITLE
No suitcases inside suitcases

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/costumes.json
+++ b/data/json/itemgroups/Clothing_Gear/costumes.json
@@ -75,7 +75,6 @@
       { "item": "gartersheath1", "prob": 25 },
       { "item": "gartersheath2", "prob": 10 },
       { "item": "eyepatch_leather", "prob": 20 },
-      { "item": "suitcase_m", "prob": 4 },
       { "item": "hakama", "prob": 1 }
     ]
   },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #66791

#### Describe the solution
Remove suitcase from `costume_accessories` group since this is heavily nested and should already have a container further up the chain.

#### Describe alternatives you've considered
I tried moving it to being the *group's* container-item in case that would still allow the rest to function, but that just results in overflow errors happening *more often*.

#### Testing
No test! Only lint!

#### Additional context
