### PR TITLE
Prevent Unload_container unloading NO_UNLOAD containers

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1671,7 +1671,7 @@ static bool valid_unload_container( const item_location &container )
     }
 
     // Item must be able to be unloaded
-    if( container->has_flag(flag_NO_UNLOAD) ) {
+    if( container->has_flag( flag_NO_UNLOAD ) ) {
         return false;
     }
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1670,6 +1670,11 @@ static bool valid_unload_container( const item_location &container )
         return false;
     }
 
+    // Item must be able to be unloaded
+    if( container->has_flag(flag_NO_UNLOAD) ) {
+        return false;
+    }
+
     // Container must contain at least one item
     if( container->empty_container() ) {
         return false;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #66850

#### Describe the solution
Check for NO_UNLOAD flag in the valid_unload_container filter

#### Describe alternatives you've considered
unload_container should probably use the unload activity actor or similar?

#### Testing
It unloaded before, it doesn't even appear as a valid selectable option now.

#### Additional context
