### PR TITLE
Use activity actor to drop items when being mugged

### DIFF
--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "activity_actor_definitions.h"
+#include <activity_handlers.h>
 #include "activity_type.h"
 #include "auto_pickup.h"
 #include "avatar.h"
@@ -1008,7 +1009,7 @@ void talk_function::player_weapon_drop( npc &/*p*/ )
 {
     Character &player_character = get_player_character();
     item weap = player_character.remove_weapon();
-    get_map().add_item_or_charges( player_character.pos(), weap );
+    drop_on_map( player_character, item_drop_reason::deliberate, {weap}, player_character.pos_bub() );
 }
 
 void talk_function::lead_to_safety( npc &p )


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #66744

#### Describe the solution
Use the activity actor, where the auto note logic is present. Also because using the activity actor is generally better than not using it?

#### Describe alternatives you've considered
talk_function::drop_weapon might want this too? (That's for when the *player* demands that the *NPC* drop their weapon)

#### Testing

https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/52829e3c-1166-476d-a3a9-c3722bba5620

(They then proceeded to take my dropped weapon and collect the remains of the unfortunate dozen of so NPCs which didn't mug me on spawn. Believe that's normal behavior for being warned off.)

Also tested with a proper mugging. Dropped weapon, got mugged. It was a great ol' normal time.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/e4065bae-6827-46fe-83a7-3899d4388a94)


#### Additional context
