### PR TITLE
Allow nests to check for neighbouring flags

### DIFF
--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -1136,6 +1136,7 @@ Place_nested allows for limited conditional spawning of chunks based on the `"id
 | x and y            | (required, int) the cardinal position in which the chunk will be placed.
 | neighbors          | (optional) Any of the neighboring overmaps that should be checked before placing the chunk.  Each direction is associated with a list of overmap `"id"` substrings.
 | joins              | (optional) Any mutable overmap special joins that should be checked before placing the chunk.  Each direction is associated with a list of join `"id"` strings.
+| flags              | (optional) Any overmap terrain flags that should be checked before placing the chunk.  Each direction is associated with a list of `oter_flags` flags.
 
 
 The adjacent overmaps which can be checked in this manner are:
@@ -1151,14 +1152,14 @@ Example:
   "place_nested": [
     { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 0, "neighbors": { "north": [ "empty_rock", "field" ] } },
     { "chunks": [ "gate_north" ], "x": 0, "y": 0, "joins": { "north": [ "interior_to_exterior" ] } },
-    { "else_chunks": [ "concrete_wall_ns" ], "x": 0, "y": 0, "neighbors": { "north_west": [ "field", "microlab" ] } }
+    { "else_chunks": [ "concrete_wall_ns" ], "x": 0, "y": 0, "flags": { "north_west": [ "LAB", "WILDERNESS" ] } }
   ],
 ```
 The code excerpt above will place chunks as follows:
 * `"concrete_wall_ew"` if the north neighbor is either a field or solid rock
 * `"gate_north"` if the join `"interior_to_exterior"` was used to the north
   during mutable overmap placement.
-* `"concrete_wall_ns"`if the north west neighbor is neither a field nor any of the microlab overmaps.
+* `"concrete_wall_ns"`if the north west neighboring overmap terrain has neither the "LAB" nor "WILDERNESS" flags.
 
 
 ### Place monster corpse from a monster group with "place_corpses"

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3529,10 +3529,6 @@ class jmapgen_nested : public jmapgen_piece
                     }
                 }
 
-                void check( const std::string_view/*oter_name*/, const mapgen_parameters & ) const {
-                    // TODO: check flag ids are valid
-                }
-
                 bool test( const mapgendata &dat ) const {
                     for( const std::pair<const direction, cata::flat_set<oter_flags>> &p :
                          neighbors ) {
@@ -3647,7 +3643,6 @@ class jmapgen_nested : public jmapgen_piece
             }
             neighbor_oters.check( oter_name, parameters );
             neighbor_joins.check( oter_name, parameters );
-            neighbor_flags.check( oter_name, parameters );
 
             // Check whether any of the nests can attempt to place stuff out of
             // bounds

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3501,11 +3501,11 @@ class jmapgen_nested : public jmapgen_piece
 
                         cata_assert( !allowed_joins.empty() );
 
-                        bool this_direction_matches = false;
+                        bool this_direction_has_join = false;
                         for( const std::string &allowed_join : allowed_joins ) {
-                            this_direction_matches |= dat.has_join( dir, allowed_join );
+                            this_direction_has_join |= dat.has_join( dir, allowed_join );
                         }
-                        if( !this_direction_matches ) {
+                        if( !this_direction_has_join ) {
                             return false;
                         }
                     }
@@ -3530,23 +3530,23 @@ class jmapgen_nested : public jmapgen_piece
                 }
 
                 void check( const std::string_view/*oter_name*/, const mapgen_parameters & ) const {
-
+                    // TODO: check flag ids are valid
                 }
 
                 bool test( const mapgendata &dat ) const {
                     for( const std::pair<const direction, cata::flat_set<oter_flags>> &p :
                          neighbors ) {
                         const direction dir = p.first;
-                        const cata::flat_set<oter_flags> &allowed_neighbors = p.second;
+                        const cata::flat_set<oter_flags> &allowed_flags = p.second;
 
-                        cata_assert( !allowed_neighbors.empty() );
+                        cata_assert( !allowed_flags.empty() );
 
-                        bool has_flag = false;
-                        for( const oter_flags &allowed_neighbor : allowed_neighbors ) {
-                            has_flag |=
-                                dat.neighbor_at( dir )->has_flag( allowed_neighbor );
+                        bool this_direction_has_flag = false;
+                        for( const oter_flags &allowed_flag : allowed_flags ) {
+                            this_direction_has_flag |=
+                                dat.neighbor_at( dir )->has_flag( allowed_flag );
                         }
-                        if( !has_flag ) {
+                        if( !this_direction_has_flag ) {
                             return false;
                         }
                     }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3512,7 +3512,6 @@ class jmapgen_nested : public jmapgen_piece
                     return true;
                 }
         };
-        
         class neighbor_flag_check
         {
             private:


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Checking flags with nests is necessary for road map unhardcoding to check SIDEWALK and should allow some other interesting possibilities

Fixes #66759

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Syntax is identical to `"neighbors"`, you just use `"flags": { "north_east": [ "WILDERNESS", "RIVER" ], "below": [ "LAB" ] }` as an example

I were strugglebussing but @bombasticSlacks came to the rescue so the function is entirely their work, if they want me to close this so they can post it that's cool

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I might have a crack at allowing combinations of &= and |= rather than it just always being |= maybe using syntax like
`"flags": { "north_east":  [ { "flag": "FLAGA" }, { "flag": "FLAGB", "operator": "AND" }, { "flag": "FLAGC", "operator": "OR" } ]`
to achieve `( ( 0 | FLAGA ) & FLAGB ) | FLAGC`
Equally being able to optionally have `||`s in `neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_flags.test( dat )` could be useful

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested basic functionality locally

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Removed the .check() because flags get checked when they're initially read so unless I'm stoopid there's no way an invalid one could get this far

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/904ecaae-8754-4955-ab7e-03230ec47f48)
Pre-existing error message if you use a nonsense flag

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->