### PR TITLE
Fix off-by-1 in ablative coverage

### DIFF
--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -308,7 +308,7 @@ bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_b
             float coverage = ablative_armor.get_coverage( bp, ctype );
 
             // if the attack hits this plate
-            if( roll < coverage ) {
+            if( roll <= coverage ) {
                 damage_unit pre_mitigation = du;
 
                 // mitigate the actual damage instance


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5534654355/jobs/10099905252?pr=66851#step:16:183

#### Describe the solution

Roll of 100 vs coverage of 100 no longer bypasses ablative

#### Describe alternatives you've considered

#### Testing

`./tests/cata_test --break --min-duration 5 --rng-seed 1689210962 ~[slow] ~[.],starting_items`

#### Additional context
