### PR TITLE
neighbor_oter_check can use om_match_type

### DIFF
--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -1146,7 +1146,7 @@ Place_nested allows for limited conditional spawning of chunks based on the `"id
 | ---                | ---
 | chunks/else_chunks | (required, string) the nested_mapgen_id of the chunk that will be conditionally placed. Chunks are placed if the specified neighbor matches, and "else_chunks" otherwise.
 | x and y            | (required, int) the cardinal position in which the chunk will be placed.
-| neighbors          | (optional) Any of the neighboring overmaps that should be checked before placing the chunk.  Each direction is associated with a list of overmap `"id"` substrings.
+| neighbors          | (optional) Any of the neighboring overmaps that should be checked before placing the chunk.  Each direction is associated with a list of overmap `"id"` substrings.  See [JSON_INFO.md](JSON_INFO.md#Starting-locations) "terrain" section to do more advanced searches.
 | joins              | (optional) Any mutable overmap special joins that should be checked before placing the chunk.  Each direction is associated with a list of join `"id"` strings.
 | flags              | (optional) Any overmap terrain flags that should be checked before placing the chunk.  Each direction is associated with a list of `oter_flags` flags.
 
@@ -1163,15 +1163,16 @@ Example:
 ```json
   "place_nested": [
     { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 0, "neighbors": { "north": [ "empty_rock", "field" ] } },
+    { "chunks": [ "gate_south" ], "x": 0, "y": 0, "neighbors": { "north": [ { "om_terrain": "fort", "om_terrain_match_type": "PREFIX" }, "mansion" ] } },
     { "chunks": [ "gate_north" ], "x": 0, "y": 0, "joins": { "north": [ "interior_to_exterior" ] } },
-    { "else_chunks": [ "concrete_wall_ns" ], "x": 0, "y": 0, "flags": { "north_west": [ "LAB", "WILDERNESS" ] } }
+    { "else_chunks": [ "concrete_wall_ns" ], "x": 0, "y": 0, "flags": { "north_west": [ "RIVER", "LAKE", "LAKE_SHORE" ] } }
   ],
 ```
 The code excerpt above will place chunks as follows:
-* `"concrete_wall_ew"` if the north neighbor is either a field or solid rock
-* `"gate_north"` if the join `"interior_to_exterior"` was used to the north
-  during mutable overmap placement.
-* `"concrete_wall_ns"`if the north west neighboring overmap terrain has neither the "LAB" nor "WILDERNESS" flags.
+* `"concrete_wall_ew"` if the north neighbor's om terrain contains `"field"` or `"empty_rock"`.
+* `"gate_south"` if the north neighbor has the prefix `"fort"` or contains `"mansion"`, so for example "fort_1a_north" and "mansion_t2u" would match but "house_fortified" wouldn't.
+* `"gate_north"` if the join `"interior_to_exterior"` was used to the north during mutable overmap placement.
+* `"concrete_wall_ns"`if the north west neighboring overmap terrain has neither the "RIVER", "LAKE" nor "LAKE_SHORE" flags.
 
 
 ### Place monster corpse from a monster group with "place_corpses"

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3442,20 +3442,19 @@ class jmapgen_nested : public jmapgen_piece
         class neighbor_oter_check
         {
             private:
-                std::unordered_map<direction, cata::flat_set<std::pair<std::string, ot_match_type>>> neighbors; // Matches the direction to check with the information to check
+                std::unordered_map<direction, cata::flat_set<std::pair<std::string, ot_match_type>>> neighbors;
             public:
                 explicit neighbor_oter_check( const JsonObject &jsi ) {
-                    for( direction dir : all_enum_values<direction>() ) { // Iterate through all 10 directions
+                    for( direction dir : all_enum_values<direction>() ) {
                         
-                        std::string location = io::enum_to_string( dir ); // Read direction
-                        cata::flat_set<std::pair<std::string, ot_match_type>> dir_neighbours; // That directions contents
-                        // Prevents needing to move all existing single checks to be part of an array, new single objects have to be in arrays though bc one unnecessary if is ugly enough
+                        std::string location = io::enum_to_string( dir );
+                        cata::flat_set<std::pair<std::string, ot_match_type>> dir_neighbours;
                         if ( !jsi.has_string( location ) ) {
-                            for ( const JsonValue entry : jsi.get_array( location ) ) { // For every array element
-                                std::pair<std::string, ot_match_type> dir_neighbour; // Singular string om_match_type element
+                            for ( const JsonValue entry : jsi.get_array( location ) ) {
+                                std::pair<std::string, ot_match_type> dir_neighbour;
                                     if ( entry.test_string() ) {
                                         dir_neighbour.first = entry.get_string();
-                                        dir_neighbour.second = ot_match_type::contains; // Default ot_match_type to contains
+                                        dir_neighbour.second = ot_match_type::contains;
                                     }
                                     else {
                                         JsonObject jo = entry.get_object();
@@ -3463,7 +3462,7 @@ class jmapgen_nested : public jmapgen_piece
                                         dir_neighbour.second = jo.get_enum_value<ot_match_type>( "om_terrain_match_type",
                                             ot_match_type::contains );
                                     }
-                                dir_neighbours.insert( dir_neighbour ); // Add it to the set
+                                dir_neighbours.insert( dir_neighbour );
                             }
                         }
                         else {
@@ -3473,13 +3472,13 @@ class jmapgen_nested : public jmapgen_piece
                             dir_neighbours.insert( dir_neighbour );
                         }
                         if( !dir_neighbours.empty() ) {
-                            neighbors[dir] = std::move( dir_neighbours ); // If the set isn't empty add it to the map
+                            neighbors[dir] = std::move( dir_neighbours );
                         }
                     }
                 }
 
                 bool test( const mapgendata &dat ) const {
-                    for( const std::pair<const direction, cata::flat_set<std::pair<std::string, ot_match_type>>> &p : // Iterate through the map
+                    for( const std::pair<const direction, cata::flat_set<std::pair<std::string, ot_match_type>>> &p :
                         neighbors) {
                         const direction dir = p.first;
                         const cata::flat_set<std::pair<std::string, ot_match_type>> &allowed_neighbors = p.second;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3446,26 +3446,23 @@ class jmapgen_nested : public jmapgen_piece
             public:
                 explicit neighbor_oter_check( const JsonObject &jsi ) {
                     for( direction dir : all_enum_values<direction>() ) {
-                        
                         std::string location = io::enum_to_string( dir );
                         cata::flat_set<std::pair<std::string, ot_match_type>> dir_neighbours;
-                        if ( !jsi.has_string( location ) ) {
-                            for ( const JsonValue entry : jsi.get_array( location ) ) {
+                        if( !jsi.has_string( location ) ) {
+                            for( const JsonValue entry : jsi.get_array( location ) ) {
                                 std::pair<std::string, ot_match_type> dir_neighbour;
-                                    if ( entry.test_string() ) {
-                                        dir_neighbour.first = entry.get_string();
-                                        dir_neighbour.second = ot_match_type::contains;
-                                    }
-                                    else {
-                                        JsonObject jo = entry.get_object();
-                                        dir_neighbour.first = jo.get_string( "om_terrain" );
-                                        dir_neighbour.second = jo.get_enum_value<ot_match_type>( "om_terrain_match_type",
-                                            ot_match_type::contains );
-                                    }
+                                if( entry.test_string() ) {
+                                    dir_neighbour.first = entry.get_string();
+                                    dir_neighbour.second = ot_match_type::contains;
+                                } else {
+                                    JsonObject jo = entry.get_object();
+                                    dir_neighbour.first = jo.get_string( "om_terrain" );
+                                    dir_neighbour.second = jo.get_enum_value<ot_match_type>( "om_terrain_match_type",
+                                                           ot_match_type::contains );
+                                }
                                 dir_neighbours.insert( dir_neighbour );
                             }
-                        }
-                        else {
+                        } else {
                             std::pair<std::string, ot_match_type> dir_neighbour;
                             dir_neighbour.first = jsi.get_string( location );
                             dir_neighbour.second = ot_match_type::contains;
@@ -3479,7 +3476,7 @@ class jmapgen_nested : public jmapgen_piece
 
                 bool test( const mapgendata &dat ) const {
                     for( const std::pair<const direction, cata::flat_set<std::pair<std::string, ot_match_type>>> &p :
-                        neighbors) {
+                         neighbors ) {
                         const direction dir = p.first;
                         const cata::flat_set<std::pair<std::string, ot_match_type>> &allowed_neighbors = p.second;
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3442,48 +3442,55 @@ class jmapgen_nested : public jmapgen_piece
         class neighbor_oter_check
         {
             private:
-                std::unordered_map<direction, cata::flat_set<oter_type_str_id>> neighbors;
+                std::unordered_map<direction, cata::flat_set<std::pair<std::string, ot_match_type>>> neighbors; // Matches the direction to check with the information to check
             public:
                 explicit neighbor_oter_check( const JsonObject &jsi ) {
-                    for( direction dir : all_enum_values<direction>() ) {
-                        cata::flat_set<oter_type_str_id> dir_neighbours =
-                            jsi.get_tags<oter_type_str_id, cata::flat_set<oter_type_str_id>>(
-                                io::enum_to_string( dir ) );
+                    for( direction dir : all_enum_values<direction>() ) { // Iterate through all 10 directions
+                        
+                        std::string location = io::enum_to_string( dir ); // Read direction
+                        cata::flat_set<std::pair<std::string, ot_match_type>> dir_neighbours; // That directions contents
+                        // Prevents needing to move all existing single checks to be part of an array, new single objects have to be in arrays though bc one unnecessary if is ugly enough
+                        if ( !jsi.has_string( location ) ) {
+                            for ( const JsonValue entry : jsi.get_array( location ) ) { // For every array element
+                                std::pair<std::string, ot_match_type> dir_neighbour; // Singular string om_match_type element
+                                    if ( entry.test_string() ) {
+                                        dir_neighbour.first = entry.get_string();
+                                        dir_neighbour.second = ot_match_type::contains; // Default ot_match_type to contains
+                                    }
+                                    else {
+                                        JsonObject jo = entry.get_object();
+                                        dir_neighbour.first = jo.get_string( "om_terrain" );
+                                        dir_neighbour.second = jo.get_enum_value<ot_match_type>( "om_terrain_match_type",
+                                            ot_match_type::contains );
+                                    }
+                                dir_neighbours.insert( dir_neighbour ); // Add it to the set
+                            }
+                        }
+                        else {
+                            std::pair<std::string, ot_match_type> dir_neighbour;
+                            dir_neighbour.first = jsi.get_string( location );
+                            dir_neighbour.second = ot_match_type::contains;
+                            dir_neighbours.insert( dir_neighbour );
+                        }
                         if( !dir_neighbours.empty() ) {
-                            neighbors[dir] = std::move( dir_neighbours );
+                            neighbors[dir] = std::move( dir_neighbours ); // If the set isn't empty add it to the map
                         }
                     }
                 }
 
-                void check( const std::string_view/*oter_name*/, const mapgen_parameters & ) const {
-                    // The check is ot_match_type::contains, so actually these
-                    // don't need to be valid ids, although they were until
-                    // recently.  TODO: permit the JSON to specify which match
-                    // type is intended and check where applicable.
-
-                    //for( const std::pair<const direction, cata::flat_set<oter_type_str_id>> &p :
-                    //     neighbors ) {
-                    //    for( const oter_type_str_id &id : p.second ) {
-                    //        if( !id.is_valid() ) {
-                    //            debugmsg( "Invalid oter_str_id '%s' in %s", id.str(), oter_name );
-                    //        }
-                    //    }
-                    //}
-                }
-
                 bool test( const mapgendata &dat ) const {
-                    for( const std::pair<const direction, cata::flat_set<oter_type_str_id>> &p :
-                         neighbors ) {
+                    for( const std::pair<const direction, cata::flat_set<std::pair<std::string, ot_match_type>>> &p : // Iterate through the map
+                        neighbors) {
                         const direction dir = p.first;
-                        const cata::flat_set<oter_type_str_id> &allowed_neighbors = p.second;
+                        const cata::flat_set<std::pair<std::string, ot_match_type>> &allowed_neighbors = p.second;
 
                         cata_assert( !allowed_neighbors.empty() );
 
                         bool this_direction_matches = false;
-                        for( const oter_type_str_id &allowed_neighbor : allowed_neighbors ) {
+                        for( const std::pair<std::string, ot_match_type> &allowed_neighbor : allowed_neighbors ) {
                             this_direction_matches |=
-                                is_ot_match( allowed_neighbor.str(), dat.neighbor_at( dir ).id(),
-                                             ot_match_type::contains );
+                                is_ot_match( allowed_neighbor.first, dat.neighbor_at( dir ).id(),
+                                             allowed_neighbor.second );
                         }
                         if( !this_direction_matches ) {
                             return false;
@@ -3660,7 +3667,6 @@ class jmapgen_nested : public jmapgen_piece
             for( const weighted_object<int, mapgen_value<nested_mapgen_id>> &p : else_entries ) {
                 p.obj.check( oter_name, parameters );
             }
-            neighbor_oters.check( oter_name, parameters );
             neighbor_joins.check( oter_name, parameters );
 
             // Check whether any of the nests can attempt to place stuff out of


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

`neighbor_oter_check` currently enforces `om_match_type::contains` on it's searches which could be leading to bugs where the provided substring matches more than the user is expecting and is generally limiting

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Allows other `om_match_type`s to be used in the same way as elsewhere in the code, still defaults to contains

New syntax example `"neighbors": { "north_east": [  { "om_terrain": "fort", "om_terrain_match_type": "PREFIX" }, "field"  ]  } `

Currently single string checks aren't in arrays so I've used an if to prevent needing to move all existing single checks to be part of an array, new single objects have to be in arrays though bc one unnecessary if is ugly enough, I can move all the single strings to arrays if that's desired though
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Compiled and tested by using `{ "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 0, "neighbors": { "north": [ { "om_terrain": "fort", "om_terrain_match_type": "PREFIX" }, "mansion" ] } },` and checking the bastion fort and mansion matched but not house_fortified

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

First commit includes a load of comments to myself explaining what's going on if they're useful to anyone

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->