### PR TITLE
Fix pathfinding around vehicles

### DIFF
--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -331,10 +331,10 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
                         int dummy = -1;
                         const bool is_outside_veh = veh_at_internal( cur, dummy ) != veh;
 
-                        if( doors && veh->next_part_to_open( part, is_outside_veh ) ) {
+                        if( doors && veh->next_part_to_open( part, is_outside_veh ) != -1 ) {
                             // Handle car doors, but don't try to path through curtains
                             newg += 10; // One turn to open, 4 to move there
-                        } else if( locks && veh->next_part_to_unlock( part, is_outside_veh ) ) {
+                        } else if( locks && veh->next_part_to_unlock( part, is_outside_veh ) != -1 ) {
                             newg += 12; // 2 turns to open, 4 to move there
                         } else if( part >= 0 && bash > 0 ) {
                             // Car obstacle that isn't a door


### PR DESCRIPTION
#### Summary
Bugfixes "Fix pathfinding around vehicles"

#### Purpose of change
I noticed that my NPC companions were no longer very good at getting in vehicles when I entered them. Sure, they would walk up to the side of the vehicle, but then they would sit there and make no attempt to go through the doors to get inside.

It turns out, pathfinding was now considering every vehicle tile a door, so my companions were trying to open and walk through the walls of my vehicle to get to me.

#### Describe the solution
This is due to a bug in https://github.com/CleverRaven/Cataclysm-DDA/pull/61087, where the return value of `vehicle::next_part_to_open` and `vehicle::next_part_to_unlock` is treated as though it will be 0 (false) when the tile cannot be opened/unlocked. However, these functions return a vehicle part index, and as 0 is a valid vehicle part index, they return -1 when the tile cannot be opened/unlocked.

To fix, check for the correct value, instead of a non-zero value.

#### Testing
This behavior is easily demonstrated with a test vehicle: (I used an ambulance)
```
 """"  " = windshield, + = door, - = quarterpanel, # = seat
 +!#+  ! =  player character, @ = npc companion
@----
```

A test has been added to demonstrate this scenario.

To get into the seat next to the player, the NPC will try to walk through the quarterpanel to the east of it, when they actually need to go around the vehicle and enter through the other door.