### PR TITLE
More nest test fail fixes

### DIFF
--- a/data/json/mapgen/nested/house_nested.json
+++ b/data/json/mapgen/nested/house_nested.json
@@ -130,6 +130,7 @@
         " 66 "
       ],
       "palettes": [ "house_w_nest_palette" ],
+      "flags": [ "ERASE_FURNITURE_BEFORE_PLACING_TERRAIN", "ERASE_TRAP_BEFORE_PLACING_TERRAIN", "ALLOW_TERRAIN_UNDER_ITEMS" ],
       "items": {
         "O": {
           "item": { "subtype": "distribution", "entries": [ { "group": "SUS_dresser_mens" }, { "group": "SUS_dresser_womens" } ] }
@@ -153,6 +154,7 @@
         " Ih "
       ],
       "palettes": [ "house_w_nest_palette" ],
+      "flags": [ "ERASE_FURNITURE_BEFORE_PLACING_TERRAIN", "ERASE_TRAP_BEFORE_PLACING_TERRAIN", "ALLOW_TERRAIN_UNDER_ITEMS" ],
       "items": {
         "O": {
           "item": { "subtype": "distribution", "entries": [ { "group": "SUS_dresser_mens" }, { "group": "SUS_dresser_womens" } ] }
@@ -176,6 +178,7 @@
         " bH "
       ],
       "palettes": [ "house_w_nest_palette" ],
+      "flags": [ "ERASE_FURNITURE_BEFORE_PLACING_TERRAIN", "ERASE_TRAP_BEFORE_PLACING_TERRAIN", "ALLOW_TERRAIN_UNDER_ITEMS" ],
       "items": {
         "O": {
           "item": { "subtype": "distribution", "entries": [ { "group": "SUS_dresser_mens" }, { "group": "SUS_dresser_womens" } ] }

--- a/data/json/mapgen/robofaq_locs/robofac_mission_chunks.json
+++ b/data/json/mapgen/robofaq_locs/robofac_mission_chunks.json
@@ -54,7 +54,8 @@
       "mapgensize": [ 1, 1 ],
       "rows": [ "T" ],
       "terrain": { "T": "t_metal_floor" },
-      "items": { "T": { "item": "nano_templates", "chance": 100 } }
+      "items": { "T": { "item": "nano_templates", "chance": 100 } },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

```
oter_type_id := "urban_13_4"
  msg := "In nested mapgen bedroom_4x4_adult_2_N in mapgen urban_13_4 on
  urban_13_4_north, setting terrain to t_carpet_yellow (from t_floor) at (5,6)
  when item stick existed.  Resolve this either by removing the terrain from
  this mapgen, adding suitable removal commands to the mapgen, or by adding an
  appropriate clearing flag to the innermost layered mapgen.  Consult the
  "mapgen flags" section in MAPGEN.md for options."
```

```
DEBUG    : In nested mapgen robofac_mi3_photonics_chunk in unknown object in add_mapgen_update_func on office_tower_collapse_b_a0_north, setting terrain to t_metal_floor (from t_open_air) at (10,22) when item steel_lump existed.  Resolve this either by removing the terrain from this mapgen, adding suitable removal commands to the mapgen, or by adding an appropriate clearing flag to the innermost layered mapgen.  Consult the "mapgen flags" section in MAPGEN.md for options.
```

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Fixes a couple of random test fails based on nest placement

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

If you have any other nest related fails happily comment them and I'll add them

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->