### PR TITLE
Clean up vpart_info fields, vpslots and their accessor functions

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -546,7 +546,7 @@ static bool vehicle_activity( Character &you, const tripoint_bub_ms &src_loc, in
     if( !veh ) {
         return false;
     }
-    int time_to_take = 0;
+    time_duration time_to_take = 0_seconds;
     if( vpindex >= veh->part_count() ) {
         // if parts got removed during our work, we can't just carry on removing, we want to repair parts!
         // so just bail out, as we don't know if the next shifted part is suitable for repair.
@@ -567,7 +567,7 @@ static bool vehicle_activity( Character &you, const tripoint_bub_ms &src_loc, in
     } else if( type == 'o' ) {
         time_to_take = vpi.removal_time( you );
     }
-    you.assign_activity( ACT_VEHICLE, time_to_take, static_cast<int>( type ) );
+    you.assign_activity( ACT_VEHICLE, to_moves<int>( time_to_take ), static_cast<int>( type ) );
     // so , NPCs can remove the last part on a position, then there is no vehicle there anymore,
     // for someone else who stored that position at the start of their activity.
     // so we may need to go looking a bit further afield to find it , at activities end.

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -701,7 +701,7 @@ static std::vector<tripoint_bub_ms> route_best_workbench(
                 }
             } else if( const std::optional<vpart_reference> vp = here.veh_at(
                            adj ).part_with_feature( "WORKBENCH", true ) ) {
-                if( const std::optional<vpslot_workbench> &wb_info = vp->part().info().get_workbench_info() ) {
+                if( const std::optional<vpslot_workbench> &wb_info = vp->part().info().workbench_info ) {
                     if( wb_info->multiplier > best_bench_multi_a ) {
                         best_bench_multi_a = wb_info->multiplier;
                     }
@@ -720,7 +720,7 @@ static std::vector<tripoint_bub_ms> route_best_workbench(
                 }
             } else if( const std::optional<vpart_reference> vp = here.veh_at(
                            adj ).part_with_feature( "WORKBENCH", true ) ) {
-                if( const std::optional<vpslot_workbench> &wb_info = vp->part().info().get_workbench_info() ) {
+                if( const std::optional<vpslot_workbench> &wb_info = vp->part().info().workbench_info ) {
                     if( wb_info->multiplier > best_bench_multi_b ) {
                         best_bench_multi_b = wb_info->multiplier;
                     }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -226,7 +226,7 @@ float Character::workbench_crafting_speed_multiplier( const item &craft,
                    *loc ).part_with_feature( "WORKBENCH", true ) ) {
         // Vehicle workbench
         const vpart_info &vp_info = vp->part().info();
-        if( const std::optional<vpslot_workbench> &wb_info = vp_info.get_workbench_info() ) {
+        if( const std::optional<vpslot_workbench> &wb_info = vp_info.workbench_info ) {
             multiplier = wb_info->multiplier;
             allowed_mass = wb_info->allowed_mass;
             allowed_volume = wb_info->allowed_volume;
@@ -775,7 +775,7 @@ static item_location place_craft_or_disassembly(
             }
         } else if( const std::optional<vpart_reference> vp = here.veh_at(
                        adj ).part_with_feature( "WORKBENCH", true ) ) {
-            if( const std::optional<vpslot_workbench> &wb_info = vp->part().info().get_workbench_info() ) {
+            if( const std::optional<vpslot_workbench> &wb_info = vp->part().info().workbench_info ) {
                 if( wb_info->multiplier > best_bench_multi ) {
                     best_bench_multi = wb_info->multiplier;
                     target = adj;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -865,7 +865,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
                 // Damage is calculated based on the weight of the vehicle,
                 // The area of it's wheels, and the area of the wheel running over the items.
                 // This number is multiplied by weight_to_damage_factor to get reasonable results, damage-wise.
-                const int wheel_damage = vpi_wheel.wheel_area() / vehicle_grounded_wheel_area *
+                const int wheel_damage = vpi_wheel.wheel_info->contact_area / vehicle_grounded_wheel_area *
                                          vehicle_mass_kg * weight_to_damage_factor;
 
                 //~ %1$s: vehicle name

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -741,7 +741,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
             // Shock damage, if the target part is a rotor treat as an aimed hit.
             // don't try to deal damage to invalid part (probably removed or destroyed)
             if( part_num != -1 ) {
-                if( veh.part( part_num ).info().rotor_diameter() > 0 ) {
+                if( veh.part( part_num ).info().has_flag( VPFLAG_ROTOR ) ) {
                     veh.damage( *this, part_num, coll_dmg, damage_bash, true );
                 } else {
                     impulse += coll_dmg;

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -504,17 +504,17 @@ void veh_app_interact::remove()
         msg += reqs.list_missing();
     }
 
-    int time = vpinfo.removal_time( you );
+    time_duration time = vpinfo.removal_time( you );
     if( you.has_trait( trait_DEBUG_HS ) ) {
         can_remove = true;
-        time = 1;
+        time = 1_seconds;
     }
 
     if( !can_remove ) {
         popup( msg );
         //~ Prompt the player if they want to remove the appliance. %s = appliance name.
     } else if( query_yn( _( "Are you sure you want to take down the %s?" ), veh->name ) ) {
-        act = player_activity( ACT_VEHICLE, time, static_cast<int>( 'O' ) );
+        act = player_activity( ACT_VEHICLE, to_moves<int>( time ), static_cast<int>( 'O' ) );
         act.str_values.push_back( vpinfo.id.str() );
         const point q = veh->coord_translate( vp.mount );
         map &here = get_map();

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -762,19 +762,6 @@ task_reason veh_interact::cant_do( char mode )
     return task_reason::CAN_DO;
 }
 
-bool veh_interact::is_drive_conflict()
-{
-    std::string conflict_type;
-    bool has_conflict = veh->has_engine_conflict( sel_vpart_info, conflict_type );
-
-    if( has_conflict ) {
-        //~ %1$s is fuel_type
-        msg = string_format( _( "Only one %1$s powered engine can be installed." ),
-                             conflict_type );
-    }
-    return has_conflict;
-}
-
 bool veh_interact::can_self_jack()
 {
     int lvl = jack_quality( *veh );
@@ -800,7 +787,9 @@ bool veh_interact::update_part_requirements()
         return false;
     }
 
-    if( is_drive_conflict() ) {
+    if( const std::optional<std::string> conflict = veh->has_engine_conflict( *sel_vpart_info ) ) {
+        //~ %1$s is fuel_type
+        msg = string_format( _( "Only one %1$s powered engine can be installed." ), conflict.value() );
         return false;
     }
     if( veh->has_part( "NO_MODIFY_VEHICLE" ) && !sel_vpart_info->has_flag( "SIMPLE_PART" ) ) {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -137,7 +137,7 @@ player_activity veh_interact::serialize_activity()
     }
 
     avatar &player_character = get_avatar();
-    int time = 1000;
+    time_duration time = 0_seconds;
     switch( sel_cmd ) {
         case 'i':
             time = vp->install_time( player_character );
@@ -158,9 +158,9 @@ player_activity veh_interact::serialize_activity()
             break;
     }
     if( player_character.has_trait( trait_DEBUG_HS ) ) {
-        time = 1;
+        time = 1_seconds;
     }
-    player_activity res( ACT_VEHICLE, time, static_cast<int>( sel_cmd ) );
+    player_activity res( ACT_VEHICLE, to_moves<int>( time ), static_cast<int>( sel_cmd ) );
 
     // if we're working on an existing part, use that part as the reference point
     // otherwise (e.g. installing a new frame), just use part 0
@@ -344,14 +344,14 @@ void veh_interact::allocate_windows()
 }
 
 bool veh_interact::format_reqs( std::string &msg, const requirement_data &reqs,
-                                const std::map<skill_id, int> &skills, int moves ) const
+                                const std::map<skill_id, int> &skills, time_duration time ) const
 {
     Character &player_character = get_player_character();
     const inventory &inv = player_character.crafting_inventory();
     bool ok = reqs.can_make_with_inventory( inv, is_crafting_component );
 
     msg += _( "<color_white>Time required:</color>\n" );
-    msg += "> " + to_string_approx( time_duration::from_moves( moves ) ) + "\n";
+    msg += "> " + to_string_approx( time ) + "\n";
 
     msg += _( "<color_white>Skills required:</color>\n" );
     for( const auto &e : skills ) {

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -255,9 +255,6 @@ class veh_interact
         bool can_remove_part( int idx, const Character &you );
         //do install support, writes requirements to ui
         bool update_part_requirements();
-        //true if trying to install foot crank with electric engines for example
-        //writes failure to ui
-        bool is_drive_conflict();
 
         /* Vector of all vpart TYPES that can be mounted in the current square.
          * Can be converted to a vector<vpart_info>.

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -133,7 +133,7 @@ class veh_interact
 
         /** Format list of requirements returning true if all are met */
         bool format_reqs( std::string &msg, const requirement_data &reqs,
-                          const std::map<skill_id, int> &skills, int moves ) const;
+                          const std::map<skill_id, int> &skills, time_duration time ) const;
 
         int part_at( const point &d );
         void move_cursor( const point &d, int dstart_at = 0 );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1068,14 +1068,6 @@ bool vpart_info::has_category( const std::string &category ) const
     return this->categories.find( category ) != this->categories.end();
 }
 
-int vpart_info::rotor_diameter() const
-{
-    if( has_flag( VPFLAG_ROTOR ) ) {
-        return rotor_info->rotor_diameter;
-    }
-    return 0;
-}
-
 std::set<std::pair<itype_id, int>> vpart_info::get_pseudo_tools() const
 {
     return pseudo_tools;

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -274,26 +274,6 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
         }
     }
 
-    if( jo.has_member( "transform_terrain" ) ) {
-        JsonObject jttd = jo.get_object( "transform_terrain" );
-        for( const std::string pre_flag : jttd.get_array( "pre_flags" ) ) {
-            transform_terrain.pre_flags.emplace( pre_flag );
-        }
-        transform_terrain.post_terrain = jttd.get_string( "post_terrain", "t_null" );
-        transform_terrain.post_furniture = jttd.get_string( "post_furniture", "f_null" );
-        transform_terrain.post_field = jttd.get_string( "post_field", "fd_null" );
-        transform_terrain.post_field_intensity = jttd.get_int( "post_field_intensity", 0 );
-        if( jttd.has_int( "post_field_age" ) ) {
-            transform_terrain.post_field_age = time_duration::from_turns(
-                                                   jttd.get_int( "post_field_age" ) );
-        } else if( jttd.has_string( "post_field_age" ) ) {
-            transform_terrain.post_field_age = read_from_json_string<time_duration>
-                                               ( jttd.get_member( "post_field_age" ), time_duration::units );
-        } else {
-            transform_terrain.post_field_age = 0_turns;
-        }
-    }
-
     if( jo.has_member( "requirements" ) ) {
         JsonObject reqs = jo.get_object( "requirements" );
 
@@ -395,6 +375,20 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
             toolkit_info.emplace();
         }
         assign( jo, "allowed_tools", toolkit_info->allowed_types, strict );
+    }
+
+    if( has_flag( "TRANSFORM_TERRAIN" ) || has_flag( "CRASH_TERRAIN_AROUND" ) ) {
+        if( !transform_terrain_info ) {
+            transform_terrain_info.emplace();
+        }
+        JsonObject jttd = jo.get_object( "transform_terrain" );
+        vpslot_terrain_transform &vtt = *transform_terrain_info;
+        optional( jttd, was_loaded, "pre_flags", vtt.pre_flags, {} );
+        optional( jttd, was_loaded, "post_terrain", vtt.post_terrain, "t_null" );
+        optional( jttd, was_loaded, "post_furniture", vtt.post_furniture, "f_null" );
+        optional( jttd, was_loaded, "post_field", vtt.post_field, "fd_null" );
+        optional( jttd, was_loaded, "post_field_intensity", vtt.post_field_intensity, 0 );
+        optional( jttd, was_loaded, "post_field_age", vtt.post_field_age, 0_seconds );
     }
 }
 

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1054,19 +1054,19 @@ static time_duration scale_time( const std::map<skill_id, int> &sk, time_duratio
                                   0.5 ) ) * ( 1 - ( helpersize / 10.0 ) );
 }
 
-int vpart_info::install_time( const Character &you ) const
+time_duration vpart_info::install_time( const Character &you ) const
 {
-    return to_moves<int>( scale_time( install_skills, install_moves, you ) );
+    return scale_time( install_skills, install_moves, you );
 }
 
-int vpart_info::removal_time( const Character &you ) const
+time_duration vpart_info::removal_time( const Character &you ) const
 {
-    return to_moves<int>( scale_time( removal_skills, removal_moves, you ) );
+    return scale_time( removal_skills, removal_moves, you );
 }
 
-int vpart_info::repair_time( const Character &you ) const
+time_duration vpart_info::repair_time( const Character &you ) const
 {
-    return to_moves<int>( scale_time( repair_skills, repair_moves, you ) );
+    return scale_time( repair_skills, repair_moves, you );
 }
 
 /**

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1063,50 +1063,6 @@ time_duration vpart_info::repair_time( const Character &you ) const
     return scale_time( repair_skills, repair_moves, you );
 }
 
-/**
- * @name Engine specific functions
- *
- */
-float vpart_info::engine_backfire_threshold() const
-{
-    return has_flag( VPFLAG_ENGINE ) ? engine_info->backfire_threshold : false;
-}
-
-int vpart_info::engine_backfire_freq() const
-{
-    return has_flag( VPFLAG_ENGINE ) ? engine_info->backfire_freq : false;
-}
-
-int vpart_info::engine_muscle_power_factor() const
-{
-    return has_flag( VPFLAG_ENGINE ) ? engine_info->muscle_power_factor : false;
-}
-
-float vpart_info::engine_damaged_power_factor() const
-{
-    return has_flag( VPFLAG_ENGINE ) ? engine_info->damaged_power_factor : false;
-}
-
-int vpart_info::engine_noise_factor() const
-{
-    return has_flag( VPFLAG_ENGINE ) ? engine_info->noise_factor : false;
-}
-
-int vpart_info::engine_m2c() const
-{
-    return has_flag( VPFLAG_ENGINE ) ? engine_info->m2c : 0;
-}
-
-std::vector<std::string> vpart_info::engine_excludes() const
-{
-    return has_flag( VPFLAG_ENGINE ) ? engine_info->exclusions : std::vector<std::string>();
-}
-
-std::vector<itype_id> vpart_info::engine_fuel_opts() const
-{
-    return has_flag( VPFLAG_ENGINE ) ? engine_info->fuel_opts : std::vector<itype_id>();
-}
-
 bool vpart_info::has_category( const std::string &category ) const
 {
     return this->categories.find( category ) != this->categories.end();

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -976,9 +976,9 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
         } ) ) );
     }
 
-    if( get_toolkit_info() && !get_toolkit_info()->allowed_types.empty() ) {
+    if( toolkit_info && !toolkit_info->allowed_types.empty() ) {
         append_desc( string_format( "\n%s<color_cyan>%s</color>", _( "Allows connecting: " ),
-        enumerate_as_string( get_toolkit_info()->allowed_types, []( const itype_id & it ) {
+        enumerate_as_string( toolkit_info->allowed_types, []( const itype_id & it ) {
             return it->nname( 1 );
         } ) ) );
     }
@@ -1144,16 +1144,6 @@ int vpart_info::rotor_diameter() const
         return rotor_info->rotor_diameter;
     }
     return 0;
-}
-
-const std::optional<vpslot_workbench> &vpart_info::get_workbench_info() const
-{
-    return workbench_info;
-}
-
-const std::optional<vpslot_toolkit> &vpart_info::get_toolkit_info() const
-{
-    return toolkit_info;
 }
 
 std::set<std::pair<itype_id, int>> vpart_info::get_pseudo_tools() const

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -343,11 +343,11 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
         assign( jo, "contact_area", wheel_info->contact_area, strict );
         assign( jo, "wheel_offroad_rating", wheel_info->offroad_rating, strict );
         if( const std::optional<JsonValue> jo_termod = jo.get_member_opt( "wheel_terrain_modifiers" ) ) {
-            wheel_info->terrain_mod.clear();
+            wheel_info->terrain_modifiers.clear();
             for( const JsonMember jo_mod : static_cast<JsonObject>( *jo_termod ) ) {
                 const JsonArray jo_mod_values = jo_mod.get_array();
                 veh_ter_mod mod { jo_mod.name(), jo_mod_values.get_int( 0 ), jo_mod_values.get_int( 1 ) };
-                wheel_info->terrain_mod.emplace_back( std::move( mod ) );
+                wheel_info->terrain_modifiers.emplace_back( std::move( mod ) );
             }
         }
     }
@@ -1110,32 +1110,6 @@ std::vector<itype_id> vpart_info::engine_fuel_opts() const
 bool vpart_info::has_category( const std::string &category ) const
 {
     return this->categories.find( category ) != this->categories.end();
-}
-
-/**
- * @name Wheel specific functions
- *
- */
-float vpart_info::wheel_rolling_resistance() const
-{
-    // caster wheels return 29, so if a part rolls worse than a caster wheel...
-    return has_flag( VPFLAG_WHEEL ) ? wheel_info->rolling_resistance : 50;
-}
-
-int vpart_info::wheel_area() const
-{
-    return has_flag( VPFLAG_WHEEL ) ? wheel_info->contact_area : 0;
-}
-
-const std::vector<veh_ter_mod> &vpart_info::wheel_terrain_modifiers() const
-{
-    static const std::vector<veh_ter_mod> null_map;
-    return has_flag( VPFLAG_WHEEL ) ? wheel_info->terrain_mod : null_map;
-}
-
-float vpart_info::wheel_offroad_rating() const
-{
-    return has_flag( VPFLAG_WHEEL ) ? wheel_info->offroad_rating : 0.0f;
 }
 
 int vpart_info::rotor_diameter() const

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -117,7 +117,7 @@ struct vpslot_engine {
     int muscle_power_factor = 0;
     float damaged_power_factor = 0.0f;
     int noise_factor = 0;
-    int m2c = 1;
+    int m2c = 100;
     std::vector<std::string> exclusions;
     std::vector<itype_id> fuel_opts;
 };
@@ -277,18 +277,6 @@ class vpart_info
         /** Repair time (in moves) to fully repair this component, accounting for player skills */
         time_duration repair_time( const Character &you ) const;
 
-        /**
-         * @name Engine specific functions
-         *
-         */
-        std::vector<std::string> engine_excludes() const;
-        int engine_m2c() const;
-        float engine_backfire_threshold() const;
-        int engine_backfire_freq() const;
-        int engine_muscle_power_factor() const;
-        float engine_damaged_power_factor() const;
-        int engine_noise_factor() const;
-        std::vector<itype_id> engine_fuel_opts() const;
         /** @name rotor specific functions
         */
         int rotor_diameter() const;

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -260,13 +260,13 @@ class vpart_info
         requirement_data install_requirements() const;
 
         /** Installation time (in moves) for this component accounting for player skills */
-        int install_time( const Character &you ) const;
+        time_duration install_time( const Character &you ) const;
 
         /** Requirements for removal of this component */
         requirement_data removal_requirements() const;
 
         /** Removal time (in moves) for this component accounting for player skills */
-        int removal_time( const Character &you ) const;
+        time_duration removal_time( const Character &you ) const;
 
         /** Requirements for repair of this component (per level of damage) */
         requirement_data repair_requirements() const;
@@ -275,7 +275,7 @@ class vpart_info
         bool is_repairable() const;
 
         /** Repair time (in moves) to fully repair this component, accounting for player skills */
-        int repair_time( const Character &you ) const;
+        time_duration repair_time( const Character &you ) const;
 
         /**
          * @name Engine specific functions
@@ -336,9 +336,9 @@ class vpart_info
         // tools required to unfold this part
         std::vector<itype_id> unfolding_tools;
         // time required to fold this part
-        time_duration folding_time = time_duration::from_seconds( 10 );
+        time_duration folding_time = 10_seconds;
         // time required to unfold this part
-        time_duration unfolding_time = time_duration::from_seconds( 10 );
+        time_duration unfolding_time = 10_seconds;
 
         std::optional<vpslot_engine> engine_info;
         std::optional<vpslot_wheel> wheel_info;

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -131,7 +131,7 @@ struct veh_ter_mod {
 struct vpslot_wheel {
     float rolling_resistance = 1.0f;
     int contact_area = 1;
-    std::vector<veh_ter_mod> terrain_mod;
+    std::vector<veh_ter_mod> terrain_modifiers;
     float offroad_rating = 0.5f;
 };
 
@@ -289,14 +289,6 @@ class vpart_info
         float engine_damaged_power_factor() const;
         int engine_noise_factor() const;
         std::vector<itype_id> engine_fuel_opts() const;
-        /**
-         * @name Wheel specific functions
-         *
-         */
-        float wheel_rolling_resistance() const;
-        int wheel_area() const;
-        const std::vector<veh_ter_mod> &wheel_terrain_modifiers() const;
-        float wheel_offroad_rating() const;
         /** @name rotor specific functions
         */
         int rotor_diameter() const;

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -151,7 +151,7 @@ struct vpslot_toolkit {
     std::set<itype_id> allowed_types;
 };
 
-struct transform_terrain_data {
+struct vpslot_terrain_transform {
     std::set<std::string> pre_flags;
     std::string post_terrain;
     std::string post_furniture;
@@ -386,7 +386,7 @@ class vpart_info
         nc_color color_broken = c_light_gray;
 
         /* Contains data for terrain transformer parts */
-        transform_terrain_data transform_terrain;
+        std::optional<vpslot_terrain_transform> transform_terrain_info;
 
         /** Fuel type of engine or tank */
         itype_id fuel_type = itype_id::NULL_ID();

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -277,10 +277,6 @@ class vpart_info
         /** Repair time (in moves) to fully repair this component, accounting for player skills */
         time_duration repair_time( const Character &you ) const;
 
-        /** @name rotor specific functions
-        */
-        int rotor_diameter() const;
-
         std::optional<vpslot_workbench> workbench_info;
         std::optional<vpslot_toolkit> toolkit_info;
         std::optional<vpslot_engine> engine_info;

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -300,11 +300,13 @@ class vpart_info
         /** @name rotor specific functions
         */
         int rotor_diameter() const;
-        /**
-         * Getter for optional workbench info
-         */
-        const std::optional<vpslot_workbench> &get_workbench_info() const;
-        const std::optional<vpslot_toolkit> &get_toolkit_info() const;
+
+        std::optional<vpslot_workbench> workbench_info;
+        std::optional<vpslot_toolkit> toolkit_info;
+        std::optional<vpslot_engine> engine_info;
+        std::optional<vpslot_wheel> wheel_info;
+        std::optional<vpslot_rotor> rotor_info;
+        std::optional<vpslot_terrain_transform> transform_terrain_info;
 
         std::set<std::pair<itype_id, int>> get_pseudo_tools() const;
 
@@ -339,12 +341,6 @@ class vpart_info
         time_duration folding_time = 10_seconds;
         // time required to unfold this part
         time_duration unfolding_time = 10_seconds;
-
-        std::optional<vpslot_engine> engine_info;
-        std::optional<vpslot_wheel> wheel_info;
-        std::optional<vpslot_rotor> rotor_info;
-        std::optional<vpslot_workbench> workbench_info;
-        std::optional<vpslot_toolkit> toolkit_info;
 
         /** Name from vehicle part definition which if set overrides the base item name */
         translation name_;
@@ -384,9 +380,6 @@ class vpart_info
         /** Color of part for different states */
         nc_color color = c_light_gray;
         nc_color color_broken = c_light_gray;
-
-        /* Contains data for terrain transformer parts */
-        std::optional<vpslot_terrain_transform> transform_terrain_info;
 
         /** Fuel type of engine or tank */
         itype_id fuel_type = itype_id::NULL_ID();

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4129,7 +4129,7 @@ double vehicle::lift_thrust_of_rotorcraft( const bool fuelled, const bool safe )
 {
     int rotor_area_in_feet = 0;
     for( const int rotor : rotors ) {
-        double rotor_diameter_in_feet = parts[ rotor ].info().rotor_diameter() * 3.28084;
+        double rotor_diameter_in_feet = parts[rotor].info().rotor_info->rotor_diameter * 3.28084;
         rotor_area_in_feet += ( M_PI / 4 ) * std::pow( rotor_diameter_in_feet, 2 );
     }
     // take off 15 % due to the imaginary tail rotor power.
@@ -6784,7 +6784,7 @@ int vehicle::damage( map &here, int p, int dmg, const damage_type_id &type, bool
         }
     }
 
-    int target_part = vp_initial.info().rotor_diameter() ? p : random_entry( parts_here );
+    int target_part = vp_initial.info().has_flag( VPFLAG_ROTOR ) ? p : random_entry( parts_here );
 
     // Parts integrated inside a door or board are protected by boards and closed doors
     if( part( target_part ).info().has_flag( "BOARD_INTERNAL" ) ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -935,30 +935,26 @@ bool vehicle::has_engine_type_not( const itype_id &ft, const bool enabled ) cons
     return false;
 }
 
-bool vehicle::has_engine_conflict( const vpart_info *possible_conflict,
-                                   std::string &conflict_type ) const
+std::optional<std::string> vehicle::has_engine_conflict( const vpart_info &possible_conflict ) const
 {
-    std::vector<std::string> new_excludes = possible_conflict->engine_excludes();
-    // skip expensive string comparisons if there are no exclusions
-    if( new_excludes.empty() ) {
-        return false;
+    if( !possible_conflict.engine_info ) {
+        return std::nullopt; // not an engine
     }
-
-    bool has_conflict = false;
-
+    const std::vector<std::string> &new_excludes = possible_conflict.engine_info->exclusions;
+    if( new_excludes.empty() ) {
+        return std::nullopt;
+    }
     for( const int p : engines ) {
         const vehicle_part &vp = parts[p];
-        std::vector<std::string> install_excludes = vp.info().engine_excludes();
+        std::vector<std::string> install_excludes = vp.info().engine_info->exclusions;
         std::vector<std::string> conflicts;
         std::set_intersection( new_excludes.begin(), new_excludes.end(), install_excludes.begin(),
                                install_excludes.end(), back_inserter( conflicts ) );
         if( !conflicts.empty() ) {
-            has_conflict = true;
-            conflict_type = conflicts.front();
-            break;
+            return conflicts.front();
         }
     }
-    return has_conflict;
+    return std::nullopt;
 }
 
 bool vehicle::is_engine_type( const vehicle_part &vp, const itype_id  &ft ) const
@@ -1057,7 +1053,7 @@ units::power vehicle::part_vpower_w( const vehicle_part &vp, const bool at_full_
                 ///\EFFECT_STR increases power produced for MUSCLE_* vehicles
                 const float muscle_multiplier = muscle_user->str_cur - 8;
                 const float weary_multiplier = muscle_user->exertion_adjusted_move_multiplier();
-                const float engine_multiplier = vpi.engine_muscle_power_factor();
+                const float engine_multiplier = vpi.engine_info->muscle_power_factor;
                 pwr += units::from_watt( muscle_multiplier * weary_multiplier * engine_multiplier );
             }
         } else if( vpi.fuel_type == fuel_type_wind ) {
@@ -1080,9 +1076,11 @@ units::power vehicle::part_vpower_w( const vehicle_part &vp, const bool at_full_
     // Damaged engines give less power, but some engines handle it better
     // dpf is 0 for engines that scale power linearly with damage and
     // provides a floor otherwise
-    const float dpf = vpi.engine_damaged_power_factor();
-    const double effective_percent = dpf + ( ( 1 - dpf ) * vp.health_percent() );
-    return pwr * effective_percent;
+    if( vpi.has_flag( VPFLAG_ENGINE ) ) {
+        const float dpf = vpi.engine_info->damaged_power_factor;
+        pwr *= dpf + ( ( 1.0f - dpf ) * vp.health_percent() );
+    }
+    return pwr;
 }
 
 // alternators, solar panels, reactors, and accessories all have epower.
@@ -1206,9 +1204,8 @@ ret_val<void> vehicle::can_mount( const point &dp, const vpart_info &vpi ) const
         }
     }
 
-    std::string engine_conflict;
-    if( has_engine_conflict( &vpi, engine_conflict ) ) {
-        return ret_val<void>::make_failure( _( "Engine conflict: %s." ), engine_conflict );
+    if( const std::optional<std::string> conflict = has_engine_conflict( vpi ) ) {
+        return ret_val<void>::make_failure( _( "Engine conflict: %s." ), conflict.value() );
     }
 
     // Check all the flags of the part to see if they require other flags
@@ -3467,7 +3464,7 @@ units::power vehicle::total_power( const bool fueled, const bool safe ) const
     for( const int p : engines ) {
         const vehicle_part &vp = parts[p];
         if( is_engine_on( vp ) && ( !fueled || engine_fuel_left( vp ) ) ) {
-            int m2c = safe ? vp.info().engine_m2c() : 100;
+            int m2c = safe ? vp.info().engine_info->m2c : 100;
             if( vp.has_fault_flag( "REDUCE_ENG_POWER" ) ) {
                 m2c *= 0.6;
             }
@@ -3811,7 +3808,7 @@ void vehicle::noise_and_smoke( int load, time_duration time )
             // idle stress = 1.0 resulting in nominal working engine noise = engine_noise_factor()
             // and preventing noise = 0
             cur_stress = std::max( cur_stress, 1.0 );
-            double part_noise = cur_stress * vp.info().engine_noise_factor();
+            double part_noise = cur_stress * vp.info().engine_info->noise_factor;
 
             if( is_engine_type_combustion( vp ) ) {
                 combustion = true;
@@ -3819,7 +3816,7 @@ void vehicle::noise_and_smoke( int load, time_duration time )
                 if( vp.has_fault_flag( "ENG_BACKFIRE" ) ) {
                     health = 0.0;
                 }
-                if( health < vp.info().engine_backfire_threshold() && one_in( 50 + 150 * health ) ) {
+                if( health < vp.info().engine_info->backfire_threshold && one_in( 50 + 150 * health ) ) {
                     backfire( vp );
                 }
                 double j = cur_stress * to_turns<int>( time ) * muffle * 1000;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3870,8 +3870,8 @@ void vehicle::noise_and_smoke( int load, time_duration time )
 int vehicle::wheel_area() const
 {
     int total_area = 0;
-    for( const int &wheel_index : wheelcache ) {
-        total_area += parts[ wheel_index ].wheel_area();
+    for( const int wheel_index : wheelcache ) {
+        total_area += parts[wheel_index].info().wheel_info->contact_area;
     }
 
     return total_area;
@@ -3885,7 +3885,7 @@ float vehicle::average_offroad_rating() const
     float total_rating = 0.0f;
     for( const int wheel_index : wheelcache ) {
         const vehicle_part &vp = part( wheel_index );
-        total_rating += vp.info().wheel_offroad_rating();
+        total_rating += vp.info().wheel_info->offroad_rating;
     }
     return total_rating / wheelcache.size();
 }
@@ -4083,7 +4083,7 @@ double vehicle::coeff_rolling_drag() const
     } else {
         // should really sum each wheel's c_rolling_resistance * its share of vehicle mass
         for( int wheel : wheelcache ) {
-            wheel_factor += parts[ wheel ].info().wheel_rolling_resistance();
+            wheel_factor += parts[wheel].info().wheel_info->rolling_resistance;
         }
         // mildly increasing rolling resistance for vehicles with more than 4 wheels and mildly
         // decrease it for vehicles with less
@@ -6295,7 +6295,7 @@ void vehicle::refresh_pivot() const
         const vehicle_part &wheel = parts[p];
 
         // TODO: load on tire?
-        int contact_area = wheel.wheel_area();
+        const int contact_area = wheel.info().wheel_info->contact_area;
         float weight_i;  // weighting for the in-line part
         float weight_p;  // weighting for the perpendicular part
         if( wheel.is_broken() ) {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -368,15 +368,6 @@ struct vehicle_part {
         /** Try to set fault returning false if specified fault cannot occur with this item */
         bool fault_set( const fault_id &f );
 
-        /** Get wheel diameter times wheel width (inches^2) or return 0 if part is not wheel */
-        int wheel_area() const;
-
-        /** Get wheel diameter (inches) or return 0 if part is not wheel */
-        int wheel_diameter() const;
-
-        /** Get wheel width (inches) or return 0 if part is not wheel */
-        int wheel_width() const;
-
         /**
          *  Get NPC currently assigned to this part (seat, turret etc)?
          *  @note checks crew member is alive and currently allied to the player

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1974,9 +1974,8 @@ class vehicle
         //true if an engine exists without the specified type
         //If enabled true, this engine must be enabled to return true
         bool has_engine_type_not( const itype_id &ft, bool enabled ) const;
-        //returns true if there's another engine with the same exclusion list; conflict_type holds
-        //the exclusion
-        bool has_engine_conflict( const vpart_info *possible_conflict, std::string &conflict_type ) const;
+        // @returns engine conflict string if another engine has same exclusion list or std::nullopt
+        std::optional<std::string> has_engine_conflict( const vpart_info &possible_conflict ) const;
         //returns true if the engine doesn't consume fuel
         bool is_perpetual_type( const vehicle_part &vp ) const;
         //if necessary, damage this engine

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -604,7 +604,7 @@ vehicle_profile vehicle::autodrive_controller::compute_profile( orientation faci
     }
     for( int part_num : driven_veh.rotors ) {
         const vehicle_part &part = driven_veh.part( part_num );
-        const int diameter = part.info().rotor_diameter();
+        const int diameter = part.info().rotor_info->rotor_diameter;
         const int radius = ( diameter + 1 ) / 2;
         if( radius > 0 ) {
             tripoint pos;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -732,7 +732,7 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
         }
 
         const vpart_info &info = vp.info();
-        if( !vp.is_fake && info.location != part_location_structure && info.rotor_diameter() == 0 ) {
+        if( !vp.is_fake && info.location != part_location_structure && !info.has_flag( VPFLAG_ROTOR ) ) {
             continue;
         }
         empty = false;
@@ -740,8 +740,8 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
         //  and turning (precalc[1])
         const tripoint dsp = global_pos3() + dp + vp.precalc[1];
         veh_collision coll = part_collision( p, dsp, just_detect, bash_floor );
-        if( coll.type == veh_coll_nothing && info.rotor_diameter() > 0 ) {
-            size_t radius = static_cast<size_t>( std::round( info.rotor_diameter() / 2.0f ) );
+        if( coll.type == veh_coll_nothing && info.has_flag( VPFLAG_ROTOR ) ) {
+            size_t radius = static_cast<size_t>( std::round( info.rotor_info->rotor_diameter / 2.0f ) );
             for( const tripoint &rotor_point : here.points_in_radius( dsp, radius ) ) {
                 veh_collision rotor_coll = part_collision( p, rotor_point, just_detect, false );
                 if( rotor_coll.type != veh_coll_nothing ) {
@@ -859,7 +859,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
     // Typical rotor tip speed in MPH * 100.
     int rotor_velocity = 45600;
     // Non-vehicle collisions can't happen when the vehicle is not moving
-    int &coll_velocity = ( parts[part].info().rotor_diameter() == 0 ) ?
+    int &coll_velocity = ( parts[part].info().has_flag( VPFLAG_ROTOR ) == 0 ) ?
                          ( vert_coll ? vertical_velocity : velocity ) :
                          rotor_velocity;
     if( !just_detect && coll_velocity == 0 ) {
@@ -950,7 +950,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
     // Calculate mass AFTER checking for collision
     //  because it involves iterating over all cargo
     // Rotors only use rotor mass in calculation.
-    const float mass = vpi.rotor_diameter() > 0
+    const float mass = vpi.has_flag( VPFLAG_ROTOR )
                        ? to_kilogram( vp.base.weight() )
                        : to_kilogram( total_mass() );
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2070,6 +2070,7 @@ float map::vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modi
     float traction_wheel_area = 0.0f;
     for( const int wheel_idx : veh.wheelcache ) {
         const vehicle_part &vp = veh.part( wheel_idx );
+        const vpart_info &vpi = vp.info();
         const tripoint pp = veh.global_part_pos3( vp );
         const ter_t &tr = ter( pp ).obj();
         if( tr.has_flag( ter_furn_flag::TFLAG_DEEP_WATER ) ||
@@ -2083,11 +2084,11 @@ float map::vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modi
         }
 
         if( ignore_movement_modifiers ) {
-            traction_wheel_area += vp.wheel_area();
+            traction_wheel_area += vpi.wheel_info->contact_area;
             continue; // Ignore the movement modifier if caller specifies a bool
         }
 
-        for( const veh_ter_mod &mod : vp.info().wheel_terrain_modifiers() ) {
+        for( const veh_ter_mod &mod : vpi.wheel_info->terrain_modifiers ) {
             const bool ter_has_flag = tr.has_flag( mod.terrain_flag );
             if( ter_has_flag && mod.move_override ) {
                 move_mod = mod.move_override;
@@ -2103,7 +2104,7 @@ float map::vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modi
             continue;
         }
 
-        traction_wheel_area += 2.0 * vp.wheel_area() / move_mod;
+        traction_wheel_area += 2.0 * vpi.wheel_info->contact_area / move_mod;
     }
 
     return traction_wheel_area;

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -233,7 +233,7 @@ itype_id vehicle_part::fuel_current() const
 bool vehicle_part::fuel_set( const itype_id &fuel )
 {
     if( is_engine() ) {
-        for( const itype_id &avail : info().engine_fuel_opts() ) {
+        for( const itype_id &avail : info().engine_info->fuel_opts ) {
             if( fuel == avail ) {
                 ammo_pref = fuel;
                 return true;

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -135,8 +135,8 @@ std::string vehicle_part::name( bool with_prefix ) const
     if( base.engine_displacement() ) {
         res += string_format( _( "%gL " ), base.engine_displacement() / 100.0 );
     }
-    if( wheel_diameter() ) {
-        res += string_format( _( "%d\" " ), wheel_diameter() );
+    if( base.is_wheel() ) {
+        res += string_format( _( "%d\" " ), base.type->wheel->diameter );
     }
     res += info().name();
     if( base.has_var( "contained_name" ) ) {
@@ -502,23 +502,6 @@ bool vehicle_part::fault_set( const fault_id &f )
     }
     base.faults.insert( f );
     return true;
-}
-
-int vehicle_part::wheel_area() const
-{
-    return info().wheel_area();
-}
-
-/** Get wheel diameter (inches) or return 0 if part is not wheel */
-int vehicle_part::wheel_diameter() const
-{
-    return base.is_wheel() ? base.type->wheel->diameter : 0;
-}
-
-/** Get wheel width (inches) or return 0 if part is not wheel */
-int vehicle_part::wheel_width() const
-{
-    return base.is_wheel() ? base.type->wheel->width : 0;
 }
 
 npc *vehicle_part::crew() const

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2248,7 +2248,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
     }
 
     const std::optional<vpart_reference> vp_toolstation = vp.avail_part_with_feature( "VEH_TOOLS" );
-    if( vp_toolstation && vp_toolstation->info().get_toolkit_info() ) {
+    if( vp_toolstation && vp_toolstation->info().toolkit_info ) {
         const size_t vp_idx = vp_toolstation->part_index();
         const std::string vp_name = vp_toolstation->part().name( /* with_prefix = */ false );
 
@@ -2257,7 +2257,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         .on_submit( [this, vp_idx, vp_name] {
             Character &you = get_player_character();
             vehicle_part &vp = part( vp_idx );
-            std::set<itype_id> allowed_types = vp.info().get_toolkit_info()->allowed_types;
+            std::set<itype_id> allowed_types = vp.info().toolkit_info->allowed_types;
             for( const std::pair<const item, input_event> &pair : prepare_tools( vp ) )
             {
                 allowed_types.erase( pair.first.typeId() ); // one tool of each kind max

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -976,7 +976,7 @@ void vehicle::crash_terrain_around()
     for( const vpart_reference &vp : get_enabled_parts( "CRASH_TERRAIN_AROUND" ) ) {
         tripoint crush_target( 0, 0, -OVERMAP_LAYERS );
         const tripoint start_pos = vp.pos();
-        const transform_terrain_data &ttd = vp.info().transform_terrain;
+        const vpslot_terrain_transform &ttd = *vp.info().transform_terrain_info;
         for( size_t i = 0; i < eight_horizontal_neighbors.size() &&
              !here.inbounds_z( crush_target.z ); i++ ) {
             tripoint cur_pos = start_pos + eight_horizontal_neighbors[i];
@@ -1007,7 +1007,7 @@ void vehicle::transform_terrain()
     map &here = get_map();
     for( const vpart_reference &vp : get_enabled_parts( "TRANSFORM_TERRAIN" ) ) {
         const tripoint start_pos = vp.pos();
-        const transform_terrain_data &ttd = vp.info().transform_terrain;
+        const vpslot_terrain_transform &ttd = *vp.info().transform_terrain_info;
         bool prereq_fulfilled = false;
         for( const std::string &flag : ttd.pre_flags ) {
             if( here.has_flag( flag, start_pos ) ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Clean up vpart_info fields, vpslots and their accessor functions:
* Propagate time_duration for install/repair/remove times further up the call stack up to player_activity.
* Make terrain_transform use std::optional and the same loading logic as other vpslots.
* Refactors vehicle::has_engine_conflict to use std::optional and inlines veh_interact::is_drive_conflict.
* Remove trivial accessors from vpslots (vpart_info are mostly const refs; open them for reads with public modifier).
* Remove accessors for data inside vpslots - reason detailed below.

#### Describe the solution

Accessors for the vpslot data are mostly useless and slightly harmful;

Most are hiding bugs by returning some arbitrary value, false, false cast to float or false cast to integer, etc... if the part isn't of the expected type. These default values aren't normally used, but when they are used it is a bug - some code chunk treats the part as something it isn't.

Some are introducing new default values (e.g. `vpart_info::wheel_rolling_resistance()` returns 50 for non-wheel parts) that are never actually used - the function is only called via `wheel_cache` which can't have non-WHEEL parts, this behavior can be emulated in the loader or set as default in the wheel struct if ever desired.

Some (engine excludes) copy vectors with not much reason to - can be changed to pass by reference but why bother... Some (`rotor_diameter()`) is used as a hackish way to check `has_flag( VPART_ROTOR )` 6 times and only 3 times to actually get the diameter.

Considering the above, and the fact `vpart_info`s are const references past json finalizing stage, we can open the slot data with a public modifier and allow reading them directly, removing the need for accessors

#### Describe alternatives you've considered

#### Testing

Tests should catch most of the changes
UI change for engine exclusion tested manually (installing 2x hand paddles shouldn't be possible)
Trencher (ROCKWHEEL flag) tested manually
There shouldn't be player-facing changes

#### Additional context
