### PR TITLE
Inline `sm_to_ms_copy` for multi% cpu wins in congested places.

### DIFF
--- a/src/coordinate_conversions.cpp
+++ b/src/coordinate_conversions.cpp
@@ -143,16 +143,6 @@ point ms_to_sm_remain( int &x, int &y )
     return point( divide( x, SEEX, x ), divide( y, SEEY, y ) );
 }
 
-point sm_to_ms_copy( const point &p )
-{
-    return point( p.x * SEEX, p.y * SEEY );
-}
-
-tripoint sm_to_ms_copy( const tripoint &p )
-{
-    return tripoint( p.x * SEEX, p.y * SEEY, p.z );
-}
-
 void sm_to_ms( int &x, int &y )
 {
     x *= SEEX;

--- a/src/coordinate_conversions.h
+++ b/src/coordinate_conversions.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_COORDINATE_CONVERSIONS_H
 #define CATA_SRC_COORDINATE_CONVERSIONS_H
 
+#include "game_constants.h"
 #include "point.h"
 
 /**
@@ -136,8 +137,15 @@ inline tripoint ms_to_sm_remain( tripoint &p )
 // submap back to map squares, basically: x *= SEEX
 // Note: this gives you the map square coordinates of the top-left corner
 // of the given submap.
-point sm_to_ms_copy( const point &p );
-tripoint sm_to_ms_copy( const tripoint &p );
+inline point sm_to_ms_copy( const point &p )
+{
+    return point( p.x * SEEX, p.y * SEEY );
+}
+
+inline tripoint sm_to_ms_copy( const tripoint &p )
+{
+    return tripoint( p.x * SEEX, p.y * SEEY, p.z );
+}
 void sm_to_ms( int &x, int &y );
 inline void sm_to_ms( point &p )
 {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I noticed during a perf trace of a different PR that these functions were showing up kinda high up in total usage. @SurFlurer tried inlining them and found that it seemed to basically eliminate their cpu overhead. I poked at it a bunch until I felt confident the effect was real and not a cost shift. Also SurFlurer did the legwork to validate the extra include would be a noop in terms of extra build complexity.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Inline them in the header.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I created a repro condition with a fresh game. Spawned in a setting with a bunch of NPCs. Debug killed all monsters. Created a cage of reinforced glass doors outside the shelter. Spawned two wasps inside the cage. Saved, then instrumented waiting here for 3 hours 7 times before/after. Discarded the fastest and slowest one for each based on total samples inside `map::getlocal` (the primary caller to `sm_to_ms_copy`.). Then compared the cost of callers of `map::getlocal` because the effect was so dramatic that I wanted to validate higher order effects. Concluded my samples were reproducible enough to feel confident in the results. Savings in this test case were ~3.7% total cpu from `Creature::pos` (essentially the only caller of `map::getlocal`), 2.5% from `npc::assess_danger` in this example. I also anecdotally saw similar but more noisy results with the same setup but with cows instead of npcs.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This is a comparsion before/after, comparing the 'fastest' before case to the 'slowest' before case, so any other comparison would show more savings than pictured.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/c49afac5-b028-4a79-be55-b041f7c8a8e4)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->