### PR TITLE
Suppress -Wmaybe-uninitialized false positives in MinGW-w64 debug build

### DIFF
--- a/src/map_iterator.h
+++ b/src/map_iterator.h
@@ -34,7 +34,7 @@ class tripoint_range
                 point_generator( const Tripoint &_p, const tripoint_range &_range )
                     : p( _p ), range( _range ) {
                     // Make sure we start on a valid point
-                    if( range.predicate && !( *range.predicate )( p ) && p != range.endp ) {
+                    if( range.predicate && !range.predicate( p ) && p != range.endp ) {
                         operator++();
                     }
                 }
@@ -56,7 +56,7 @@ class tripoint_range
 
                         traits::z( p )++;
                         traits::y( p ) = traits::y( range.minp );
-                    } while( range.predicate && !( *range.predicate )( p ) && p != range.endp );
+                    } while( range.predicate && !range.predicate( p ) && p != range.endp );
 
                     return *this;
                 }
@@ -84,7 +84,7 @@ class tripoint_range
 
         Tripoint endp;
 
-        std::optional<std::function<bool( const Tripoint & )>> predicate;
+        std::function<bool( const Tripoint & )> predicate;
     public:
         using value_type = typename point_generator::value_type;
         using difference_type = typename point_generator::difference_type;

--- a/tests/map_iterator_test.cpp
+++ b/tests/map_iterator_test.cpp
@@ -136,11 +136,18 @@ TEST_CASE( "tripoint_range_iteration_order", "[tripoint_range]" )
     }
 }
 
+// Using static functions instead of lambdas to suppress -Wmaybe-uninitialized
+// false positives triggered by lambda's implicit anonymous data structure in
+// debug builds
+static bool tripoint_range_handle_bad_predicates_test_func( const tripoint & )
+{
+    return false;
+}
+
 TEST_CASE( "tripoint_range_handle_bad_predicates", "[tripoint_range]" )
 {
-    tripoint_range<tripoint> tested( tripoint( 4, 4, 0 ), tripoint( 6, 6, 0 ), []( const tripoint & ) {
-        return false;
-    } );
+    tripoint_range<tripoint> tested( tripoint( 4, 4, 0 ), tripoint( 6, 6, 0 ),
+                                     tripoint_range_handle_bad_predicates_test_func );
     REQUIRE( tested.empty() );
     int visited = 0;
     for( const tripoint &pt : tested ) {
@@ -228,6 +235,9 @@ TEST_CASE( "tripoint_range_circle_sizes_correct", "[tripoint_range]" )
     CHECK( points_in_radius_circ( tripoint_zero, 4 ).size() == 69 );
 }
 
+// Using static functions instead of lambdas to suppress -Wmaybe-uninitialized
+// false positives triggered by lambda's implicit anonymous data structure in
+// debug builds
 static bool tripoint_range_predicates_radius_test_func( const tripoint &pt )
 {
     return pt.z < 0;
@@ -259,12 +269,18 @@ TEST_CASE( "tripoint_range_predicates_radius", "[tripoint_range]" )
     CHECK( i == tested.size() );
 }
 
+// Using static functions instead of lambdas to suppress -Wmaybe-uninitialized
+// false positives triggered by lambda's implicit anonymous data structure in
+// debug builds
+static bool tripoint_range_predicates_test_func( const tripoint &pt )
+{
+    return pt.x == 0;
+}
+
 TEST_CASE( "tripoint_range_predicates", "[tripoint_range]" )
 {
-    tripoint_range<tripoint> tested( tripoint_north_west,
-    tripoint_south_east, []( const tripoint & pt ) {
-        return pt.x == 0;
-    } );
+    tripoint_range<tripoint> tested( tripoint_north_west, tripoint_south_east,
+                                     tripoint_range_predicates_test_func );
     std::vector<tripoint> expected = {
         tripoint_north, tripoint_zero, tripoint_south
     };


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
MinGW-w64 is generating maybe-uninitialized warnings in debug builds for `std::function` constructed from lambdas.

It seems to only happen with non-capturing lambdas, and the warning messages mention something about `std::_Any_data` so my guess is that the compiler thinks the lambdas' internal data used to keep the captured values are uninitialized.

#### Describe the solution
Convert the lambdas into static functions to suppress the warnings.

Also remove `std::optional` from `tripoint_range::predicate` because `std::function` already has a null state.

#### Describe alternatives you've considered
Somehow explain to the compiler that if a lambda does not capture any value, then its captured value data structure is okay to be uninitialized.

#### Testing
The debug build completed without warnings.

#### Additional context
