### PR TITLE
Fix Nested List lag in crafting menu

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1056,8 +1056,8 @@ static void expand_recipes( std::vector<const recipe *> &current,
     }
 }
 
-static std::string list_nested( const recipe *rec, const inventory &crafting_inv,
-                                const std::vector<npc *> &helpers, int indent = 0 )
+static std::string list_nested( const recipe *rec, const recipe_subset &available_recipes,
+                                int indent = 0 )
 {
     std::string description;
     availability avail( rec );
@@ -1065,9 +1065,9 @@ static std::string list_nested( const recipe *rec, const inventory &crafting_inv
         description += colorize( std::string( indent,
                                               ' ' ) + rec->result_name() + ":\n", avail.color() );
         for( const recipe_id &r : rec->nested_category_data ) {
-            description += list_nested( &r.obj(), crafting_inv, helpers, indent + 2 );
+            description += list_nested( &r.obj(), available_recipes, indent + 2 );
         }
-    } else if( get_avatar().has_recipe( rec, crafting_inv, helpers ) ) {
+    } else if( available_recipes.contains( rec ) ){
         description += colorize( std::string( indent,
                                               ' ' ) + rec->result_name() + "\n", avail.color() );
     }
@@ -1463,7 +1463,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
                 wnoutrefresh( w_iteminfo );
             } else if( cur_recipe->is_nested() ) {
                 std::string desc = cur_recipe->description.translated() + "\n\n";;
-                desc += list_nested( cur_recipe, crafting_inv, helpers );
+                desc += list_nested( cur_recipe, available_recipes );
                 fold_and_print( w_iteminfo, point_zero, item_info_width, c_light_gray, desc );
                 scrollbar().offset_x( item_info_width - 1 ).offset_y( 0 ).content_size( 1 ).viewport_size( getmaxy(
                             w_iteminfo ) ).apply( w_iteminfo );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1067,7 +1067,7 @@ static std::string list_nested( const recipe *rec, const recipe_subset &availabl
         for( const recipe_id &r : rec->nested_category_data ) {
             description += list_nested( &r.obj(), available_recipes, indent + 2 );
         }
-    } else if( available_recipes.contains( rec ) ){
+    } else if( available_recipes.contains( rec ) ) {
         description += colorize( std::string( indent,
                                               ' ' ) + rec->result_name() + "\n", avail.color() );
     }


### PR DESCRIPTION
#### Summary
Performance "Fix Nested List lag in crafting menu"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Showing nested recipe does not use cache in spite of cache exists.

#### Describe the solution
use cache available_recipes.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Recipe is displayed collectly. Performance is improved.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->