### PR TITLE
Allow owned vehicle cargo items in barter

### DIFF
--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -111,9 +111,9 @@ trade_ui::trade_ui( party_t &you, npc &trader, currency_t cost, std::string titl
       _parties{ &trader, &you }, _title( std::move( title ) )
 
 {
-    map &here = get_map();
     _panes[_you]->add_character_items( you );
     _panes[_you]->add_nearby_items( 1 );
+    map &here = get_map();
     for( const wrapped_vehicle &wv : here.get_vehicles() ) {
         if( wv.v->is_owned_by( you ) ) {
             for( const tripoint pos : wv.v->get_points() ) {

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -19,6 +19,7 @@
 #include "point.h"
 #include "string_formatter.h"
 #include "type_id.h"
+#include "vehicle.h"
 
 static const flag_id json_flag_NO_UNWIELD( "NO_UNWIELD" );
 static const item_category_id item_category_ITEMS_WORN( "ITEMS_WORN" );
@@ -110,8 +111,18 @@ trade_ui::trade_ui( party_t &you, npc &trader, currency_t cost, std::string titl
       _parties{ &trader, &you }, _title( std::move( title ) )
 
 {
+    map &here = get_map();
     _panes[_you]->add_character_items( you );
     _panes[_you]->add_nearby_items( 1 );
+    for( const wrapped_vehicle &wv : here.get_vehicles() ) {
+        if( wv.v->is_owned_by( you ) ) {
+            for( const tripoint pos : wv.v->get_points() ) {
+                if( here.inbounds( pos ) && square_dist( you.pos(), pos ) > 1 ) {
+                    _panes[_you]->add_vehicle_items( pos );
+                }
+            }
+        }
+    }
     _panes[_trader]->add_character_items( trader );
     if( trader.is_shopkeeper() ) {
         _panes[_trader]->categorize_map_items( true );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -965,9 +965,7 @@ class vehicle
             theft_time = std::nullopt;
             old_owner = faction_id::NULL_ID();
         }
-        void set_owner( const faction_id &new_owner ) {
-            owner = new_owner;
-        }
+        void set_owner( const faction_id &new_owner );
         void set_owner( const Character &c );
         faction_id get_owner() const {
             return owner;


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Allow owned vehicle cargo items in barter

#### Describe the solution

What it says on the tin

Also makes taking ownership of a vehicle (after theft timer expires) assign cargo items' owner - otherwise default spawned items remain owner-less until player picks up/drops them

#### Describe alternatives you've considered

#### Testing

Spawn a vehicle, take ownership (e.g. examine it or try to drive), talk to npc and try to barter - vehicle cargo should be available in trade screen

#### Additional context
