### PR TITLE
Fix grenade manhacks

### DIFF
--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -702,6 +702,28 @@
     "use_action": [ "MACE" ]
   },
   {
+    "id": "c4_payload",
+    "type": "TOOL",
+    "category": "weapons",
+    "name": { "str": "C-4 payload" },
+    "description": "This is a dummy item used by c4 hacks.  You should never see it outside of debug.",
+    "symbol": "*",
+    "color": "dark_gray",
+    "use_action": { "target": "c4armed", "target_timer": "10 seconds", "type": "transform" },
+    "flags": [ "TRADER_AVOID", "BOMB", "GRENADE", "ZERO_WEIGHT" ]
+  },
+  {
+    "id": "mininuke_payload",
+    "type": "TOOL",
+    "category": "weapons",
+    "name": { "str": "mininuke payload" },
+    "description": "This is a dummy item used by mininuke hacks.  You should never see it outside of debug.",
+    "symbol": "*",
+    "color": "dark_gray",
+    "use_action": { "target": "mininuke_act", "target_timer": "20 seconds", "type": "transform" },
+    "flags": [ "TRADER_AVOID", "BOMB", "GRENADE", "ZERO_WEIGHT" ]
+  },
+  {
     "id": "tear_gas_payload",
     "type": "TOOL",
     "category": "weapons",

--- a/data/json/monsters/drones.json
+++ b/data/json/monsters/drones.json
@@ -40,7 +40,7 @@
     "speed": 250,
     "color": "light_gray",
     "revert_to_itype": "bot_c4_hack",
-    "starting_ammo": { "c4": 1 },
+    "starting_ammo": { "c4_payload": 1 },
     "special_attacks": [ [ "KAMIKAZE", 0 ] ],
     "armor": { "cut": 4, "bullet": 3 }
   },
@@ -116,7 +116,7 @@
     "speed": 150,
     "color": "light_green_magenta",
     "revert_to_itype": "bot_mininuke_hack",
-    "starting_ammo": { "mininuke": 1 },
+    "starting_ammo": { "mininuke_payload": 1 },
     "special_attacks": [ [ "KAMIKAZE", 0 ] ],
     "armor": { "bash": 1, "cut": 6, "bullet": 5 }
   },

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -5303,7 +5303,7 @@ bool mattack::kamikaze( monster *z )
 {
     if( z->ammo.empty() ) {
         // We somehow lost our ammo! Toggle this special off so we stop processing
-        add_msg_debug( debugmode::DF_MATTACK, "Missing ammo in kamikaze special for %s.", z->name() );
+        debugmsg( "Missing ammo in kamikaze special for %s.", z->name() );
         z->disable_special( "KAMIKAZE" );
         return true;
     }
@@ -5323,15 +5323,15 @@ bool mattack::kamikaze( monster *z )
         const use_function *usage = bomb_type->get_use( "transform" );
         if( usage == nullptr ) {
             // Invalid item usage, Toggle this special off so we stop processing
-            add_msg_debug( debugmode::DF_MATTACK, "Invalid bomb transform use in kamikaze special for %s.",
-                           z->name() );
+            debugmsg( "Invalid bomb transform use in kamikaze special for %s.",
+                      z->name() );
             z->disable_special( "KAMIKAZE" );
             return true;
         }
         const iuse_transform *actor = dynamic_cast<const iuse_transform *>( usage->get_actor_ptr() );
         if( actor == nullptr ) {
             // Invalid bomb item, Toggle this special off so we stop processing
-            add_msg_debug( debugmode::DF_MATTACK, "Invalid bomb type in kamikaze special for %s.", z->name() );
+            debugmsg( "Invalid bomb type in kamikaze special for %s.", z->name() );
             z->disable_special( "KAMIKAZE" );
             return true;
         }
@@ -5355,18 +5355,20 @@ bool mattack::kamikaze( monster *z )
 
     const use_function *use = act_bomb_type->get_use( "explosion" );
     if( use == nullptr ) {
+        // The explosion may be in countdown_action instead
+    }
+    if( use == nullptr ) {
         // Invalid active bomb item usage, Toggle this special off so we stop processing
-        add_msg_debug( debugmode::DF_MATTACK,
-                       "Invalid active bomb explosion use in kamikaze special for %s.",
-                       z->name() );
+        debugmsg( "Invalid active bomb explosion use in kamikaze special for %s.",
+                  z->name() );
         z->disable_special( "KAMIKAZE" );
         return true;
     }
     const explosion_iuse *exp_actor = dynamic_cast<const explosion_iuse *>( use->get_actor_ptr() );
     if( exp_actor == nullptr ) {
         // Invalid active bomb item, Toggle this special off so we stop processing
-        add_msg_debug( debugmode::DF_MATTACK, "Invalid active bomb type in kamikaze special for %s.",
-                       z->name() );
+        debugmsg( "Invalid active bomb type in kamikaze special for %s.",
+                  z->name() );
         z->disable_special( "KAMIKAZE" );
         return true;
     }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -161,11 +161,7 @@ static const itype_id itype_bot_grenade_hack( "bot_grenade_hack" );
 static const itype_id itype_bot_manhack( "bot_manhack" );
 static const itype_id itype_bot_mininuke_hack( "bot_mininuke_hack" );
 static const itype_id itype_bot_pacification_hack( "bot_pacification_hack" );
-static const itype_id itype_c4( "c4" );
-static const itype_id itype_c4armed( "c4armed" );
 static const itype_id itype_e_handcuffs( "e_handcuffs" );
-static const itype_id itype_mininuke( "mininuke" );
-static const itype_id itype_mininuke_act( "mininuke_act" );
 
 static const limb_score_id limb_score_grip( "grip" );
 static const limb_score_id limb_score_reaction( "reaction" );


### PR DESCRIPTION

#### Summary
Bugfixes "Fix grenade manhacks"

#### Purpose of change

Fix  #66758

#### Describe the solution

* Use `countdown_action` instead of `use_action`.
* Elevate `add_msg_debug` to `debugmsg`. These are bad errors and should be visible.

#### Describe alternatives you've considered



#### Testing

All the manhacks in vanilla fly to their target, light up and then blow up on its face.

#### Additional context

