### PR TITLE
Put Some Clothes On There Are Survivors Looking

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2600,9 +2600,17 @@
   {
     "id": "mil_base_corpse_soldier",
     "type": "item_group",
-    "//": "Soldier corpse with clothes, without gear.",
+    "//": "Nested to damage corpse.",
     "subtype": "collection",
-    "entries": [ { "group": "mil_base_clothes_corpse_soldier", "damage": [ 1, 4 ] }, { "item": "corpse_generic_human" } ]
+    "entries": [ { "group": "mil_base_corpse_corpse_soldier", "damage": [ 2, 4 ] } ]
+  },
+  {
+    "id": "mil_base_corpse_corpse_soldier",
+    "type": "item_group",
+    "//": "Nested to damage all gear.",
+    "subtype": "collection",
+    "container-item": "corpse_generic_human",
+    "entries": [ { "group": "mil_base_clothes_corpse_soldier", "damage": [ 1, 4 ] } ]
   },
   {
     "id": "mil_base_clothes_corpse_soldier",

--- a/data/json/itemgroups/Locations_MapExtras/map_extras.json
+++ b/data/json/itemgroups/Locations_MapExtras/map_extras.json
@@ -3,79 +3,112 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "map_extra_science",
+    "//": "Nested group to damage the container-item",
+    "entries": [ { "group": "map_extra_science_corpse", "prob": 100, "damage": [ 3, 4 ] } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "map_extra_science_corpse",
+    "container-item": "corpse_generic_human",
+    "//": "Half the time a wallet with an id card, all the time a lab coat",
     "entries": [
-      { "group": "wallets_science", "prob": 50, "//": "half the time a wallet with an id card" },
-      { "item": "coat_lab", "damage-min": 1, "damage-max": 3, "//": "all the time a lab coat" },
+      { "group": "wallets_science", "prob": 50 },
+      { "item": "coat_lab", "damage": [ 1, 3 ] },
       { "group": "science" },
-      { "group": "lab_pants", "damage-min": 1, "damage-max": 3 },
-      { "group": "socks_unisex", "damage-min": 1, "damage-max": 3 },
-      { "group": "lab_shoes", "damage-min": 1, "damage-max": 3 },
-      { "group": "lab_torso", "damage-min": 1, "damage-max": 3 },
-      { "group": "underwear", "damage-min": 1, "damage-max": 3 },
-      { "item": "corpse", "damage": 4, "//": "always a corpse, pulped!" }
+      { "group": "lab_pants", "damage": [ 1, 3 ] },
+      { "group": "socks_unisex", "damage": [ 1, 3 ] },
+      { "group": "lab_shoes", "damage": [ 1, 3 ] },
+      { "group": "lab_torso", "damage": [ 1, 3 ] },
+      { "group": "underwear", "damage": [ 1, 3 ] }
     ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "map_extra_college_camping",
+    "entries": [ { "group": "map_extra_college_camping_corpse", "prob": 100, "damage": [ 3, 4 ] } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "map_extra_college_camping_corpse",
+    "container-item": "corpse_generic_human",
     "entries": [
-      { "group": "underwear", "damage-min": 1, "damage-max": 3 },
-      { "group": "shirts", "damage-min": 1, "damage-max": 4 },
-      { "group": "jackets", "damage-min": 1, "damage-max": 4, "prob": 30 },
-      { "group": "pants", "damage-min": 1, "damage-max": 4 },
-      { "group": "socks_unisex", "damage-min": 1, "damage-max": 4 },
-      { "group": "shoes", "damage-min": 1, "damage-max": 4 },
-      { "group": "hatstore_hats", "damage-min": 1, "damage-max": 4, "prob": 40 },
+      { "group": "underwear", "damage": [ 1, 3 ] },
+      { "group": "shirts", "damage": [ 1, 4 ] },
+      { "group": "jackets", "damage": [ 1, 4 ], "prob": 30 },
+      { "group": "pants", "damage": [ 1, 4 ] },
+      { "group": "socks_unisex", "damage": [ 1, 4 ] },
+      { "group": "shoes", "damage": [ 1, 4 ] },
+      { "group": "hatstore_hats", "damage": [ 1, 4 ], "prob": 40 },
       { "group": "college_camping", "prob": 50 },
       { "group": "college_camping", "prob": 80 },
       { "group": "SUS_book_nonf_soft", "prob": 20 },
       { "item": "pride_flag", "prob": 5 },
-      { "item": "national_flag", "prob": 2 },
-      { "item": "corpse", "damage": 4 }
+      { "item": "national_flag", "prob": 2 }
     ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "map_extra_college_sports",
+    "entries": [ { "group": "map_extra_college_sports_corpse", "prob": 100, "damage": [ 3, 4 ] } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "map_extra_college_sports_corpse",
+    "container-item": "corpse_generic_human",
     "entries": [
-      { "group": "underwear", "damage-min": 1, "damage-max": 3 },
-      { "group": "shirts", "damage-min": 1, "damage-max": 4 },
-      { "group": "jackets", "damage-min": 1, "damage-max": 4, "prob": 30 },
-      { "group": "pants", "damage-min": 1, "damage-max": 4 },
-      { "group": "socks_unisex", "damage-min": 1, "damage-max": 4 },
-      { "group": "shoes", "damage-min": 1, "damage-max": 4 },
-      { "group": "hatstore_hats", "damage-min": 1, "damage-max": 4, "prob": 40 },
+      { "group": "underwear", "damage": [ 1, 3 ] },
+      { "group": "shirts", "damage": [ 1, 4 ] },
+      { "group": "jackets", "damage": [ 1, 4 ], "prob": 30 },
+      { "group": "pants", "damage": [ 1, 4 ] },
+      { "group": "socks_unisex", "damage": [ 1, 4 ] },
+      { "group": "shoes", "damage": [ 1, 4 ] },
+      { "group": "hatstore_hats", "damage": [ 1, 4 ], "prob": 40 },
       { "group": "college_sports", "prob": 50 },
       { "group": "college_sports", "prob": 90 },
       { "group": "SUS_book_sports", "prob": 30 },
-      { "item": "pride_flag", "prob": 2 },
-      { "item": "corpse", "damage": 4 }
+      { "item": "pride_flag", "prob": 2 }
     ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "map_extra_college_lake",
+    "entries": [ { "group": "map_extra_college_lake_corpse", "prob": 100, "damage": [ 3, 4 ] } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "map_extra_college_lake_corpse",
+    "container-item": "corpse_generic_human",
     "entries": [
-      { "group": "underwear", "damage-min": 1, "damage-max": 3 },
-      { "group": "shirts", "damage-min": 1, "damage-max": 4 },
-      { "group": "jackets", "damage-min": 1, "damage-max": 4, "prob": 30 },
-      { "group": "pants", "damage-min": 1, "damage-max": 4 },
+      { "group": "underwear", "damage": [ 1, 3 ] },
+      { "group": "shirts", "damage": [ 1, 4 ] },
+      { "group": "jackets", "damage": [ 1, 4 ], "prob": 30 },
+      { "group": "pants", "damage": [ 1, 4 ] },
       { "group": "socks_unisex", "damage-min": 1, "damage-max": 4 },
       { "group": "shoes", "damage-min": 1, "damage-max": 4 },
       { "group": "hatstore_hats", "damage-min": 1, "damage-max": 4, "prob": 40 },
       { "group": "college_lake", "prob": 50 },
       { "group": "college_lake", "prob": 70 },
-      { "group": "SUS_book_nonf_soft", "prob": 25 },
-      { "item": "corpse", "damage": 4 }
+      { "group": "SUS_book_nonf_soft", "prob": 25 }
     ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "map_extra_drugdeal",
+    "entries": [ { "group": "map_extra_drugdeal_corpse", "prob": 100, "damage": 4 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "map_extra_drugdeal_corpse",
+    "container-item": "corpse_generic_human",
     "entries": [
       { "group": "drugdealer", "prob": 75 },
       {
@@ -92,15 +125,21 @@
       { "group": "lab_shoes", "damage-min": 1, "damage-max": 4, "prob": 50 },
       { "group": "shirts", "damage-min": 1, "damage-max": 4, "prob": 50 },
       { "group": "jackets", "damage-min": 1, "damage-max": 4, "prob": 30 },
-      { "group": "underwear", "damage-min": 1, "damage-max": 3 },
-      { "item": "corpse", "damage": 4 }
+      { "group": "underwear", "damage-min": 1, "damage-max": 3 }
     ]
   },
   {
-    "id": "map_extra_police",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "mon_zombie_cop_death_drops" }, { "item": "corpse", "damage": 4 } ]
+    "id": "map_extra_police",
+    "entries": [ { "group": "map_extra_police_corpse", "prob": 100, "damage": 4 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "map_extra_police_corpse",
+    "container-item": "corpse_generic_human",
+    "entries": [ { "group": "mon_zombie_cop_death_drops" } ]
   },
   {
     "type": "item_group",
@@ -135,17 +174,6 @@
       { "item": "cigar_butt" },
       { "item": "cig_butt" },
       { "item": "can_drink" }
-    ]
-  },
-  {
-    "type": "item_group",
-    "subtype": "distribution",
-    "id": "corpse_in_body_bag",
-    "container-item": "bag_body_bag",
-    "entries": [
-      { "group": "corpse_male", "damage": [ 1, 4 ] },
-      { "group": "corpse_male", "damage": [ 1, 4 ] },
-      { "group": "corpse_child", "damage": [ 1, 4 ] }
     ]
   }
 ]

--- a/data/json/itemgroups/Locations_MapExtras/prison_item_groups.json
+++ b/data/json/itemgroups/Locations_MapExtras/prison_item_groups.json
@@ -41,8 +41,16 @@
   },
   {
     "type": "item_group",
-    "id": "prisoner_or_cop_clothes",
     "subtype": "collection",
+    "id": "prisoner_or_cop_clothes",
+    "//": "Nested group to damage the container-item",
+    "entries": [ { "group": "prisoner_or_cop_clothes_corpse", "prob": 100, "damage": [ 3, 4 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "prisoner_or_cop_clothes_corpse",
+    "subtype": "collection",
+    "container-item": "corpse_generic_human",
     "entries": [
       { "group": "male_underwear", "damage": [ 1, 4 ] },
       {
@@ -68,8 +76,7 @@
         "prob": 90
       },
       { "group": "socks_unisex", "damage": [ 1, 4 ] },
-      { "group": "clothing_glasses", "prob": 20 },
-      { "item": "corpse_generic_human", "damage": 4 }
+      { "group": "clothing_glasses", "prob": 20 }
     ]
   }
 ]

--- a/data/json/itemgroups/corpses.json
+++ b/data/json/itemgroups/corpses.json
@@ -84,42 +84,70 @@
   {
     "id": "corpses",
     "type": "item_group",
-    "items": [
-      [ "corpse_generic_male", 80 ],
-      [ "corpse_generic_female", 80 ],
-      [ "corpse_generic_boy", 15 ],
-      [ "corpse_generic_girl", 15 ],
-      [ "corpse_generic_human", 10 ],
-      [ "corpse_generic_gunned", 40 ],
-      [ "corpse_generic_infected", 40 ],
-      [ "corpse_bloody", 10 ],
-      [ "corpse_painful", 10 ],
-      [ "corpse_scorched", 10 ],
-      [ "corpse_stabbed", 10 ],
-      [ "corpse_gunned", 10 ],
-      [ "corpse_halved_upper", 10 ],
-      [ "corpse_half_beheaded", 10 ],
-      [ "corpse_child_calm", 10 ],
-      [ "corpse_child_gunned", 10 ],
-      [ "corpse_oldwoman_jewelry", 10 ]
+    "//": "Damage based off descriptions",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "corpse_generic_male", "prob": 80, "damage": [ 0, 1 ] },
+      { "group": "corpse_generic_female", "prob": 80, "damage": [ 0, 1 ] },
+      { "group": "corpse_generic_boy", "prob": 15, "damage": [ 0, 1 ] },
+      { "group": "corpse_generic_girl", "prob": 15, "damage": [ 0, 1 ] },
+      { "group": "corpse_generic_human", "prob": 10, "damage": [ 0, 1 ] },
+      { "group": "corpse_generic_gunned", "prob": 40, "damage": [ 1, 3 ] },
+      { "group": "corpse_generic_infected", "prob": 40 },
+      { "group": "corpse_bloody", "prob": 10, "damage": [ 1, 3 ] },
+      { "group": "corpse_painful", "prob": 10, "damage": [ 0, 2 ] },
+      { "group": "corpse_scorched", "prob": 10, "damage": [ 3, 4 ] },
+      { "group": "corpse_stabbed", "prob": 10, "damage": [ 1, 3 ] },
+      { "group": "corpse_gunned", "prob": 10, "damage": [ 1, 3 ] },
+      { "group": "corpse_halved_upper", "prob": 10, "damage": 4 },
+      { "group": "corpse_half_beheaded", "prob": 10, "damage": 4 },
+      { "group": "corpse_child_calm", "prob": 10 },
+      { "group": "corpse_child_gunned", "prob": 10, "damage": [ 2, 4 ] },
+      { "group": "corpse_oldwoman_jewelry", "prob": 10, "damage": [ 1, 3 ] }
     ]
   },
   {
-    "id": "corpses_bodybag",
+    "id": "corpses_no_items",
     "type": "item_group",
-    "items": [ { "group": "corpses", "prob": 100, "container-item": "bag_body_bag" } ]
+    "subtype": "distribution",
+    "entries": [
+      { "item": "corpse_generic_male", "prob": 80, "damage": [ 0, 1 ] },
+      { "item": "corpse_generic_female", "prob": 80, "damage": [ 0, 1 ] },
+      { "item": "corpse_generic_boy", "prob": 15, "damage": [ 0, 1 ] },
+      { "item": "corpse_generic_girl", "prob": 15, "damage": [ 0, 1 ] },
+      { "item": "corpse_generic_human", "prob": 10, "damage": [ 0, 1 ] },
+      { "item": "corpse_generic_gunned", "prob": 40, "damage": [ 1, 3 ] },
+      { "item": "corpse_generic_infected", "prob": 40 },
+      { "item": "corpse_bloody", "prob": 10, "damage": [ 1, 3 ] },
+      { "item": "corpse_painful", "prob": 10, "damage": [ 0, 2 ] },
+      { "item": "corpse_scorched", "prob": 10, "damage": [ 3, 4 ] },
+      { "item": "corpse_stabbed", "prob": 10, "damage": [ 1, 3 ] },
+      { "item": "corpse_gunned", "prob": 10, "damage": [ 1, 3 ] },
+      { "item": "corpse_halved_upper", "prob": 10, "damage": 4 },
+      { "item": "corpse_half_beheaded", "prob": 10, "damage": 4 },
+      { "item": "corpse_child_calm", "prob": 10 },
+      { "item": "corpse_child_gunned", "prob": 10, "damage": [ 2, 4 ] },
+      { "item": "corpse_oldwoman_jewelry", "prob": 10, "damage": [ 1, 3 ] }
+    ]
+  },
+  {
+    "id": "corpse_in_body_bag",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "bag_body_bag",
+    "entries": [ { "group": "corpses_no_items", "damage": [ 0, 1 ] } ]
   },
   {
     "id": "corpse_male",
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "item": "corpse_generic_male" },
-      { "item": "corpse_bloody" },
-      { "item": "corpse_painful" },
-      { "item": "corpse_stabbed" },
-      { "item": "corpse_half_beheaded" },
-      { "item": "corpse_generic_boy" }
+      { "group": "corpse_generic_male", "damage": [ 0, 1 ] },
+      { "group": "corpse_bloody", "damage": [ 1, 3 ] },
+      { "group": "corpse_painful", "damage": [ 0, 2 ] },
+      { "group": "corpse_stabbed", "prob": 10, "damage": [ 1, 3 ] },
+      { "group": "corpse_half_beheaded", "damage": 4 },
+      { "group": "corpse_generic_boy", "damage": [ 0, 1 ] }
     ]
   },
   {
@@ -127,19 +155,139 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "item": "corpse_generic_female" },
-      { "item": "corpse_bloody" },
-      { "item": "corpse_painful" },
-      { "item": "corpse_gunned" },
-      { "item": "corpse_half_beheaded" },
-      { "item": "corpse_oldwoman_jewelry" },
-      { "item": "corpse_generic_girl" }
+      { "group": "corpse_generic_female", "damage": [ 0, 1 ] },
+      { "group": "corpse_bloody", "damage": [ 1, 3 ] },
+      { "group": "corpse_painful", "damage": [ 0, 2 ] },
+      { "group": "corpse_gunned", "damage": [ 1, 3 ] },
+      { "group": "corpse_half_beheaded", "damage": 4 },
+      { "group": "corpse_oldwoman_jewelry", "damage": [ 1, 3 ] },
+      { "group": "corpse_generic_girl", "damage": [ 0, 1 ] }
     ]
   },
   {
     "id": "corpse_child",
     "type": "item_group",
     "subtype": "distribution",
-    "entries": [ { "item": "corpse_child_calm" }, { "item": "corpse_child_gunned" } ]
+    "entries": [ { "group": "corpse_child_calm" }, { "group": "corpse_child_gunned" } ]
+  },
+  {
+    "id": "corpse_generic_human",
+    "//": "Bc of corpses being partially hardcoded container-item in entries doesn't work so these get to be one group per corpse for now",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_generic_human",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_generic_male",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_generic_male",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_generic_female",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_generic_female",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_generic_boy",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_generic_boy",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_generic_girl",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_generic_girl",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_generic_gunned",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_generic_gunned",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_generic_infected",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_generic_infected",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_bloody",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_bloody",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_painful",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_painful",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_scorched",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_scorched",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_stabbed",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_stabbed",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_gunned",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_gunned",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_halved_upper",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_halved_upper",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_half_beheaded",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_half_beheaded",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_child_calm",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_child_calm",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_child_gunned",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_child_gunned",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
+  },
+  {
+    "id": "corpse_oldwoman_jewelry",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "corpse_oldwoman_jewelry",
+    "entries": [ { "group": "default_zombie_death_drops" } ]
   }
 ]

--- a/data/json/mapgen/hazardous_waste_sarcophagus.json
+++ b/data/json/mapgen/hazardous_waste_sarcophagus.json
@@ -289,7 +289,7 @@
         "c": { "item": "office_supplies", "chance": 60 },
         "l": { "item": "cleaning", "chance": 60, "repeat": 2 },
         "F": { "item": "office_paper", "chance": 50 },
-        " ": { "item": "corpse_and_science", "chance": 1 },
+        " ": { "item": "map_extra_science", "chance": 1 },
         "~": [
           { "item": "trash", "chance": 15 },
           { "item": "sewer", "chance": 15 },
@@ -339,12 +339,6 @@
       { "group": "toxic_waste_mx_chems", "prob": 35 },
       { "item": "55gal_drum", "prob": 50 }
     ]
-  },
-  {
-    "id": "corpse_and_science",
-    "type": "item_group",
-    "subtype": "collection",
-    "entries": [ { "item": "corpse_generic_human", "prob": 100 }, { "group": "science", "prob": 100 } ]
   },
   {
     "id": "nanomaterials",

--- a/data/json/mapgen/hospital.json
+++ b/data/json/mapgen/hospital.json
@@ -48,12 +48,12 @@
       { "x": -4, "y": 2, "parts": [ "frame#se", "halfboard#se" ] }
     ],
     "items": [
-      { "x": -2, "y": 0, "chance": 90, "item_groups": [ "corpses_bodybag" ] },
-      { "x": -2, "y": 1, "chance": 90, "item_groups": [ "corpses_bodybag" ] },
-      { "x": -3, "y": 0, "chance": 90, "item_groups": [ "corpses_bodybag" ] },
-      { "x": -3, "y": 1, "chance": 90, "item_groups": [ "corpses_bodybag" ] },
-      { "x": -4, "y": 0, "chance": 90, "item_groups": [ "corpses_bodybag" ] },
-      { "x": -4, "y": 1, "chance": 90, "item_groups": [ "corpses_bodybag" ] }
+      { "x": -2, "y": 0, "chance": 90, "item_groups": [ "corpse_in_body_bag" ] },
+      { "x": -2, "y": 1, "chance": 90, "item_groups": [ "corpse_in_body_bag" ] },
+      { "x": -3, "y": 0, "chance": 90, "item_groups": [ "corpse_in_body_bag" ] },
+      { "x": -3, "y": 1, "chance": 90, "item_groups": [ "corpse_in_body_bag" ] },
+      { "x": -4, "y": 0, "chance": 90, "item_groups": [ "corpse_in_body_bag" ] },
+      { "x": -4, "y": 1, "chance": 90, "item_groups": [ "corpse_in_body_bag" ] }
     ]
   },
   {
@@ -62,7 +62,7 @@
     "nested_mapgen_id": "pile_bodybag_corpses",
     "object": {
       "mapgensize": [ 3, 3 ],
-      "place_items": [ { "item": "corpses_bodybag", "x": [ 0, 2 ], "y": [ 0, 2 ], "chance": 100, "repeat": [ 20, 40 ] } ]
+      "place_items": [ { "item": "corpse_in_body_bag", "x": [ 0, 2 ], "y": [ 0, 2 ], "chance": 100, "repeat": [ 20, 40 ] } ]
     }
   },
   {

--- a/data/json/mapgen/motel.json
+++ b/data/json/mapgen/motel.json
@@ -795,11 +795,11 @@
     "nested_mapgen_id": "corpse_crossbow_1x1",
     "object": {
       "mapgensize": [ 1, 1 ],
-      "place_item": [
-        { "item": "corpse_generic_human", "x": 0, "y": 0, "chance": 100 },
-        { "item": "compcrossbow", "x": 0, "y": 0, "chance": 100 }
+      "place_item": [ { "item": "compcrossbow", "x": 0, "y": 0, "chance": 100 } ],
+      "place_items": [
+        { "item": "corpses", "x": 0, "y": 0, "chance": 100 },
+        { "item": "bolt_makeshift", "x": 0, "y": 0, "repeat": [ 1, 3 ], "chance": 66 }
       ],
-      "place_items": [ { "item": "bolt_makeshift", "x": 0, "y": 0, "repeat": [ 1, 3 ], "chance": 66 } ],
       "place_fields": [ { "field": "fd_blood", "x": 0, "y": 0, "intensity": [ 1, 3 ], "age": 10 } ]
     }
   },

--- a/data/json/mapgen/nested/aux_nested.json
+++ b/data/json/mapgen/nested/aux_nested.json
@@ -270,8 +270,10 @@
     "nested_mapgen_id": "corpse_blood_casings_3x3",
     "object": {
       "mapgensize": [ 3, 3 ],
-      "place_item": [ { "item": "corpse_generic_human", "x": 0, "y": 0, "chance": 100 } ],
-      "place_items": [ { "item": "ammo_casings", "x": [ 0, 2 ], "y": [ 0, 2 ], "chance": 50 } ],
+      "place_items": [
+        { "item": "corpses", "x": 0, "y": 0, "chance": 100 },
+        { "item": "ammo_casings", "x": [ 0, 2 ], "y": [ 0, 2 ], "chance": 50 }
+      ],
       "place_fields": [ { "field": "fd_blood", "x": [ 0, 2 ], "y": [ 0, 2 ], "intensity": 1, "age": 10 } ]
     }
   },
@@ -281,7 +283,7 @@
     "nested_mapgen_id": "corpse_blood_1x1",
     "object": {
       "mapgensize": [ 1, 1 ],
-      "place_item": [ { "item": "corpse_generic_human", "x": 0, "y": 0, "chance": 100 } ],
+      "place_items": [ { "item": "corpses", "x": 0, "y": 0, "chance": 100 } ],
       "place_fields": [ { "field": "fd_blood", "x": 0, "y": 0, "intensity": [ 1, 3 ], "age": 10 } ]
     }
   },
@@ -291,8 +293,10 @@
     "nested_mapgen_id": "corpse_blood_casings_1x1",
     "object": {
       "mapgensize": [ 1, 1 ],
-      "place_item": [ { "item": "corpse_generic_human", "x": 0, "y": 0, "chance": 50, "repeat": [ 1, 3 ] } ],
-      "place_items": [ { "item": "casings", "x": 0, "y": 0, "chance": 100 } ],
+      "place_items": [
+        { "item": "corpses", "x": 0, "y": 0, "chance": 50, "repeat": [ 1, 3 ] },
+        { "item": "casings", "x": 0, "y": 0, "chance": 100 }
+      ],
       "place_fields": [
         { "field": "fd_blood", "x": 0, "y": 0, "intensity": 2, "age": 10 },
         { "field": "fd_gibs_flesh", "x": 0, "y": 0, "intensity": 1, "age": 10 }

--- a/data/json/mapgen/riverside/whaleys_house_river.json
+++ b/data/json/mapgen/riverside/whaleys_house_river.json
@@ -286,7 +286,7 @@
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": { "X": "t_pit_corpsed", "x": "t_pit", "4": "t_gutter_downspout" },
       "items": {
-        "n": [ { "item": "corpses", "chance": 33 }, { "item": "butcher_tools", "chance": 75, "repeat": [ 1, 3 ] } ],
+        "n": [ { "item": "corpses_no_items", "chance": 33 }, { "item": "butcher_tools", "chance": 75, "repeat": [ 1, 3 ] } ],
         "X": { "item": "creepy", "chance": 50, "repeat": [ 1, 2 ] },
         ".": { "item": "creepy", "chance": 10 }
       },

--- a/data/json/mapgen/survivor_forest_camp.json
+++ b/data/json/mapgen/survivor_forest_camp.json
@@ -122,42 +122,58 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "clothes_unisex_survival",
+    "entries": [
+      { "group": "underwear_unisex", "prob": 100 },
+      { "group": "pants_unisex", "prob": 100 },
+      { "group": "shoes_unisex", "prob": 100 },
+      { "group": "shirts_unisex", "prob": 100 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "corpse_child_survival",
+    "entries": [ { "group": "corpse_child_survival_undam", "damage": [ 3, 4 ], "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "corpse_child_survival_undam",
+    "container-item": "corpse_child_calm",
     "entries": [
       { "item": "childnote" },
       { "group": "child_items", "damage-min": 1, "damage-max": 3, "prob": 100 },
       { "group": "child_items", "damage-min": 1, "damage-max": 3, "prob": 50 },
       { "group": "child_bugout", "damage-min": 1, "damage-max": 3, "prob": 100 },
-      { "group": "corpse_child", "damage-min": 3, "damage-max": 4, "prob": 100 },
-      { "group": "underwear_unisex", "damage-min": 1, "damage-max": 3, "prob": 100 },
-      { "group": "pants_unisex", "damage-min": 1, "damage-max": 3, "prob": 100 },
-      { "group": "shoes_unisex", "damage-min": 1, "damage-max": 3, "prob": 100 },
-      { "group": "shirts_unisex", "damage-min": 1, "damage-max": 3, "prob": 100 }
+      { "group": "clothes_unisex_survival", "damage": [ 1, 3 ], "prob": 100 }
     ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "corpse_female_survival",
-    "entries": [
-      { "group": "corpse_female", "damage-min": 3, "damage-max": 4 },
-      { "group": "underwear_unisex", "damage-min": 1, "damage-max": 3, "prob": 100 },
-      { "group": "pants_unisex", "damage-min": 1, "damage-max": 3, "prob": 100 },
-      { "group": "shoes_unisex", "damage-min": 1, "damage-max": 3, "prob": 100 },
-      { "group": "shirts_unisex", "damage-min": 1, "damage-max": 3, "prob": 100 }
-    ]
+    "entries": [ { "group": "corpse_female_survival_undam", "damage": [ 3, 4 ], "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "corpse_female_survival_undam",
+    "container-item": "corpse_generic_female",
+    "entries": [ { "group": "clothes_unisex_survival", "damage": [ 1, 3 ], "prob": 100 } ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "corpses_unisex_survival",
-    "entries": [
-      { "group": "corpses", "damage-min": 3, "damage-max": 4 },
-      { "group": "underwear_unisex", "damage-min": 1, "damage-max": 3, "prob": 100 },
-      { "group": "pants_unisex", "damage-min": 1, "damage-max": 3, "prob": 100 },
-      { "group": "shoes_unisex", "damage-min": 1, "damage-max": 3, "prob": 100 },
-      { "group": "shirts_unisex", "damage-min": 1, "damage-max": 3, "prob": 100 }
-    ]
+    "entries": [ { "group": "corpses_unisex_survival_undam", "damage": [ 3, 4 ], "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "corpses_unisex_survival_undam",
+    "container-item": "corpse_generic_human",
+    "entries": [ { "group": "clothes_unisex_survival", "damage": [ 1, 3 ], "prob": 100 } ]
   },
   {
     "type": "mapgen",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Spawned corpses should now spawn with and contain their clothes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #66861

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I think this is every human corpse spawn in the game but I wouldn't be surprised if I missed some

For whatever reason due to corpses being partially hardcoded they can only be used as container-item outside of entries/items/groups so some of this looks messy but is just working around that.

Example working container:
```
{
  "id": "corpse_generic_human",
  "type": "item_group",
  "subtype": "distribution",
  "container-item": "corpse_generic_human",
  "entries": [ { "group": "default_zombie_death_drops" } ]
},
```

Example non working containers:

```
{
  "id": "corpse_generic_human",
  "type": "item_group",
  "subtype": "distribution",
  "entries": [ { "group": "default_zombie_death_drops", "container-item": "corpse_generic_human" } ]
}
```

```
{
  "id": "corpses",
  "type": "item_group",
  "subtype": "distribution",
  "entries": [
    { "group": "default_zombie_death_drops", "container-item": "corpse_generic_human" },
    { "group": "default_zombie_death_drops", "container-item": "corpse_generic_male" },
    ...
  ]
}
```

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Yeeting some of the weirder corpses
Making a looted corpse drops item palette or something to differentiate between basic drops
Giving a chance for other categories of drops (survivor zed etc)

Making container-group able be used outside of entries/items/groups

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Will look into making mapgen corpses take a more random length of time to rez so they don't all stand up really fast, though more are damaged now so it's less of a problem outside of mass graves
Zeds still rez while inside bodybags not sure if there's a good way to stop that though

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->